### PR TITLE
clean up the registry query output

### DIFF
--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -211,6 +211,12 @@ fn get_reg_key(reg_params: RegistryQueryArgs, call_span: Span) -> Result<RegKey,
     Ok(registry_key)
 }
 
+fn clean_string(string: &str) -> String {
+    string
+        .trim_start_matches('"')
+        .trim_end_matches('"')
+        .replace("\\\\", "\\")
+}
 fn reg_value_to_nu_value(
     reg_value: winreg::RegValue,
     call_span: Span,
@@ -218,11 +224,11 @@ fn reg_value_to_nu_value(
     match reg_value.vtype {
         REG_NONE => (Value::nothing(call_span), reg_value.vtype),
         REG_SZ => (
-            Value::string(reg_value.to_string(), call_span),
+            Value::string(clean_string(&reg_value.to_string()), call_span),
             reg_value.vtype,
         ),
         REG_EXPAND_SZ => (
-            Value::string(reg_value.to_string(), call_span),
+            Value::string(clean_string(&reg_value.to_string()), call_span),
             reg_value.vtype,
         ),
         REG_BINARY => (Value::binary(reg_value.bytes, call_span), reg_value.vtype),
@@ -241,23 +247,23 @@ fn reg_value_to_nu_value(
             reg_value.vtype,
         ),
         REG_LINK => (
-            Value::string(reg_value.to_string(), call_span),
+            Value::string(clean_string(&reg_value.to_string()), call_span),
             reg_value.vtype,
         ),
         REG_MULTI_SZ => (
-            Value::string(reg_value.to_string(), call_span),
+            Value::string(clean_string(&reg_value.to_string()), call_span),
             reg_value.vtype,
         ),
         REG_RESOURCE_LIST => (
-            Value::string(reg_value.to_string(), call_span),
+            Value::string(clean_string(&reg_value.to_string()), call_span),
             reg_value.vtype,
         ),
         REG_FULL_RESOURCE_DESCRIPTOR => (
-            Value::string(reg_value.to_string(), call_span),
+            Value::string(clean_string(&reg_value.to_string()), call_span),
             reg_value.vtype,
         ),
         REG_RESOURCE_REQUIREMENTS_LIST => (
-            Value::string(reg_value.to_string(), call_span),
+            Value::string(clean_string(&reg_value.to_string()), call_span),
             reg_value.vtype,
         ),
         REG_QWORD => (


### PR DESCRIPTION
# Description

This cleans up the `registry query` output so that it's more usable.

Before:
![image](https://user-images.githubusercontent.com/343840/216129871-7cadcb68-a289-4e29-8857-6fc20b6a57f7.png)

After:
![image](https://user-images.githubusercontent.com/343840/216129814-70021706-f58a-4647-b5f1-a0e30f5fae16.png)


# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
