### PR TITLE
use winget releaser action for manifest submission

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -23,3 +23,4 @@ jobs:
           version: ${{ inputs.tag_name || github.event.release.tag_name }}
           release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
           token: ${{ secrets.NUSHELL_PAT }}
+          fork-user: fdncred

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -1,9 +1,14 @@
 name: Submit Nushell package to Windows Package Manager Community Repository
 
 on:
-  workflow_dispatch:
   release:
-    types: [published]
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Specific tag name'
+        required: true 
+        type: string
 
 jobs:
 
@@ -12,8 +17,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Submit package to Windows Package Manager Community Repository
-        run: |
-          iwr https://github.com/microsoft/winget-create/releases/download/v1.0.4.0/wingetcreate.exe -OutFile wingetcreate.exe
-          $github = Get-Content '${{ github.event_path }}' | ConvertFrom-Json
-          $installerUrl = $github.release.assets | Where-Object -Property name -match 'windows-msvc.msi' | Select -ExpandProperty browser_download_url -First 1
-          .\wingetcreate.exe update Nushell.Nushell -s -v $github.release.tag_name -u $installerUrl -t ${{ secrets.NUSHELL_PAT }}
+        uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Nushell.Nushell
+          version: ${{ inputs.tag_name || github.event.release.tag_name }}
+          release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
+          token: ${{ secrets.NUSHELL_PAT }}


### PR DESCRIPTION
# Description

Other than simplifying the CI, [Winget Releaser](https://github.com/vedantmgoyal2009/winget-releaser) includes more metadata in the manifest as it uses [Komac](https://github.com/russellbanks/Komac).

I recommend installing [Pull](https://github.com/apps/pull) on https://github.com/fdncred/winget-pkgs to automatically keep it up to date.

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).

> Migrate from [winget-pkgs-automation manifest](https://github.com/vedantmgoyal2009/vedantmgoyal2009/blob/main/winget-pkgs-automation/packages/n/nushell.nushell.json)