### PR TITLE
http: add `--insecure` flag to `http get`, share common code

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -1,0 +1,9 @@
+// Only panics if the user agent is invalid but we define it statically so either
+// it always or never fails
+pub fn http_client(allow_insecure: bool) -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .user_agent("nushell")
+        .danger_accept_invalid_certs(allow_insecure)
+        .build()
+        .expect("Failed to build reqwest client")
+}

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -61,6 +61,11 @@ impl Command for SubCommand {
                 "fetch contents as text rather than a table",
                 Some('r'),
             )
+            .switch(
+                "insecure",
+                "allow insecure server connections when using SSL",
+                Some('k'),
+            )
             .filter()
             .category(Category::Network)
     }
@@ -113,6 +118,7 @@ impl Command for SubCommand {
 struct Arguments {
     url: Value,
     raw: bool,
+    insecure: Option<bool>,
     user: Option<String>,
     password: Option<String>,
     timeout: Option<Value>,
@@ -128,6 +134,7 @@ fn run_fetch(
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,
         raw: call.has_flag("raw"),
+        insecure: call.get_flag(engine_state, stack, "insecure")?,
         user: call.get_flag(engine_state, stack, "user")?,
         password: call.get_flag(engine_state, stack, "password")?,
         timeout: call.get_flag(engine_state, stack, "timeout")?,
@@ -184,7 +191,7 @@ fn helper(
         _ => None,
     };
 
-    let client = http_client(false);
+    let client = http_client(args.insecure.is_some());
     let mut request = client.get(url);
 
     if let Some(timeout) = timeout {

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -1,3 +1,4 @@
+use crate::network::http::client::http_client;
 use base64::{alphabet, engine::general_purpose::PAD, engine::GeneralPurpose, Engine};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -183,7 +184,7 @@ fn helper(
         _ => None,
     };
 
-    let client = http_client();
+    let client = http_client(false);
     let mut request = client.get(url);
 
     if let Some(timeout) = timeout {
@@ -406,14 +407,4 @@ fn response_to_buffer(
         metadata: None,
         trim_end_newline: false,
     }
-}
-
-// Only panics if the user agent is invalid but we define it statically so either
-// it always or never fails
-#[allow(clippy::unwrap_used)]
-fn http_client() -> reqwest::blocking::Client {
-    reqwest::blocking::Client::builder()
-        .user_agent("nushell")
-        .build()
-        .unwrap()
 }

--- a/crates/nu-command/src/network/http/mod.rs
+++ b/crates/nu-command/src/network/http/mod.rs
@@ -1,3 +1,4 @@
+mod client;
 mod get;
 mod http_;
 mod post;

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -14,6 +14,8 @@ use std::io::BufReader;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use crate::network::http::client::http_client;
+
 #[derive(Clone)]
 pub struct SubCommand;
 
@@ -92,6 +94,7 @@ impl Command for SubCommand {
     ) -> Result<PipelineData, ShellError> {
         run_post(engine_state, stack, call, input)
     }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
@@ -429,13 +432,4 @@ fn response_to_buffer(
         metadata: None,
         trim_end_newline: false,
     }
-}
-// Only panics if the user agent is invalid but we define it statically so either
-// it always or never fails
-fn http_client(allow_insecure: bool) -> reqwest::blocking::Client {
-    reqwest::blocking::Client::builder()
-        .user_agent("nushell")
-        .danger_accept_invalid_certs(allow_insecure)
-        .build()
-        .expect("Failed to build reqwest client")
 }

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -432,7 +432,6 @@ fn response_to_buffer(
 }
 // Only panics if the user agent is invalid but we define it statically so either
 // it always or never fails
-#[allow(clippy::unwrap_used)]
 fn http_client(allow_insecure: bool) -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
         .user_agent("nushell")


### PR DESCRIPTION
# Description

I factorized the HTTP client from HTTP Post and HTTP Get into a common file, in order to reduce the code duplication. This PR has to be looked commit by commit.

# User-Facing Changes

A new option has been to HTTP Get: `--insecure`. This option was already available for HTTP Post command.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
