### PR TITLE
Fix: dst error on cp command

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -352,8 +352,8 @@ fn copy_file(src: PathBuf, dst: PathBuf, span: Span) -> Value {
             Value::String { val: msg, span }
         }
         Err(e) => {
-            let message_src = format!("copy file {src:?} failed: {e}");
-            let message_dst = format!("copy file {dst:?} failed: {e}");
+            let message_src = format!("copying file '{src_display}' failed: {e}", src_display = src.display());
+            let message_dst = format!("copying to destination '{dst_display}' failed: {e}", dst_display = dst.display());
             use std::io::ErrorKind;
             let shell_error = match e.kind() {
                 ErrorKind::NotFound => {

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -352,8 +352,14 @@ fn copy_file(src: PathBuf, dst: PathBuf, span: Span) -> Value {
             Value::String { val: msg, span }
         }
         Err(e) => {
-            let message_src = format!("copying file '{src_display}' failed: {e}", src_display = src.display());
-            let message_dst = format!("copying to destination '{dst_display}' failed: {e}", dst_display = dst.display());
+            let message_src = format!(
+                "copying file '{src_display}' failed: {e}",
+                src_display = src.display()
+            );
+            let message_dst = format!(
+                "copying to destination '{dst_display}' failed: {e}",
+                dst_display = dst.display()
+            );
             use std::io::ErrorKind;
             let shell_error = match e.kind() {
                 ErrorKind::NotFound => {

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -1,5 +1,8 @@
 use nu_test_support::fs::file_contents;
-use nu_test_support::fs::{files_exist_at, AbsoluteFile, Stub::EmptyFile};
+use nu_test_support::fs::{
+    files_exist_at, AbsoluteFile,
+    Stub::{EmptyFile, FileWithPremission},
+};
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use std::path::Path;
@@ -342,5 +345,38 @@ fn copy_ignores_ansi() {
             "ls | find test | get name | cp $in.0 success.txt; ls | find success | get name | ansi strip | get 0",
         );
         assert_eq!(actual.out, "success.txt");
+    });
+}
+
+#[test]
+fn copy_file_not_exists_dst() {
+    Playground::setup("cp_test_17", |_dirs, sandbox| {
+        sandbox.with_files(vec![EmptyFile("valid.txt")]);
+
+        let actual = nu!(
+            cwd: sandbox.cwd(),
+            "cp valid.txt ~/invlid_dir/invalid_dir1"
+        );
+        assert!(actual
+            .err
+            .contains("/invlid_dir/invalid_dir1\" failed: No such file or directory"));
+    });
+}
+
+#[test]
+fn copy_file_with_read_premission() {
+    Playground::setup("cp_test_18", |_dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("valid.txt"),
+            FileWithPremission("invalid_prem.txt", false),
+        ]);
+
+        let actual = nu!(
+            cwd: sandbox.cwd(),
+            "cp valid.txt invalid_prem.txt",
+        );
+        assert!(actual
+            .err
+            .contains("/cp_test_18/invalid_prem.txt\" failed: Permission denied"));
     });
 }

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -358,11 +358,7 @@ fn copy_file_not_exists_dst() {
             "cp valid.txt ~/invalid_dir/invalid_dir1"
         );
         assert!(
-            actual.err.contains("invalid_dir1")
-                && (actual.err.contains("No such file or directory")
-                    || actual
-                        .err
-                        .contains("The system cannot find the path specified"))
+            actual.err.contains("invalid_dir1") && actual.err.contains("copying to destination")
         );
     });
 }
@@ -381,8 +377,7 @@ fn copy_file_with_read_permission() {
         );
         assert!(
             actual.err.contains("invalid_prem.txt")
-                && (actual.err.contains("Access is denied")
-                    || actual.err.contains("Permission denied"))
+                && actual.err.contains("copying to destination")
         );
     });
 }

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -364,7 +364,7 @@ fn copy_file_not_exists_dst() {
 }
 
 #[test]
-fn copy_file_with_read_premission() {
+fn copy_file_with_read_permission() {
     Playground::setup("cp_test_18", |_dirs, sandbox| {
         sandbox.with_files(vec![
             EmptyFile("valid.txt"),

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -357,9 +357,13 @@ fn copy_file_not_exists_dst() {
             cwd: sandbox.cwd(),
             "cp valid.txt ~/invalid_dir/invalid_dir1"
         );
-        assert!(actual
-            .err
-            .contains("/invalid_dir/invalid_dir1\" failed: No such file or directory"));
+        assert!(
+            actual.err.contains("invalid_dir1")
+                && (actual.err.contains("No such file or directory")
+                    || actual
+                        .err
+                        .contains("The system cannot find the path specified"))
+        );
     });
 }
 
@@ -375,8 +379,10 @@ fn copy_file_with_read_permission() {
             cwd: sandbox.cwd(),
             "cp valid.txt invalid_prem.txt",
         );
-        assert!(actual
-            .err
-            .contains("/cp_test_18/invalid_prem.txt\" failed: Permission denied"));
+        assert!(
+            actual.err.contains("invalid_prem.txt")
+                && (actual.err.contains("Access is denied")
+                    || actual.err.contains("Permission denied"))
+        );
     });
 }

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -1,7 +1,7 @@
 use nu_test_support::fs::file_contents;
 use nu_test_support::fs::{
     files_exist_at, AbsoluteFile,
-    Stub::{EmptyFile, FileWithPremission},
+    Stub::{EmptyFile, FileWithPermission},
 };
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
@@ -368,7 +368,7 @@ fn copy_file_with_read_permission() {
     Playground::setup("cp_test_18", |_dirs, sandbox| {
         sandbox.with_files(vec![
             EmptyFile("valid.txt"),
-            FileWithPremission("invalid_prem.txt", false),
+            FileWithPermission("invalid_prem.txt", false),
         ]);
 
         let actual = nu!(

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -355,11 +355,11 @@ fn copy_file_not_exists_dst() {
 
         let actual = nu!(
             cwd: sandbox.cwd(),
-            "cp valid.txt ~/invlid_dir/invalid_dir1"
+            "cp valid.txt ~/invalid_dir/invalid_dir1"
         );
         assert!(actual
             .err
-            .contains("/invlid_dir/invalid_dir1\" failed: No such file or directory"));
+            .contains("/invalid_dir/invalid_dir1\" failed: No such file or directory"));
     });
 }
 

--- a/crates/nu-test-support/src/fs.rs
+++ b/crates/nu-test-support/src/fs.rs
@@ -137,7 +137,7 @@ pub enum Stub<'a> {
     FileWithContent(&'a str, &'a str),
     FileWithContentToBeTrimmed(&'a str, &'a str),
     EmptyFile(&'a str),
-    FileWithPremission(&'a str, bool),
+    FileWithPermission(&'a str, bool),
 }
 
 pub fn file_contents(full_path: impl AsRef<Path>) -> String {

--- a/crates/nu-test-support/src/fs.rs
+++ b/crates/nu-test-support/src/fs.rs
@@ -137,6 +137,7 @@ pub enum Stub<'a> {
     FileWithContent(&'a str, &'a str),
     FileWithContentToBeTrimmed(&'a str, &'a str),
     EmptyFile(&'a str),
+    FileWithPremission(&'a str, bool),
 }
 
 pub fn file_contents(full_path: impl AsRef<Path>) -> String {

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -216,7 +216,7 @@ impl<'a> Playground<'a> {
                             .collect::<Vec<&str>>()
                             .join(&endl),
                     ),
-                    Stub::FileWithPremission(name, is_write_able) => {
+                    Stub::FileWithPermission(name, is_write_able) => {
                         permission_set = true;
                         write_able = is_write_able;
                         (name, "check permission".to_string())

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -202,7 +202,7 @@ impl<'a> Playground<'a> {
             .iter()
             .map(|f| {
                 let mut path = PathBuf::from(&self.cwd);
-                let mut premission_set = false;
+                let mut permission_set = false;
                 let mut write_able = true;
                 let (file_name, contents) = match *f {
                     Stub::EmptyFile(name) => (name, "fake data".to_string()),
@@ -217,18 +217,17 @@ impl<'a> Playground<'a> {
                             .join(&endl),
                     ),
                     Stub::FileWithPremission(name, is_write_able) => {
-                        premission_set = true;
+                        permission_set = true;
                         write_able = is_write_able;
-                        (name, "check premission".to_string())
+                        (name, "check permission".to_string())
                     }
                 };
 
                 path.push(file_name);
 
-                // std::fs::set_permissions(path, ).expect("can not set premission");
                 std::fs::write(&path, contents.as_bytes()).expect("can not create file");
-                if premission_set {
-                    let err_perm = "can not set premission";
+                if permission_set {
+                    let err_perm = "can not set permission";
                     let mut perm = std::fs::metadata(path.clone())
                         .expect(err_perm)
                         .permissions();


### PR DESCRIPTION
Fixes #7693 

On `cp` commands there were two error which pass error message with invalid detail about source and destination files . there error were for Not exist file and Permission denied .

Examples:
  Before :
Copy `source_file_valid` to `destination_invalid_dir` throw this error ;
  `copy file "/source_file_valid" failed: No such file or directory (os error 2) `

 After this PR it will throw this if destination will be invalid :
  `copying to destination "/destination_invalid_dir" failed: No such file or directory (os error 2) `

it was for Permission denied too .