### PR TITLE
Let redirection keep exit code

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -126,6 +126,33 @@ fn separate_redirection() {
     )
 }
 
+#[test]
+fn redirection_keep_exit_codes() {
+    Playground::setup(
+        "redirection should keep exit code the same",
+        |dirs, sandbox| {
+            let script_body = r#"exit 10"#;
+            #[cfg(not(windows))]
+            let output = {
+                sandbox.with_files(vec![FileWithContent("test.sh", script_body)]);
+                nu!(
+                    cwd: dirs.test(),
+                    r#"bash test.sh out> out.txt err> err.txt; echo $env.LAST_EXIT_CODE"#
+                )
+            };
+            #[cfg(windows)]
+            let output = {
+                sandbox.with_files(vec![FileWithContent("test.bat", script_body)]);
+                nu!(
+                    cwd: dirs.test(),
+                    r#"cmd /D /c test.bat out> out.txt err> err.txt; echo $env.LAST_EXIT_CODE"#
+                );
+            };
+            assert_eq!(output.out, "10")
+        },
+    )
+}
+
 #[cfg(not(windows))]
 #[test]
 fn redirection_with_pipeline_works() {

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -146,7 +146,7 @@ fn redirection_keep_exit_codes() {
                 nu!(
                     cwd: dirs.test(),
                     r#"cmd /D /c test.bat out> out.txt err> err.txt; echo $env.LAST_EXIT_CODE"#
-                );
+                )
             };
             assert_eq!(output.out, "10")
         },


### PR DESCRIPTION
# Description

Fixes: #7828

We delegate to `save` command to finish redirection, then if it runs to success, the relative exit code is set to 0.  To fix it, in redirection context, we take exit_code stream before sending it to `save` command, than manually returns `PipelineData::ExternalStream` to make nushell set relative code properly.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
