### PR TITLE
Fix panic when assigning value to $env

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -467,6 +467,12 @@ pub fn eval_expression(
 
                                     lhs.upsert_data_at_cell_path(&cell_path.tail, rhs)?;
                                     if is_env {
+                                        if cell_path.tail.is_empty() {
+                                            return Err(ShellError::CannotReplaceEnv(
+                                                cell_path.head.span,
+                                            ));
+                                        }
+
                                         // The special $env treatment: for something like $env.config.history.max_size = 2000,
                                         // get $env.config (or whichever one it is) AFTER the above mutation, and set it
                                         // as the "config" environment variable.

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -365,6 +365,20 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     )]
     AutomaticEnvVarSetManually(String, #[label("cannot set '{0}' manually")] Span),
 
+    /// It is not possible to replace the entire environment at once
+    ///
+    /// ## Resolution
+    ///
+    /// Setting the entire environment is not allowed. Change environment variables individually
+    /// instead.
+    #[error("Cannot replace environment.")]
+    #[diagnostic(
+        code(nu::shell::cannot_replace_env),
+        url(docsrs),
+        help(r#"Assigning a value to $env is not allowed."#)
+    )]
+    CannotReplaceEnv(#[label("setting $env not allowed")] Span),
+
     /// Division by zero is not a thing.
     ///
     /// ## Resolution

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -371,3 +371,8 @@ fn range_right_exclusive() -> TestResult {
 fn assignment_to_in_var_no_panic() -> TestResult {
     fail_test(r#"$in = 3"#, "needs to be a mutable variable")
 }
+
+#[test]
+fn assignment_to_env_no_panic() -> TestResult {
+    fail_test(r#"$env = 3"#, "cannot_replace_env")
+}


### PR DESCRIPTION
# Description

Calling `$env = 3` caused panic. No more.

# User-Facing Changes

One panic less.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
