### PR TITLE
Fix panic when using `alias` with an `if` condition

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -47,6 +47,10 @@ impl Highlighter for NuHighlighter {
                 // We've already output something for this span
                 // so just skip this one
                 continue;
+            } else if shape.1 == FlatShape::Operator
+                && (shape.0.end - 1 <= last_seen_span || shape.0.end - 2 <= last_seen_span)
+            {
+                continue;
             }
             if shape.0.start > last_seen_span {
                 let gap = line

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -43,13 +43,11 @@ impl Highlighter for NuHighlighter {
             if shape.0.end <= last_seen_span
                 || last_seen_span < global_span_offset
                 || shape.0.start < global_span_offset
+                || (shape.1 == FlatShape::Operator
+                    && (shape.0.end - 1 <= last_seen_span || shape.0.end - 2 <= last_seen_span))
             {
                 // We've already output something for this span
                 // so just skip this one
-                continue;
-            } else if shape.1 == FlatShape::Operator
-                && (shape.0.end - 1 <= last_seen_span || shape.0.end - 2 <= last_seen_span)
-            {
                 continue;
             }
             if shape.0.start > last_seen_span {

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -119,5 +119,5 @@ fn alias_short_attr2() {
         "#
     ));
 
-    assert!(actual.out.contains("first_one"));
+    assert_eq!(actual.out, "first_one");
 }

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -87,3 +87,37 @@ fn alias_alone_lists_aliases() {
     ));
     assert!(actual.out.contains("name") && actual.out.contains("expansion"));
 }
+
+#[test]
+fn alias_short_attr1() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            alias t = if not true { ls } else { echo "should_type_this"}; t
+        "#
+    ));
+
+    assert_eq!(actual.out, "should_type_this");
+}
+
+#[test]
+fn alias_short_attr2() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            alias vi = if not ( [] | is-empty) { echo "first_one" } else if not ( [1] | is-empty) { echo "second_one" } ; vi;
+        "#
+    ));
+
+    assert!(actual.err.is_empty());
+    assert!(actual.out.contains("second_one"));
+
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            alias v = if not false { echo "first_one" } else { echo "second_one" }; v;
+        "#
+    ));
+
+    assert!(actual.out.contains("first_one"));
+}

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -110,7 +110,7 @@ fn alias_short_attr2() {
     ));
 
     assert!(actual.err.is_empty());
-    assert!(actual.out.contains("second_one"));
+    assert_eq!(actual.out, "second_one");
 
     let actual = nu!(
         cwd: ".", pipeline(


### PR DESCRIPTION
# Description

Fixes #7512 
In `Highlighter` because of comparison between Span to set color on them when codes reached to `not` or `unrayNot` it faced issue because of length of Span .
We can pass it away if we reach to this when we want to call an alias . as we only looking for `InternalCall` in our alias to execute .

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
