### PR TITLE
fixes a def parsing bug with a default list

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -149,3 +149,51 @@ fn def_fails_with_invalid_name() {
     ));
     assert!(actual.err.contains(err_msg));
 }
+
+#[test]
+fn def_errors_with_specified_list_type() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def test-command [ foo: list<any> ] {}
+        "#
+    ));
+
+    assert!(actual.err.contains("unknown type"));
+}
+
+#[test]
+fn def_with_list() {
+    Playground::setup("def_with_list", |dirs, _| {
+        let data = r#"
+def e [
+param: list
+] {echo $param};
+            "#;
+        fs::write(dirs.root().join("def_test"), data).expect("Unable to write file");
+        let actual = nu!(
+            cwd: dirs.root(),
+            "source def_test; e [one] | to json -r"
+        );
+
+        assert!(actual.out.contains(r#"one"#));
+    })
+}
+
+#[test]
+fn def_with_default_list() {
+    Playground::setup("def_with_default_list", |dirs, _| {
+        let data = r#"
+def f [
+param: list = [one]
+] {echo $param};
+            "#;
+        fs::write(dirs.root().join("def_test"), data).expect("Unable to write file");
+        let actual = nu!(
+            cwd: dirs.root(),
+            "source def_test; f | to json -r"
+        );
+
+        assert!(actual.out.contains(r#"["one"]"#));
+    })
+}

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3662,6 +3662,25 @@ pub fn parse_signature_helper(
                                                     expression.ty.clone(),
                                                 );
                                             }
+                                            Type::List(_) => {
+                                                if var_type.is_list() && expression.ty.is_list() {
+                                                    working_set.set_variable_type(
+                                                        var_id,
+                                                        expression.ty.clone(),
+                                                    );
+                                                } else {
+                                                    error = error.or_else(|| {
+                                                        Some(ParseError::AssignmentMismatch(
+                                                            "Default value wrong type".into(),
+                                                            format!(
+                                                                "default value not {0}",
+                                                                expression.ty
+                                                            ),
+                                                            expression.span,
+                                                        ))
+                                                    })
+                                                }
+                                            }
                                             t => {
                                                 if t != &expression.ty {
                                                     error = error.or_else(|| {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -61,6 +61,10 @@ impl Type {
         matches!(self, Type::Int | Type::Float | Type::Number)
     }
 
+    pub fn is_list(&self) -> bool {
+        matches!(self, Type::List(_))
+    }
+
     /// Does this type represent a data structure containing values that can be addressed using 'cell paths'?
     pub fn accepts_cell_paths(&self) -> bool {
         matches!(self, Type::List(_) | Type::Record(_) | Type::Table(_))


### PR DESCRIPTION
# Description

This PR fixes a bug where a default list in a custom command parameter wasn't being accepted. The reason was because it was comparing specific types of list like `list<any>` != `list<string>`. So, this PR attempts to fix that.

### Before

```
> def f [param: list = [one]] { echo $param }
Error: nu::parser::assignment_mismatch (link)

  × Default value wrong type
   ╭─[entry #1:1:1]
 1 │ def f [param: list = [one]] { echo $param }
   ·                      ──┬──
   ·                        ╰── default value not list<any>
   ╰────
```

### After

```
> def f [param: list = [one]] {echo $param}
> f
╭───┬─────╮
│ 0 │ one │
╰───┴─────╯
```

closes #8092 

# User-Facing Changes



# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
