### PR TITLE
with the release of rust 1.67, let's bump to 1.66.1

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -29,7 +29,7 @@ pub fn evaluate_file(
 
     let cwd = current_dir(engine_state, stack)?;
 
-    let file_path = canonicalize_with(&path, &cwd).unwrap_or_else(|e| {
+    let file_path = canonicalize_with(&path, cwd).unwrap_or_else(|e| {
         let working_set = StateWorkingSet::new(engine_state);
         report_error(
             &working_set,

--- a/crates/nu-command/src/bits/rotate_left.rs
+++ b/crates/nu-command/src/bits/rotate_left.rs
@@ -132,7 +132,7 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
                 SignedOne => get_rotate_left(val as i8, bits, span),
                 SignedTwo => get_rotate_left(val as i16, bits, span),
                 SignedFour => get_rotate_left(val as i32, bits, span),
-                SignedEight => get_rotate_left(val as i64, bits, span),
+                SignedEight => get_rotate_left(val, bits, span),
             }
         }
         // Propagate errors by explicitly matching them before the final case.

--- a/crates/nu-command/src/bits/rotate_right.rs
+++ b/crates/nu-command/src/bits/rotate_right.rs
@@ -136,7 +136,7 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
                 SignedOne => get_rotate_right(val as i8, bits, span),
                 SignedTwo => get_rotate_right(val as i16, bits, span),
                 SignedFour => get_rotate_right(val as i32, bits, span),
-                SignedEight => get_rotate_right(val as i64, bits, span),
+                SignedEight => get_rotate_right(val, bits, span),
             }
         }
         // Propagate errors by explicitly matching them before the final case.

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -158,7 +158,7 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
                 SignedOne => get_shift_left(val as i8, bits, span),
                 SignedTwo => get_shift_left(val as i16, bits, span),
                 SignedFour => get_shift_left(val as i32, bits, span),
-                SignedEight => get_shift_left(val as i64, bits, span),
+                SignedEight => get_shift_left(val, bits, span),
             }
         }
         // Propagate errors by explicitly matching them before the final case.

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -148,7 +148,7 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
                 SignedOne => get_shift_right(val as i8, bits, span),
                 SignedTwo => get_shift_right(val as i16, bits, span),
                 SignedFour => get_shift_right(val as i32, bits, span),
-                SignedEight => get_shift_right(val as i64, bits, span),
+                SignedEight => get_shift_right(val, bits, span),
             }
         }
         // Propagate errors by explicitly matching them before the final case.

--- a/crates/nu-command/src/dataframe/eager/get.rs
+++ b/crates/nu-command/src/dataframe/eager/get.rs
@@ -67,7 +67,7 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     df.as_ref()
-        .select(&col_string)
+        .select(col_string)
         .map_err(|e| {
             ShellError::GenericError(
                 "Error selecting columns".into(),

--- a/crates/nu-command/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/conversion.rs
@@ -307,10 +307,7 @@ pub fn create_column(
                 .skip(from_row)
                 .take(size)
                 .map(|v| match v {
-                    Some(a) => Value::Int {
-                        val: a as i64,
-                        span,
-                    },
+                    Some(a) => Value::Int { val: a, span },
                     None => Value::Nothing { span },
                 })
                 .collect::<Vec<Value>>();

--- a/crates/nu-command/src/strings/encode_decode/base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/base64.rs
@@ -151,8 +151,7 @@ fn action(
                     let val = val.clone();
                     let val = val.replace("\r\n", "").replace('\n', "");
 
-                    //match Engine::decode_string(&val, base64_engine) {
-                    match base64_engine.decode(&val) {
+                    match base64_engine.decode(val) {
                         Ok(decoded_value) => {
                             if output_binary {
                                 Value::binary(decoded_value, command_span)

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -266,7 +266,13 @@ fn which(
     let paths = env::path_str(engine_state, stack, call.head)?;
 
     for app in which_args.applications {
-        let values = which_single(app, which_args.all, engine_state, &cwd, &paths);
+        let values = which_single(
+            app,
+            which_args.all,
+            engine_state,
+            cwd.clone(),
+            paths.clone(),
+        );
         output.extend(values);
     }
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1798,6 +1798,7 @@ enum TableView {
     },
 }
 
+#[allow(clippy::manual_filter)]
 fn strip_output_color(output: Option<String>, config: &Config) -> Option<String> {
     match output {
         Some(output) => {

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -484,14 +484,14 @@ fn set_cursor_cmd_bar(f: &mut Frame, area: Rect, pager: &Pager) {
         let next_pos = (pager.cmd_buf.buf_cmd2.len() + 1) as u16;
         // 1 skips a ':' char
         if next_pos < area.width {
-            f.set_cursor(next_pos as u16, area.height - 1);
+            f.set_cursor(next_pos, area.height - 1);
         }
     } else if pager.search_buf.is_search_input {
         // todo: deal with a situation where we exceed the bar width
         let next_pos = (pager.search_buf.buf_cmd_input.len() + 1) as u16;
         // 1 skips a ':' char
         if next_pos < area.width {
-            f.set_cursor(next_pos as u16, area.height - 1);
+            f.set_cursor(next_pos, area.height - 1);
         }
     }
 }

--- a/crates/nu-explore/src/views/coloredtextw.rs
+++ b/crates/nu-explore/src/views/coloredtextw.rs
@@ -32,7 +32,7 @@ impl Widget for ColoredTextW<'_> {
             let text = block.text();
             let style = style_to_tui(block.style());
 
-            let x = area.x + offset as u16;
+            let x = area.x + offset;
             let (o, _) = buf.set_stringn(x, area.y, text, area.width as usize, style);
 
             offset = o

--- a/crates/nu-explore/src/views/interactive.rs
+++ b/crates/nu-explore/src/views/interactive.rs
@@ -112,10 +112,10 @@ impl View for InteractiveView<'_> {
         f.render_widget(cmd_input, cmd_input_area);
 
         if !self.view_mode {
-            let cur_w = area.x + 1 + 1 + 1 + max_cmd_len as u16;
+            let cur_w = area.x + 1 + 1 + 1 + max_cmd_len;
             let cur_w_max = area.x + 1 + 1 + 1 + area.width - 2 - 1 - 1 - 1 - 1;
             if cur_w < cur_w_max {
-                f.set_cursor(area.x + 1 + 1 + 1 + max_cmd_len as u16, area.y + 1);
+                f.set_cursor(area.x + 1 + 1 + 1 + max_cmd_len, area.y + 1);
             }
         }
 

--- a/crates/nu-explore/src/views/record/tablew.rs
+++ b/crates/nu-explore/src/views/record/tablew.rs
@@ -705,7 +705,7 @@ fn repeat_vertical(
     let span = Span::styled(text, style);
 
     for row in 0..height {
-        buf.set_span(x_offset, y_offset + row as u16, &span, width);
+        buf.set_span(x_offset, y_offset + row, &span, width);
     }
 }
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2406,8 +2406,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::Int {
                         val: (*lhs as f64 / *rhs as f64)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2419,8 +2418,7 @@ impl Value {
                 if *rhs != 0.0 {
                     Ok(Value::Int {
                         val: (*lhs as f64 / *rhs)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2432,8 +2430,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::Int {
                         val: (*lhs / *rhs as f64)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2445,8 +2442,7 @@ impl Value {
                 if *rhs != 0.0 {
                     Ok(Value::Int {
                         val: (lhs / rhs)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2458,8 +2454,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::Int {
                         val: (*lhs as f64 / *rhs as f64)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2471,8 +2466,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::Filesize {
                         val: ((*lhs as f64) / (*rhs as f64))
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2484,8 +2478,7 @@ impl Value {
                 if *rhs != 0.0 {
                     Ok(Value::Filesize {
                         val: (*lhs as f64 / *rhs)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2497,8 +2490,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::Int {
                         val: (*lhs as f64 / *rhs as f64)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2510,8 +2502,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::Duration {
                         val: (*lhs as f64 / *rhs as f64)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })
@@ -2523,8 +2514,7 @@ impl Value {
                 if *rhs != 0.0 {
                     Ok(Value::Duration {
                         val: (*lhs as f64 / *rhs)
-                            .max(std::i64::MIN as f64)
-                            .min(std::i64::MAX as f64)
+                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
                             .floor() as i64,
                         span,
                     })

--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -154,7 +154,7 @@ unsafe fn get_unchecked_str(cp: *mut u8, start: *mut u8) -> String {
 
 #[cfg_attr(tarpaulin, skip)]
 fn get_path_info(pid: i32, mut size: size_t) -> Option<PathInfo> {
-    let mut proc_args = Vec::with_capacity(size as usize);
+    let mut proc_args = Vec::with_capacity(size);
     let ptr: *mut u8 = proc_args.as_mut_slice().as_mut_ptr();
 
     let mut mib: [c_int; 3] = [libc::CTL_KERN, libc::KERN_PROCARGS2, pid as c_int];

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -574,14 +574,6 @@ impl Peaker for PriorityMax {
 
     fn peak(&mut self, _: &[usize], widths: &[usize]) -> Option<usize> {
         let col = (0..widths.len()).rev().max_by_key(|&i| widths[i]);
-        if let Some(col) = col {
-            if widths[col] == 0 {
-                None
-            } else {
-                Some(col)
-            }
-        } else {
-            None
-        }
+        col.filter(|&col| widths[col] != 0)
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -9,11 +9,12 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-# The current plan is to be 2 releases behind the latest stable release. So, if the
-# latest stable release is 1.62.0, the channel should be 1.60.0. We want to do this
+# The current plan is to be 1 release behind the latest stable release. So, if the
+# latest stable release is 1.62.0, the channel should be 1.61.0. We want to do this
 # so that we give repo maintainers and package managers a chance to update to a more
 # recent version of rust. However, if there is a "cool new feature" that we want to
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 3 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.65.0"
+channel = "1.66.1"
+


### PR DESCRIPTION
# Description

This PR bumps the required rust version to 1.66.1.

# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
