### PR TITLE
Make ++ operator work with strings and binary values

### DIFF
--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -473,6 +473,8 @@ fn compound_where_paren() {
     assert_eq!(actual.out, r#"[{"a": 2,"b": 1},{"a": 2,"b": 2}]"#);
 }
 
+// TODO: these ++ tests are not really testing *math* functionality, maybe find another place for them
+
 #[test]
 fn adding_lists() {
     let actual = nu!(
@@ -518,4 +520,26 @@ fn adding_tables() {
         "#
     ));
     assert_eq!(actual.out, "[{a: 1, b: 2}, {c: 10, d: 11}]");
+}
+
+#[test]
+fn append_strings() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "foo" ++ "bar"
+        "#
+    ));
+    assert_eq!(actual.out, "foobar");
+}
+
+#[test]
+fn append_binary_values() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            0x[01 02] ++ 0x[03 04] | to nuon
+        "#
+    ));
+    assert_eq!(actual.out, "0x[01020304]");
 }

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -84,6 +84,8 @@ pub fn math_result_type(
                     }
                 }
                 (Type::Table(a), Type::Table(_)) => (Type::Table(a.clone()), None),
+                (Type::String, Type::String) => (Type::String, None),
+                (Type::Binary, Type::Binary) => (Type::Binary, None),
                 (Type::Any, _) | (_, Type::Any) => (Type::Any, None),
                 _ => {
                     *op = Expression::garbage(op.span);

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2084,6 +2084,15 @@ impl Value {
                 rhs.insert(0, val.clone());
                 Ok(Value::List { vals: rhs, span })
             }
+            (Value::String { val: lhs, .. }, Value::String { val: rhs, .. }) => Ok(Value::String {
+                val: lhs.to_string() + rhs,
+                span,
+            }),
+            (Value::Binary { val: lhs, .. }, Value::Binary { val: rhs, .. }) => {
+                let mut val = lhs.clone();
+                val.extend(rhs);
+                Ok(Value::Binary { val, span })
+            }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
                 lhs_ty: self.get_type(),


### PR DESCRIPTION
This PR makes `++` (the append operator) work with strings and binary values. Can now do things like:

```bash
〉"a" ++ "b"
ab
〉0x[01 02] ++ 0x[03]
Length: 3 (0x3) bytes | printable whitespace ascii_other non_ascii
00000000:   01 02 03                                             •••
```

Closes #8015.