### PR TITLE
To csv fix

### DIFF
--- a/crates/nu-command/src/formats/to/csv.rs
+++ b/crates/nu-command/src/formats/to/csv.rs
@@ -17,7 +17,10 @@ impl Command for ToCsv {
 
     fn signature(&self) -> Signature {
         Signature::build("to csv")
-            .input_output_types(vec![(Type::Any, Type::String)])
+            .input_output_types(vec![
+                (Type::Record(vec![]), Type::String),
+                (Type::Table(vec![]), Type::String),
+            ])
             .named(
                 "separator",
                 SyntaxShape::String,

--- a/crates/nu-command/src/formats/to/csv.rs
+++ b/crates/nu-command/src/formats/to/csv.rs
@@ -48,7 +48,7 @@ impl Command for ToCsv {
                 result: Some(Value::test_string("foo;bar\n1;2\n")),
             },
             Example {
-                description: "Outputs an CSV string representing the contents of this table",
+                description: "Outputs an CSV string representing the contents of this record",
                 example: "{a: 1 b: 2} | to csv",
                 result: Some(Value::test_string("a,b\n1,2\n")),
             },

--- a/crates/nu-command/src/formats/to/csv.rs
+++ b/crates/nu-command/src/formats/to/csv.rs
@@ -47,6 +47,11 @@ impl Command for ToCsv {
                 example: "[[foo bar]; [1 2]] | to csv -s ';' ",
                 result: Some(Value::test_string("foo;bar\n1;2\n")),
             },
+            Example {
+                description: "Outputs an CSV string representing the contents of this table",
+                example: "{a: 1 b: 2} | to csv",
+                result: Some(Value::test_string("a,b\n1,2\n")),
+            },
         ]
     }
 

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -17,13 +17,13 @@ fn from_value_to_delimited_string(
         Value::List { vals, span } => table_to_delimited(vals, span, separator, config, head),
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { error } => Err(error.clone()),
-        v => Err(make_unsupported_input_error(&v, head, v.expect_span())),
+        v => Err(make_unsupported_input_error(v, head, v.expect_span())),
     }
 }
 
 fn record_to_delimited(
-    cols: &Vec<String>,
-    vals: &Vec<Value>,
+    cols: &[String],
+    vals: &[Value],
     span: &Span,
     separator: char,
     config: &Config,
@@ -118,7 +118,7 @@ fn to_string_tagged_value(
         Value::Nothing { .. } => Ok(String::new()),
         // Propagate existing errors
         Value::Error { error } => Err(error.clone()),
-        _ => Err(make_unsupported_input_error(&v, head, span)),
+        _ => Err(make_unsupported_input_error(v, head, span)),
     }
 }
 

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -54,6 +54,10 @@ fn table_to_delimited(
     config: &Config,
     head: Span,
 ) -> Result<String, ShellError> {
+    if let Some(val) = find_non_record(vals) {
+        return Err(make_unsupported_input_error(val, head, *span));
+    }
+
     let mut wtr = WriterBuilder::new()
         .delimiter(separator as u8)
         .from_writer(vec![]);
@@ -127,6 +131,12 @@ fn make_unsupported_input_error(value: &Value, head: Span, span: Span) -> ShellE
         head,
         span,
     )
+}
+
+pub fn find_non_record(values: &[Value]) -> Option<&Value> {
+    values
+        .iter()
+        .find(|val| !matches!(val, Value::Record { .. }))
 }
 
 pub fn merge_descriptors(values: &[Value]) -> Vec<String> {

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -113,8 +113,6 @@ fn to_string_tagged_value(
         | Value::CustomValue { .. }
         | Value::Filesize { .. }
         | Value::CellPath { .. }
-        | Value::List { .. }
-        | Value::Record { .. }
         | Value::Float { .. } => Ok(v.clone().into_abbreviated_string(config)),
         Value::Date { val, .. } => Ok(val.to_string()),
         Value::Nothing { .. } => Ok(String::new()),

--- a/crates/nu-command/src/formats/to/tsv.rs
+++ b/crates/nu-command/src/formats/to/tsv.rs
@@ -32,11 +32,18 @@ impl Command for ToTsv {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Outputs an TSV string representing the contents of this table",
-            example: "[[foo bar]; [1 2]] | to tsv",
-            result: Some(Value::test_string("foo\tbar\n1\t2\n")),
-        }]
+        vec![
+            Example {
+                description: "Outputs an TSV string representing the contents of this table",
+                example: "[[foo bar]; [1 2]] | to tsv",
+                result: Some(Value::test_string("foo\tbar\n1\t2\n")),
+            },
+            Example {
+                description: "Outputs an CSV string representing the contents of this table",
+                example: "{a: 1 b: 2} | to csv",
+                result: Some(Value::test_string("a\tb\n1\t2\n")),
+            },
+        ]
     }
 
     fn run(

--- a/crates/nu-command/src/formats/to/tsv.rs
+++ b/crates/nu-command/src/formats/to/tsv.rs
@@ -15,7 +15,10 @@ impl Command for ToTsv {
 
     fn signature(&self) -> Signature {
         Signature::build("to tsv")
-            .input_output_types(vec![(Type::Any, Type::String)])
+            .input_output_types(vec![
+                (Type::Record(vec![]), Type::String),
+                (Type::Table(vec![]), Type::String),
+            ])
             .switch(
                 "noheaders",
                 "do not output the column names as the first row",
@@ -42,7 +45,7 @@ impl Command for ToTsv {
         _stack: &mut Stack,
         call: &Call,
         input: PipelineData,
-    ) -> Result<nu_protocol::PipelineData, ShellError> {
+    ) -> Result<PipelineData, ShellError> {
         let head = call.head;
         let noheaders = call.has_flag("noheaders");
         let config = engine_state.get_config();

--- a/crates/nu-command/src/formats/to/tsv.rs
+++ b/crates/nu-command/src/formats/to/tsv.rs
@@ -39,7 +39,7 @@ impl Command for ToTsv {
                 result: Some(Value::test_string("foo\tbar\n1\t2\n")),
             },
             Example {
-                description: "Outputs an CSV string representing the contents of this table",
+                description: "Outputs an TSV string representing the contents of this table",
                 example: "{a: 1 b: 2} | to tsv",
                 result: Some(Value::test_string("a\tb\n1\t2\n")),
             },

--- a/crates/nu-command/src/formats/to/tsv.rs
+++ b/crates/nu-command/src/formats/to/tsv.rs
@@ -40,7 +40,7 @@ impl Command for ToTsv {
             },
             Example {
                 description: "Outputs an CSV string representing the contents of this table",
-                example: "{a: 1 b: 2} | to csv",
+                example: "{a: 1 b: 2} | to tsv",
                 result: Some(Value::test_string("a\tb\n1\t2\n")),
             },
         ]

--- a/crates/nu-command/src/formats/to/tsv.rs
+++ b/crates/nu-command/src/formats/to/tsv.rs
@@ -39,7 +39,7 @@ impl Command for ToTsv {
                 result: Some(Value::test_string("foo\tbar\n1\t2\n")),
             },
             Example {
-                description: "Outputs an TSV string representing the contents of this table",
+                description: "Outputs an TSV string representing the contents of this record",
                 example: "{a: 1 b: 2} | to tsv",
                 result: Some(Value::test_string("a\tb\n1\t2\n")),
             },

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -207,3 +207,41 @@ fn from_csv_text_skipping_headers_to_table() {
         assert_eq!(actual.out, "3");
     })
 }
+
+#[test]
+fn table_with_record_error() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [[a b]; [1 2] [3 {a: 1 b: 2}]] 
+            | to csv
+        "#
+    ));
+
+    assert!(actual.err.contains("can't convert"))
+}
+
+#[test]
+fn list_not_table_error() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [{a: 1 b: 2} {a: 3 b: 4} 1]
+            | to csv
+        "#
+    ));
+
+    assert!(actual.err.contains("can't convert"))
+}
+
+#[test]
+fn string_to_csv_error() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            'qwe' | to csv
+        "#
+    ));
+
+    assert!(actual.err.contains("can't convert"))
+}


### PR DESCRIPTION
# Description

Fixes #7800 . 
`to csv` and `to tsv` no longer:
- accept anything but records and tables as input,
- accept lists that are not tables,
- accept tables and records with values that are not primitives (other lists, tables and records).

# User-Facing Changes

Using `to csv` and `to tsv` on any of inputs mentioned above will result in `cant_convert` error.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
