### PR TITLE
fix: fix `commandline` when called with no arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2745,6 +2745,7 @@ dependencies = [
  "nu-test-support",
  "nu-utils",
  "shadow-rs",
+ "unicode-segmentation",
 ]
 
 [[package]]

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -463,15 +463,13 @@ pub fn evaluate_repl(
                 // fire the "pre_execution" hook
                 if let Some(hook) = config.hooks.pre_execution.clone() {
                     // Set the REPL buffer to the current command for the "pre_execution" hook
-                    let next_repl_buffer = engine_state
+                    let mut repl_buffer = engine_state
                         .repl_buffer_state
                         .lock()
-                        .expect("repl buffer state mutex")
-                        .to_string();
-                    *engine_state
-                        .repl_buffer_state
-                        .lock()
-                        .expect("repl buffer state mutex") = s.to_string();
+                        .expect("repl buffer state mutex");
+                    let next_repl_buffer = repl_buffer.to_string();
+                    *repl_buffer = s.to_string();
+                    drop(repl_buffer);
 
                     if let Err(err) = eval_hook(engine_state, stack, None, vec![], &hook) {
                         report_error_new(engine_state, &err);
@@ -479,10 +477,12 @@ pub fn evaluate_repl(
 
                     // Restore the REPL buffer state for the next command. It could've been edited
                     // by `commandline`.
-                    *engine_state
+                    let mut repl_buffer = engine_state
                         .repl_buffer_state
                         .lock()
-                        .expect("repl buffer state mutex") = next_repl_buffer.to_string();
+                        .expect("repl buffer state mutex");
+                    *repl_buffer = next_repl_buffer;
+                    drop(repl_buffer);
                 }
 
                 if shell_integration {
@@ -640,24 +640,23 @@ pub fn evaluate_repl(
                     run_ansi_sequence(RESET_APPLICATION_MODE)?;
                 }
 
-                let repl_buffer = engine_state
+                let mut repl_buffer = engine_state
                     .repl_buffer_state
                     .lock()
-                    .expect("repl buffer state mutex")
-                    .to_string();
+                    .expect("repl buffer state mutex");
                 line_editor.run_edit_commands(&[
                     EditCommand::Clear,
-                    EditCommand::InsertString(repl_buffer),
+                    EditCommand::InsertString(repl_buffer.to_string()),
                 ]);
+                *repl_buffer = "".to_string();
+                drop(repl_buffer);
 
-                *engine_state
-                    .repl_buffer_state
-                    .lock()
-                    .expect("repl buffer state mutex") = "".to_string();
-                *engine_state
+                let mut repl_cursor_pos = engine_state
                     .repl_cursor_pos
                     .lock()
-                    .expect("repl cursor pos mutex") = 0;
+                    .expect("repl cursor pos mutex");
+                *repl_cursor_pos = 0;
+                drop(repl_cursor_pos);
             }
             Ok(Signal::CtrlC) => {
                 // `Reedline` clears the line content. New prompt is shown

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -644,17 +644,17 @@ pub fn evaluate_repl(
                     .repl_buffer_state
                     .lock()
                     .expect("repl buffer state mutex");
-                line_editor.run_edit_commands(&[
-                    EditCommand::Clear,
-                    EditCommand::InsertString(repl_buffer.to_string()),
-                ]);
-                *repl_buffer = "".to_string();
-                drop(repl_buffer);
-
                 let mut repl_cursor_pos = engine_state
                     .repl_cursor_pos
                     .lock()
                     .expect("repl cursor pos mutex");
+                line_editor.run_edit_commands(&[
+                    EditCommand::Clear,
+                    EditCommand::InsertString(repl_buffer.to_string()),
+                    EditCommand::MoveToPosition(*repl_cursor_pos),
+                ]);
+                *repl_buffer = "".to_string();
+                drop(repl_buffer);
                 *repl_cursor_pos = 0;
                 drop(repl_cursor_pos);
             }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -23,6 +23,7 @@ fancy-regex = "0.11.0"
 itertools = "0.10.0"
 log = "0.4.14"
 shadow-rs = { version = "0.21.0", default-features = false }
+unicode-segmentation = "1.10.0"
 
 [build-dependencies]
 shadow-rs = { version = "0.21.0", default-features = false }

--- a/crates/nu-cmd-lang/src/core_commands/commandline.rs
+++ b/crates/nu-cmd-lang/src/core_commands/commandline.rs
@@ -97,11 +97,13 @@ impl Command for Commandline {
                 }
             } else if call.has_flag("append") {
                 buffer.push_str(&cmd.as_string()?);
-                *cursor_pos = buffer.len();
             } else if call.has_flag("insert") {
-                buffer.insert_str(*cursor_pos, &cmd.as_string()?);
+                let cmd_str = cmd.as_string()?;
+                buffer.insert_str(*cursor_pos, &cmd_str);
+                *cursor_pos += cmd_str.len();
             } else {
                 *buffer = cmd.as_string()?;
+                *cursor_pos = buffer.len();
             }
             Ok(Value::Nothing { span: call.head }.into_pipeline_data())
         } else {

--- a/crates/nu-cmd-lang/src/core_commands/commandline.rs
+++ b/crates/nu-cmd-lang/src/core_commands/commandline.rs
@@ -4,6 +4,7 @@ use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::Category;
 use nu_protocol::IntoPipelineData;
 use nu_protocol::{PipelineData, ShellError, Signature, SyntaxShape, Type, Value};
+use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Clone)]
 pub struct Commandline;
@@ -77,7 +78,7 @@ impl Command for Commandline {
                             0usize
                         } else {
                             buffer
-                                .char_indices()
+                                .grapheme_indices(true)
                                 .map(|(i, _c)| i)
                                 .nth(n as usize)
                                 .unwrap_or(buffer.len())
@@ -114,7 +115,7 @@ impl Command for Commandline {
                     .lock()
                     .expect("repl cursor pos mutex");
                 let char_pos = buffer
-                    .char_indices()
+                    .grapheme_indices(true)
                     .position(|(i, _c)| i == *cursor_pos)
                     .unwrap_or(buffer.len());
                 Ok(Value::String {

--- a/crates/nu-cmd-lang/src/core_commands/commandline.rs
+++ b/crates/nu-cmd-lang/src/core_commands/commandline.rs
@@ -65,28 +65,24 @@ impl Command for Commandline {
                 .expect("repl cursor pos mutex");
 
             if call.has_flag("append") {
-                let buffer = buffer.as_mut().unwrap();
                 buffer.push_str(&cmd.as_string()?);
                 *cursor_pos = buffer.len();
             } else if call.has_flag("insert") {
-                let buffer = buffer.as_mut().unwrap();
                 buffer.insert_str(*cursor_pos, &cmd.as_string()?);
             } else {
-                buffer.replace(cmd.as_string()?);
+                *buffer = cmd.as_string()?;
             }
             Ok(Value::Nothing { span: call.head }.into_pipeline_data())
-        } else if let Some(ref cmd) = *engine_state
-            .repl_buffer_state
-            .lock()
-            .expect("repl buffer state mutex")
-        {
+        } else {
+            let buffer = engine_state
+                .repl_buffer_state
+                .lock()
+                .expect("repl buffer state mutex");
             Ok(Value::String {
-                val: cmd.clone(),
+                val: buffer.to_string(),
                 span: call.head,
             }
             .into_pipeline_data())
-        } else {
-            Ok(Value::Nothing { span: call.head }.into_pipeline_data())
         }
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/commandline.rs
+++ b/crates/nu-cmd-lang/src/core_commands/commandline.rs
@@ -1,6 +1,5 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
-use nu_protocol::engine::ReplOperation;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::Category;
 use nu_protocol::IntoPipelineData;
@@ -60,28 +59,21 @@ impl Command for Commandline {
                 .repl_buffer_state
                 .lock()
                 .expect("repl buffer state mutex");
-            let mut ops = engine_state
-                .repl_operation_queue
-                .lock()
-                .expect("repl op queue mutex");
             let mut cursor_pos = engine_state
                 .repl_cursor_pos
                 .lock()
                 .expect("repl cursor pos mutex");
 
-            ops.push_back(if call.has_flag("append") {
+            if call.has_flag("append") {
                 let buffer = buffer.as_mut().unwrap();
                 buffer.push_str(&cmd.as_string()?);
                 *cursor_pos = buffer.len();
-                ReplOperation::Append(cmd.as_string()?)
             } else if call.has_flag("insert") {
                 let buffer = buffer.as_mut().unwrap();
                 buffer.insert_str(*cursor_pos, &cmd.as_string()?);
-                ReplOperation::Insert(cmd.as_string()?)
             } else {
                 buffer.replace(cmd.as_string()?);
-                ReplOperation::Replace(cmd.as_string()?)
-            });
+            }
             Ok(Value::Nothing { span: call.head }.into_pipeline_data())
         } else if let Some(ref cmd) = *engine_state
             .repl_buffer_state

--- a/crates/nu-cmd-lang/src/core_commands/commandline.rs
+++ b/crates/nu-cmd-lang/src/core_commands/commandline.rs
@@ -56,15 +56,30 @@ impl Command for Commandline {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         if let Some(cmd) = call.opt::<Value>(engine_state, stack, 0)? {
+            let mut buffer = engine_state
+                .repl_buffer_state
+                .lock()
+                .expect("repl buffer state mutex");
             let mut ops = engine_state
                 .repl_operation_queue
                 .lock()
                 .expect("repl op queue mutex");
+            let mut cursor_pos = engine_state
+                .repl_cursor_pos
+                .lock()
+                .expect("repl cursor pos mutex");
+
             ops.push_back(if call.has_flag("append") {
+                let buffer = buffer.as_mut().unwrap();
+                buffer.push_str(&cmd.as_string()?);
+                *cursor_pos = buffer.len();
                 ReplOperation::Append(cmd.as_string()?)
             } else if call.has_flag("insert") {
+                let buffer = buffer.as_mut().unwrap();
+                buffer.insert_str(*cursor_pos, &cmd.as_string()?);
                 ReplOperation::Insert(cmd.as_string()?)
             } else {
+                buffer.replace(cmd.as_string()?);
                 ReplOperation::Replace(cmd.as_string()?)
             });
             Ok(Value::Nothing { span: call.head }.into_pipeline_data())

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -125,7 +125,7 @@ pub struct EngineState {
     pub previous_env_vars: HashMap<String, Value>,
     pub config: Config,
     pub pipeline_externals_state: Arc<(AtomicU32, AtomicU32)>,
-    pub repl_buffer_state: Arc<Mutex<Option<String>>>,
+    pub repl_buffer_state: Arc<Mutex<String>>,
     pub repl_cursor_pos: Arc<Mutex<usize>>,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,
@@ -177,7 +177,7 @@ impl EngineState {
             previous_env_vars: HashMap::new(),
             config: Config::default(),
             pipeline_externals_state: Arc::new((AtomicU32::new(0), AtomicU32::new(0))),
-            repl_buffer_state: Arc::new(Mutex::new(Some("".to_string()))),
+            repl_buffer_state: Arc::new(Mutex::new("".to_string())),
             repl_cursor_pos: Arc::new(Mutex::new(0)),
             #[cfg(feature = "plugin")]
             plugin_signatures: None,

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -126,6 +126,7 @@ pub struct EngineState {
     pub config: Config,
     pub pipeline_externals_state: Arc<(AtomicU32, AtomicU32)>,
     pub repl_buffer_state: Arc<Mutex<String>>,
+    // A byte position, as `EditCommand::MoveToPosition` is also a byte position
     pub repl_cursor_pos: Arc<Mutex<usize>>,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -135,6 +135,7 @@ pub struct EngineState {
     pub config: Config,
     pub pipeline_externals_state: Arc<(AtomicU32, AtomicU32)>,
     pub repl_buffer_state: Arc<Mutex<Option<String>>>,
+    pub repl_cursor_pos: Arc<Mutex<usize>>,
     pub repl_operation_queue: Arc<Mutex<VecDeque<ReplOperation>>>,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,
@@ -186,7 +187,8 @@ impl EngineState {
             previous_env_vars: HashMap::new(),
             config: Config::default(),
             pipeline_externals_state: Arc::new((AtomicU32::new(0), AtomicU32::new(0))),
-            repl_buffer_state: Arc::new(Mutex::new(None)),
+            repl_buffer_state: Arc::new(Mutex::new(Some("".to_string()))),
+            repl_cursor_pos: Arc::new(Mutex::new(0)),
             repl_operation_queue: Arc::new(Mutex::new(VecDeque::new())),
             #[cfg(feature = "plugin")]
             plugin_signatures: None,

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -13,7 +13,7 @@ use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{HashMap, HashSet},
     sync::{
         atomic::{AtomicBool, AtomicU32},
         Arc, Mutex,
@@ -21,15 +21,6 @@ use std::{
 };
 
 static PWD_ENV: &str = "PWD";
-
-// TODO: move to different file? where?
-/// An operation to be performed with the current buffer of the interactive shell.
-#[derive(Debug, Clone)]
-pub enum ReplOperation {
-    Append(String),
-    Insert(String),
-    Replace(String),
-}
 
 /// Organizes usage messages for various primitives
 #[derive(Debug, Clone)]
@@ -136,7 +127,6 @@ pub struct EngineState {
     pub pipeline_externals_state: Arc<(AtomicU32, AtomicU32)>,
     pub repl_buffer_state: Arc<Mutex<Option<String>>>,
     pub repl_cursor_pos: Arc<Mutex<usize>>,
-    pub repl_operation_queue: Arc<Mutex<VecDeque<ReplOperation>>>,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,
     #[cfg(not(windows))]
@@ -189,7 +179,6 @@ impl EngineState {
             pipeline_externals_state: Arc::new((AtomicU32::new(0), AtomicU32::new(0))),
             repl_buffer_state: Arc::new(Mutex::new(Some("".to_string()))),
             repl_cursor_pos: Arc::new(Mutex::new(0)),
-            repl_operation_queue: Arc::new(Mutex::new(VecDeque::new())),
             #[cfg(feature = "plugin")]
             plugin_signatures: None,
             #[cfg(not(windows))]

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -210,11 +210,10 @@ pub fn nu_repl() {
         // Check for pre_execution hook
         let config = engine_state.get_config();
 
-        engine_state
+        *engine_state
             .repl_buffer_state
             .lock()
-            .expect("repl buffer state mutex")
-            .replace(line.to_string());
+            .expect("repl buffer state mutex") = line.to_string();
 
         if let Some(hook) = config.hooks.pre_execution.clone() {
             if let Err(err) = eval_hook(&mut engine_state, &mut stack, None, vec![], &hook) {

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -209,6 +209,13 @@ pub fn nu_repl() {
 
         // Check for pre_execution hook
         let config = engine_state.get_config();
+
+        engine_state
+            .repl_buffer_state
+            .lock()
+            .expect("repl buffer state mutex")
+            .replace(line.to_string());
+
         if let Some(hook) = config.hooks.pre_execution.clone() {
             if let Err(err) = eval_hook(&mut engine_state, &mut stack, None, vec![], &hook) {
                 outcome_err(&engine_state, &err);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,6 @@
 mod test_bits;
 mod test_cell_path;
+mod test_commandline;
 mod test_conditionals;
 mod test_config_path;
 mod test_converters;

--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -1,0 +1,42 @@
+use crate::tests::{run_test, TestResult};
+
+#[test]
+fn commandline_test_get_empty() -> TestResult {
+    run_test("commandline", "")
+}
+
+#[test]
+fn commandline_test_append() -> TestResult {
+    run_test(
+        "commandline --append '123'\n\
+        commandline\n\
+        commandline --append '456'\n\
+        commandline",
+        "123\n\
+        123456",
+    )
+}
+
+#[test]
+fn commandline_test_insert() -> TestResult {
+    run_test(
+        "commandline --insert '123'\n\
+        commandline\n\
+        commandline --insert '456'\n\
+        commandline",
+        "123\n\
+        456123",
+    )
+}
+
+#[test]
+fn commandline_test_replace() -> TestResult {
+    run_test(
+        "commandline --append '123'\n\
+        commandline\n\
+        commandline --replace '456'\n\
+        commandline",
+        "123\n\
+        456",
+    )
+}

--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -1,4 +1,4 @@
-use crate::tests::{run_test, TestResult};
+use crate::tests::{fail_test, run_test, TestResult};
 
 #[test]
 fn commandline_test_get_empty() -> TestResult {
@@ -38,5 +38,70 @@ fn commandline_test_replace() -> TestResult {
         commandline",
         "123\n\
         456",
+    )
+}
+
+#[test]
+fn commandline_test_cursor() -> TestResult {
+    run_test(
+        "commandline --replace '0😀2'\n\
+        commandline --cursor '1' \n\
+        commandline --insert 'x'\n\
+        commandline",
+        "0x😀2",
+    )?;
+    run_test(
+        "commandline --replace '0😀2'\n\
+        commandline --cursor '2' \n\
+        commandline --insert 'x'\n\
+        commandline",
+        "0😀x2",
+    )
+}
+
+#[test]
+fn commandline_test_cursor_show_pos() -> TestResult {
+    run_test(
+        "commandline --replace '0😀2'\n\
+        commandline --cursor '1' \n\
+        commandline --cursor",
+        "1",
+    )?;
+    run_test(
+        "commandline --replace '0😀2'\n\
+        commandline --cursor '2' \n\
+        commandline --cursor",
+        "2",
+    )
+}
+
+#[test]
+fn commandline_test_cursor_too_small() -> TestResult {
+    run_test(
+        "commandline --replace '123456'\n\
+        commandline --cursor '-1' \n\
+        commandline --insert '0'\n\
+        commandline",
+        "0123456",
+    )
+}
+
+#[test]
+fn commandline_test_cursor_too_large() -> TestResult {
+    run_test(
+        "commandline --replace '123456'\n\
+        commandline --cursor '10' \n\
+        commandline --insert '0'\n\
+        commandline",
+        "1234560",
+    )
+}
+
+#[test]
+fn commandline_test_cursor_invalid() -> TestResult {
+    fail_test(
+        "commandline --replace '123456'\n\
+        commandline --cursor 'abc'",
+        r#"string "abc" does not represent a valid integer"#,
     )
 }

--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -44,31 +44,31 @@ fn commandline_test_replace() -> TestResult {
 #[test]
 fn commandline_test_cursor() -> TestResult {
     run_test(
-        "commandline --replace '0😀2'\n\
+        "commandline --replace '0👩‍❤️‍👩2'\n\
         commandline --cursor '1' \n\
         commandline --insert 'x'\n\
         commandline",
-        "0x😀2",
+        "0x👩‍❤️‍👩2",
     )?;
     run_test(
-        "commandline --replace '0😀2'\n\
+        "commandline --replace '0👩‍❤️‍👩2'\n\
         commandline --cursor '2' \n\
         commandline --insert 'x'\n\
         commandline",
-        "0😀x2",
+        "0👩‍❤️‍👩x2",
     )
 }
 
 #[test]
 fn commandline_test_cursor_show_pos() -> TestResult {
     run_test(
-        "commandline --replace '0😀2'\n\
+        "commandline --replace '0👩‍❤️‍👩2'\n\
         commandline --cursor '1' \n\
         commandline --cursor",
         "1",
     )?;
     run_test(
-        "commandline --replace '0😀2'\n\
+        "commandline --replace '0👩‍❤️‍👩2'\n\
         commandline --cursor '2' \n\
         commandline --cursor",
         "2",

--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -8,36 +8,38 @@ fn commandline_test_get_empty() -> TestResult {
 #[test]
 fn commandline_test_append() -> TestResult {
     run_test(
-        "commandline --append '123'\n\
+        "commandline --replace '0👩‍❤️‍👩2'\n\
+        commandline --cursor '2'\n\
+        commandline --append 'ab'\n\
         commandline\n\
-        commandline --append '456'\n\
-        commandline",
-        "123\n\
-        123456",
+        commandline --cursor",
+        "0👩‍❤️‍👩2ab\n\
+        2",
     )
 }
 
 #[test]
 fn commandline_test_insert() -> TestResult {
     run_test(
-        "commandline --insert '123'\n\
+        "commandline --replace '0👩‍❤️‍👩2'\n\
+        commandline --cursor '2'\n\
+        commandline --insert 'ab'\n\
         commandline\n\
-        commandline --insert '456'\n\
-        commandline",
-        "123\n\
-        456123",
+        commandline --cursor",
+        "0👩‍❤️‍👩ab2\n\
+        4",
     )
 }
 
 #[test]
 fn commandline_test_replace() -> TestResult {
     run_test(
-        "commandline --append '123'\n\
+        "commandline --replace '0👩‍❤️‍👩2'\n\
+        commandline --replace 'ab'\n\
         commandline\n\
-        commandline --replace '456'\n\
-        commandline",
-        "123\n\
-        456",
+        commandline --cursor",
+        "ab\n\
+        2",
     )
 }
 

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -326,6 +326,19 @@ fn pre_execution_block_preserve_env_var() {
 }
 
 #[test]
+fn pre_execution_commandline() {
+    let inp = &[
+        &pre_execution_hook_code(r#"{ let-env repl_commandline = (commandline) }"#),
+        "echo foo!; $env.repl_commandline",
+    ];
+
+    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+
+    assert_eq!(actual_repl.err, "");
+    assert_eq!(actual_repl.out, "foo!echo foo!; $env.repl_commandline");
+}
+
+#[test]
 fn env_change_shadow_command() {
     let inp = &[
         &env_change_hook_code_list(


### PR DESCRIPTION
# Description

This fixes the `commandline` command when it's run with no arguments, so it outputs the command being run. New line characters are included.

This allows for:

- [A way to get current command inside pre_execution hook · Issue #6264 · nushell/nushell](https://github.com/nushell/nushell/issues/6264)
- The possibility of *Atuin* to work work *Nushell*. *Atuin* hooks need to know the current repl input before it is run.

# User-Facing Changes

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
