### PR TITLE
Do not list deprecated subcommands in `help <cmd>`

### DIFF
--- a/crates/nu-command/src/strings/str_/collect.rs
+++ b/crates/nu-command/src/strings/str_/collect.rs
@@ -26,7 +26,7 @@ impl Command for StrCollect {
     }
 
     fn usage(&self) -> &str {
-        "'str collect' is deprecated. Please use 'str join' instead."
+        "Deprecated command"
     }
 
     fn run(

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -69,7 +69,10 @@ fn get_documentation(
     if !config.no_subcommands {
         let signatures = engine_state.get_signatures(true);
         for sig in signatures {
-            if sig.name.starts_with(&format!("{} ", cmd_name)) {
+            if sig.name.starts_with(&format!("{} ", cmd_name))
+                // Don't display deprecated commands in the Subcommands list
+                    && !sig.usage.starts_with("Deprecated command")
+            {
                 subcommands.push(format!("  {C}{}{RESET} - {}", sig.name, sig.usage));
             }
         }


### PR DESCRIPTION
# Description

BEFORE:
```
Subcommands:
  str camel-case - Convert a string to camelCase
  str capitalize - Capitalize first letter of text
  str collect - 'str collect' is deprecated. Please use 'str join' instead.
  str contains - Checks if string input contains a substring
  str distance - Compare two strings and return the edit distance/Levenshtein distance
  str downcase - Make text lowercase
  str ends-with - Check if an input ends with a string
  str find-replace - Deprecated command
  str index-of - Returns start index of first occurrence of string in input, or -1 if no match
  str join - Concatenate multiple strings into a single string, with an optional separator between each
  str kebab-case - Convert a string to kebab-case
  str length - Output the length of any strings in the pipeline
  str lpad - Left-pad a string to a specific length
  str pascal-case - Convert a string to PascalCase
  str replace - Find and replace text
  str reverse - Reverse every string in the pipeline
  str rpad - Right-pad a string to a specific length
  str screaming-snake-case - Convert a string to SCREAMING_SNAKE_CASE
  str snake-case - Convert a string to snake_case
  str starts-with - Check if an input starts with a string
  str substring - Get part of a string. Note that the start is included but the end is excluded, and that the first character of a string is index 0.
  str title-case - Convert a string to Title Case
  str to-datetime - Deprecated command
  str to-decimal - Deprecated command
  str to-int - Deprecated command
  str trim - Trim whitespace or specific character
  str upcase - Make text uppercase
```

AFTER:

```
Subcommands:
  str camel-case - Convert a string to camelCase
  str capitalize - Capitalize first letter of text
  str contains - Checks if string input contains a substring
  str distance - Compare two strings and return the edit distance/Levenshtein distance
  str downcase - Make text lowercase
  str ends-with - Check if an input ends with a string
  str index-of - Returns start index of first occurrence of string in input, or -1 if no match
  str join - Concatenate multiple strings into a single string, with an optional separator between each     
  str kebab-case - Convert a string to kebab-case
  str length - Output the length of any strings in the pipeline
  str lpad - Left-pad a string to a specific length
  str pascal-case - Convert a string to PascalCase
  str replace - Find and replace text
  str reverse - Reverse every string in the pipeline
  str rpad - Right-pad a string to a specific length
  str screaming-snake-case - Convert a string to SCREAMING_SNAKE_CASE
  str snake-case - Convert a string to snake_case
  str starts-with - Check if an input starts with a string
  str substring - Get part of a string. Note that the start is included but the end is excluded, and that the first character of a string is index 0.
  str title-case - Convert a string to Title Case
  str trim - Trim whitespace or specific character
  str upcase - Make text uppercase
```

The deprecated subcommands still exist, but are no longer listed in `help` for the containing command.

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
