### PR TITLE
Reorder `help <keyword>` priority

### DIFF
--- a/crates/nu-command/src/core_commands/help.rs
+++ b/crates/nu-command/src/core_commands/help.rs
@@ -86,15 +86,15 @@ You can also learn more at https://www.nushell.sh/book/"#;
         } else if find.is_some() {
             help_commands(engine_state, stack, call)
         } else {
-            let result = help_commands(engine_state, stack, call);
+            let result = help_aliases(engine_state, stack, call);
 
-            let result = if let Err(ShellError::CommandNotFound(_)) = result {
-                help_aliases(engine_state, stack, call)
+            let result = if let Err(ShellError::AliasNotFound(_)) = result {
+                help_commands(engine_state, stack, call)
             } else {
                 result
             };
 
-            let result = if let Err(ShellError::AliasNotFound(_)) = result {
+            let result = if let Err(ShellError::CommandNotFound(_)) = result {
                 help_modules(engine_state, stack, call)
             } else {
                 result

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -342,3 +342,15 @@ fn help_modules_main_2() {
 
     assert_eq!(actual.out, "spam");
 }
+
+#[test]
+fn help_alias_before_command() {
+    let code = &[
+        "alias SPAM = print 'spam'",
+        "def SPAM [] { 'spam' }",
+        "help SPAM",
+    ];
+    let actual = nu!(cwd: ".", nu_repl_code(code));
+
+    assert!(actual.out.contains("Alias"));
+}


### PR DESCRIPTION
# Description

`help <keyword>` will now search for `<keyword>` in aliases first, then commands. This matches the way the parser resolves aliases before commands. 

# User-Facing Changes

Not significant

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
