### PR TITLE
refactor: use `input_handler::operate` in ansi_strip command

### DIFF
--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -66,8 +66,6 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, command_span: Span) -> Value 
 
 #[cfg(test)]
 mod tests {
-    use crate::input_handler::CellPathOnlyArgs;
-
     use super::{action, SubCommand};
     use nu_protocol::{Span, Value};
 
@@ -84,11 +82,7 @@ mod tests {
             Value::test_string("\u{1b}[3;93;41mHello\u{1b}[0m \u{1b}[1;32mNu \u{1b}[1;35mWorld");
         let expected = Value::test_string("Hello Nu World");
 
-        let actual = action(
-            &input_string,
-            &CellPathOnlyArgs { cell_paths: None },
-            &Span::test_data(),
-        );
+        let actual = action(&input_string, &vec![].into(), Span::test_data());
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -1,3 +1,4 @@
+use crate::input_handler::{operate, CellPathOnlyArgs};
 use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call, ast::CellPath, engine::Command, engine::EngineState, engine::Stack, Category,
@@ -34,7 +35,9 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, ShellError> {
-        operate(engine_state, stack, call, input)
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+        let arg = CellPathOnlyArgs::from(cell_paths);
+        operate(action, arg, input, call.head, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -46,37 +49,7 @@ impl Command for SubCommand {
     }
 }
 
-fn operate(
-    engine_state: &EngineState,
-    stack: &mut Stack,
-    call: &Call,
-    input: PipelineData,
-) -> Result<PipelineData, ShellError> {
-    let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
-    let head = call.head;
-    input.map(
-        move |v| {
-            if column_paths.is_empty() {
-                action(&v, &head)
-            } else {
-                let mut ret = v;
-
-                for path in &column_paths {
-                    let r = ret
-                        .update_cell_path(&path.members, Box::new(move |old| action(old, &head)));
-                    if let Err(error) = r {
-                        return Value::Error { error };
-                    }
-                }
-
-                ret
-            }
-        },
-        engine_state.ctrlc.clone(),
-    )
-}
-
-fn action(input: &Value, command_span: &Span) -> Value {
+fn action(input: &Value, _args: &CellPathOnlyArgs, command_span: Span) -> Value {
     match input {
         Value::String { val, span } => {
             Value::string(nu_utils::strip_ansi_likely(val).to_string(), *span)
@@ -85,7 +58,7 @@ fn action(input: &Value, command_span: &Span) -> Value {
             let got = format!("value is {}, not string", other.get_type());
 
             Value::Error {
-                error: ShellError::TypeMismatch(got, other.span().unwrap_or(*command_span)),
+                error: ShellError::TypeMismatch(got, other.span().unwrap_or(command_span)),
             }
         }
     }
@@ -93,6 +66,8 @@ fn action(input: &Value, command_span: &Span) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use crate::input_handler::CellPathOnlyArgs;
+
     use super::{action, SubCommand};
     use nu_protocol::{Span, Value};
 
@@ -109,7 +84,11 @@ mod tests {
             Value::test_string("\u{1b}[3;93;41mHello\u{1b}[0m \u{1b}[1;32mNu \u{1b}[1;35mWorld");
         let expected = Value::test_string("Hello Nu World");
 
-        let actual = action(&input_string, &Span::test_data());
+        let actual = action(
+            &input_string,
+            &CellPathOnlyArgs { cell_paths: None },
+            &Span::test_data(),
+        );
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
# Description

While investigating `do --ignore-errors` issue, just found that `ansi_strip` command using a custom `operate` function(which is not needed), this pr is just a refactor

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
