### PR TITLE
Fix command name lookup for known externals

### DIFF
--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -51,7 +51,15 @@ impl Command for KnownExternal {
 
         let mut extern_call = Call::new(head_span);
 
-        let extern_name = engine_state.get_decl(call.decl_id).name();
+        let extern_name = if let Some(name_bytes) = engine_state.find_decl_name(call.decl_id, &[]) {
+            String::from_utf8_lossy(name_bytes)
+        } else {
+            return Err(ShellError::NushellFailedSpanned(
+                "known external name not found".to_string(),
+                "could not find name for this command".to_string(),
+                call.head,
+            ));
+        };
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -585,6 +585,24 @@ impl EngineState {
         None
     }
 
+    pub fn find_decl_name(&self, decl_id: DeclId, removed_overlays: &[Vec<u8>]) -> Option<&[u8]> {
+        let mut visibility: Visibility = Visibility::new();
+
+        for overlay_frame in self.active_overlays(removed_overlays).iter().rev() {
+            visibility.append(&overlay_frame.visibility);
+
+            if visibility.is_decl_id_visible(&decl_id) {
+                for ((name, _), id) in overlay_frame.decls.iter() {
+                    if id == &decl_id {
+                        return Some(name);
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
     pub fn find_alias(&self, name: &[u8], removed_overlays: &[Vec<u8>]) -> Option<AliasId> {
         let mut visibility: Visibility = Visibility::new();
 

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -76,3 +76,34 @@ fn known_external_misc_values() -> TestResult {
         "abc a b c",
     )
 }
+
+/// GitHub issue #7822
+#[test]
+fn known_external_subcommand_from_module() -> TestResult {
+    run_test_contains(
+        r#"
+            module cargo {
+                export extern check []
+            };
+            use cargo;
+            cargo check -h
+        "#,
+        "cargo check",
+    )
+}
+
+/// GitHub issue #7822
+#[test]
+fn known_external_aliased_subcommand_from_module() -> TestResult {
+    run_test_contains(
+        r#"
+            module cargo {
+                export extern check []
+            };
+            use cargo;
+            alias cc = cargo check;
+            cc -h
+        "#,
+        "cargo check",
+    )
+}


### PR DESCRIPTION
# Description

When known externals were imported from modules with a prefix (`use spam` instead of `use spam *`), it was impossible to call them. This PR fixes it.

Fixes https://github.com/nushell/nushell/issues/7822

The following now works:
```
> module cargo { export extern check [] }
> use cargo
> cargo check
```

# User-Facing Changes

Enables subcommand folding of modules with `export extern`s. Should not break anything.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
