### PR TITLE
remove spurious use from default_context.rs

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -358,7 +358,6 @@ pub fn create_default_context() -> EngineState {
             ToToml,
             ToTsv,
             Touch,
-            Use,
             Upsert,
             Where,
             ToXml,


### PR DESCRIPTION

For some reason this "Use" in default_context.rs was in the code,
but it is not being "used" --- pun intended...
 