### PR TITLE
Fixes #7991 sqlite3 auxiliary files deletion

### DIFF
--- a/crates/nu-command/src/misc/history.rs
+++ b/crates/nu-command/src/misc/history.rs
@@ -75,7 +75,9 @@ impl Command for History {
 
             if clear {
                 while let Some(file) = history_paths.pop() {
-                    if let Err(e) = std::fs::remove_file(&file) { println!("Error while deleting {}: {:?}", file.display(), e) }
+                    if let Err(e) = std::fs::remove_file(&file) {
+                        println!("Error while deleting {}: {:?}", file.display(), e)
+                    }
                 }
                 Ok(PipelineData::empty())
             } else {


### PR DESCRIPTION
# Description

Fixes issue #7991 by removing auxiliary sqlite3 files while maintaining compatibility with plaintext history.

# User-Facing Changes

No user-facing changes.

# Other

I've added a printout of a filename in case it would cause an error (permission issue, no file, etc).

These are my first lines in Rust - total beginner and welcoming all suggestions.