### PR TITLE
move `hash md5` and `hash sha256` commands to the hash category

### DIFF
--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -3,7 +3,9 @@ use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::Span;
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+};
 use std::marker::PhantomData;
 
 pub trait HashDigest: digest::Digest + Clone {

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -3,7 +3,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::Span;
-use nu_protocol::{Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value};
 use std::marker::PhantomData;
 
 pub trait HashDigest: digest::Digest + Clone {
@@ -50,6 +50,7 @@ where
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
+            .category(Category::Hash)
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::String, Type::Binary),


### PR DESCRIPTION
# Description

For auto-generated documentation, move the `hash _` commands into the Hash category

# User-Facing Changes

Apart from documentation, none.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
