### PR TITLE
Feat/7725 url join

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -439,6 +439,7 @@ pub fn create_default_context() -> EngineState {
             Url,
             UrlBuildQuery,
             UrlEncode,
+            UrlJoin,
             UrlParse,
             Port,
         }

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -197,7 +197,7 @@ impl UrlComponents {
                                 right_message: format!("instead query is: {}", q),
                                 right_span: self
                                     .query_span
-                                    .expect("query param span should be present"),
+                                    .unwrap_or(Span::unknown()),
                             });
                         }
                     }
@@ -257,7 +257,7 @@ impl UrlComponents {
                                         right_message: format!("instead qs from params is: {}", q),
                                         right_span: self
                                             .params_span
-                                            .expect("params span should be present"),
+                                            .unwrap_or(Span::unknown()),
                                     });
                                 }
                             }
@@ -316,11 +316,11 @@ impl UrlComponents {
             host_result?,
             self.port
                 .map(|p| format!(":{}", p))
-                .as_ref()
-                .unwrap_or(&String::from("")),
-            self.path.as_ref().unwrap_or(&String::from("")),
-            self.query.as_ref().unwrap_or(&String::from("")),
-            self.fragment.as_ref().unwrap_or(&String::from(""))
+                .as_deref()
+                .unwrap_or_default(),
+            self.path.as_deref().unwrap_or_default(),
+            self.query.as_deref().unwrap_or_default(),
+            self.fragment.as_deref().unwrap_or_default()
         ))
     }
 

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -29,21 +29,21 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Outputs a url representing the contents of this record",
-                example: r#"{
-                    "scheme": "http",
-                    "username": "",
-                    "password": "",
-                    "host": "www.pixiv.net",
-                    "port": "",
-                    "path": "/member_illust.php",
-                    "query": "mode=medium&illust_id=99260204",
-                    "fragment": "",
-                    "params":
-                    {
-                      "mode": "medium",
-                      "illust_id": "99260204"
-                    }
-                  } | url join"#,
+                example: r#"{ 
+        "scheme": "http",
+        "username": "",
+        "password": "",
+        "host": "www.pixiv.net",
+        "port": "",
+        "path": "/member_illust.php",
+        "query": "mode=medium&illust_id=99260204",
+        "fragment": "",
+        "params":
+        {
+            "mode": "medium",
+            "illust_id": "99260204"
+        }
+    } | url join"#,
                 result: Some(Value::test_string(
                     "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=99260204",
                 )),
@@ -51,14 +51,14 @@ impl Command for SubCommand {
             Example {
                 description: "Outputs a url representing the contents of this record",
                 example: r#"{
-                    "scheme": "http",
-                    "username": "user",
-                    "password": "pwd",
-                    "host": "www.pixiv.net",
-                    "port": "1234",
-                    "query": "test=a",
-                    "fragment": ""
-                  } | url join"#,
+        "scheme": "http",
+        "username": "user",
+        "password": "pwd",
+        "host": "www.pixiv.net",
+        "port": "1234",
+        "query": "test=a",
+        "fragment": ""
+    } | url join"#,
                 result: Some(Value::test_string(
                     "http://user:pwd@www.pixiv.net:1234?test=a",
                 )),
@@ -66,12 +66,12 @@ impl Command for SubCommand {
             Example {
                 description: "Outputs a url representing the contents of this record",
                 example: r#"{
-                    "scheme": "http",
-                    "host": "www.pixiv.net",
-                    "port": "1234",
-                    "path": "user",
-                    "fragment": "frag"
-                  } | url join"#,
+        "scheme": "http",
+        "host": "www.pixiv.net",
+        "port": "1234",
+        "path": "user",
+        "fragment": "frag"
+    } | url join"#,
                 result: Some(Value::test_string("http://www.pixiv.net:1234/user#frag")),
             },
         ]

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -1,0 +1,255 @@
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, IntoPipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "url join"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("url join")
+            .input_output_types(vec![(Type::Record(vec![]), Type::String)])
+            .category(Category::Network)
+    }
+
+    fn usage(&self) -> &str {
+        "Converts a record to url"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &nu_protocol::ast::Call,
+        input: nu_protocol::PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+
+        let output: Result<String, ShellError> = input
+            .into_iter()
+            .map(move |value| match value {
+                Value::Record {
+                    ref cols,
+                    ref vals,
+                    span,
+                } => {
+                    let url_components = cols
+                        .iter()
+                        .zip(vals.iter())
+                        .fold(Ok(UrlComponents::new()), |url, (k, v)| {
+                            url?.add_component(k.clone(), v.clone(), span)
+                        });
+
+                    url_components?.to_url(head, span)
+                }
+                Value::Error { error } => Err(error),
+                other => Err(ShellError::UnsupportedInput(
+                    "Expected a record from pipeline".to_string(),
+                    "value originates from here".into(),
+                    head,
+                    other.expect_span(),
+                )),
+            })
+            .collect();
+
+        Ok(Value::string(output?, head).into_pipeline_data())
+    }
+}
+
+#[derive(Default, Debug)]
+struct UrlComponents {
+    scheme: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+    host: Option<String>,
+    port: Option<i64>,
+    path: Option<String>,
+    query: Option<String>,
+    fragment: Option<String>,
+}
+
+impl UrlComponents {
+    fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn add_component(
+        self: Self,
+        key: String,
+        value: Value,
+        span: Span,
+    ) -> Result<Self, ShellError> {
+        if key == "port" {
+            return match value {
+                Value::String { val, span } => {
+                    if val.trim().is_empty() {
+                        Ok(self)
+                    } else {
+                        match val.parse::<i64>() {
+                            Ok(p) => Ok(Self {
+                                port: Some(p),
+                                ..self
+                            }),
+                            Err(_) => Err(ShellError::IncompatibleParametersSingle(
+                                String::from("Port parameter should represent an unsigned integer"),
+                                span,
+                            )),
+                        }
+                    }
+                }
+                Value::Int { val, span } => Ok(Self {
+                    port: Some(val),
+                    ..self
+                }),
+                other => Err(ShellError::IncompatibleParametersSingle(
+                    String::from(
+                        "Port parameter should be an unsigned integer or a string representing it",
+                    ),
+                    other.expect_span(),
+                )),
+            };
+        }
+
+        if key == "params" {
+            return match value {
+                Value::Record {
+                    ref cols,
+                    ref vals,
+                    span,
+                } => {
+                    let mut qs = cols
+                        .iter()
+                        .zip(vals.iter())
+                        .map(|(k, v)| match v.as_string() {
+                            Ok(val) => Ok(format!("{}={}", k, val)),
+                            Err(err) => Err(err),
+                        })
+                        .collect::<Result<Vec<String>, ShellError>>()?
+                        .join("&")
+                        .to_string();
+
+                    qs = format!("?{}", qs);
+
+                    if let Some(q) = self.query {
+                        if q != qs {
+                            return Err(ShellError::IncompatibleParametersSingle(
+                                String::from("Parameters query and params are in conflict"),
+                                span,
+                            ));
+                        }
+                    }
+
+                    Ok(Self {
+                        query: Some(qs),
+                        ..self
+                    })
+                }
+                Value::Error { error } => Err(error),
+                other => Err(ShellError::IncompatibleParametersSingle(
+                    String::from("Key params has to be a record"),
+                    other.expect_span(),
+                )),
+            };
+        }
+
+        match value.as_string() {
+            Ok(s) => match key.as_str() {
+                "host" => Ok(Self {
+                    host: Some(s),
+                    ..self
+                }),
+                "scheme" => Ok(Self {
+                    scheme: Some(s),
+                    ..self
+                }),
+                "username" => Ok(Self {
+                    username: Some(s),
+                    ..self
+                }),
+                "password" => Ok(Self {
+                    password: Some(s),
+                    ..self
+                }),
+                "path" => Ok(Self {
+                    path: Some(if s.starts_with('/') {
+                        s
+                    } else {
+                        format!("/{}", s)
+                    }),
+                    ..self
+                }),
+                "query" => {
+                    if let Some(q) = self.query {
+                        if q != s {
+                            return Err(ShellError::IncompatibleParametersSingle(
+                                String::from("Parameters query and params are in conflict"),
+                                span,
+                            ));
+                        }
+                    }
+
+                    Ok(Self {
+                        query: Some(format!("?{}", s)),
+                        ..self
+                    })
+                }
+                "fragment" => Ok(Self {
+                    fragment: Some(if s.starts_with("#") {
+                        s
+                    } else {
+                        format!("#{}", s)
+                    }),
+                    ..self
+                }),
+                _ => Ok(self),
+            },
+            _ => Ok(self),
+        }
+    }
+
+    pub fn to_url(self: &Self, head: Span, span: Span) -> Result<String, ShellError> {
+        let mut user_and_pwd: String = String::from("");
+
+        if let Some(usr) = &self.username {
+            if let Some(pwd) = &self.password {
+                user_and_pwd = format!("{}:{}@", usr, pwd);
+            }
+        }
+
+        Ok(format!(
+            "{}://{}{}{}{}{}{}",
+            self.scheme.as_ref().ok_or(
+                UrlComponents::generate_shell_error_for_missing_parameter("scheme", head, span)
+            )?,
+            user_and_pwd,
+            self.host
+                .as_ref()
+                .ok_or(UrlComponents::generate_shell_error_for_missing_parameter(
+                    "host", head, span
+                ))?,
+            self.port
+                .map(|p| format!(":{}", p))
+                .as_ref()
+                .unwrap_or(&String::from("")),
+            self.path.as_ref().unwrap_or(&String::from("")),
+            self.query.as_ref().unwrap_or(&String::from("")),
+            self.fragment.as_ref().unwrap_or(&String::from(""))
+        ))
+    }
+
+    fn generate_shell_error_for_missing_parameter(
+        pname: &str,
+        head: Span,
+        span: Span,
+    ) -> ShellError {
+        ShellError::UnsupportedInput(
+            format!("Missing required param: {}", pname),
+            String::from("value originates from here"),
+            head,
+            span,
+        )
+    }
+}

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -195,9 +195,7 @@ impl UrlComponents {
                                 left_message: format!("Mismatch, qs from params is: {}", qs),
                                 left_span: value.expect_span(),
                                 right_message: format!("instead query is: {}", q),
-                                right_span: self
-                                    .query_span
-                                    .unwrap_or(Span::unknown()),
+                                right_span: self.query_span.unwrap_or(Span::unknown()),
                             });
                         }
                     }
@@ -255,9 +253,7 @@ impl UrlComponents {
                                         left_message: format!("Mismatch, query param is: {}", s),
                                         left_span: value.expect_span(),
                                         right_message: format!("instead qs from params is: {}", q),
-                                        right_span: self
-                                            .params_span
-                                            .unwrap_or(Span::unknown()),
+                                        right_span: self.params_span.unwrap_or(Span::unknown()),
                                     });
                                 }
                             }

--- a/crates/nu-command/src/network/url/mod.rs
+++ b/crates/nu-command/src/network/url/mod.rs
@@ -1,5 +1,6 @@
 mod build_query;
 mod encode;
+mod join;
 mod parse;
 mod url_;
 
@@ -8,4 +9,5 @@ use url::{self};
 pub use self::parse::SubCommand as UrlParse;
 pub use build_query::SubCommand as UrlBuildQuery;
 pub use encode::SubCommand as UrlEncode;
+pub use join::SubCommand as UrlJoin;
 pub use url_::Url;

--- a/crates/nu-command/tests/commands/url/join.rs
+++ b/crates/nu-command/tests/commands/url/join.rs
@@ -1,0 +1,368 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn url_join_simple() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "",
+                    "password": "",
+                    "host": "localhost",
+                    "port": "",
+                } | url join
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "http://localhost");
+}
+
+#[test]
+fn url_join_with_only_user() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "",
+                    "host": "localhost",
+                    "port": "",
+                } | url join 
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "http://localhost");
+}
+
+#[test]
+fn url_join_with_only_pwd() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "port": "",
+                } | url join 
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "http://localhost");
+}
+
+#[test]
+fn url_join_with_user_and_pwd() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "port": "",
+                } | url join 
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "http://usr:pwd@localhost");
+}
+
+#[test]
+fn url_join_with_query() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "query": "par_1=aaa&par_2=bbb"
+                    "port": "",
+                } | url join 
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "http://usr:pwd@localhost?par_1=aaa&par_2=bbb");
+}
+
+#[test]
+fn url_join_with_params() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "params": {
+                        "par_1": "aaa",
+                        "par_2": "bbb"
+                    },
+                    "port": "1234",
+                } | url join
+            "#
+        )
+    );
+
+    assert_eq!(
+        actual.out,
+        "http://usr:pwd@localhost:1234?par_1=aaa&par_2=bbb"
+    );
+}
+
+#[test]
+fn url_join_with_same_query_and_params() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "query": "par_1=aaa&par_2=bbb",
+                    "params": {
+                        "par_1": "aaa",
+                        "par_2": "bbb"
+                    },
+                    "port": "1234",
+                } | url join
+            "#
+        )
+    );
+
+    assert_eq!(
+        actual.out,
+        "http://usr:pwd@localhost:1234?par_1=aaa&par_2=bbb"
+    );
+}
+
+#[test]
+fn url_join_with_different_query_and_params() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "query": "par_1=aaa&par_2=bbb",
+                    "params": {
+                        "par_1": "aaab",
+                        "par_2": "bbb"
+                    },
+                    "port": "1234",
+                } | url join
+            "#
+        )
+    );
+
+    assert!(actual
+        .err
+        .contains("Mismatch, qs from params is: ?par_1=aaab&par_2=bbb"));
+    assert!(actual
+        .err
+        .contains("instead query is: ?par_1=aaa&par_2=bbb"));
+
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "params": {
+                        "par_1": "aaab",
+                        "par_2": "bbb"
+                    },
+                    "query": "par_1=aaa&par_2=bbb",
+                    "port": "1234",
+                } | url join
+            "#
+        )
+    );
+
+    assert!(actual
+        .err
+        .contains("Mismatch, query param is: par_1=aaa&par_2=bbb"));
+    assert!(actual
+        .err
+        .contains("instead qs from params is: ?par_1=aaab&par_2=bbb"));
+}
+
+#[test]
+fn url_join_with_invalid_params() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "params": "aaa",
+                    "port": "1234",
+                } | url join
+            "#
+        )
+    );
+
+    assert!(actual.err.contains("Key params has to be a record"));
+}
+
+#[test]
+fn url_join_with_port() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "host": "localhost",
+                    "port": "1234",
+                } | url join
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "http://localhost:1234");
+
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "host": "localhost",
+                    "port": 1234,
+                } | url join
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "http://localhost:1234");
+}
+
+#[test]
+fn url_join_with_invalid_port() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "host": "localhost",
+                    "port": "aaaa",
+                } | url join
+            "#
+        )
+    );
+
+    assert!(actual
+        .err
+        .contains("Port parameter should represent an unsigned integer"));
+
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "host": "localhost",
+                    "port": [],
+                } | url join
+            "#
+        )
+    );
+
+    assert!(actual
+        .err
+        .contains("Port parameter should be an unsigned integer or a string representing it"));
+}
+
+#[test]
+fn url_join_with_missing_scheme() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "host": "localhost"
+                } | url join
+            "#
+        )
+    );
+
+    assert!(actual.err.contains("missing parameter: scheme"));
+}
+
+#[test]
+fn url_join_with_missing_host() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "https"
+                } | url join
+            "#
+        )
+    );
+
+    assert!(actual.err.contains("missing parameter: host"));
+}
+
+#[test]
+fn url_join_with_fragment() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "fragment": "frag",
+                    "port": "1234",
+                } | url join
+            "#
+        )
+    );
+
+    assert_eq!(actual.out, "http://usr:pwd@localhost:1234#frag");
+}
+
+#[test]
+fn url_join_with_fragment_and_params() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+            r#"
+                {
+                    "scheme": "http",
+                    "username": "usr",
+                    "password": "pwd",
+                    "host": "localhost",
+                    "params": {
+                        "par_1": "aaa",
+                        "par_2": "bbb"
+                    },
+                    "port": "1234",
+                    "fragment": "frag"
+                } | url join
+            "#
+        )
+    );
+
+    assert_eq!(
+        actual.out,
+        "http://usr:pwd@localhost:1234?par_1=aaa&par_2=bbb#frag"
+    );
+}

--- a/crates/nu-command/tests/commands/url/mod.rs
+++ b/crates/nu-command/tests/commands/url/mod.rs
@@ -1,1 +1,2 @@
+mod join;
 mod parse;


### PR DESCRIPTION
# Description

Added command: `url join`.
Closes: #7725 

# User-Facing Changes

```
Converts a record to url

Search terms: scheme, username, password, hostname, port, path, query, fragment

Usage:
  > url join

Flags:
  -h, --help - Display the help message for this command

Signatures:
  <record> | url join -> <string>

Examples:
  Outputs a url representing the contents of this record
  > {
          "scheme": "http",
          "username": "",
          "password": "",
          "host": "www.pixiv.net",
          "port": "",
          "path": "/member_illust.php",
          "query": "mode=medium&illust_id=99260204",
          "fragment": "",
          "params":
          {
            "mode": "medium",
            "illust_id": "99260204"
          }
        } | url join

  Outputs a url representing the contents of this record
  > {
        "scheme": "http",
        "username": "user",
        "password": "pwd",
        "host": "www.pixiv.net",
        "port": "1234",
        "query": "test=a",
        "fragment": ""
      } | url join

  Outputs a url representing the contents of this record
  > {
        "scheme": "http",
        "host": "www.pixiv.net",
        "port": "1234",
        "path": "user",
        "fragment": "frag"
      } | url join
```                  

# Questions
- Which parameters should be required? Currenlty are: `scheme` and `host`.

