### PR TITLE
make help commands search term don't generate $nothing

### DIFF
--- a/crates/nu-command/src/core_commands/help_commands.rs
+++ b/crates/nu-command/src/core_commands/help_commands.rs
@@ -163,13 +163,9 @@ fn build_help_commands(engine_state: &EngineState, span: Span) -> Vec<Value> {
         });
 
         cols.push("search_terms".into());
-        vals.push(if search_terms.is_empty() {
-            Value::nothing(span)
-        } else {
-            Value::String {
-                val: search_terms.join(", "),
-                span,
-            }
+        vals.push(Value::String {
+            val: search_terms.join(", "),
+            span,
         });
 
         found_cmds_vec.push(Value::Record { cols, vals, span });

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -234,13 +234,9 @@ impl<'e, 's> ScopeData<'e, 's> {
 
                 let search_terms = decl.search_terms();
                 cols.push("search_terms".to_string());
-                vals.push(if search_terms.is_empty() {
-                    Value::nothing(span)
-                } else {
-                    Value::String {
-                        val: search_terms.join(", "),
-                        span,
-                    }
+                vals.push(Value::String {
+                    val: search_terms.join(", "),
+                    span,
                 });
 
                 commands.push(Value::Record { cols, vals, span })


### PR DESCRIPTION
# Description

Relative: `https://github.com/nushell/nushell/pull/7889#issuecomment-1407503567`

Make `search_terms` return empty string rather than nothing, so some other command can handle it better

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
