### PR TITLE
report which datetime couldn't be converted

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -280,13 +280,13 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                 Zone::East(i) => match FixedOffset::east_opt((*i as i32) * HOUR) {
                     Some(eastoffset) => match_datetime!(eastoffset.timestamp_opt(ts, 0)),
                     None => Value::Error {
-                        error: ShellError::DatetimeParseError(*span),
+                        error: ShellError::DatetimeParseError(input.debug_value(), *span),
                     },
                 },
                 Zone::West(i) => match FixedOffset::west_opt((*i as i32) * HOUR) {
                     Some(westoffset) => match_datetime!(westoffset.timestamp_opt(ts, 0)),
                     None => Value::Error {
-                        error: ShellError::DatetimeParseError(*span),
+                        error: ShellError::DatetimeParseError(input.debug_value(), *span),
                     },
                 },
                 Zone::Error => Value::Error {

--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -149,7 +149,7 @@ fn format_helper(value: Value, formatter: &str, formatter_span: Span, head_span:
             }
         }
         _ => Value::Error {
-            error: ShellError::DatetimeParseError(head_span),
+            error: ShellError::DatetimeParseError(value.debug_value(), head_span),
         },
     }
 }
@@ -174,7 +174,7 @@ fn format_helper_rfc2822(value: Value, span: Span) -> Value {
             }
         }
         _ => Value::Error {
-            error: ShellError::DatetimeParseError(span),
+            error: ShellError::DatetimeParseError(value.debug_value(), span),
         },
     }
 }

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -90,7 +90,7 @@ fn helper(value: Value, head: Span) -> Value {
             span: head,
         },
         _ => Value::Error {
-            error: ShellError::DatetimeParseError(head),
+            error: ShellError::DatetimeParseError(value.debug_value(), head),
         },
     }
 }

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -149,7 +149,7 @@ fn helper(val: Value, head: Span) -> Value {
         }
         Value::Date { val, span: _ } => parse_date_into_table(Ok(val), head),
         _ => Value::Error {
-            error: DatetimeParseError(head),
+            error: DatetimeParseError(val.debug_value(), head),
         },
     }
 }

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -155,7 +155,7 @@ fn helper(val: Value, head: Span) -> Value {
         }
         Value::Date { val, span: _ } => parse_date_into_table(Ok(val), head),
         _ => Value::Error {
-            error: DatetimeParseError(head),
+            error: DatetimeParseError(val.debug_value(), head),
         },
     }
 }

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -128,7 +128,7 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
             _to_timezone(dt.with_timezone(dt.offset()), timezone, head)
         }
         _ => Value::Error {
-            error: ShellError::DatetimeParseError(head),
+            error: ShellError::DatetimeParseError(value.debug_value(), head),
         },
     }
 }

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -15,12 +15,12 @@ pub(crate) fn parse_date_from_string(
                 LocalResult::Single(d) => Ok(d),
                 LocalResult::Ambiguous(d, _) => Ok(d),
                 LocalResult::None => Err(Value::Error {
-                    error: ShellError::DatetimeParseError(span),
+                    error: ShellError::DatetimeParseError(input.to_string(), span),
                 }),
             }
         }
         Err(_) => Err(Value::Error {
-            error: ShellError::DatetimeParseError(span),
+            error: ShellError::DatetimeParseError(input.to_string(), span),
         }),
     }
 }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -522,7 +522,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     /// * "2020-04-12 22:10:57 +02:00"
     /// * "2020-04-12T22:10:57.213231+02:00"
     /// * "Tue, 1 Jul 2003 10:52:37 +0200""#
-    #[error("Unable to parse datetime")]
+    #[error("Unable to parse datetime: [{0}].")]
     #[diagnostic(
         code(nu::shell::datetime_parse_error),
         url(docsrs),
@@ -536,7 +536,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
  * "Tue, 1 Jul 2003 10:52:37 +0200""#
         )
     )]
-    DatetimeParseError(#[label("datetime parsing failed")] Span),
+    DatetimeParseError(String, #[label("datetime parsing failed")] Span),
 
     /// A network operation failed.
     ///


### PR DESCRIPTION
# Description

This PR will help report a bad date that can't be converted where the error message says `* Unable to parse datetime`. This is helpful when you're converting a big table and it fails somewhere that you really can't see. I put it in `[]` so that when it's null, you can see that there should be something there.

Before:
```
> 'Tue 1 0' | into datetime 
Error: nu::shell::datetime_parse_error (link)

  × Unable to parse datetime
   ╭─[entry #1:1:1]
 1 │ 'Tue 1 0' | into datetime
   · ────┬────
   ·     ╰── datetime parsing failed
   ╰────
  help: Examples of supported inputs:
         * "5 pm"
         * "2020/12/4"
         * "2020.12.04 22:10 +2"
         * "2020-04-12 22:10:57 +02:00"
         * "2020-04-12T22:10:57.213231+02:00"
         * "Tue, 1 Jul 2003 10:52:37 +0200"
```
After:
```
> 'Tue 1 0' | into datetime
Error: nu::shell::datetime_parse_error (link)

  × Unable to parse datetime: [Tue 1 0].
   ╭─[entry #4:1:1]
 1 │ 'Tue 1 0' | into datetime
   · ────┬────
   ·     ╰── datetime parsing failed
   ╰────
  help: Examples of supported inputs:
         * "5 pm"
         * "2020/12/4"
         * "2020.12.04 22:10 +2"
         * "2020-04-12 22:10:57 +02:00"
         * "2020-04-12T22:10:57.213231+02:00"
         * "Tue, 1 Jul 2003 10:52:37 +0200"
```

# User-Facing Changes

New format for the error message.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
