### PR TITLE
Allow for multiline commands in scripts by escaping newlines with '\'

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -78,9 +78,9 @@ pub fn evaluate_file(
     for (idx, arr_chars) in file.clone().windows(3).enumerate() {
         if arr_chars.first() == Some(&b'\\') {
             if arr_chars.get(1) == Some(&b'\n') {
-                file.drain(idx..(idx + 1));
-            } else if arr_chars.get(1) == Some(&b'\r') && arr_chars.get(2) == Some(&b'\n') {
                 file.drain(idx..(idx + 2));
+            } else if arr_chars.get(1) == Some(&b'\r') && arr_chars.get(2) == Some(&b'\n') {
+                file.drain(idx..(idx + 3));
             }
         }
     }

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -236,8 +236,6 @@ fn escape_newline_with_backslash() {
 
     assert_eq!(
         actual.out,
-        r"
-        2arg 11
-    "
+        "2"
     );
 }

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -226,3 +226,15 @@ fn parse_export_env_missing_block() {
 
     assert!(actual.err.contains("missing block"));
 }
+
+#[test]
+fn escape_newline_with_backslash() {
+    let actual = nu!(cwd: "tests/parsing/samples",
+        r#"
+            nu multiline_command.nu
+        "#);
+
+    assert_eq!(actual.out, r"
+        2arg 11
+    ");
+}

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -234,7 +234,10 @@ fn escape_newline_with_backslash() {
             nu multiline_command.nu
         "#);
 
-    assert_eq!(actual.out, r"
+    assert_eq!(
+        actual.out,
+        r"
         2arg 11
-    ");
+    "
+    );
 }

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -234,8 +234,5 @@ fn escape_newline_with_backslash() {
             nu multiline_command.nu
         "#);
 
-    assert_eq!(
-        actual.out,
-        "2"
-    );
+    assert_eq!(actual.out, "2");
 }

--- a/tests/parsing/samples/multiline_command.nu
+++ b/tests/parsing/samples/multiline_command.nu
@@ -1,0 +1,13 @@
+# if echo treats both of the below as arguments, it will output a list.
+
+echo "first very long argument that necessitates multiline" \
+"second long argument that should appear as the second element in a list" | length
+
+# below, see what it looks like without the linebreak
+echo "arg 1"
+"arg 2" | length
+
+# if everything has gone well the whole output of this script will look like:
+# 2
+# arg 1
+# 1

--- a/tests/parsing/samples/multiline_command.nu
+++ b/tests/parsing/samples/multiline_command.nu
@@ -1,13 +1,4 @@
-# if echo treats both of the below as arguments, it will output a list.
+# if echo treats both of the below as arguments, it will output a list, which means length should be 2.
 
 echo "first very long argument that necessitates multiline" \
 "second long argument that should appear as the second element in a list" | length
-
-# below, see what it looks like without the linebreak
-echo "arg 1"
-"arg 2" | length
-
-# if everything has gone well the whole output of this script will look like:
-# 2
-# arg 1
-# 1


### PR DESCRIPTION
# Description

Fixes #7780 (?)

The functionality is borrowed from bash, but I don't have strong feelings about it. My main concern is that the substitution for the escape happens at the wrong time, which could be problematic for future maintainers.

As seen in the example, 
```
echo "longarg" \
"longarg2"
```
is parsed as 
``` 
echo "longarg" "longarg2"
```
Same can be done for flags, for instance
```
ls --all \
--du
``` 
Should work properly.

# User-Facing Changes

A backslash followed by a newline now escapes the newline.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
