### PR TITLE
fix rename when it is passed an empty column list to rename

### DIFF
--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -107,7 +107,15 @@ fn rename(
         span: column_span,
     }) = call.get_flag(engine_state, stack, "column")?
     {
-        (Some(columns[0].span()?), column_span)
+        if columns.is_empty() {
+            return Err(ShellError::TypeMismatch(
+                    "The column list cannot be empty and must contain only two values: the column's name and its replacement value"
+                        .to_string(),
+                        column_span,
+                ));
+        } else {
+            (Some(columns[0].span()?), column_span)
+        }
     } else {
         (None, call.head)
     };
@@ -115,7 +123,7 @@ fn rename(
     if let Some(ref cols) = specified_column {
         if cols.len() != 2 {
             return Err(ShellError::TypeMismatch(
-                    "The list must contain only two values: the column's name and its replacement value"
+                    "The column list must contain only two values: the column's name and its replacement value"
                         .to_string(),
                         list_span,
                 ));

--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -86,3 +86,31 @@ fn errors_if_no_columns_present() {
         assert!(actual.err.contains("only record input data is supported"));
     })
 }
+
+#[test]
+fn errors_if_columns_param_is_empty() {
+    Playground::setup("rename_test_4", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_cuatro_mosqueteros.txt",
+            r#"
+                Andrés N. Robalino
+                Jonathan Turner
+                Yehuda Katz
+                Jason Gedge
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open los_cuatro_mosqueteros.txt
+                | lines
+                | wrap name
+                | default "arepa!" hit
+                | rename -c []
+                "#
+        ));
+
+        assert!(actual.err.contains("The list cannot be empty"));
+    })
+}

--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -111,6 +111,6 @@ fn errors_if_columns_param_is_empty() {
                 "#
         ));
 
-        assert!(actual.err.contains("The list cannot be empty"));
+        assert!(actual.err.contains("The column list cannot be empty"));
     })
 }


### PR DESCRIPTION
# Description

This PR fixes a bug that occurs if you pass `rename --column` and empty list like `ls | rename -c []`.

## Before

```
> ls | rename -c []
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', crates\nu-command\src\filters\rename.rs:110:15
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## After

```
> ls | rename -c []
Error: nu::shell::type_mismatch (link)

  × Type mismatch.
   ╭─[entry #1:1:1]
 1 │ ls | rename -c []
   ·                ─┬
   ·                 ╰── The list cannot be empty and must contain only two values: the column's name and its replacement value
   ╰────
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
