### PR TITLE
Fix one error message in `into string`

### DIFF
--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -246,9 +246,10 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             vals: _,
             span: _,
         } => Value::Error {
+            // Watch out for CantConvert's argument order
             error: ShellError::CantConvert(
-                "record".into(),
                 "string".into(),
+                "record".into(),
                 span,
                 Some("try using the `to nuon` command".into()),
             ),


### PR DESCRIPTION
# Description

Fixes the following message:
```
〉(ls).0 | into string
Error: nu::shell::cant_convert (link)

  × Can't convert to record.
   ╭─[entry #4:1:1]
 1 │ (ls).0 | into string
   ·          ─────┬─────
   ·               ╰── can't convert string to record
   ╰────
  help: try using the `to nuon` command
```

# User-Facing Changes

See above.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
