### PR TITLE
Fix wrong VarId of $in variable

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5995,7 +5995,7 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
     if let Some(decl_id) = working_set.find_decl(b"collect", &Type::Any) {
         let mut output = vec![];
 
-        let var_id = working_set.next_var_id();
+        let var_id = IN_VARIABLE_ID;
         let mut signature = Signature::new("");
         signature.required_positional.push(PositionalArg {
             var_id: Some(var_id),

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -365,3 +365,9 @@ fn better_operator_spans() -> TestResult {
 fn range_right_exclusive() -> TestResult {
     run_test(r#"[1, 4, 5, 8, 9] | range 1..<3 | math sum"#, "9")
 }
+
+/// Issue #7872
+#[test]
+fn assignment_to_in_var_no_panic() -> TestResult {
+    fail_test(r#"$in = 3"#, "needs to be a mutable variable")
+}


### PR DESCRIPTION
# Description

For some reason, in the parser the ID assigned to `$in` was not its real id but a new, non-existent ID which caused panic in #7872. Now, the actual ID of `$in` is passed.

Fixes https://github.com/nushell/nushell/issues/7872.

# User-Facing Changes

No panic

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
