### PR TITLE
check external failed in let assignment

### DIFF
--- a/crates/nu-command/src/core_commands/let_.rs
+++ b/crates/nu-command/src/core_commands/let_.rs
@@ -60,7 +60,7 @@ impl Command for Let {
             .as_keyword()
             .expect("internal error: missing keyword");
 
-        let (rhs, may_external_failed) = eval_expression_with_input(
+        let (rhs, external_failed) = eval_expression_with_input(
             engine_state,
             stack,
             keyword_expr,
@@ -68,9 +68,9 @@ impl Command for Let {
             call.redirect_stdout,
             call.redirect_stderr,
         )?;
-        if may_external_failed {
-            // rhs must be PipelineData::ExternamStream and it's failed
-            // here we return this stream(the exit code is non-zero) to stop running.
+        if external_failed {
+            // rhs must be a PipelineData::ExternalStream and it's failed
+            // return the failed stream (with a non-zero exit code) so the engine knows to stop running
             Ok(rhs)
         } else {
             stack.add_var(var_id, rhs.into_value(call.head));

--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -25,3 +25,13 @@ fn let_doesnt_mutate() {
 
     assert!(actual.err.contains("immutable"));
 }
+
+#[test]
+fn let_with_external_failed() {
+    let actual = nu!(
+        cwd: ".",
+        pipeline(r#"let x = nu --testbin outcome_err "aa"; echo fail"#)
+    );
+
+    assert!(!actual.out.contains("fail"));
+}


### PR DESCRIPTION
# Description

Fixes: #8136

# User-Facing Changes

The following command

```
let VAR = ^cat non-existing-file; echo "failed"
```
will no longer output `failed` message


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
