### PR TITLE
remove unnecessary rows in `into datetime --list`

### DIFF
--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -207,14 +207,6 @@ pub(crate) fn generate_strftime_list(head: Span, show_parse_only_formats: bool) 
             description: "The proleptic Gregorian year divided by 100, zero-padded to 2 digits.",
         },
         FormatSpecification {
-            spec: "%Y",
-            description: "The full proleptic Gregorian year, zero-padded to 4 digits.",
-        },
-        FormatSpecification {
-            spec: "%C",
-            description: "The proleptic Gregorian year divided by 100, zero-padded to 2 digits.",
-        },
-        FormatSpecification {
             spec: "%y",
             description: "The proleptic Gregorian year modulo 100, zero-padded to 2 digits.",
         },


### PR DESCRIPTION
Below is the result of `into datetime --list | uniq -d`.

```
╭───┬───────────────┬─────────┬───────────────────────────────────────╮
│ # │ Specification │ Example │              Description              │
├───┼───────────────┼─────────┼───────────────────────────────────────┤
│ 0 │ %Y            │ 2023    │ The full proleptic Gregorian year,    │
│   │               │         │ zero-padded to 4 digits.              │
│ 1 │ %C            │ 20      │ The proleptic Gregorian year divided  │
│   │               │         │ by 100, zero-padded to 2 digits.      │
╰───┴───────────────┴─────────┴───────────────────────────────────────╯
```

It's supposed to be an empty table, but it has two rows. I removed the duplicates.

# User-Facing Changes

`into datetime --list` will print out a correct table.
