### PR TITLE
fix signature display in help commands

### DIFF
--- a/crates/nu-command/src/core_commands/help_commands.rs
+++ b/crates/nu-command/src/core_commands/help_commands.rs
@@ -132,7 +132,7 @@ fn build_help_commands(engine_state: &EngineState, span: Span) -> Vec<Value> {
         let decl = engine_state.get_decl(decl_id);
         let sig = decl.signature().update_from_command(name, decl.borrow());
 
-        let signatures = sig.to_string();
+        let signatures = sig.to_string().trim_start().replace("\n  ", "\n");
         let key = sig.name;
         let usage = sig.usage;
         let search_terms = sig.search_terms;


### PR DESCRIPTION
# Description

This PR fixes the signature display when running `help commands`. Before this PR, there were leading spaces in the signatures column. Now, they're left aligned for a cleaner look.

Before:
![image](https://user-images.githubusercontent.com/343840/213711847-368fba0d-c902-47e6-b777-54de978b1ce3.png)

After:
![image](https://user-images.githubusercontent.com/343840/213711551-c5eb29c9-1d47-444b-86a1-8e14711e9771.png)


# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
