### PR TITLE
Re-enable some good tests, remove some bad tests

### DIFF
--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -17,8 +17,6 @@ fn cd_works_with_in_var() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_change_from_current_directory_using_relative_path() {
     Playground::setup("cd_test_1", |dirs, _| {
@@ -26,7 +24,7 @@ fn filesystem_change_from_current_directory_using_relative_path() {
             cwd: dirs.root(),
             r#"
                 cd cd_test_1
-                echo (pwd)
+                $env.PWD
             "#
         );
 
@@ -34,8 +32,6 @@ fn filesystem_change_from_current_directory_using_relative_path() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_change_from_current_directory_using_absolute_path() {
     Playground::setup("cd_test_2", |dirs, _| {
@@ -43,7 +39,7 @@ fn filesystem_change_from_current_directory_using_absolute_path() {
             cwd: dirs.test(),
             r#"
                 cd "{}"
-                echo (pwd)
+                $env.PWD
             "#,
             dirs.formats().display()
         );
@@ -52,8 +48,6 @@ fn filesystem_change_from_current_directory_using_absolute_path() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_switch_back_to_previous_working_directory() {
     Playground::setup("cd_test_3", |dirs, sandbox| {
@@ -64,7 +58,7 @@ fn filesystem_switch_back_to_previous_working_directory() {
             r#"
                 cd {}
                 cd -
-                echo (pwd)
+                $env.PWD
             "#,
             dirs.test().display()
         );
@@ -73,8 +67,6 @@ fn filesystem_switch_back_to_previous_working_directory() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_change_from_current_directory_using_relative_path_and_dash() {
     Playground::setup("cd_test_4", |dirs, sandbox| {
@@ -84,7 +76,7 @@ fn filesystem_change_from_current_directory_using_relative_path_and_dash() {
             cwd: dirs.test(),
             r#"
                 cd odin/-
-                echo (pwd)
+                $env.PWD
             "#
         );
 
@@ -95,8 +87,6 @@ fn filesystem_change_from_current_directory_using_relative_path_and_dash() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_change_current_directory_to_parent_directory() {
     Playground::setup("cd_test_5", |dirs, _| {
@@ -104,7 +94,7 @@ fn filesystem_change_current_directory_to_parent_directory() {
             cwd: dirs.test(),
             r#"
                 cd ..
-                echo (pwd)
+                $env.PWD
             "#
         );
 
@@ -112,8 +102,6 @@ fn filesystem_change_current_directory_to_parent_directory() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_change_current_directory_to_two_parents_up_using_multiple_dots() {
     Playground::setup("cd_test_6", |dirs, sandbox| {
@@ -123,7 +111,7 @@ fn filesystem_change_current_directory_to_two_parents_up_using_multiple_dots() {
             cwd: dirs.test().join("foo/bar"),
             r#"
                 cd ...
-                echo (pwd)
+                $env.PWD
             "#
         );
 
@@ -131,32 +119,6 @@ fn filesystem_change_current_directory_to_two_parents_up_using_multiple_dots() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
-#[test]
-fn filesystem_change_current_directory_to_parent_directory_after_delete_cwd() {
-    Playground::setup("cd_test_7", |dirs, sandbox| {
-        sandbox.within("foo").mkdir("bar");
-
-        let actual = nu!(
-            cwd: dirs.test().join("foo/bar"),
-            r#"
-                rm {}/foo/bar
-                echo ","
-                cd ..
-                echo (pwd)
-            "#,
-            dirs.test().display()
-        );
-
-        let actual = actual.out.split(',').nth(1).unwrap();
-
-        assert_eq!(PathBuf::from(actual), *dirs.test().join("foo"));
-    })
-}
-
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_change_to_home_directory() {
     Playground::setup("cd_test_8", |dirs, _| {
@@ -164,7 +126,7 @@ fn filesystem_change_to_home_directory() {
             cwd: dirs.test(),
             r#"
                 cd ~
-                echo (pwd)
+                $env.PWD
             "#
         );
 
@@ -172,8 +134,6 @@ fn filesystem_change_to_home_directory() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_change_to_a_directory_containing_spaces() {
     Playground::setup("cd_test_9", |dirs, sandbox| {
@@ -183,7 +143,7 @@ fn filesystem_change_to_a_directory_containing_spaces() {
             cwd: dirs.test(),
             r#"
                 cd "robalino turner katz"
-                echo (pwd)
+                $env.PWD
             "#
         );
 
@@ -194,8 +154,6 @@ fn filesystem_change_to_a_directory_containing_spaces() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_not_a_directory() {
     Playground::setup("cd_test_10", |dirs, sandbox| {
@@ -219,8 +177,6 @@ fn filesystem_not_a_directory() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_directory_not_found() {
     Playground::setup("cd_test_11", |dirs, _| {
@@ -243,8 +199,6 @@ fn filesystem_directory_not_found() {
     })
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn filesystem_change_directory_to_symlink_relative() {
     Playground::setup("cd_test_12", |dirs, sandbox| {
@@ -256,7 +210,7 @@ fn filesystem_change_directory_to_symlink_relative() {
             cwd: dirs.test().join("boo"),
             r#"
                 cd ../foo_link
-                echo (pwd)
+                $env.PWD
             "#
         );
 

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -38,7 +38,7 @@ fn filesystem_change_from_current_directory_using_absolute_path() {
         let actual = nu!(
             cwd: dirs.test(),
             r#"
-                cd "{}"
+                cd '{}'
                 $env.PWD
             "#,
             dirs.formats().display()

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -28,8 +28,6 @@ fn skip_cell_rejection() {
     assert_eq!(actual.out, "txt");
 }
 
-// FIXME: needs more work
-#[ignore]
 #[test]
 fn complex_nested_columns() {
     let actual = nu!(cwd: ".", pipeline(

--- a/crates/nu-command/tests/commands/with_env.rs
+++ b/crates/nu-command/tests/commands/with_env.rs
@@ -82,8 +82,6 @@ fn with_env_hides_variables_in_parent_scope() {
     assert_eq!(actual.out, "11");
 }
 
-// FIXME: jt: needs more work
-#[ignore]
 #[test]
 fn with_env_shorthand_can_not_hide_variables() {
     let actual = nu!(

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -704,20 +704,6 @@ fn index_out_of_bounds() {
     assert!(actual.err.contains("too large"));
 }
 
-//FIXME: jt - umm, do we actually want to support this?
-#[ignore]
-#[test]
-fn dash_def() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
-            def - [x, y] { $x - $y }; - 4 1
-        "#
-    );
-
-    assert_eq!(actual.out, "3");
-}
-
 #[test]
 fn negative_decimal_start() {
     let actual = nu!(


### PR DESCRIPTION
I tackled some of the disabled `FIXME`/`#[ignore]` tests. Most were straightforward to re-enable, and a few of them did not deserve to be re-enabled.