### PR TITLE
print nushell startup time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
 dependencies = [
- "nix 0.25.0",
+ "nix",
  "winapi 0.3.9",
 ]
 
@@ -2548,18 +2548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "libc",
- "static_assertions",
-]
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,7 +2627,7 @@ dependencies = [
  "itertools",
  "log",
  "miette",
- "nix 0.26.2",
+ "nix",
  "nu-ansi-term",
  "nu-cli",
  "nu-color-config",
@@ -2956,7 +2944,7 @@ dependencies = [
  "libproc",
  "log",
  "mach2",
- "nix 0.25.0",
+ "nix",
  "ntapi",
  "once_cell",
  "procfs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,7 +2660,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "reedline",
- "rstest 0.16.0",
+ "rstest",
  "serial_test",
  "signal-hook",
  "simplelog",
@@ -2703,7 +2703,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "reedline",
- "rstest 0.16.0",
+ "rstest",
  "sysinfo",
  "thiserror",
 ]
@@ -2796,7 +2796,7 @@ dependencies = [
  "regex",
  "reqwest",
  "roxmltree",
- "rstest 0.15.0",
+ "rstest",
  "rusqlite",
  "rust-embed",
  "same-file",
@@ -4327,17 +4327,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
 dependencies = [
- "rstest_macros 0.14.0",
- "rustc_version 0.4.0",
-]
-
-[[package]]
-name = "rstest"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
-dependencies = [
- "rstest_macros 0.16.0",
+ "rstest_macros",
  "rustc_version 0.4.0",
 ]
 
@@ -4352,20 +4342,6 @@ dependencies = [
  "quote",
  "rustc_version 0.4.0",
  "syn",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
-dependencies = [
- "cfg-if 1.0.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.0",
- "syn",
- "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
  "percent-encoding",
  "reedline",
  "rstest 0.16.0",
- "sysinfo 0.27.7",
+ "sysinfo",
  "thiserror",
 ]
 
@@ -2807,7 +2807,7 @@ dependencies = [
  "sha2",
  "shadow-rs",
  "sqlparser",
- "sysinfo 0.26.4",
+ "sysinfo",
  "terminal_size 0.2.1",
  "thiserror",
  "titlecase",
@@ -2834,7 +2834,7 @@ dependencies = [
  "nu-protocol",
  "nu-utils",
  "serde",
- "sysinfo 0.26.4",
+ "sysinfo",
 ]
 
 [[package]]
@@ -5027,21 +5027,6 @@ dependencies = [
  "libc",
  "wasm-bindgen",
  "web-sys",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975fe381e0ecba475d4acff52466906d95b153a40324956552e027b2a9eaa89e"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation-sys",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
  "winapi 0.3.9",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "devtimer"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907339959a92f6b98846570500c0a567c9aecbb3871cef00561eb5d20d47b7c1"
+
+[[package]]
 name = "dialoguer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2628,7 @@ dependencies = [
  "criterion",
  "crossterm 0.24.0",
  "ctrlc",
+ "devtimer",
  "hamcrest2",
  "is_executable",
  "itertools",
@@ -2648,7 +2655,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "reedline",
- "rstest",
+ "rstest 0.15.0",
  "serial_test",
  "signal-hook",
  "simplelog",
@@ -2674,7 +2681,8 @@ dependencies = [
  "atty",
  "chrono",
  "crossterm 0.24.0",
- "fancy-regex 0.10.0",
+ "devtimer",
+ "fancy-regex 0.11.0",
  "fuzzy-matcher",
  "is_executable",
  "log",
@@ -2691,8 +2699,8 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "reedline",
- "rstest",
- "sysinfo",
+ "rstest 0.16.0",
+ "sysinfo 0.27.7",
  "thiserror",
 ]
 
@@ -2784,7 +2792,7 @@ dependencies = [
  "regex",
  "reqwest",
  "roxmltree",
- "rstest",
+ "rstest 0.15.0",
  "rusqlite",
  "rust-embed",
  "same-file",
@@ -2795,7 +2803,7 @@ dependencies = [
  "sha2",
  "shadow-rs",
  "sqlparser",
- "sysinfo",
+ "sysinfo 0.26.4",
  "terminal_size 0.2.1",
  "thiserror",
  "titlecase",
@@ -2822,7 +2830,7 @@ dependencies = [
  "nu-protocol",
  "nu-utils",
  "serde",
- "sysinfo",
+ "sysinfo 0.26.4",
 ]
 
 [[package]]
@@ -4317,7 +4325,17 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
 dependencies = [
- "rstest_macros",
+ "rstest_macros 0.14.0",
+ "rustc_version 0.4.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "rstest_macros 0.16.0",
  "rustc_version 0.4.0",
 ]
 
@@ -4332,6 +4350,20 @@ dependencies = [
  "quote",
  "rustc_version 0.4.0",
  "syn",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.0",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -5012,6 +5044,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975fe381e0ecba475d4acff52466906d95b153a40324956552e027b2a9eaa89e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "tabled"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5401,9 +5448,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-linebreak"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,16 +1235,6 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
-name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
@@ -2674,7 +2664,7 @@ dependencies = [
  "atty",
  "chrono",
  "crossterm 0.24.0",
- "fancy-regex 0.11.0",
+ "fancy-regex",
  "fuzzy-matcher",
  "is_executable",
  "log",
@@ -2732,7 +2722,7 @@ dependencies = [
  "dtparse",
  "eml-parser",
  "encoding_rs",
- "fancy-regex 0.10.0",
+ "fancy-regex",
  "filesize",
  "filetime",
  "fs_extra",
@@ -2916,7 +2906,7 @@ dependencies = [
  "byte-unit",
  "chrono",
  "chrono-humanize",
- "fancy-regex 0.11.0",
+ "fancy-regex",
  "indexmap",
  "lru",
  "miette",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d91974fbbe88ec1df0c24a4f00f99583667a7e2e6272b2b92d294d81e462173"
 dependencies = [
- "nix",
+ "nix 0.25.0",
  "winapi 0.3.9",
 ]
 
@@ -1004,12 +1004,6 @@ dependencies = [
  "rustc_version 0.4.0",
  "syn",
 ]
-
-[[package]]
-name = "devtimer"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907339959a92f6b98846570500c0a567c9aecbb3871cef00561eb5d20d47b7c1"
 
 [[package]]
 name = "dialoguer"
@@ -2124,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
@@ -2554,6 +2548,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,13 +2634,12 @@ dependencies = [
  "criterion",
  "crossterm 0.24.0",
  "ctrlc",
- "devtimer",
  "hamcrest2",
  "is_executable",
  "itertools",
  "log",
  "miette",
- "nix",
+ "nix 0.26.2",
  "nu-ansi-term",
  "nu-cli",
  "nu-color-config",
@@ -2655,7 +2660,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "reedline",
- "rstest 0.15.0",
+ "rstest 0.16.0",
  "serial_test",
  "signal-hook",
  "simplelog",
@@ -2681,7 +2686,6 @@ dependencies = [
  "atty",
  "chrono",
  "crossterm 0.24.0",
- "devtimer",
  "fancy-regex 0.11.0",
  "fuzzy-matcher",
  "is_executable",
@@ -2952,7 +2956,7 @@ dependencies = [
  "libproc",
  "log",
  "mach2",
- "nix",
+ "nix 0.25.0",
  "ntapi",
  "once_cell",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,27 +45,26 @@ ctrlc = "3.2.1"
 log = "0.4"
 miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 nu-ansi-term = "0.46.0"
-nu-cli = { path="./crates/nu-cli", version = "0.74.1"  }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.74.1"  }
-nu-command = { path="./crates/nu-command", version = "0.74.1"  }
-nu-engine = { path="./crates/nu-engine", version = "0.74.1"  }
-nu-json = { path="./crates/nu-json", version = "0.74.1"  }
-nu-parser = { path="./crates/nu-parser", version = "0.74.1"  }
-nu-path = { path="./crates/nu-path", version = "0.74.1"  }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.74.1"  }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.74.1"  }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.74.1"  }
+nu-cli = { path = "./crates/nu-cli", version = "0.74.1" }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.74.1" }
+nu-command = { path = "./crates/nu-command", version = "0.74.1" }
+nu-engine = { path = "./crates/nu-engine", version = "0.74.1" }
+nu-json = { path = "./crates/nu-json", version = "0.74.1" }
+nu-parser = { path = "./crates/nu-parser", version = "0.74.1" }
+nu-path = { path = "./crates/nu-path", version = "0.74.1" }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.74.1" }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.74.1" }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.74.1" }
 nu-system = { path = "./crates/nu-system", version = "0.74.1" }
-nu-table = { path = "./crates/nu-table", version = "0.74.1"  }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.74.1"  }
-nu-utils = { path = "./crates/nu-utils", version = "0.74.1"  }
-reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
+nu-table = { path = "./crates/nu-table", version = "0.74.1" }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.74.1" }
+nu-utils = { path = "./crates/nu-utils", version = "0.74.1" }
+reedline = { version = "0.14.0", features = ["bashisms", "sqlite"] }
 
 rayon = "1.5.1"
 is_executable = "1.0.1"
 simplelog = "0.12.0"
 time = "0.3.12"
-devtimer = "4.0.1"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Our dependencies don't use OpenSSL on Windows
@@ -77,22 +76,34 @@ signal-hook = { version = "0.3.14", default-features = false }
 winres = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.25", default-features = false, features = ["signal", "process", "fs", "term"]}
+nix = { version = "0.26.2", default-features = false, features = [
+	"signal",
+	"process",
+	"fs",
+	"term",
+] }
 atty = "0.2"
 
 [dev-dependencies]
-nu-test-support = { path="./crates/nu-test-support", version = "0.74.1"  }
+nu-test-support = { path = "./crates/nu-test-support", version = "0.74.1" }
 tempfile = "3.2.0"
 assert_cmd = "2.0.2"
 criterion = "0.4"
 pretty_assertions = "1.0.0"
 serial_test = "0.10.0"
 hamcrest2 = "0.3.0"
-rstest = {version = "0.15.0", default-features = false}
+rstest = { version = "0.16.0", default-features = false }
 itertools = "0.10.3"
 
 [features]
-plugin = ["nu-plugin", "nu-cli/plugin", "nu-parser/plugin", "nu-command/plugin", "nu-protocol/plugin", "nu-engine/plugin"]
+plugin = [
+	"nu-plugin",
+	"nu-cli/plugin",
+	"nu-parser/plugin",
+	"nu-command/plugin",
+	"nu-protocol/plugin",
+	"nu-engine/plugin",
+]
 # extra used to be more useful but now it's the same as default. Leaving it in for backcompat with existing build scripts
 extra = ["default"]
 default = ["plugin", "which-support", "trash-support", "sqlite"]
@@ -115,7 +126,7 @@ dataframe = ["nu-command/dataframe"]
 sqlite = ["nu-command/sqlite"]
 
 [profile.release]
-opt-level = "s" # Optimize for size
+opt-level = "s"     # Optimize for size
 strip = "debuginfo"
 lto = "thin"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ signal-hook = { version = "0.3.14", default-features = false }
 winres = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.26.2", default-features = false, features = ["signal", "process", "fs", "term"] }
+nix = { version = "0.25", default-features = false, features = ["signal", "process", "fs", "term"] }
 atty = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ rayon = "1.5.1"
 is_executable = "1.0.1"
 simplelog = "0.12.0"
 time = "0.3.12"
+devtimer = "4.0.1"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Our dependencies don't use OpenSSL on Windows

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,12 +76,7 @@ signal-hook = { version = "0.3.14", default-features = false }
 winres = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.26.2", default-features = false, features = [
-	"signal",
-	"process",
-	"fs",
-	"term",
-] }
+nix = { version = "0.26.2", default-features = false, features = ["signal", "process", "fs", "term"] }
 atty = "0.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ criterion = "0.4"
 pretty_assertions = "1.0.0"
 serial_test = "0.10.0"
 hamcrest2 = "0.3.0"
-rstest = { version = "0.16.0", default-features = false }
+rstest = { version = "0.15.0", default-features = false }
 itertools = "0.10.3"
 
 [features]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.74.1"
 [dev-dependencies]
 nu-test-support = { path = "../nu-test-support", version = "0.74.1" }
 nu-command = { path = "../nu-command", version = "0.74.1" }
-rstest = { version = "0.16.0", default-features = false }
+rstest = { version = "0.15.0", default-features = false }
 
 [dependencies]
 nu-engine = { path = "../nu-engine", version = "0.74.1" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.74.1"
 [dev-dependencies]
 nu-test-support = { path="../nu-test-support", version = "0.74.1"  }
 nu-command = { path = "../nu-command", version = "0.74.1" }
-rstest = {version = "0.15.0", default-features = false}
+rstest = {version = "0.16.0", default-features = false}
 
 [dependencies]
 nu-engine = { path = "../nu-engine", version = "0.74.1"  }
@@ -25,15 +25,16 @@ reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
 atty = "0.2.14"
 chrono = { default-features = false, features = ["std"], version = "0.4.23" }
 crossterm = "0.24.0"
-fancy-regex = "0.10.0"
+fancy-regex = "0.11.0"
 fuzzy-matcher = "0.3.7"
 is_executable = "1.0.1"
 once_cell = "1.17.0"
 log = "0.4"
 miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 percent-encoding = "2"
-sysinfo = "0.26.2"
+sysinfo = "0.27.7"
 thiserror = "1.0.31"
+devtimer = "4.0.1"
 
 [features]
 plugin = []

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -8,19 +8,19 @@ name = "nu-cli"
 version = "0.74.1"
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.74.1"  }
+nu-test-support = { path = "../nu-test-support", version = "0.74.1" }
 nu-command = { path = "../nu-command", version = "0.74.1" }
-rstest = {version = "0.16.0", default-features = false}
+rstest = { version = "0.16.0", default-features = false }
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.74.1"  }
-nu-path = { path = "../nu-path", version = "0.74.1"  }
-nu-parser = { path = "../nu-parser", version = "0.74.1"  }
-nu-protocol = { path = "../nu-protocol", version = "0.74.1"  }
-nu-utils = { path = "../nu-utils", version = "0.74.1"  }
+nu-engine = { path = "../nu-engine", version = "0.74.1" }
+nu-path = { path = "../nu-path", version = "0.74.1" }
+nu-parser = { path = "../nu-parser", version = "0.74.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.74.1" }
+nu-utils = { path = "../nu-utils", version = "0.74.1" }
 nu-ansi-term = "0.46.0"
-nu-color-config = { path = "../nu-color-config", version = "0.74.1"  }
-reedline = { version = "0.14.0", features = ["bashisms", "sqlite"]}
+nu-color-config = { path = "../nu-color-config", version = "0.74.1" }
+reedline = { version = "0.14.0", features = ["bashisms", "sqlite"] }
 
 atty = "0.2.14"
 chrono = { default-features = false, features = ["std"], version = "0.4.23" }
@@ -34,7 +34,6 @@ miette = { version = "5.1.0", features = ["fancy-no-backtrace"] }
 percent-encoding = "2"
 sysinfo = "0.27.7"
 thiserror = "1.0.31"
-devtimer = "4.0.1"
 
 [features]
 plugin = []

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -309,7 +309,7 @@ pub fn evaluate_repl(
             column!()
         );
 
-        if entry_num == 1 && show_banner == true {
+        if entry_num == 1 && show_banner {
             start_time.stop();
             println!(
                 "Startup Time: {}",

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -6,7 +6,6 @@ use crate::{
     NuHighlighter, NuValidator, NushellPrompt,
 };
 use crossterm::cursor::CursorShape;
-use devtimer::SimpleTimer;
 use log::{info, trace, warn};
 use miette::{IntoDiagnostic, Result};
 use nu_color_config::StyleComputer;
@@ -42,7 +41,7 @@ pub fn evaluate_repl(
     stack: &mut Stack,
     nushell_path: &str,
     prerun_command: Option<Spanned<String>>,
-    start_time: &mut SimpleTimer,
+    start_time: Instant,
 ) -> Result<()> {
     use reedline::{FileBackedHistory, Reedline, Signal};
 
@@ -310,10 +309,9 @@ pub fn evaluate_repl(
         );
 
         if entry_num == 1 && show_banner {
-            start_time.stop();
             println!(
                 "Startup Time: {}",
-                format_duration(start_time.time_in_nanos().unwrap_or(0) as i64)
+                format_duration(start_time.elapsed().as_nanos() as i64)
             );
         }
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -6,6 +6,7 @@ use crate::{
     NuHighlighter, NuValidator, NushellPrompt,
 };
 use crossterm::cursor::CursorShape;
+use devtimer::SimpleTimer;
 use log::{info, trace, warn};
 use miette::{IntoDiagnostic, Result};
 use nu_color_config::StyleComputer;
@@ -41,6 +42,7 @@ pub fn evaluate_repl(
     stack: &mut Stack,
     nushell_path: &str,
     prerun_command: Option<Spanned<String>>,
+    start_time: &mut SimpleTimer,
 ) -> Result<()> {
     use reedline::{FileBackedHistory, Reedline, Signal};
 
@@ -306,6 +308,14 @@ pub fn evaluate_repl(
             line!(),
             column!()
         );
+
+        if entry_num == 1 && show_banner == true {
+            start_time.stop();
+            println!(
+                "Startup Time: {}",
+                format_duration(start_time.time_in_nanos().unwrap_or(0) as i64)
+            );
+        }
 
         let input = line_editor.read_line(prompt);
         let shell_integration = config.shell_integration;

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -588,15 +588,7 @@ Our {}Documentation{} is located at {}http://nushell.sh{}
 {}Tweet{} us at {}@nu_shell{}
 
 It's been this long since {}Nushell{}'s first commit:
-{}
-
-{}You can disable this banner using the {}config nu{}{} command
-to modify the config.nu file and setting show_banner to false.
-
-let-env config = {{
-    show_banner: false
-    ...
-}}{}
+{}{}
 "#,
         "\x1b[32m",   //start line 1 green
         "\x1b[32m",   //start line 2
@@ -628,11 +620,7 @@ let-env config = {{
         "\x1b[32m",   //before Nushell
         "\x1b[0m",    //after Nushell
         age,
-        "\x1b[2;37m", //before banner disable dim white
-        "\x1b[2;36m", //before config nu dim cyan
-        "\x1b[0m",    //after config nu
-        "\x1b[2;37m", //after config nu dim white
-        "\x1b[0m",    //after banner disable
+        "\x1b[0m", //after banner disable
     );
 
     banner

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -34,10 +34,7 @@ base64 = "0.21.0"
 byteorder = "1.4.3"
 bytesize = "1.1.0"
 calamine = "0.19.1"
-chrono = { version = "0.4.23", features = [
-	"unstable-locales",
-	"std",
-], default-features = false }
+chrono = { version = "0.4.23", features = ["unstable-locales", "std"], default-features = false }
 chrono-humanize = "0.2.1"
 chrono-tz = "0.6.3"
 crossterm = "0.24.0"
@@ -47,7 +44,7 @@ digest = { default-features = false, version = "0.10.0" }
 dtparse = "1.2.0"
 eml-parser = "0.1.0"
 encoding_rs = "0.8.30"
-fancy-regex = "0.10.0"
+fancy-regex = "0.11.0"
 filesize = "0.2.0"
 filetime = "0.2.15"
 fs_extra = "1.2.0"
@@ -59,9 +56,7 @@ Inflector = "0.11"
 is-root = "0.1.2"
 itertools = "0.10.0"
 log = "0.4.14"
-lscolors = { version = "0.12.0", features = [
-	"crossterm",
-], default-features = false }
+lscolors = { version = "0.12.0", features = ["crossterm"], default-features = false }
 md5 = { package = "md-5", version = "0.10.0" }
 mime = "0.3.16"
 mime_guess = "2.0.4"
@@ -147,20 +142,14 @@ features = [
 
 [target.'cfg(windows)'.dependencies.windows]
 version = "0.43.0"
-features = [
-	"Win32_Foundation",
-	"Win32_Storage_FileSystem",
-	"Win32_System_SystemServices",
-]
+features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_SystemServices"]
 
 [features]
 trash-support = ["trash"]
 which-support = ["which"]
 plugin = ["nu-parser/plugin"]
 dataframe = ["polars", "num", "sqlparser"]
-sqlite = [
-	"rusqlite",
-] # TODO: given that rusqlite is included in reedline, should we just always include it?
+sqlite = ["rusqlite"]                      # TODO: given that rusqlite is included in reedline, should we just always include it?
 
 [build-dependencies]
 shadow-rs = { version = "0.20.0", default-features = false }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ use crate::{
     logger::{configure, logger},
     terminal::acquire_terminal,
 };
-use devtimer::DevTime;
 use log::{info, Level};
 use miette::Result;
 #[cfg(feature = "plugin")]
@@ -28,15 +27,15 @@ use nu_command::create_default_context;
 use nu_parser::{escape_for_script_arg, escape_quote_string};
 use nu_protocol::{util::BufferedReader, PipelineData, RawStream};
 use signals::{ctrlc_protection, sigquit_protection};
-use std::str::FromStr;
 use std::{
     io::BufReader,
+    str::FromStr,
     sync::{atomic::AtomicBool, Arc},
+    time::Instant,
 };
 
 fn main() -> Result<()> {
-    let mut start_time = DevTime::new_simple();
-    start_time.start();
+    let start_time = Instant::now();
     let miette_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |x| {
         crossterm::terminal::disable_raw_mode().expect("unable to disable raw mode");
@@ -319,7 +318,7 @@ fn main() -> Result<()> {
             &mut stack,
             config_files::NUSHELL_FOLDER,
             parsed_nu_cli_args.execute,
-            &mut start_time,
+            start_time,
         );
         info!("repl eval {}:{}:{}", file!(), line!(), column!());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use crate::{
     logger::{configure, logger},
     terminal::acquire_terminal,
 };
+use devtimer::DevTime;
 use log::{info, Level};
 use miette::Result;
 #[cfg(feature = "plugin")]
@@ -34,6 +35,8 @@ use std::{
 };
 
 fn main() -> Result<()> {
+    let mut start_time = DevTime::new_simple();
+    start_time.start();
     let miette_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |x| {
         crossterm::terminal::disable_raw_mode().expect("unable to disable raw mode");
@@ -316,6 +319,7 @@ fn main() -> Result<()> {
             &mut stack,
             config_files::NUSHELL_FOLDER,
             parsed_nu_cli_args.execute,
+            &mut start_time,
         );
         info!("repl eval {}:{}:{}", file!(), line!(), column!());
 


### PR DESCRIPTION
# Description

This PR shows the startup time and decreases the banner. This startup time output can be disabled with the `show_banner: false` setting in the config. This is the startup in debug mode.
![image](https://user-images.githubusercontent.com/343840/213955410-f319f8d4-1f96-47ae-8366-1c564a08d3e4.png)

On my mac in release mode
```
Startup Time: 368ms 429µs 83ns
```
On my mac without a config as `nu --config foo --env-config foo`
```
Startup Time: 11ms 663µs 791ns
```

I could really go either way on this. If people don't like this change, we don't have to merge it.

# User-Facing Changes

Startup Time

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
