### PR TITLE
allow different types of lists to be appended

### DIFF
--- a/crates/nu-command/tests/commands/assignment/append_assign.rs
+++ b/crates/nu-command/tests/commands/assignment/append_assign.rs
@@ -99,10 +99,9 @@ fn append_assign_type_mismatch() {
         r#"
             mut a = [1 2];
             $a ++= [a];
+            $a | to json -r;
         "#
     ));
 
-    assert!(actual
-        .err
-        .contains("expected list<int>, found list<string>"));
+    assert_eq!(actual.out, r#"[1,2,"a"]"#);
 }

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -568,6 +568,7 @@ pub fn math_result_type(
                 (x, y) if x == y => (Type::Nothing, None),
                 (Type::Any, _) => (Type::Nothing, None),
                 (_, Type::Any) => (Type::Nothing, None),
+                (Type::List(_), Type::List(_)) => (Type::Nothing, None),
                 (x, y) => (
                     Type::Nothing,
                     Some(ParseError::Mismatch(x.to_string(), y.to_string(), rhs.span)),


### PR DESCRIPTION
# Description

closes #8153

This PR allows different types of lists, like `list<string>` and `list<any>` to be appended with the `++=` operator.

## Before

```
mut args = [ hello ("hello" | path join world)]
$args ++= [ foo bar ]
Error: nu::parser::type_mismatch (link)

  × Type mismatch during operation.
   ╭─[entry #2:1:1]
 1 │ $args ++= [ foo bar ]
   ·           ─────┬─────
   ·                ╰── expected list<any>, found list<string>
   ╰────
```

## After

```
mut args = [ hello ("hello" | path join world)]
$args ++= [ foo bar ]
$args
╭───┬─────────────╮
│ 0 │ hello       │
│ 1 │ hello\world │
│ 2 │ foo         │
│ 3 │ bar         │
╰───┴─────────────╯
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
