### PR TITLE
Add dfr to dataframe cmds

### DIFF
--- a/crates/nu-command/src/dataframe/eager/append.rs
+++ b/crates/nu-command/src/dataframe/eager/append.rs
@@ -12,7 +12,7 @@ pub struct AppendDF;
 
 impl Command for AppendDF {
     fn name(&self) -> &str {
-        "append"
+        "dfr append"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/append.rs
+++ b/crates/nu-command/src/dataframe/eager/append.rs
@@ -32,8 +32,8 @@ impl Command for AppendDF {
         vec![
             Example {
                 description: "Appends a dataframe as new columns",
-                example: r#"let a = ([[a b]; [1 2] [3 4]] | into df);
-    $a | append $a"#,
+                example: r#"let a = ([[a b]; [1 2] [3 4]] | dfr into-df);
+    $a | dfr append $a"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -59,8 +59,8 @@ impl Command for AppendDF {
             },
             Example {
                 description: "Appends a dataframe merging at the end of columns",
-                example: r#"let a = ([[a b]; [1 2] [3 4]] | into df);
-    $a | append $a --col"#,
+                example: r#"let a = ([[a b]; [1 2] [3 4]] | dfr into-df);
+    $a | dfr append $a --col"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/eager/columns.rs
+++ b/crates/nu-command/src/dataframe/eager/columns.rs
@@ -10,7 +10,7 @@ pub struct ColumnsDF;
 
 impl Command for ColumnsDF {
     fn name(&self) -> &str {
-        "columns"
+        "dfr columns"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/columns.rs
+++ b/crates/nu-command/src/dataframe/eager/columns.rs
@@ -27,7 +27,7 @@ impl Command for ColumnsDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Dataframe columns",
-            example: "[[a b]; [1 2] [3 4]] | into df | columns",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr columns",
             result: Some(Value::List {
                 vals: vec![Value::test_string("a"), Value::test_string("b")],
                 span: Span::test_data(),

--- a/crates/nu-command/src/dataframe/eager/drop.rs
+++ b/crates/nu-command/src/dataframe/eager/drop.rs
@@ -31,7 +31,7 @@ impl Command for DropDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop column a",
-            example: "[[a b]; [1 2] [3 4]] | into df | drop a",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr drop a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "b".to_string(),

--- a/crates/nu-command/src/dataframe/eager/drop.rs
+++ b/crates/nu-command/src/dataframe/eager/drop.rs
@@ -13,7 +13,7 @@ pub struct DropDF;
 
 impl Command for DropDF {
     fn name(&self) -> &str {
-        "drop"
+        "dfr drop"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
@@ -14,7 +14,7 @@ pub struct DropDuplicates;
 
 impl Command for DropDuplicates {
     fn name(&self) -> &str {
-        "drop-duplicates"
+        "dfr drop-duplicates"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
@@ -42,7 +42,7 @@ impl Command for DropDuplicates {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop duplicates",
-            example: "[[a b]; [1 2] [3 4] [1 2]] | into df | drop-duplicates",
+            example: "[[a b]; [1 2] [3 4] [1 2]] | dfr into-df | dfr drop-duplicates",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_nulls.rs
@@ -13,7 +13,7 @@ pub struct DropNulls;
 
 impl Command for DropNulls {
     fn name(&self) -> &str {
-        "drop-nulls"
+        "dfr drop-nulls"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_nulls.rs
@@ -36,10 +36,10 @@ impl Command for DropNulls {
         vec![
             Example {
                 description: "drop null values in dataframe",
-                example: r#"let df = ([[a b]; [1 2] [3 0] [1 2]] | into df);
+                example: r#"let df = ([[a b]; [1 2] [3 0] [1 2]] | dfr into-df);
     let res = ($df.b / $df.b);
-    let a = ($df | with-column $res --name res);
-    $a | drop-nulls"#,
+    let a = ($df | dfr with-column $res --name res);
+    $a | dfr drop-nulls"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -61,8 +61,8 @@ impl Command for DropNulls {
             },
             Example {
                 description: "drop null values in dataframe",
-                example: r#"let s = ([1 2 0 0 3 4] | into df);
-    ($s / $s) | drop-nulls"#,
+                example: r#"let s = ([1 2 0 0 3 4] | dfr into-df);
+    ($s / $s) | dfr drop-nulls"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "div_0_0".to_string(),

--- a/crates/nu-command/src/dataframe/eager/dtypes.rs
+++ b/crates/nu-command/src/dataframe/eager/dtypes.rs
@@ -10,7 +10,7 @@ pub struct DataTypes;
 
 impl Command for DataTypes {
     fn name(&self) -> &str {
-        "dtypes"
+        "dfr dtypes"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/dtypes.rs
+++ b/crates/nu-command/src/dataframe/eager/dtypes.rs
@@ -27,7 +27,7 @@ impl Command for DataTypes {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Dataframe dtypes",
-            example: "[[a b]; [1 2] [3 4]] | into df | dtypes",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr dtypes",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/dummies.rs
+++ b/crates/nu-command/src/dataframe/eager/dummies.rs
@@ -11,7 +11,7 @@ pub struct Dummies;
 
 impl Command for Dummies {
     fn name(&self) -> &str {
-        "dummies"
+        "dfr dummies"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/dummies.rs
+++ b/crates/nu-command/src/dataframe/eager/dummies.rs
@@ -29,7 +29,7 @@ impl Command for Dummies {
         vec![
             Example {
                 description: "Create new dataframe with dummy variables from a dataframe",
-                example: "[[a b]; [1 2] [3 4]] | into df | dummies",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr dummies",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -55,7 +55,7 @@ impl Command for Dummies {
             },
             Example {
                 description: "Create new dataframe with dummy variables from a series",
-                example: "[1 2 2 3 3] | into df | dummies",
+                example: "[1 2 2 3 3] | dfr into-df | dfr dummies",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-command/src/dataframe/eager/filter_with.rs
@@ -38,8 +38,8 @@ impl Command for FilterWith {
         vec![
             Example {
                 description: "Filter dataframe using a bool mask",
-                example: r#"let mask = ([true false] | into df);
-    [[a b]; [1 2] [3 4]] | into df | filter-with $mask"#,
+                example: r#"let mask = ([true false] | dfr into-df);
+    [[a b]; [1 2] [3 4]] | dfr into-df | dfr filter-with $mask"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(1)]),
@@ -51,7 +51,7 @@ impl Command for FilterWith {
             },
             Example {
                 description: "Filter dataframe using an expression",
-                example: "[[a b]; [1 2] [3 4]] | into df | filter-with ((col a) > 1)",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr filter-with ((dfr col a) > 1)",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(3)]),

--- a/crates/nu-command/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-command/src/dataframe/eager/filter_with.rs
@@ -15,7 +15,7 @@ pub struct FilterWith;
 
 impl Command for FilterWith {
     fn name(&self) -> &str {
-        "filter-with"
+        "dfr filter-with"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/first.rs
+++ b/crates/nu-command/src/dataframe/eager/first.rs
@@ -11,7 +11,7 @@ pub struct FirstDF;
 
 impl Command for FirstDF {
     fn name(&self) -> &str {
-        "first"
+        "dfr first"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/first.rs
+++ b/crates/nu-command/src/dataframe/eager/first.rs
@@ -34,7 +34,7 @@ impl Command for FirstDF {
         vec![
             Example {
                 description: "Return the first row of a dataframe",
-                example: "[[a b]; [1 2] [3 4]] | into df | first",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr first",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(1)]),
@@ -46,7 +46,7 @@ impl Command for FirstDF {
             },
             Example {
                 description: "Return the first two rows of a dataframe",
-                example: "[[a b]; [1 2] [3 4]] | into df | first 2",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr first 2",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/eager/get.rs
+++ b/crates/nu-command/src/dataframe/eager/get.rs
@@ -14,7 +14,7 @@ pub struct GetDF;
 
 impl Command for GetDF {
     fn name(&self) -> &str {
-        "get"
+        "dfr get"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/get.rs
+++ b/crates/nu-command/src/dataframe/eager/get.rs
@@ -32,7 +32,7 @@ impl Command for GetDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns the selected column",
-            example: "[[a b]; [1 2] [3 4]] | into df | get a",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr get a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),

--- a/crates/nu-command/src/dataframe/eager/last.rs
+++ b/crates/nu-command/src/dataframe/eager/last.rs
@@ -11,7 +11,7 @@ pub struct LastDF;
 
 impl Command for LastDF {
     fn name(&self) -> &str {
-        "last"
+        "dfr last"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/last.rs
+++ b/crates/nu-command/src/dataframe/eager/last.rs
@@ -29,7 +29,7 @@ impl Command for LastDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create new dataframe with last rows",
-            example: "[[a b]; [1 2] [3 4]] | into df | last 1",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr last 1",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_int(3)]),

--- a/crates/nu-command/src/dataframe/eager/list.rs
+++ b/crates/nu-command/src/dataframe/eager/list.rs
@@ -11,7 +11,7 @@ pub struct ListDF;
 
 impl Command for ListDF {
     fn name(&self) -> &str {
-        "ls-df"
+        "dfr ls-df"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/list.rs
+++ b/crates/nu-command/src/dataframe/eager/list.rs
@@ -11,7 +11,7 @@ pub struct ListDF;
 
 impl Command for ListDF {
     fn name(&self) -> &str {
-        "dfr ls-df"
+        "dfr ls"
     }
 
     fn usage(&self) -> &str {
@@ -25,8 +25,8 @@ impl Command for ListDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a new dataframe and shows it in the dataframe list",
-            example: r#"let test = ([[a b];[1 2] [3 4]] | into df);
-    ls-df"#,
+            example: r#"let test = ([[a b];[1 2] [3 4]] | dfr into-df);
+    ls"#,
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/eager/melt.rs
+++ b/crates/nu-command/src/dataframe/eager/melt.rs
@@ -15,7 +15,7 @@ pub struct MeltDF;
 
 impl Command for MeltDF {
     fn name(&self) -> &str {
-        "melt"
+        "dfr melt"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/melt.rs
+++ b/crates/nu-command/src/dataframe/eager/melt.rs
@@ -57,7 +57,7 @@ impl Command for MeltDF {
         vec![Example {
             description: "melt dataframe",
             example:
-                "[[a b c d]; [x 1 4 a] [y 2 5 b] [z 3 6 c]] | into df | melt -c [b c] -v [a d]",
+                "[[a b c d]; [x 1 4 a] [y 2 5 b] [z 3 6 c]] | dfr into-df | dfr melt -c [b c] -v [a d]",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/open.rs
+++ b/crates/nu-command/src/dataframe/eager/open.rs
@@ -18,7 +18,7 @@ pub struct OpenDataFrame;
 
 impl Command for OpenDataFrame {
     fn name(&self) -> &str {
-        "dfr open-df"
+        "dfr open"
     }
 
     fn usage(&self) -> &str {
@@ -76,7 +76,7 @@ impl Command for OpenDataFrame {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Takes a file name and creates a dataframe",
-            example: "open test.csv",
+            example: "dfr open test.csv",
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/eager/open.rs
+++ b/crates/nu-command/src/dataframe/eager/open.rs
@@ -18,7 +18,7 @@ pub struct OpenDataFrame;
 
 impl Command for OpenDataFrame {
     fn name(&self) -> &str {
-        "open-df"
+        "dfr open-df"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/query_df.rs
+++ b/crates/nu-command/src/dataframe/eager/query_df.rs
@@ -18,7 +18,7 @@ pub struct QueryDf;
 
 impl Command for QueryDf {
     fn name(&self) -> &str {
-        "query df"
+        "dfr query-df"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/query_df.rs
+++ b/crates/nu-command/src/dataframe/eager/query_df.rs
@@ -18,7 +18,7 @@ pub struct QueryDf;
 
 impl Command for QueryDf {
     fn name(&self) -> &str {
-        "dfr query-df"
+        "dfr query"
     }
 
     fn usage(&self) -> &str {
@@ -40,7 +40,7 @@ impl Command for QueryDf {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Query dataframe using SQL",
-            example: "[[a b]; [1 2] [3 4]] | into df | query df 'select a from df'",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr query 'select a from df'",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),

--- a/crates/nu-command/src/dataframe/eager/rename.rs
+++ b/crates/nu-command/src/dataframe/eager/rename.rs
@@ -42,7 +42,7 @@ impl Command for RenameDF {
         vec![
             Example {
                 description: "Renames a series",
-                example: "[5 6 7 8] | into df | rename '0' new_name",
+                example: "[5 6 7 8] | dfr into-df | dfr rename '0' new_name",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "new_name".to_string(),
@@ -59,7 +59,7 @@ impl Command for RenameDF {
             },
             Example {
                 description: "Renames a dataframe column",
-                example: "[[a b]; [1 2] [3 4]] | into df | rename a a_new",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr rename a a_new",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -77,7 +77,7 @@ impl Command for RenameDF {
             },
             Example {
                 description: "Renames two dataframe columns",
-                example: "[[a b]; [1 2] [3 4]] | into df | rename [a b] [a_new b_new]",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr rename [a b] [a_new b_new]",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/eager/rename.rs
+++ b/crates/nu-command/src/dataframe/eager/rename.rs
@@ -14,7 +14,7 @@ pub struct RenameDF;
 
 impl Command for RenameDF {
     fn name(&self) -> &str {
-        "rename"
+        "dfr rename"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/sample.rs
+++ b/crates/nu-command/src/dataframe/eager/sample.rs
@@ -12,7 +12,7 @@ pub struct SampleDF;
 
 impl Command for SampleDF {
     fn name(&self) -> &str {
-        "sample"
+        "dfr sample"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/sample.rs
+++ b/crates/nu-command/src/dataframe/eager/sample.rs
@@ -50,12 +50,12 @@ impl Command for SampleDF {
         vec![
             Example {
                 description: "Sample rows from dataframe",
-                example: "[[a b]; [1 2] [3 4]] | into df | sample -n 1",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr sample -n 1",
                 result: None, // No expected value because sampling is random
             },
             Example {
                 description: "Shows sample row using fraction and replace",
-                example: "[[a b]; [1 2] [3 4] [5 6]] | into df | sample -f 0.5 -e",
+                example: "[[a b]; [1 2] [3 4] [5 6]] | dfr into-df | dfr sample -f 0.5 -e",
                 result: None, // No expected value because sampling is random
             },
         ]

--- a/crates/nu-command/src/dataframe/eager/shape.rs
+++ b/crates/nu-command/src/dataframe/eager/shape.rs
@@ -13,7 +13,7 @@ pub struct ShapeDF;
 
 impl Command for ShapeDF {
     fn name(&self) -> &str {
-        "shape"
+        "dfr shape"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/shape.rs
+++ b/crates/nu-command/src/dataframe/eager/shape.rs
@@ -30,7 +30,7 @@ impl Command for ShapeDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shows row and column shape",
-            example: "[[a b]; [1 2] [3 4]] | into df | shape",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr shape",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("rows".to_string(), vec![Value::test_int(2)]),

--- a/crates/nu-command/src/dataframe/eager/slice.rs
+++ b/crates/nu-command/src/dataframe/eager/slice.rs
@@ -33,7 +33,7 @@ impl Command for SliceDF {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create new dataframe from a slice of the rows",
-            example: "[[a b]; [1 2] [3 4]] | into df | slice 0 1",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr slice 0 1",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_int(1)]),

--- a/crates/nu-command/src/dataframe/eager/slice.rs
+++ b/crates/nu-command/src/dataframe/eager/slice.rs
@@ -14,7 +14,7 @@ pub struct SliceDF;
 
 impl Command for SliceDF {
     fn name(&self) -> &str {
-        "slice"
+        "dfr slice"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/summary.rs
+++ b/crates/nu-command/src/dataframe/eager/summary.rs
@@ -19,7 +19,7 @@ pub struct Summary;
 
 impl Command for Summary {
     fn name(&self) -> &str {
-        "summary"
+        "dfr summary"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/summary.rs
+++ b/crates/nu-command/src/dataframe/eager/summary.rs
@@ -42,7 +42,7 @@ impl Command for Summary {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "list dataframe descriptives",
-            example: "[[a b]; [1 1] [1 1]] | into df | summary",
+            example: "[[a b]; [1 1] [1 1]] | dfr into-df | dfr summary",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/eager/take.rs
+++ b/crates/nu-command/src/dataframe/eager/take.rs
@@ -15,7 +15,7 @@ pub struct TakeDF;
 
 impl Command for TakeDF {
     fn name(&self) -> &str {
-        "take"
+        "dfr take"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/take.rs
+++ b/crates/nu-command/src/dataframe/eager/take.rs
@@ -38,9 +38,9 @@ impl Command for TakeDF {
         vec![
             Example {
                 description: "Takes selected rows from dataframe",
-                example: r#"let df = ([[a b]; [4 1] [5 2] [4 3]] | into df);
-    let indices = ([0 2] | into df);
-    $df | take $indices"#,
+                example: r#"let df = ([[a b]; [4 1] [5 2] [4 3]] | dfr into-df);
+    let indices = ([0 2] | dfr into-df);
+    $df | dfr take $indices"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -58,9 +58,9 @@ impl Command for TakeDF {
             },
             Example {
                 description: "Takes selected rows from series",
-                example: r#"let series = ([4 1 5 2 4 3] | into df);
-    let indices = ([0 2] | into df);
-    $series | take $indices"#,
+                example: r#"let series = ([4 1 5 2 4 3] | dfr into-df);
+    let indices = ([0 2] | dfr into-df);
+    $series | dfr take $indices"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),

--- a/crates/nu-command/src/dataframe/eager/to_arrow.rs
+++ b/crates/nu-command/src/dataframe/eager/to_arrow.rs
@@ -33,7 +33,7 @@ impl Command for ToArrow {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Saves dataframe to arrow file",
-            example: "[[a b]; [1 2] [3 4]] | into df | to arrow test.arrow",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr to-arrow test.arrow",
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/eager/to_arrow.rs
+++ b/crates/nu-command/src/dataframe/eager/to_arrow.rs
@@ -15,7 +15,7 @@ pub struct ToArrow;
 
 impl Command for ToArrow {
     fn name(&self) -> &str {
-        "to arrow"
+        "dfr to-arrow"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/to_csv.rs
+++ b/crates/nu-command/src/dataframe/eager/to_csv.rs
@@ -15,7 +15,7 @@ pub struct ToCSV;
 
 impl Command for ToCSV {
     fn name(&self) -> &str {
-        "to csv"
+        "dfr to-csv"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/to_csv.rs
+++ b/crates/nu-command/src/dataframe/eager/to_csv.rs
@@ -41,12 +41,12 @@ impl Command for ToCSV {
         vec![
             Example {
                 description: "Saves dataframe to csv file",
-                example: "[[a b]; [1 2] [3 4]] | into df | to csv test.csv",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr to-csv test.csv",
                 result: None,
             },
             Example {
                 description: "Saves dataframe to csv file using other delimiter",
-                example: "[[a b]; [1 2] [3 4]] | into df | to csv test.csv -d '|'",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr to-csv test.csv -d '|'",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/dataframe/eager/to_df.rs
+++ b/crates/nu-command/src/dataframe/eager/to_df.rs
@@ -11,7 +11,7 @@ pub struct ToDataFrame;
 
 impl Command for ToDataFrame {
     fn name(&self) -> &str {
-        "into df"
+        "dfr into-df"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/to_df.rs
+++ b/crates/nu-command/src/dataframe/eager/to_df.rs
@@ -29,7 +29,7 @@ impl Command for ToDataFrame {
         vec![
             Example {
                 description: "Takes a dictionary and creates a dataframe",
-                example: "[[a b];[1 2] [3 4]] | into df",
+                example: "[[a b];[1 2] [3 4]] | dfr into-df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -47,7 +47,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list of tables and creates a dataframe",
-                example: "[[1 2 a] [3 4 b] [5 6 c]] | into df",
+                example: "[[1 2 a] [3 4 b] [5 6 c]] | dfr into-df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -73,7 +73,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list and creates a dataframe",
-                example: "[a b c] | into df",
+                example: "[a b c] | dfr into-df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),
@@ -89,7 +89,7 @@ impl Command for ToDataFrame {
             },
             Example {
                 description: "Takes a list of booleans and creates a dataframe",
-                example: "[true true false] | into df",
+                example: "[true true false] | dfr into-df",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),

--- a/crates/nu-command/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-command/src/dataframe/eager/to_nu.rs
@@ -12,7 +12,7 @@ pub struct ToNu;
 
 impl Command for ToNu {
     fn name(&self) -> &str {
-        "into nu"
+        "dfr into-nu"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-command/src/dataframe/eager/to_nu.rs
@@ -54,7 +54,7 @@ impl Command for ToNu {
         vec![
             Example {
                 description: "Shows head rows from dataframe",
-                example: "[[a b]; [1 2] [3 4]] | into df | into nu",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr into-nu",
                 result: Some(Value::List {
                     vals: vec![rec_1, rec_2],
                     span: Span::test_data(),
@@ -62,7 +62,7 @@ impl Command for ToNu {
             },
             Example {
                 description: "Shows tail rows from dataframe",
-                example: "[[a b]; [1 2] [5 6] [3 4]] | into df | into nu -t -n 1",
+                example: "[[a b]; [1 2] [5 6] [3 4]] | dfr into-df | dfr into-nu -t -n 1",
                 result: Some(Value::List {
                     vals: vec![rec_3],
                     span: Span::test_data(),

--- a/crates/nu-command/src/dataframe/eager/to_parquet.rs
+++ b/crates/nu-command/src/dataframe/eager/to_parquet.rs
@@ -15,7 +15,7 @@ pub struct ToParquet;
 
 impl Command for ToParquet {
     fn name(&self) -> &str {
-        "to parquet"
+        "dfr to-parquet"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/to_parquet.rs
+++ b/crates/nu-command/src/dataframe/eager/to_parquet.rs
@@ -33,7 +33,7 @@ impl Command for ToParquet {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Saves dataframe to parquet file",
-            example: "[[a b]; [1 2] [3 4]] | into df | to parquet test.parquet",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr to-parquet test.parquet",
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/eager/with_column.rs
+++ b/crates/nu-command/src/dataframe/eager/with_column.rs
@@ -12,7 +12,7 @@ pub struct WithColumn;
 
 impl Command for WithColumn {
     fn name(&self) -> &str {
-        "with-column"
+        "dfr with-column"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/eager/with_column.rs
+++ b/crates/nu-command/src/dataframe/eager/with_column.rs
@@ -37,8 +37,8 @@ impl Command for WithColumn {
             Example {
                 description: "Adds a series to the dataframe",
                 example: r#"[[a b]; [1 2] [3 4]]
-    | into df
-    | with-column ([5 6] | into df) --name c"#,
+    | dfr into-df
+    | dfr with-column ([5 6] | dfr into-df) --name c"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -61,12 +61,12 @@ impl Command for WithColumn {
             Example {
                 description: "Adds a series to the dataframe",
                 example: r#"[[a b]; [1 2] [3 4]]
-    | into lazy
-    | with-column [
-        ((col a) * 2 | as "c")
-        ((col a) * 3 | as "d")
+    | dfr into-lazy
+    | dfr with-column [
+        ((dfr col a) * 2 | dfr as "c")
+        ((dfr col a) * 3 | dfr as "d")
       ]
-    | collect"#,
+    | dfr collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/expressions/alias.rs
+++ b/crates/nu-command/src/dataframe/expressions/alias.rs
@@ -12,7 +12,7 @@ pub struct ExprAlias;
 
 impl Command for ExprAlias {
     fn name(&self) -> &str {
-        "as"
+        "dfr as"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/alias.rs
+++ b/crates/nu-command/src/dataframe/expressions/alias.rs
@@ -34,7 +34,7 @@ impl Command for ExprAlias {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates and alias expression",
-            example: "col a | as new_a | into nu",
+            example: "dfr col a | dfr as new_a | dfr into-nu",
             result: {
                 let cols = vec!["expr".into(), "value".into()];
                 let expr = Value::test_string("column");

--- a/crates/nu-command/src/dataframe/expressions/arg_where.rs
+++ b/crates/nu-command/src/dataframe/expressions/arg_where.rs
@@ -12,7 +12,7 @@ pub struct ExprArgWhere;
 
 impl Command for ExprArgWhere {
     fn name(&self) -> &str {
-        "arg-where"
+        "dfr arg-where"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/arg_where.rs
+++ b/crates/nu-command/src/dataframe/expressions/arg_where.rs
@@ -30,8 +30,8 @@ impl Command for ExprArgWhere {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Return a dataframe where the value match the expression",
-            example: "let df = ([[a b]; [one 1] [two 2] [three 3]] | into df);
-    $df | select (arg-where ((col b) >= 2) | as b_arg)",
+            example: "let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
+    $df | dfr select (dfr arg-where ((dfr col b) >= 2) | dfr as b_arg)",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "b_arg".to_string(),

--- a/crates/nu-command/src/dataframe/expressions/as_nu.rs
+++ b/crates/nu-command/src/dataframe/expressions/as_nu.rs
@@ -28,7 +28,7 @@ impl Command for ExprAsNu {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Convert a col expression into a nushell value",
-            example: "col a | into nu",
+            example: "dfr col a | dfr into-nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![Value::test_string("column"), Value::test_string("a")],

--- a/crates/nu-command/src/dataframe/expressions/as_nu.rs
+++ b/crates/nu-command/src/dataframe/expressions/as_nu.rs
@@ -11,7 +11,7 @@ pub struct ExprAsNu;
 
 impl Command for ExprAsNu {
     fn name(&self) -> &str {
-        "into nu"
+        "dfr into-nu"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/col.rs
+++ b/crates/nu-command/src/dataframe/expressions/col.rs
@@ -12,7 +12,7 @@ pub struct ExprCol;
 
 impl Command for ExprCol {
     fn name(&self) -> &str {
-        "col"
+        "dfr col"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/col.rs
+++ b/crates/nu-command/src/dataframe/expressions/col.rs
@@ -34,7 +34,7 @@ impl Command for ExprCol {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a named column expression and converts it to a nu object",
-            example: "col a | into nu",
+            example: "dfr col a | dfr into-nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![Value::test_string("column"), Value::test_string("a")],

--- a/crates/nu-command/src/dataframe/expressions/concat_str.rs
+++ b/crates/nu-command/src/dataframe/expressions/concat_str.rs
@@ -12,7 +12,7 @@ pub struct ExprConcatStr;
 
 impl Command for ExprConcatStr {
     fn name(&self) -> &str {
-        "concat-str"
+        "dfr concat-str"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/concat_str.rs
+++ b/crates/nu-command/src/dataframe/expressions/concat_str.rs
@@ -39,8 +39,8 @@ impl Command for ExprConcatStr {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a concat string expression",
-            example: r#"let df = ([[a b c]; [one two 1] [three four 2]] | into df);
-    $df | with-column ((concat-str "-" [(col a) (col b) ((col c) * 2)]) | as concat)"#,
+            example: r#"let df = ([[a b c]; [one two 1] [three four 2]] | dfr into-df);
+    $df | dfr with-column ((dfr concat-str "-" [(dfr col a) (dfr col b) ((dfr col c) * 2)]) | dfr as concat)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-command/src/dataframe/expressions/expressions_macro.rs
@@ -134,7 +134,7 @@ macro_rules! expr_command {
 // Expands to a command definition for a list expression
 expr_command!(
     ExprList,
-    "list",
+    "dfr list",
     "Aggregates a group to a Series",
     vec![Example {
         description: "",
@@ -149,7 +149,7 @@ expr_command!(
 // Expands to a command definition for a agg groups expression
 expr_command!(
     ExprAggGroups,
-    "agg-groups",
+    "dfr agg-groups",
     "creates an agg_groups expression",
     vec![Example {
         description: "",
@@ -164,7 +164,7 @@ expr_command!(
 // Expands to a command definition for a flatten expression
 expr_command!(
     ExprFlatten,
-    "flatten",
+    "dfr flatten",
     "creates a flatten expression",
     vec![Example {
         description: "",
@@ -179,7 +179,7 @@ expr_command!(
 // Expands to a command definition for a explode expression
 expr_command!(
     ExprExplode,
-    "explode",
+    "dfr explode",
     "creates an explode expression",
     vec![Example {
         description: "",
@@ -194,7 +194,7 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprCount,
-    "count",
+    "dfr count",
     "creates a count expression",
     vec![Example {
         description: "",
@@ -209,11 +209,11 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprFirst,
-    "first",
+    "dfr first",
     "creates a first expression",
     vec![Example {
         description: "Creates a first expression from a column",
-        example: "col a | first",
+        example: "dfr col a | dfr first",
         result: None,
     },],
     first,
@@ -224,11 +224,11 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprLast,
-    "last",
+    "dfr last",
     "creates a last expression",
     vec![Example {
         description: "Creates a last expression from a column",
-        example: "col a | last",
+        example: "dfr col a | dfr last",
         result: None,
     },],
     last,
@@ -239,11 +239,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprNUnique,
-    "n-unique",
+    "dfr n-unique",
     "creates a n-unique expression",
     vec![Example {
         description: "Creates a is n-unique expression from a column",
-        example: "col a | n-unique",
+        example: "dfr col a | dfr n-unique",
         result: None,
     },],
     n_unique,
@@ -254,11 +254,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprIsNotNull,
-    "is-not-null",
+    "dfr is-not-null",
     "creates a is not null expression",
     vec![Example {
         description: "Creates a is not null expression from a column",
-        example: "col a | is-not-null",
+        example: "dfr col a | dfr is-not-null",
         result: None,
     },],
     is_not_null,
@@ -269,11 +269,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprIsNull,
-    "is-null",
+    "dfr is-null",
     "creates a is null expression",
     vec![Example {
         description: "Creates a is null expression from a column",
-        example: "col a | is-null",
+        example: "dfr col a | dfr is-null",
         result: None,
     },],
     is_null,
@@ -284,11 +284,11 @@ expr_command!(
 // Expands to a command definition for a not expression
 expr_command!(
     ExprNot,
-    "expr-not",
+    "dfr expr-not",
     "creates a not expression",
     vec![Example {
         description: "Creates a not expression",
-        example: "(col a) > 2) | expr-not",
+        example: "(dfr col a) > 2) | dfr expr-not",
         result: None,
     },],
     not,
@@ -299,14 +299,14 @@ expr_command!(
 // Expands to a command definition for max aggregation
 expr_command!(
     ExprMax,
-    "max",
+    "dfr max",
     "Creates a max expression",
     vec![Example {
         description: "Max aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | into df
-    | group-by a
-    | agg (col b | max)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfr col b | dfr max)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -330,14 +330,14 @@ expr_command!(
 // Expands to a command definition for min aggregation
 expr_command!(
     ExprMin,
-    "min",
+    "dfr min",
     "Creates a min expression",
     vec![Example {
         description: "Min aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | into df
-    | group-by a
-    | agg (col b | min)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfr col b | dfr min)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -361,14 +361,14 @@ expr_command!(
 // Expands to a command definition for sum aggregation
 expr_command!(
     ExprSum,
-    "sum",
+    "dfr sum",
     "Creates a sum expression for an aggregation",
     vec![Example {
         description: "Sum aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | into df
-    | group-by a
-    | agg (col b | sum)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfr col b | dfr sum)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -392,14 +392,14 @@ expr_command!(
 // Expands to a command definition for mean aggregation
 expr_command!(
     ExprMean,
-    "mean",
+    "dfr mean",
     "Creates a mean expression for an aggregation",
     vec![Example {
         description: "Mean aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | into df
-    | group-by a
-    | agg (col b | mean)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfr col b | dfr mean)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -423,14 +423,14 @@ expr_command!(
 // Expands to a command definition for median aggregation
 expr_command!(
     ExprMedian,
-    "median",
+    "dfr median",
     "Creates a median expression for an aggregation",
     vec![Example {
         description: "Median aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | into df
-    | group-by a
-    | agg (col b | median)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfr col b | dfr median)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -454,14 +454,14 @@ expr_command!(
 // Expands to a command definition for std aggregation
 expr_command!(
     ExprStd,
-    "std",
+    "dfr std",
     "Creates a std expression for an aggregation",
     vec![Example {
         description: "Std aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | into df
-    | group-by a
-    | agg (col b | std)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfr col b | dfr std)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -486,14 +486,14 @@ expr_command!(
 // Expands to a command definition for var aggregation
 expr_command!(
     ExprVar,
-    "var",
+    "dfr var",
     "Create a var expression for an aggregation",
     vec![Example {
         description: "Var aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | into df
-    | group-by a
-    | agg (col b | var)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfr col b | dfr var)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(

--- a/crates/nu-command/src/dataframe/expressions/is_in.rs
+++ b/crates/nu-command/src/dataframe/expressions/is_in.rs
@@ -12,7 +12,7 @@ pub struct ExprIsIn;
 
 impl Command for ExprIsIn {
     fn name(&self) -> &str {
-        "is-in"
+        "dfr is-in"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/is_in.rs
+++ b/crates/nu-command/src/dataframe/expressions/is_in.rs
@@ -34,8 +34,8 @@ impl Command for ExprIsIn {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a is-in expression",
-            example: r#"let df = ([[a b]; [one 1] [two 2] [three 3]] | into df);
-    $df | with-column (col a | is-in [one two] | as a_in)"#,
+            example: r#"let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
+    $df | dfr with-column (dfr col a | dfr is-in [one two] | dfr as a_in)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/expressions/lit.rs
+++ b/crates/nu-command/src/dataframe/expressions/lit.rs
@@ -11,7 +11,7 @@ pub struct ExprLit;
 
 impl Command for ExprLit {
     fn name(&self) -> &str {
-        "lit"
+        "dfr lit"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/lit.rs
+++ b/crates/nu-command/src/dataframe/expressions/lit.rs
@@ -33,7 +33,7 @@ impl Command for ExprLit {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Created a literal expression and converts it to a nu object",
-            example: "lit 2 | into nu",
+            example: "dfr lit 2 | dfr into-nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![Value::test_string("literal"), Value::test_string("2i64")],

--- a/crates/nu-command/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-command/src/dataframe/expressions/otherwise.rs
@@ -11,7 +11,7 @@ pub struct ExprOtherwise;
 
 impl Command for ExprOtherwise {
     fn name(&self) -> &str {
-        "otherwise"
+        "dfr otherwise"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-command/src/dataframe/expressions/otherwise.rs
@@ -34,25 +34,26 @@ impl Command for ExprOtherwise {
         vec![
             Example {
                 description: "Create a when conditions",
-                example: "when ((col a) > 2) 4 | otherwise 5",
+                example: "dfr when ((dfr col a) > 2) 4 | dfr otherwise 5",
                 result: None,
             },
             Example {
                 description: "Create a when conditions",
-                example: "when ((col a) > 2) 4 | when ((col a) < 0) 6 | otherwise 0",
+                example:
+                    "dfr when ((dfr col a) > 2) 4 | dfr when ((dfr col a) < 0) 6 | dfr otherwise 0",
                 result: None,
             },
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | into lazy
-   | with-column (
-       when ((col a) > 2) 4 | otherwise 5 | as c
+   | dfr into-lazy
+   | dfr with-column (
+    dfr when ((dfr col a) > 2) 4 | dfr otherwise 5 | dfr as c
      )
-   | with-column (
-       when ((col a) > 5) 10 | when ((col a) < 2) 6 | otherwise 0 | as d
+   | dfr with-column (
+    dfr when ((dfr col a) > 5) 10 | dfr when ((dfr col a) < 2) 6 | dfr otherwise 0 | dfr as d
      )
-   | collect"#,
+   | dfr collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-command/src/dataframe/expressions/quantile.rs
@@ -35,9 +35,9 @@ impl Command for ExprQuantile {
         vec![Example {
             description: "Quantile aggregation for a group-by",
             example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | into df
-    | group-by a
-    | agg (col b | quantile 0.5)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfr col b | dfr quantile 0.5)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-command/src/dataframe/expressions/quantile.rs
@@ -12,7 +12,7 @@ pub struct ExprQuantile;
 
 impl Command for ExprQuantile {
     fn name(&self) -> &str {
-        "quantile"
+        "dfr quantile"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/when.rs
+++ b/crates/nu-command/src/dataframe/expressions/when.rs
@@ -12,7 +12,7 @@ pub struct ExprWhen;
 
 impl Command for ExprWhen {
     fn name(&self) -> &str {
-        "when"
+        "dfr when"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/expressions/when.rs
+++ b/crates/nu-command/src/dataframe/expressions/when.rs
@@ -40,25 +40,25 @@ impl Command for ExprWhen {
         vec![
             Example {
                 description: "Create a when conditions",
-                example: "when ((col a) > 2) 4",
+                example: "dfr when ((dfr col a) > 2) 4",
                 result: None,
             },
             Example {
                 description: "Create a when conditions",
-                example: "when ((col a) > 2) 4 | when ((col a) < 0) 6",
+                example: "dfr when ((dfr col a) > 2) 4 | dfr when ((dfr col a) < 0) 6",
                 result: None,
             },
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | into lazy
-   | with-column (
-       when ((col a) > 2) 4 | otherwise 5 | as c
+   | dfr into-lazy
+   | dfr with-column (
+    dfr when ((dfr col a) > 2) 4 | dfr otherwise 5 | dfr as c
      )
-   | with-column (
-       when ((col a) > 5) 10 | when ((col a) < 2) 6 | otherwise 0 | as d
+   | dfr with-column (
+    dfr when ((dfr col a) > 5) 10 | dfr when ((dfr col a) < 2) 6 | dfr otherwise 0 | dfr as d
      )
-   | collect"#,
+   | dfr collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-command/src/dataframe/lazy/aggregate.rs
@@ -13,7 +13,7 @@ pub struct LazyAggregate;
 
 impl Command for LazyAggregate {
     fn name(&self) -> &str {
-        "agg"
+        "dfr agg"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-command/src/dataframe/lazy/aggregate.rs
@@ -37,12 +37,12 @@ impl Command for LazyAggregate {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | into df
-    | group-by a
-    | agg [
-        (col b | min | as "b_min")
-        (col b | max | as "b_max")
-        (col b | sum | as "b_sum")
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg [
+        (dfr col b | dfr min | dfr as "b_min")
+        (dfr col b | dfr max | dfr as "b_max")
+        (dfr col b | dfr sum | dfr as "b_sum")
      ]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -70,14 +70,14 @@ impl Command for LazyAggregate {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | into lazy
-    | group-by a
-    | agg [
-        (col b | min | as "b_min")
-        (col b | max | as "b_max")
-        (col b | sum | as "b_sum")
+    | dfr into-lazy
+    | dfr group-by a
+    | dfr agg [
+        (dfr col b | dfr min | dfr as "b_min")
+        (dfr col b | dfr max | dfr as "b_max")
+        (dfr col b | dfr sum | dfr as "b_sum")
      ]
-    | collect"#,
+    | dfr collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/lazy/collect.rs
+++ b/crates/nu-command/src/dataframe/lazy/collect.rs
@@ -29,7 +29,7 @@ impl Command for LazyCollect {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "drop duplicates",
-            example: "[[a b]; [1 2] [3 4]] | into lazy | collect",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-lazy | dfr collect",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/lazy/collect.rs
+++ b/crates/nu-command/src/dataframe/lazy/collect.rs
@@ -12,7 +12,7 @@ pub struct LazyCollect;
 
 impl Command for LazyCollect {
     fn name(&self) -> &str {
-        "collect"
+        "dfr collect"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/fetch.rs
+++ b/crates/nu-command/src/dataframe/lazy/fetch.rs
@@ -34,7 +34,7 @@ impl Command for LazyFetch {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Fetch a rows from the dataframe",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | into df | fetch 2",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr fetch 2",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/lazy/fetch.rs
+++ b/crates/nu-command/src/dataframe/lazy/fetch.rs
@@ -12,7 +12,7 @@ pub struct LazyFetch;
 
 impl Command for LazyFetch {
     fn name(&self) -> &str {
-        "fetch"
+        "dfr fetch"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/fill_nan.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_nan.rs
@@ -34,7 +34,7 @@ impl Command for LazyFillNA {
         vec![
             Example {
                 description: "Fills the NaN values with 0",
-                example: "[1 2 NaN 3 NaN] | into df | fill-nan 0",
+                example: "[1 2 NaN 3 NaN] | dfr into-df | dfr fill-nan 0",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),
@@ -52,7 +52,7 @@ impl Command for LazyFillNA {
             },
             Example {
                 description: "Fills the NaN values of a whole dataframe",
-                example: "[[a b]; [0.2 1] [0.1 NaN]] | into df | fill-nan 0",
+                example: "[[a b]; [0.2 1] [0.1 NaN]] | dfr into-df | dfr fill-nan 0",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/lazy/fill_nan.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_nan.rs
@@ -11,7 +11,7 @@ pub struct LazyFillNA;
 
 impl Command for LazyFillNA {
     fn name(&self) -> &str {
-        "fill-nan"
+        "dfr fill-nan"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/fill_null.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_null.rs
@@ -11,7 +11,7 @@ pub struct LazyFillNull;
 
 impl Command for LazyFillNull {
     fn name(&self) -> &str {
-        "fill-null"
+        "dfr fill-null"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/fill_null.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_null.rs
@@ -33,7 +33,7 @@ impl Command for LazyFillNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Fills the null values by 0",
-            example: "[1 2 2 3 3] | into df | shift 2 | fill-null 0",
+            example: "[1 2 2 3 3] | dfr into-df | dfr shift 2 | dfr fill-null 0",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/lazy/filter.rs
+++ b/crates/nu-command/src/dataframe/lazy/filter.rs
@@ -34,7 +34,7 @@ impl Command for LazyFilter {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Filter dataframe using an expression",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | into df | filter ((col a) >= 4)",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr filter ((dfr col a) >= 4)",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/lazy/filter.rs
+++ b/crates/nu-command/src/dataframe/lazy/filter.rs
@@ -12,7 +12,7 @@ pub struct LazyFilter;
 
 impl Command for LazyFilter {
     fn name(&self) -> &str {
-        "filter"
+        "dfr filter"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/groupby.rs
+++ b/crates/nu-command/src/dataframe/lazy/groupby.rs
@@ -36,12 +36,12 @@ impl Command for ToLazyGroupBy {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | into df
-    | group-by a
-    | agg [
-        (col b | min | as "b_min")
-        (col b | max | as "b_max")
-        (col b | sum | as "b_sum")
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg [
+        (dfr col b | dfr min | dfr as "b_min")
+        (dfr col b | dfr max | dfr as "b_max")
+        (dfr col b | dfr sum | dfr as "b_sum")
      ]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -69,14 +69,14 @@ impl Command for ToLazyGroupBy {
             Example {
                 description: "Group by and perform an aggregation",
                 example: r#"[[a b]; [1 2] [1 4] [2 6] [2 4]]
-    | into lazy
-    | group-by a
-    | agg [
-        (col b | min | as "b_min")
-        (col b | max | as "b_max")
-        (col b | sum | as "b_sum")
+    | dfr into-lazy
+    | dfr group-by a
+    | dfr agg [
+        (dfr col b | dfr min | dfr as "b_min")
+        (dfr col b | dfr max | dfr as "b_max")
+        (dfr col b | dfr sum | dfr as "b_sum")
      ]
-    | collect"#,
+    | dfr collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/lazy/groupby.rs
+++ b/crates/nu-command/src/dataframe/lazy/groupby.rs
@@ -12,7 +12,7 @@ pub struct ToLazyGroupBy;
 
 impl Command for ToLazyGroupBy {
     fn name(&self) -> &str {
-        "group-by"
+        "dfr group-by"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/join.rs
+++ b/crates/nu-command/src/dataframe/lazy/join.rs
@@ -12,7 +12,7 @@ pub struct LazyJoin;
 
 impl Command for LazyJoin {
     fn name(&self) -> &str {
-        "join"
+        "dfr join"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/join.rs
+++ b/crates/nu-command/src/dataframe/lazy/join.rs
@@ -47,9 +47,9 @@ impl Command for LazyJoin {
         vec![
             Example {
                 description: "Join two lazy dataframes",
-                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | into lazy);
-    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | into lazy);
-    $df_a | join $df_b a foo | collect"#,
+                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | dfr into-lazy);
+    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | dfr into-lazy);
+    $df_a | dfr join $df_b a foo | dfr collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -104,9 +104,9 @@ impl Command for LazyJoin {
             },
             Example {
                 description: "Join one eager dataframe with a lazy dataframe",
-                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | into df);
-    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | into lazy);
-    $df_a | join $df_b a foo"#,
+                example: r#"let df_a = ([[a b c];[1 "a" 0] [2 "b" 1] [1 "c" 2] [1 "c" 3]] | dfr into-df);
+    let df_b = ([["foo" "bar" "ham"];[1 "a" "let"] [2 "c" "var"] [3 "c" "const"]] | dfr into-lazy);
+    $df_a | dfr join $df_b a foo"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/lazy/macro_commands.rs
+++ b/crates/nu-command/src/dataframe/lazy/macro_commands.rs
@@ -118,7 +118,7 @@ lazy_command!(
     "Reverses the LazyFrame",
     vec![Example {
         description: "Reverses the dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | reverse",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr reverse",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -146,7 +146,7 @@ lazy_command!(
     "Caches operations in a new LazyFrame",
     vec![Example {
         description: "Caches the result into a new LazyFrame",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | reverse | cache",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr reverse | dfr cache",
         result: None,
     }],
     cache,
@@ -161,7 +161,7 @@ lazy_command!(
     "Aggregates columns to their max value",
     vec![Example {
         description: "Max value from columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | into df | max",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | dfr into-df | dfr max",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(6)],),
@@ -183,7 +183,7 @@ lazy_command!(
     "Aggregates columns to their min value",
     vec![Example {
         description: "Min value from columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | into df | min",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | dfr into-df | dfr min",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(1)],),
@@ -205,7 +205,7 @@ lazy_command!(
     "Aggregates columns to their sum value",
     vec![Example {
         description: "Sums all columns in a dataframe",
-        example: "[[a b]; [6 2] [1 4] [4 1]] | into df | sum",
+        example: "[[a b]; [6 2] [1 4] [4 1]] | dfr into-df | dfr sum",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_int(11)],),
@@ -227,7 +227,7 @@ lazy_command!(
     "Aggregates columns to their mean value",
     vec![Example {
         description: "Mean value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | mean",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr mean",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),
@@ -249,7 +249,7 @@ lazy_command!(
     "Aggregates columns to their median value",
     vec![Example {
         description: "Median value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | median",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr median",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),
@@ -271,7 +271,7 @@ lazy_command!(
     "Aggregates columns to their std value",
     vec![Example {
         description: "Std value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | std",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr std",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(2.0)],),
@@ -294,7 +294,7 @@ lazy_command!(
     "Aggregates columns to their var value",
     vec![Example {
         description: "Var value from columns in a dataframe",
-        example: "[[a b]; [6 2] [4 2] [2 2]] | into df | var",
+        example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr var",
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new("a".to_string(), vec![Value::test_float(4.0)],),

--- a/crates/nu-command/src/dataframe/lazy/macro_commands.rs
+++ b/crates/nu-command/src/dataframe/lazy/macro_commands.rs
@@ -114,7 +114,7 @@ macro_rules! lazy_command {
 // Expands to a command definition for reverse
 lazy_command!(
     LazyReverse,
-    "reverse",
+    "dfr reverse",
     "Reverses the LazyFrame",
     vec![Example {
         description: "Reverses the dataframe",
@@ -142,7 +142,7 @@ lazy_command!(
 // Expands to a command definition for cache
 lazy_command!(
     LazyCache,
-    "cache",
+    "dfr cache",
     "Caches operations in a new LazyFrame",
     vec![Example {
         description: "Caches the result into a new LazyFrame",
@@ -157,7 +157,7 @@ lazy_command!(
 // Expands to a command definition for max aggregation
 lazy_command!(
     LazyMax,
-    "max",
+    "dfr max",
     "Aggregates columns to their max value",
     vec![Example {
         description: "Max value from columns in a dataframe",
@@ -179,7 +179,7 @@ lazy_command!(
 // Expands to a command definition for min aggregation
 lazy_command!(
     LazyMin,
-    "min",
+    "dfr min",
     "Aggregates columns to their min value",
     vec![Example {
         description: "Min value from columns in a dataframe",
@@ -201,7 +201,7 @@ lazy_command!(
 // Expands to a command definition for sum aggregation
 lazy_command!(
     LazySum,
-    "sum",
+    "dfr sum",
     "Aggregates columns to their sum value",
     vec![Example {
         description: "Sums all columns in a dataframe",
@@ -223,7 +223,7 @@ lazy_command!(
 // Expands to a command definition for mean aggregation
 lazy_command!(
     LazyMean,
-    "mean",
+    "dfr mean",
     "Aggregates columns to their mean value",
     vec![Example {
         description: "Mean value from columns in a dataframe",
@@ -245,7 +245,7 @@ lazy_command!(
 // Expands to a command definition for median aggregation
 lazy_command!(
     LazyMedian,
-    "median",
+    "dfr median",
     "Aggregates columns to their median value",
     vec![Example {
         description: "Median value from columns in a dataframe",
@@ -267,7 +267,7 @@ lazy_command!(
 // Expands to a command definition for std aggregation
 lazy_command!(
     LazyStd,
-    "std",
+    "dfr std",
     "Aggregates columns to their std value",
     vec![Example {
         description: "Std value from columns in a dataframe",
@@ -290,7 +290,7 @@ lazy_command!(
 // Expands to a command definition for var aggregation
 lazy_command!(
     LazyVar,
-    "var",
+    "dfr var",
     "Aggregates columns to their var value",
     vec![Example {
         description: "Var value from columns in a dataframe",

--- a/crates/nu-command/src/dataframe/lazy/quantile.rs
+++ b/crates/nu-command/src/dataframe/lazy/quantile.rs
@@ -12,7 +12,7 @@ pub struct LazyQuantile;
 
 impl Command for LazyQuantile {
     fn name(&self) -> &str {
-        "quantile"
+        "dfr quantile"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/quantile.rs
+++ b/crates/nu-command/src/dataframe/lazy/quantile.rs
@@ -34,7 +34,7 @@ impl Command for LazyQuantile {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "quantile value from columns in a dataframe",
-            example: "[[a b]; [6 2] [1 4] [4 1]] | into df | quantile 0.5",
+            example: "[[a b]; [6 2] [1 4] [4 1]] | dfr into-df | dfr quantile 0.5",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new("a".to_string(), vec![Value::test_float(4.0)]),

--- a/crates/nu-command/src/dataframe/lazy/select.rs
+++ b/crates/nu-command/src/dataframe/lazy/select.rs
@@ -33,7 +33,7 @@ impl Command for LazySelect {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Select a column from the dataframe",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | into df | select a",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr select a",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "a".to_string(),

--- a/crates/nu-command/src/dataframe/lazy/select.rs
+++ b/crates/nu-command/src/dataframe/lazy/select.rs
@@ -11,7 +11,7 @@ pub struct LazySelect;
 
 impl Command for LazySelect {
     fn name(&self) -> &str {
-        "select"
+        "dfr select"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
@@ -12,7 +12,7 @@ pub struct LazySortBy;
 
 impl Command for LazySortBy {
     fn name(&self) -> &str {
-        "sort-by"
+        "dfr sort-by"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
@@ -46,7 +46,7 @@ impl Command for LazySortBy {
         vec![
             Example {
                 description: "Sort dataframe by one column",
-                example: "[[a b]; [6 2] [1 4] [4 1]] | into df | sort-by a",
+                example: "[[a b]; [6 2] [1 4] [4 1]] | dfr into-df | dfr sort-by a",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(
@@ -65,7 +65,7 @@ impl Command for LazySortBy {
             Example {
                 description: "Sort column using two columns",
                 example:
-                    "[[a b]; [6 2] [1 1] [1 4] [2 4]] | into df | sort-by [a b] -r [false true]",
+                    "[[a b]; [6 2] [1 1] [1 4] [2 4]] | dfr into-df | dfr sort-by [a b] -r [false true]",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-command/src/dataframe/lazy/to_lazy.rs
+++ b/crates/nu-command/src/dataframe/lazy/to_lazy.rs
@@ -28,7 +28,7 @@ impl Command for ToLazyFrame {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Takes a dictionary and creates a lazy dataframe",
-            example: "[[a b];[1 2] [3 4]] | into lazy",
+            example: "[[a b];[1 2] [3 4]] | dfr into-lazy",
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/lazy/to_lazy.rs
+++ b/crates/nu-command/src/dataframe/lazy/to_lazy.rs
@@ -11,7 +11,7 @@ pub struct ToLazyFrame;
 
 impl Command for ToLazyFrame {
     fn name(&self) -> &str {
-        "into lazy"
+        "dfr into-lazy"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -29,7 +29,7 @@ impl Command for AllFalse {
         vec![
             Example {
                 description: "Returns true if all values are false",
-                example: "[false false false] | into df | all-false",
+                example: "[false false false] | dfr into-df | dfr all-false",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_false".to_string(),
@@ -41,9 +41,9 @@ impl Command for AllFalse {
             },
             Example {
                 description: "Checks the result from a comparison",
-                example: r#"let s = ([5 6 2 10] | into df);
+                example: r#"let s = ([5 6 2 10] | dfr into-df);
     let res = ($s > 9);
-    $res | all-false"#,
+    $res | dfr all-false"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_false".to_string(),

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -11,7 +11,7 @@ pub struct AllFalse;
 
 impl Command for AllFalse {
     fn name(&self) -> &str {
-        "all-false"
+        "dfr all-false"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -11,7 +11,7 @@ pub struct AllTrue;
 
 impl Command for AllTrue {
     fn name(&self) -> &str {
-        "all-true"
+        "dfr all-true"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -29,7 +29,7 @@ impl Command for AllTrue {
         vec![
             Example {
                 description: "Returns true if all values are true",
-                example: "[true true true] | into df | all-true",
+                example: "[true true true] | dfr into-df | dfr all-true",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_true".to_string(),
@@ -41,9 +41,9 @@ impl Command for AllTrue {
             },
             Example {
                 description: "Checks the result from a comparison",
-                example: r#"let s = ([5 6 2 8] | into df);
+                example: r#"let s = ([5 6 2 8] | dfr into-df);
     let res = ($s > 9);
-    $res | all-true"#,
+    $res | dfr all-true"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "all_true".to_string(),

--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -12,7 +12,7 @@ pub struct ArgMax;
 
 impl Command for ArgMax {
     fn name(&self) -> &str {
-        "arg-max"
+        "dfr arg-max"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -33,7 +33,7 @@ impl Command for ArgMax {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns index for max value",
-            example: "[1 3 2] | into df | arg-max",
+            example: "[1 3 2] | dfr into-df | dfr arg-max",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_max".to_string(),

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -33,7 +33,7 @@ impl Command for ArgMin {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns index for min value",
-            example: "[1 3 2] | into df | arg-min",
+            example: "[1 3 2] | dfr into-df | dfr arg-min",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_min".to_string(),

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -12,7 +12,7 @@ pub struct ArgMin;
 
 impl Command for ArgMin {
     fn name(&self) -> &str {
-        "arg-min"
+        "dfr arg-min"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/cumulative.rs
+++ b/crates/nu-command/src/dataframe/series/cumulative.rs
@@ -64,7 +64,7 @@ impl Command for Cumulative {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Cumulative sum for a series",
-            example: "[1 2 3 4 5] | into df | cumulative sum",
+            example: "[1 2 3 4 5] | dfr into-df | dfr cumulative sum",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0_cumulative_sum".to_string(),

--- a/crates/nu-command/src/dataframe/series/cumulative.rs
+++ b/crates/nu-command/src/dataframe/series/cumulative.rs
@@ -45,7 +45,7 @@ pub struct Cumulative;
 
 impl Command for Cumulative {
     fn name(&self) -> &str {
-        "cumulative"
+        "dfr cumulative"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/as_date.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_date.rs
@@ -13,7 +13,7 @@ pub struct AsDate;
 
 impl Command for AsDate {
     fn name(&self) -> &str {
-        "as-date"
+        "dfr as-date"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/as_date.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_date.rs
@@ -39,7 +39,7 @@ impl Command for AsDate {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Converts string to date",
-            example: r#"["2021-12-30" "2021-12-31"] | into df | as-datetime "%Y-%m-%d""#,
+            example: r#"["2021-12-30" "2021-12-31"] | dfr into-df | dfr as-datetime "%Y-%m-%d""#,
             result: None,
         }]
     }

--- a/crates/nu-command/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_datetime.rs
@@ -48,7 +48,7 @@ impl Command for AsDateTime {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Converts string to datetime",
-            example: r#"["2021-12-30 00:00:00" "2021-12-31 00:00:00"] | into df | as-datetime "%Y-%m-%d %H:%M:%S""#,
+            example: r#"["2021-12-30 00:00:00" "2021-12-31 00:00:00"] | dfr into-df | dfr as-datetime "%Y-%m-%d %H:%M:%S""#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "datetime".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_datetime.rs
@@ -14,7 +14,7 @@ pub struct AsDateTime;
 
 impl Command for AsDateTime {
     fn name(&self) -> &str {
-        "as-datetime"
+        "dfr as-datetime"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_day.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_day.rs
@@ -30,8 +30,8 @@ impl Command for GetDay {
         vec![Example {
             description: "Returns day from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-day"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-day"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_day.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_day.rs
@@ -12,7 +12,7 @@ pub struct GetDay;
 
 impl Command for GetDay {
     fn name(&self) -> &str {
-        "get-day"
+        "dfr get-day"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_hour.rs
@@ -12,7 +12,7 @@ pub struct GetHour;
 
 impl Command for GetHour {
     fn name(&self) -> &str {
-        "get-hour"
+        "dfr get-hour"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_hour.rs
@@ -30,8 +30,8 @@ impl Command for GetHour {
         vec![Example {
             description: "Returns hour from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-hour"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-hour"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_minute.rs
@@ -30,8 +30,8 @@ impl Command for GetMinute {
         vec![Example {
             description: "Returns minute from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-minute"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-minute"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_minute.rs
@@ -12,7 +12,7 @@ pub struct GetMinute;
 
 impl Command for GetMinute {
     fn name(&self) -> &str {
-        "get-minute"
+        "dfr get-minute"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_month.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_month.rs
@@ -30,8 +30,8 @@ impl Command for GetMonth {
         vec![Example {
             description: "Returns month from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-month"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-month"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_month.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_month.rs
@@ -12,7 +12,7 @@ pub struct GetMonth;
 
 impl Command for GetMonth {
     fn name(&self) -> &str {
-        "get-month"
+        "dfr get-month"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
@@ -12,7 +12,7 @@ pub struct GetNanosecond;
 
 impl Command for GetNanosecond {
     fn name(&self) -> &str {
-        "get-nanosecond"
+        "dfr get-nanosecond"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
@@ -30,8 +30,8 @@ impl Command for GetNanosecond {
         vec![Example {
             description: "Returns nanosecond from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-nanosecond"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-nanosecond"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
@@ -30,8 +30,8 @@ impl Command for GetOrdinal {
         vec![Example {
             description: "Returns ordinal from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-ordinal"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-ordinal"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
@@ -12,7 +12,7 @@ pub struct GetOrdinal;
 
 impl Command for GetOrdinal {
     fn name(&self) -> &str {
-        "get-ordinal"
+        "dfr get-ordinal"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_second.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_second.rs
@@ -30,8 +30,8 @@ impl Command for GetSecond {
         vec![Example {
             description: "Returns second from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-second"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-second"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_second.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_second.rs
@@ -12,7 +12,7 @@ pub struct GetSecond;
 
 impl Command for GetSecond {
     fn name(&self) -> &str {
-        "get-second"
+        "dfr get-second"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_week.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_week.rs
@@ -30,8 +30,8 @@ impl Command for GetWeek {
         vec![Example {
             description: "Returns week from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-week"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-week"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_week.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_week.rs
@@ -12,7 +12,7 @@ pub struct GetWeek;
 
 impl Command for GetWeek {
     fn name(&self) -> &str {
-        "get-week"
+        "dfr get-week"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_weekday.rs
@@ -30,8 +30,8 @@ impl Command for GetWeekDay {
         vec![Example {
             description: "Returns weekday from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-weekday"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-weekday"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_weekday.rs
@@ -12,7 +12,7 @@ pub struct GetWeekDay;
 
 impl Command for GetWeekDay {
     fn name(&self) -> &str {
-        "get-weekday"
+        "dfr get-weekday"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_year.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_year.rs
@@ -12,7 +12,7 @@ pub struct GetYear;
 
 impl Command for GetYear {
     fn name(&self) -> &str {
-        "get-year"
+        "dfr get-year"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/date/get_year.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_year.rs
@@ -30,8 +30,8 @@ impl Command for GetYear {
         vec![Example {
             description: "Returns year from a date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | get-year"#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr get-year"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -36,7 +36,7 @@ impl Command for ArgSort {
         vec![
             Example {
                 description: "Returns indexes for a sorted series",
-                example: "[1 2 2 3 3] | into df | arg-sort",
+                example: "[1 2 2 3 3] | dfr into-df | dfr arg-sort",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "arg_sort".to_string(),
@@ -54,7 +54,7 @@ impl Command for ArgSort {
             },
             Example {
                 description: "Returns indexes for a sorted series",
-                example: "[1 2 2 3 3] | into df | arg-sort -r",
+                example: "[1 2 2 3 3] | dfr into-df | dfr arg-sort -r",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "arg_sort".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -12,7 +12,7 @@ pub struct ArgSort;
 
 impl Command for ArgSort {
     fn name(&self) -> &str {
-        "arg-sort"
+        "dfr arg-sort"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -12,7 +12,7 @@ pub struct ArgTrue;
 
 impl Command for ArgTrue {
     fn name(&self) -> &str {
-        "arg-true"
+        "dfr arg-true"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -33,7 +33,7 @@ impl Command for ArgTrue {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns indexes where values are true",
-            example: "[false true false] | into df | arg-true",
+            example: "[false true false] | dfr into-df | dfr arg-true",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_true".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -12,7 +12,7 @@ pub struct ArgUnique;
 
 impl Command for ArgUnique {
     fn name(&self) -> &str {
-        "arg-unique"
+        "dfr arg-unique"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -33,7 +33,7 @@ impl Command for ArgUnique {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns indexes for unique values",
-            example: "[1 2 2 3 3] | into df | arg-unique",
+            example: "[1 2 2 3 3] | dfr into-df | dfr arg-unique",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "arg_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
@@ -37,9 +37,9 @@ impl Command for SetWithIndex {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Set value in selected rows from series",
-            example: r#"let series = ([4 1 5 2 4 3] | into df);
-    let indices = ([0 2] | into df);
-    $series | set-with-idx 6 -i $indices"#,
+            example: r#"let series = ([4 1 5 2 4 3] | dfr into-df);
+    let indices = ([0 2] | dfr into-df);
+    $series | dfr set-with-idx 6 -i $indices"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
@@ -13,7 +13,7 @@ pub struct SetWithIndex;
 
 impl Command for SetWithIndex {
     fn name(&self) -> &str {
-        "set-with-idx"
+        "dfr set-with-idx"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
@@ -12,7 +12,7 @@ pub struct IsDuplicated;
 
 impl Command for IsDuplicated {
     fn name(&self) -> &str {
-        "is-duplicated"
+        "dfr is-duplicated"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
@@ -30,7 +30,7 @@ impl Command for IsDuplicated {
         vec![
             Example {
                 description: "Create mask indicating duplicated values",
-                example: "[5 6 6 6 8 8 8] | into df | is-duplicated",
+                example: "[5 6 6 6 8 8 8] | dfr into-df | dfr is-duplicated",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "is_duplicated".to_string(),
@@ -50,7 +50,8 @@ impl Command for IsDuplicated {
             },
             Example {
                 description: "Create mask indicating duplicated rows in a dataframe",
-                example: "[[a, b]; [1 2] [1 2] [3 3] [3 3] [1 1]] | into df | is-duplicated",
+                example:
+                    "[[a, b]; [1 2] [1 2] [3 3] [3 3] [1 1]] | dfr into-df | dfr is-duplicated",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "is_duplicated".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_in.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_in.rs
@@ -31,8 +31,8 @@ impl Command for IsIn {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Checks if elements from a series are contained in right series",
-            example: r#"let other = ([1 3 6] | into df);
-    [5 6 6 6 8 8 8] | into df | is-in $other"#,
+            example: r#"let other = ([1 3 6] | dfr into-df);
+    [5 6 6 6 8 8 8] | dfr into-df | dfr is-in $other"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_in".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_in.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_in.rs
@@ -13,7 +13,7 @@ pub struct IsIn;
 
 impl Command for IsIn {
     fn name(&self) -> &str {
-        "is-in"
+        "dfr is-in"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
@@ -28,9 +28,9 @@ impl Command for IsNotNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask where values are not null",
-            example: r#"let s = ([5 6 0 8] | into df);
+            example: r#"let s = ([5 6 0 8] | dfr into-df);
     let res = ($s / $s);
-    $res | is-not-null"#,
+    $res | dfr is-not-null"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_not_null".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
@@ -11,7 +11,7 @@ pub struct IsNotNull;
 
 impl Command for IsNotNull {
     fn name(&self) -> &str {
-        "is-not-null"
+        "dfr is-not-null"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/masks/is_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_null.rs
@@ -28,9 +28,9 @@ impl Command for IsNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Create mask where values are null",
-            example: r#"let s = ([5 6 0 8] | into df);
+            example: r#"let s = ([5 6 0 8] | dfr into-df);
     let res = ($s / $s);
-    $res | is-null"#,
+    $res | dfr is-null"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "is_null".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/is_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_null.rs
@@ -11,7 +11,7 @@ pub struct IsNull;
 
 impl Command for IsNull {
     fn name(&self) -> &str {
-        "is-null"
+        "dfr is-null"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_unique.rs
@@ -12,7 +12,7 @@ pub struct IsUnique;
 
 impl Command for IsUnique {
     fn name(&self) -> &str {
-        "is-unique"
+        "dfr is-unique"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_unique.rs
@@ -30,7 +30,7 @@ impl Command for IsUnique {
         vec![
             Example {
                 description: "Create mask indicating unique values",
-                example: "[5 6 6 6 8 8 8] | into df | is-unique",
+                example: "[5 6 6 6 8 8 8] | dfr into-df | dfr is-unique",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "is_unique".to_string(),
@@ -50,7 +50,7 @@ impl Command for IsUnique {
             },
             Example {
                 description: "Create mask indicating duplicated rows in a dataframe",
-                example: "[[a, b]; [1 2] [1 2] [3 3] [3 3] [1 1]] | into df | is-unique",
+                example: "[[a, b]; [1 2] [1 2] [3 3] [3 3] [1 1]] | dfr into-df | dfr is-unique",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "is_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/not.rs
+++ b/crates/nu-command/src/dataframe/series/masks/not.rs
@@ -13,7 +13,7 @@ pub struct NotSeries;
 
 impl Command for NotSeries {
     fn name(&self) -> &str {
-        "df-not"
+        "dfr df-not"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/masks/not.rs
+++ b/crates/nu-command/src/dataframe/series/masks/not.rs
@@ -13,7 +13,7 @@ pub struct NotSeries;
 
 impl Command for NotSeries {
     fn name(&self) -> &str {
-        "dfr df-not"
+        "dfr not"
     }
 
     fn usage(&self) -> &str {
@@ -30,7 +30,7 @@ impl Command for NotSeries {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Inverts boolean mask",
-            example: "[true false true] | into df | df-not",
+            example: "[true false true] | dfr into-df | dfr not",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/set.rs
+++ b/crates/nu-command/src/dataframe/series/masks/set.rs
@@ -37,9 +37,9 @@ impl Command for SetSeries {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shifts the values by a given period",
-            example: r#"let s = ([1 2 2 3 3] | into df | shift 2);
-    let mask = ($s | is-null);
-    $s | set 0 --mask $mask"#,
+            example: r#"let s = ([1 2 2 3 3] | dfr into-df | dfr shift 2);
+    let mask = ($s | dfr is-null);
+    $s | dfr set 0 --mask $mask"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/masks/set.rs
+++ b/crates/nu-command/src/dataframe/series/masks/set.rs
@@ -13,7 +13,7 @@ pub struct SetSeries;
 
 impl Command for SetSeries {
     fn name(&self) -> &str {
-        "set"
+        "dfr set"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/n_null.rs
+++ b/crates/nu-command/src/dataframe/series/n_null.rs
@@ -11,7 +11,7 @@ pub struct NNull;
 
 impl Command for NNull {
     fn name(&self) -> &str {
-        "count-null"
+        "dfr count-null"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/n_null.rs
+++ b/crates/nu-command/src/dataframe/series/n_null.rs
@@ -28,8 +28,8 @@ impl Command for NNull {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Counts null values",
-            example: r#"let s = ([1 1 0 0 3 3 4] | into df);
-    ($s / $s) | count-null"#,
+            example: r#"let s = ([1 1 0 0 3 3 4] | dfr into-df);
+    ($s / $s) | dfr count-null"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "count_null".to_string(),

--- a/crates/nu-command/src/dataframe/series/n_unique.rs
+++ b/crates/nu-command/src/dataframe/series/n_unique.rs
@@ -27,7 +27,7 @@ impl Command for NUnique {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Counts unique values",
-            example: "[1 1 2 2 3 3 4] | into df | n-unique",
+            example: "[1 1 2 2 3 3 4] | dfr into-df | dfr n-unique",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "count_unique".to_string(),

--- a/crates/nu-command/src/dataframe/series/n_unique.rs
+++ b/crates/nu-command/src/dataframe/series/n_unique.rs
@@ -10,7 +10,7 @@ pub struct NUnique;
 
 impl Command for NUnique {
     fn name(&self) -> &str {
-        "n-unique"
+        "dfr n-unique"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/rolling.rs
+++ b/crates/nu-command/src/dataframe/series/rolling.rs
@@ -68,7 +68,7 @@ impl Command for Rolling {
         vec![
             Example {
                 description: "Rolling sum for a series",
-                example: "[1 2 3 4 5] | into df | rolling sum 2 | drop-nulls",
+                example: "[1 2 3 4 5] | dfr into-df | dfr rolling sum 2 | dfr drop-nulls",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0_rolling_sum".to_string(),
@@ -85,7 +85,7 @@ impl Command for Rolling {
             },
             Example {
                 description: "Rolling max for a series",
-                example: "[1 2 3 4 5] | into df | rolling max 2 | drop-nulls",
+                example: "[1 2 3 4 5] | dfr into-df | dfr rolling max 2 | dfr drop-nulls",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0_rolling_max".to_string(),

--- a/crates/nu-command/src/dataframe/series/rolling.rs
+++ b/crates/nu-command/src/dataframe/series/rolling.rs
@@ -48,7 +48,7 @@ pub struct Rolling;
 
 impl Command for Rolling {
     fn name(&self) -> &str {
-        "rolling"
+        "dfr rolling"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/shift.rs
+++ b/crates/nu-command/src/dataframe/series/shift.rs
@@ -38,7 +38,7 @@ impl Command for Shift {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shifts the values by a given period",
-            example: "[1 2 2 3 3] | into df | shift 2 | drop-nulls",
+            example: "[1 2 2 3 3] | dfr into-df | dfr shift 2 | dfr drop-nulls",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/shift.rs
+++ b/crates/nu-command/src/dataframe/series/shift.rs
@@ -14,7 +14,7 @@ pub struct Shift;
 
 impl Command for Shift {
     fn name(&self) -> &str {
-        "shift"
+        "dfr shift"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu-command/src/dataframe/series/string/concatenate.rs
@@ -13,7 +13,7 @@ pub struct Concatenate;
 
 impl Command for Concatenate {
     fn name(&self) -> &str {
-        "concatenate"
+        "dfr concatenate"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu-command/src/dataframe/series/string/concatenate.rs
@@ -35,8 +35,8 @@ impl Command for Concatenate {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Concatenate string",
-            example: r#"let other = ([za xs cd] | into df);
-    [abc abc abc] | into df | concatenate $other"#,
+            example: r#"let other = ([za xs cd] | dfr into-df);
+    [abc abc abc] | dfr into-df | dfr concatenate $other"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/contains.rs
+++ b/crates/nu-command/src/dataframe/series/string/contains.rs
@@ -13,7 +13,7 @@ pub struct Contains;
 
 impl Command for Contains {
     fn name(&self) -> &str {
-        "contains"
+        "dfr contains"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/contains.rs
+++ b/crates/nu-command/src/dataframe/series/string/contains.rs
@@ -35,7 +35,7 @@ impl Command for Contains {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns boolean indicating if pattern was found",
-            example: "[abc acb acb] | into df | contains ab",
+            example: "[abc acb acb] | dfr into-df | dfr contains ab",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/replace.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace.rs
@@ -42,7 +42,7 @@ impl Command for Replace {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Replaces string",
-            example: "[abc abc abc] | into df | replace -p ab -r AB",
+            example: "[abc abc abc] | dfr into-df | dfr replace -p ab -r AB",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/replace.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace.rs
@@ -13,7 +13,7 @@ pub struct Replace;
 
 impl Command for Replace {
     fn name(&self) -> &str {
-        "replace"
+        "dfr replace"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace_all.rs
@@ -42,7 +42,7 @@ impl Command for ReplaceAll {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Replaces string",
-            example: "[abac abac abac] | into df | replace-all -p a -r A",
+            example: "[abac abac abac] | dfr into-df | dfr replace-all -p a -r A",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace_all.rs
@@ -13,7 +13,7 @@ pub struct ReplaceAll;
 
 impl Command for ReplaceAll {
     fn name(&self) -> &str {
-        "replace-all"
+        "dfr replace-all"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_lengths.rs
@@ -12,7 +12,7 @@ pub struct StrLengths;
 
 impl Command for StrLengths {
     fn name(&self) -> &str {
-        "str-lengths"
+        "dfr str-lengths"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_lengths.rs
@@ -29,7 +29,7 @@ impl Command for StrLengths {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Returns string lengths",
-            example: "[a ab abc] | into df | str-lengths",
+            example: "[a ab abc] | dfr into-df | dfr str-lengths",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_slice.rs
@@ -13,7 +13,7 @@ pub struct StrSlice;
 
 impl Command for StrSlice {
     fn name(&self) -> &str {
-        "str-slice"
+        "dfr str-slice"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_slice.rs
@@ -32,7 +32,7 @@ impl Command for StrSlice {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates slices from the strings",
-            example: "[abcded abc321 abc123] | into df | str-slice 1 -l 2",
+            example: "[abcded abc321 abc123] | dfr into-df | dfr str-slice 1 -l 2",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/strftime.rs
+++ b/crates/nu-command/src/dataframe/series/string/strftime.rs
@@ -13,7 +13,7 @@ pub struct StrFTime;
 
 impl Command for StrFTime {
     fn name(&self) -> &str {
-        "strftime"
+        "dfr strftime"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/strftime.rs
+++ b/crates/nu-command/src/dataframe/series/string/strftime.rs
@@ -32,8 +32,8 @@ impl Command for StrFTime {
         vec![Example {
             description: "Formats date",
             example: r#"let dt = ('2020-08-04T16:39:18+00:00' | into datetime -z 'UTC');
-    let df = ([$dt $dt] | into df);
-    $df | strftime "%Y/%m/%d""#,
+    let df = ([$dt $dt] | dfr into-df);
+    $df | dfr strftime "%Y/%m/%d""#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
@@ -12,7 +12,7 @@ pub struct ToLowerCase;
 
 impl Command for ToLowerCase {
     fn name(&self) -> &str {
-        "lowercase"
+        "dfr lowercase"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
@@ -29,7 +29,7 @@ impl Command for ToLowerCase {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Modifies strings to lowercase",
-            example: "[Abc aBc abC] | into df | lowercase",
+            example: "[Abc aBc abC] | dfr into-df | dfr lowercase",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
@@ -33,7 +33,7 @@ impl Command for ToUpperCase {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Modifies strings to uppercase",
-            example: "[Abc aBc abC] | into df | uppercase",
+            example: "[Abc aBc abC] | dfr into-df | dfr uppercase",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
@@ -12,7 +12,7 @@ pub struct ToUpperCase;
 
 impl Command for ToUpperCase {
     fn name(&self) -> &str {
-        "uppercase"
+        "dfr uppercase"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/unique.rs
+++ b/crates/nu-command/src/dataframe/series/unique.rs
@@ -49,7 +49,7 @@ impl Command for Unique {
         vec![
             Example {
                 description: "Returns unique values from a series",
-                example: "[2 2 2 2 2] | into df | unique",
+                example: "[2 2 2 2 2] | dfr into-df | dfr unique",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![Column::new(
                         "0".to_string(),

--- a/crates/nu-command/src/dataframe/series/unique.rs
+++ b/crates/nu-command/src/dataframe/series/unique.rs
@@ -15,7 +15,7 @@ pub struct Unique;
 
 impl Command for Unique {
     fn name(&self) -> &str {
-        "unique"
+        "dfr unique"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/dataframe/series/value_counts.rs
+++ b/crates/nu-command/src/dataframe/series/value_counts.rs
@@ -30,7 +30,7 @@ impl Command for ValueCount {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Calculates value counts",
-            example: "[5 5 5 5 6 6] | into df | value-counts",
+            example: "[5 5 5 5 6 6] | dfr into-df | dfr value-counts",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-command/src/dataframe/series/value_counts.rs
+++ b/crates/nu-command/src/dataframe/series/value_counts.rs
@@ -13,7 +13,7 @@ pub struct ValueCount;
 
 impl Command for ValueCount {
     fn name(&self) -> &str {
-        "value-counts"
+        "dfr value-counts"
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -214,8 +214,8 @@ fn parses_arrow_ipc() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            open-df caco3_plastics.arrow
-            | into nu
+            dfr open caco3_plastics.arrow
+            | dfr into-nu
             | first
             | get origin
         "#


### PR DESCRIPTION
# Description

This PR tries to resolve the overloading issue by going back to our original naming convention for dataframes. So, this PR renames all dataframe commands with a prefix of `dfr`. Some commands like `open-df` were renamed to `dfr open` and things like `into df` were renamed `dfr into-df`. I'm sure we can optimize naming a bit, but it seems to compile now.

# User-Facing Changes

All dataframe commands are prefixed with dfr.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
