### PR TITLE
remove links to `ShellError` and `ParseError` docs - #8167

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -8,48 +8,43 @@ pub enum ParseError {
     /// finished. You should remove these or finish adding what you intended
     /// to add.
     #[error("Extra tokens in code.")]
-    #[diagnostic(
-        code(nu::parser::extra_tokens),
-        url(docsrs),
-        help("Try removing them.")
-    )]
+    #[diagnostic(code(nu::parser::extra_tokens), help("Try removing them."))]
     ExtraTokens(#[label = "extra tokens"] Span),
 
     #[error("Extra positional argument.")]
-    #[diagnostic(code(nu::parser::extra_positional), url(docsrs), help("Usage: {0}"))]
+    #[diagnostic(code(nu::parser::extra_positional), help("Usage: {0}"))]
     ExtraPositional(String, #[label = "extra positional argument"] Span),
 
     #[error("Required positional parameter after optional parameter")]
-    #[diagnostic(code(nu::parser::required_after_optional), url(docsrs))]
+    #[diagnostic(code(nu::parser::required_after_optional))]
     RequiredAfterOptional(
         String,
         #[label = "required parameter {0} after optional parameter"] Span,
     ),
 
     #[error("Unexpected end of code.")]
-    #[diagnostic(code(nu::parser::unexpected_eof), url(docsrs))]
+    #[diagnostic(code(nu::parser::unexpected_eof))]
     UnexpectedEof(String, #[label("expected closing {0}")] Span),
 
     #[error("Unclosed delimiter.")]
-    #[diagnostic(code(nu::parser::unclosed_delimiter), url(docsrs))]
+    #[diagnostic(code(nu::parser::unclosed_delimiter))]
     Unclosed(String, #[label("unclosed {0}")] Span),
 
     #[error("Unbalanced delimiter.")]
-    #[diagnostic(code(nu::parser::unbalanced_delimiter), url(docsrs))]
+    #[diagnostic(code(nu::parser::unbalanced_delimiter))]
     Unbalanced(String, String, #[label("unbalanced {0} and {1}")] Span),
 
     #[error("Parse mismatch during operation.")]
-    #[diagnostic(code(nu::parser::parse_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::parser::parse_mismatch))]
     Expected(String, #[label("expected {0}")] Span),
 
     #[error("Type mismatch during operation.")]
-    #[diagnostic(code(nu::parser::type_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::parser::type_mismatch))]
     Mismatch(String, String, #[label("expected {0}, found {1}")] Span), // expected, found, span
 
     #[error("The '&&' operator is not supported in Nushell")]
     #[diagnostic(
         code(nu::parser::shell_andand),
-        url(docsrs),
         help("use ';' instead of the shell '&&', or 'and' instead of the boolean '&&'")
     )]
     ShellAndAnd(#[label("instead of '&&', use ';' or 'and'")] Span),
@@ -57,19 +52,17 @@ pub enum ParseError {
     #[error("The '||' operator is not supported in Nushell")]
     #[diagnostic(
         code(nu::parser::shell_oror),
-        url(docsrs),
         help("use 'try' instead of the shell '||', or 'or' instead of the boolean '||'")
     )]
     ShellOrOr(#[label("instead of '||', use 'try' or 'or'")] Span),
 
     #[error("The '2>' shell operation is 'err>' in Nushell.")]
-    #[diagnostic(code(nu::parser::shell_err), url(docsrs))]
+    #[diagnostic(code(nu::parser::shell_err))]
     ShellErrRedirect(#[label("use 'err>' instead of '2>' in Nushell")] Span),
 
     #[error("The '2>&1' shell operation is 'out+err>' in Nushell.")]
     #[diagnostic(
         code(nu::parser::shell_outerr),
-        url(docsrs),
         help("Nushell redirection will write all of stdout before stderr.")
     )]
     ShellOutErrRedirect(#[label("use 'out+err>' instead of '2>&1' in Nushell")] Span),
@@ -77,7 +70,6 @@ pub enum ParseError {
     #[error("Types mismatched for operation.")]
     #[diagnostic(
         code(nu::parser::unsupported_operation),
-        url(docsrs),
         help("Change {2} or {4} to be the right types and try again.")
     )]
     UnsupportedOperation(
@@ -89,23 +81,22 @@ pub enum ParseError {
     ),
 
     #[error("Capture of mutable variable.")]
-    #[diagnostic(code(nu::parser::expected_keyword), url(docsrs))]
+    #[diagnostic(code(nu::parser::expected_keyword))]
     CaptureOfMutableVar(#[label("capture of mutable variable")] Span),
 
     #[error("Expected keyword.")]
-    #[diagnostic(code(nu::parser::expected_keyword), url(docsrs))]
+    #[diagnostic(code(nu::parser::expected_keyword))]
     ExpectedKeyword(String, #[label("expected {0}")] Span),
 
     #[error("Unexpected keyword.")]
     #[diagnostic(
         code(nu::parser::unexpected_keyword),
-        url(docsrs),
         help("'{0}' keyword is allowed only in a module.")
     )]
     UnexpectedKeyword(String, #[label("unexpected {0}")] Span),
 
     #[error("Unknown operator")]
-    #[diagnostic(code(nu::parser::unknown_operator), url(docsrs), help("{1}"))]
+    #[diagnostic(code(nu::parser::unknown_operator), help("{1}"))]
     UnknownOperator(
         &'static str,
         &'static str,
@@ -115,7 +106,6 @@ pub enum ParseError {
     #[error("Statement used in pipeline.")]
     #[diagnostic(
         code(nu::parser::unexpected_keyword),
-        url(docsrs),
         help(
             "'{0}' keyword is not allowed in pipeline. Use '{0}' by itself, outside of a pipeline."
         )
@@ -125,7 +115,6 @@ pub enum ParseError {
     #[error("{0} statement used in pipeline.")]
     #[diagnostic(
         code(nu::parser::unexpected_keyword),
-        url(docsrs),
         help(
             "Assigning '{1}' to '{2}' does not produce a value to be piped. If the pipeline result is meant to be assigned to '{2}', use '{0} {2} = ({1} | ...)'."
         )
@@ -135,7 +124,6 @@ pub enum ParseError {
     #[error("Let used with builtin variable name.")]
     #[diagnostic(
         code(nu::parser::let_builtin_var),
-        url(docsrs),
         help("'{0}' is the name of a builtin Nushell variable. `let` cannot assign to it.")
     )]
     LetBuiltinVar(String, #[label("already a builtin variable")] Span),
@@ -143,7 +131,6 @@ pub enum ParseError {
     #[error("Const used with builtin variable name.")]
     #[diagnostic(
         code(nu::parser::let_builtin_var),
-        url(docsrs),
         help("'{0}' is the name of a builtin Nushell variable. `const` cannot assign to it.")
     )]
     ConstBuiltinVar(String, #[label("already a builtin variable")] Span),
@@ -151,35 +138,34 @@ pub enum ParseError {
     #[error("Mut used with builtin variable name.")]
     #[diagnostic(
         code(nu::parser::let_builtin_var),
-        url(docsrs),
         help("'{0}' is the name of a builtin Nushell variable. `mut` cannot assign to it.")
     )]
     MutBuiltinVar(String, #[label("already a builtin variable")] Span),
 
     #[error("Incorrect value")]
-    #[diagnostic(code(nu::parser::incorrect_value), url(docsrs), help("{2}"))]
+    #[diagnostic(code(nu::parser::incorrect_value), help("{2}"))]
     IncorrectValue(String, #[label("unexpected {0}")] Span, String),
 
     #[error("Multiple rest params.")]
-    #[diagnostic(code(nu::parser::multiple_rest_params), url(docsrs))]
+    #[diagnostic(code(nu::parser::multiple_rest_params))]
     MultipleRestParams(#[label = "multiple rest params"] Span),
 
     #[error("Variable not found.")]
-    #[diagnostic(code(nu::parser::variable_not_found), url(docsrs))]
+    #[diagnostic(code(nu::parser::variable_not_found))]
     VariableNotFound(#[label = "variable not found"] Span),
 
     #[error("Variable name not supported.")]
-    #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
+    #[diagnostic(code(nu::parser::variable_not_valid))]
     VariableNotValid(#[label = "variable name can't contain spaces or quotes"] Span),
 
     #[error("Alias name not supported.")]
-    #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
+    #[diagnostic(code(nu::parser::variable_not_valid))]
     AliasNotValid(
         #[label = "alias name can't be a number, a filesize, or contain a hash # or caret ^"] Span,
     ),
 
     #[error("Command name not supported.")]
-    #[diagnostic(code(nu::parser::variable_not_valid), url(docsrs))]
+    #[diagnostic(code(nu::parser::variable_not_valid))]
     CommandDefNotValid(
         #[label = "command name can't be a number, a filesize, or contain a hash # or caret ^"]
         Span,
@@ -188,19 +174,17 @@ pub enum ParseError {
     #[error("Module not found.")]
     #[diagnostic(
         code(nu::parser::module_not_found),
-        url(docsrs),
         help("module files and their paths must be available before your script is run as parsing occurs before anything is evaluated")
     )]
     ModuleNotFound(#[label = "module not found"] Span),
 
     #[error("Cyclical module import.")]
-    #[diagnostic(code(nu::parser::cyclical_module_import), url(docsrs), help("{0}"))]
+    #[diagnostic(code(nu::parser::cyclical_module_import), help("{0}"))]
     CyclicalModuleImport(String, #[label = "detected cyclical module import"] Span),
 
     #[error("Can't export {0} named same as the module.")]
     #[diagnostic(
         code(nu::parser::named_as_module),
-        url(docsrs),
         help("Module {1} can't export {0} named the same as the module. Either change the module name, or export `main` custom command.")
     )]
     NamedAsModule(
@@ -212,19 +196,17 @@ pub enum ParseError {
     #[error("Can't export alias defined as 'main'.")]
     #[diagnostic(
         code(nu::parser::export_main_alias_not_allowed),
-        url(docsrs),
         help("Exporting aliases as 'main' is not allowed. Either rename the alias or convert it to a custom command.")
     )]
     ExportMainAliasNotAllowed(#[label = "can't export from module"] Span),
 
     #[error("Active overlay not found.")]
-    #[diagnostic(code(nu::parser::active_overlay_not_found), url(docsrs))]
+    #[diagnostic(code(nu::parser::active_overlay_not_found))]
     ActiveOverlayNotFound(#[label = "not an active overlay"] Span),
 
     #[error("Overlay prefix mismatch.")]
     #[diagnostic(
         code(nu::parser::overlay_prefix_mismatch),
-        url(docsrs),
         help("Overlay {0} already exists {1} a prefix. To add it again, do it {1} the --prefix flag.")
     )]
     OverlayPrefixMismatch(
@@ -236,7 +218,6 @@ pub enum ParseError {
     #[error("Module or overlay not found.")]
     #[diagnostic(
         code(nu::parser::module_or_overlay_not_found),
-        url(docsrs),
         help("Requires either an existing overlay, a module, or an import pattern defining a module.")
     )]
     ModuleOrOverlayNotFound(#[label = "not a module or an overlay"] Span),
@@ -244,7 +225,6 @@ pub enum ParseError {
     #[error("Cannot remove the last overlay.")]
     #[diagnostic(
         code(nu::parser::cant_remove_last_overlay),
-        url(docsrs),
         help("At least one overlay must always be active.")
     )]
     CantRemoveLastOverlay(#[label = "this is the last overlay, can't remove it"] Span),
@@ -252,57 +232,55 @@ pub enum ParseError {
     #[error("Cannot hide default overlay.")]
     #[diagnostic(
         code(nu::parser::cant_hide_default_overlay),
-        url(docsrs),
         help("'{0}' is a default overlay. Default overlays cannot be hidden.")
     )]
     CantHideDefaultOverlay(String, #[label = "can't hide overlay"] Span),
 
     #[error("Cannot add overlay.")]
-    #[diagnostic(code(nu::parser::cant_add_overlay_help), url(docsrs), help("{0}"))]
+    #[diagnostic(code(nu::parser::cant_add_overlay_help), help("{0}"))]
     CantAddOverlayHelp(String, #[label = "cannot add this overlay"] Span),
 
     #[error("Not found.")]
-    #[diagnostic(code(nu::parser::not_found), url(docsrs))]
+    #[diagnostic(code(nu::parser::not_found))]
     NotFound(#[label = "did not find anything under this name"] Span),
 
     #[error("Duplicate command definition within a block.")]
-    #[diagnostic(code(nu::parser::duplicate_command_def), url(docsrs))]
+    #[diagnostic(code(nu::parser::duplicate_command_def))]
     DuplicateCommandDef(#[label = "defined more than once"] Span),
 
     #[error("Unknown command.")]
     #[diagnostic(
         code(nu::parser::unknown_command),
-        url(docsrs),
         // TODO: actual suggestions like "Did you mean `foo`?"
     )]
     UnknownCommand(#[label = "unknown command"] Span),
 
     #[error("Non-UTF8 string.")]
-    #[diagnostic(code(nu::parser::non_utf8), url(docsrs))]
+    #[diagnostic(code(nu::parser::non_utf8))]
     NonUtf8(#[label = "non-UTF8 string"] Span),
 
     #[error("The `{0}` command doesn't have flag `{1}`.")]
-    #[diagnostic(code(nu::parser::unknown_flag), url(docsrs), help("{3}"))]
+    #[diagnostic(code(nu::parser::unknown_flag), help("{3}"))]
     UnknownFlag(String, String, #[label = "unknown flag"] Span, String),
 
     #[error("Unknown type.")]
-    #[diagnostic(code(nu::parser::unknown_type), url(docsrs))]
+    #[diagnostic(code(nu::parser::unknown_type))]
     UnknownType(#[label = "unknown type"] Span),
 
     #[error("Missing flag argument.")]
-    #[diagnostic(code(nu::parser::missing_flag_param), url(docsrs))]
+    #[diagnostic(code(nu::parser::missing_flag_param))]
     MissingFlagParam(String, #[label = "flag missing {0} argument"] Span),
 
     #[error("Batches of short flags can't take arguments.")]
-    #[diagnostic(code(nu::parser::short_flag_arg_cant_take_arg), url(docsrs))]
+    #[diagnostic(code(nu::parser::short_flag_arg_cant_take_arg))]
     ShortFlagBatchCantTakeArg(#[label = "short flag batches can't take args"] Span),
 
     #[error("Missing required positional argument.")]
-    #[diagnostic(code(nu::parser::missing_positional), url(docsrs), help("Usage: {2}"))]
+    #[diagnostic(code(nu::parser::missing_positional), help("Usage: {2}"))]
     MissingPositional(String, #[label("missing {0}")] Span, String),
 
     #[error("Missing argument to `{1}`.")]
-    #[diagnostic(code(nu::parser::keyword_missing_arg), url(docsrs))]
+    #[diagnostic(code(nu::parser::keyword_missing_arg))]
     KeywordMissingArgument(
         String,
         String,
@@ -310,39 +288,39 @@ pub enum ParseError {
     ),
 
     #[error("Missing type.")]
-    #[diagnostic(code(nu::parser::missing_type), url(docsrs))]
+    #[diagnostic(code(nu::parser::missing_type))]
     MissingType(#[label = "expected type"] Span),
 
     #[error("Type mismatch.")]
-    #[diagnostic(code(nu::parser::type_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::parser::type_mismatch))]
     TypeMismatch(Type, Type, #[label("expected {0:?}, found {1:?}")] Span), // expected, found, span
 
     #[error("Missing required flag.")]
-    #[diagnostic(code(nu::parser::missing_required_flag), url(docsrs))]
+    #[diagnostic(code(nu::parser::missing_required_flag))]
     MissingRequiredFlag(String, #[label("missing required flag {0}")] Span),
 
     #[error("Incomplete math expression.")]
-    #[diagnostic(code(nu::parser::incomplete_math_expression), url(docsrs))]
+    #[diagnostic(code(nu::parser::incomplete_math_expression))]
     IncompleteMathExpression(#[label = "incomplete math expression"] Span),
 
     #[error("Unknown state.")]
-    #[diagnostic(code(nu::parser::unknown_state), url(docsrs))]
+    #[diagnostic(code(nu::parser::unknown_state))]
     UnknownState(String, #[label("{0}")] Span),
 
     #[error("Internal error.")]
-    #[diagnostic(code(nu::parser::unknown_state), url(docsrs))]
+    #[diagnostic(code(nu::parser::unknown_state))]
     InternalError(String, #[label("{0}")] Span),
 
     #[error("Parser incomplete.")]
-    #[diagnostic(code(nu::parser::parser_incomplete), url(docsrs))]
+    #[diagnostic(code(nu::parser::parser_incomplete))]
     IncompleteParser(#[label = "parser support missing for this expression"] Span),
 
     #[error("Rest parameter needs a name.")]
-    #[diagnostic(code(nu::parser::rest_needs_name), url(docsrs))]
+    #[diagnostic(code(nu::parser::rest_needs_name))]
     RestNeedsName(#[label = "needs a parameter name"] Span),
 
     #[error("Parameter not correct type.")]
-    #[diagnostic(code(nu::parser::parameter_mismatch_type), url(docsrs))]
+    #[diagnostic(code(nu::parser::parameter_mismatch_type))]
     ParameterMismatchType(
         String,
         String,
@@ -351,39 +329,38 @@ pub enum ParseError {
     ),
 
     #[error("Extra columns.")]
-    #[diagnostic(code(nu::parser::extra_columns), url(docsrs))]
+    #[diagnostic(code(nu::parser::extra_columns))]
     ExtraColumns(
         usize,
         #[label("expected {0} column{}", if *.0 == 1 { "" } else { "s" })] Span,
     ),
 
     #[error("Missing columns.")]
-    #[diagnostic(code(nu::parser::missing_columns), url(docsrs))]
+    #[diagnostic(code(nu::parser::missing_columns))]
     MissingColumns(
         usize,
         #[label("expected {0} column{}", if *.0 == 1 { "" } else { "s" })] Span,
     ),
 
     #[error("{0}")]
-    #[diagnostic(code(nu::parser::assignment_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::parser::assignment_mismatch))]
     AssignmentMismatch(String, String, #[label("{1}")] Span),
 
     #[error("Missing import pattern.")]
-    #[diagnostic(code(nu::parser::missing_import_pattern), url(docsrs))]
+    #[diagnostic(code(nu::parser::missing_import_pattern))]
     MissingImportPattern(#[label = "needs an import pattern"] Span),
 
     #[error("Wrong import pattern structure.")]
-    #[diagnostic(code(nu::parser::missing_import_pattern), url(docsrs))]
+    #[diagnostic(code(nu::parser::missing_import_pattern))]
     WrongImportPattern(#[label = "invalid import pattern structure"] Span),
 
     #[error("Export not found.")]
-    #[diagnostic(code(nu::parser::export_not_found), url(docsrs))]
+    #[diagnostic(code(nu::parser::export_not_found))]
     ExportNotFound(#[label = "could not find imports"] Span),
 
     #[error("File not found")]
     #[diagnostic(
         code(nu::parser::sourced_file_not_found),
-        url(docsrs),
         help("sourced files need to be available before your script is run")
     )]
     SourcedFileNotFound(String, #[label("File not found: {0}")] Span),
@@ -391,13 +368,12 @@ pub enum ParseError {
     #[error("File not found")]
     #[diagnostic(
         code(nu::parser::registered_file_not_found),
-        url(docsrs),
         help("registered files need to be available before your script is run")
     )]
     RegisteredFileNotFound(String, #[label("File not found: {0}")] Span),
 
     #[error("File not found")]
-    #[diagnostic(code(nu::parser::file_not_found), url(docsrs))]
+    #[diagnostic(code(nu::parser::file_not_found))]
     FileNotFound(String, #[label("File not found: {0}")] Span),
 
     /// Error while trying to read a file
@@ -406,7 +382,7 @@ pub enum ParseError {
     ///
     /// The error will show the result from a file operation
     #[error("Error trying to read file")]
-    #[diagnostic(code(nu::shell::error_reading_file), url(docsrs))]
+    #[diagnostic(code(nu::shell::error_reading_file))]
     ReadingFile(String, #[label("{0}")] Span),
 
     /// Tried assigning non-constant value to a constant
@@ -417,7 +393,6 @@ pub enum ParseError {
     #[error("Not a constant.")]
     #[diagnostic(
         code(nu::parser::not_a_constant),
-        url(docsrs),
         help("Only a subset of expressions are allowed constants during parsing. Try using the 'let' command or typing the value literally.")
     )]
     NotAConstant(#[label = "Value is not a parse-time constant"] Span),

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -15,7 +15,7 @@ pub enum ShellError {
     ///
     /// Check each argument's type and convert one or both as needed.
     #[error("Type mismatch during operation.")]
-    #[diagnostic(code(nu::shell::type_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::shell::type_mismatch))]
     OperatorMismatch {
         #[label = "type mismatch for operator"]
         op_span: Span,
@@ -34,7 +34,7 @@ pub enum ShellError {
     /// Check the inputs to the operation and add guards for their sizes.
     /// Integers are generally of size i64, floats are generally f64.
     #[error("Operator overflow.")]
-    #[diagnostic(code(nu::shell::operator_overflow), url(docsrs), help("{2}"))]
+    #[diagnostic(code(nu::shell::operator_overflow), help("{2}"))]
     OperatorOverflow(String, #[label = "{0}"] Span, String),
 
     /// The pipelined input into a command was not of the expected type. For example, it might
@@ -44,7 +44,7 @@ pub enum ShellError {
     ///
     /// Check the relevant pipeline and extract or convert values as needed.
     #[error("Pipeline mismatch.")]
-    #[diagnostic(code(nu::shell::pipeline_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::shell::pipeline_mismatch))]
     PipelineMismatch(
         String,
         #[label("expected: {0}")] Span,
@@ -52,7 +52,7 @@ pub enum ShellError {
     ),
 
     #[error("Input type not supported.")]
-    #[diagnostic(code(nu::shell::only_supports_this_input_type), url(docsrs))]
+    #[diagnostic(code(nu::shell::only_supports_this_input_type))]
     OnlySupportsThisInputType(
         String,
         String,
@@ -66,7 +66,7 @@ pub enum ShellError {
     ///
     /// Only use this command to process values from a previous expression.
     #[error("Pipeline empty.")]
-    #[diagnostic(code(nu::shell::pipeline_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::shell::pipeline_mismatch))]
     PipelineEmpty(#[label("no input value was piped in")] Span),
 
     /// A command received an argument of the wrong type.
@@ -75,7 +75,7 @@ pub enum ShellError {
     ///
     /// Convert the argument type before passing it in, or change the command to accept the type.
     #[error("Type mismatch.")]
-    #[diagnostic(code(nu::shell::type_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::shell::type_mismatch))]
     TypeMismatch(String, #[label = "{0}"] Span),
 
     /// A command received an argument of the wrong type.
@@ -84,7 +84,7 @@ pub enum ShellError {
     ///
     /// Convert the argument type before passing it in, or change the command to accept the type.
     #[error("Type mismatch.")]
-    #[diagnostic(code(nu::shell::type_mismatch), url(docsrs))]
+    #[diagnostic(code(nu::shell::type_mismatch))]
     TypeMismatchGenericMessage {
         err_message: String,
         #[label = "{err_message}"]
@@ -97,7 +97,7 @@ pub enum ShellError {
     ///
     /// Correct the argument value before passing it in or change the command.
     #[error("Incorrect value.")]
-    #[diagnostic(code(nu::shell::incorrect_value), url(docsrs))]
+    #[diagnostic(code(nu::shell::incorrect_value))]
     IncorrectValue(String, #[label = "{0}"] Span),
 
     /// This value cannot be used with this operator.
@@ -107,7 +107,7 @@ pub enum ShellError {
     /// Not all values, for example custom values, can be used with all operators. Either
     /// implement support for the operator on this type, or convert the type to a supported one.
     #[error("Unsupported operator: {0}.")]
-    #[diagnostic(code(nu::shell::unsupported_operator), url(docsrs))]
+    #[diagnostic(code(nu::shell::unsupported_operator))]
     UnsupportedOperator(Operator, #[label = "unsupported operator"] Span),
 
     /// This value cannot be used with this operator.
@@ -116,7 +116,7 @@ pub enum ShellError {
     ///
     /// Assignment requires that you assign to a variable or variable cell path.
     #[error("Assignment operations require a variable.")]
-    #[diagnostic(code(nu::shell::assignment_requires_variable), url(docsrs))]
+    #[diagnostic(code(nu::shell::assignment_requires_variable))]
     AssignmentRequiresVar(#[label = "needs to be a variable"] Span),
 
     /// This value cannot be used with this operator.
@@ -125,7 +125,7 @@ pub enum ShellError {
     ///
     /// Assignment requires that you assign to a mutable variable or cell path.
     #[error("Assignment to an immutable variable.")]
-    #[diagnostic(code(nu::shell::assignment_requires_mutable_variable), url(docsrs))]
+    #[diagnostic(code(nu::shell::assignment_requires_mutable_variable))]
     AssignmentRequiresMutableVar(#[label = "needs to be a mutable variable"] Span),
 
     /// An operator was not recognized during evaluation.
@@ -134,7 +134,7 @@ pub enum ShellError {
     ///
     /// Did you write the correct operator?
     #[error("Unknown operator: {0}.")]
-    #[diagnostic(code(nu::shell::unknown_operator), url(docsrs))]
+    #[diagnostic(code(nu::shell::unknown_operator))]
     UnknownOperator(String, #[label = "unknown operator"] Span),
 
     /// An expected command parameter is missing.
@@ -143,7 +143,7 @@ pub enum ShellError {
     ///
     /// Add the expected parameter and try again.
     #[error("Missing parameter: {0}.")]
-    #[diagnostic(code(nu::shell::missing_parameter), url(docsrs))]
+    #[diagnostic(code(nu::shell::missing_parameter))]
     MissingParameter(String, #[label = "missing parameter: {0}"] Span),
 
     /// Two parameters conflict with each other or are otherwise mutually exclusive.
@@ -152,7 +152,7 @@ pub enum ShellError {
     ///
     /// Remove one of the parameters/options and try again.
     #[error("Incompatible parameters.")]
-    #[diagnostic(code(nu::shell::incompatible_parameters), url(docsrs))]
+    #[diagnostic(code(nu::shell::incompatible_parameters))]
     IncompatibleParameters {
         left_message: String,
         // Be cautious, as flags can share the same span, resulting in a panic (ex: `rm -pt`)
@@ -169,7 +169,7 @@ pub enum ShellError {
     ///
     /// Check your syntax for mismatched braces, RegExp syntax errors, etc, based on the specific error message.
     #[error("Delimiter error")]
-    #[diagnostic(code(nu::shell::delimiter_error), url(docsrs))]
+    #[diagnostic(code(nu::shell::delimiter_error))]
     DelimiterError(String, #[label("{0}")] Span),
 
     /// An operation received parameters with some sort of incompatibility
@@ -180,7 +180,7 @@ pub enum ShellError {
     /// Refer to the specific error message for details on what's incompatible and then fix your
     /// inputs to make sure they match that way.
     #[error("Incompatible parameters.")]
-    #[diagnostic(code(nu::shell::incompatible_parameters), url(docsrs))]
+    #[diagnostic(code(nu::shell::incompatible_parameters))]
     IncompatibleParametersSingle(String, #[label = "{0}"] Span),
 
     /// This build of nushell implements this feature, but it has not been enabled.
@@ -189,7 +189,7 @@ pub enum ShellError {
     ///
     /// Rebuild nushell with the appropriate feature enabled.
     #[error("Feature not enabled.")]
-    #[diagnostic(code(nu::shell::feature_not_enabled), url(docsrs))]
+    #[diagnostic(code(nu::shell::feature_not_enabled))]
     FeatureNotEnabled(#[label = "feature not enabled"] Span),
 
     /// You're trying to run an unsupported external command.
@@ -198,7 +198,7 @@ pub enum ShellError {
     ///
     /// Make sure there's an appropriate `run-external` declaration for this external command.
     #[error("Running external commands not supported")]
-    #[diagnostic(code(nu::shell::external_commands), url(docsrs))]
+    #[diagnostic(code(nu::shell::external_commands))]
     ExternalNotSupported(#[label = "external not supported"] Span),
 
     /// The given probability input is invalid. The probability must be between 0 and 1.
@@ -207,7 +207,7 @@ pub enum ShellError {
     ///
     /// Make sure the probability is between 0 and 1 and try again.
     #[error("Invalid Probability.")]
-    #[diagnostic(code(nu::shell::invalid_probability), url(docsrs))]
+    #[diagnostic(code(nu::shell::invalid_probability))]
     InvalidProbability(#[label = "invalid probability"] Span),
 
     /// The first value in a `..` range must be compatible with the second one.
@@ -216,7 +216,7 @@ pub enum ShellError {
     ///
     /// Check to make sure both values are compatible, and that the values are enumerable in Nushell.
     #[error("Invalid range {0}..{1}")]
-    #[diagnostic(code(nu::shell::invalid_range), url(docsrs))]
+    #[diagnostic(code(nu::shell::invalid_range))]
     InvalidRange(String, String, #[label = "expected a valid range"] Span),
 
     /// Catastrophic nushell failure. This reflects a completely unexpected or unrecoverable error.
@@ -225,7 +225,7 @@ pub enum ShellError {
     ///
     /// It is very likely that this is a bug. Please file an issue at https://github.com/nushell/nushell/issues with relevant information.
     #[error("Nushell failed: {0}.")]
-    #[diagnostic(code(nu::shell::nushell_failed), url(docsrs))]
+    #[diagnostic(code(nu::shell::nushell_failed))]
     // Only use this one if Nushell completely falls over and hits a state that isn't possible or isn't recoverable
     NushellFailed(String),
 
@@ -235,7 +235,7 @@ pub enum ShellError {
     ///
     /// It is very likely that this is a bug. Please file an issue at https://github.com/nushell/nushell/issues with relevant information.
     #[error("Nushell failed: {0}.")]
-    #[diagnostic(code(nu::shell::nushell_failed_spanned), url(docsrs))]
+    #[diagnostic(code(nu::shell::nushell_failed_spanned))]
     // Only use this one if Nushell completely falls over and hits a state that isn't possible or isn't recoverable
     NushellFailedSpanned(String, String, #[label = "{1}"] Span),
 
@@ -245,7 +245,7 @@ pub enum ShellError {
     ///
     /// It is very likely that this is a bug. Please file an issue at https://github.com/nushell/nushell/issues with relevant information.
     #[error("Nushell failed: {0}.")]
-    #[diagnostic(code(nu::shell::nushell_failed_help), url(docsrs))]
+    #[diagnostic(code(nu::shell::nushell_failed_help))]
     // Only use this one if Nushell completely falls over and hits a state that isn't possible or isn't recoverable
     NushellFailedHelp(String, #[help] String),
 
@@ -255,7 +255,7 @@ pub enum ShellError {
     ///
     /// It is very likely that this is a bug. Please file an issue at https://github.com/nushell/nushell/issues with relevant information.
     #[error("Nushell failed: {0}.")]
-    #[diagnostic(code(nu::shell::nushell_failed_spanned_help), url(docsrs))]
+    #[diagnostic(code(nu::shell::nushell_failed_spanned_help))]
     // Only use this one if Nushell completely falls over and hits a state that isn't possible or isn't recoverable
     NushellFailedSpannedHelp(String, String, #[label = "{1}"] Span, #[help] String),
 
@@ -265,7 +265,7 @@ pub enum ShellError {
     ///
     /// Check the variable name. Did you typo it? Did you forget to declare it? Is the casing right?
     #[error("Variable not found")]
-    #[diagnostic(code(nu::shell::variable_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::variable_not_found))]
     VariableNotFoundAtRuntime(#[label = "variable not found"] Span),
 
     /// A referenced environment variable was not found at runtime.
@@ -274,7 +274,7 @@ pub enum ShellError {
     ///
     /// Check the environment variable name. Did you typo it? Did you forget to declare it? Is the casing right?
     #[error("Environment variable '{0}' not found")]
-    #[diagnostic(code(nu::shell::env_variable_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::env_variable_not_found))]
     EnvVarNotFoundAtRuntime(String, #[label = "environment variable not found"] Span),
 
     /// A referenced module was not found at runtime.
@@ -283,7 +283,7 @@ pub enum ShellError {
     ///
     /// Check the module name. Did you typo it? Did you forget to declare it? Is the casing right?
     #[error("Module '{0}' not found")]
-    #[diagnostic(code(nu::shell::module_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::module_not_found))]
     ModuleNotFoundAtRuntime(String, #[label = "module not found"] Span),
 
     /// A referenced module or overlay was not found at runtime.
@@ -292,7 +292,7 @@ pub enum ShellError {
     ///
     /// Check the module name. Did you typo it? Did you forget to declare it? Is the casing right?
     #[error("Module or overlay'{0}' not found")]
-    #[diagnostic(code(nu::shell::module_or_overlay_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::module_or_overlay_not_found))]
     ModuleOrOverlayNotFoundAtRuntime(String, #[label = "not a module or overlay"] Span),
 
     /// A referenced overlay was not found at runtime.
@@ -301,7 +301,7 @@ pub enum ShellError {
     ///
     /// Check the overlay name. Did you typo it? Did you forget to declare it? Is the casing right?
     #[error("Overlay '{0}' not found")]
-    #[diagnostic(code(nu::shell::overlay_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::overlay_not_found))]
     OverlayNotFoundAtRuntime(String, #[label = "overlay not found"] Span),
 
     /// The given item was not found. This is a fairly generic error that depends on context.
@@ -310,7 +310,7 @@ pub enum ShellError {
     ///
     /// This error is triggered in various places, and simply signals that "something" was not found. Refer to the specific error message for further details.
     #[error("Not found.")]
-    #[diagnostic(code(nu::parser::not_found), url(docsrs))]
+    #[diagnostic(code(nu::parser::not_found))]
     NotFound(#[label = "did not find anything under this name"] Span),
 
     /// Failed to convert a value of one type into a different type.
@@ -319,7 +319,7 @@ pub enum ShellError {
     ///
     /// Not all values can be coerced this way. Check the supported type(s) and try again.
     #[error("Can't convert to {0}.")]
-    #[diagnostic(code(nu::shell::cant_convert), url(docsrs))]
+    #[diagnostic(code(nu::shell::cant_convert))]
     CantConvert(
         String,
         String,
@@ -333,7 +333,7 @@ pub enum ShellError {
     ///
     /// Not all values can be coerced this way. Check the supported type(s) and try again.
     #[error("Can't convert {1} `{2}` to {0}.")]
-    #[diagnostic(code(nu::shell::cant_convert_with_value), url(docsrs))]
+    #[diagnostic(code(nu::shell::cant_convert_with_value))]
     CantConvertWithValue(
         String,
         String,
@@ -351,7 +351,6 @@ pub enum ShellError {
     #[error("{0} is not representable as a string.")]
     #[diagnostic(
         code(nu::shell::env_var_not_a_string),
-        url(docsrs),
         help(
             r#"The '{0}' environment variable must be a string or be convertible to a string.
 Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVERSIONS."#
@@ -367,7 +366,6 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("{0} cannot be set manually.")]
     #[diagnostic(
         code(nu::shell::automatic_env_var_set_manually),
-        url(docsrs),
         help(
             r#"The environment variable '{0}' is set automatically by Nushell and cannot not be set manually."#
         )
@@ -383,7 +381,6 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("Cannot replace environment.")]
     #[diagnostic(
         code(nu::shell::cannot_replace_env),
-        url(docsrs),
         help(r#"Assigning a value to $env is not allowed."#)
     )]
     CannotReplaceEnv(#[label("setting $env not allowed")] Span),
@@ -394,7 +391,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Add a guard of some sort to check whether a denominator input to this division is zero, and branch off if that's the case.
     #[error("Division by zero.")]
-    #[diagnostic(code(nu::shell::division_by_zero), url(docsrs))]
+    #[diagnostic(code(nu::shell::division_by_zero))]
     DivisionByZero(#[label("division by zero")] Span),
 
     /// An error happened while tryin to create a range.
@@ -405,7 +402,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check your range values to make sure they're countable and would not loop forever.
     #[error("Can't convert range to countable values")]
-    #[diagnostic(code(nu::shell::range_to_countable), url(docsrs))]
+    #[diagnostic(code(nu::shell::range_to_countable))]
     CannotCreateRange(#[label = "can't convert to countable values"] Span),
 
     /// You attempted to access an index beyond the available length of a value.
@@ -414,7 +411,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check your lengths and try again.
     #[error("Row number too large (max: {0}).")]
-    #[diagnostic(code(nu::shell::access_beyond_end), url(docsrs))]
+    #[diagnostic(code(nu::shell::access_beyond_end))]
     AccessBeyondEnd(usize, #[label = "index too large (max: {0})"] Span),
 
     /// You attempted to insert data at a list position higher than the end.
@@ -423,7 +420,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// To insert data into a list, assign to the last used index + 1.
     #[error("Inserted at wrong row number (should be {0}).")]
-    #[diagnostic(code(nu::shell::access_beyond_end), url(docsrs))]
+    #[diagnostic(code(nu::shell::access_beyond_end))]
     InsertAfterNextFreeIndex(
         usize,
         #[label = "can't insert at index (the next available index is {0})"] Span,
@@ -435,7 +432,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check your lengths and try again.
     #[error("Row number too large (empty content).")]
-    #[diagnostic(code(nu::shell::access_beyond_end), url(docsrs))]
+    #[diagnostic(code(nu::shell::access_beyond_end))]
     AccessEmptyContent(#[label = "index too large (empty content)"] Span),
 
     /// You attempted to access an index beyond the available length of a stream.
@@ -444,7 +441,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check your lengths and try again.
     #[error("Row number too large.")]
-    #[diagnostic(code(nu::shell::access_beyond_end_of_stream), url(docsrs))]
+    #[diagnostic(code(nu::shell::access_beyond_end_of_stream))]
     AccessBeyondEndOfStream(#[label = "index too large"] Span),
 
     /// Tried to index into a type that does not support pathed access.
@@ -453,7 +450,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check your types. Only composite types can be pathed into.
     #[error("Data cannot be accessed with a cell path")]
-    #[diagnostic(code(nu::shell::incompatible_path_access), url(docsrs))]
+    #[diagnostic(code(nu::shell::incompatible_path_access))]
     IncompatiblePathAccess(String, #[label("{0} doesn't support cell paths")] Span),
 
     /// The requested column does not exist.
@@ -462,7 +459,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check the spelling of your column name. Did you forget to rename a column somewhere?
     #[error("Cannot find column")]
-    #[diagnostic(code(nu::shell::column_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::column_not_found))]
     CantFindColumn(
         String,
         #[label = "cannot find column '{0}'"] Span,
@@ -475,7 +472,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Drop or rename the existing column (check `rename -h`) and try again.
     #[error("Column already exists")]
-    #[diagnostic(code(nu::shell::column_already_exists), url(docsrs))]
+    #[diagnostic(code(nu::shell::column_already_exists))]
     ColumnAlreadyExists(
         String,
         #[label = "column '{0}' already exists"] Span,
@@ -488,7 +485,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check the input type to this command. Are you sure it's a list?
     #[error("Not a list value")]
-    #[diagnostic(code(nu::shell::not_a_list), url(docsrs))]
+    #[diagnostic(code(nu::shell::not_a_list))]
     NotAList(
         #[label = "value not a list"] Span,
         #[label = "value originates here"] Span,
@@ -500,7 +497,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This error is fairly generic. Refer to the specific error message for further details.
     #[error("External command failed")]
-    #[diagnostic(code(nu::shell::external_command), url(docsrs), help("{1}"))]
+    #[diagnostic(code(nu::shell::external_command), help("{1}"))]
     ExternalCommand(String, String, #[label("{0}")] Span),
 
     /// An operation was attempted with an input unsupported for some reason.
@@ -509,7 +506,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This error is fairly generic. Refer to the specific error message for further details.
     #[error("Unsupported input")]
-    #[diagnostic(code(nu::shell::unsupported_input), url(docsrs))]
+    #[diagnostic(code(nu::shell::unsupported_input))]
     UnsupportedInput(
         String,
         String,
@@ -534,7 +531,6 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     #[error("Unable to parse datetime: [{0}].")]
     #[diagnostic(
         code(nu::shell::datetime_parse_error),
-        url(docsrs),
         help(
             r#"Examples of supported inputs:
  * "5 pm"
@@ -553,7 +549,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// It's always DNS.
     #[error("Network failure")]
-    #[diagnostic(code(nu::shell::network_failure), url(docsrs))]
+    #[diagnostic(code(nu::shell::network_failure))]
     NetworkFailure(String, #[label("{0}")] Span),
 
     /// Help text for this command could not be found.
@@ -562,7 +558,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check the spelling for the requested command and try again. Are you sure it's defined and your configurations are loading correctly? Can you execute it?
     #[error("Command not found")]
-    #[diagnostic(code(nu::shell::command_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::command_not_found))]
     CommandNotFound(#[label("command not found")] Span),
 
     /// This alias could not be found
@@ -571,12 +567,12 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// The alias does not exist in the current scope. It might exist in another scope or overlay or be hidden.
     #[error("Alias not found")]
-    #[diagnostic(code(nu::shell::alias_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::alias_not_found))]
     AliasNotFound(#[label("alias not found")] Span),
 
     /// A flag was not found.
     #[error("Flag not found")]
-    #[diagnostic(code(nu::shell::flag_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::flag_not_found))]
     // NOTE: Seems to be unused. Removable?
     FlagNotFound(String, #[label("{0} not found")] Span),
 
@@ -586,7 +582,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Does the file in the error message exist? Is it readable and accessible? Is the casing right?
     #[error("File not found")]
-    #[diagnostic(code(nu::shell::file_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::file_not_found))]
     FileNotFound(#[label("file not found")] Span),
 
     /// Failed to find a file during a nushell operation.
@@ -595,7 +591,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Does the file in the error message exist? Is it readable and accessible? Is the casing right?
     #[error("File not found")]
-    #[diagnostic(code(nu::shell::file_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::file_not_found))]
     FileNotFoundCustom(String, #[label("{0}")] Span),
 
     /// A plugin failed to load.
@@ -604,7 +600,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is a fairly generic error. Refer to the specific error message for further details.
     #[error("Plugin failed to load: {0}")]
-    #[diagnostic(code(nu::shell::plugin_failed_to_load), url(docsrs))]
+    #[diagnostic(code(nu::shell::plugin_failed_to_load))]
     PluginFailedToLoad(String),
 
     /// A message from a plugin failed to encode.
@@ -613,7 +609,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is likely a bug with the plugin itself.
     #[error("Plugin failed to encode: {0}")]
-    #[diagnostic(code(nu::shell::plugin_failed_to_encode), url(docsrs))]
+    #[diagnostic(code(nu::shell::plugin_failed_to_encode))]
     PluginFailedToEncode(String),
 
     /// A message to a plugin failed to decode.
@@ -622,7 +618,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is either an issue with the inputs to a plugin (bad JSON?) or a bug in the plugin itself. Fix or report as appropriate.
     #[error("Plugin failed to decode: {0}")]
-    #[diagnostic(code(nu::shell::plugin_failed_to_decode), url(docsrs))]
+    #[diagnostic(code(nu::shell::plugin_failed_to_decode))]
     PluginFailedToDecode(String),
 
     /// I/O operation interrupted.
@@ -631,7 +627,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is a generic error. Refer to the specific error message for further details.
     #[error("I/O interrupted")]
-    #[diagnostic(code(nu::shell::io_interrupted), url(docsrs))]
+    #[diagnostic(code(nu::shell::io_interrupted))]
     IOInterrupted(String, #[label("{0}")] Span),
 
     /// An I/O operation failed.
@@ -640,7 +636,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is a generic error. Refer to the specific error message for further details.
     #[error("I/O error")]
-    #[diagnostic(code(nu::shell::io_error), url(docsrs), help("{0}"))]
+    #[diagnostic(code(nu::shell::io_error), help("{0}"))]
     IOError(String),
 
     /// An I/O operation failed.
@@ -649,7 +645,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is a generic error. Refer to the specific error message for further details.
     #[error("I/O error")]
-    #[diagnostic(code(nu::shell::io_error), url(docsrs))]
+    #[diagnostic(code(nu::shell::io_error))]
     IOErrorSpanned(String, #[label("{0}")] Span),
 
     /// Permission for an operation was denied.
@@ -658,7 +654,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is a generic error. Refer to the specific error message for further details.
     #[error("Permission Denied")]
-    #[diagnostic(code(nu::shell::permission_denied), url(docsrs))]
+    #[diagnostic(code(nu::shell::permission_denied))]
     PermissionDeniedError(String, #[label("{0}")] Span),
 
     /// Out of memory.
@@ -667,7 +663,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is a generic error. Refer to the specific error message for further details.
     #[error("Out of memory")]
-    #[diagnostic(code(nu::shell::out_of_memory), url(docsrs))]
+    #[diagnostic(code(nu::shell::out_of_memory))]
     OutOfMemoryError(String, #[label("{0}")] Span),
 
     /// Tried to `cd` to a path that isn't a directory.
@@ -676,7 +672,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Make sure the path is a directory. It currently exists, but is of some other type, like a file.
     #[error("Cannot change to directory")]
-    #[diagnostic(code(nu::shell::cannot_cd_to_directory), url(docsrs))]
+    #[diagnostic(code(nu::shell::cannot_cd_to_directory))]
     NotADirectory(#[label("is not a directory")] Span),
 
     /// Attempted to perform an operation on a directory that doesn't exist.
@@ -685,7 +681,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Make sure the directory in the error message actually exists before trying again.
     #[error("Directory not found")]
-    #[diagnostic(code(nu::shell::directory_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::directory_not_found))]
     DirectoryNotFound(#[label("directory not found")] Span, #[help] Option<String>),
 
     /// Attempted to perform an operation on a directory that doesn't exist.
@@ -694,7 +690,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Make sure the directory in the error message actually exists before trying again.
     #[error("Directory not found")]
-    #[diagnostic(code(nu::shell::directory_not_found_custom), url(docsrs))]
+    #[diagnostic(code(nu::shell::directory_not_found_custom))]
     DirectoryNotFoundCustom(String, #[label("{0}")] Span),
 
     /// The requested move operation cannot be completed. This is typically because both paths exist,
@@ -705,7 +701,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Make sure the destination path does not exist before moving a directory.
     #[error("Move not possible")]
-    #[diagnostic(code(nu::shell::move_not_possible), url(docsrs))]
+    #[diagnostic(code(nu::shell::move_not_possible))]
     MoveNotPossible {
         source_message: String,
         #[label("{source_message}")]
@@ -723,7 +719,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Make sure the destination path does not exist before moving a directory.
     #[error("Move not possible")]
-    #[diagnostic(code(nu::shell::move_not_possible_single), url(docsrs))]
+    #[diagnostic(code(nu::shell::move_not_possible_single))]
     // NOTE: Currently not actively used.
     MoveNotPossibleSingle(String, #[label("{0}")] Span),
 
@@ -733,7 +729,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This is a fairly generic error. Refer to the specific error message for further details.
     #[error("Create not possible")]
-    #[diagnostic(code(nu::shell::create_not_possible), url(docsrs))]
+    #[diagnostic(code(nu::shell::create_not_possible))]
     CreateNotPossible(String, #[label("{0}")] Span),
 
     /// Changing the access time ("atime") of this file is not possible.
@@ -742,7 +738,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This can be for various reasons, such as your platform or permission flags. Refer to the specific error message for more details.
     #[error("Not possible to change the access time")]
-    #[diagnostic(code(nu::shell::change_access_time_not_possible), url(docsrs))]
+    #[diagnostic(code(nu::shell::change_access_time_not_possible))]
     ChangeAccessTimeNotPossible(String, #[label("{0}")] Span),
 
     /// Changing the modification time ("mtime") of this file is not possible.
@@ -751,12 +747,12 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// This can be for various reasons, such as your platform or permission flags. Refer to the specific error message for more details.
     #[error("Not possible to change the modified time")]
-    #[diagnostic(code(nu::shell::change_modified_time_not_possible), url(docsrs))]
+    #[diagnostic(code(nu::shell::change_modified_time_not_possible))]
     ChangeModifiedTimeNotPossible(String, #[label("{0}")] Span),
 
     /// Unable to remove this item.
     #[error("Remove not possible")]
-    #[diagnostic(code(nu::shell::remove_not_possible), url(docsrs))]
+    #[diagnostic(code(nu::shell::remove_not_possible))]
     // NOTE: Currently unused. Remove?
     RemoveNotPossible(String, #[label("{0}")] Span),
 
@@ -774,7 +770,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// The error will show the result from a file operation
     #[error("Error trying to read file")]
-    #[diagnostic(code(nu::shell::error_reading_file), url(docsrs))]
+    #[diagnostic(code(nu::shell::error_reading_file))]
     ReadingFile(String, #[label("{0}")] Span),
 
     /// A name was not found. Did you mean a different name?
@@ -783,7 +779,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// The error message will suggest a possible match for what you meant.
     #[error("Name not found")]
-    #[diagnostic(code(nu::shell::name_not_found), url(docsrs))]
+    #[diagnostic(code(nu::shell::name_not_found))]
     DidYouMean(String, #[label("did you mean '{0}'?")] Span),
 
     /// A name was not found. Did you mean a different name?
@@ -792,7 +788,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// The error message will suggest a possible match for what you meant.
     #[error("{0}")]
-    #[diagnostic(code(nu::shell::did_you_mean_custom), url(docsrs))]
+    #[diagnostic(code(nu::shell::did_you_mean_custom))]
     DidYouMeanCustom(String, String, #[label("did you mean '{1}'?")] Span),
 
     /// The given input must be valid UTF-8 for further processing.
@@ -801,7 +797,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check your input's encoding. Are there any funny characters/bytes?
     #[error("Non-UTF8 string")]
-    #[diagnostic(code(nu::parser::non_utf8), url(docsrs))]
+    #[diagnostic(code(nu::parser::non_utf8))]
     NonUtf8(#[label = "non-UTF8 string"] Span),
 
     /// The given input must be valid UTF-8 for further processing.
@@ -810,7 +806,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check your input's encoding. Are there any funny characters/bytes?
     #[error("Non-UTF8 string")]
-    #[diagnostic(code(nu::parser::non_utf8_custom), url(docsrs))]
+    #[diagnostic(code(nu::parser::non_utf8_custom))]
     NonUtf8Custom(String, #[label = "{0}"] Span),
 
     /// A custom value could not be converted to a Dataframe.
@@ -819,7 +815,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Make sure conversion to a Dataframe is possible for this value or convert it to a type that does, first.
     #[error("Casting error")]
-    #[diagnostic(code(nu::shell::downcast_not_possible), url(docsrs))]
+    #[diagnostic(code(nu::shell::downcast_not_possible))]
     DowncastNotPossible(String, #[label("{0}")] Span),
 
     /// The value given for this configuration is not supported.
@@ -828,7 +824,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Refer to the specific error message for details and convert values as needed.
     #[error("Unsupported config value")]
-    #[diagnostic(code(nu::shell::unsupported_config_value), url(docsrs))]
+    #[diagnostic(code(nu::shell::unsupported_config_value))]
     UnsupportedConfigValue(String, String, #[label = "expected {0}, got {1}"] Span),
 
     /// An expected configuration value is not present.
@@ -837,7 +833,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Refer to the specific error message and add the configuration value to your config file as needed.
     #[error("Missing config value")]
-    #[diagnostic(code(nu::shell::missing_config_value), url(docsrs))]
+    #[diagnostic(code(nu::shell::missing_config_value))]
     MissingConfigValue(String, #[label = "missing {0}"] Span),
 
     /// Negative value passed when positive one is required.
@@ -846,7 +842,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Guard against negative values or check your inputs.
     #[error("Negative value passed when positive one is required")]
-    #[diagnostic(code(nu::shell::needs_positive_value), url(docsrs))]
+    #[diagnostic(code(nu::shell::needs_positive_value))]
     NeedsPositiveValue(#[label = "use a positive value"] Span),
 
     /// This is a generic error type used for different situations.
@@ -871,7 +867,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check the help for the new suggested command and update your script accordingly.
     #[error("Deprecated command {0}")]
-    #[diagnostic(code(nu::shell::deprecated_command), url(docsrs))]
+    #[diagnostic(code(nu::shell::deprecated_command))]
     DeprecatedCommand(
         String,
         String,
@@ -884,7 +880,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check the help for the command and update your script accordingly.
     #[error("Deprecated parameter {0}")]
-    #[diagnostic(code(nu::shell::deprecated_command), url(docsrs))]
+    #[diagnostic(code(nu::shell::deprecated_command))]
     DeprecatedParameter(
         String,
         String,
@@ -897,7 +893,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check that your path is UTF-8 compatible.
     #[error("Non-Unicode input received.")]
-    #[diagnostic(code(nu::shell::non_unicode_input), url(docsrs))]
+    #[diagnostic(code(nu::shell::non_unicode_input))]
     NonUnicodeInput,
 
     /// Unexpected abbr component.
@@ -906,13 +902,13 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Check the path abbreviation to ensure that it is valid.
     #[error("Unexpected abbr component `{0}`.")]
-    #[diagnostic(code(nu::shell::unexpected_path_abbreviateion), url(docsrs))]
+    #[diagnostic(code(nu::shell::unexpected_path_abbreviateion))]
     UnexpectedAbbrComponent(String),
 
     // It should be only used by commands accepts block, and accept inputs from pipeline.
     /// Failed to eval block with specific pipeline input.
     #[error("Eval block failed with pipeline input")]
-    #[diagnostic(code(nu::shell::eval_block_with_input), url(docsrs))]
+    #[diagnostic(code(nu::shell::eval_block_with_input))]
     EvalBlockWithInput(#[label("source value")] Span, #[related] Vec<ShellError>),
 
     /// Break event, which may become an error if used outside of a loop
@@ -933,7 +929,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
     ///
     /// Adjust your Nu code to
     #[error("Recursion limit ({recursion_limit}) reached")]
-    #[diagnostic(code(nu::shell::recursion_limit_reached), url(docsrs))]
+    #[diagnostic(code(nu::shell::recursion_limit_reached))]
     RecursionLimitReached {
         recursion_limit: u64,
         #[label("This called itself too many times")]
@@ -942,7 +938,7 @@ Either make sure {0} is a string, or add a 'to_string' entry for it in ENV_CONVE
 
     /// An attempt to access a record column failed.
     #[error("Access failure: {message}")]
-    #[diagnostic(code(nu::shell::lazy_record_access_failed), url(docsrs))]
+    #[diagnostic(code(nu::shell::lazy_record_access_failed))]
     LazyRecordAccessFailed {
         message: String,
         column_name: String,

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -358,7 +358,7 @@ fn env_change_block_dont_preserve_command() {
     #[cfg(windows)]
     assert_ne!(actual_repl.out, "foo");
     #[cfg(not(windows))]
-    assert!(actual_repl.err.contains("ExternalCommand"));
+    assert!(actual_repl.err.contains("external_command"));
 }
 
 #[test]
@@ -409,7 +409,7 @@ fn env_change_dont_panic_with_many_args() {
 
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
-    assert!(actual_repl.err.contains("IncompatibleParametersSingle"));
+    assert!(actual_repl.err.contains("incompatible_parameters"));
     assert_eq!(actual_repl.out, "");
 }
 
@@ -428,8 +428,9 @@ fn err_hook_wrong_env_type_1() {
     ];
 
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    dbg!(&actual_repl.err);
 
-    assert!(actual_repl.err.contains("UnsupportedConfigValue"));
+    assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
 }
 
@@ -446,7 +447,7 @@ fn err_hook_wrong_env_type_2() {
 
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
-    assert!(actual_repl.err.contains("TypeMismatch"));
+    assert!(actual_repl.err.contains("type_mismatch"));
     assert_eq!(actual_repl.out, "");
 }
 
@@ -468,7 +469,7 @@ fn err_hook_wrong_env_type_3() {
 
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
-    assert!(actual_repl.err.contains("UnsupportedConfigValue"));
+    assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
 }
 
@@ -491,7 +492,7 @@ fn err_hook_non_boolean_condition_output() {
 
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
-    assert!(actual_repl.err.contains("UnsupportedConfigValue"));
+    assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
 }
 
@@ -514,7 +515,7 @@ fn err_hook_non_condition_not_a_block() {
 
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
-    assert!(actual_repl.err.contains("UnsupportedConfigValue"));
+    assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
 }
 
@@ -536,7 +537,7 @@ fn err_hook_parse_error() {
 
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
-    assert!(actual_repl.err.contains("UnsupportedConfigValue"));
+    assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
 }
 
@@ -547,5 +548,5 @@ fn err_hook_dont_allow_string() {
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
     assert!(actual_repl.out.is_empty());
-    assert!(actual_repl.err.contains("UnsupportedConfigValue"));
+    assert!(actual_repl.err.contains("unsupported_config_value"));
 }


### PR DESCRIPTION
# Description

issue #8167

Remove the `(link)` to the docs for `ShellError` and `ParseError`.  As per discussion on the issue, the nu-parser version didn't update on the docs causing deadlinks for those errors, which brought the usefullness of these links into question and it was decided to remove all of them that `derive(diagnostic)`.

# User-Facing Changes
Before:
```
/home/rdevenney/projects/open_source/nushell〉ls | get name}
Error: nu::parser::unbalanced_delimiter (link)

  × Unbalanced delimiter.
   ╭─[entry #1:1:1]
 1 │ ls | get name}
   ·              ▲
   ·              ╰── unbalanced { and }
   ╰────
```

After:
```
/home/rdevenney/projects/open_source/nushell〉ls | get name}
Error: nu::parser::unbalanced_delimiter

  × Unbalanced delimiter.
   ╭─[entry #1:1:1]
 1 │ ls | get name}
   ·              ▲
   ·              ╰── unbalanced { and }
   ╰────
```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
