### PR TITLE
Revert range expansion for `to nuon`

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -34,7 +34,6 @@ impl Command for ToNuon {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let input = input.try_expand_range()?;
         Ok(Value::String {
             val: to_nuon(call, input)?,
             span: call.head,

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -178,6 +178,19 @@ fn to_nuon_records() {
 }
 
 #[test]
+fn to_nuon_range() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            1..42
+            | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "1..42");
+}
+
+#[test]
 fn binary_to() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -191,6 +191,20 @@ fn to_nuon_range() {
 }
 
 #[test]
+fn from_nuon_range() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "1..42"
+            | from nuon
+            | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "range");
+}
+
+#[test]
 fn binary_to() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(


### PR DESCRIPTION
# Description

The code to generate the nuon format supports writing range literals, which obviates the need to expand the range as added in #8047

# User-Facing Changes

`to nuon` will still output ranges as literals

# Tests + Formatting

- Add test for `to nuon` range output
