### PR TITLE
Fixes insecure and timeout flags

### DIFF
--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -140,7 +140,7 @@ struct Arguments {
     content_type: Option<String>,
     content_length: Option<String>,
     raw: bool,
-    insecure: Option<bool>,
+    insecure: bool,
     user: Option<String>,
     password: Option<String>,
     timeout: Option<Value>,
@@ -159,10 +159,10 @@ fn run_get(
         content_type: call.get_flag(engine_state, stack, "content-type")?,
         content_length: call.get_flag(engine_state, stack, "content-length")?,
         raw: call.has_flag("raw"),
-        insecure: call.get_flag(engine_state, stack, "insecure")?,
+        insecure: call.has_flag("insecure"),
         user: call.get_flag(engine_state, stack, "user")?,
         password: call.get_flag(engine_state, stack, "password")?,
-        timeout: call.get_flag(engine_state, stack, "timeout")?,
+        timeout: call.get_flag(engine_state, stack, "max-time")?,
     };
     helper(engine_state, stack, call, args)
 }
@@ -178,7 +178,7 @@ fn helper(
     let span = args.url.span()?;
     let (requested_url, url) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure.is_some());
+    let client = http_client(args.insecure);
     let mut request = client.get(url);
 
     if let Some(data) = args.data {


### PR DESCRIPTION
# Description

Fixes #8098 by properly parsing `insecure` flag and also fixes the `timeout` flag, which is described as `max-time` (from curl?).

# User-Facing Changes

The only change is that the flags now work.

# Tests + Formatting

Everything passes.

# Screenshots

Before
![image](https://user-images.githubusercontent.com/4399118/221845043-6dfba69d-daea-49a7-b55c-7ee628551b1c.png)

After

![image](https://user-images.githubusercontent.com/4399118/221845382-0111cbe9-4ba6-4de1-9e2a-655efbc65a26.png)