### PR TITLE
Only abbreviate to "[table x rows]" if every value is a record

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -565,17 +565,21 @@ impl Value {
                 )
             }
             Value::String { val, .. } => val.to_string(),
-            Value::List { ref vals, .. } => format!(
-                "[{} {} row{}]",
-                // Only say 'table' if every value is a Record
+            Value::List { ref vals, .. } => {
                 if vals.iter().all(|x| matches!(x, Value::Record { .. })) {
-                    "table"
+                    format!(
+                        "[table {} row{}]",
+                        vals.len(),
+                        if vals.len() == 1 { "" } else { "s" }
+                    )
                 } else {
-                    "list"
-                },
-                vals.len(),
-                if vals.len() == 1 { "" } else { "s" }
-            ),
+                    format!(
+                        "[list {} item{}]",
+                        vals.len(),
+                        if vals.len() == 1 { "" } else { "s" }
+                    )
+                }
+            }
             Value::Record { cols, .. } => format!(
                 "{{record {} field{}}}",
                 cols.len(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -565,18 +565,17 @@ impl Value {
                 )
             }
             Value::String { val, .. } => val.to_string(),
-            Value::List { ref vals, .. } => match &vals[..] {
-                [Value::Record { .. }, _end @ ..] => format!(
-                    "[table {} row{}]",
-                    vals.len(),
-                    if vals.len() == 1 { "" } else { "s" }
-                ),
-                _ => format!(
-                    "[list {} item{}]",
-                    vals.len(),
-                    if vals.len() == 1 { "" } else { "s" }
-                ),
-            },
+            Value::List { ref vals, .. } => format!(
+                "[{} {} row{}]",
+                // Only say 'table' if every value is a Record
+                if vals.iter().all(|x| matches!(x, Value::Record { .. })) {
+                    "table"
+                } else {
+                    "list"
+                },
+                vals.len(),
+                if vals.len() == 1 { "" } else { "s" }
+            ),
             Value::Record { cols, .. } => format!(
                 "{{record {} field{}}}",
                 cols.len(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -566,7 +566,7 @@ impl Value {
             }
             Value::String { val, .. } => val.to_string(),
             Value::List { ref vals, .. } => {
-                if vals.iter().all(|x| matches!(x, Value::Record { .. })) {
+                if !vals.is_empty() && vals.iter().all(|x| matches!(x, Value::Record { .. })) {
                     format!(
                         "[table {} row{}]",
                         vals.len(),


### PR DESCRIPTION
# Description

Closes #6768.

BEFORE:
```
〉{ foo: [{a:1, b:2},2,3,4,5] }
╭─────┬────────────────╮
│ foo │ [table 5 rows] │
╰─────┴────────────────╯
```
AFTER:
```
〉{ foo: [{a:1, b:2},2,3,4,5] }
╭─────┬────────────────╮
│ foo │ [list 5 items] │
╰─────┴────────────────╯
```

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
