### PR TITLE
[nu-test-support] Gate system locale tests

### DIFF
--- a/crates/nu-test-support/tests/get_system_locale.rs
+++ b/crates/nu-test-support/tests/get_system_locale.rs
@@ -1,3 +1,5 @@
+#![cfg(debug_assertions)]
+
 use nu_test_support::locale_override::with_locale_override;
 use nu_utils::get_system_locale;
 use num_format::Grouping;


### PR DESCRIPTION
# Description

`src/locale_override.rs` is gated with `#![cfg(debug_assertions)]` but `tests/get_system_locale.rs` is not; this makes `cargo test --release` fails:

```
error[E0432]: unresolved import `nu_test_support::locale_override`
 --> crates/nu-test-support/tests/get_system_locale.rs:1:22
  |
1 | use nu_test_support::locale_override::with_locale_override;
  |                      ^^^^^^^^^^^^^^^ could not find `locale_override` in `nu_test_support`

For more information about this error, try `rustc --explain E0432`.
error: could not compile `nu-test-support` due to previous error
warning: build failed, waiting for other jobs to finish...
```

With the change it now passes:

```
❯ cargo test --release
   Compiling nu-test-support v0.74.1 (/home/michel/src/github/nushell/nushell/crates/nu-test-support)
    Finished release [optimized] target(s) in 7.57s
     Running unittests src/lib.rs (/home/michel/src/github/nushell/nushell/target/release/deps/nu_test_support-750505b13c102d2c)

running 3 tests
test tests::constructs_a_pipeline ... ok
test playground::tests::current_working_directory_back_to_root_from_anywhere ... ok
test playground::tests::current_working_directory_in_sandbox_directory_created ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/get_system_locale.rs (/home/michel/src/github/nushell/nushell/target/release/deps/get_system_locale-e0ecabe312044fa8)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>

# User-Facing Changes

N/A

