### PR TITLE
Uniformize usage() and extra_usage() message ending for commands helper.

### DIFF
--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -28,7 +28,7 @@ impl Command for Print {
     }
 
     fn usage(&self) -> &str {
-        "Print the given values to stdout"
+        "Print the given values to stdout."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-cmd-lang/src/core_commands/alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/alias.rs
@@ -13,7 +13,7 @@ impl Command for Alias {
     }
 
     fn usage(&self) -> &str {
-        "Alias a command (with optional flags) to a new name"
+        "Alias a command (with optional flags) to a new name."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -11,7 +11,7 @@ impl Command for Break {
     }
 
     fn usage(&self) -> &str {
-        "Break a loop"
+        "Break a loop."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/commandline.rs
+++ b/crates/nu-cmd-lang/src/core_commands/commandline.rs
@@ -41,7 +41,7 @@ impl Command for Commandline {
     }
 
     fn usage(&self) -> &str {
-        "View or modify the current command line input buffer"
+        "View or modify the current command line input buffer."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -11,7 +11,7 @@ impl Command for Continue {
     }
 
     fn usage(&self) -> &str {
-        "Continue a loop from the next iteration"
+        "Continue a loop from the next iteration."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -13,7 +13,7 @@ impl Command for Def {
     }
 
     fn usage(&self) -> &str {
-        "Define a custom command"
+        "Define a custom command."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/def_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def_env.rs
@@ -13,7 +13,7 @@ impl Command for DefEnv {
     }
 
     fn usage(&self) -> &str {
-        "Define a custom command, which participates in the caller environment"
+        "Define a custom command, which participates in the caller environment."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -17,7 +17,7 @@ impl Command for Do {
     }
 
     fn usage(&self) -> &str {
-        "Run a closure, providing it with the pipeline input"
+        "Run a closure, providing it with the pipeline input."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-cmd-lang/src/core_commands/export_alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_alias.rs
@@ -13,7 +13,7 @@ impl Command for ExportAlias {
     }
 
     fn usage(&self) -> &str {
-        "Alias a command (with optional flags) to a new name and export it from a module"
+        "Alias a command (with optional flags) to a new name and export it from a module."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -13,7 +13,7 @@ impl Command for ExportDef {
     }
 
     fn usage(&self) -> &str {
-        "Define a custom command and export it from a module"
+        "Define a custom command and export it from a module."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/export_def_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def_env.rs
@@ -13,7 +13,7 @@ impl Command for ExportDefEnv {
     }
 
     fn usage(&self) -> &str {
-        "Define a custom command that participates in the environment and export it from a module"
+        "Define a custom command that participates in the environment and export it from a module."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/export_extern.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_extern.rs
@@ -11,7 +11,7 @@ impl Command for ExportExtern {
     }
 
     fn usage(&self) -> &str {
-        "Define an extern and export it from a module"
+        "Define an extern and export it from a module."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/export_use.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_use.rs
@@ -13,7 +13,7 @@ impl Command for ExportUse {
     }
 
     fn usage(&self) -> &str {
-        "Use definitions from a module and export them from this module"
+        "Use definitions from a module and export them from this module."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/extern_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_.rs
@@ -11,7 +11,7 @@ impl Command for Extern {
     }
 
     fn usage(&self) -> &str {
-        "Define a signature for an external command"
+        "Define a signature for an external command."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -14,7 +14,7 @@ impl Command for For {
     }
 
     fn usage(&self) -> &str {
-        "Loop over a range"
+        "Loop over a range."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide.rs
@@ -23,7 +23,7 @@ impl Command for Hide {
     }
 
     fn usage(&self) -> &str {
-        "Hide definitions in the current scope"
+        "Hide definitions in the current scope."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -31,7 +31,7 @@ impl Command for HideEnv {
     }
 
     fn usage(&self) -> &str {
-        "Hide environment variables in the current scope"
+        "Hide environment variables in the current scope."
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/ignore.rs
+++ b/crates/nu-cmd-lang/src/core_commands/ignore.rs
@@ -11,7 +11,7 @@ impl Command for Ignore {
     }
 
     fn usage(&self) -> &str {
-        "Ignore the output of the previous command in the pipeline"
+        "Ignore the output of the previous command in the pipeline."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/module.rs
@@ -13,7 +13,7 @@ impl Command for Module {
     }
 
     fn usage(&self) -> &str {
-        "Define a custom module"
+        "Define a custom module."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -14,7 +14,7 @@ impl Command for OverlayHide {
     }
 
     fn usage(&self) -> &str {
-        "Hide an active overlay"
+        "Hide an active overlay."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/overlay/list.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/list.rs
@@ -13,7 +13,7 @@ impl Command for OverlayList {
     }
 
     fn usage(&self) -> &str {
-        "List all active overlays"
+        "List all active overlays."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
@@ -14,7 +14,7 @@ impl Command for OverlayNew {
     }
 
     fn usage(&self) -> &str {
-        "Create an empty overlay"
+        "Create an empty overlay."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -17,7 +17,7 @@ impl Command for OverlayUse {
     }
 
     fn usage(&self) -> &str {
-        "Use definitions from a module as an overlay"
+        "Use definitions from a module as an overlay."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/register.rs
+++ b/crates/nu-cmd-lang/src/core_commands/register.rs
@@ -11,7 +11,7 @@ impl Command for Register {
     }
 
     fn usage(&self) -> &str {
-        "Register a plugin"
+        "Register a plugin."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -14,7 +14,7 @@ impl Command for Return {
     }
 
     fn usage(&self) -> &str {
-        "Return early from a function"
+        "Return early from a function."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -15,7 +15,7 @@ impl Command for Try {
     }
 
     fn usage(&self) -> &str {
-        "Try to run a block, if it fails optionally run a catch block"
+        "Try to run a block, if it fails optionally run a catch block."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -14,7 +14,7 @@ impl Command for Use {
     }
 
     fn usage(&self) -> &str {
-        "Use definitions from a module"
+        "Use definitions from a module."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/bits/and.rs
+++ b/crates/nu-command/src/bits/and.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Performs bitwise and for integers"
+        "Performs bitwise and for integers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bits/bits_.rs
+++ b/crates/nu-command/src/bits/bits_.rs
@@ -20,7 +20,7 @@ impl Command for Bits {
     }
 
     fn usage(&self) -> &str {
-        "Various commands for working with bits"
+        "Various commands for working with bits."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -33,7 +33,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Performs logical negation on each bit"
+        "Performs logical negation on each bit."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bits/or.rs
+++ b/crates/nu-command/src/bits/or.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Performs bitwise or for integers"
+        "Performs bitwise or for integers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bits/rotate_left.rs
+++ b/crates/nu-command/src/bits/rotate_left.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise rotate left for integers"
+        "Bitwise rotate left for integers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bits/rotate_right.rs
+++ b/crates/nu-command/src/bits/rotate_right.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise rotate right for integers"
+        "Bitwise rotate right for integers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise shift left for integers"
+        "Bitwise shift left for integers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise shift right for integers"
+        "Bitwise shift right for integers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bits/xor.rs
+++ b/crates/nu-command/src/bits/xor.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Performs bitwise xor for integers"
+        "Performs bitwise xor for integers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -49,7 +49,7 @@ impl Command for BytesAdd {
     }
 
     fn usage(&self) -> &str {
-        "Add specified bytes to the input"
+        "Add specified bytes to the input."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/bytes_.rs
+++ b/crates/nu-command/src/bytes/bytes_.rs
@@ -20,7 +20,7 @@ impl Command for Bytes {
     }
 
     fn usage(&self) -> &str {
-        "Various commands for working with byte data"
+        "Various commands for working with byte data."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -26,7 +26,7 @@ impl Command for BytesCollect {
     }
 
     fn usage(&self) -> &str {
-        "Concatenate multiple binary into a single binary, with an optional separator between each"
+        "Concatenate multiple binary into a single binary, with an optional separator between each."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -39,7 +39,7 @@ impl Command for BytesEndsWith {
     }
 
     fn usage(&self) -> &str {
-        "Check if bytes ends with a pattern"
+        "Check if bytes ends with a pattern."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -49,7 +49,7 @@ impl Command for BytesIndexOf {
     }
 
     fn usage(&self) -> &str {
-        "Returns start index of first occurrence of pattern in bytes, or -1 if no match"
+        "Returns start index of first occurrence of pattern in bytes, or -1 if no match."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -27,7 +27,7 @@ impl Command for BytesLen {
     }
 
     fn usage(&self) -> &str {
-        "Output the length of any bytes in the pipeline"
+        "Output the length of any bytes in the pipeline."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -43,7 +43,7 @@ impl Command for BytesRemove {
     }
 
     fn usage(&self) -> &str {
-        "Remove bytes"
+        "Remove bytes."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -43,7 +43,7 @@ impl Command for BytesReplace {
     }
 
     fn usage(&self) -> &str {
-        "Find and replace binary"
+        "Find and replace binary."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/reverse.rs
+++ b/crates/nu-command/src/bytes/reverse.rs
@@ -27,7 +27,7 @@ impl Command for BytesReverse {
     }
 
     fn usage(&self) -> &str {
-        "Reverse the bytes in the pipeline"
+        "Reverse the bytes in the pipeline."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -40,7 +40,7 @@ impl Command for BytesStartsWith {
     }
 
     fn usage(&self) -> &str {
-        "Check if bytes starts with a pattern"
+        "Check if bytes starts with a pattern."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -37,7 +37,7 @@ impl Command for Fill {
     }
 
     fn usage(&self) -> &str {
-        "Fill and Align"
+        "Fill and Align."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/conversions/fmt.rs
+++ b/crates/nu-command/src/conversions/fmt.rs
@@ -15,7 +15,7 @@ impl Command for Fmt {
     }
 
     fn usage(&self) -> &str {
-        "Format a number"
+        "Format a number."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert value to a binary primitive"
+        "Convert value to a binary primitive."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -32,7 +32,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert value to boolean"
+        "Convert value to boolean."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -139,7 +139,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert text into a datetime"
+        "Convert text into a datetime."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert text into a decimal"
+        "Convert text into a decimal."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -39,7 +39,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert value to duration"
+        "Convert value to duration."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -31,7 +31,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert value to filesize"
+        "Convert value to filesize."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -49,7 +49,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert value to integer"
+        "Convert value to integer."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert value to record"
+        "Convert value to record."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -57,7 +57,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert value to string"
+        "Convert value to string."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -48,7 +48,7 @@ impl Command for IntoSqliteDb {
     }
 
     fn usage(&self) -> &str {
-        "Convert table into a SQLite database"
+        "Convert table into a SQLite database."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/dataframe/eager/append.rs
+++ b/crates/nu-command/src/dataframe/eager/append.rs
@@ -16,7 +16,7 @@ impl Command for AppendDF {
     }
 
     fn usage(&self) -> &str {
-        "Appends a new dataframe"
+        "Appends a new dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/columns.rs
+++ b/crates/nu-command/src/dataframe/eager/columns.rs
@@ -14,7 +14,7 @@ impl Command for ColumnsDF {
     }
 
     fn usage(&self) -> &str {
-        "Show dataframe columns"
+        "Show dataframe columns."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/drop.rs
+++ b/crates/nu-command/src/dataframe/eager/drop.rs
@@ -17,7 +17,7 @@ impl Command for DropDF {
     }
 
     fn usage(&self) -> &str {
-        "Creates a new dataframe by dropping the selected columns"
+        "Creates a new dataframe by dropping the selected columns."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_duplicates.rs
@@ -18,7 +18,7 @@ impl Command for DropDuplicates {
     }
 
     fn usage(&self) -> &str {
-        "Drops duplicate values in dataframe"
+        "Drops duplicate values in dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-command/src/dataframe/eager/drop_nulls.rs
@@ -17,7 +17,7 @@ impl Command for DropNulls {
     }
 
     fn usage(&self) -> &str {
-        "Drops null values in dataframe"
+        "Drops null values in dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/dtypes.rs
+++ b/crates/nu-command/src/dataframe/eager/dtypes.rs
@@ -14,7 +14,7 @@ impl Command for DataTypes {
     }
 
     fn usage(&self) -> &str {
-        "Show dataframe data types"
+        "Show dataframe data types."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/dummies.rs
+++ b/crates/nu-command/src/dataframe/eager/dummies.rs
@@ -15,7 +15,7 @@ impl Command for Dummies {
     }
 
     fn usage(&self) -> &str {
-        "Creates a new dataframe with dummy variables"
+        "Creates a new dataframe with dummy variables."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-command/src/dataframe/eager/filter_with.rs
@@ -19,7 +19,7 @@ impl Command for FilterWith {
     }
 
     fn usage(&self) -> &str {
-        "Filters dataframe using a mask or expression as reference"
+        "Filters dataframe using a mask or expression as reference."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/get.rs
+++ b/crates/nu-command/src/dataframe/eager/get.rs
@@ -18,7 +18,7 @@ impl Command for GetDF {
     }
 
     fn usage(&self) -> &str {
-        "Creates dataframe with the selected columns"
+        "Creates dataframe with the selected columns."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/last.rs
+++ b/crates/nu-command/src/dataframe/eager/last.rs
@@ -15,7 +15,7 @@ impl Command for LastDF {
     }
 
     fn usage(&self) -> &str {
-        "Creates new dataframe with tail rows or creates a last expression"
+        "Creates new dataframe with tail rows or creates a last expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/list.rs
+++ b/crates/nu-command/src/dataframe/eager/list.rs
@@ -15,7 +15,7 @@ impl Command for ListDF {
     }
 
     fn usage(&self) -> &str {
-        "Lists stored dataframes"
+        "Lists stored dataframes."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/melt.rs
+++ b/crates/nu-command/src/dataframe/eager/melt.rs
@@ -19,7 +19,7 @@ impl Command for MeltDF {
     }
 
     fn usage(&self) -> &str {
-        "Unpivot a DataFrame from wide to long format"
+        "Unpivot a DataFrame from wide to long format."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/open.rs
+++ b/crates/nu-command/src/dataframe/eager/open.rs
@@ -22,7 +22,7 @@ impl Command for OpenDataFrame {
     }
 
     fn usage(&self) -> &str {
-        "Opens csv, json, arrow, or parquet file to create dataframe"
+        "Opens csv, json, arrow, or parquet file to create dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/rename.rs
+++ b/crates/nu-command/src/dataframe/eager/rename.rs
@@ -18,7 +18,7 @@ impl Command for RenameDF {
     }
 
     fn usage(&self) -> &str {
-        "Rename a dataframe column"
+        "Rename a dataframe column."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/sample.rs
+++ b/crates/nu-command/src/dataframe/eager/sample.rs
@@ -16,7 +16,7 @@ impl Command for SampleDF {
     }
 
     fn usage(&self) -> &str {
-        "Create sample dataframe"
+        "Create sample dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/shape.rs
+++ b/crates/nu-command/src/dataframe/eager/shape.rs
@@ -17,7 +17,7 @@ impl Command for ShapeDF {
     }
 
     fn usage(&self) -> &str {
-        "Shows column and row size for a dataframe"
+        "Shows column and row size for a dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/slice.rs
+++ b/crates/nu-command/src/dataframe/eager/slice.rs
@@ -18,7 +18,7 @@ impl Command for SliceDF {
     }
 
     fn usage(&self) -> &str {
-        "Creates new dataframe from a slice of rows"
+        "Creates new dataframe from a slice of rows."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/take.rs
+++ b/crates/nu-command/src/dataframe/eager/take.rs
@@ -19,7 +19,7 @@ impl Command for TakeDF {
     }
 
     fn usage(&self) -> &str {
-        "Creates new dataframe using the given indices"
+        "Creates new dataframe using the given indices."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/to_arrow.rs
+++ b/crates/nu-command/src/dataframe/eager/to_arrow.rs
@@ -19,7 +19,7 @@ impl Command for ToArrow {
     }
 
     fn usage(&self) -> &str {
-        "Saves dataframe to arrow file"
+        "Saves dataframe to arrow file."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/to_csv.rs
+++ b/crates/nu-command/src/dataframe/eager/to_csv.rs
@@ -19,7 +19,7 @@ impl Command for ToCSV {
     }
 
     fn usage(&self) -> &str {
-        "Saves dataframe to csv file"
+        "Saves dataframe to csv file."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/to_df.rs
+++ b/crates/nu-command/src/dataframe/eager/to_df.rs
@@ -15,7 +15,7 @@ impl Command for ToDataFrame {
     }
 
     fn usage(&self) -> &str {
-        "Converts a list, table or record into a dataframe"
+        "Converts a list, table or record into a dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-command/src/dataframe/eager/to_nu.rs
@@ -16,7 +16,7 @@ impl Command for ToNu {
     }
 
     fn usage(&self) -> &str {
-        "Converts a section of the dataframe into nushell Table"
+        "Converts a section of the dataframe into nushell Table."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/to_parquet.rs
+++ b/crates/nu-command/src/dataframe/eager/to_parquet.rs
@@ -19,7 +19,7 @@ impl Command for ToParquet {
     }
 
     fn usage(&self) -> &str {
-        "Saves dataframe to parquet file"
+        "Saves dataframe to parquet file."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/eager/with_column.rs
+++ b/crates/nu-command/src/dataframe/eager/with_column.rs
@@ -16,7 +16,7 @@ impl Command for WithColumn {
     }
 
     fn usage(&self) -> &str {
-        "Adds a series to the dataframe"
+        "Adds a series to the dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/alias.rs
+++ b/crates/nu-command/src/dataframe/expressions/alias.rs
@@ -16,7 +16,7 @@ impl Command for ExprAlias {
     }
 
     fn usage(&self) -> &str {
-        "Creates an alias expression"
+        "Creates an alias expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/arg_where.rs
+++ b/crates/nu-command/src/dataframe/expressions/arg_where.rs
@@ -16,7 +16,7 @@ impl Command for ExprArgWhere {
     }
 
     fn usage(&self) -> &str {
-        "Creates an expression that returns the arguments where expression is true"
+        "Creates an expression that returns the arguments where expression is true."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/as_nu.rs
+++ b/crates/nu-command/src/dataframe/expressions/as_nu.rs
@@ -15,7 +15,7 @@ impl Command for ExprAsNu {
     }
 
     fn usage(&self) -> &str {
-        "Convert expression into a nu value for access and exploration"
+        "Convert expression into a nu value for access and exploration."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/col.rs
+++ b/crates/nu-command/src/dataframe/expressions/col.rs
@@ -16,7 +16,7 @@ impl Command for ExprCol {
     }
 
     fn usage(&self) -> &str {
-        "Creates a named column expression"
+        "Creates a named column expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/concat_str.rs
+++ b/crates/nu-command/src/dataframe/expressions/concat_str.rs
@@ -16,7 +16,7 @@ impl Command for ExprConcatStr {
     }
 
     fn usage(&self) -> &str {
-        "Creates a concat string expression"
+        "Creates a concat string expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/is_in.rs
+++ b/crates/nu-command/src/dataframe/expressions/is_in.rs
@@ -16,7 +16,7 @@ impl Command for ExprIsIn {
     }
 
     fn usage(&self) -> &str {
-        "Creates an is-in expression"
+        "Creates an is-in expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/lit.rs
+++ b/crates/nu-command/src/dataframe/expressions/lit.rs
@@ -15,7 +15,7 @@ impl Command for ExprLit {
     }
 
     fn usage(&self) -> &str {
-        "Creates a literal expression"
+        "Creates a literal expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-command/src/dataframe/expressions/otherwise.rs
@@ -15,7 +15,7 @@ impl Command for ExprOtherwise {
     }
 
     fn usage(&self) -> &str {
-        "completes a when expression"
+        "completes a when expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-command/src/dataframe/expressions/quantile.rs
@@ -16,7 +16,7 @@ impl Command for ExprQuantile {
     }
 
     fn usage(&self) -> &str {
-        "Aggregates the columns to the selected quantile"
+        "Aggregates the columns to the selected quantile."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/expressions/when.rs
+++ b/crates/nu-command/src/dataframe/expressions/when.rs
@@ -16,7 +16,7 @@ impl Command for ExprWhen {
     }
 
     fn usage(&self) -> &str {
-        "Creates and modifies a when expression"
+        "Creates and modifies a when expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-command/src/dataframe/lazy/aggregate.rs
@@ -17,7 +17,7 @@ impl Command for LazyAggregate {
     }
 
     fn usage(&self) -> &str {
-        "Performs a series of aggregations from a group-by"
+        "Performs a series of aggregations from a group-by."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/collect.rs
+++ b/crates/nu-command/src/dataframe/lazy/collect.rs
@@ -16,7 +16,7 @@ impl Command for LazyCollect {
     }
 
     fn usage(&self) -> &str {
-        "Collect lazy dataframe into eager dataframe"
+        "Collect lazy dataframe into eager dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/fetch.rs
+++ b/crates/nu-command/src/dataframe/lazy/fetch.rs
@@ -16,7 +16,7 @@ impl Command for LazyFetch {
     }
 
     fn usage(&self) -> &str {
-        "collects the lazyframe to the selected rows"
+        "collects the lazyframe to the selected rows."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/fill_nan.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_nan.rs
@@ -15,7 +15,7 @@ impl Command for LazyFillNA {
     }
 
     fn usage(&self) -> &str {
-        "Replaces NaN values with the given expression"
+        "Replaces NaN values with the given expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/fill_null.rs
+++ b/crates/nu-command/src/dataframe/lazy/fill_null.rs
@@ -15,7 +15,7 @@ impl Command for LazyFillNull {
     }
 
     fn usage(&self) -> &str {
-        "Replaces NULL values with the given expression"
+        "Replaces NULL values with the given expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/filter.rs
+++ b/crates/nu-command/src/dataframe/lazy/filter.rs
@@ -16,7 +16,7 @@ impl Command for LazyFilter {
     }
 
     fn usage(&self) -> &str {
-        "Filter dataframe based in expression"
+        "Filter dataframe based in expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/groupby.rs
+++ b/crates/nu-command/src/dataframe/lazy/groupby.rs
@@ -16,7 +16,7 @@ impl Command for ToLazyGroupBy {
     }
 
     fn usage(&self) -> &str {
-        "Creates a group-by object that can be used for other aggregations"
+        "Creates a group-by object that can be used for other aggregations."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/join.rs
+++ b/crates/nu-command/src/dataframe/lazy/join.rs
@@ -16,7 +16,7 @@ impl Command for LazyJoin {
     }
 
     fn usage(&self) -> &str {
-        "Joins a lazy frame with other lazy frame"
+        "Joins a lazy frame with other lazy frame."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/quantile.rs
+++ b/crates/nu-command/src/dataframe/lazy/quantile.rs
@@ -16,7 +16,7 @@ impl Command for LazyQuantile {
     }
 
     fn usage(&self) -> &str {
-        "Aggregates the columns to the selected quantile"
+        "Aggregates the columns to the selected quantile."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/select.rs
+++ b/crates/nu-command/src/dataframe/lazy/select.rs
@@ -15,7 +15,7 @@ impl Command for LazySelect {
     }
 
     fn usage(&self) -> &str {
-        "Selects columns from lazyframe"
+        "Selects columns from lazyframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu-command/src/dataframe/lazy/sort_by_expr.rs
@@ -16,7 +16,7 @@ impl Command for LazySortBy {
     }
 
     fn usage(&self) -> &str {
-        "sorts a lazy dataframe based on expression(s)"
+        "sorts a lazy dataframe based on expression(s)."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/lazy/to_lazy.rs
+++ b/crates/nu-command/src/dataframe/lazy/to_lazy.rs
@@ -15,7 +15,7 @@ impl Command for ToLazyFrame {
     }
 
     fn usage(&self) -> &str {
-        "Converts a dataframe into a lazy dataframe"
+        "Converts a dataframe into a lazy dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/all_false.rs
+++ b/crates/nu-command/src/dataframe/series/all_false.rs
@@ -15,7 +15,7 @@ impl Command for AllFalse {
     }
 
     fn usage(&self) -> &str {
-        "Returns true if all values are false"
+        "Returns true if all values are false."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/all_true.rs
+++ b/crates/nu-command/src/dataframe/series/all_true.rs
@@ -15,7 +15,7 @@ impl Command for AllTrue {
     }
 
     fn usage(&self) -> &str {
-        "Returns true if all values are true"
+        "Returns true if all values are true."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/arg_max.rs
+++ b/crates/nu-command/src/dataframe/series/arg_max.rs
@@ -16,7 +16,7 @@ impl Command for ArgMax {
     }
 
     fn usage(&self) -> &str {
-        "Return index for max value in series"
+        "Return index for max value in series."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/dataframe/series/arg_min.rs
+++ b/crates/nu-command/src/dataframe/series/arg_min.rs
@@ -16,7 +16,7 @@ impl Command for ArgMin {
     }
 
     fn usage(&self) -> &str {
-        "Return index for min value in series"
+        "Return index for min value in series."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/dataframe/series/cumulative.rs
+++ b/crates/nu-command/src/dataframe/series/cumulative.rs
@@ -49,7 +49,7 @@ impl Command for Cumulative {
     }
 
     fn usage(&self) -> &str {
-        "Cumulative calculation for a series"
+        "Cumulative calculation for a series."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_day.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_day.rs
@@ -16,7 +16,7 @@ impl Command for GetDay {
     }
 
     fn usage(&self) -> &str {
-        "Gets day from date"
+        "Gets day from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_hour.rs
@@ -16,7 +16,7 @@ impl Command for GetHour {
     }
 
     fn usage(&self) -> &str {
-        "Gets hour from date"
+        "Gets hour from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_minute.rs
@@ -16,7 +16,7 @@ impl Command for GetMinute {
     }
 
     fn usage(&self) -> &str {
-        "Gets minute from date"
+        "Gets minute from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_month.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_month.rs
@@ -16,7 +16,7 @@ impl Command for GetMonth {
     }
 
     fn usage(&self) -> &str {
-        "Gets month from date"
+        "Gets month from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_nanosecond.rs
@@ -16,7 +16,7 @@ impl Command for GetNanosecond {
     }
 
     fn usage(&self) -> &str {
-        "Gets nanosecond from date"
+        "Gets nanosecond from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_ordinal.rs
@@ -16,7 +16,7 @@ impl Command for GetOrdinal {
     }
 
     fn usage(&self) -> &str {
-        "Gets ordinal from date"
+        "Gets ordinal from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_second.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_second.rs
@@ -16,7 +16,7 @@ impl Command for GetSecond {
     }
 
     fn usage(&self) -> &str {
-        "Gets second from date"
+        "Gets second from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_week.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_week.rs
@@ -16,7 +16,7 @@ impl Command for GetWeek {
     }
 
     fn usage(&self) -> &str {
-        "Gets week from date"
+        "Gets week from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_weekday.rs
@@ -16,7 +16,7 @@ impl Command for GetWeekDay {
     }
 
     fn usage(&self) -> &str {
-        "Gets weekday from date"
+        "Gets weekday from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/date/get_year.rs
+++ b/crates/nu-command/src/dataframe/series/date/get_year.rs
@@ -16,7 +16,7 @@ impl Command for GetYear {
     }
 
     fn usage(&self) -> &str {
-        "Gets year from date"
+        "Gets year from date."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_sort.rs
@@ -16,7 +16,7 @@ impl Command for ArgSort {
     }
 
     fn usage(&self) -> &str {
-        "Returns indexes for a sorted series"
+        "Returns indexes for a sorted series."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_true.rs
@@ -16,7 +16,7 @@ impl Command for ArgTrue {
     }
 
     fn usage(&self) -> &str {
-        "Returns indexes where values are true"
+        "Returns indexes where values are true."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/arg_unique.rs
@@ -16,7 +16,7 @@ impl Command for ArgUnique {
     }
 
     fn usage(&self) -> &str {
-        "Returns indexes for unique values"
+        "Returns indexes for unique values."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
+++ b/crates/nu-command/src/dataframe/series/indexes/set_with_idx.rs
@@ -17,7 +17,7 @@ impl Command for SetWithIndex {
     }
 
     fn usage(&self) -> &str {
-        "Sets value in the given index"
+        "Sets value in the given index."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_duplicated.rs
@@ -16,7 +16,7 @@ impl Command for IsDuplicated {
     }
 
     fn usage(&self) -> &str {
-        "Creates mask indicating duplicated values"
+        "Creates mask indicating duplicated values."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/masks/is_in.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_in.rs
@@ -17,7 +17,7 @@ impl Command for IsIn {
     }
 
     fn usage(&self) -> &str {
-        "Checks if elements from a series are contained in right series"
+        "Checks if elements from a series are contained in right series."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_not_null.rs
@@ -15,7 +15,7 @@ impl Command for IsNotNull {
     }
 
     fn usage(&self) -> &str {
-        "Creates mask where value is not null"
+        "Creates mask where value is not null."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/masks/is_null.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_null.rs
@@ -15,7 +15,7 @@ impl Command for IsNull {
     }
 
     fn usage(&self) -> &str {
-        "Creates mask where value is null"
+        "Creates mask where value is null."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu-command/src/dataframe/series/masks/is_unique.rs
@@ -16,7 +16,7 @@ impl Command for IsUnique {
     }
 
     fn usage(&self) -> &str {
-        "Creates mask indicating unique values"
+        "Creates mask indicating unique values."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/masks/not.rs
+++ b/crates/nu-command/src/dataframe/series/masks/not.rs
@@ -17,7 +17,7 @@ impl Command for NotSeries {
     }
 
     fn usage(&self) -> &str {
-        "Inverts boolean mask"
+        "Inverts boolean mask."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/masks/set.rs
+++ b/crates/nu-command/src/dataframe/series/masks/set.rs
@@ -17,7 +17,7 @@ impl Command for SetSeries {
     }
 
     fn usage(&self) -> &str {
-        "Sets value where given mask is true"
+        "Sets value where given mask is true."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/n_null.rs
+++ b/crates/nu-command/src/dataframe/series/n_null.rs
@@ -15,7 +15,7 @@ impl Command for NNull {
     }
 
     fn usage(&self) -> &str {
-        "Counts null values"
+        "Counts null values."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/n_unique.rs
+++ b/crates/nu-command/src/dataframe/series/n_unique.rs
@@ -14,7 +14,7 @@ impl Command for NUnique {
     }
 
     fn usage(&self) -> &str {
-        "Counts unique values"
+        "Counts unique values."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/rolling.rs
+++ b/crates/nu-command/src/dataframe/series/rolling.rs
@@ -52,7 +52,7 @@ impl Command for Rolling {
     }
 
     fn usage(&self) -> &str {
-        "Rolling calculation for a series"
+        "Rolling calculation for a series."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/shift.rs
+++ b/crates/nu-command/src/dataframe/series/shift.rs
@@ -18,7 +18,7 @@ impl Command for Shift {
     }
 
     fn usage(&self) -> &str {
-        "Shifts the values by a given period"
+        "Shifts the values by a given period."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu-command/src/dataframe/series/string/concatenate.rs
@@ -17,7 +17,7 @@ impl Command for Concatenate {
     }
 
     fn usage(&self) -> &str {
-        "Concatenates strings with other array"
+        "Concatenates strings with other array."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/contains.rs
+++ b/crates/nu-command/src/dataframe/series/string/contains.rs
@@ -17,7 +17,7 @@ impl Command for Contains {
     }
 
     fn usage(&self) -> &str {
-        "Checks if a pattern is contained in a string"
+        "Checks if a pattern is contained in a string."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/replace.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace.rs
@@ -17,7 +17,7 @@ impl Command for Replace {
     }
 
     fn usage(&self) -> &str {
-        "Replace the leftmost (sub)string by a regex pattern"
+        "Replace the leftmost (sub)string by a regex pattern."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu-command/src/dataframe/series/string/replace_all.rs
@@ -17,7 +17,7 @@ impl Command for ReplaceAll {
     }
 
     fn usage(&self) -> &str {
-        "Replace all (sub)strings by a regex pattern"
+        "Replace all (sub)strings by a regex pattern."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_lengths.rs
@@ -16,7 +16,7 @@ impl Command for StrLengths {
     }
 
     fn usage(&self) -> &str {
-        "Get lengths of all strings"
+        "Get lengths of all strings."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu-command/src/dataframe/series/string/str_slice.rs
@@ -17,7 +17,7 @@ impl Command for StrSlice {
     }
 
     fn usage(&self) -> &str {
-        "Slices the string from the start position until the selected length"
+        "Slices the string from the start position until the selected length."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/strftime.rs
+++ b/crates/nu-command/src/dataframe/series/string/strftime.rs
@@ -17,7 +17,7 @@ impl Command for StrFTime {
     }
 
     fn usage(&self) -> &str {
-        "Formats date based on string rule"
+        "Formats date based on string rule."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_lowercase.rs
@@ -16,7 +16,7 @@ impl Command for ToLowerCase {
     }
 
     fn usage(&self) -> &str {
-        "Lowercase the strings in the column"
+        "Lowercase the strings in the column."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu-command/src/dataframe/series/string/to_uppercase.rs
@@ -16,7 +16,7 @@ impl Command for ToUpperCase {
     }
 
     fn usage(&self) -> &str {
-        "Uppercase the strings in the column"
+        "Uppercase the strings in the column."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/dataframe/series/unique.rs
+++ b/crates/nu-command/src/dataframe/series/unique.rs
@@ -19,7 +19,7 @@ impl Command for Unique {
     }
 
     fn usage(&self) -> &str {
-        "Returns unique values from a dataframe"
+        "Returns unique values from a dataframe."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/dataframe/series/value_counts.rs
+++ b/crates/nu-command/src/dataframe/series/value_counts.rs
@@ -17,7 +17,7 @@ impl Command for ValueCount {
     }
 
     fn usage(&self) -> &str {
-        "Returns a dataframe with the counts for unique values in series"
+        "Returns a dataframe with the counts for unique values in series."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/date/date_.rs
+++ b/crates/nu-command/src/date/date_.rs
@@ -20,7 +20,7 @@ impl Command for Date {
     }
 
     fn usage(&self) -> &str {
-        "Date-related commands"
+        "Date-related commands."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/debug/inspect.rs
+++ b/crates/nu-command/src/debug/inspect.rs
@@ -15,7 +15,7 @@ impl Command for Inspect {
     }
 
     fn usage(&self) -> &str {
-        "Inspect pipeline results while running a pipeline"
+        "Inspect pipeline results while running a pipeline."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -15,7 +15,7 @@ impl Command for Metadata {
     }
 
     fn usage(&self) -> &str {
-        "Get the metadata for items in the stream"
+        "Get the metadata for items in the stream."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/debug/timeit.rs
+++ b/crates/nu-command/src/debug/timeit.rs
@@ -16,7 +16,7 @@ impl Command for TimeIt {
     }
 
     fn usage(&self) -> &str {
-        "Time the running time of a closure"
+        "Time the running time of a closure."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/debug/view.rs
+++ b/crates/nu-command/src/debug/view.rs
@@ -20,7 +20,7 @@ impl Command for View {
     }
 
     fn usage(&self) -> &str {
-        "Various commands for viewing debug information"
+        "Various commands for viewing debug information."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/debug/view_files.rs
+++ b/crates/nu-command/src/debug/view_files.rs
@@ -13,7 +13,7 @@ impl Command for ViewFiles {
     }
 
     fn usage(&self) -> &str {
-        "View the files registered in nushell's EngineState memory"
+        "View the files registered in nushell's EngineState memory."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -16,7 +16,7 @@ impl Command for ViewSource {
     }
 
     fn usage(&self) -> &str {
-        "View a block, module, or a definition"
+        "View a block, module, or a definition."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -15,7 +15,7 @@ impl Command for ViewSpan {
     }
 
     fn usage(&self) -> &str {
-        "View the contents of a span"
+        "View the contents of a span."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/deprecated/export_old_alias.rs
+++ b/crates/nu-command/src/deprecated/export_old_alias.rs
@@ -11,7 +11,7 @@ impl Command for ExportOldAlias {
     }
 
     fn usage(&self) -> &str {
-        "Define an alias and export it from a module"
+        "Define an alias and export it from a module."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/deprecated/hash_base64.rs
+++ b/crates/nu-command/src/deprecated/hash_base64.rs
@@ -15,7 +15,7 @@ impl Command for HashBase64 {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/deprecated/lpad.rs
+++ b/crates/nu-command/src/deprecated/lpad.rs
@@ -16,7 +16,7 @@ impl Command for LPadDeprecated {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/deprecated/math_eval.rs
+++ b/crates/nu-command/src/deprecated/math_eval.rs
@@ -21,7 +21,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/deprecated/old_alias.rs
+++ b/crates/nu-command/src/deprecated/old_alias.rs
@@ -13,7 +13,7 @@ impl Command for OldAlias {
     }
 
     fn usage(&self) -> &str {
-        "Alias a command (with optional flags) to a new name"
+        "Alias a command (with optional flags) to a new name."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/deprecated/rpad.rs
+++ b/crates/nu-command/src/deprecated/rpad.rs
@@ -16,7 +16,7 @@ impl Command for RPadDeprecated {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/deprecated/str_datetime.rs
+++ b/crates/nu-command/src/deprecated/str_datetime.rs
@@ -17,7 +17,7 @@ impl Command for StrDatetimeDeprecated {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/deprecated/str_decimal.rs
+++ b/crates/nu-command/src/deprecated/str_decimal.rs
@@ -17,7 +17,7 @@ impl Command for StrDecimalDeprecated {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/deprecated/str_find_replace.rs
+++ b/crates/nu-command/src/deprecated/str_find_replace.rs
@@ -17,7 +17,7 @@ impl Command for StrFindReplaceDeprecated {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/deprecated/str_int.rs
+++ b/crates/nu-command/src/deprecated/str_int.rs
@@ -17,7 +17,7 @@ impl Command for StrIntDeprecated {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -20,7 +20,7 @@ impl Command for ConfigMeta {
     }
 
     fn usage(&self) -> &str {
-        "Edit nushell configuration files"
+        "Edit nushell configuration files."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -23,7 +23,7 @@ impl Command for ConfigEnv {
     }
 
     fn usage(&self) -> &str {
-        "Edit nu environment configurations"
+        "Edit nu environment configurations."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -23,7 +23,7 @@ impl Command for ConfigNu {
     }
 
     fn usage(&self) -> &str {
-        "Edit nu configurations"
+        "Edit nu configurations."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -26,7 +26,7 @@ impl Command for ConfigReset {
     }
 
     fn usage(&self) -> &str {
-        "Reset nushell environment configurations to default, and saves old config files in the config location as oldconfig.nu and oldenv.nu"
+        "Reset nushell environment configurations to default, and saves old config files in the config location as oldconfig.nu and oldenv.nu."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/env/env_command.rs
+++ b/crates/nu-command/src/env/env_command.rs
@@ -14,7 +14,7 @@ impl Command for Env {
     }
 
     fn usage(&self) -> &str {
-        "Display current environment variables"
+        "Display current environment variables."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -14,7 +14,7 @@ impl Command for IsAdmin {
     }
 
     fn usage(&self) -> &str {
-        "Check if nushell is running with administrator or root privileges"
+        "Check if nushell is running with administrator or root privileges."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -18,7 +18,7 @@ impl Command for Lines {
     }
 
     fn usage(&self) -> &str {
-        "Converts input to lines"
+        "Converts input to lines."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -21,7 +21,7 @@ impl Command for Move {
     }
 
     fn usage(&self) -> &str {
-        "Move columns before or after other columns"
+        "Move columns before or after other columns."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/filters/roll/roll_.rs
+++ b/crates/nu-command/src/filters/roll/roll_.rs
@@ -22,7 +22,7 @@ impl Command for Roll {
     }
 
     fn usage(&self) -> &str {
-        "Rolling commands for tables"
+        "Rolling commands for tables."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/filters/roll/roll_down.rs
+++ b/crates/nu-command/src/filters/roll/roll_down.rs
@@ -29,7 +29,7 @@ impl Command for RollDown {
     }
 
     fn usage(&self) -> &str {
-        "Roll table rows down"
+        "Roll table rows down."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/roll/roll_left.rs
+++ b/crates/nu-command/src/filters/roll/roll_left.rs
@@ -41,7 +41,7 @@ impl Command for RollLeft {
     }
 
     fn usage(&self) -> &str {
-        "Roll record or table columns left"
+        "Roll record or table columns left."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/roll/roll_right.rs
+++ b/crates/nu-command/src/filters/roll/roll_right.rs
@@ -41,7 +41,7 @@ impl Command for RollRight {
     }
 
     fn usage(&self) -> &str {
-        "Roll table columns right"
+        "Roll table columns right."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/roll/roll_up.rs
+++ b/crates/nu-command/src/filters/roll/roll_up.rs
@@ -29,7 +29,7 @@ impl Command for RollUp {
     }
 
     fn usage(&self) -> &str {
-        "Roll table rows up"
+        "Roll table rows up."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -15,7 +15,7 @@ impl Command for Zip {
     }
 
     fn usage(&self) -> &str {
-        "Combine a stream with the input"
+        "Combine a stream with the input."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/formats/from/command.rs
+++ b/crates/nu-command/src/formats/from/command.rs
@@ -12,7 +12,7 @@ impl Command for From {
     }
 
     fn usage(&self) -> &str {
-        "Parse a string or binary data into structured data"
+        "Parse a string or binary data into structured data."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -14,7 +14,7 @@ impl Command for FromJson {
     }
 
     fn usage(&self) -> &str {
-        "Convert from json to structured data"
+        "Convert from json to structured data."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -13,7 +13,7 @@ impl Command for FromNuon {
     }
 
     fn usage(&self) -> &str {
-        "Convert from nuon to structured data"
+        "Convert from nuon to structured data."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/formats/to/command.rs
+++ b/crates/nu-command/src/formats/to/command.rs
@@ -12,7 +12,7 @@ impl Command for To {
     }
 
     fn usage(&self) -> &str {
-        "Translate structured data to a format"
+        "Translate structured data to a format."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/formats/to/csv.rs
+++ b/crates/nu-command/src/formats/to/csv.rs
@@ -56,7 +56,7 @@ impl Command for ToCsv {
     }
 
     fn usage(&self) -> &str {
-        "Convert table into .csv text "
+        "Convert table into .csv text ."
     }
 
     fn run(

--- a/crates/nu-command/src/formats/to/html.rs
+++ b/crates/nu-command/src/formats/to/html.rs
@@ -144,11 +144,11 @@ impl Command for ToHtml {
     }
 
     fn usage(&self) -> &str {
-        "Convert table into simple HTML"
+        "Convert table into simple HTML."
     }
 
     fn extra_usage(&self) -> &str {
-        "Screenshots of the themes can be browsed here: https://github.com/mbadolato/iTerm2-Color-Schemes"
+        "Screenshots of the themes can be browsed here: https://github.com/mbadolato/iTerm2-Color-Schemes."
     }
 
     fn run(

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -32,7 +32,7 @@ impl Command for ToMd {
     }
 
     fn usage(&self) -> &str {
-        "Convert table into simple Markdown"
+        "Convert table into simple Markdown."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -19,7 +19,7 @@ impl Command for ToToml {
     }
 
     fn usage(&self) -> &str {
-        "Convert record into .toml text"
+        "Convert record into .toml text."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/formats/to/tsv.rs
+++ b/crates/nu-command/src/formats/to/tsv.rs
@@ -28,7 +28,7 @@ impl Command for ToTsv {
     }
 
     fn usage(&self) -> &str {
-        "Convert table into .tsv text"
+        "Convert table into .tsv text."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -51,7 +51,7 @@ impl Command for ToXml {
     }
 
     fn usage(&self) -> &str {
-        "Convert table into .xml text"
+        "Convert table into .xml text."
     }
 
     fn run(

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -19,7 +19,7 @@ impl Command for ToYaml {
     }
 
     fn usage(&self) -> &str {
-        "Convert table into .yaml/.yml text"
+        "Convert table into .yaml/.yml text."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/generators/seq_char.rs
+++ b/crates/nu-command/src/generators/seq_char.rs
@@ -14,7 +14,7 @@ impl Command for SeqChar {
     }
 
     fn usage(&self) -> &str {
-        "Print a sequence of ASCII characters"
+        "Print a sequence of ASCII characters."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/generators/seq_date.rs
+++ b/crates/nu-command/src/generators/seq_date.rs
@@ -17,7 +17,7 @@ impl Command for SeqDate {
     }
 
     fn usage(&self) -> &str {
-        "Print sequences of dates"
+        "Print sequences of dates."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -18,7 +18,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the absolute value of a number"
+        "Returns the absolute value of a number."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the average of a list of numbers"
+        "Returns the average of a list of numbers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -18,7 +18,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the ceil of a number (smallest integer greater than or equal to that number)"
+        "Returns the ceil of a number (smallest integer greater than or equal to that number)."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -18,7 +18,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the floor of a number (largest integer less than or equal to that number)"
+        "Returns the floor of a number (largest integer less than or equal to that number)."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/ln.rs
+++ b/crates/nu-command/src/math/ln.rs
@@ -18,7 +18,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the natural logarithm. Base: (math e)"
+        "Returns the natural logarithm. Base: (math e)."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the maximum of a list of numbers, or of columns in a table"
+        "Returns the maximum of a list of numbers, or of columns in a table."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -24,7 +24,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Computes the median of a list of numbers"
+        "Computes the median of a list of numbers."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Finds the minimum within a list of numbers or tables"
+        "Finds the minimum within a list of numbers or tables."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -48,7 +48,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the most frequent element(s) from a list of numbers or tables"
+        "Returns the most frequent element(s) from a list of numbers or tables."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the product of a list of numbers or the products of each column of a table"
+        "Returns the product of a list of numbers or the products of each column of a table."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the input number rounded to the specified precision"
+        "Returns the input number rounded to the specified precision."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -18,7 +18,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the square root of the input number"
+        "Returns the square root of the input number."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -24,7 +24,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the standard deviation of a list of numbers, or of each column in a table"
+        "Returns the standard deviation of a list of numbers, or of each column in a table."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the sum of a list of numbers or of each column in a table"
+        "Returns the sum of a list of numbers or of each column in a table."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -23,7 +23,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the variance of a list of numbers or of each column in a table"
+        "Returns the variance of a list of numbers or of each column in a table."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/misc/history.rs
+++ b/crates/nu-command/src/misc/history.rs
@@ -18,7 +18,7 @@ impl Command for History {
     }
 
     fn usage(&self) -> &str {
-        "Get the command history"
+        "Get the command history."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/misc/history_session.rs
+++ b/crates/nu-command/src/misc/history_session.rs
@@ -13,7 +13,7 @@ impl Command for HistorySession {
     }
 
     fn usage(&self) -> &str {
-        "Get the command history session"
+        "Get the command history session."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -34,7 +34,7 @@ impl Command for Tutor {
     }
 
     fn usage(&self) -> &str {
-        "Run the tutorial. To begin, run: tutor"
+        "Run the tutorial. To begin, run: tutor."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/network/http/http_.rs
+++ b/crates/nu-command/src/network/http/http_.rs
@@ -20,7 +20,7 @@ impl Command for Http {
     }
 
     fn usage(&self) -> &str {
-        "Various commands for working with http methods"
+        "Various commands for working with http methods."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Get a free port from system"
+        "Get a free port from system."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -20,7 +20,7 @@ impl Command for SubCommand {
             .input_output_types(vec![(Type::String, Type::String)])
             .vectorizes_over_list(true)
             .switch(
-            "all", 
+            "all",
             "encode all non-alphanumeric chars including `/`, `.`, `:`",
             Some('a'))
             .rest(
@@ -32,7 +32,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Converts a string to a percent encoded web safe string"
+        "Converts a string to a percent encoded web safe string."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Converts a record to url"
+        "Converts a record to url."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/network/url/parse.rs
+++ b/crates/nu-command/src/network/url/parse.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Parses a url"
+        "Parses a url."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/network/url/url_.rs
+++ b/crates/nu-command/src/network/url/url_.rs
@@ -20,7 +20,7 @@ impl Command for Url {
     }
 
     fn usage(&self) -> &str {
-        "Various commands for working with URLs"
+        "Various commands for working with URLs."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/path/basename.rs
+++ b/crates/nu-command/src/path/basename.rs
@@ -51,7 +51,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Get the final component of a path"
+        "Get the final component of a path."
     }
 
     fn run(

--- a/crates/nu-command/src/path/dirname.rs
+++ b/crates/nu-command/src/path/dirname.rs
@@ -54,7 +54,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Get the parent directory of a path"
+        "Get the parent directory of a path."
     }
 
     fn run(

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -41,7 +41,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Check whether a path exists"
+        "Check whether a path exists."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -50,7 +50,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Try to expand a path to its absolute form"
+        "Try to expand a path to its absolute form."
     }
 
     fn run(

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -39,7 +39,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Get the type of the object a path refers to (e.g., file, dir, symlink)"
+        "Get the type of the object a path refers to (e.g., file, dir, symlink)."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/platform/ansi/gradient.rs
@@ -54,7 +54,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Add a color gradient (using ANSI color codes) to the given string"
+        "Add a color gradient (using ANSI color codes) to the given string."
     }
 
     fn run(

--- a/crates/nu-command/src/platform/ansi/link.rs
+++ b/crates/nu-command/src/platform/ansi/link.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Add a link (using OSC 8 escape sequence) to the given string"
+        "Add a link (using OSC 8 escape sequence) to the given string."
     }
 
     fn run(

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -25,7 +25,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Strip ANSI escape sequences from a string"
+        "Strip ANSI escape sequences from a string."
     }
 
     fn run(

--- a/crates/nu-command/src/platform/reedline_commands/keybindings.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings.rs
@@ -20,7 +20,7 @@ impl Command for Keybindings {
     }
 
     fn usage(&self) -> &str {
-        "Keybindings related commands"
+        "Keybindings related commands."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_default.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_default.rs
@@ -20,7 +20,7 @@ impl Command for KeybindingsDefault {
     }
 
     fn usage(&self) -> &str {
-        "List default keybindings"
+        "List default keybindings."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
+++ b/crates/nu-command/src/platform/reedline_commands/keybindings_list.rs
@@ -28,7 +28,7 @@ impl Command for KeybindingsList {
     }
 
     fn usage(&self) -> &str {
-        "List available options that can be used to create keybindings"
+        "List available options that can be used to create keybindings."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/platform/term_size.rs
+++ b/crates/nu-command/src/platform/term_size.rs
@@ -14,7 +14,7 @@ impl Command for TermSize {
     }
 
     fn usage(&self) -> &str {
-        "Returns a record containing the number of columns (width) and rows (height) of the terminal"
+        "Returns a record containing the number of columns (width) and rows (height) of the terminal."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/random/bool.rs
+++ b/crates/nu-command/src/random/bool.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Generate a random boolean value"
+        "Generate a random boolean value."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/random/chars.rs
+++ b/crates/nu-command/src/random/chars.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Generate random chars"
+        "Generate random chars."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/random/decimal.rs
+++ b/crates/nu-command/src/random/decimal.rs
@@ -24,7 +24,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Generate a random decimal within a range [min..max]"
+        "Generate a random decimal within a range [min..max]."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/random/dice.rs
+++ b/crates/nu-command/src/random/dice.rs
@@ -34,7 +34,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Generate a random dice roll"
+        "Generate a random dice roll."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/random/integer.rs
+++ b/crates/nu-command/src/random/integer.rs
@@ -24,7 +24,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Generate a random integer [min..max]"
+        "Generate a random integer [min..max]."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/random/uuid.rs
+++ b/crates/nu-command/src/random/uuid.rs
@@ -19,7 +19,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Generate a random uuid4 string"
+        "Generate a random uuid4 string."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -33,7 +33,7 @@ impl Command for DetectColumns {
     }
 
     fn usage(&self) -> &str {
-        "Attempt to automatically split text into multiple columns"
+        "Attempt to automatically split text into multiple columns."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -40,7 +40,7 @@ impl Command for DecodeBase64 {
     }
 
     fn usage(&self) -> &str {
-        "Base64 decode a value"
+        "Base64 decode a value."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -36,7 +36,7 @@ impl Command for EncodeBase64 {
     }
 
     fn usage(&self) -> &str {
-        "Encode a string or binary value using Base64"
+        "Encode a string or binary value using Base64."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -43,7 +43,7 @@ impl Command for FileSize {
     }
 
     fn usage(&self) -> &str {
-        "Converts a column of filesizes to some specified format"
+        "Converts a column of filesizes to some specified format."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/split/chars.rs
+++ b/crates/nu-command/src/strings/split/chars.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Split a string into a list of characters"
+        "Split a string into a list of characters."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -39,7 +39,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Split a string into multiple columns using a separator"
+        "Split a string into multiple columns using a separator."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Split a list into multiple lists using a separator"
+        "Split a list into multiple lists using a separator."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -33,7 +33,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Split a string into multiple rows using a separator"
+        "Split a string into multiple rows using a separator."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/split/words.rs
+++ b/crates/nu-command/src/strings/split/words.rs
@@ -55,7 +55,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Split a string's words into separate rows"
+        "Split a string's words into separate rows."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/strings/str_/case/camel_case.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert a string to camelCase"
+        "Convert a string to camelCase."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Capitalize first letter of text"
+        "Capitalize first letter of text."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Make text lowercase"
+        "Make text lowercase."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/strings/str_/case/kebab_case.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert a string to kebab-case"
+        "Convert a string to kebab-case."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/strings/str_/case/pascal_case.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert a string to PascalCase"
+        "Convert a string to PascalCase."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert a string to SCREAMING_SNAKE_CASE"
+        "Convert a string to SCREAMING_SNAKE_CASE."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert a string to snake_case"
+        "Convert a string to snake_case."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/str_.rs
+++ b/crates/nu-command/src/strings/str_/case/str_.rs
@@ -20,7 +20,7 @@ impl Command for Str {
     }
 
     fn usage(&self) -> &str {
-        "Various commands for working with string data"
+        "Various commands for working with string data."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Convert a string to Title Case"
+        "Convert a string to Title Case."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -24,7 +24,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Make text uppercase"
+        "Make text uppercase."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/collect.rs
+++ b/crates/nu-command/src/strings/str_/collect.rs
@@ -26,7 +26,7 @@ impl Command for StrCollect {
     }
 
     fn usage(&self) -> &str {
-        "Deprecated command"
+        "Deprecated command."
     }
 
     fn run(

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -43,7 +43,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Checks if string input contains a substring"
+        "Checks if string input contains a substring."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -43,7 +43,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Compare two strings and return the edit distance/Levenshtein distance"
+        "Compare two strings and return the edit distance/Levenshtein distance."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -41,7 +41,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Check if an input ends with a string"
+        "Check if an input ends with a string."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -65,7 +65,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns start index of first occurrence of string in input, or -1 if no match"
+        "Returns start index of first occurrence of string in input, or -1 if no match."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -26,7 +26,7 @@ impl Command for StrJoin {
     }
 
     fn usage(&self) -> &str {
-        "Concatenate multiple strings into a single string, with an optional separator between each"
+        "Concatenate multiple strings into a single string, with an optional separator between each."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -50,7 +50,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Output the length of any strings in the pipeline"
+        "Output the length of any strings in the pipeline."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -57,7 +57,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Find and replace text"
+        "Find and replace text."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Reverse every string in the pipeline"
+        "Reverse every string in the pipeline."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -43,7 +43,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Check if an input starts with a string"
+        "Check if an input starts with a string."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -60,7 +60,7 @@ impl Command for SubCommand {
             )
     }
     fn usage(&self) -> &str {
-        "Trim whitespace or specific character"
+        "Trim whitespace or specific character."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -21,7 +21,7 @@ impl Command for Complete {
     }
 
     fn usage(&self) -> &str {
-        "Capture the outputs and exit code from an external piped in command in a nushell table"
+        "Capture the outputs and exit code from an external piped in command in a nushell table."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -28,7 +28,7 @@ impl Command for NuCheck {
     }
 
     fn usage(&self) -> &str {
-        "Validate and parse input content"
+        "Validate and parse input content."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -32,7 +32,7 @@ impl Command for External {
     }
 
     fn usage(&self) -> &str {
-        "Runs external command"
+        "Runs external command."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/viewers/explore.rs
+++ b/crates/nu-command/src/viewers/explore.rs
@@ -23,7 +23,7 @@ impl Command for Explore {
     }
 
     fn usage(&self) -> &str {
-        "Explore acts as a table pager, just like `less` does for text"
+        "Explore acts as a table pager, just like `less` does for text."
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -48,7 +48,7 @@ impl Command for Table {
     }
 
     fn extra_usage(&self) -> &str {
-        "If the table contains a column called 'index', this column is used as the table index instead of the usual continuous index"
+        "If the table contains a column called 'index', this column is used as the table index instead of the usual continuous index."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1201,7 +1201,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock ls command"
+            "Mock ls command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {
@@ -1228,7 +1228,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock group-by command"
+            "Mock group-by command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {
@@ -1257,7 +1257,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock converter command"
+            "Mock converter command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {
@@ -1287,7 +1287,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock custom group-by command"
+            "Mock custom group-by command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {
@@ -1319,7 +1319,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock custom agg command"
+            "Mock custom agg command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {
@@ -1349,7 +1349,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock custom min command"
+            "Mock custom min command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {
@@ -1376,7 +1376,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock custom with-column command"
+            "Mock custom with-column command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {
@@ -1407,7 +1407,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock custom collect command"
+            "Mock custom collect command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {
@@ -1437,7 +1437,7 @@ mod input_types {
         }
 
         fn usage(&self) -> &str {
-            "Mock if command"
+            "Mock if command."
         }
 
         fn signature(&self) -> nu_protocol::Signature {


### PR DESCRIPTION
# Description

Working on uniformizing the ending messages regarding methods usage() and extra_usage(). This is related to the issue https://github.com/nushell/nushell/issues/5066 after discussing it with @jntrnr 

# User-Facing Changes

None.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
