### PR TITLE
rename benchmark to time

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -177,7 +177,7 @@ pub fn create_default_context() -> EngineState {
             External,
             NuCheck,
             Sys,
-            Time,
+            TimeIt,
         };
 
         #[cfg(unix)]

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -172,12 +172,12 @@ pub fn create_default_context() -> EngineState {
 
         // System
         bind_command! {
-            Benchmark,
             Complete,
             Explain,
             External,
             NuCheck,
             Sys,
+            Time,
         };
 
         #[cfg(unix)]

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -1,4 +1,3 @@
-mod benchmark;
 mod complete;
 #[cfg(unix)]
 mod exec;
@@ -15,9 +14,9 @@ mod ps;
 mod registry_query;
 mod run_external;
 mod sys;
+mod time;
 mod which_;
 
-pub use benchmark::Benchmark;
 pub use complete::Complete;
 #[cfg(unix)]
 pub use exec::Exec;
@@ -34,4 +33,5 @@ pub use ps::Ps;
 pub use registry_query::RegistryQuery;
 pub use run_external::{External, ExternalCommand};
 pub use sys::Sys;
+pub use time::Time;
 pub use which_::Which;

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -14,7 +14,7 @@ mod ps;
 mod registry_query;
 mod run_external;
 mod sys;
-mod time;
+mod timeit;
 mod which_;
 
 pub use complete::Complete;
@@ -33,5 +33,5 @@ pub use ps::Ps;
 pub use registry_query::RegistryQuery;
 pub use run_external::{External, ExternalCommand};
 pub use sys::Sys;
-pub use time::Time;
+pub use timeit::TimeIt;
 pub use which_::Which;

--- a/crates/nu-command/src/system/time.rs
+++ b/crates/nu-command/src/system/time.rs
@@ -35,6 +35,10 @@ impl Command for Time {
             .category(Category::System)
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["timing", "timer", "benchmark", "measure"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/system/time.rs
+++ b/crates/nu-command/src/system/time.rs
@@ -9,11 +9,11 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct Benchmark;
+pub struct Time;
 
-impl Command for Benchmark {
+impl Command for Time {
     fn name(&self) -> &str {
-        "benchmark"
+        "time"
     }
 
     fn usage(&self) -> &str {
@@ -21,7 +21,7 @@ impl Command for Benchmark {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("benchmark")
+        Signature::build("time")
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
@@ -88,13 +88,13 @@ impl Command for Benchmark {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Benchmarks a command within a closure",
-                example: "benchmark { sleep 500ms }",
+                description: "Times a command within a closure",
+                example: "time { sleep 500ms }",
                 result: None,
             },
             Example {
-                description: "Benchmark a command using an existing input",
-                example: "fetch https://www.nushell.sh/book/ | benchmark { split chars }",
+                description: "Times a command using an existing input",
+                example: "http get https://www.nushell.sh/book/ | time { split chars }",
                 result: None,
             },
         ]
@@ -102,13 +102,13 @@ impl Command for Benchmark {
 }
 
 #[test]
-// Due to difficulty in observing side-effects from benchmark closures,
+// Due to difficulty in observing side-effects from time closures,
 // checks that the closures have run correctly must use the filesystem.
-fn test_benchmark_closure() {
+fn test_time_closure() {
     use nu_test_support::{nu, nu_repl_code, playground::Playground};
-    Playground::setup("test_benchmark_closure", |dirs, _| {
+    Playground::setup("test_time_closure", |dirs, _| {
         let inp = [
-            r#"[2 3 4] | benchmark { to nuon | save foo.txt }"#,
+            r#"[2 3 4] | time { to nuon | save foo.txt }"#,
             "open foo.txt",
         ];
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(&inp));
@@ -118,11 +118,11 @@ fn test_benchmark_closure() {
 }
 
 #[test]
-fn test_benchmark_closure_2() {
+fn test_time_closure_2() {
     use nu_test_support::{nu, nu_repl_code, playground::Playground};
-    Playground::setup("test_benchmark_closure", |dirs, _| {
+    Playground::setup("test_time_closure", |dirs, _| {
         let inp = [
-            r#"[2 3 4] | benchmark {|e| {result: $e} | to nuon | save foo.txt }"#,
+            r#"[2 3 4] | time {|e| {result: $e} | to nuon | save foo.txt }"#,
             "open foo.txt",
         ];
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(&inp));

--- a/crates/nu-command/src/system/timeit.rs
+++ b/crates/nu-command/src/system/timeit.rs
@@ -1,19 +1,18 @@
-use std::time::Instant;
-
 use nu_engine::{eval_block, CallExt};
-use nu_protocol::ast::Call;
-use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
+    ast::Call,
+    engine::{Closure, Command, EngineState, Stack},
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type,
     Value,
 };
+use std::time::Instant;
 
 #[derive(Clone)]
-pub struct Time;
+pub struct TimeIt;
 
-impl Command for Time {
+impl Command for TimeIt {
     fn name(&self) -> &str {
-        "time"
+        "timeit"
     }
 
     fn usage(&self) -> &str {
@@ -21,7 +20,7 @@ impl Command for Time {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("time")
+        Signature::build("timeit")
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
@@ -93,12 +92,12 @@ impl Command for Time {
         vec![
             Example {
                 description: "Times a command within a closure",
-                example: "time { sleep 500ms }",
+                example: "timeit { sleep 500ms }",
                 result: None,
             },
             Example {
                 description: "Times a command using an existing input",
-                example: "http get https://www.nushell.sh/book/ | time { split chars }",
+                example: "http get https://www.nushell.sh/book/ | timeit { split chars }",
                 result: None,
             },
         ]
@@ -112,7 +111,7 @@ fn test_time_closure() {
     use nu_test_support::{nu, nu_repl_code, playground::Playground};
     Playground::setup("test_time_closure", |dirs, _| {
         let inp = [
-            r#"[2 3 4] | time { to nuon | save foo.txt }"#,
+            r#"[2 3 4] | timeit { to nuon | save foo.txt }"#,
             "open foo.txt",
         ];
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(&inp));
@@ -126,7 +125,7 @@ fn test_time_closure_2() {
     use nu_test_support::{nu, nu_repl_code, playground::Playground};
     Playground::setup("test_time_closure", |dirs, _| {
         let inp = [
-            r#"[2 3 4] | time {|e| {result: $e} | to nuon | save foo.txt }"#,
+            r#"[2 3 4] | timeit {|e| {result: $e} | to nuon | save foo.txt }"#,
             "open foo.txt",
         ];
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(&inp));

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -116,8 +116,8 @@ fn command_not_found_error_suggests_search_term() {
 
 #[test]
 fn command_not_found_error_suggests_typo_fix() {
-    let actual = nu!(cwd: ".", "benhcmark { echo 'foo'}");
-    assert!(actual.err.contains("benchmark"));
+    let actual = nu!(cwd: ".", "time { echo 'foo'}");
+    assert!(actual.err.contains("time"));
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -116,7 +116,7 @@ fn command_not_found_error_suggests_search_term() {
 
 #[test]
 fn command_not_found_error_suggests_typo_fix() {
-    let actual = nu!(cwd: ".", "time { echo 'foo'}");
+    let actual = nu!(cwd: ".", "benchmark { echo 'foo'}");
     assert!(actual.err.contains("time"));
 }
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -117,7 +117,7 @@ fn command_not_found_error_suggests_search_term() {
 #[test]
 fn command_not_found_error_suggests_typo_fix() {
     let actual = nu!(cwd: ".", "benchmark { echo 'foo'}");
-    assert!(actual.err.contains("time"));
+    assert!(actual.err.contains("timeit"));
 }
 
 #[test]


### PR DESCRIPTION
# Description

This PR renames the `benchmark` command to the `time` command.

# User-Facing Changes

new command name

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
