### PR TITLE
Check ctrl+c when collecting a RawStream

### DIFF
--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -34,6 +34,9 @@ impl RawStream {
         let mut output = vec![];
 
         for item in self.stream {
+            if nu_utils::ctrl_c::was_pressed(&self.ctrlc) {
+                break;
+            }
             output.extend(item?);
         }
 
@@ -46,8 +49,12 @@ impl RawStream {
     pub fn into_string(self) -> Result<Spanned<String>, ShellError> {
         let mut output = String::new();
         let span = self.span;
+        let ctrlc = &self.ctrlc.clone();
 
         for item in self {
+            if nu_utils::ctrl_c::was_pressed(ctrlc) {
+                break;
+            }
             output.push_str(&item?.as_string()?);
         }
 


### PR DESCRIPTION
I noticed that `open some_big_file | into binary` cannot be cancelled with `ctrl+c`.

This small PR fixes that by checking `ctrl+c` in `RawStream::into_bytes()`, and does the same in `RawStream::into_string()` for good measure.