### PR TITLE
Type mismatch span fix #7288

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -115,7 +115,7 @@ impl PipelineData {
         match self {
             PipelineData::Empty => Value::nothing(span),
             PipelineData::Value(Value::Nothing { .. }, ..) => Value::nothing(span),
-            PipelineData::Value(v, ..) => v,
+            PipelineData::Value(v, ..) => v.with_span(span),
             PipelineData::ListStream(s, ..) => Value::List {
                 vals: s.collect(),
                 span, // FIXME?

--- a/crates/nu-protocol/tests/test_pipeline_data.rs
+++ b/crates/nu-protocol/tests/test_pipeline_data.rs
@@ -1,0 +1,24 @@
+use nu_protocol::{IntoPipelineData, Span, Value};
+
+#[test]
+fn test_convert_pipeline_data_to_value() {
+    // Setup PipelineData
+    let value_val = 10;
+    let value = Value::Int {
+        val: value_val,
+        span: Span::new(1, 3),
+    };
+    let pipeline_data = value.into_pipeline_data();
+
+    // Test that conversion into Value is correct
+    let new_span = Span::new(5, 6);
+    let converted_value = pipeline_data.into_value(new_span);
+
+    assert_eq!(
+        converted_value,
+        Value::Int {
+            val: value_val,
+            span: new_span
+        }
+    );
+}


### PR DESCRIPTION
# Description

This change fixes the bug associated with an incorrect span in `type_mismatch` error message as described in #7288 

The `span` argument in the method `into_value` was not being used to convert a `PipelineData::Value` type so when called in [eval_expression](https://github.com/nushell/nushell/blob/main/crates/nu-engine/src/eval.rs#L514-L515), the original expression's span was not being used to overwrite the result of `eval_subexpression`.

# User-Facing Changes

Using the example described in the issue, the whole bracketed subexpression is correctly underlined.

Behavior before change:

```
let val = 10
($val | into string) + $val
Error: nu::shell::type_mismatch

  × Type mismatch during operation.
   ╭─[entry #2:1:1]
 1 │ ($val | into string) + $val
   ·         ─────┬─────  ┬ ──┬─
   ·              │       │   ╰── int
   ·              │       ╰── type mismatch for operator
   ·              ╰── string
   ╰────
```

Behavior after change:
```
let val = 10
($val | into string) + $val
Error: nu::shell::type_mismatch

  × Type mismatch during operation.
   ╭─[entry #2:1:1]
 1 │ ($val | into string) + $val
   · ──────────┬───────── ┬ ──┬─
   ·           │          │   ╰── int
   ·           │          ╰── type mismatch for operator
   ·           ╰── string
   ╰────
```


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
