### PR TITLE
Improve error when regex rejects pattern.  Resolution of #8037

### DIFF
--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -209,10 +209,7 @@ fn action(
                         }
                     }
                     Err(e) => Value::Error {
-                        error: ShellError::IncorrectValue(
-                            format!("Regex error: {e}"),
-                            find.span,
-                        ),
+                        error: ShellError::IncorrectValue(format!("Regex error: {e}"), find.span),
                     },
                 }
             }

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -209,10 +209,8 @@ fn action(
                         }
                     }
                     Err(e) => Value::Error {
-                        error: ShellError::UnsupportedInput(
-                            format!("{e}"),
-                            "value originates from here".into(),
-                            head,
+                        error: ShellError::IncorrectValue(
+                            format!("Regex error: {e}"),
                             find.span,
                         ),
                     },

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -200,6 +200,26 @@ fn find_and_replaces_without_passing_field() {
 }
 
 #[test]
+fn regex_error_in_pattern() {
+    Playground::setup("str_test_8", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                 'source string'
+                 | str replace 'source \Ufoo' "destination"
+             "#
+        ));
+
+        let err = actual.err;
+        let expecting_str = "Incorrect value";
+        assert!(
+            err.contains(expecting_str),
+            "Error should contain '{expecting_str}', but was: {err}"
+        );
+    })
+}
+
+#[test]
 fn substrings_the_input() {
     Playground::setup("str_test_8", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContent(

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -91,6 +91,15 @@ pub enum ShellError {
         span: Span,
     },
 
+    /// A command received an argument with correct type but incorrect value.
+    ///
+    /// ## Resolution
+    ///
+    /// Correct the argument value before passing it in or change the command.
+    #[error("Incorrect value.")]
+    #[diagnostic(code(nu::shell::incorrect_value), url(docsrs))]
+    IncorrectValue(String, #[label = "{0}"] Span),
+
     /// This value cannot be used with this operator.
     ///
     /// ## Resolution


### PR DESCRIPTION
# Description

Improve error when `str replace <pattern>` detects a problem with <pattern>.

# User-Facing Changes

New "Incorrect value" error:
```
〉 'C:\Users\kubouch' | str replace 'C:\Users' 'foo'
Error: nu::shell::incorrect_value (link)

  × Incorrect value.
   ╭─[entry #1:1:1]
 1 │  'C:\Users\kubouch' | str replace 'C:\Users' 'foo'
   ·                                   ─────┬────
   ·                                        ╰── Regex error: Parsing error at position 4: Invalid hex escape
   ╰────
```

We could fruitfully replace some of the current uses of `ShellError::UnsupportedInput`  with this error.  'Incorrect value' is different from 'wrong type'

# Tests + Formatting

Don't forget to add tests that cover your changes.
* none added / changed.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
