### PR TITLE
add decimal to SyntaxShape

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2758,7 +2758,7 @@ pub fn parse_shape_name(
         b"duration" => SyntaxShape::Duration,
         b"error" => SyntaxShape::Error,
         b"expr" => SyntaxShape::Expression,
-        b"float" => SyntaxShape::Float,
+        b"float" | b"decimal" => SyntaxShape::Decimal,
         b"filesize" => SyntaxShape::Filesize,
         b"full-cell-path" => SyntaxShape::FullCellPath,
         b"glob" => SyntaxShape::GlobPattern,
@@ -2823,7 +2823,7 @@ pub fn parse_type(_working_set: &StateWorkingSet, bytes: &[u8]) -> Type {
         b"duration" => Type::Duration,
         b"error" => Type::Error,
         b"filesize" => Type::Filesize,
-        b"float" => Type::Float,
+        b"float" | b"decimal" => Type::Float,
         b"int" => Type::Int,
         b"list" => Type::List(Box::new(Type::Any)),
         b"number" => Type::Number,
@@ -4443,7 +4443,7 @@ pub fn parse_value(
             (expression, err)
         }
         SyntaxShape::Number => parse_number(bytes, span),
-        SyntaxShape::Float => parse_float(bytes, span),
+        SyntaxShape::Decimal => parse_float(bytes, span),
         SyntaxShape::Int => parse_int(bytes, span),
         SyntaxShape::Duration => parse_duration(working_set, span),
         SyntaxShape::DateTime => parse_datetime(working_set, span),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2758,6 +2758,7 @@ pub fn parse_shape_name(
         b"duration" => SyntaxShape::Duration,
         b"error" => SyntaxShape::Error,
         b"expr" => SyntaxShape::Expression,
+        b"float" => SyntaxShape::Float,
         b"filesize" => SyntaxShape::Filesize,
         b"full-cell-path" => SyntaxShape::FullCellPath,
         b"glob" => SyntaxShape::GlobPattern,
@@ -4442,6 +4443,7 @@ pub fn parse_value(
             (expression, err)
         }
         SyntaxShape::Number => parse_number(bytes, span),
+        SyntaxShape::Float => parse_float(bytes, span),
         SyntaxShape::Int => parse_int(bytes, span),
         SyntaxShape::Duration => parse_duration(working_set, span),
         SyntaxShape::DateTime => parse_datetime(working_set, span),

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -49,6 +49,9 @@ pub enum SyntaxShape {
     /// A filesize value is allowed, eg `10kb`
     Filesize,
 
+    /// A floating point value, eg `1.0`
+    Float,
+
     /// A dotted path to navigate the table (including variable)
     FullCellPath,
 
@@ -122,6 +125,7 @@ impl SyntaxShape {
             SyntaxShape::Expression => Type::Any,
             SyntaxShape::Filepath => Type::String,
             SyntaxShape::Directory => Type::String,
+            SyntaxShape::Float => Type::Float,
             SyntaxShape::Filesize => Type::Filesize,
             SyntaxShape::FullCellPath => Type::Any,
             SyntaxShape::GlobPattern => Type::String,
@@ -164,6 +168,7 @@ impl Display for SyntaxShape {
             SyntaxShape::Number => write!(f, "number"),
             SyntaxShape::Range => write!(f, "range"),
             SyntaxShape::Int => write!(f, "int"),
+            SyntaxShape::Float => write!(f, "float"),
             SyntaxShape::Filepath => write!(f, "path"),
             SyntaxShape::Directory => write!(f, "directory"),
             SyntaxShape::GlobPattern => write!(f, "glob"),

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -31,6 +31,9 @@ pub enum SyntaxShape {
     /// A datetime value, eg `2022-02-02` or `2019-10-12T07:20:50.52+00:00`
     DateTime,
 
+    /// A decimal value, eg `1.0`
+    Decimal,
+
     /// A directory is allowed
     Directory,
 
@@ -48,9 +51,6 @@ pub enum SyntaxShape {
 
     /// A filesize value is allowed, eg `10kb`
     Filesize,
-
-    /// A floating point value, eg `1.0`
-    Float,
 
     /// A dotted path to navigate the table (including variable)
     FullCellPath,
@@ -125,7 +125,7 @@ impl SyntaxShape {
             SyntaxShape::Expression => Type::Any,
             SyntaxShape::Filepath => Type::String,
             SyntaxShape::Directory => Type::String,
-            SyntaxShape::Float => Type::Float,
+            SyntaxShape::Decimal => Type::Float,
             SyntaxShape::Filesize => Type::Filesize,
             SyntaxShape::FullCellPath => Type::Any,
             SyntaxShape::GlobPattern => Type::String,
@@ -168,7 +168,7 @@ impl Display for SyntaxShape {
             SyntaxShape::Number => write!(f, "number"),
             SyntaxShape::Range => write!(f, "range"),
             SyntaxShape::Int => write!(f, "int"),
-            SyntaxShape::Float => write!(f, "float"),
+            SyntaxShape::Decimal => write!(f, "decimal"),
             SyntaxShape::Filepath => write!(f, "path"),
             SyntaxShape::Directory => write!(f, "directory"),
             SyntaxShape::GlobPattern => write!(f, "glob"),


### PR DESCRIPTION
# Description

This adds the `SyntaxShape::Decimal` so you can create custom commands with `decimal` types such as:
```shell
def cmd [x:decimal] { echo $x }
```

/cc @kurokirasama

Internally this is a little messy since we have `Type::Float` and `SyntaxShape::Decimal`. I originally named it `float` and `SyntaxShape::Float` but since we have `into decimal` and `1.1 | describe` reports `decimal`, I decided to change the SyntaxShape.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
