### PR TITLE
Use `with-env` to avoid calling external command on invalid command

### DIFF
--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -58,10 +58,13 @@ fn checks_all_columns_of_a_table_is_true() {
 
 #[test]
 fn checks_if_all_returns_error_with_invalid_command() {
+    // Using `with-env` to remove `st` possibly being an external program
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            [red orange yellow green blue purple] | all {|it| ($it | st length) > 4 }
+            with-env {PATH: ""} {
+                [red orange yellow green blue purple] | all {|it| ($it | st length) > 4 }
+            }
         "#
     ));
 

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -34,10 +34,13 @@ fn checks_any_column_of_a_table_is_true() {
 
 #[test]
 fn checks_if_any_returns_error_with_invalid_command() {
+    // Using `with-env` to remove `st` possibly being an external program
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            [red orange yellow green blue purple] | any {|it| ($it | st length) > 4 }
+            with-env {PATH: ""} {
+                [red orange yellow green blue purple] | any {|it| ($it | st length) > 4 }
+            }
         "#
     ));
 


### PR DESCRIPTION
# Description

My terminal emulator happens to be called `st` (https://st.suckless.org/) which breaks these tests for me

_(Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.)_

_(Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.)_

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
