### PR TITLE
fix: allow subtraction of durations from dates

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -107,6 +107,7 @@ pub fn math_result_type(
                 (Type::Int, Type::Float) => (Type::Float, None),
                 (Type::Float, Type::Float) => (Type::Float, None),
                 (Type::Date, Type::Date) => (Type::Duration, None),
+                (Type::Date, Type::Duration) => (Type::Date, None),
                 (Type::Duration, Type::Duration) => (Type::Duration, None),
                 (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
 

--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -24,3 +24,17 @@ fn number_int() -> TestResult {
 fn number_float() -> TestResult {
     run_test(r#"def foo [x:number] { $x }; foo 1.4"#, "1.4")
 }
+
+#[test]
+fn date_minus_duration() -> TestResult {
+    let input = "2023-04-22 - 2day | date format %Y-%m-%d";
+    let expected = "2023-04-20";
+    run_test(input, expected)
+}
+
+#[test]
+fn date_plus_duration() -> TestResult {
+    let input = "2023-04-18 + 2day | date format %Y-%m-%d";
+    let expected = "2023-04-20";
+    run_test(input, expected)
+}


### PR DESCRIPTION
`date` - `duration` is [implemented](https://github.com/nushell/nushell/blob/ba5258d7165423b360edf1747d0ffec00052db13/crates/nu-protocol/src/value/mod.rs#L2145) but the type checker rejects it

this pr fixes that