### PR TITLE
update code coversage script to work better with windows

### DIFF
--- a/coverage-local.nu
+++ b/coverage-local.nu
@@ -1,5 +1,6 @@
 #!/usr/bin/env nu
 
+let start = (date now)
 # Script to generate coverage locally
 #
 # Output: `lcov.info` file
@@ -20,17 +21,31 @@ let-env NUSHELL_CARGO_TARGET = "ci"
 # This is relevant for tests using the `nu!` macro from `nu-test-support`
 # see: https://github.com/taiki-e/cargo-llvm-cov#get-coverage-of-external-tests
 
+print "Setting up environment variables for coverage"
 # Enable LLVM coverage tracking through environment variables
 # show env outputs .ini/.toml style description of the variables
-cargo llvm-cov show-env | from toml | load-env
+# In order to use from toml, we need to make sure our string literals are single quoted
+# This is especially important when running on Windows since "C:\blah" is treated as an escape
+cargo llvm-cov show-env | str replace (char dq) (char sq) -a | from toml | load-env
+
+print "Cleaning up coverage data"
 cargo llvm-cov clean --workspace
+
+print "Building with workspace and profile=ci"
 # Apparently we need to explicitly build the necessary parts
 # using the `--profile=ci` is basically `debug` build with unnecessary symbols stripped
 # leads to smaller binaries and potential savings when compiling and running
 cargo build --workspace --profile=ci
+
+print "Running tests with --workspace and profile=ci"
 cargo test --workspace --profile=ci
+
 # You need to provide the used profile to find the raw data
+print "Generating coverage report as lcov.info"
 cargo llvm-cov report --lcov --output-path lcov.info --profile=ci
+
+let end = (date now)
+$"Coverage generation took ($end - $start)."
 
 # To display the coverage in your editor see:
 #


### PR DESCRIPTION
# Description

This PR updates the code coverage script to help it work better on Windows. The main changes here are to give you some progress outputs and to enable `cargo llvm-cov show-env | from toml` to work better since the toml spec says these literal strings should be single quoted vs double quoted.

Closed #8139

# User-Facing Changes



# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
