### PR TITLE
table --collapse dont do truncation return message instead

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -354,17 +354,9 @@ fn build_collapsed_table(
     colorize_value(&mut value, config, style_computer);
 
     let theme = load_theme_from_config(config);
-    let table = nu_table::NuTable::new(
-        value,
-        true,
-        term_width,
-        config,
-        style_computer,
-        &theme,
-        false,
-    );
+    let table = nu_table::NuTable::new(value, true, config, style_computer, &theme, false);
 
-    let table = table.draw();
+    let table = table.draw(term_width);
 
     Ok(table)
 }
@@ -1674,17 +1666,10 @@ impl PagingTableCreator {
 
         colorize_value(&mut value, config, &style_computer);
 
-        let table = nu_table::NuTable::new(
-            value,
-            true,
-            term_width,
-            config,
-            &style_computer,
-            &theme,
-            need_footer,
-        );
+        let table =
+            nu_table::NuTable::new(value, true, config, &style_computer, &theme, need_footer);
 
-        Ok(table.draw())
+        Ok(table.draw(term_width))
     }
 
     fn build_general(&mut self, batch: &[Value]) -> Result<Option<String>, ShellError> {

--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -232,6 +232,14 @@ fn table_collapse_hearts() {
 }
 
 #[test]
+fn table_collapse_doesnot_support_width_control() {
+    let actual = nu!(
+        r#"[[a]; [11111111111111111111111111111111111111111111111111111111111111111111111111111111]] | table --collapse"#
+    );
+    assert_eq!(actual.out, "Couldn't fit table into 80 columns!");
+}
+
+#[test]
 fn table_expand_0() {
     let actual = nu!(r#"[[a b, c]; [1 2 3] [4 5 [1 2 3]]] | table --expand"#);
     assert_eq!(


### PR DESCRIPTION
Reverts #8042

I've just noticed that #8042 was merged, but I didn't addressed your @fdncred last comment.
This PR reverts #8042 and returns a message in cases where we need truncation/wrapping.

https://github.com/nushell/nushell/blob/157b7e0b603c43d8e4f3bd0b028218d1e1d29114/crates/nu-command/tests/commands/table.rs#L234-L240



