### PR TITLE
Bump version for `0.76.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "assert_cmd",
  "atty",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "atty",
  "chrono",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "Inflector",
  "alphanumeric-sort",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "chrono",
  "nu-glob",
@@ -2831,7 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "nu-explore"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "ansi-str 0.7.2",
  "crossterm 0.24.0",
@@ -2851,14 +2851,14 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "doc-comment",
 ]
 
 [[package]]
 name = "nu-json"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "linked-hash-map",
  "num-traits",
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "bincode",
  "nu-engine",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "heapless",
  "nu-ansi-term",
@@ -2915,7 +2915,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "atty",
  "chrono",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "atty",
  "json_to_table",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "nu-utils",
  "unicode-width",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "getset",
  "hamcrest2",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "git2",
  "nu-engine",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "gjson",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.60"
-version = "0.75.1"
+version = "0.76.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -46,20 +46,20 @@ ctrlc = "3.2.1"
 log = "0.4"
 miette = { version = "5.5.0", features = ["fancy-no-backtrace"] }
 nu-ansi-term = "0.46.0"
-nu-cli = { path = "./crates/nu-cli", version = "0.75.1" }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.75.1" }
-nu-command = { path = "./crates/nu-command", version = "0.75.1" }
-nu-engine = { path = "./crates/nu-engine", version = "0.75.1" }
-nu-json = { path = "./crates/nu-json", version = "0.75.1" }
-nu-parser = { path = "./crates/nu-parser", version = "0.75.1" }
-nu-path = { path = "./crates/nu-path", version = "0.75.1" }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.75.1" }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.75.1" }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.75.1" }
-nu-system = { path = "./crates/nu-system", version = "0.75.1" }
-nu-table = { path = "./crates/nu-table", version = "0.75.1" }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.75.1" }
-nu-utils = { path = "./crates/nu-utils", version = "0.75.1" }
+nu-cli = { path = "./crates/nu-cli", version = "0.76.0" }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.76.0" }
+nu-command = { path = "./crates/nu-command", version = "0.76.0" }
+nu-engine = { path = "./crates/nu-engine", version = "0.76.0" }
+nu-json = { path = "./crates/nu-json", version = "0.76.0" }
+nu-parser = { path = "./crates/nu-parser", version = "0.76.0" }
+nu-path = { path = "./crates/nu-path", version = "0.76.0" }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.76.0" }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.76.0" }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.76.0" }
+nu-system = { path = "./crates/nu-system", version = "0.76.0" }
+nu-table = { path = "./crates/nu-table", version = "0.76.0" }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.76.0" }
+nu-utils = { path = "./crates/nu-utils", version = "0.76.0" }
 reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
 
 rayon = "1.6.1"
@@ -81,7 +81,7 @@ nix = { version = "0.25", default-features = false, features = ["signal", "proce
 atty = "0.2"
 
 [dev-dependencies]
-nu-test-support = { path = "./crates/nu-test-support", version = "0.75.1" }
+nu-test-support = { path = "./crates/nu-test-support", version = "0.76.0" }
 tempfile = "3.2.0"
 assert_cmd = "2.0.2"
 criterion = "0.4"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -5,24 +5,24 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.75.1" }
-nu-command = { path = "../nu-command", version = "0.75.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.76.0" }
+nu-command = { path = "../nu-command", version = "0.76.0" }
 rstest = { version = "0.16.0", default-features = false }
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.75.1" }
-nu-path = { path = "../nu-path", version = "0.75.1" }
-nu-parser = { path = "../nu-parser", version = "0.75.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.75.1" }
-nu-utils = { path = "../nu-utils", version = "0.75.1" }
+nu-engine = { path = "../nu-engine", version = "0.76.0" }
+nu-path = { path = "../nu-path", version = "0.76.0" }
+nu-parser = { path = "../nu-parser", version = "0.76.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0" }
+nu-utils = { path = "../nu-utils", version = "0.76.0" }
 nu-ansi-term = "0.46.0"
-nu-color-config = { path = "../nu-color-config", version = "0.75.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.76.0" }
 reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
 
 atty = "0.2.14"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-confi
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false
@@ -15,11 +15,11 @@ serde = { version="1.0.123", features=["derive"] }
 # used only for text_style Alignments
 tabled = { version = "0.10.0", features = ["color"], default-features = false }
 
-nu-protocol = { path = "../nu-protocol", version = "0.75.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0"  }
 nu-ansi-term = "0.46.0"
-nu-utils = { path = "../nu-utils", version = "0.75.1" }
-nu-engine = { path = "../nu-engine", version = "0.75.1" }
-nu-json = { path="../nu-json", version = "0.75.1"  }
+nu-utils = { path = "../nu-utils", version = "0.76.0" }
+nu-engine = { path = "../nu-engine", version = "0.76.0" }
+nu-json = { path="../nu-json", version = "0.76.0"  }
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.75.1"  }
+nu-test-support = { path="../nu-test-support", version = "0.76.0"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-command"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
-version = "0.75.1"
+version = "0.76.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,19 +15,19 @@ bench = false
 
 [dependencies]
 nu-ansi-term = "0.46.0"
-nu-color-config = { path = "../nu-color-config", version = "0.75.1" }
-nu-engine = { path = "../nu-engine", version = "0.75.1" }
-nu-explore = { path = "../nu-explore", version = "0.75.1" }
-nu-glob = { path = "../nu-glob", version = "0.75.1" }
-nu-json = { path = "../nu-json", version = "0.75.1" }
-nu-parser = { path = "../nu-parser", version = "0.75.1" }
-nu-path = { path = "../nu-path", version = "0.75.1" }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.75.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.75.1" }
-nu-system = { path = "../nu-system", version = "0.75.1" }
-nu-table = { path = "../nu-table", version = "0.75.1" }
-nu-term-grid = { path = "../nu-term-grid", version = "0.75.1" }
-nu-utils = { path = "../nu-utils", version = "0.75.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.76.0" }
+nu-engine = { path = "../nu-engine", version = "0.76.0" }
+nu-explore = { path = "../nu-explore", version = "0.76.0" }
+nu-glob = { path = "../nu-glob", version = "0.76.0" }
+nu-json = { path = "../nu-json", version = "0.76.0" }
+nu-parser = { path = "../nu-parser", version = "0.76.0" }
+nu-path = { path = "../nu-path", version = "0.76.0" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.76.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0" }
+nu-system = { path = "../nu-system", version = "0.76.0" }
+nu-table = { path = "../nu-table", version = "0.76.0" }
+nu-term-grid = { path = "../nu-term-grid", version = "0.76.0" }
+nu-utils = { path = "../nu-utils", version = "0.76.0" }
 num-format = { version = "0.4.3" }
 
 # Potential dependencies for extras
@@ -157,7 +157,7 @@ which-support = ["which"]
 shadow-rs = { version = "0.20.0", default-features = false }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.75.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.76.0" }
 
 dirs-next = "2.0.0"
 hamcrest2 = "0.3.0"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.75.1"  }
-nu-path = { path = "../nu-path", version = "0.75.1"  }
-nu-glob = { path = "../nu-glob", version = "0.75.1" }
-nu-utils = { path = "../nu-utils", version = "0.75.1"  }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.76.0"  }
+nu-path = { path = "../nu-path", version = "0.76.0"  }
+nu-glob = { path = "../nu-glob", version = "0.76.0" }
+nu-utils = { path = "../nu-utils", version = "0.76.0"  }
 
 chrono = { version="0.4.23", features = ["std"], default-features = false }
 serde = {version = "1.0.143", default-features = false }

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -5,20 +5,20 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-explore"
 edition = "2021"
 license = "MIT"
 name = "nu-explore"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false
 
 [dependencies]
 nu-ansi-term = "0.46.0"
-nu-protocol = { path = "../nu-protocol", version = "0.75.1" }
-nu-parser = { path = "../nu-parser", version = "0.75.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.75.1" }
-nu-engine = { path = "../nu-engine", version = "0.75.1" }
-nu-table = { path = "../nu-table", version = "0.75.1" }
-nu-json = { path = "../nu-json", version = "0.75.1"  }
-nu-utils = { path = "../nu-utils", version = "0.75.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0" }
+nu-parser = { path = "../nu-parser", version = "0.76.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.76.0" }
+nu-engine = { path = "../nu-engine", version = "0.76.0" }
+nu-table = { path = "../nu-table", version = "0.76.0" }
+nu-json = { path = "../nu-json", version = "0.76.0"  }
+nu-utils = { path = "../nu-utils", version = "0.76.0"  }
 
 terminal_size = "0.2.1"
 strip-ansi-escapes = "0.1.1"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.75.1"
+version = "0.76.0"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.75.1"
+version = "0.76.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,5 +22,5 @@ num-traits = "0.2.14"
 serde = "1.0"
 
 [dev-dependencies]
-# nu-path = { path="../nu-path", version = "0.75.1" }
+# nu-path = { path="../nu-path", version = "0.76.0" }
 # serde_json = "1.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false
@@ -17,10 +17,10 @@ itertools = "0.10"
 miette = {version = "5.5.0", features = ["fancy-no-backtrace"]}
 thiserror = "1.0.31"
 serde_json = "1.0"
-nu-path = {path = "../nu-path", version = "0.75.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.75.1" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.75.1"  }
-nu-engine = { path = "../nu-engine", version = "0.75.1" }
+nu-path = {path = "../nu-path", version = "0.76.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0" }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.76.0"  }
+nu-engine = { path = "../nu-engine", version = "0.76.0" }
 log = "0.4"
 
 [features]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -5,15 +5,15 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false
 
 [dependencies]
 bincode = "1.3.3"
-nu-protocol = { path = "../nu-protocol", version = "0.75.1"  }
-nu-engine = { path = "../nu-engine", version = "0.75.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0"  }
+nu-engine = { path = "../nu-engine", version = "0.76.0"  }
 serde = { version = "1.0.143" }
 serde_json = { version = "1.0"}
 rmp = "0.8.11"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.75.1"
+version = "0.76.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,8 +13,8 @@ version = "0.75.1"
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.75.1" }
-nu-json = { path = "../nu-json", version = "0.75.1" }
+nu-utils = { path = "../nu-utils", version = "0.76.0" }
+nu-json = { path = "../nu-json", version = "0.76.0" }
 
 byte-unit = "4.0.9"
 chrono = { version = "0.4.23", features = [
@@ -40,4 +40,4 @@ plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = "1.0"
-nu-test-support = { path = "../nu-test-support", version = "0.75.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.76.0" }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.75.1"
+version = "0.76.0"
 edition = "2021"
 license = "MIT"
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -5,21 +5,21 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false
 
 [dependencies]
 nu-ansi-term = "0.46.0"
-nu-protocol = { path = "../nu-protocol", version = "0.75.1" }
-nu-utils = { path = "../nu-utils", version = "0.75.1" }
-nu-engine = { path = "../nu-engine", version = "0.75.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.75.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0" }
+nu-utils = { path = "../nu-utils", version = "0.76.0" }
+nu-engine = { path = "../nu-engine", version = "0.76.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.76.0" }
 atty = "0.2.14"
 tabled = { version = "0.10.0", features = ["color"], default-features = false }
 json_to_table = { version = "0.3.1", features = ["color"] }
 serde_json = "1"
 
 [dev-dependencies]
-# nu-test-support = { path="../nu-test-support", version = "0.75.1"  }
+# nu-test-support = { path="../nu-test-support", version = "0.76.0"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 bench = false
@@ -13,4 +13,4 @@ bench = false
 [dependencies]
 unicode-width = "0.1.9"
 
-nu-utils = { path = "../nu-utils", version = "0.75.1"  }
+nu-utils = { path = "../nu-utils", version = "0.76.0"  }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-suppor
 edition = "2021"
 license = "MIT"
 name = "nu-test-support"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 doctest = false
 bench = false
 
 [dependencies]
-nu-path = { path="../nu-path", version = "0.75.1"  }
-nu-glob = { path = "../nu-glob", version = "0.75.1" }
-nu-utils = { path="../nu-utils", version = "0.75.1"  }
+nu-path = { path="../nu-path", version = "0.76.0"  }
+nu-glob = { path = "../nu-glob", version = "0.76.0" }
+nu-utils = { path="../nu-utils", version = "0.76.0"  }
 once_cell = "1.16.0"
 num-format = "0.4.3"
 which = "4.3.0"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-utils"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
-version = "0.75.1"
+version = "0.76.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -10,7 +10,7 @@ name = "nu_plugin_custom_values"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.75.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.75.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.76.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0", features = ["plugin"] }
 serde = { version = "1.0", default-features = false }
 typetag = "0.2.5"

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_exam
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.75.1"
+version = "0.76.0"
 
 [[bin]]
 name = "nu_plugin_example"
@@ -15,5 +15,5 @@ bench = false
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.75.1" }
-nu-protocol = { path="../nu-protocol", version = "0.75.1", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.76.0" }
+nu-protocol = { path="../nu-protocol", version = "0.76.0", features = ["plugin"]}

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.75.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.75.1", features = ["plugin"] }
-nu-engine = { path = "../nu-engine", version = "0.75.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.76.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.76.0", features = ["plugin"] }
+nu-engine = { path = "../nu-engine", version = "0.76.0" }
 indexmap = { version = "1.7", features = ["serde-1"] }
 
 eml-parser = "0.1.0"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gsta
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 doctest = false
@@ -16,8 +16,8 @@ name = "nu_plugin_gstat"
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.75.1" }
-nu-protocol = { path="../nu-protocol", version = "0.75.1" }
-nu-engine = { path="../nu-engine", version = "0.75.1" }
+nu-plugin = { path="../nu-plugin", version = "0.76.0" }
+nu-protocol = { path="../nu-protocol", version = "0.76.0" }
+nu-engine = { path="../nu-engine", version = "0.76.0" }
 
 git2 = "0.16.1"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_inc"
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.75.1" }
-nu-protocol = { path="../nu-protocol", version = "0.75.1", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.76.0" }
+nu-protocol = { path="../nu-protocol", version = "0.76.0", features = ["plugin"]}
 
 semver = "1.0.16"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_quer
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.75.1"
+version = "0.76.0"
 
 [lib]
 doctest = false
@@ -17,9 +17,9 @@ bench = false
 
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.75.1" }
-nu-protocol = { path="../nu-protocol", version = "0.75.1" }
-nu-engine = { path="../nu-engine", version = "0.75.1" }
+nu-plugin = { path="../nu-plugin", version = "0.76.0" }
+nu-protocol = { path="../nu-protocol", version = "0.76.0" }
+nu-engine = { path="../nu-engine", version = "0.76.0" }
 gjson = "0.8.0"
 scraper = { default-features = false, version = "0.14.0" }
 sxd-document = "0.3.2"


### PR DESCRIPTION
Before landing:

- [x] `reedline 0.16.0` is out and pinned.
- [x] all fixes and features necessary are landed.

In the meantime:

- [ ] feed the release notes with relevant features and breaking changes
