### PR TITLE
Error out when Select gets same row

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -121,8 +121,8 @@ fn select(
                 }
                 if unique_rows.contains(val) {
                     return Err(ShellError::GenericError(
-                        "Select only allows unique rows".into(),
-                        "duplicated row".into(),
+                        "Select can't get the same row twice".into(),
+                        "duplicated row index".into(),
                         Some(*span),
                         None,
                         Vec::new(),

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -272,3 +272,15 @@ fn select_failed3() {
     assert!(actual.out.is_empty());
     assert!(actual.err.contains("cannot find column"));
 }
+
+#[test]
+fn select_failed4() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        [{a: 1 b: 10}, {a:2, b:11}] | select 0 0
+        "#
+    ));
+
+    assert!(actual.err.contains("Select only allows unique row"));
+}

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -282,5 +282,5 @@ fn select_failed4() {
         "#
     ));
 
-    assert!(actual.err.contains("Select only allows unique row"));
+    assert!(actual.err.contains("Select can't get the same row twice"));
 }


### PR DESCRIPTION
# Description
Fixes #8145, by disallowing any rows that are duplicated.

```
❯ ls | select 0 0
Error: 
  × Select only allows unique rows
   ╭─[entry #1:1:1]
 1 │ ls | select 0 0
   ·               ┬
   ·               ╰── duplicated row
   ╰────

```

# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
