### PR TITLE
Fix insecure + max-time arguments for HTTP commands.

### DIFF
--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -139,7 +139,7 @@ struct Arguments {
     content_type: Option<String>,
     content_length: Option<String>,
     raw: bool,
-    insecure: Option<bool>,
+    insecure: bool,
     user: Option<String>,
     password: Option<String>,
     timeout: Option<Value>,
@@ -158,11 +158,12 @@ fn run_delete(
         content_type: call.get_flag(engine_state, stack, "content-type")?,
         content_length: call.get_flag(engine_state, stack, "content-length")?,
         raw: call.has_flag("raw"),
-        insecure: call.get_flag(engine_state, stack, "insecure")?,
+        insecure: call.has_flag("insecure"),
         user: call.get_flag(engine_state, stack, "user")?,
         password: call.get_flag(engine_state, stack, "password")?,
-        timeout: call.get_flag(engine_state, stack, "timeout")?,
+        timeout: call.get_flag(engine_state, stack, "max-time")?,
     };
+
     helper(engine_state, stack, call, args)
 }
 
@@ -177,7 +178,7 @@ fn helper(
     let span = args.url.span()?;
     let (requested_url, url) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure.is_some());
+    let client = http_client(args.insecure);
     let mut request = client.delete(url);
 
     if let Some(data) = args.data {

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -106,7 +106,7 @@ impl Command for SubCommand {
 struct Arguments {
     url: Value,
     headers: Option<Value>,
-    insecure: Option<bool>,
+    insecure: bool,
     user: Option<String>,
     password: Option<String>,
     timeout: Option<Value>,
@@ -121,11 +121,12 @@ fn run_head(
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,
         headers: call.get_flag(engine_state, stack, "headers")?,
-        insecure: call.get_flag(engine_state, stack, "insecure")?,
+        insecure: call.has_flag("insecure"),
         user: call.get_flag(engine_state, stack, "user")?,
         password: call.get_flag(engine_state, stack, "password")?,
-        timeout: call.get_flag(engine_state, stack, "timeout")?,
+        timeout: call.get_flag(engine_state, stack, "max-time")?,
     };
+
     helper(call, args)
 }
 
@@ -135,7 +136,7 @@ fn helper(call: &Call, args: Arguments) -> Result<PipelineData, ShellError> {
     let span = args.url.span()?;
     let (requested_url, url) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure.is_some());
+    let client = http_client(args.insecure);
     let mut request = client.head(url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -129,7 +129,7 @@ struct Arguments {
     content_type: Option<String>,
     content_length: Option<String>,
     raw: bool,
-    insecure: Option<bool>,
+    insecure: bool,
     user: Option<String>,
     password: Option<String>,
     timeout: Option<Value>,
@@ -148,11 +148,12 @@ fn run_patch(
         content_type: call.get_flag(engine_state, stack, "content-type")?,
         content_length: call.get_flag(engine_state, stack, "content-length")?,
         raw: call.has_flag("raw"),
-        insecure: call.get_flag(engine_state, stack, "insecure")?,
+        insecure: call.has_flag("insecure"),
         user: call.get_flag(engine_state, stack, "user")?,
         password: call.get_flag(engine_state, stack, "password")?,
-        timeout: call.get_flag(engine_state, stack, "timeout")?,
+        timeout: call.get_flag(engine_state, stack, "max-time")?,
     };
+
     helper(engine_state, stack, call, args)
 }
 
@@ -167,7 +168,7 @@ fn helper(
     let span = args.url.span()?;
     let (requested_url, url) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure.is_some());
+    let client = http_client(args.insecure);
     let mut request = client.patch(url);
 
     request = request_set_body(args.content_type, args.content_length, args.data, request)?;

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -129,7 +129,7 @@ struct Arguments {
     content_type: Option<String>,
     content_length: Option<String>,
     raw: bool,
-    insecure: Option<bool>,
+    insecure: bool,
     user: Option<String>,
     password: Option<String>,
     timeout: Option<Value>,
@@ -148,11 +148,12 @@ fn run_post(
         content_type: call.get_flag(engine_state, stack, "content-type")?,
         content_length: call.get_flag(engine_state, stack, "content-length")?,
         raw: call.has_flag("raw"),
-        insecure: call.get_flag(engine_state, stack, "insecure")?,
+        insecure: call.has_flag("insecure"),
         user: call.get_flag(engine_state, stack, "user")?,
         password: call.get_flag(engine_state, stack, "password")?,
-        timeout: call.get_flag(engine_state, stack, "timeout")?,
+        timeout: call.get_flag(engine_state, stack, "max-time")?,
     };
+
     helper(engine_state, stack, call, args)
 }
 
@@ -167,7 +168,7 @@ fn helper(
     let span = args.url.span()?;
     let (requested_url, url) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure.is_some());
+    let client = http_client(args.insecure);
     let mut request = client.post(url);
 
     request = request_set_body(args.content_type, args.content_length, args.data, request)?;

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -129,7 +129,7 @@ struct Arguments {
     content_type: Option<String>,
     content_length: Option<String>,
     raw: bool,
-    insecure: Option<bool>,
+    insecure: bool,
     user: Option<String>,
     password: Option<String>,
     timeout: Option<Value>,
@@ -148,11 +148,12 @@ fn run_put(
         content_type: call.get_flag(engine_state, stack, "content-type")?,
         content_length: call.get_flag(engine_state, stack, "content-length")?,
         raw: call.has_flag("raw"),
-        insecure: call.get_flag(engine_state, stack, "insecure")?,
+        insecure: call.has_flag("insecure"),
         user: call.get_flag(engine_state, stack, "user")?,
         password: call.get_flag(engine_state, stack, "password")?,
-        timeout: call.get_flag(engine_state, stack, "timeout")?,
+        timeout: call.get_flag(engine_state, stack, "max-time")?,
     };
+
     helper(engine_state, stack, call, args)
 }
 
@@ -167,7 +168,7 @@ fn helper(
     let span = args.url.span()?;
     let (requested_url, url) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure.is_some());
+    let client = http_client(args.insecure);
     let mut request = client.put(url);
 
     request = request_set_body(args.content_type, args.content_length, args.data, request)?;


### PR DESCRIPTION
# Description

Follow up of https://github.com/nushell/nushell/pull/8255

Sorry about the max-time argument, I didn't pay attention to the copy-paste. Regarding the insecure argument, the problem was before I began to work on the refacto. My mistake was to not have tested this argument.

# User-Facing Changes

None.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
