### PR TITLE
add benchmark to deprecated commands

### DIFF
--- a/crates/nu-command/src/deprecated/deprecated_commands.rs
+++ b/crates/nu-command/src/deprecated/deprecated_commands.rs
@@ -22,5 +22,6 @@ pub fn deprecated_commands() -> HashMap<String, String> {
         ("post".to_string(), "http post".to_string()),
         ("str lpad".to_string(), "fill".to_string()),
         ("str rpad".to_string(), "fill".to_string()),
+        ("benchmark".to_string(), "timeit".to_string()),
     ])
 }


### PR DESCRIPTION
# Description

This PR adds a deprecated message to the `benchmark` command.
```
> benchmark
Error: nu::shell::deprecated_command (link)

  × Deprecated command benchmark
   ╭─[entry #1:1:1]
 1 │ benchmark
   · ────┬────
   ·     ╰── 'benchmark' is deprecated. Please use 'timeit' instead.
   ╰────
```

# User-Facing Changes

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
