### PR TITLE
add case insensitive switch to starts-with and ends-with

### DIFF
--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -77,6 +77,11 @@ impl Command for SubCommand {
                 example: "'my_library.rb' | str ends-with '.txt'",
                 result: Some(Value::test_bool(false)),
             },
+            Example {
+                description: "Checks if string ends with '.RB', case-insensitive",
+                example: "'my_library.rb' | str ends-with -i '.RB'",
+                result: Some(Value::test_bool(true)),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -9,6 +9,7 @@ use nu_protocol::{Example, PipelineData, ShellError, Signature, Span, SyntaxShap
 struct Arguments {
     substring: String,
     cell_paths: Option<Vec<CellPath>>,
+    case_insensitive: bool,
 }
 
 impl CmdArgument for Arguments {
@@ -35,6 +36,7 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "For a data structure input, check strings at the given cell paths, and replace with result",
             )
+            .switch("ignore-case", "search is case insensitive", Some('i'))
             .category(Category::Strings)
     }
 
@@ -58,6 +60,7 @@ impl Command for SubCommand {
         let args = Arguments {
             substring: call.req::<String>(engine_state, stack, 0)?,
             cell_paths,
+            case_insensitive: call.has_flag("ignore-case"),
         };
         operate(action, args, input, call.head, engine_state.ctrlc.clone())
     }
@@ -80,7 +83,14 @@ impl Command for SubCommand {
 
 fn action(input: &Value, args: &Arguments, head: Span) -> Value {
     match input {
-        Value::String { val, .. } => Value::boolean(val.ends_with(&args.substring), head),
+        Value::String { val: s, .. } => {
+            let ends_with = if args.case_insensitive {
+                s.to_lowercase().ends_with(&args.substring.to_lowercase())
+            } else {
+                s.ends_with(&args.substring)
+            };
+            Value::boolean(ends_with, head)
+        }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
             error: ShellError::OnlySupportsThisInputType(

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -10,6 +10,7 @@ use nu_protocol::{Example, PipelineData, ShellError, Signature, Span, SyntaxShap
 struct Arguments {
     substring: String,
     cell_paths: Option<Vec<CellPath>>,
+    case_insensitive: bool,
 }
 
 impl CmdArgument for Arguments {
@@ -37,6 +38,7 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "For a data structure input, check strings at the given cell paths, and replace with result",
             )
+            .switch("ignore-case", "search is case insensitive", Some('i'))
             .category(Category::Strings)
     }
 
@@ -61,6 +63,7 @@ impl Command for SubCommand {
         let args = Arguments {
             substring: substring.item,
             cell_paths,
+            case_insensitive: call.has_flag("ignore-case"),
         };
         operate(action, args, input, call.head, engine_state.ctrlc.clone())
     }
@@ -86,10 +89,14 @@ impl Command for SubCommand {
     }
 }
 
-fn action(input: &Value, Arguments { substring, .. }: &Arguments, head: Span) -> Value {
+fn action(input: &Value, Arguments { substring, case_insensitive, .. }: &Arguments, head: Span) -> Value {
     match input {
         Value::String { val: s, .. } => {
-            let starts_with = s.starts_with(substring);
+            let starts_with = if *case_insensitive {
+                s.to_lowercase().starts_with(&substring.to_lowercase())
+            } else {
+                s.starts_with(substring)
+            };
             Value::boolean(starts_with, head)
         }
         Value::Error { .. } => input.clone(),

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -76,14 +76,19 @@ impl Command for SubCommand {
                 result: Some(Value::test_bool(true)),
             },
             Example {
-                description: "Checks if input string starts with 'my'",
+                description: "Checks if input string starts with 'Car'",
                 example: "'Cargo.toml' | str starts-with 'Car'",
                 result: Some(Value::test_bool(true)),
             },
             Example {
-                description: "Checks if input string starts with 'my'",
+                description: "Checks if input string starts with '.toml'",
                 example: "'Cargo.toml' | str starts-with '.toml'",
                 result: Some(Value::test_bool(false)),
+            },
+            Example {
+                description: "Checks if input string starts with 'cargo', case-insensitive",
+                example: "'Cargo.toml' | str starts-with -i 'cargo'",
+                result: Some(Value::test_bool(true)),
             },
         ]
     }

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -94,7 +94,15 @@ impl Command for SubCommand {
     }
 }
 
-fn action(input: &Value, Arguments { substring, case_insensitive, .. }: &Arguments, head: Span) -> Value {
+fn action(
+    input: &Value,
+    Arguments {
+        substring,
+        case_insensitive,
+        ..
+    }: &Arguments,
+    head: Span,
+) -> Value {
     match input {
         Value::String { val: s, .. } => {
             let starts_with = if *case_insensitive {


### PR DESCRIPTION
# Description

Fixes #8202

# User-Facing Changes
`str starts-with` and `str ends-with` now has a `-i` switch.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
