### PR TITLE
Error out when config.nu has no editor configured

### DIFF
--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -58,7 +58,7 @@ impl Command for ConfigEnv {
         let mut nu_config = config_path.clone();
         nu_config.push("env.nu");
 
-        let (item, config_args) = get_editor(engine_state, stack)?;
+        let (item, config_args) = get_editor(engine_state, stack, call.head)?;
 
         gen_command(call.head, nu_config, item, config_args, env_vars_str).run_with_input(
             engine_state,

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -58,7 +58,7 @@ impl Command for ConfigNu {
         let mut nu_config = config_path.clone();
         nu_config.push("config.nu");
 
-        let (item, config_args) = get_editor(engine_state, stack)?;
+        let (item, config_args) = get_editor(engine_state, stack, call.head)?;
 
         gen_command(call.head, nu_config, item, config_args, env_vars_str).run_with_input(
             engine_state,

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, path::PathBuf};
 
 use nu_protocol::{
     engine::{EngineState, Stack},
-    Span, Spanned,
+    ShellError, Span, Spanned,
 };
 
 use crate::ExternalCommand;
@@ -10,7 +10,8 @@ use crate::ExternalCommand;
 pub(crate) fn get_editor(
     engine_state: &EngineState,
     stack: &mut Stack,
-) -> Result<(String, Vec<String>), nu_protocol::ShellError> {
+    span: Span,
+) -> Result<(String, Vec<String>), ShellError> {
     let config = engine_state.get_config();
     let env_vars = stack.get_env_vars(engine_state);
     let editor = if !config.buffer_editor.is_empty() {
@@ -19,10 +20,17 @@ pub(crate) fn get_editor(
         value.as_string()
     } else if let Some(value) = env_vars.get("VISUAL") {
         value.as_string()
-    } else if cfg!(target_os = "windows") {
-        Ok("notepad".to_string())
     } else {
-        Ok("nano".to_string())
+        Err(ShellError::GenericError(
+            "No editor configured".into(),
+            "Please specify one via environment variables $EDITOR or $VISUAL".into(),
+            Some(span),
+            Some(
+                "Nushell's config file can be found with the command: $nu.config-path. For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)"
+                    .into(),
+            ),
+            vec![],
+        ))
     }?;
     if let Some((a, b)) = editor.split_once(' ') {
         Ok((


### PR DESCRIPTION
# Description
Fixes #8245. Instead of trying to use `nano` or `notepad` as defaults, it errors out if finds that `buffer_editor` , $EDITOR, $VISUAL do not exist.

If the PR is landed, Ill update the website as it means what its in there is no longer correct. 
```
❯ config nu
Error: 
  × No editor configured
   ╭─[entry #3:1:1]
 1 │ config nu
   · ────┬────
   ·     ╰── Please specify one via environment variables $EDITOR or $VISUAL
   ╰────
  help: Nushell's config file can be found with the command: $nu.config-path. For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)
  
  ``` 
# User-Facing Changes

# Tests + Formatting


Make sure you've run and fixed any issues with these commands:

- [X]  `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [X] `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
