### PR TITLE
remove the `--encoding` option from `register` in the examples

### DIFF
--- a/crates/nu_plugin_gstat/README.md
+++ b/crates/nu_plugin_gstat/README.md
@@ -10,4 +10,4 @@ To install:
 
 To register (from inside Nushell):
 ```
-> register <path to installed plugin> --encoding msgpack
+> register <path to installed plugin>

--- a/crates/nu_plugin_inc/README.md
+++ b/crates/nu_plugin_inc/README.md
@@ -10,4 +10,4 @@ cargo install --path .
 
 To register (from inside Nushell):
 ```
-register <path to installed plugin> --encoding json
+register <path to installed plugin>

--- a/crates/nu_plugin_query/README.md
+++ b/crates/nu_plugin_query/README.md
@@ -10,4 +10,4 @@ To install:
 
 To register (from inside Nushell):
 ```
-> register <path to installed plugin> --encoding json
+> register <path to installed plugin>


### PR DESCRIPTION
# Description
As `register` does not have `--encoding` as an option now, the [*Git stat plugin for Nushell*](https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gstat#git-stat-plugin-for-nushell) is not correct anymore

```
> register ~/.local/share/cargo/bin/nu_plugin_gstat --encoding msgpack
Error: nu::parser::unknown_flag (link)

  × The `register` command doesn't have flag `encoding`.
   ╭─[entry #22:1:1]
 1 │ register ~/.local/share/cargo/bin/nu_plugin_gstat --encoding msgpack
   ·                                                   ─────┬────
   ·                                                        ╰── unknown flag
   ╰────
  help: Available flags: --help(-h), --shell(-s). Use `--help` for more information.
```

This PR then simply removes `--encoding msgpack` from the `register` call in the documentation of the `gstat` plugin.

# User-Facing Changes
There is no user-facing change in this PR.

# Tests + Formatting
This PR does not change any source code.

# After Submitting
Same here, nothing to report :wink: 
