### PR TITLE
fix `NotAConstant` error help message

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -393,7 +393,7 @@ pub enum ParseError {
     #[error("Not a constant.")]
     #[diagnostic(
         code(nu::parser::not_a_constant),
-        help("Only a subset of expressions are allowed constants during parsing. Try using the 'let' command or typing the value literally.")
+        help("Only a subset of expressions are allowed constants during parsing. Try using the 'const' command or typing the value literally.")
     )]
     NotAConstant(#[label = "Value is not a parse-time constant"] Span),
 


### PR DESCRIPTION
```
Error: nu::parser::not_a_constant (link)

  × Not a constant.
   ╭─[entry #23:1:1]
 1 │ let file = "/home/user/file"; source $file
   ·                                      ──┬──
   ·                                        ╰── Value is not a parse-time constant
   ╰────
  help: Only a subset of expressions are allowed
        constants during parsing. Try using the 'let'
        command or typing the value literally.
```
this pr changes the help message to 'Try using the `const` command ...'