### PR TITLE
Shadow rs dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4795,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da90bd2a722461267a2c5d20b2c6de76dba087348e60484fd6c3fbb48b766d6"
+checksum = "427f07ab5f873000cf55324882e12a88c0a7ea7025df4fc1e7e35e688877a583"
 dependencies = [
  "const_format",
  "is_debug",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,7 +2818,6 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "sha2",
- "shadow-rs",
  "sqlparser",
  "sysinfo 0.28.0",
  "tabled",

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -22,10 +22,10 @@ nu-utils = { path = "../nu-utils", version = "0.76.1" }
 fancy-regex = "0.11.0"
 itertools = "0.10.0"
 log = "0.4.14"
-shadow-rs = { version = "0.20.0", default-features = false }
+shadow-rs = { version = "0.21.0", default-features = false }
 
 [build-dependencies]
-shadow-rs = { version = "0.20.0", default-features = false }
+shadow-rs = { version = "0.21.0", default-features = false }
 
 [dev-dependencies]
 nu-test-support = { path="../nu-test-support", version = "0.76.1"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -84,7 +84,6 @@ sha2 = "0.10.0"
 percent-encoding = "2.2.0"
 reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
-shadow-rs = { version = "0.20.0", default-features = false }
 sqlparser = { version = "0.30.0", features = ["serde"], optional = true }
 sysinfo = "0.28.0"
 tabled = "0.10.0"


### PR DESCRIPTION
# Description

While looking at the recent MR merged, I noticed that a dependency was no more used with https://github.com/nushell/nushell/pull/8280.

# User-Facing Changes

None.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
