### PR TITLE
Remove deprecated `where -b` parameter

### DIFF
--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -38,13 +38,6 @@ not supported."#
                 SyntaxShape::RowCondition,
                 "Filter condition",
             )
-            // TODO: Remove this flag after 0.73.0 release
-            .named(
-                "closure",
-                SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "use with a closure instead (deprecated: use 'filter' command instead)",
-                Some('b'),
-            )
             .category(Category::Filters)
     }
 
@@ -59,14 +52,6 @@ not supported."#
         call: &Call,
         input: PipelineData,
     ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
-        if let Some(closure) = call.get_flag::<Spanned<Closure>>(engine_state, stack, "closure")? {
-            return Err(ShellError::DeprecatedParameter(
-                "-b, --closure".to_string(),
-                "filter command".to_string(),
-                closure.span,
-            ));
-        }
-
         let closure: Closure = call.req(engine_state, stack, 0)?;
 
         let span = call.head;

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -2,8 +2,8 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, Span, Spanned, SyntaxShape, Type, Value,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Signature,
+    Span, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]


### PR DESCRIPTION
# Description

Removes a deprecated flag

# User-Facing Changes

Just removes the flag which was already deprecated and threw an error when used. So no real user change.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
