### PR TITLE
Add a `codecov.yml` configuration

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 55%
+        threshold: 2%
+
+comment:
+  layout: reach, diff, files
+  behavior: default
+  require_base: yes
+  require_head: yes
+  after_n_builds: 2
+  


### PR DESCRIPTION
Goal: avoid failing based on small coverage fluctuations.

See:

https://docs.codecov.com/docs/codecovyml-reference
