### PR TITLE
Bare word improvements

### DIFF
--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -141,6 +141,16 @@ pub fn file_path_completion(
                             || path.contains('#')
                             || path.contains('(')
                             || path.contains(')')
+                            || path.starts_with('0')
+                            || path.starts_with('1')
+                            || path.starts_with('2')
+                            || path.starts_with('3')
+                            || path.starts_with('4')
+                            || path.starts_with('5')
+                            || path.starts_with('6')
+                            || path.starts_with('7')
+                            || path.starts_with('8')
+                            || path.starts_with('9')
                         {
                             path = format!("`{path}`");
                         }

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -80,7 +80,7 @@ fn ignore_program_errors_works_for_external_with_semicolon() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        do -p { nu -c 'exit 1' }; `text`
+        do -p { nu -c 'exit 1' }; "text"
         "#
     ));
 

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -141,7 +141,7 @@ fn save_string_and_stream_as_raw() {
         nu!(
             cwd: dirs.root(),
             r#"
-            `<!DOCTYPE html><html><body><a href='http://example.org/'>Example</a></body></html>` | save save_test_7/temp.html
+            "<!DOCTYPE html><html><body><a href='http://example.org/'>Example</a></body></html>" | save save_test_7/temp.html
             "#,
         );
         let actual = file_contents(expected_file);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -76,15 +76,7 @@ pub fn is_math_expression_like(
 
     let b = bytes[0];
 
-    if b == b'('
-        || b == b'{'
-        || b == b'['
-        || b == b'$'
-        || b == b'"'
-        || b == b'\''
-        || b == b'`'
-        || b == b'-'
-    {
+    if b == b'(' || b == b'{' || b == b'[' || b == b'$' || b == b'"' || b == b'\'' || b == b'-' {
         return true;
     }
 

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -494,7 +494,7 @@ fn remove_overlay_discard_alias() {
 fn remove_overlay_discard_env() {
     let inp = &[
         r#"overlay use samples/spam.nu"#,
-        r#"let-env BAGR = `bagr`"#,
+        r#"let-env BAGR = 'bagr'"#,
         r#"overlay hide spam"#,
         r#"$env.BAGR"#,
     ];
@@ -526,7 +526,7 @@ fn remove_overlay_keep_decl() {
 fn remove_overlay_keep_alias() {
     let inp = &[
         r#"overlay use samples/spam.nu"#,
-        r#"alias bagr = `bagr`"#,
+        r#"alias bagr = 'bagr'"#,
         r#"overlay hide --keep-custom spam"#,
         r#"bagr"#,
     ];
@@ -542,7 +542,7 @@ fn remove_overlay_keep_alias() {
 fn remove_overlay_dont_keep_env() {
     let inp = &[
         r#"overlay use samples/spam.nu"#,
-        r#"let-env BAGR = `bagr`"#,
+        r#"let-env BAGR = 'bagr'"#,
         r#"overlay hide --keep-custom spam"#,
         r#"$env.BAGR"#,
     ];
@@ -596,7 +596,7 @@ fn remove_overlay_dont_keep_overwritten_alias() {
 fn remove_overlay_dont_keep_overwritten_env() {
     let inp = &[
         r#"overlay use samples/spam.nu"#,
-        r#"let-env BAZ = `bagr`"#,
+        r#"let-env BAZ = 'bagr'"#,
         r#"overlay hide --keep-custom spam"#,
         r#"$env.BAZ"#,
     ];
@@ -630,7 +630,7 @@ fn remove_overlay_keep_decl_in_latest_overlay() {
 fn remove_overlay_keep_alias_in_latest_overlay() {
     let inp = &[
         r#"overlay use samples/spam.nu"#,
-        r#"alias bagr = `bagr`"#,
+        r#"alias bagr = 'bagr'"#,
         r#"module eggs { }"#,
         r#"overlay use eggs"#,
         r#"overlay hide --keep-custom spam"#,
@@ -648,7 +648,7 @@ fn remove_overlay_keep_alias_in_latest_overlay() {
 fn remove_overlay_dont_keep_env_in_latest_overlay() {
     let inp = &[
         r#"overlay use samples/spam.nu"#,
-        r#"let-env BAGR = `bagr`"#,
+        r#"let-env BAGR = 'bagr'"#,
         r#"module eggs { }"#,
         r#"overlay use eggs"#,
         r#"overlay hide --keep-custom spam"#,

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1258,6 +1258,13 @@ mod parse {
 
         assert!(actual.err.contains("extra positional argument"),);
     }
+
+    #[test]
+    fn ensure_backticks_are_bareword_command() {
+        let actual = nu!(cwd: ".", "`8abc123`");
+
+        assert!(actual.err.contains("was not found"),);
+    }
 }
 
 mod tilde_expansion {


### PR DESCRIPTION
# Description

This does two fixes for bare words:

* It changes completions for paths to wrap a path with backticks if it starts with a number. This helps bare words that start with numbers be separate from unit values
* It allows bare words wrapped with backticks to be the name of a command. Backtick values in command positions are no longer treated as strings

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
