### PR TITLE
Update few examples of math commands

### DIFF
--- a/crates/nu-command/src/math/cos.rs
+++ b/crates/nu-command/src/math/cos.rs
@@ -48,7 +48,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Apply the cosine to pi",
+                description: "Apply the cosine to π",
                 example: "math pi | math cos",
                 result: Some(Value::test_float(-1f64)),
             },

--- a/crates/nu-command/src/math/tan.rs
+++ b/crates/nu-command/src/math/tan.rs
@@ -48,7 +48,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Apply the tangent to pi/4",
+                description: "Apply the tangent to π/4",
                 example: "(math pi) / 4 | math tan",
                 result: Some(Value::test_float(1f64)),
             },

--- a/crates/nu-command/src/math/tanh.rs
+++ b/crates/nu-command/src/math/tanh.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Apply the hyperbolic tangent to 10*pi",
+            description: "Apply the hyperbolic tangent to 10*π",
             example: "(math pi) * 10 | math tanh",
             result: Some(Value::test_float(1f64)),
         }]

--- a/crates/nu-command/src/math/tau.rs
+++ b/crates/nu-command/src/math/tau.rs
@@ -29,9 +29,9 @@ impl Command for SubCommand {
     #[allow(clippy::approx_constant)]
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            example: "(math tau) / 2",
-            description: "Compare π and τ",
-            result: Some(Value::test_float(std::f64::consts::PI)),
+            example: "math tau | math round --precision 2",
+            description: "Get the first two decimal digits of τ",
+            result: Some(Value::test_float(6.28)),
         }]
     }
 


### PR DESCRIPTION
# Description

I just updated a few examples linked to math commands.

I used the character of pi where possible, and I updated one example since the example was misleading IMO (for the tau command).

# User-Facing Changes

Only examples have been updated, there is no real user changes.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
