### PR TITLE
Document and critically review `ShellError` variants - Ep. 1

### DIFF
--- a/crates/nu-command/src/bits/and.rs
+++ b/crates/nu-command/src/bits/and.rs
@@ -81,13 +81,12 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bits/and.rs
+++ b/crates/nu-command/src/bits/and.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, target, head),

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -151,7 +151,7 @@ fn operate(value: Value, head: Span, signed: bool, number_size: NumberBytes) -> 
             Value::Error { .. } => other,
             _ => Value::Error {
                 error: ShellError::OnlySupportsThisInputType {
-                    exp_input_type: "numeric".into(),
+                    exp_input_type: "integer".into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.expect_span(),

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -65,7 +65,7 @@ impl Command for SubCommand {
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head, signed, bytes_len),

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -150,12 +150,12 @@ fn operate(value: Value, head: Span, signed: bool, number_size: NumberBytes) -> 
             // Propagate errors inside the value
             Value::Error { .. } => other,
             _ => Value::Error {
-                error: ShellError::OnlySupportsThisInputType(
-                    "numeric".into(),
-                    other.get_type().to_string(),
-                    head,
-                    other.expect_span(),
-                ),
+                error: ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "numeric".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.expect_span(),
+                },
             },
         },
     }

--- a/crates/nu-command/src/bits/or.rs
+++ b/crates/nu-command/src/bits/or.rs
@@ -81,13 +81,12 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bits/or.rs
+++ b/crates/nu-command/src/bits/or.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, target, head),

--- a/crates/nu-command/src/bits/rotate_left.rs
+++ b/crates/nu-command/src/bits/rotate_left.rs
@@ -68,7 +68,7 @@ impl Command for SubCommand {
         }
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, bits, head, signed, bytes_len),

--- a/crates/nu-command/src/bits/rotate_left.rs
+++ b/crates/nu-command/src/bits/rotate_left.rs
@@ -137,13 +137,12 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bits/rotate_right.rs
+++ b/crates/nu-command/src/bits/rotate_right.rs
@@ -68,7 +68,7 @@ impl Command for SubCommand {
         }
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, bits, head, signed, bytes_len),

--- a/crates/nu-command/src/bits/rotate_right.rs
+++ b/crates/nu-command/src/bits/rotate_right.rs
@@ -141,13 +141,12 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -68,7 +68,7 @@ impl Command for SubCommand {
         }
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, bits, head, signed, bytes_len),

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -160,13 +160,12 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -68,7 +68,7 @@ impl Command for SubCommand {
         }
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, bits, head, signed, bytes_len),

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -150,13 +150,12 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bits/xor.rs
+++ b/crates/nu-command/src/bits/xor.rs
@@ -44,7 +44,7 @@ impl Command for SubCommand {
         let target: i64 = call.req(engine_state, stack, 0)?;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, target, head),

--- a/crates/nu-command/src/bits/xor.rs
+++ b/crates/nu-command/src/bits/xor.rs
@@ -80,13 +80,12 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -126,7 +126,7 @@ fn add(val: &Value, args: &Arguments, span: Span) -> Value {
         Value::Error { .. } => val.clone(),
         other => Value::Error {
             error: ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -125,13 +125,12 @@ fn add(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -250,7 +250,7 @@ fn at(val: &Value, args: &Arguments, span: Span) -> Value {
         Value::Error { .. } => val.clone(),
         other => Value::Error {
             error: ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -249,13 +249,12 @@ fn at(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -58,7 +58,7 @@ impl Command for BytesCollect {
                 Value::Error { error } => return Err(error),
                 other => {
                     return Err(ShellError::OnlySupportsThisInputType {
-                        exp_input_type: "integer".into(),
+                        exp_input_type: "binary".into(),
                         wrong_type: other.get_type().to_string(),
                         dst_span: call.head,
                         src_span: other.expect_span(),

--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -57,13 +57,12 @@ impl Command for BytesCollect {
                 // Explicitly propagate errors instead of dropping them.
                 Value::Error { error } => return Err(error),
                 other => {
-                    return Err(ShellError::OnlySupportsThisInputType(
-                        "integer".into(),
-                        other.get_type().to_string(),
-                        call.head,
-                        // This line requires the Value::Error match above.
-                        other.expect_span(),
-                    ));
+                    return Err(ShellError::OnlySupportsThisInputType {
+                        exp_input_type: "integer".into(),
+                        wrong_type: other.get_type().to_string(),
+                        dst_span: call.head,
+                        src_span: other.expect_span(),
+                    });
                 }
             }
         }

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -93,13 +93,12 @@ fn ends_with(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "binary".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "binary".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -135,13 +135,12 @@ fn index_of(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "binary".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "binary".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -74,13 +74,12 @@ fn length(val: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "binary".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "binary".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -142,13 +142,12 @@ fn remove(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "binary".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "binary".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -133,13 +133,12 @@ fn replace(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "binary".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "binary".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/reverse.rs
+++ b/crates/nu-command/src/bytes/reverse.rs
@@ -84,13 +84,12 @@ fn reverse(val: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "binary".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "binary".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -80,13 +80,12 @@ impl Command for BytesStartsWith {
                         // Unsupported data
                         Ok(other) => {
                             return Ok(Value::Error {
-                                error: ShellError::OnlySupportsThisInputType(
-                                    "string and binary".into(),
-                                    other.get_type().to_string(),
-                                    span,
-                                    // This line requires the Value::Error match above.
-                                    other.expect_span(),
-                                ),
+                                error: ShellError::OnlySupportsThisInputType {
+                                    exp_input_type: "string and binary".into(),
+                                    wrong_type: other.get_type().to_string(),
+                                    dst_span: span,
+                                    src_span: other.expect_span(),
+                                },
                             }
                             .into_pipeline_data());
                         }
@@ -150,13 +149,12 @@ fn starts_with(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "binary".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "binary".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -193,13 +193,12 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "int, filesize, float, string".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "int, filesize, float, string".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/conversions/fmt.rs
+++ b/crates/nu-command/src/conversions/fmt.rs
@@ -87,13 +87,12 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer or filesize".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer or filesize".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -188,13 +188,13 @@ pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer, float, filesize, string, date, duration, binary or bool".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer, float, filesize, string, date, duration, binary or bool"
+                    .into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -166,13 +166,12 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "bool, integer, float or string".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "bool, integer, float or string".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -213,13 +213,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         Value::Error { .. } => return input.clone(),
         other => {
             return Value::Error {
-                error: ShellError::OnlySupportsThisInputType(
-                    "string and integer".into(),
-                    other.get_type().to_string(),
-                    head,
-                    // This line requires the Value::Error match above.
-                    other.expect_span(),
-                ),
+                error: ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "string and integer".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.expect_span(),
+                },
             };
         }
     };
@@ -332,13 +331,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -108,13 +108,12 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string, integer or bool".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string, integer or bool".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -486,13 +486,12 @@ fn action(
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string or duration".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string or duration".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -117,12 +117,12 @@ pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
                 span: value_span,
             },
             other => Value::Error {
-                error: ShellError::OnlySupportsThisInputType(
-                    "string and integer".into(),
-                    other.get_type().to_string(),
-                    span,
-                    value_span,
-                ),
+                error: ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "string and integer".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: span,
+                    src_span: value_span,
+                },
             },
         }
     } else {

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -246,13 +246,13 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "integer, float, filesize, date, string, binary, duration or bool".into(),
-                other.get_type().to_string(),
-                span,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer, float, filesize, date, string, binary, duration or bool"
+                    .into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            },
         },
     }
 }
@@ -293,13 +293,12 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
         Value::Error { .. } => return input.clone(),
         other => {
             return Value::Error {
-                error: ShellError::OnlySupportsThisInputType(
-                    "string and integer".into(),
-                    other.get_type().to_string(),
-                    head,
-                    // This line requires the Value::Error match above.
-                    other.expect_span(),
-                ),
+                error: ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "string and integer".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.expect_span(),
+                },
             };
         }
     };

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -185,13 +185,12 @@ fn into_record(
         Value::Record { cols, vals, span } => Value::Record { cols, vals, span },
         Value::Error { .. } => input,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                other.get_type().to_string(),
-                call.head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: call.head,
+                src_span: other.expect_span(),
+            },
         },
     };
     Ok(res.into_pipeline_data())

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -218,13 +218,12 @@ fn action(
         }
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { error } => Err(error.clone()),
-        other => Err(ShellError::OnlySupportsThisInputType(
-            "list".into(),
-            other.get_type().to_string(),
-            span,
-            // This line requires the Value::Error match above.
-            other.expect_span(),
-        )),
+        other => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "list".into(),
+            wrong_type: other.get_type().to_string(),
+            dst_span: span,
+            src_span: other.expect_span(),
+        }),
     }
 }
 

--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -63,7 +63,7 @@ impl Command for SubCommand {
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| match &format {

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -49,7 +49,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(move |value| helper(value, head), engine_state.ctrlc.clone())
     }

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -44,7 +44,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(PipelineEmpty(head));
+            return Err(PipelineEmpty { dst_span: head });
         }
         input.map(move |value| helper(value, head), engine_state.ctrlc.clone())
     }

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -44,7 +44,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(PipelineEmpty(head));
+            return Err(PipelineEmpty { dst_span: head });
         }
         input.map(move |value| helper(value, head), engine_state.ctrlc.clone())
     }

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -58,7 +58,7 @@ impl Command for SubCommand {
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| helper(value, head, &timezone),

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -380,13 +380,12 @@ fn stream_to_file(
                     // Propagate errors by explicitly matching them before the final case.
                     Value::Error { error } => return Err(error),
                     other => {
-                        return Err(ShellError::OnlySupportsThisInputType(
-                            "string or binary".into(),
-                            other.get_type().to_string(),
-                            span,
-                            // This line requires the Value::Error match above.
-                            other.expect_span(),
-                        ));
+                        return Err(ShellError::OnlySupportsThisInputType {
+                            exp_input_type: "string or binary".into(),
+                            wrong_type: other.get_type().to_string(),
+                            dst_span: span,
+                            src_span: other.expect_span(),
+                        });
                     }
                 },
                 Err(err) => {

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -138,26 +138,20 @@ fn getcol(
             .set_metadata(metadata)),
         // Propagate errors
         PipelineData::Value(Value::Error { error }, ..) => Err(error),
-        PipelineData::Value(other, ..) => {
-            Err(ShellError::OnlySupportsThisInputType(
-                "record or table".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            ))
-        }
-        PipelineData::ExternalStream { .. } => {
-            Err(ShellError::OnlySupportsThisInputType(
-                "record or table".into(),
-                "raw data".into(),
-                head,
-                // This line requires the PipelineData::Empty and PipelineData::ListStream matches above.
-                input
-                    .span()
-                    .expect("PipelineData::ExternalStream had no span"),
-            ))
-        }
+        PipelineData::Value(other, ..) => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "record or table".into(),
+            wrong_type: other.get_type().to_string(),
+            dst_span: head,
+            src_span: other.expect_span(),
+        }),
+        PipelineData::ExternalStream { .. } => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "record or table".into(),
+            wrong_type: "raw data".into(),
+            dst_span: head,
+            src_span: input
+                .span()
+                .expect("PipelineData::ExternalStream had no span"),
+        }),
     }
 }
 

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -142,13 +142,12 @@ fn first_helper(
             }
             // Propagate errors by explicitly matching them before the final case.
             Value::Error { error } => Err(error),
-            other => Err(ShellError::OnlySupportsThisInputType(
-                "list, binary or range".into(),
-                other.get_type().to_string(),
-                head,
-                // This line requires the Value::Error match above.
-                other.expect_span(),
-            )),
+            other => Err(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "list, binary or range".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            }),
         },
         PipelineData::ListStream(mut ls, metadata) => {
             if return_single_element {
@@ -164,18 +163,18 @@ fn first_helper(
                     .set_metadata(metadata))
             }
         }
-        PipelineData::ExternalStream { span, .. } => Err(ShellError::OnlySupportsThisInputType(
-            "list, binary or range".into(),
-            "raw data".into(),
-            head,
-            span,
-        )),
-        PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType(
-            "list, binary or range".into(),
-            "null".into(),
-            call.head,
-            call.head, // TODO: make PipelineData::Empty spanned, so that the span can be used here.
-        )),
+        PipelineData::ExternalStream { span, .. } => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "list, binary or range".into(),
+            wrong_type: "raw data".into(),
+            dst_span: head,
+            src_span: span,
+        }),
+        PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "list, binary or range".into(),
+            wrong_type: "null".into(),
+            dst_span: call.head,
+            src_span: call.head,
+        }),
     }
 }
 #[cfg(test)]

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -172,13 +172,12 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                 Value::Error { .. } => return vec![item.clone()],
                 other => {
                     return vec![Value::Error {
-                        error: ShellError::OnlySupportsThisInputType(
-                            "record".into(),
-                            other.get_type().to_string(),
-                            _name_tag,
-                            // This line requires the Value::Error match above.
-                            other.expect_span(),
-                        ),
+                        error: ShellError::OnlySupportsThisInputType {
+                            exp_input_type: "record".into(),
+                            wrong_type: other.get_type().to_string(),
+                            dst_span: _name_tag,
+                            src_span: other.expect_span(),
+                        },
                     }];
                 }
             };

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -113,12 +113,12 @@ impl Command for Lines {
                 match val {
                     // Propagate existing errors
                     Value::Error { error } => Err(error),
-                    _ => Err(ShellError::OnlySupportsThisInputType(
-                        "string or raw data".into(),
-                        val.get_type().to_string(),
-                        head,
-                        val.expect_span(),
-                    )),
+                    _ => Err(ShellError::OnlySupportsThisInputType {
+                        exp_input_type: "string or raw data".into(),
+                        wrong_type: val.get_type().to_string(),
+                        dst_span: head,
+                        src_span: val.expect_span(),
+                    }),
                 }
             }
             PipelineData::ExternalStream { stdout: None, .. } => Ok(PipelineData::empty()),
@@ -234,13 +234,12 @@ impl Iterator for RawStreamLinesAdapter {
                                 // Propagate errors by explicitly matching them before the final case.
                                 Value::Error { error } => return Some(Err(error)),
                                 other => {
-                                    return Some(Err(ShellError::OnlySupportsThisInputType(
-                                        "string".into(),
-                                        other.get_type().to_string(),
-                                        self.span,
-                                        // This line requires the Value::Error match above.
-                                        other.expect_span(),
-                                    )));
+                                    return Some(Err(ShellError::OnlySupportsThisInputType {
+                                        exp_input_type: "string".into(),
+                                        wrong_type: other.get_type().to_string(),
+                                        dst_span: self.span,
+                                        src_span: other.expect_span(),
+                                    }));
                                 }
                             }
                         }

--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -174,17 +174,18 @@ repeating this process with row 1, and so on."#
                     val.span()?
                 };
 
-                Err(ShellError::PipelineMismatch(
-                    "input, and argument, to be both record or both table".to_string(),
-                    call.head,
-                    span,
-                ))
+                Err(ShellError::PipelineMismatch {
+                    exp_input_type: "input, and argument, to be both record or both table"
+                        .to_string(),
+                    dst_span: call.head,
+                    src_span: span,
+                })
             }
-            _ => Err(ShellError::PipelineMismatch(
-                "input, and argument, to be both record or both table".to_string(),
-                call.head,
-                Span::new(call.head.start, call.head.start),
-            )),
+            _ => Err(ShellError::PipelineMismatch {
+                exp_input_type: "input, and argument, to be both record or both table".to_string(),
+                dst_span: call.head,
+                src_span: Span::new(call.head.start, call.head.start),
+            }),
         }
     }
 }

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -184,11 +184,11 @@ impl Command for Move {
                 call.head,
             )?
             .into_pipeline_data()),
-            _ => Err(ShellError::PipelineMismatch(
-                "record or table".to_string(),
-                call.head,
-                Span::new(call.head.start, call.head.start),
-            )),
+            _ => Err(ShellError::PipelineMismatch {
+                exp_input_type: "record or table".to_string(),
+                dst_span: call.head,
+                src_span: Span::new(call.head.start, call.head.start),
+            }),
         }
     }
 }

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -183,13 +183,12 @@ fn rename(
                 // Propagate errors by explicitly matching them before the final case.
                 Value::Error { .. } => item.clone(),
                 other => Value::Error {
-                    error: ShellError::OnlySupportsThisInputType(
-                        "record".into(),
-                        other.get_type().to_string(),
-                        head_span,
-                        // This line requires the Value::Error match above.
-                        other.expect_span(),
-                    ),
+                    error: ShellError::OnlySupportsThisInputType {
+                        exp_input_type: "record".into(),
+                        wrong_type: other.get_type().to_string(),
+                        dst_span: head_span,
+                        src_span: other.expect_span(),
+                    },
                 },
             },
             engine_state.ctrlc.clone(),

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -74,32 +74,31 @@ impl Command for Take {
                     .set_metadata(metadata)),
                 // Propagate errors by explicitly matching them before the final case.
                 Value::Error { error } => Err(error),
-                other => Err(ShellError::OnlySupportsThisInputType(
-                    "list, binary or range".into(),
-                    other.get_type().to_string(),
-                    call.head,
-                    // This line requires the Value::Error match above.
-                    other.expect_span(),
-                )),
+                other => Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "list, binary or range".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: call.head,
+                    src_span: other.expect_span(),
+                }),
             },
             PipelineData::ListStream(ls, metadata) => Ok(ls
                 .take(rows_desired)
                 .into_pipeline_data(ctrlc)
                 .set_metadata(metadata)),
             PipelineData::ExternalStream { span, .. } => {
-                Err(ShellError::OnlySupportsThisInputType(
-                    "list, binary or range".into(),
-                    "raw data".into(),
-                    call.head,
-                    span,
-                ))
+                Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "list, binary or range".into(),
+                    wrong_type: "raw data".into(),
+                    dst_span: call.head,
+                    src_span: span,
+                })
             }
-            PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType(
-                "list, binary or range".into(),
-                "null".into(),
-                call.head,
-                call.head, // TODO: make PipelineData::Empty spanned, so that the span can be used here.
-            )),
+            PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "list, binary or range".into(),
+                wrong_type: "null".into(),
+                dst_span: call.head,
+                src_span: call.head,
+            }),
         }
     }
 

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -115,12 +115,12 @@ where
             };
 
             return Value::Error {
-                error: ShellError::OnlySupportsThisInputType(
-                    "string or binary".into(),
-                    other.get_type().to_string(),
-                    span,
-                    other.expect_span(),
-                ),
+                error: ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "string or binary".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: span,
+                    src_span: other.expect_span(),
+                },
             };
         }
     };

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -68,12 +68,12 @@ fn abs_helper(val: Value, head: Span) -> Value {
         },
         Value::Error { .. } => val,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/arccos.rs
+++ b/crates/nu-command/src/math/arccos.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
         let use_degrees = call.has_flag("degrees");
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head, use_degrees),

--- a/crates/nu-command/src/math/arccos.rs
+++ b/crates/nu-command/src/math/arccos.rs
@@ -88,12 +88,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/arccosh.rs
+++ b/crates/nu-command/src/math/arccosh.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/arccosh.rs
+++ b/crates/nu-command/src/math/arccosh.rs
@@ -78,12 +78,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/arcsin.rs
+++ b/crates/nu-command/src/math/arcsin.rs
@@ -89,12 +89,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/arcsin.rs
+++ b/crates/nu-command/src/math/arcsin.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
         let use_degrees = call.has_flag("degrees");
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head, use_degrees),

--- a/crates/nu-command/src/math/arcsinh.rs
+++ b/crates/nu-command/src/math/arcsinh.rs
@@ -67,12 +67,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/arcsinh.rs
+++ b/crates/nu-command/src/math/arcsinh.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/arctan.rs
+++ b/crates/nu-command/src/math/arctan.rs
@@ -78,12 +78,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/arctan.rs
+++ b/crates/nu-command/src/math/arctan.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
         let use_degrees = call.has_flag("degrees");
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head, use_degrees),

--- a/crates/nu-command/src/math/arctanh.rs
+++ b/crates/nu-command/src/math/arctanh.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/arctanh.rs
+++ b/crates/nu-command/src/math/arctanh.rs
@@ -78,12 +78,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -64,12 +64,12 @@ fn operate(value: Value, head: Span) -> Value {
         },
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/cos.rs
+++ b/crates/nu-command/src/math/cos.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
         let use_degrees = call.has_flag("degrees");
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head, use_degrees),

--- a/crates/nu-command/src/math/cos.rs
+++ b/crates/nu-command/src/math/cos.rs
@@ -88,12 +88,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/cosh.rs
+++ b/crates/nu-command/src/math/cosh.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/cosh.rs
+++ b/crates/nu-command/src/math/cosh.rs
@@ -69,12 +69,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -64,12 +64,12 @@ fn operate(value: Value, head: Span) -> Value {
         },
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/ln.rs
+++ b/crates/nu-command/src/math/ln.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/ln.rs
+++ b/crates/nu-command/src/math/ln.rs
@@ -78,12 +78,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -53,7 +53,7 @@ impl Command for SubCommand {
         }
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         let base = base.item;
         input.map(

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -118,12 +118,12 @@ fn operate(value: Value, head: Span, base: f64) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -95,12 +95,12 @@ fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
         Value::Int { .. } => value,
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head, precision_param),

--- a/crates/nu-command/src/math/sin.rs
+++ b/crates/nu-command/src/math/sin.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
         let use_degrees = call.has_flag("degrees");
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head, use_degrees),

--- a/crates/nu-command/src/math/sin.rs
+++ b/crates/nu-command/src/math/sin.rs
@@ -88,12 +88,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/sinh.rs
+++ b/crates/nu-command/src/math/sinh.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/sinh.rs
+++ b/crates/nu-command/src/math/sinh.rs
@@ -69,12 +69,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -73,12 +73,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/tan.rs
+++ b/crates/nu-command/src/math/tan.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
         let use_degrees = call.has_flag("degrees");
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head, use_degrees),

--- a/crates/nu-command/src/math/tan.rs
+++ b/crates/nu-command/src/math/tan.rs
@@ -86,12 +86,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/tanh.rs
+++ b/crates/nu-command/src/math/tanh.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
         let head = call.head;
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| operate(value, head),

--- a/crates/nu-command/src/math/tanh.rs
+++ b/crates/nu-command/src/math/tanh.rs
@@ -68,12 +68,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "numeric".into(),
-                other.get_type().to_string(),
-                head,
-                other.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -106,7 +106,7 @@ pub fn calculate(
             mf(&new_vals?, span, &name)
         }
         PipelineData::Value(val, ..) => mf(&[val], span, &name),
-        PipelineData::Empty { .. } => Err(ShellError::PipelineEmpty(name)),
+        PipelineData::Empty { .. } => Err(ShellError::PipelineEmpty { dst_span: name }),
         val => Err(ShellError::UnsupportedInput(
             "Only integers, floats, lists, records or ranges are supported".into(),
             "value originates from here".into(),

--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -79,11 +79,11 @@ fn get_free_port(
 
         // check input range valid.
         if start_port > end_port {
-            return Err(ShellError::InvalidRange(
-                start_port.to_string(),
-                end_port.to_string(),
-                call.head,
-            ));
+            return Err(ShellError::InvalidRange {
+                left_flank: start_port.to_string(),
+                right_flank: end_port.to_string(),
+                span: call.head,
+            });
         }
 
         // try given port one by one.

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -100,12 +100,12 @@ fn action_all(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }
@@ -121,12 +121,12 @@ fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/path/basename.rs
+++ b/crates/nu-command/src/path/basename.rs
@@ -69,7 +69,7 @@ impl Command for SubCommand {
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| super::operate(&get_basename, &args, value, head),

--- a/crates/nu-command/src/path/dirname.rs
+++ b/crates/nu-command/src/path/dirname.rs
@@ -73,7 +73,7 @@ impl Command for SubCommand {
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| super::operate(&get_dirname, &args, value, head),

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -63,7 +63,7 @@ If you need to distinguish dirs and files, please use `path type`."#
         };
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| super::operate(&exists, &args, value, head),

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -69,7 +69,7 @@ impl Command for SubCommand {
         };
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| super::operate(&expand, &args, value, head),

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -80,7 +80,7 @@ the output of 'path parse' and 'path split' subcommands."#
                 handle_value(input.into_value(head), &args, head),
                 metadata,
             )),
-            PipelineData::Empty { .. } => Err(ShellError::PipelineEmpty(head)),
+            PipelineData::Empty { .. } => Err(ShellError::PipelineEmpty { dst_span: head }),
             _ => Err(ShellError::UnsupportedInput(
                 "Input value cannot be joined".to_string(),
                 "value originates from here".into(),

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -197,7 +197,11 @@ fn join_list(parts: &[Value], head: Span, span: Span, args: &Arguments) -> Value
                     Value::List { vals, span }
                 }
                 Err(_) => Value::Error {
-                    error: ShellError::PipelineMismatch("string or record".into(), head, span),
+                    error: ShellError::PipelineMismatch {
+                        exp_input_type: "string or record".into(),
+                        dst_span: head,
+                        src_span: span,
+                    },
                 },
             }
         }

--- a/crates/nu-command/src/path/mod.rs
+++ b/crates/nu-command/src/path/mod.rs
@@ -93,12 +93,12 @@ fn err_from_value(rest: &Value, name: Span) -> ShellError {
     match rest.span() {
         Ok(span) => {
             if rest.is_nothing() {
-                ShellError::OnlySupportsThisInputType(
-                    "string, record or list".into(),
-                    "nothing".into(),
-                    name,
-                    span,
-                )
+                ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "string, record or list".into(),
+                    wrong_type: "nothing".into(),
+                    dst_span: name,
+                    src_span: span,
+                }
             } else {
                 ShellError::PipelineMismatch {
                     exp_input_type: "string, row or list".into(),

--- a/crates/nu-command/src/path/mod.rs
+++ b/crates/nu-command/src/path/mod.rs
@@ -100,7 +100,11 @@ fn err_from_value(rest: &Value, name: Span) -> ShellError {
                     span,
                 )
             } else {
-                ShellError::PipelineMismatch("string, row or list".into(), name, span)
+                ShellError::PipelineMismatch {
+                    exp_input_type: "string, row or list".into(),
+                    dst_span: name,
+                    src_span: span,
+                }
             }
         }
         Err(error) => error,

--- a/crates/nu-command/src/path/parse.rs
+++ b/crates/nu-command/src/path/parse.rs
@@ -71,7 +71,7 @@ On Windows, an extra 'prefix' column is added."#
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| super::operate(&parse, &args, value, head),

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -71,7 +71,7 @@ path."#
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| super::operate(&relative_to, &args, value, head),

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -56,7 +56,7 @@ impl Command for SubCommand {
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| super::operate(&split, &args, value, head),

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -61,7 +61,7 @@ If nothing is found, an empty string will be returned."#
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty(head));
+            return Err(ShellError::PipelineEmpty { dst_span: head });
         }
         input.map(
             move |value| super::operate(&r#type, &args, value, head),

--- a/crates/nu-command/src/random/decimal.rs
+++ b/crates/nu-command/src/random/decimal.rs
@@ -88,11 +88,11 @@ fn decimal(
     };
 
     match min.partial_cmp(&max) {
-        Some(Ordering::Greater) => Err(ShellError::InvalidRange(
-            min.to_string(),
-            max.to_string(),
+        Some(Ordering::Greater) => Err(ShellError::InvalidRange {
+            left_flank: min.to_string(),
+            right_flank: max.to_string(),
             span,
-        )),
+        }),
         Some(Ordering::Equal) => Ok(PipelineData::Value(
             Value::Float {
                 val: min,

--- a/crates/nu-command/src/random/integer.rs
+++ b/crates/nu-command/src/random/integer.rs
@@ -88,11 +88,11 @@ fn integer(
     };
 
     match min.partial_cmp(&max) {
-        Some(Ordering::Greater) => Err(ShellError::InvalidRange(
-            min.to_string(),
-            max.to_string(),
+        Some(Ordering::Greater) => Err(ShellError::InvalidRange {
+            left_flank: min.to_string(),
+            right_flank: max.to_string(),
             span,
-        )),
+        }),
         Some(Ordering::Equal) => Ok(PipelineData::Value(Value::Int { val: min, span }, None)),
         _ => {
             let mut thread_rng = thread_rng();

--- a/crates/nu-command/src/strings/encode_decode/decode.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode.rs
@@ -78,12 +78,12 @@ documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#
                 Value::Binary { val: bytes, .. } => super::encoding::decode(head, encoding, &bytes)
                     .map(|val| val.into_pipeline_data()),
                 Value::Error { error } => Err(error),
-                _ => Err(ShellError::OnlySupportsThisInputType(
-                    "binary".into(),
-                    v.get_type().to_string(),
-                    head,
-                    v.expect_span(),
-                )),
+                _ => Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "binary".into(),
+                    wrong_type: v.get_type().to_string(),
+                    dst_span: head,
+                    src_span: v.expect_span(),
+                }),
             },
             // This should be more precise, but due to difficulties in getting spans
             // from PipelineData::ListData, this is as it is.

--- a/crates/nu-command/src/strings/encode_decode/encode.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode.rs
@@ -101,12 +101,12 @@ documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#
                         .map(|val| val.into_pipeline_data())
                 }
                 Value::Error { error } => Err(error),
-                _ => Err(ShellError::OnlySupportsThisInputType(
-                    "string".into(),
-                    v.get_type().to_string(),
-                    head,
-                    v.expect_span(),
-                )),
+                _ => Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "string".into(),
+                    wrong_type: v.get_type().to_string(),
+                    dst_span: head,
+                    src_span: v.expect_span(),
+                }),
             },
             // This should be more precise, but due to difficulties in getting spans
             // from PipelineData::ListStream, this is as it is.

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -232,12 +232,12 @@ fn format(
                     }
                     Value::Error { error } => return Err(error.clone()),
                     _ => {
-                        return Err(ShellError::OnlySupportsThisInputType(
-                            "record".to_string(),
-                            val.get_type().to_string(),
-                            head_span,
-                            val.expect_span(),
-                        ))
+                        return Err(ShellError::OnlySupportsThisInputType {
+                            exp_input_type: "record".to_string(),
+                            wrong_type: val.get_type().to_string(),
+                            dst_span: head_span,
+                            src_span: val.expect_span(),
+                        })
                     }
                 }
             }
@@ -250,13 +250,12 @@ fn format(
         // Unwrapping this ShellError is a bit unfortunate.
         // Ideally, its Span would be preserved.
         Value::Error { error } => Err(error),
-        _ => Err(ShellError::OnlySupportsThisInputType(
-            "record".to_string(),
-            data_as_value.get_type().to_string(),
-            head_span,
-            // This line requires the Value::Error match above.
-            data_as_value.expect_span(),
-        )),
+        _ => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "record".to_string(),
+            wrong_type: data_as_value.get_type().to_string(),
+            dst_span: head_span,
+            src_span: data_as_value.expect_span(),
+        }),
     }
 }
 

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -106,12 +106,12 @@ fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
         },
         Value::Error { .. } => val.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "filesize".into(),
-                val.get_type().to_string(),
-                span,
-                val.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "filesize".into(),
+                wrong_type: val.get_type().to_string(),
+                dst_span: span,
+                src_span: val.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -204,11 +204,11 @@ fn operate(
                         }
                     }
                     Err(_) => {
-                        return Err(ShellError::PipelineMismatch(
-                            "string".into(),
-                            head,
-                            v.span()?,
-                        ))
+                        return Err(ShellError::PipelineMismatch {
+                            exp_input_type: "string".into(),
+                            dst_span: head,
+                            src_span: v.span()?,
+                        })
                     }
                 }
             }
@@ -346,11 +346,11 @@ impl Iterator for ParseStreamer {
                     &mut self.excess,
                 ),
                 Err(_) => Some(Value::Error {
-                    error: ShellError::PipelineMismatch(
-                        "string".into(),
-                        self.span,
-                        v.span().unwrap_or(self.span),
-                    ),
+                    error: ShellError::PipelineMismatch {
+                        exp_input_type: "string".into(),
+                        dst_span: self.span,
+                        src_span: v.span().unwrap_or(self.span),
+                    },
                 }),
             }
         } else {
@@ -386,7 +386,11 @@ impl Iterator for ParseStreamerExternal {
                     &mut self.excess,
                 ),
                 Err(_) => Some(Value::Error {
-                    error: ShellError::PipelineMismatch("string".into(), self.span, self.span),
+                    error: ShellError::PipelineMismatch {
+                        exp_input_type: "string".into(),
+                        dst_span: self.span,
+                        src_span: self.span,
+                    },
                 }),
             }
         } else if let Some(Err(err)) = v {

--- a/crates/nu-command/src/strings/size.rs
+++ b/crates/nu-command/src/strings/size.rs
@@ -118,7 +118,7 @@ fn size(
     let span = call.head;
     // This doesn't match explicit nulls
     if matches!(input, PipelineData::Empty) {
-        return Err(ShellError::PipelineEmpty(span));
+        return Err(ShellError::PipelineEmpty { dst_span: span });
     }
     input.map(
         move |v| {

--- a/crates/nu-command/src/strings/size.rs
+++ b/crates/nu-command/src/strings/size.rs
@@ -131,7 +131,11 @@ fn size(
             match v.as_string() {
                 Ok(s) => counter(&s, span),
                 Err(_) => Value::Error {
-                    error: ShellError::PipelineMismatch("string".into(), span, value_span),
+                    error: ShellError::PipelineMismatch {
+                        exp_input_type: "string".into(),
+                        dst_span: span,
+                        src_span: value_span,
+                    },
                 },
             }
         },

--- a/crates/nu-command/src/strings/split/chars.rs
+++ b/crates/nu-command/src/strings/split/chars.rs
@@ -110,7 +110,11 @@ fn split_chars_helper(v: &Value, name: Span, graphemes: bool) -> Vec<Value> {
                 }
             } else {
                 vec![Value::Error {
-                    error: ShellError::PipelineMismatch("string".into(), name, v_span),
+                    error: ShellError::PipelineMismatch {
+                        exp_input_type: "string".into(),
+                        dst_span: name,
+                        src_span: v_span,
+                    },
                 }]
             }
         }

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -182,7 +182,11 @@ fn split_column_helper(
     } else {
         match v.span() {
             Ok(span) => vec![Value::Error {
-                error: ShellError::PipelineMismatch("string".into(), head, span),
+                error: ShellError::PipelineMismatch {
+                    exp_input_type: "string".into(),
+                    dst_span: head,
+                    src_span: span,
+                },
             }],
             Err(error) => vec![Value::Error { error }],
         }

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -132,7 +132,11 @@ fn split_row_helper(
                 }
             } else {
                 vec![Value::Error {
-                    error: ShellError::PipelineMismatch("string".into(), name, v_span),
+                    error: ShellError::PipelineMismatch {
+                        exp_input_type: "string".into(),
+                        dst_span: name,
+                        src_span: v_span,
+                    },
                 }]
             }
         }

--- a/crates/nu-command/src/strings/split/words.rs
+++ b/crates/nu-command/src/strings/split/words.rs
@@ -185,7 +185,11 @@ fn split_words_helper(
                     .collect::<Vec<Value>>()
             } else {
                 vec![Value::Error {
-                    error: ShellError::PipelineMismatch("string".into(), span, v_span),
+                    error: ShellError::PipelineMismatch {
+                        exp_input_type: "string".into(),
+                        dst_span: span,
+                        src_span: v_span,
+                    },
                 }]
             }
         }

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -107,12 +107,12 @@ fn action(input: &Value, head: Span) -> Value {
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -119,12 +119,12 @@ fn action(input: &Value, head: Span) -> Value {
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/case/mod.rs
+++ b/crates/nu-command/src/strings/str_/case/mod.rs
@@ -69,12 +69,12 @@ where
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -86,12 +86,12 @@ fn action(input: &Value, head: Span) -> Value {
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -183,12 +183,12 @@ fn action(
         ),
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -99,12 +99,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -98,12 +98,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -186,12 +186,12 @@ fn action(
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }
@@ -236,12 +236,12 @@ fn process_range(
             }
         }
         Value::Error { error } => Err(error.clone()),
-        _ => Err(ShellError::OnlySupportsThisInputType(
-            "string".into(),
-            input.get_type().to_string(),
-            head,
-            input.expect_span(),
-        )),
+        _ => Err(ShellError::OnlySupportsThisInputType {
+            exp_input_type: "string".into(),
+            wrong_type: input.get_type().to_string(),
+            dst_span: head,
+            src_span: input.expect_span(),
+        }),
     }?;
 
     let start_index = r.0.parse::<i32>().unwrap_or(0);

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -108,12 +108,12 @@ fn action(input: &Value, arg: &Arguments, head: Span) -> Value {
         ),
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -216,12 +216,12 @@ fn action(
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -77,12 +77,12 @@ fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -114,12 +114,12 @@ fn action(
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType(
-                "string".into(),
-                input.get_type().to_string(),
-                head,
-                input.expect_span(),
-            ),
+            error: ShellError::OnlySupportsThisInputType {
+                exp_input_type: "string".into(),
+                wrong_type: input.get_type().to_string(),
+                dst_span: head,
+                src_span: input.expect_span(),
+            },
         },
     }
 }

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -228,20 +228,19 @@ impl PipelineData {
                 },
                 // Propagate errors by explicitly matching them before the final case.
                 Value::Error { error } => Err(error),
-                other => Err(ShellError::OnlySupportsThisInputType(
-                    "list, binary, raw data or range".into(),
-                    other.get_type().to_string(),
-                    span,
-                    // This line requires the Value::Error match above.
-                    other.expect_span(),
-                )),
+                other => Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "list, binary, raw data or range".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: span,
+                    src_span: other.expect_span(),
+                }),
             },
-            PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType(
-                "list, binary, raw data or range".into(),
-                "null".into(),
-                span,
-                span, // TODO: make PipelineData::Empty spanned, so that the span can be used here.
-            )),
+            PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "list, binary, raw data or range".into(),
+                wrong_type: "null".into(),
+                dst_span: span,
+                src_span: span,
+            }),
             other => Ok(PipelineIterator(other)),
         }
     }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -34,8 +34,13 @@ pub enum ShellError {
     /// Check the inputs to the operation and add guards for their sizes.
     /// Integers are generally of size i64, floats are generally f64.
     #[error("Operator overflow.")]
-    #[diagnostic(code(nu::shell::operator_overflow), help("{2}"))]
-    OperatorOverflow(String, #[label = "{0}"] Span, String),
+    #[diagnostic(code(nu::shell::operator_overflow), help("{help}"))]
+    OperatorOverflow {
+        msg: String,
+        #[label = "{msg}"]
+        span: Span,
+        help: String,
+    },
 
     /// The pipelined input into a command was not of the expected type. For example, it might
     /// expect a string input, but received a table instead.

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -238,9 +238,14 @@ pub enum ShellError {
     /// ## Resolution
     ///
     /// Check to make sure both values are compatible, and that the values are enumerable in Nushell.
-    #[error("Invalid range {0}..{1}")]
+    #[error("Invalid range {left_flank}..{right_flank}")]
     #[diagnostic(code(nu::shell::invalid_range))]
-    InvalidRange(String, String, #[label = "expected a valid range"] Span),
+    InvalidRange {
+        left_flank: String,
+        right_flank: String,
+        #[label = "expected a valid range"]
+        span: Span,
+    },
 
     /// Catastrophic nushell failure. This reflects a completely unexpected or unrecoverable error.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -85,7 +85,10 @@ pub enum ShellError {
     /// Only use this command to process values from a previous expression.
     #[error("Pipeline empty.")]
     #[diagnostic(code(nu::shell::pipeline_mismatch))]
-    PipelineEmpty(#[label("no input value was piped in")] Span),
+    PipelineEmpty {
+        #[label("no input value was piped in")]
+        dst_span: Span,
+    },
 
     /// A command received an argument of the wrong type.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -50,11 +50,13 @@ pub enum ShellError {
     /// Check the relevant pipeline and extract or convert values as needed.
     #[error("Pipeline mismatch.")]
     #[diagnostic(code(nu::shell::pipeline_mismatch))]
-    PipelineMismatch(
-        String,
-        #[label("expected: {0}")] Span,
-        #[label("value originates from here")] Span,
-    ),
+    PipelineMismatch {
+        exp_input_type: String,
+        #[label("expected: {exp_input_type}")]
+        dst_span: Span,
+        #[label("value originates from here")]
+        src_span: Span,
+    },
 
     #[error("Input type not supported.")]
     #[diagnostic(code(nu::shell::only_supports_this_input_type))]

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -69,12 +69,14 @@ pub enum ShellError {
     /// Check the relevant pipeline and extract or convert values as needed.
     #[error("Input type not supported.")]
     #[diagnostic(code(nu::shell::only_supports_this_input_type))]
-    OnlySupportsThisInputType(
-        String,
-        String,
-        #[label("only {0} input data is supported")] Span,
-        #[label("input type: {1}")] Span,
-    ),
+    OnlySupportsThisInputType {
+        exp_input_type: String,
+        wrong_type: String,
+        #[label("only {exp_input_type} input data is supported")]
+        dst_span: Span,
+        #[label("input type: {wrong_type}")]
+        src_span: Span,
+    },
 
     /// No input value was piped into the command.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -58,6 +58,15 @@ pub enum ShellError {
         src_span: Span,
     },
 
+    // TODO: properly unify
+    /// The pipelined input into a command was not of the expected type. For example, it might
+    /// expect a string input, but received a table instead.
+    ///
+    /// (duplicate of [`ShellError::PipelineMismatch`] that reports the observed type)
+    ///
+    /// ## Resolution
+    ///
+    /// Check the relevant pipeline and extract or convert values as needed.
     #[error("Input type not supported.")]
     #[diagnostic(code(nu::shell::only_supports_this_input_type))]
     OnlySupportsThisInputType(

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -90,6 +90,7 @@ pub enum ShellError {
         dst_span: Span,
     },
 
+    // TODO: remove non type error usages
     /// A command received an argument of the wrong type.
     ///
     /// ## Resolution
@@ -99,6 +100,7 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::type_mismatch))]
     TypeMismatch(String, #[label = "{0}"] Span),
 
+    // TODO: merge with `TypeMismatch` as they are currently identical in capability
     /// A command received an argument of the wrong type.
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1996,11 +1996,7 @@ impl Value {
                 if let Some(val) = lhs.checked_add(*rhs) {
                     Ok(Value::Int { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "add operation overflowed".into(),
-                        span,
-                        "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into()
-                    ))
+                    Err(ShellError::OperatorOverflow { msg: "add operation overflowed".into(), span, help: "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into() })
                 }
             }
             (Value::Int { val: lhs, .. }, Value::Float { val: rhs, .. }) => Ok(Value::Float {
@@ -2023,33 +2019,33 @@ impl Value {
                 if let Some(val) = lhs.checked_add_signed(chrono::Duration::nanoseconds(*rhs)) {
                     Ok(Value::Date { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "addition operation overflowed".into(),
+                    Err(ShellError::OperatorOverflow {
+                        msg: "addition operation overflowed".into(),
                         span,
-                        "".into(),
-                    ))
+                        help: "".into(),
+                    })
                 }
             }
             (Value::Duration { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
                 if let Some(val) = lhs.checked_add(*rhs) {
                     Ok(Value::Duration { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "add operation overflowed".into(),
+                    Err(ShellError::OperatorOverflow {
+                        msg: "add operation overflowed".into(),
                         span,
-                        "".into(),
-                    ))
+                        help: "".into(),
+                    })
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
                 if let Some(val) = lhs.checked_add(*rhs) {
                     Ok(Value::Filesize { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "add operation overflowed".into(),
+                    Err(ShellError::OperatorOverflow {
+                        msg: "add operation overflowed".into(),
                         span,
-                        "".into(),
-                    ))
+                        help: "".into(),
+                    })
                 }
             }
 
@@ -2110,11 +2106,7 @@ impl Value {
                 if let Some(val) = lhs.checked_sub(*rhs) {
                     Ok(Value::Int { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "subtraction operation overflowed".into(),
-                        span,
-                        "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into()
-                    ))
+                    Err(ShellError::OperatorOverflow { msg: "subtraction operation overflowed".into(), span, help: "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into() })
                 }
             }
             (Value::Int { val: lhs, .. }, Value::Float { val: rhs, .. }) => Ok(Value::Float {
@@ -2135,43 +2127,43 @@ impl Value {
                 if let Some(v) = result.num_nanoseconds() {
                     Ok(Value::Duration { val: v, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "subtraction operation overflowed".into(),
+                    Err(ShellError::OperatorOverflow {
+                        msg: "subtraction operation overflowed".into(),
                         span,
-                        "".into(),
-                    ))
+                        help: "".into(),
+                    })
                 }
             }
             (Value::Date { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
                 match lhs.checked_sub_signed(chrono::Duration::nanoseconds(*rhs)) {
                     Some(val) => Ok(Value::Date { val, span }),
-                    _ => Err(ShellError::OperatorOverflow(
-                        "subtraction operation overflowed".into(),
+                    _ => Err(ShellError::OperatorOverflow {
+                        msg: "subtraction operation overflowed".into(),
                         span,
-                        "".into(),
-                    )),
+                        help: "".into(),
+                    }),
                 }
             }
             (Value::Duration { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
                 if let Some(val) = lhs.checked_sub(*rhs) {
                     Ok(Value::Duration { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "subtraction operation overflowed".into(),
+                    Err(ShellError::OperatorOverflow {
+                        msg: "subtraction operation overflowed".into(),
                         span,
-                        "".into(),
-                    ))
+                        help: "".into(),
+                    })
                 }
             }
             (Value::Filesize { val: lhs, .. }, Value::Filesize { val: rhs, .. }) => {
                 if let Some(val) = lhs.checked_sub(*rhs) {
                     Ok(Value::Filesize { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "add operation overflowed".into(),
+                    Err(ShellError::OperatorOverflow {
+                        msg: "add operation overflowed".into(),
                         span,
-                        "".into(),
-                    ))
+                        help: "".into(),
+                    })
                 }
             }
 
@@ -2195,11 +2187,7 @@ impl Value {
                 if let Some(val) = lhs.checked_mul(*rhs) {
                     Ok(Value::Int { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "multiply operation overflowed".into(),
-                        span,
-                        "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into()
-                    ))
+                    Err(ShellError::OperatorOverflow { msg: "multiply operation overflowed".into(), span, help: "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into() })
                 }
             }
             (Value::Int { val: lhs, .. }, Value::Float { val: rhs, .. }) => Ok(Value::Float {
@@ -3192,11 +3180,7 @@ impl Value {
                 if let Some(val) = lhs.checked_pow(*rhs as u32) {
                     Ok(Value::Int { val, span })
                 } else {
-                    Err(ShellError::OperatorOverflow(
-                        "pow operation overflowed".into(),
-                        span,
-                        "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into()
-                    ))
+                    Err(ShellError::OperatorOverflow { msg: "pow operation overflowed".into(), span, help: "Consider using floating point values for increased range by promoting operand with 'into decimal'. Note: float has reduced precision!".into() })
                 }
             }
             (Value::Int { val: lhs, .. }, Value::Float { val: rhs, .. }) => Ok(Value::Float {


### PR DESCRIPTION
# Description

The `ShellError` enum at the moment is kind of messy. 

Many variants are basic tuple structs where you always have to reference the implementation with its macro invocation to know which field serves which purpose.
Furthermore we have both variants that are kind of redundant or either overly broad to be useful for the user to match on or overly specific with few uses.

So I set out to start fixing the lacking documentation and naming to make it feasible to critically review the individual usages and fix those. 
Furthermore we can decide to join or split up variants that don't seem to be fit for purpose.

Feel free to add review comments if you spot inconsistent use of `ShellError` variants.

- Name fields on `ShellError::OperatorOverflow`
- Name fields on `ShellError::PipelineMismatch`
- Add doc to `ShellError::OnlySupportsThisInputType`
- Name `ShellError::OnlySupportsThisInputType`
- Name field on `ShellError::PipelineEmpty`
- Comment about issues with `TypeMismatch*`
- Fix a few `exp_input_type`s
- Name fields on `ShellError::InvalidRange`

# User-Facing Changes

(None now, end goal more explicit and consistent error messages)

# Tests + Formatting

(No additional tests needed so far)
