### PR TITLE
Test more datatypes in nuon

### DIFF
--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -205,6 +205,33 @@ fn from_nuon_range() {
 }
 
 #[test]
+fn to_nuon_filesize() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            1kib
+            | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "1024b");
+}
+
+#[test]
+fn from_nuon_filesize() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "1024b"
+            | from nuon
+            | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "filesize");
+}
+
+#[test]
 fn binary_to() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -259,6 +259,33 @@ fn from_nuon_duration() {
 }
 
 #[test]
+fn to_nuon_datetime() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            2019-05-10
+            | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "2019-05-10T00:00:00+00:00");
+}
+
+#[test]
+fn from_nuon_datetime() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "2019-05-10T00:00:00+00:00"
+            | from nuon
+            | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "date");
+}
+
+#[test]
 fn binary_to() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -232,6 +232,33 @@ fn from_nuon_filesize() {
 }
 
 #[test]
+fn to_nuon_duration() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            1min
+            | to nuon
+        "#
+    ));
+
+    assert_eq!(actual.out, "60000000000ns");
+}
+
+#[test]
+fn from_nuon_duration() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            "60000000000ns"
+            | from nuon
+            | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "duration");
+}
+
+#[test]
 fn binary_to() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -286,6 +286,19 @@ fn from_nuon_datetime() {
 }
 
 #[test]
+fn to_nuon_errs_on_closure() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            {|| to nuon}
+            | to nuon
+        "#
+    ));
+
+    assert!(actual.err.contains("not nuon-compatible"));
+}
+
+#[test]
 fn binary_to() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(


### PR DESCRIPTION
# Description

While working on #8210 I noticed that we did not explicitly check a number of `Value` variants for proper serialization and deserialization.


- Test filesize in `to/from nuon`
- Test duration in `from/to nuon`
- Test datetime in `from/to nuon`



# User-Facing Changes

(-)

# Tests + Formatting

All about them tests
