### PR TITLE
Make patch coverage check informational only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,9 @@ coverage:
       default:
         target: 55%
         threshold: 2%
+    patch:
+      default:
+        informational: true
 
 comment:
   layout: reach, diff, files


### PR DESCRIPTION
See: https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks