### PR TITLE
Pin `reedline` to `0.16.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4201,8 +4201,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.15.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#829a1a9f491a04d7b4159bc69d46cfc8184ccf53"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02723e44c03f5ef62ad35665a43cfa1df3b78cbb75e31ea9ddc6d2f0d9b4658"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ nu-system = { path = "./crates/nu-system", version = "0.75.1" }
 nu-table = { path = "./crates/nu-table", version = "0.75.1" }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.75.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.75.1" }
-reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
 rayon = "1.6.1"
 is_executable = "1.0.1"
@@ -154,7 +154,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
 
 # Criterion benchmarking setup
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -23,7 +23,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.75.1" }
 nu-utils = { path = "../nu-utils", version = "0.75.1" }
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.75.1" }
-reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
 atty = "0.2.14"
 chrono = { default-features = false, features = ["std"], version = "0.4.23" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -82,7 +82,7 @@ serde_yaml = "0.9.4"
 sha2 = "0.10.0"
 # Disable default features b/c the default features build Git (very slow to compile)
 percent-encoding = "2.2.0"
-reedline = { version = "0.15.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 shadow-rs = { version = "0.20.0", default-features = false }
 sqlparser = { version = "0.30.0", features = ["serde"], optional = true }


### PR DESCRIPTION
# Description

See release notes:
https://github.com/nushell/reedline/releases/tag/v0.16.0

# User-Facing Changes

Only internal

# Tests + Formatting

(-)
