### PR TITLE
return in reduce command closure

### DIFF
--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, CallExt};
+use nu_engine::{CallExt, eval_block_with_early_return};
 
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Closure, Command, EngineState, Stack};
@@ -140,7 +140,7 @@ impl Command for Reduce {
                 }
             }
 
-            acc = eval_block(
+            acc = eval_block_with_early_return(
                 engine_state,
                 &mut stack,
                 block,

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -1,4 +1,4 @@
-use nu_engine::{CallExt, eval_block_with_early_return};
+use nu_engine::{eval_block_with_early_return, CallExt};
 
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Closure, Command, EngineState, Stack};


### PR DESCRIPTION
# Description

Fix for #7933.  I've read through code and found the obvious difference between them, where `each` command calls eval_with_early_return https://github.com/nushell/nushell/blob/e89e734ca2063c76c2c79286d6e3ebb8ff4042d3/crates/nu-command/src/filters/each.rs#L158, while `reduce` command uses eval_block https://github.com/nushell/nushell/blob/e89e734ca2063c76c2c79286d6e3ebb8ff4042d3/crates/nu-command/src/filters/reduce.rs#L143

That simple change seems to resolve the problem. 

# User-Facing Changes

Allows the use of `return` in reduce closures, as per example in #7933 description. Arguably it's restoring consistency, than changing user interface.

```
[1, 2] | reduce --fold null { |it, state|                                                           
::: if $it == 1 {
:::     return 10
::: }
::: return ($it * $state)
::: }
20
```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

    

- [x] `cargo fmt --all -- --check` to check standard code formatting (cargo fmt --all applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x]  `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
