### PR TITLE
Disable Windows coverage tracking for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [windows-latest, ubuntu-20.04]
+        # disabled mac due to problems with merging coverage and similarity to linux
+        # disabled windows due to running out of disk space when having too many crates or tests
+        platform: [ubuntu-20.04] # windows-latest
         rust:
           - stable
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,5 +13,5 @@ comment:
   behavior: default
   require_base: yes
   require_head: yes
-  after_n_builds: 2
+  after_n_builds: 1 # Disabled windows else: 2
   


### PR DESCRIPTION
# Description

Avoids running out of disk through additional files after cratification on Windows.

Revert as soon as we reduced the binary or test footprint.

Will mess with the coverage values without change in test suite as we only track the linux conditional compilation

Should resolve the CI failure for #8181 

# User-Facing Changes

None

# Tests + Formatting

Altered coverage value thresholds might be the result