### PR TITLE
add ctrl+j to insert new line at current cursor

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -605,6 +605,13 @@ let-env config = {
       }
     }
     {
+      name: insert-new-line
+      modifier: control
+      keycode: char_j
+      mode: emacs
+      event: {edit: insertnewline}
+    }
+    {
       name: unix-line-discard
       modifier: control
       keycode: char_u


### PR DESCRIPTION
# Description

I keep getting stuck on how to insert a newline without running the command, and @kurokirasama mentioned about adding a keybinding.  And I think it's good to make such keybinding to default config.

So this pr is trying to add `ctrl-j` to insert a new line , it's the same to emacs `ctrl-j` keybinding

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
