### PR TITLE
simplify `parse_expression` function code.

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -122,35 +122,15 @@ pub enum ParseError {
     )]
     BuiltinCommandInPipeline(String, #[label("not allowed in pipeline")] Span),
 
-    #[error("Let statement used in pipeline.")]
+    #[error("{0} statement used in pipeline.")]
     #[diagnostic(
         code(nu::parser::unexpected_keyword),
         url(docsrs),
         help(
-            "Assigning '{0}' to '{1}' does not produce a value to be piped. If the pipeline result is meant to be assigned to '{1}', use 'let {1} = ({0} | ...)'."
+            "Assigning '{1}' to '{2}' does not produce a value to be piped. If the pipeline result is meant to be assigned to '{2}', use '{0} {2} = ({1} | ...)'."
         )
     )]
-    LetInPipeline(String, String, #[label("let in pipeline")] Span),
-
-    #[error("Const statement used in pipeline.")]
-    #[diagnostic(
-        code(nu::parser::unexpected_keyword),
-        url(docsrs),
-        help(
-            "Assigning '{0}' to '{1}' does not produce a value to be piped. If the pipeline result is meant to be assigned to '{1}', use 'const {1} = ({0} | ...)'."
-        )
-    )]
-    ConstInPipeline(String, String, #[label("const in pipeline")] Span),
-
-    #[error("Mut statement used in pipeline.")]
-    #[diagnostic(
-        code(nu::parser::unexpected_keyword),
-        url(docsrs),
-        help(
-            "Assigning '{0}' to '{1}' does not produce a value to be piped. If the pipeline result is meant to be assigned to '{1}', use 'mut {1} = ({0} | ...)'."
-        )
-    )]
-    MutInPipeline(String, String, #[label("mut in pipeline")] Span),
+    AssignInPipeline(String, String, String, #[label("'{0}' in pipeline")] Span),
 
     #[error("Let used with builtin variable name.")]
     #[diagnostic(
@@ -465,9 +445,7 @@ impl ParseError {
             ParseError::ExpectedKeyword(_, s) => *s,
             ParseError::UnexpectedKeyword(_, s) => *s,
             ParseError::BuiltinCommandInPipeline(_, s) => *s,
-            ParseError::LetInPipeline(_, _, s) => *s,
-            ParseError::MutInPipeline(_, _, s) => *s,
-            ParseError::ConstInPipeline(_, _, s) => *s,
+            ParseError::AssignInPipeline(_, _, _, s) => *s,
             ParseError::LetBuiltinVar(_, s) => *s,
             ParseError::MutBuiltinVar(_, s) => *s,
             ParseError::ConstBuiltinVar(_, s) => *s,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5044,7 +5044,9 @@ pub fn parse_expression(
                     is_subexpression,
                 )
                 .0,
-                Some(ParseError::LetInPipeline(
+                Some(ParseError::AssignInPipeline(
+                    String::from_utf8(bytes)
+                        .expect("builtin commands bytes should be able to convert to string"),
                     String::from_utf8_lossy(match spans.len() {
                         1 | 2 | 3 => b"value",
                         _ => working_set.get_span_contents(spans[3]),


### PR DESCRIPTION
# Description

When reading parser code to see how it works, I found that `parse_expression` function contains some duplicate code about function call, we can match several values at once to simplify code

# User-Facing Changes

None

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
