### PR TITLE
update colors in dark theme

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -148,21 +148,21 @@ let dark_theme = {
     duration: white
     date: { (date now) - $in |
       if $in < 1hr {
-        '#e61919'
+        'red3b'
       } else if $in < 6hr {
-        '#e68019'
+        'orange3'
       } else if $in < 1day {
-        '#e5e619'
+        'yellow3b'
       } else if $in < 3day {
-        '#80e619'
+        'chartreuse2b'
       } else if $in < 1wk {
-        '#19e619'
+        'green3b'
       } else if $in < 6wk {
-        '#19e5e6'
+        'darkturquoise'
       } else if $in < 52wk {
-        '#197fe6'
-      } else { 'light_gray' }
-    }
+        'deepskyblue3b'
+      } else { 'dark_gray' }
+    }    
     range: white
     float: white
     string: white


### PR DESCRIPTION
# Description

I noticed a bug in the default_config.nu while debugging something else. The colors in the dark_theme should be named colors and not rgb colors. Rgb colors prevents the dark theme from working properly in terminals that don't support 24-bit aka rgb colors.

# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
