### PR TITLE
Make the default prompt play nice with basic fonts

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -131,12 +131,12 @@ impl Prompt for NushellPrompt {
         match edit_mode {
             PromptEditMode::Default => match &self.default_prompt_indicator {
                 Some(indicator) => indicator,
-                None => ">",
+                None => "> ",
             }
             .into(),
             PromptEditMode::Emacs => match &self.default_prompt_indicator {
                 Some(indicator) => indicator,
-                None => ">",
+                None => "> ",
             }
             .into(),
             PromptEditMode::Vi(vi_mode) => match vi_mode {
@@ -146,7 +146,7 @@ impl Prompt for NushellPrompt {
                 },
                 PromptViMode::Insert => match &self.default_vi_insert_prompt_indicator {
                     Some(indicator) => indicator,
-                    None => ">",
+                    None => "> ",
                 },
             }
             .into(),

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -131,12 +131,12 @@ impl Prompt for NushellPrompt {
         match edit_mode {
             PromptEditMode::Default => match &self.default_prompt_indicator {
                 Some(indicator) => indicator,
-                None => "〉",
+                None => ">",
             }
             .into(),
             PromptEditMode::Emacs => match &self.default_prompt_indicator {
                 Some(indicator) => indicator,
-                None => "〉",
+                None => ">",
             }
             .into(),
             PromptEditMode::Vi(vi_mode) => match vi_mode {
@@ -146,7 +146,7 @@ impl Prompt for NushellPrompt {
                 },
                 PromptViMode::Insert => match &self.default_vi_insert_prompt_indicator {
                     Some(indicator) => indicator,
-                    None => "〉",
+                    None => ">",
                 },
             }
             .into(),

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -24,9 +24,9 @@ let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt
-let-env PROMPT_INDICATOR = { "〉" }
+let-env PROMPT_INDICATOR = { ">" }
 let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
-let-env PROMPT_INDICATOR_VI_NORMAL = { "〉" }
+let-env PROMPT_INDICATOR_VI_NORMAL = { ">" }
 let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
 
 # Specifies how environment variables are:

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -24,9 +24,9 @@ let-env PROMPT_COMMAND_RIGHT = { create_right_prompt }
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt
-let-env PROMPT_INDICATOR = { ">" }
+let-env PROMPT_INDICATOR = { "> " }
 let-env PROMPT_INDICATOR_VI_INSERT = { ": " }
-let-env PROMPT_INDICATOR_VI_NORMAL = { ">" }
+let-env PROMPT_INDICATOR_VI_NORMAL = { "> " }
 let-env PROMPT_MULTILINE_INDICATOR = { "::: " }
 
 # Specifies how environment variables are:

--- a/crates/nu-utils/src/sample_config/sample_login.nu
+++ b/crates/nu-utils/src/sample_config/sample_login.nu
@@ -3,7 +3,7 @@
 # - will be sourced after config.nu and env.nu in case of nushell started as login shell
 
 # just as an example for overwriting of an environment variable of env.nu
-let-env PROMPT_INDICATOR = { "(LS)>" }
+let-env PROMPT_INDICATOR = { "(LS)> " }
 
 # Similar to env-path and config-path there is a variable containing the path to login.nu
 echo $nu.loginshell-path

--- a/crates/nu-utils/src/sample_config/sample_login.nu
+++ b/crates/nu-utils/src/sample_config/sample_login.nu
@@ -3,7 +3,7 @@
 # - will be sourced after config.nu and env.nu in case of nushell started as login shell
 
 # just as an example for overwriting of an environment variable of env.nu
-let-env PROMPT_INDICATOR = { "(LS)〉" }
+let-env PROMPT_INDICATOR = { "(LS)>" }
 
 # Similar to env-path and config-path there is a variable containing the path to login.nu
 echo $nu.loginshell-path


### PR DESCRIPTION
# Description
This commit changes the `PROMPT_INDICATOR` and `PROMPT_INDICATOR_VI_NORMAL` in the default_env and sample_login files. It also changes its missing fallback in the prompt.rs file.

This has the intention of making the default prompt friendlier when dealing with basic terminals that may not support displaying a huge range of the Unicode standard, or users who don't want to get out of their way to install custom fonts for their terminals. It's also nicer/more balanced on the eyes, to me, and brings it in line with the logo of nushell `nu>`.

# User-Facing Changes
New installations of nushell will have > as the default prompt indicator, and running `config reset` will also change it. This might be confusing for a few seconds, it could be minor enough that it just feels slightly off. Anyone who has, for some reason, unset the PROMPT_INDICATOR variable, or set it to $nothing, will also receive the `>` treatment.

Users running on basic terminals (like cmd.exe on Windows 10) should no longer face font issues with the default basic prompt.

# Drawbacks
The Unicode arrow is pretty cool. And it predates many of us. Maybe it's worth keeping. One argument I could see, and mildly disagree with, is that it might make users lean towards installing a modern font for their terminal which will would have good consequences in the future.