### PR TITLE
make `parse -r` columns return 0-indexed uncapitalised

### DIFF
--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -93,7 +93,7 @@ impl Command for Parse {
                     "\" @another(foo bar)   \" | parse -r '\\s*(?<=[() ])(@\\w+)(\\([^)]*\\))?\\s*'",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
-                        cols: vec!["Capture1".to_string(), "Capture2".to_string()],
+                        cols: vec!["capture0".to_string(), "capture1".to_string()],
                         vals: vec![
                             Value::test_string("@another"),
                             Value::test_string("(foo bar)"),
@@ -108,7 +108,7 @@ impl Command for Parse {
                 example: "\"abcd\" | parse -r '^a(bc(?=d)|b)cd$'",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
-                        cols: vec!["Capture1".to_string()],
+                        cols: vec!["capture0".to_string()],
                         vals: vec![Value::test_string("b")],
                         span: Span::test_data(),
                     }],
@@ -276,7 +276,7 @@ fn column_names(regex: &Regex) -> Vec<String> {
         .skip(1)
         .map(|(i, name)| {
             name.map(String::from)
-                .unwrap_or_else(|| format!("Capture{}", i))
+                .unwrap_or_else(|| format!("capture{}", i - 1))
         })
         .collect()
 }

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -74,12 +74,12 @@ impl Command for Parse {
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {
-                            cols: vec!["Capture1".to_string(), "Capture2".to_string()],
+                            cols: vec!["capture0".to_string(), "capture1".to_string()],
                             vals: vec![Value::test_string(""), Value::test_string("foo")],
                             span: Span::test_data(),
                         },
                         Value::Record {
-                            cols: vec!["Capture1".to_string(), "Capture2".to_string()],
+                            cols: vec!["capture0".to_string(), "capture1".to_string()],
                             vals: vec![Value::test_string("bar"), Value::test_string("")],
                             span: Span::test_data(),
                         },

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -144,7 +144,7 @@ mod regex {
                     open nushell_git_log_oneline.txt
                     | parse --regex "(\\w+) (.+) \\(#(\\d+)\\)"
                     | get 1
-                    | get Capture1
+                    | get capture0
                 "#
             ));
 
@@ -163,7 +163,7 @@ mod regex {
                     open nushell_git_log_oneline.txt
                     | parse --regex "(?P<Hash>\\w+) (.+) \\(#(?P<PR>\\d+)\\)"
                     | get 1
-                    | get Capture2
+                    | get capture1
                 "#
             ));
 


### PR DESCRIPTION
# Description

Fixes #7886.

```
/home/gabriel/CodingProjects/nushell〉'A|B|C' | parse -r '(\w)\|(\w)\|(\w)'                                                                                             01/29/2023 01:08:29 PM
╭───┬──────────┬──────────┬──────────╮
│ # │ capture0 │ capture1 │ capture2 │
├───┼──────────┼──────────┼──────────┤
│ 0 │ A        │ B        │ C        │
╰───┴──────────┴──────────┴──────────╯
```

# User-Facing Changes
Columns automatically named by `parse -r` are now 0-indexec and uncapitalised.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
