### PR TITLE
change how escapes are interpreted in strings

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1692,7 +1692,9 @@ pub fn parse_string_interpolation(
                 0
             };
 
-            if current_byte == b'(' && (!double_quote || preceding_consecutive_backslashes % 2 == 0)
+            if current_byte == b'('
+                && ((!starts_with_dollar_double_quote && !starts_with_dollar_single_quote)
+                    || preceding_consecutive_backslashes % 2 == 0)
             {
                 mode = InterpolationMode::Expression;
                 if token_start < b {


### PR DESCRIPTION
# Description

This PR takes a stab at changing how string escapes are interpreted. Prior to this PR, strings with escapes were interpreted only in strings with double quotes.

Now, with this PR, a new type of string interpolation is introduced but instead of using `$` as the sigil, we use `%` as the sigil to make nushell understand that the following string will have escapes in it that need to be interpreted.

![image](https://user-images.githubusercontent.com/343840/221012900-888ff94b-3e4b-4489-9cf0-b75df705787a.png)

This shows that it's also acting like a normal string interpolated string.
![image](https://user-images.githubusercontent.com/343840/221013006-65673ad4-795d-4841-bed3-c76ab3924622.png)

We can debate which sigil to use. I just chose `%` because it was available but I also considered `@`. You decide and let me know. :)

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
