### PR TITLE
DOCUMENTATION: add a new "key-value" example to `with-env`

### DIFF
--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -69,7 +69,7 @@ impl Command for WithEnv {
             },
             Example {
                 description: "Set by row(e.g. `open x.json` or `from json`)",
-                example: r#"'{"X":"Y","W":"Z"}'|from json|with-env $in { [$env.X $env.W] }"#,
+                example: r#"'{"X":"Y","W":"Z"}' | from json | with-env $in { [$env.X $env.W] }"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -63,6 +63,11 @@ impl Command for WithEnv {
                 result: Some(Value::test_string("Z")),
             },
             Example {
+                description: "Set by key-value record",
+                example: r#"with-env {X: "Y", W: "Z"} { [$env.X $env.W] }"#,
+                result: None,
+            },
+            Example {
                 description: "Set by row(e.g. `open x.json` or `from json`)",
                 example: r#"'{"X":"Y","W":"Z"}'|from json|with-env $in { [$env.X $env.W] }"#,
                 result: None,

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -67,11 +67,6 @@ impl Command for WithEnv {
                 example: r#"with-env {X: "Y", W: "Z"} { [$env.X $env.W] }"#,
                 result: None,
             },
-            Example {
-                description: "Set by row(e.g. `open x.json` or `from json`)",
-                example: r#"'{"X":"Y","W":"Z"}' | from json | with-env $in { [$env.X $env.W] }"#,
-                result: None,
-            },
         ]
     }
 }


### PR DESCRIPTION
hello there :wave: :yum: 

when messing around with `with-env`, looking at the examples, i did not understand that we could directly run `with-env` with a record as the argument and not from the input of a pipe :open_mouth: 

even though the last example, i.e. 
```bash
  Set by row(e.g. `open x.json` or `from json`)
  > '{"X":"Y","W":"Z"}'|from json|with-env $in { [$env.X $env.W] }
```
, is equivalent, just the record comes from the pipe, i thought adding that explicite new example could be helpful :relieved: 
 
# Description
looking at the single real change of this PR, i.e. 86ef34e90, you can see i've simply added
```bash
  Set by key-value record
  > with-env {X: "Y", W: "Z"} { [$env.X $env.W] }
```
just before the example above

> **Note**
> i've also added spaces around the '|' in the last examples, from
> ```bash
>   > '{"X":"Y","W":"Z"}'|from json|with-env $in { [$env.X $env.W] }
> ```
> to
> ```bash
>   > '{"X":"Y","W":"Z"}' | from json | with-env $in { [$env.X $env.W] }
> ```
> hopefully making the pipeline a bit easier to read :+1:

### hope you like that :smirk: 

# User-Facing Changes
a new example has been added to `with-env`

# Tests + Formatting
no tests have been added

# After Submitting
the change should not affect the website, i think

=> if i need to generate the associated `HTML` file on https://github.com/nushell/nushell.github.io, please tell me :yum: 