### PR TITLE
allow date grouping in group-by

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -205,6 +205,7 @@ impl Value {
                     ));
                 }
             }),
+            Value::Date { val, .. } => Ok(val.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
             x => Err(ShellError::CantConvert(
                 "string".into(),
                 x.get_type().to_string(),


### PR DESCRIPTION
# Description

This small change allows tables to be grouped by date. It was previously failing because nushell didn't know how to represent the date as a string. This change allows the date to be formatted in rfc3339 format with subseconds represented as dot milliseconds. This formatted datetime representation is already understood by nushell.

Now you can do things like 

### Grouping by the exact time
```
> ls | group-by modified | table
╭───────────────────────────────┬────────────────╮
│ 2022-01-07T07:53:44.658-06:00 │ [table 1 row]  │
│ 2022-11-29T08:08:09.411-06:00 │ [table 2 rows] │
│ 2023-02-15T08:23:16.044-06:00 │ [table 5 rows] │
│ 2023-01-04T14:45:08.940-06:00 │ [table 2 rows] │
│ 2022-04-08T08:12:50.295-05:00 │ [table 1 row]  │
│ 2022-09-15T10:11:21.177-05:00 │ [table 1 row]  │
│ 2022-06-22T14:26:56.409-05:00 │ [table 1 row]  │
│ 2023-02-08T09:24:32.774-06:00 │ [table 1 row]  │
│ 2022-05-25T11:57:00.866-05:00 │ [table 2 rows] │
│ 2023-02-15T08:23:16.054-06:00 │ [table 4 rows] │
│ 2023-01-04T14:45:08.970-06:00 │ [table 3 rows] │
│ 2022-08-05T07:14:06.265-05:00 │ [table 1 row]  │
│ 2022-01-07T07:53:44.728-06:00 │ [table 1 row]  │
│ 2023-01-27T09:39:34.351-06:00 │ [table 1 row]  │
│ 2023-02-08T09:24:32.794-06:00 │ [table 1 row]  │
│ 2023-02-15T08:36:26.524-06:00 │ [table 1 row]  │
│ 2023-01-19T12:53:22.033-06:00 │ [table 1 row]  │
╰───────────────────────────────┴────────────────╯
```
### Grouping by only the date (truncating the time componenet to 0)
```
> ls | default "" date | update date {|r| $r.modified | date format '%Y-%m-%d' | into datetime} | group-by date | table
╭───────────────────────────────┬─────────────────╮
│ 2022-01-07T00:00:00.000-06:00 │ [table 2 rows]  │
│ 2022-11-29T00:00:00.000-06:00 │ [table 2 rows]  │
│ 2023-02-15T00:00:00.000-06:00 │ [table 10 rows] │
│ 2023-01-04T00:00:00.000-06:00 │ [table 5 rows]  │
│ 2022-04-08T00:00:00.000-06:00 │ [table 1 row]   │
│ 2022-09-15T00:00:00.000-06:00 │ [table 1 row]   │
│ 2022-06-22T00:00:00.000-06:00 │ [table 1 row]   │
│ 2023-02-08T00:00:00.000-06:00 │ [table 2 rows]  │
│ 2022-05-25T00:00:00.000-06:00 │ [table 2 rows]  │
│ 2022-08-05T00:00:00.000-06:00 │ [table 1 row]   │
│ 2023-01-27T00:00:00.000-06:00 │ [table 1 row]   │
│ 2023-01-19T00:00:00.000-06:00 │ [table 1 row]   │
╰───────────────────────────────┴─────────────────╯
```
### Grouping and Displaying only the date (you could do this before this PR too)
```
> ls | default "" date | update date {|r| $r.modified | date format '%Y-%m-%d'} | group-by date | table
╭────────────┬─────────────────╮
│ 2022-01-07 │ [table 2 rows]  │
│ 2022-11-29 │ [table 2 rows]  │
│ 2023-02-15 │ [table 10 rows] │
│ 2023-01-04 │ [table 5 rows]  │
│ 2022-04-08 │ [table 1 row]   │
│ 2022-09-15 │ [table 1 row]   │
│ 2022-06-22 │ [table 1 row]   │
│ 2023-02-08 │ [table 2 rows]  │
│ 2022-05-25 │ [table 2 rows]  │
│ 2022-08-05 │ [table 1 row]   │
│ 2023-01-27 │ [table 1 row]   │
│ 2023-01-19 │ [table 1 row]   │
╰────────────┴─────────────────╯
```
### Shows that nushell understands the rfc3339 format
```
> 2022-01-07T07:53:44.658-06:00 | describe 
date
> 2022-01-07T07:53:44.658-06:00 | date format '%Y-%m-%d'
2022-01-07
```
# User-Facing Changes

Related to #8036

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
