### PR TITLE
show more informaiton when there are toml errors

### DIFF
--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -106,11 +106,11 @@ pub fn convert_string_to_value(string_input: String, span: Span) -> Result<Value
     match result {
         Ok(value) => Ok(convert_toml_to_value(&value, span)),
 
-        Err(_x) => Err(ShellError::CantConvert(
+        Err(err) => Err(ShellError::CantConvert(
             "structured toml data".into(),
             "string".into(),
             span,
-            None,
+            Some(err.to_string()),
         )),
     }
 }
@@ -131,7 +131,7 @@ mod tests {
         let input_string = String::from(
             r#"
             command.build = "go build"
-        
+
             [command.deploy]
             script = "./deploy.sh"
             "#,
@@ -148,8 +148,8 @@ mod tests {
     fn string_to_toml_value_fails() {
         let input_string = String::from(
             r#"
-            command.build = 
-        
+            command.build =
+
             [command.deploy]
             script = "./deploy.sh"
             "#,


### PR DESCRIPTION
# Description

While debugging #8139 I noticed that there was some error information coming from the toml crate that we were not displaying. This would've helped me to understand what was going on. So, this PR shows more verbose errors when toml fails to parse.

### Before

```
cargo llvm-cov show-env | from toml 
Error: nu::shell::cant_convert (link)

  × Can't convert to structured toml data.
   ╭─[entry #1:1:1]
 1 │ cargo llvm-cov show-env | from toml
   · ──┬──
   ·   ╰── can't convert string to structured toml data
   ╰────
```

### After

```
cargo llvm-cov show-env | from toml
Error: nu::shell::cant_convert (link)

  × Can't convert to structured toml data.
   ╭─[entry #1:1:1]
 1 │ cargo llvm-cov show-env | from toml
   · ──┬──
   ·   ╰── can't convert string to structured toml data
   ╰────
  help: TOML parse error at line 2, column 24
          |
        2 | LLVM_PROFILE_FILE="C:\CarTar\nushell-%p-%m.profraw"
          |                        ^
        invalid escape sequence
        expected `b`, `f`, `n`, `r`, `t`, `u`, `U`, `\`, `"`
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
