### PR TITLE
Pin `reedline` to new `0.15` for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,8 +4152,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.14.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#e1366260c1bf025b1ad08d0b32dfd7bb53948c7f"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da60f4ca4517626e4621dba4fb252069572d5bfaf41efb96dfa5c93f39f2e978"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ nu-system = { path = "./crates/nu-system", version = "0.74.1" }
 nu-table = { path = "./crates/nu-table", version = "0.74.1" }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.74.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.74.1" }
-reedline = { version = "0.14.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
 
 rayon = "1.6.1"
 is_executable = "1.0.1"
@@ -147,7 +147,7 @@ path = "src/main.rs"
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
 
 # Criterion benchmarking setup
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -20,7 +20,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.74.1" }
 nu-utils = { path = "../nu-utils", version = "0.74.1" }
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.74.1" }
-reedline = { version = "0.14.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
 
 atty = "0.2.14"
 chrono = { default-features = false, features = ["std"], version = "0.4.23" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -92,7 +92,7 @@ url = "2.2.1"
 percent-encoding = "2.2.0"
 uuid = { version = "1.2.2", features = ["v4"] }
 which = { version = "4.3.0", optional = true }
-reedline = { version = "0.14.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
 wax = { version = "0.5.0" }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.30.0", features = ["serde"], optional = true }


### PR DESCRIPTION
# Description

See release notes:

https://github.com/nushell/reedline/releases/tag/v0.15.0


