### PR TITLE
Fix `Cargo.toml` of `nu_plugin_formats`

### DIFF
--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
-name = "nu_plugin_formats"
-version = "0.1.0"
+authors = ["The Nushell Project Developers"]
+description = "An I/O for a set of fileformats for Nushell"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_formats"
 edition = "2021"
-
+license = "MIT"
+name = "nu_plugin_formats"
+version = "0.76.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "An I/O for a set of fileformats for Nushell"
+description = "An I/O plugin for a set of file formats for Nushell"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_formats"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
# Description


The crate manifest didn't include vital information to publish to
crates.io

This now includes the basic description and license information



