### PR TITLE
move ast command to the debug group

### DIFF
--- a/crates/nu-command/src/core_commands/mod.rs
+++ b/crates/nu-command/src/core_commands/mod.rs
@@ -1,5 +1,4 @@
 mod alias;
-mod ast;
 mod break_;
 mod commandline;
 mod const_;
@@ -39,7 +38,6 @@ mod version;
 mod while_;
 
 pub use alias::Alias;
-pub use ast::Ast;
 pub use break_::Break;
 pub use commandline::Commandline;
 pub use const_::Const;

--- a/crates/nu-command/src/debug/ast.rs
+++ b/crates/nu-command/src/debug/ast.rs
@@ -3,8 +3,8 @@ use nu_parser::parse;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack, StateWorkingSet},
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
+    Type, Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu-command/src/debug/ast.rs
+++ b/crates/nu-command/src/debug/ast.rs
@@ -63,17 +63,17 @@ impl Command for Ast {
             Example {
                 description: "Print the ast of a string",
                 example: "ast 'hello'",
-                result: Some(Value::nothing(Span::test_data())),
+                result: None,
             },
             Example {
                 description: "Print the ast of a pipeline",
                 example: "ast 'ls | where name =~ README'",
-                result: Some(Value::nothing(Span::test_data())),
+                result: None,
             },
             Example {
                 description: "Print the ast of a pipeline with an error",
                 example: "ast 'for x in 1..10 { echo $x '",
-                result: Some(Value::nothing(Span::test_data())),
+                result: None,
             },
         ]
     }

--- a/crates/nu-command/src/debug/ast.rs
+++ b/crates/nu-command/src/debug/ast.rs
@@ -21,12 +21,13 @@ impl Command for Ast {
 
     fn signature(&self) -> Signature {
         Signature::build("ast")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::String, Type::Record(vec![]))])
             .required(
                 "pipeline",
                 SyntaxShape::String,
                 "the pipeline to print the ast for",
             )
+            .allow_variants_without_examples(true)
             .category(Category::Debug)
     }
 

--- a/crates/nu-command/src/debug/mod.rs
+++ b/crates/nu-command/src/debug/mod.rs
@@ -1,3 +1,4 @@
+mod ast;
 mod debug_;
 mod explain;
 mod inspect;
@@ -10,6 +11,7 @@ mod view_files;
 mod view_source;
 mod view_span;
 
+pub use ast::Ast;
 pub use debug_::Debug;
 pub use explain::Explain;
 pub use inspect::Inspect;

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -29,7 +29,6 @@ pub fn create_default_context() -> EngineState {
         // Core
         bind_command! {
             Alias,
-            Ast,
             Break,
             Commandline,
             Const,
@@ -178,6 +177,7 @@ pub fn create_default_context() -> EngineState {
 
         // Debug
         bind_command! {
+            Ast,
             Debug,
             Explain,
             Inspect,


### PR DESCRIPTION
# Description

This PR tweaks how `ast` works a tiny bit by outputting values in stead of eprintln!'s. It also moves the `ast` command into the folder with the rest of the debug commands and changes the category to debug.

I started adding some tests but couldn't figure out a good way to do it since every `ast` command contains spans that will be different on each invocation.

# User-Facing Changes



# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
