### PR TITLE
Refactor `PipelineData`

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -1095,7 +1095,7 @@ fn run_hook_block(
 ) -> Result<PipelineData, ShellError> {
     let block = engine_state.get_block(block_id);
 
-    let input = optional_input.unwrap_or_else(PipelineData::empty);
+    let input = optional_input.unwrap_or_default();
 
     let mut callee_stack = stack.gather_captures(&block.captures);
 

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -38,7 +38,7 @@ const LINE_ENDING_PATTERN: &[char] = &['\r', '\n'];
 /// * A balance of the two approaches is what we've landed on: Values are thread-safe to pass, and we can stream
 /// them into any sources. Streams are still available to model the infinite streams approach of original
 /// Nushell.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum PipelineData {
     Value(Value, Option<PipelineMetadata>),
     ListStream(ListStream, Option<PipelineMetadata>),
@@ -50,6 +50,7 @@ pub enum PipelineData {
         metadata: Option<PipelineMetadata>,
         trim_end_newline: bool,
     },
+    #[default]
     Empty,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,26 +183,28 @@ fn main() -> Result<()> {
     );
 
     start_time = std::time::Instant::now();
-    let input = if let Some(redirect_stdin) = &parsed_nu_cli_args.redirect_stdin {
-        let stdin = std::io::stdin();
-        let buf_reader = BufReader::new(stdin);
+    let input = parsed_nu_cli_args
+        .redirect_stdin
+        .as_ref()
+        .map(|redirect_stdin| {
+            let stdin = std::io::stdin();
+            let buf_reader = BufReader::new(stdin);
 
-        PipelineData::ExternalStream {
-            stdout: Some(RawStream::new(
-                Box::new(BufferedReader::new(buf_reader)),
-                Some(ctrlc),
-                redirect_stdin.span,
-                None,
-            )),
-            stderr: None,
-            exit_code: None,
-            span: redirect_stdin.span,
-            metadata: None,
-            trim_end_newline: false,
-        }
-    } else {
-        PipelineData::empty()
-    };
+            PipelineData::ExternalStream {
+                stdout: Some(RawStream::new(
+                    Box::new(BufferedReader::new(buf_reader)),
+                    Some(ctrlc),
+                    redirect_stdin.span,
+                    None,
+                )),
+                stderr: None,
+                exit_code: None,
+                span: redirect_stdin.span,
+                metadata: None,
+                trim_end_newline: false,
+            }
+        })
+        .unwrap_or_default();
     perf(
         "redirect stdin",
         start_time,


### PR DESCRIPTION
The [second commit](557e6a7d0bcebe7f2967db61c999ad573a3658fe) is much more invasive than the first one.
I just couldn't see an obvious reason why the method `empty()` exists in the first place.
However, I am happy to remove the second commit if asked. 