### PR TITLE
use newer reedline (once available)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,8 +4153,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da60f4ca4517626e4621dba4fb252069572d5bfaf41efb96dfa5c93f39f2e978"
+source = "git+https://github.com/nushell/reedline.git?branch=main#829a1a9f491a04d7b4159bc69d46cfc8184ccf53"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ nu-system = { path = "./crates/nu-system", version = "0.74.1" }
 nu-table = { path = "./crates/nu-table", version = "0.74.1" }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.74.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.74.1" }
-reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
 
 rayon = "1.6.1"
 is_executable = "1.0.1"
@@ -147,7 +147,7 @@ path = "src/main.rs"
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
 
 # Criterion benchmarking setup
 # Run all benchmarks with `cargo bench`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ nu-system = { path = "./crates/nu-system", version = "0.74.1" }
 nu-table = { path = "./crates/nu-table", version = "0.74.1" }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.74.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.74.1" }
-reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
 rayon = "1.6.1"
 is_executable = "1.0.1"


### PR DESCRIPTION
# Description

Use newer reedline that fixes the code completion crash in https://github.com/nushell/nushell/issues/7885 by subtracting from the insertion point if the suggestion is shorter than the editor span.

Closes https://github.com/nushell/nushell/issues/7885

Depends on https://github.com/nushell/reedline/pull/534

# User-Facing Changes


# Tests + Formatting

Tested in reedline.

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
