### PR TITLE
#8027 Hide implementation details in invalid cd call

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -135,7 +135,7 @@ impl Command for Cd {
                         }
 
                         // if canonicalize failed, let's check to see if it's abbreviated
-                        Err(e1) => {
+                        Err(_e1) => {
                             if use_abbrev {
                                 match query(&path_no_whitespace, None, v.span) {
                                     Ok(path) => path,
@@ -149,7 +149,7 @@ impl Command for Cd {
                             } else {
                                 return Err(ShellError::DirectoryNotFound(
                                     v.span,
-                                    Some(format!("IO Error: {e1:?}")),
+                                    Some(String::from("IO Error: DirectoryNotFound")),
                                 ));
                             }
                         }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -135,7 +135,7 @@ impl Command for Cd {
                         }
 
                         // if canonicalize failed, let's check to see if it's abbreviated
-                        Err(_e1) => {
+                        Err(_) => {
                             if use_abbrev {
                                 match query(&path_no_whitespace, None, v.span) {
                                     Ok(path) => path,
@@ -147,10 +147,7 @@ impl Command for Cd {
                                     }
                                 }
                             } else {
-                                return Err(ShellError::DirectoryNotFound(
-                                    v.span,
-                                    Some(String::from("IO Error: DirectoryNotFound")),
-                                ));
+                                return Err(ShellError::DirectoryNotFound(v.span, None));
                             }
                         }
                     };


### PR DESCRIPTION
# Description

[GH issue](https://github.com/nushell/nushell/issues/8027)

The current error message for a cd command includes a Debug output of the `io::Error` being returned from `canonicalize_with`, so it's been replaced with a more user friendly and readable depiction of the error.

# User-Facing Changes

As described in the issue, I've changed the error message for a cd into a directory that does not exist from:
```
/home/rdevenney/projects/open_source/nushell〉cd asdfasdf                                                                               02/11/2023 08:59:59 PM
Error: nu::shell::directory_not_found (link)

 × Directory not found
   ╭─[entry #2:1:1]
 1 │ cd asdfasdf
   ·    ────┬───
   ·        ╰── directory not found
   ╰────
  help: IO Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```
To:
```
/home/rdevenney/projects/open_source/nushell〉cd asdfasdf                                                                               02/11/2023 08:58:38 PM
Error: nu::shell::directory_not_found (link)

  × Directory not found
   ╭─[entry #1:1:1]
 1 │ cd asdfasdf
   ·    ────┬───
   ·        ╰── directory not found
   ╰────
  help: IO Error: DirectoryNotFound
```
# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
