### PR TITLE
improve doc about flatten

### DIFF
--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -29,7 +29,7 @@ impl Command for Flatten {
                 SyntaxShape::String,
                 "optionally flatten data by column",
             )
-            .switch("all", "flatten inner table out", Some('a'))
+            .switch("all", "flatten inner table one level out", Some('a'))
             .category(Category::Filters)
     }
 


### PR DESCRIPTION
# Description

Relative #7210 

Improve doc to clarify current behavior.

To flatten all nested levels, we can use the following custom command(maybe making it into our lib):
```
def flatten_all_nested [input_table: any] {
    mut input = $input_table

    mut flattened = ($input | flatten --all)
    while $input != $flattened {
        $input = $flattened
        $flattened = ($input | flatten --all)
    }
    $flattened
}
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
