### PR TITLE
Add auto-cd for directories not starting with ., ./, ../, etc, #8222

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -20,6 +20,7 @@ use nu_protocol::{
 };
 use nu_utils::utils::perf;
 use reedline::{CursorConfig, DefaultHinter, EditCommand, Emacs, SqliteBackedHistory, Vi};
+use std::path::Path;
 use std::{
     io::{self, Write},
     sync::atomic::Ordering,
@@ -1183,6 +1184,7 @@ fn looks_like_path(orig: &str) -> bool {
         || orig.starts_with('~')
         || orig.starts_with('/')
         || orig.starts_with('\\')
+        || Path::new(&orig).is_dir()
 }
 
 #[test]


### PR DESCRIPTION
# Description

#8222 

Add functionality for auto-cd on paths that don't start with ., ./, ../, ~.

# User-Facing Changes

Before:
```
/home/rdevenney〉Documents/Postman/                                                                                                                     02/28/2023 01:11:41 PM
Error: nu::shell::external_command

  × External command failed
   ╭─[entry #3:1:1]
 1 │ Documents/Postman/
   · ─────────┬────────
   ·          ╰── can't run executable
   ╰────
  help: Permission denied (os error 13)

/home/rdevenney〉                                                                                                                                       02/28/2023 01:11:45 PM

```

After:
```
/home/rdevenney〉Documents/Postman/                                                                                                                     02/28/2023 01:10:36 PM
/home/rdevenney/Documents/Postman〉                                                                                                                     02/28/2023 01:10:48 PM
```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
