### PR TITLE
Sync history on exit

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -445,6 +445,7 @@ pub fn evaluate_repl(
                         PipelineData::empty(),
                     );
                 }
+
                 let cmd_duration = start_time.elapsed();
 
                 stack.add_env_var(
@@ -466,6 +467,17 @@ pub fn evaluate_repl(
                             c
                         })
                         .into_diagnostic()?; // todo: don't stop repl if error here?
+                }
+
+                if let Some(exit_code) = stack.exit {
+                    if let Err(e) = line_editor.sync_history() {
+                        warn!("Failed to sync history: {}", e);
+                    }
+                    if shell_integration {
+                        run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
+                    }
+                    println!();
+                    std::process::exit(exit_code as i32);
                 }
 
                 if shell_integration {

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -71,7 +71,7 @@ impl Command for Exit {
 
         if shells.is_empty() {
             stack.exit = Some(exit_code.unwrap_or(0));
-            return Err(ShellError::Exit());
+            Err(ShellError::Exit())
         } else {
             let new_path = shells[current_shell].clone();
 

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -47,12 +47,9 @@ impl Command for Exit {
     ) -> Result<PipelineData, ShellError> {
         let exit_code: Option<i64> = call.opt(engine_state, stack, 0)?;
 
-        if let Some(exit_code) = exit_code {
-            std::process::exit(exit_code as i32);
-        }
-
         if call.has_flag("now") {
-            std::process::exit(0);
+            stack.exit = Some(exit_code.unwrap_or(0));
+            return Err(ShellError::Exit());
         }
 
         let cwd = current_dir(engine_state, stack)?;
@@ -73,7 +70,8 @@ impl Command for Exit {
         }
 
         if shells.is_empty() {
-            std::process::exit(0);
+            stack.exit = Some(exit_code.unwrap_or(0));
+            return Err(ShellError::Exit());
         } else {
             let new_path = shells[current_shell].clone();
 

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -35,6 +35,8 @@ pub struct Stack {
     /// List of active overlays
     pub active_overlays: Vec<String>,
     pub recursion_count: Box<u64>,
+    /// Should the repl exit now?
+    pub exit: Option<i64>,
 }
 
 impl Stack {
@@ -45,6 +47,7 @@ impl Stack {
             env_hidden: HashMap::new(),
             active_overlays: vec![DEFAULT_OVERLAY_NAME.to_string()],
             recursion_count: Box::new(0),
+            exit: None,
         }
     }
 
@@ -126,6 +129,7 @@ impl Stack {
             env_hidden: HashMap::new(),
             active_overlays: self.active_overlays.clone(),
             recursion_count: self.recursion_count.to_owned(),
+            exit: None,
         }
     }
 
@@ -151,6 +155,7 @@ impl Stack {
             env_hidden: HashMap::new(),
             active_overlays: self.active_overlays.clone(),
             recursion_count: self.recursion_count.to_owned(),
+            exit: None,
         }
     }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -904,6 +904,10 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("Return used outside of function")]
     Return(#[label = "used outside of function"] Span, Box<Value>),
 
+    /// Exit event
+    #[error("Exit")]
+    Exit(),
+
     /// The code being executed called itself too many times.
     ///
     /// ## Resolution


### PR DESCRIPTION
# Description

Attempts to act as a partial solution for #7790. It works by moving the handling of `exit` from within the `run` itself to the `repl`. (This only happens if the `exit` does not happen through a nushell sub-shell.)

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
