### PR TITLE
Support extended unicode escapes in strings: "\u{10fff}"

### DIFF
--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -412,30 +412,6 @@ mod string {
         }
     }
 
-    #[test]
-    pub fn parse_escaped_string() {
-        let engine_state = EngineState::new();
-        let mut working_set = StateWorkingSet::new(&engine_state);
-
-        let (block, err) = parse(
-            &mut working_set,
-            None,
-            b"\"hello \\u006e\\u0075\\u0073hell\"",
-            true,
-            &[],
-        );
-
-        assert!(err.is_none());
-        assert_eq!(block.len(), 1);
-        let expressions = &block[0];
-        assert_eq!(expressions.len(), 1);
-        if let PipelineElement::Expression(_, expr) = &expressions[0] {
-            assert_eq!(expr.expr, Expr::String("hello nushell".to_string()))
-        } else {
-            panic!("Not an expression")
-        }
-    }
-
     mod interpolation {
         use nu_protocol::Span;
 

--- a/crates/nu-parser/tests/test_parser_unicode_escapes.rs
+++ b/crates/nu-parser/tests/test_parser_unicode_escapes.rs
@@ -1,0 +1,33 @@
+#![cfg(test)]
+
+use nu_parser::ParseError;
+use nu_parser::*;
+use nu_protocol::{
+    ast::{Expr, Expression, PipelineElement},
+    engine::{Command, EngineState, Stack, StateWorkingSet},
+    Signature, SyntaxShape,
+};
+
+#[test]
+pub fn parse_unicode_escaped_string1() {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+
+    let (block, err) = parse(
+        &mut working_set,
+        None,
+        b"\"hello \\u{6e}\\u{000075}\\u{073}hell\"",
+        true,
+        &[],
+    );
+
+    assert!(err.is_none());
+    assert_eq!(block.len(), 1);
+    let expressions = &block[0];
+    assert_eq!(expressions.len(), 1);
+    if let PipelineElement::Expression(_, expr) = &expressions[0] {
+        assert_eq!(expr.expr, Expr::String("hello nushell".to_string()))
+    } else {
+        panic!("Not an expression")
+    }
+}

--- a/crates/nu-parser/tests/test_parser_unicode_escapes.rs
+++ b/crates/nu-parser/tests/test_parser_unicode_escapes.rs
@@ -81,7 +81,7 @@ pub fn unicode_escapes_in_strings_expected_failures() {
             br#""\u{39}8\u{000000000000000000000000000000000000000000000037}""#,
             "any shape",
         ), // hex too long, but small value
-        Tc(br#""\u{110000}""#, "any shape"), // max unicode <= 0x10ffff
+        Tc(br#""\u{110000}""#, "any shape"),  // max unicode <= 0x10ffff
     ];
 
     for tci in test_vec {

--- a/crates/nu-parser/tests/test_parser_unicode_escapes.rs
+++ b/crates/nu-parser/tests/test_parser_unicode_escapes.rs
@@ -55,10 +55,10 @@ pub fn unicode_escapes_in_strings() {
         Tc(br#""\u006enu\u0075\u0073\u0073""#, "nnuuss"),
         Tc(br#""hello \u{6e}\u{000075}\u{073}hell""#, "hello nushell"),
         Tc(br#""abc""#, "abc"),
-        Tc(br#""\u{39}8\u{10ffff}""#, "98\u{10ffff}"), // shouldn't work?
-                                                       //Tc(br#""#,""),
-                                                       //Tc(br#""#,""),
-                                                       //Tc(br#""#,""),
+        Tc(br#""\u{39}8\u{10ffff}""#, "98\u{10ffff}"),
+        Tc(br#""abc\u{41}""#, "abcA"), // at end of string
+        Tc(br#""\u{41}abc""#, "Aabc"), // at start of string
+        Tc(br#""\u{a}""#, "\n"),       // single digit
     ];
 
     for tci in test_vec {
@@ -81,11 +81,8 @@ pub fn unicode_escapes_in_strings_expected_failures() {
         Tc(
             br#""\u{39}8\u{000000000000000000000000000000000000000000000037}""#,
             "any shape",
-        ), // shouldn't work?
-        Tc(br#""\u{110000}""#, "any shape"), // max unicode <= 0x10ffff?
-                                        //Tc(br#""#,""),
-                                        //Tc(br#""#,""),
-                                        //Tc(br#""#,""),
+        ), // hex too long, but small value
+        Tc(br#""\u{110000}""#, "any shape"), // max unicode <= 0x10ffff
     ];
 
     for tci in test_vec {

--- a/crates/nu-parser/tests/test_parser_unicode_escapes.rs
+++ b/crates/nu-parser/tests/test_parser_unicode_escapes.rs
@@ -1,33 +1,101 @@
 #![cfg(test)]
 
-use nu_parser::ParseError;
+//use nu_parser::ParseError;
 use nu_parser::*;
 use nu_protocol::{
-    ast::{Expr, Expression, PipelineElement},
-    engine::{Command, EngineState, Stack, StateWorkingSet},
-    Signature, SyntaxShape,
+    //ast::{Expr, Expression, PipelineElement},
+    ast::{Expr, PipelineElement},
+    //engine::{Command, EngineState, Stack, StateWorkingSet},
+    engine::{EngineState, StateWorkingSet},
+    //Signature, SyntaxShape,
 };
 
-#[test]
-pub fn parse_unicode_escaped_string1() {
+pub fn do_test (test: &[u8], expected:&str, error_contains:Option<&str>) {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
     let (block, err) = parse(
         &mut working_set,
         None,
-        b"\"hello \\u{6e}\\u{000075}\\u{073}hell\"",
+        test,
         true,
         &[],
     );
 
-    assert!(err.is_none());
-    assert_eq!(block.len(), 1);
-    let expressions = &block[0];
-    assert_eq!(expressions.len(), 1);
-    if let PipelineElement::Expression(_, expr) = &expressions[0] {
-        assert_eq!(expr.expr, Expr::String("hello nushell".to_string()))
-    } else {
-        panic!("Not an expression")
+
+    match err {
+        None => {
+            assert_eq!(block.len(), 1);
+            let expressions = &block[0];
+            assert_eq!(expressions.len(), 1);
+            if let PipelineElement::Expression(_, expr) = &expressions[0] {
+                assert_eq!(expr.expr, Expr::String(expected.to_string()))
+            } else {
+                panic!("Not an expression")
+            }
+        }
+        Some(pev) => {
+            match error_contains {
+                None => {
+                    panic!("Err:{:#?}", pev);
+                }
+                Some(contains_string) => {
+                    let full_err = format!("{:#?}", pev);
+                    assert!(full_err.contains(contains_string), "Expected error containing {}, instead got {}", contains_string, full_err);
+                }
+            }
+
+        }
     }
+    
+    
+}
+
+// cases that all should work
+#[test]
+pub fn parse_unicode_many() {
+    pub struct Tc(&'static [u8], &'static str);
+
+    let test_vec = vec![
+        Tc(  b"\"hello \\u{6e}\\u{000075}\\u{073}hell\"", "hello nushell"),
+        // template: Tc(br#""<string literal without #'s>"", "<Rust literal comparand>")
+        Tc(br#""\u006enu\u0075\u0073\u0073""#, "nnuuss"),
+        Tc(br#""hello \u{6e}\u{000075}\u{073}hell""#, "hello nushell"),
+        Tc(br#""abc""#, "abc"),
+        Tc(br#""\u{39}8\u{10ffff}""#,"98\u{10ffff}"),  // shouldn't work?
+        //Tc(br#""#,""),
+        //Tc(br#""#,""),
+        //Tc(br#""#,""),
+        
+    ];
+
+    for tci in test_vec {
+        println!("Expecting: {}", tci.1);
+        do_test( tci.0, tci.1, None);
+    }    
+}
+
+// cases that all should fail (in expected way)
+#[test]
+pub fn parse_unicode_many_fail() {
+    // input, substring of expected failure
+    pub struct Tc(&'static [u8], &'static str);
+
+    let test_vec = vec![
+        // template: Tc(br#""<string literal without #'s>"", "<pattern in expected error>")
+        Tc(br#""\u06e""#, "any shape"),   // 4digit too short, next char is EOF
+        Tc(br#""\u06ex""#, "any shape"),  // 4digit too short, next char is non-hex-digit
+        Tc(br#""hello \u{6e""#, "any shape"),   // extended, missing close delim
+        Tc(br#""\u{39}8\u{000000000000000000000000000000000000000000000037}""#,"any shape"),  // shouldn't work?
+        Tc(br#""\u{110000}""#,"any shape"),  // max unicode <= 0x10ffff?
+        //Tc(br#""#,""),
+        //Tc(br#""#,""),
+        //Tc(br#""#,""),
+        
+    ];
+
+    for tci in test_vec {
+        println!("Expecting failure containing: {}", tci.1);
+        do_test( tci.0, "--success not expected--", Some(tci.1));
+    }    
 }

--- a/crates/nu-parser/tests/test_parser_unicode_escapes.rs
+++ b/crates/nu-parser/tests/test_parser_unicode_escapes.rs
@@ -52,9 +52,8 @@ pub fn unicode_escapes_in_strings() {
     let test_vec = vec![
         Tc(b"\"hello \\u{6e}\\u{000075}\\u{073}hell\"", "hello nushell"),
         // template: Tc(br#""<string literal without #'s>"", "<Rust literal comparand>")
-        Tc(br#""\u006enu\u0075\u0073\u0073""#, "nnuuss"),
+        //deprecated Tc(br#""\u006enu\u0075\u0073\u0073""#, "nnuuss"),
         Tc(br#""hello \u{6e}\u{000075}\u{073}hell""#, "hello nushell"),
-        Tc(br#""abc""#, "abc"),
         Tc(br#""\u{39}8\u{10ffff}""#, "98\u{10ffff}"),
         Tc(br#""abc\u{41}""#, "abcA"), // at end of string
         Tc(br#""\u{41}abc""#, "Aabc"), // at start of string
@@ -75,8 +74,8 @@ pub fn unicode_escapes_in_strings_expected_failures() {
 
     let test_vec = vec![
         // template: Tc(br#""<string literal without #'s>"", "<pattern in expected error>")
-        Tc(br#""\u06e""#, "any shape"), // 4digit too short, next char is EOF
-        Tc(br#""\u06ex""#, "any shape"), // 4digit too short, next char is non-hex-digit
+        //deprecated Tc(br#""\u06e""#, "any shape"), // 4digit too short, next char is EOF
+        //deprecatedTc(br#""\u06ex""#, "any shape"), // 4digit too short, next char is non-hex-digit
         Tc(br#""hello \u{6e""#, "any shape"), // extended, missing close delim
         Tc(
             br#""\u{39}8\u{000000000000000000000000000000000000000000000037}""#,

--- a/crates/nu-parser/tests/test_parser_unicode_escapes.rs
+++ b/crates/nu-parser/tests/test_parser_unicode_escapes.rs
@@ -10,18 +10,11 @@ use nu_protocol::{
     //Signature, SyntaxShape,
 };
 
-pub fn do_test (test: &[u8], expected:&str, error_contains:Option<&str>) {
+pub fn do_test(test: &[u8], expected: &str, error_contains: Option<&str>) {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let (block, err) = parse(
-        &mut working_set,
-        None,
-        test,
-        true,
-        &[],
-    );
-
+    let (block, err) = parse(&mut working_set, None, test, true, &[]);
 
     match err {
         None => {
@@ -34,68 +27,69 @@ pub fn do_test (test: &[u8], expected:&str, error_contains:Option<&str>) {
                 panic!("Not an expression")
             }
         }
-        Some(pev) => {
-            match error_contains {
-                None => {
-                    panic!("Err:{:#?}", pev);
-                }
-                Some(contains_string) => {
-                    let full_err = format!("{:#?}", pev);
-                    assert!(full_err.contains(contains_string), "Expected error containing {}, instead got {}", contains_string, full_err);
-                }
+        Some(pev) => match error_contains {
+            None => {
+                panic!("Err:{:#?}", pev);
             }
-
-        }
+            Some(contains_string) => {
+                let full_err = format!("{:#?}", pev);
+                assert!(
+                    full_err.contains(contains_string),
+                    "Expected error containing {}, instead got {}",
+                    contains_string,
+                    full_err
+                );
+            }
+        },
     }
-    
-    
 }
 
 // cases that all should work
 #[test]
-pub fn parse_unicode_many() {
+pub fn unicode_escapes_in_strings() {
     pub struct Tc(&'static [u8], &'static str);
 
     let test_vec = vec![
-        Tc(  b"\"hello \\u{6e}\\u{000075}\\u{073}hell\"", "hello nushell"),
+        Tc(b"\"hello \\u{6e}\\u{000075}\\u{073}hell\"", "hello nushell"),
         // template: Tc(br#""<string literal without #'s>"", "<Rust literal comparand>")
         Tc(br#""\u006enu\u0075\u0073\u0073""#, "nnuuss"),
         Tc(br#""hello \u{6e}\u{000075}\u{073}hell""#, "hello nushell"),
         Tc(br#""abc""#, "abc"),
-        Tc(br#""\u{39}8\u{10ffff}""#,"98\u{10ffff}"),  // shouldn't work?
-        //Tc(br#""#,""),
-        //Tc(br#""#,""),
-        //Tc(br#""#,""),
-        
+        Tc(br#""\u{39}8\u{10ffff}""#, "98\u{10ffff}"), // shouldn't work?
+                                                       //Tc(br#""#,""),
+                                                       //Tc(br#""#,""),
+                                                       //Tc(br#""#,""),
     ];
 
     for tci in test_vec {
         println!("Expecting: {}", tci.1);
-        do_test( tci.0, tci.1, None);
-    }    
+        do_test(tci.0, tci.1, None);
+    }
 }
 
 // cases that all should fail (in expected way)
 #[test]
-pub fn parse_unicode_many_fail() {
+pub fn unicode_escapes_in_strings_expected_failures() {
     // input, substring of expected failure
     pub struct Tc(&'static [u8], &'static str);
 
     let test_vec = vec![
         // template: Tc(br#""<string literal without #'s>"", "<pattern in expected error>")
-        Tc(br#""\u06e""#, "any shape"),   // 4digit too short, next char is EOF
-        Tc(br#""\u06ex""#, "any shape"),  // 4digit too short, next char is non-hex-digit
-        Tc(br#""hello \u{6e""#, "any shape"),   // extended, missing close delim
-        Tc(br#""\u{39}8\u{000000000000000000000000000000000000000000000037}""#,"any shape"),  // shouldn't work?
-        Tc(br#""\u{110000}""#,"any shape"),  // max unicode <= 0x10ffff?
-        //Tc(br#""#,""),
-        //Tc(br#""#,""),
-        //Tc(br#""#,""),
-        
+        Tc(br#""\u06e""#, "any shape"), // 4digit too short, next char is EOF
+        Tc(br#""\u06ex""#, "any shape"), // 4digit too short, next char is non-hex-digit
+        Tc(br#""hello \u{6e""#, "any shape"), // extended, missing close delim
+        Tc(
+            br#""\u{39}8\u{000000000000000000000000000000000000000000000037}""#,
+            "any shape",
+        ), // shouldn't work?
+        Tc(br#""\u{110000}""#, "any shape"), // max unicode <= 0x10ffff?
+                                        //Tc(br#""#,""),
+                                        //Tc(br#""#,""),
+                                        //Tc(br#""#,""),
     ];
 
     for tci in test_vec {
         println!("Expecting failure containing: {}", tci.1);
-        do_test( tci.0, "--success not expected--", Some(tci.1));
-    }    
+        do_test(tci.0, "--success not expected--", Some(tci.1));
+    }
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -380,11 +380,7 @@ fn block_arity_check1() -> TestResult {
     )
 }
 
-#[test]
-fn string_escape() -> TestResult {
-    run_test(r#""\u015B""#, "ś")
-}
-
+// deprecating former support for escapes like `/uNNNN`, dropping test.
 #[test]
 fn string_escape_unicode_extended() -> TestResult {
     run_test(r#""\u{015B}\u{1f10b}""#, "ś🄋")
@@ -392,7 +388,7 @@ fn string_escape_unicode_extended() -> TestResult {
 
 #[test]
 fn string_escape_interpolation() -> TestResult {
-    run_test(r#"$"\u015B(char hamburger)abc""#, "ś≡abc")
+    run_test(r#"$"\u{015B}(char hamburger)abc""#, "ś≡abc")
 }
 
 #[test]

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -386,6 +386,11 @@ fn string_escape() -> TestResult {
 }
 
 #[test]
+fn string_escape_unicode_extended() -> TestResult {
+    run_test(r#""\u{015B}\u{1f10b}""#, "ś🄋")
+}
+
+#[test]
 fn string_escape_interpolation() -> TestResult {
     run_test(r#"$"\u015B(char hamburger)abc""#, "ś≡abc")
 }


### PR DESCRIPTION
# Description

Support extended unicode escapes in strings with same syntax as Rust: `"\u{6e}"`.

# User-Facing Changes

New syntax in string literals, `\u{NNNNNN}`, to go along with the existing `\uNNNN`.  
New syntax accepts 1-6 hex digits and rejects values greater than 0x10FFFF (max Unicode char)..

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

Won't break existing scripts, since this is new syntax.  

We might consider deprecating `char -u`, since users can now embed unicode chars > 0xFFFF with the new escape.

# Tests + Formatting

Several unit tests and one integration test added.

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)  
Done
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style  
Done
- [x] `cargo test --workspace` to check that all tests pass  
Done

# After Submitting

- [ ] If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
