### PR TITLE
update type check so that ++ with lists works better

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -84,6 +84,7 @@ pub fn math_result_type(
                     }
                 }
                 (Type::Table(a), Type::Table(_)) => (Type::Table(a.clone()), None),
+                (Type::Any, _) | (_, Type::Any) => (Type::Any, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (


### PR DESCRIPTION
# Description

This PR updates the type checking in such a way to allow `++` to work better with lists.
closes #7913 

Before:
```
> def identity [x] { $x }
> let my_list = identity [0]
> $my_list ++ $my_list
Error: nu::parser::unsupported_operation (link)

  × Types mismatched for operation.
   ╭─[entry #3:1:1]
 1 │ $my_list ++ $my_list
   · ────┬─── ─┬ ────┬───
   ·     │     │     ╰── any
   ·     │     ╰── doesn't support these values.
   ·     ╰── any
   ╰────
  help: Change any or any to be the right types and try again.
```

After:
```
> def identity [x] { $x }
> let my_list = (identity [0])
> $my_list ++ $my_list
╭───┬───╮
│ 0 │ 0 │
│ 1 │ 0 │
╰───┴───╯
```

JT's explanation of the fix.
> In the case both are any, we should allow the ++ to go through and have the types checked at runtime. Once we do that, we should see both are list and then the list concatenation should work.
> 
> Arguably, it'd be nice for the type inference to be a little bit stronger for this case, but it shouldn't error

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
