### PR TITLE
Update polars to 0.27.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b843531e0a9d8dac44b0aa6adc926b2d970e8a627fe2105cd0498d5f93a6e97f"
+checksum = "7a4c5b03335bc1cb0fd9f5297f8fd3bbfd6fb04f3cb0bc7d6c91b7128cb8336a"
 dependencies = [
  "ahash 0.8.1",
  "arrow-format",
@@ -442,9 +442,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "bytesize"
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.1.2"
+version = "6.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1090f39f45786ec6dc6286f8ea9c75d0a7ef0a0d3cda674cef0c3af7b307fbc2"
+checksum = "6e7b787b0dc42e8111badfdbe4c3059158ccb2db8780352fa1b01e8ccf45cc4d"
 dependencies = [
  "crossterm 0.25.0",
  "strum",
@@ -846,7 +846,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio 0.8.4",
- "parking_lot",
+ "parking_lot 0.12.1",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -863,7 +863,7 @@ dependencies = [
  "crossterm_winapi",
  "libc",
  "mio 0.8.4",
- "parking_lot",
+ "parking_lot 0.12.1",
  "signal-hook",
  "signal-hook-mio",
  "winapi 0.3.9",
@@ -989,7 +989,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
- "parking_lot_core",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -2697,7 +2697,7 @@ dependencies = [
  "percent-encoding",
  "reedline",
  "rstest",
- "sysinfo",
+ "sysinfo 0.28.0",
  "thiserror",
 ]
 
@@ -2798,7 +2798,7 @@ dependencies = [
  "sha2",
  "shadow-rs",
  "sqlparser",
- "sysinfo",
+ "sysinfo 0.28.0",
  "tabled",
  "terminal_size 0.2.1",
  "thiserror",
@@ -2827,7 +2827,7 @@ dependencies = [
  "nu-protocol",
  "nu-utils",
  "serde",
- "sysinfo",
+ "sysinfo 0.28.0",
 ]
 
 [[package]]
@@ -3372,12 +3372,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.3",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3647,10 +3672,11 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77dddd763763d977fd17e7d3300425da866be08c7185c94fb3979195fbc8fdc7"
+checksum = "8918f4add49e6244bae2fe91cac89be339f2d6a77c59a4df3d7348bd40f98d1e"
 dependencies = [
+ "getrandom 0.2.7",
  "polars-core",
  "polars-io",
  "polars-lazy",
@@ -3661,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5e894b6908d288ea24b56c8d99c2944f4b94af51ba662d58631c04806511b7"
+checksum = "06e57a7b929edf6c73475dbc3f63d35152f14f4a9455476acc6127d770daa0f6"
 dependencies = [
  "arrow2",
  "hashbrown 0.13.2",
@@ -3674,9 +3700,9 @@ dependencies = [
 
 [[package]]
 name = "polars-core"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ab5c1e10e42a34a44a6e1421869c84ad56fe217c6120cda697c84bc467eb9c"
+checksum = "5a440cd53916f1a87fac1fda36cd7cc2d226247b4d4570d96242da5fa7f07b2a"
 dependencies = [
  "ahash 0.8.1",
  "anyhow",
@@ -3698,19 +3724,21 @@ dependencies = [
  "serde_json",
  "smartstring",
  "thiserror",
+ "wasm-timer",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "polars-io"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882e392cbc3e645bfa7ad582065764e21dc271cfeefee904f43a95ccd1b52cb7"
+checksum = "a1d941750cba70a3acf150b959fcf446c09e8a8a4a35d03472d941bd6740bc43"
 dependencies = [
  "ahash 0.8.1",
  "anyhow",
  "arrow2",
- "csv-core",
+ "bytes",
+ "chrono",
  "dirs",
  "lexical",
  "lexical-core",
@@ -3732,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "polars-lazy"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb356861b8967e39ca6205b8bded68b4986f0edd49f259cebbd59ad056e67cc"
+checksum = "d227fcb817485be462748d3172d2e55c61d56fbdc7fd56c24b72fa2e510e7be6"
 dependencies = [
  "ahash 0.8.1",
  "bitflags",
@@ -3752,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ops"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771a404f0f84e6801632c534a7b99410a017e227ecc7b9c64bab728c614f05d6"
+checksum = "36638340fd9f4377dab11f307877ebb5bdac3bc9b25ea32a771584de76e5280a"
 dependencies = [
  "arrow2",
  "polars-arrow",
@@ -3765,16 +3793,18 @@ dependencies = [
 
 [[package]]
 name = "polars-pipe"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1bb37bd32c44defa19be36fcab9387d5b3ad4c683596479caf414e5a00e82af"
+checksum = "ac1dfae18a14a812119d3328dae8790be53f1bc0fbcb977606dcf0f181490a8f"
 dependencies = [
+ "crossbeam-channel",
  "enum_dispatch",
  "hashbrown 0.13.2",
  "num 0.4.0",
  "polars-arrow",
  "polars-core",
  "polars-io",
+ "polars-ops",
  "polars-plan",
  "polars-utils",
  "rayon",
@@ -3783,11 +3813,12 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b4b3daee78b95937930ad3cfc2a454d57802a92a39ee0ce220bb1ae627ef9"
+checksum = "9ca57df4974f25fa0642ae18ef00c0836c5120d4371be77a34d4684173b043c3"
 dependencies = [
  "ahash 0.8.1",
+ "once_cell",
  "polars-arrow",
  "polars-core",
  "polars-io",
@@ -3800,27 +3831,31 @@ dependencies = [
 
 [[package]]
 name = "polars-time"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93593a1a507004f5ac535210542d730178d4f729ef5da48ff2cd13abf570d65e"
+checksum = "d961a9ccbe3c739de063fbf78449b3c172baf3379f958769c42ee9c309289786"
 dependencies = [
  "chrono",
  "lexical",
  "now",
+ "once_cell",
  "polars-arrow",
  "polars-core",
  "polars-ops",
  "polars-utils",
+ "regex",
  "serde",
 ]
 
 [[package]]
 name = "polars-utils"
-version = "0.26.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e4fda3c2781247ef4137221f1013398e3d56aa1899f4f99ecf86fa96f64670"
+checksum = "a741a3325c544c97c7a9ff57d857f089b60041bd92b06c41582df6940ffaa05b"
 dependencies = [
+ "once_cell",
  "rayon",
+ "sysinfo 0.27.7",
 ]
 
 [[package]]
@@ -4681,7 +4716,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "parking_lot",
+ "parking_lot 0.12.1",
  "serial_test_derive",
 ]
 
@@ -4915,7 +4950,7 @@ checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -5033,6 +5068,20 @@ dependencies = [
  "libc",
  "wasm-bindgen",
  "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975fe381e0ecba475d4acff52466906d95b153a40324956552e027b2a9eaa89e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
  "winapi 0.3.9",
 ]
 
@@ -5756,6 +5805,21 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wax"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -141,7 +141,7 @@ features = [
 	"to_dummies",
 ]
 optional = true
-version = "0.26.1"
+version = "0.27.2"
 
 [target.'cfg(windows)'.dependencies.windows]
 features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_SystemServices"]

--- a/crates/nu-command/src/dataframe/eager/dummies.rs
+++ b/crates/nu-command/src/dataframe/eager/dummies.rs
@@ -116,7 +116,7 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     df.as_ref()
-        .to_dummies()
+        .to_dummies(None)
         .map_err(|e| {
             ShellError::GenericError(
                 "Error calculating dummies".into(),

--- a/crates/nu-command/src/dataframe/eager/open.rs
+++ b/crates/nu-command/src/dataframe/eager/open.rs
@@ -145,6 +145,7 @@ fn from_parquet(
             rechunk: false,
             row_count: None,
             low_memory: false,
+            cloud_options: None,
         };
 
         let df: NuLazyFrame = LazyFrame::scan_parquet(file, args)

--- a/crates/nu-command/src/dataframe/eager/sql_context.rs
+++ b/crates/nu-command/src/dataframe/eager/sql_context.rs
@@ -30,7 +30,7 @@ impl SQLContext {
         // Determine involved dataframe
         // Implicit join require some more work in query parsers, Explicit join are preferred for now.
         let tbl = select_stmt.from.get(0).ok_or_else(|| {
-            PolarsError::NotFound(ErrString::from("No table found in select statement"))
+            PolarsError::ComputeError(ErrString::from("No table found in select statement"))
         })?;
         let mut alias_map = HashMap::new();
         let tbl_name = match &tbl.relation {
@@ -39,7 +39,9 @@ impl SQLContext {
                     .0
                     .get(0)
                     .ok_or_else(|| {
-                        PolarsError::NotFound(ErrString::from("No table found in select statement"))
+                        PolarsError::ComputeError(ErrString::from(
+                            "No table found in select statement",
+                        ))
                     })?
                     .value
                     .to_string();
@@ -181,7 +183,7 @@ impl SQLContext {
         } else {
             let ast = ast
                 .get(0)
-                .ok_or_else(|| PolarsError::NotFound(ErrString::from("No statement found")))?;
+                .ok_or_else(|| PolarsError::ComputeError(ErrString::from("No statement found")))?;
             Ok(match ast {
                 Statement::Query(query) => {
                     let rs = match &*query.body {

--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
     engine::{Command, EngineState, Stack},
     Category, Example, PipelineData, ShellError, Signature, Span, Type, Value,
 };
-use polars::prelude::{IntoSeries, NewChunkedArray, UInt32Chunked};
+use polars::prelude::{ArgAgg, IntoSeries, NewChunkedArray, UInt32Chunked};
 
 #[derive(Clone)]
 pub struct ArgMax;

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
     engine::{Command, EngineState, Stack},
     Category, Example, PipelineData, ShellError, Signature, Span, Type, Value,
 };
-use polars::prelude::{IntoSeries, NewChunkedArray, UInt32Chunked};
+use polars::prelude::{ArgAgg, IntoSeries, NewChunkedArray, UInt32Chunked};
 
 #[derive(Clone)]
 pub struct ArgMin;

--- a/crates/nu-command/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu-command/src/dataframe/series/date/as_datetime.rs
@@ -110,9 +110,16 @@ fn command(
     })?;
 
     let res = if not_exact {
-        casted.as_datetime_not_exact(Some(format.as_str()), TimeUnit::Milliseconds)
+        casted.as_datetime_not_exact(Some(format.as_str()), TimeUnit::Milliseconds, None)
     } else {
-        casted.as_datetime(Some(format.as_str()), TimeUnit::Milliseconds, false, false)
+        casted.as_datetime(
+            Some(format.as_str()),
+            TimeUnit::Milliseconds,
+            false,
+            false,
+            true,
+            None,
+        )
     };
 
     let mut res = res

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -95,6 +95,7 @@ fn command(
     let sort_options = SortOptions {
         descending: call.has_flag("reverse"),
         nulls_last: call.has_flag("nulls-last"),
+        multithreaded: true,
     };
 
     let mut res = df.as_series(call.head)?.argsort(sort_options).into_series();


### PR DESCRIPTION
Mostly to get rid of https://github.com/pola-rs/polars/pull/6098/files

This currently breaks nushell's table formatting:

```
nu ❯  open-df forcing.arrow | first
could not mmap compressed IPC file, defaulting to normal read╭───┬──────────┬────┬────────┬──────────┬───────┬──────────┬──────┬──────────┬─────╮
│ # │   time   │ id │ demand │ drainage │ E_pot │ infiltra │  P   │ priority │ ... │
│   │          │    │        │          │       │ tion     │      │          │     │
├───┼──────────┼────┼────────┼──────────┼───────┼──────────┼──────┼──────────┼─────┤
│ 0 │ 4 years  │  1 │   0.00 │     0.02 │  0.00 │     0.00 │ 0.00 │     4.00 │ ... │
│   │ ago      │    │        │          │       │          │      │          │     │
╰───┴──────────┴────┴────────┴──────────┴───────┴──────────┴──────┴──────────┴─────╯
```

@visr