### PR TITLE
REFACTOR: format some example commands

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -72,15 +72,15 @@ impl Command for ErrorMake {
             Example {
                 description: "Create a custom error for a custom command",
                 example: r#"def foo [x] {
-      let span = (metadata $x).span;
-      error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
+        let span = (metadata $x).span;
+        error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
     }"#,
                 result: None,
             },
             Example {
                 description: "Create a simple custom error for a custom command",
                 example: r#"def foo [x] {
-      error make {msg: "this is fishy"}
+        error make {msg: "this is fishy"}
     }"#,
                 result: None,
             },

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -53,7 +53,7 @@ impl Command for Compact {
         vec![
             Example {
                 description: "Filter out all records where 'Hello' is null (returns nothing)",
-                example: r#"[["Hello" "World"]; [null 3]]| compact Hello"#,
+                example: r#"[["Hello" "World"]; [null 3]] | compact Hello"#,
                 result: Some(Value::List {
                     vals: vec![],
                     span: Span::test_data(),
@@ -61,7 +61,7 @@ impl Command for Compact {
             },
             Example {
                 description: "Filter out all records where 'World' is null (Returns the table)",
-                example: r#"[["Hello" "World"]; [null 3]]| compact World"#,
+                example: r#"[["Hello" "World"]; [null 3]] | compact World"#,
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["Hello".into(), "World".into()],

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -37,17 +37,15 @@ impl Command for SplitBy {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "split items by column named \"lang\"",
-            example: r#"
-                {
-                    '2019': [
-                      { name: 'andres', lang: 'rb', year: '2019' },
-                      { name: 'jt', lang: 'rs', year: '2019' }
-                    ],
-                    '2021': [
-                      { name: 'storm', lang: 'rs', 'year': '2021' }
-                    ]
-                } | split-by lang
-                "#,
+            example: r#"{
+        '2019': [
+          { name: 'andres', lang: 'rb', year: '2019' },
+          { name: 'jt', lang: 'rs', year: '2019' }
+        ],
+        '2021': [
+          { name: 'storm', lang: 'rs', 'year': '2021' }
+        ]
+    } | split-by lang"#,
             result: Some(Value::Record {
                 cols: vec!["rb".to_string(), "rs".to_string()],
                 vals: vec![

--- a/crates/nu-command/src/filters/update_cells.rs
+++ b/crates/nu-command/src/filters/update_cells.rs
@@ -42,15 +42,15 @@ impl Command for UpdateCells {
             Example {
                 description: "Update the zero value cells to empty strings.",
                 example: r#"[
-    ["2021-04-16", "2021-06-10", "2021-09-18", "2021-10-15", "2021-11-16", "2021-11-17", "2021-11-18"];
-    [          37,            0,            0,            0,           37,            0,            0]
-] | update cells { |value|
-      if $value == 0 {
-        ""
-      } else {
-        $value
-      }
-}"#,
+        ["2021-04-16", "2021-06-10", "2021-09-18", "2021-10-15", "2021-11-16", "2021-11-17", "2021-11-18"];
+        [          37,            0,            0,            0,           37,            0,            0]
+    ] | update cells { |value|
+          if $value == 0 {
+            ""
+          } else {
+            $value
+          }
+    }"#,
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec![
@@ -79,15 +79,15 @@ impl Command for UpdateCells {
             Example {
                 description: "Update the zero value cells to empty strings in 2 last columns.",
                 example: r#"[
-    ["2021-04-16", "2021-06-10", "2021-09-18", "2021-10-15", "2021-11-16", "2021-11-17", "2021-11-18"];
-    [          37,            0,            0,            0,           37,            0,            0]
-] | update cells -c ["2021-11-18", "2021-11-17"] { |value|
-        if $value == 0 {
-          ""
-        } else {
-          $value
-        }
-}"#,
+        ["2021-04-16", "2021-06-10", "2021-09-18", "2021-10-15", "2021-11-16", "2021-11-17", "2021-11-18"];
+        [          37,            0,            0,            0,           37,            0,            0]
+    ] | update cells -c ["2021-11-18", "2021-11-17"] { |value|
+            if $value == 0 {
+              ""
+            } else {
+              $value
+            }
+    }"#,
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec![


### PR DESCRIPTION
hellord :wave: :yum: 

# Description
this PR fixes the format of a few single-line examples and the indentation of some multi-line examples 
- single-line example formatting
  - `compact`
- multi-line example indentation
  - `update cells`
  - `error make
  - `split-by`

# User-Facing Changes
- `compact`

from
```bash
Examples:
  Filter out all records where 'Hello' is null (returns nothing)
  > [["Hello" "World"]; [null 3]]| compact Hello

  Filter out all records where 'World' is null (Returns the table)
  > [["Hello" "World"]; [null 3]]| compact World
```
to
```bash
Examples:
  Filter out all records where 'Hello' is null (returns nothing)
  > [["Hello" "World"]; [null 3]] | compact Hello

  Filter out all records where 'World' is null (Returns the table)
  > [["Hello" "World"]; [null 3]] | compact World
```
- `update cells`

from
```bash
Examples:
  Update the zero value cells to empty strings.
  > [
    ["2021-04-16", "2021-06-10", "2021-09-18", "2021-10-15", "2021-11-16", "2021-11-17", "2021-11-18"];
    [          37,            0,            0,            0,           37,            0,            0]
] | update cells { |value|
      if $value == 0 {
        ""
      } else {
        $value
      }
}

  Update the zero value cells to empty strings in 2 last columns.
  > [
    ["2021-04-16", "2021-06-10", "2021-09-18", "2021-10-15", "2021-11-16", "2021-11-17", "2021-11-18"];
    [          37,            0,            0,            0,           37,            0,            0]
] | update cells -c ["2021-11-18", "2021-11-17"] { |value|
        if $value == 0 {
          ""
        } else {
          $value
        }
}
```
to
```bash
Examples:
  Update the zero value cells to empty strings.
  > [
        ["2021-04-16", "2021-06-10", "2021-09-18", "2021-10-15", "2021-11-16", "2021-11-17", "2021-11-18"];
        [          37,            0,            0,            0,           37,            0,            0]
    ] | update cells { |value|
          if $value == 0 {
            ""
          } else {
            $value
          }
    }

  Update the zero value cells to empty strings in 2 last columns.
  > [
        ["2021-04-16", "2021-06-10", "2021-09-18", "2021-10-15", "2021-11-16", "2021-11-17", "2021-11-18"];
        [          37,            0,            0,            0,           37,            0,            0]
    ] | update cells -c ["2021-11-18", "2021-11-17"] { |value|
            if $value == 0 {
              ""
            } else {
              $value
            }
    }
```
- `split-by`

from
```bash
Examples:
  split items by column named "lang"
  >
                {
                    '2019': [
                      { name: 'andres', lang: 'rb', year: '2019' },
                      { name: 'jt', lang: 'rs', year: '2019' }
                    ],
                    '2021': [
                      { name: 'storm', lang: 'rs', 'year': '2021' }
                    ]
                } | split-by lang
```
to
```bash
Examples:
  split items by column named "lang"
  > {
        '2019': [
          { name: 'andres', lang: 'rb', year: '2019' },
          { name: 'jt', lang: 'rs', year: '2019' }
        ],
        '2021': [
          { name: 'storm', lang: 'rs', 'year': '2021' }
        ]
    } | split-by lang
```
- `error make`

from
```bash
Examples:
  Create a custom error for a custom command
  > def foo [x] {
      let span = (metadata $x).span;
      error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
    }

  Create a simple custom error for a custom command
  > def foo [x] {
      error make {msg: "this is fishy"}
    }
```
to
```bash
Examples:
  Create a custom error for a custom command
  > def foo [x] {
        let span = (metadata $x).span;
        error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
    }

  Create a simple custom error for a custom command
  > def foo [x] {
        error make {msg: "this is fishy"}
    }
```

# Tests + Formatting
no tests have been changed => this is a pure formatting PR

- :heavy_check_mark: `cargo fmt --all`
- :heavy_check_mark: `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect`
- :heavy_check_mark: `cargo test --workspace`

# After Submitting
need to change the book? :thinking: 