### PR TITLE
Disable auto-benchmark harness for crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,7 @@ debug = false
 [[bin]]
 name = "nu"
 path = "src/main.rs"
+bench = false
 
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-cli"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dev-dependencies]
 nu-test-support = { path = "../nu-test-support", version = "0.75.1" }
 nu-command = { path = "../nu-command", version = "0.75.1" }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-color-config"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dependencies]
 serde = { version="1.0.123", features=["derive"] }
 # used only for text_style Alignments

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -10,6 +10,9 @@ version = "0.75.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+bench = false
+
 [dependencies]
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.75.1" }

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-engine"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dependencies]
 nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.75.1"  }
 nu-path = { path = "../nu-path", version = "0.75.1"  }

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-explore"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dependencies]
 nu-ansi-term = "0.46.0"
 nu-protocol = { path = "../nu-protocol", version = "0.75.1" }

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -10,5 +10,8 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-glob"
 edition = "2021"
 categories = ["filesystem"]
 
+[lib]
+bench = false
+
 [dev-dependencies]
 doc-comment = "0.3"

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -9,6 +9,9 @@ version = "0.75.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+bench = false
+
 [features]
 preserve_order = ["linked-hash-map", "linked-hash-map/serde_impl"]
 default = ["preserve_order"]

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-parser"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dependencies]
 bytesize = "1.1.0"
 chrono = { default-features = false, features = ['std'], version = "0.4.23" }

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-path"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dependencies]
 dirs-next = "2.0.0"
 

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-plugin"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dependencies]
 bincode = "1.3.3"
 nu-protocol = { path = "../nu-protocol", version = "0.75.1"  }

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.75.1"
 doctest = false
 name = "nu_pretty_hex"
 path = "src/lib.rs"
+bench = false
 
 [dependencies]
 nu-ansi-term = "0.46.0"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -9,6 +9,9 @@ version = "0.75.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+bench = false
+
 [dependencies]
 nu-utils = { path = "../nu-utils", version = "0.75.1" }
 nu-json = { path = "../nu-json", version = "0.75.1" }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -9,6 +9,9 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+bench = false
+
 [dependencies]
 libc = "0.2"
 log = "0.4"

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-table"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dependencies]
 nu-ansi-term = "0.46.0"
 nu-protocol = { path = "../nu-protocol", version = "0.75.1" }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT"
 name = "nu-term-grid"
 version = "0.75.1"
 
+[lib]
+bench = false
+
 [dependencies]
 unicode-width = "0.1.9"
 

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.75.1"
 
 [lib]
 doctest = false
+bench = false
 
 [dependencies]
 nu-path = { path="../nu-path", version = "0.75.1"  }

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -11,6 +11,10 @@ version = "0.75.1"
 [[bin]]
 name = "utils"
 path = "src/main.rs"
+bench = false
+
+[lib]
+bench = false
 
 [dependencies]
 log = "0.4"

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "nu_plugin_custom_values"
+bench = false
 
 [dependencies]
 nu-plugin = { path = "../nu-plugin", version = "0.75.1" }

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -7,6 +7,13 @@ license = "MIT"
 name = "nu_plugin_example"
 version = "0.75.1"
 
+[[bin]]
+name = "nu_plugin_example"
+bench = false
+
+[lib]
+bench = false
+
 [dependencies]
 nu-plugin = { path="../nu-plugin", version = "0.75.1" }
 nu-protocol = { path="../nu-protocol", version = "0.75.1", features = ["plugin"]}

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -9,6 +9,11 @@ version = "0.75.1"
 
 [lib]
 doctest = false
+bench = false
+
+[[bin]]
+name = "nu_plugin_gstat"
+bench = false
 
 [dependencies]
 nu-plugin = { path="../nu-plugin", version = "0.75.1" }

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -9,6 +9,11 @@ version = "0.75.1"
 
 [lib]
 doctest = false
+bench = false
+
+[[bin]]
+name = "nu_plugin_inc"
+bench = false
 
 [dependencies]
 nu-plugin = { path="../nu-plugin", version = "0.75.1" }

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -9,6 +9,12 @@ version = "0.75.1"
 
 [lib]
 doctest = false
+bench = false
+
+[[bin]]
+name = "nu_plugin_query"
+bench = false
+
 
 [dependencies]
 nu-plugin = { path="../nu-plugin", version = "0.75.1" }


### PR DESCRIPTION
# Description

This disables automatic detection of `#[bench]` and other benchmarks
within the crates. Our benchmarks should all live in `benches`

This fixes a problem with criterion flags and should also reduce the
build requirements for `cargo bench` a bit

Taken from https://github.com/nushell/nushell/pull/7952

See: https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options


# User-Facing Changes

None

