### PR TITLE
math floor and ceil round to int rather than float #8258

### DIFF
--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -58,8 +58,8 @@ impl Command for SubCommand {
 fn operate(value: Value, head: Span) -> Value {
     match value {
         Value::Int { .. } => value,
-        Value::Float { val, span } => Value::Float {
-            val: val.ceil(),
+        Value::Float { val, span } => Value::Int {
+            val: val.ceil() as i64,
             span,
         },
         Value::Error { .. } => value,

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -58,8 +58,8 @@ impl Command for SubCommand {
 fn operate(value: Value, head: Span) -> Value {
     match value {
         Value::Int { .. } => value,
-        Value::Float { val, span } => Value::Float {
-            val: val.floor(),
+        Value::Float { val, span } => Value::Int {
+            val: val.floor() as i64,
             span,
         },
         Value::Error { .. } => value,


### PR DESCRIPTION
# Description

#8258 

Math floor and ceil return int types rather than floats.

# User-Facing Changes

Before:
```
/home/rdevenney/projects/open_source/nushell〉[(3.14 | math ceil | describe), 
(3.14 | math floor | describe), 
(3 | math ceil | describe), 
(3 | math floor | describe)]
╭───┬───────╮
│ 0 │ float │
│ 1 │ float │
│ 2 │ int   │
│ 3 │ int   │
╰───┴───────╯

```

After:
```
/home/rdevenney/projects/open_source/nushell〉[(3.14 | math ceil | describe), 
(3.14 | math floor | describe), 
(3 | math ceil | describe), 
(3 | math floor | describe)]
╭───┬─────╮
│ 0 │ int │
│ 1 │ int │
│ 2 │ int │
│ 3 │ int │
╰───┴─────╯

```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
