### PR TITLE
Make metadata a `Category::Debug` command

### DIFF
--- a/crates/nu-command/src/core_commands/metadata.rs
+++ b/crates/nu-command/src/core_commands/metadata.rs
@@ -27,7 +27,7 @@ impl Command for Metadata {
                 SyntaxShape::Any,
                 "the expression you want metadata for",
             )
-            .category(Category::Core)
+            .category(Category::Debug)
     }
 
     fn run(


### PR DESCRIPTION
# Description

This PR changes the `metadata` command to a `Category::Debug` command for better organization.

# User-Facing Changes

Just a different category.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
