### PR TITLE
prevent `RowCondition`s from accepting `Operator::Assignment`

### DIFF
--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -199,5 +199,5 @@ fn fail_on_non_iterator() {
 fn does_not_panic_when_condition_has_assignment_operator() {
     let actual = nu!(cwd: ".", pipeline(r#"[{a: 1}, {a: 2}] | where $in = 1"#));
 
-    assert!(actual.err.contains("expected comparative operator"));
+    assert!(actual.err.contains("expected valid boolean condition"));
 }

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -194,3 +194,10 @@ fn fail_on_non_iterator() {
 
     assert!(actual.err.contains("only_supports_this_input_type"));
 }
+
+#[test]
+fn does_not_panic_when_condition_has_assignment_operator() {
+    let actual = nu!(cwd: ".", pipeline(r#"[{a: 1}, {a: 2}] | where $in = 1"#));
+
+    assert!(actual.err.contains("expected comparative operator"));
+}

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4801,6 +4801,14 @@ pub fn parse_math_expression(
         let (op, err) = parse_operator(working_set, spans[idx]);
         error = error.or(err);
 
+        if matches!(op.expr, Expr::Operator(Operator::Assignment(..))) {
+            error = error.or(Some(ParseError::Expected(
+                "comparative operator".to_string(),
+                spans[idx],
+            )));
+            break;
+        }
+
         let op_prec = op.precedence();
 
         idx += 1;


### PR DESCRIPTION
# Description

Fixes #7872. Prior, `=` and other assignment operators were allowed in `RowCondition`.

# User-Facing Changes

Using "=" and other assignemtn operators like "+=" in RowConditions now gives an error.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
