### PR TITLE
add ability to view-source on closures

### DIFF
--- a/crates/nu-command/src/experimental/view_source.rs
+++ b/crates/nu-command/src/experimental/view_source.rs
@@ -37,7 +37,7 @@ impl Command for ViewSource {
         let arg_span = arg.span()?;
 
         match arg {
-            Value::Block { val: block_id, .. } => {
+            Value::Block { val: block_id, .. } | Value::Closure { val: block_id, .. } => {
                 let block = engine_state.get_block(block_id);
 
                 if let Some(span) = block.span {


### PR DESCRIPTION
# Description

This PR adds the ability to view-source on `Value::Closure` instead of just `Value::Block`.

@kubouch does this pr look right?
closes #7934 

# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
