### PR TITLE
Revert #7779 (enables back subcommand completions)

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -165,7 +165,7 @@ impl Completer for CommandCompletion {
             .flattened
             .iter()
             .rev()
-            .skip_while(|x| x.0.end + offset > pos)
+            .skip_while(|x| x.0.end > pos)
             .take_while(|x| {
                 matches!(
                     x.1,

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -111,18 +111,11 @@ impl NuCompleter {
     }
 
     fn completion_helper(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
-        // pos: is the position of the cursor in the shell input.
-        // e.g. lets say you have an alias -> `alias ll = ls -l` and you type in the shell:
-        // > ll -a | c
-        // and your cursor is right after `c` then `pos` = 9
-
         let mut working_set = StateWorkingSet::new(&self.engine_state);
-        let mut offset = working_set.next_span_start();
+        let offset = working_set.next_span_start();
         let (mut new_line, alias_offset) = try_find_alias(line.as_bytes(), &working_set);
-        // new_line: vector containing all alias "translations" so if it was `ll` now is `ls -l`.
-        // alias_offset:vector the offset between the name and the alias)
-        let initial_line = line.to_string(); // Entire line in the shell input.
-        let alias_total_offset: usize = alias_offset.iter().sum(); // the sum of all alias offsets.
+        let initial_line = line.to_string();
+        let alias_total_offset: usize = alias_offset.iter().sum();
         new_line.insert(alias_total_offset + pos, b'a');
         let pos = offset + pos;
         let config = self.engine_state.get_config();
@@ -163,22 +156,14 @@ impl NuCompleter {
                                     most_left_variable(flat_idx, &working_set, flattened.clone());
 
                                 // Create a new span
-                                // if flat_idx == 0
-                                let mut span_start = flat.0.start;
-                                let mut span_end = flat.0.end - 1 - span_offset;
-
-                                if flat_idx != 0 {
-                                    span_start = flat.0.start - span_offset;
-                                    span_end = flat.0.end - 1 - span_offset;
-                                }
-
-                                if span_end < span_start {
-                                    span_start = flat.0.start;
-                                    span_end = flat.0.end - 1;
-                                    offset += span_offset
-                                }
-
-                                let new_span = Span::new(span_start, span_end);
+                                let new_span = if flat_idx == 0 {
+                                    Span::new(flat.0.start, flat.0.end - 1 - span_offset)
+                                } else {
+                                    Span::new(
+                                        flat.0.start - span_offset,
+                                        flat.0.end - 1 - span_offset,
+                                    )
+                                };
 
                                 // Parses the prefix. Completion should look up to the cursor position, not after.
                                 let mut prefix = working_set.get_span_contents(flat.0).to_vec();
@@ -192,10 +177,6 @@ impl NuCompleter {
                                         self.stack.clone(),
                                         most_left_var.unwrap_or((vec![], vec![])),
                                     );
-
-                                    if offset > new_span.start {
-                                        offset -= span_offset;
-                                    }
 
                                     return self.process_completion(
                                         &mut completer,

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -819,8 +819,9 @@ fn extern_complete_flags(mut extern_completer: NuCompleter) {
     match_suggestions(expected, suggestions);
 }
 
+#[ignore = "was reverted, still needs fixing"]
 #[rstest]
-fn alias_offset_bug_7748() {
+fn alias_offset_bug_7648() {
     let (dir, _, mut engine, mut stack) = new_engine();
 
     // Create an alias
@@ -829,15 +830,15 @@ fn alias_offset_bug_7748() {
 
     let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
 
-    // Issue #7748
+    // Issue #7648
     // Nushell crashes when an alias name is shorter than the alias command
     // and the alias command is a external command
     // This happens because of offset is not correct.
     // This crashes before PR #7779
     let _suggestions = completer.complete("e", 1);
-    //println!(" --------- suggestions: {:?}", suggestions);
 }
 
+#[ignore = "was reverted, still needs fixing"]
 #[rstest]
 fn alias_offset_bug_7754() {
     let (dir, _, mut engine, mut stack) = new_engine();
@@ -853,8 +854,6 @@ fn alias_offset_bug_7754() {
     // and the alias command contains pipes.
     // This crashes before PR #7756
     let _suggestions = completer.complete("ll -a | c", 9);
-
-    //println!(" --------- suggestions: {:?}", suggestions);
 }
 
 #[test]


### PR DESCRIPTION
# Description

Reverts the PR #7779 which breaks subcommand completions. The issues #7648 and #7754 thus still need fixing. 

This reverts commit 8acced5.

# User-Facing Changes

Enables subcommand completions.

Unfortunately, also brings back the completion panic if alias is shorter than the command name.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
