### PR TITLE
Bump `trash` to `3.0.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,7 +2798,7 @@ dependencies = [
  "uuid",
  "wax",
  "which",
- "windows 0.44.0",
+ "windows",
  "winreg",
 ]
 
@@ -5287,9 +5287,9 @@ dependencies = [
 
 [[package]]
 name = "trash"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f74274f95c7e7340d7c5bcd4863af87a9ed6a117cf73cf483c71cb4d744a948"
+checksum = "a27b2a127810fceb959593bbc6c7b8e0282c2d318d76f0749252197c52a1dd0c"
 dependencies = [
  "chrono",
  "libc",
@@ -5298,7 +5298,7 @@ dependencies = [
  "once_cell",
  "scopeguard",
  "url",
- "windows 0.43.0",
+ "windows",
 ]
 
 [[package]]
@@ -5745,21 +5745,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
-]
 
 [[package]]
 name = "windows"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -106,7 +106,7 @@ users = "0.11.0"
 libc = "0.2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
-version = "3.0.0"
+version = "3.0.1"
 optional = true
 
 [dependencies.polars]


### PR DESCRIPTION
# Description

Avoids duplication of `windows` crate and friends as it updates to the
most recent `windows 0.44` version.

# User-Facing Changes

None intended
