### PR TITLE
FEATURE: add a `path add` to the standard library

### DIFF
--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -122,3 +122,19 @@ export def match [
         do $default
     }
 }
+
+# Add the given paths to PATH
+export def-env "path-add" [
+    --ret(-r) # return the env (useful in pipelines to avoid scoping)
+    --prepend(-p) # prepend instead of appending.
+    ...paths # the paths to add
+    ] {
+    let-env PATH = if $prepend {
+        ($env.PATH | prepend  $paths)
+    } else {
+        ($env.PATH | append $paths)
+    }
+    if $ret {
+        $env.PATH
+    }
+}

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -123,17 +123,18 @@ export def match [
     }
 }
 
-# Add the given paths to PATH
-export def-env "path-add" [
-    --ret(-r) # return the env (useful in pipelines to avoid scoping)
-    --prepend(-p) # prepend instead of appending.
-    ...paths # the paths to add
-    ] {
-    let-env PATH = if $prepend {
-        ($env.PATH | prepend  $paths)
-    } else {
-        ($env.PATH | append $paths)
-    }
+# Add the given paths to the PATH.
+export def-env "path add" [
+    --ret (-r)  # return $env.PATH, useful in pipelines to avoid scoping.
+    --append (-a)  # append to $env.PATH instead of prepending to.
+    ...paths  # the paths to add to $env.PATH.
+] {
+    let-env PATH = (
+        $env.PATH
+        | if $append { append $paths }
+        else { prepend $paths }
+    )
+
     if $ret {
         $env.PATH
     }

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -124,6 +124,27 @@ export def match [
 }
 
 # Add the given paths to the PATH.
+#
+# # Example
+# - adding some dummy paths to an empty PATH
+# ```nushell
+# >_ with-env [PATH []] {
+#     std path add "foo"
+#     std path add "bar" "baz"
+#     std path add "fooo" --append
+#
+#     assert eq $env.PATH ["bar" "baz" "foo" "fooo"]
+#
+#     print (std path add "returned" --ret)
+# }
+# ╭───┬──────────╮
+# │ 0 │ returned │
+# │ 1 │ bar      │
+# │ 2 │ baz      │
+# │ 3 │ foo      │
+# │ 4 │ fooo     │
+# ╰───┴──────────╯
+# ```
 export def-env "path add" [
     --ret (-r)  # return $env.PATH, useful in pipelines to avoid scoping.
     --append (-a)  # append to $env.PATH instead of prepending to.

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -40,7 +40,31 @@ def tests [] {
     assert ((std match 3 $branches { 0 }) == 0)
 }
 
+def test_path_add [] {
+    use std.nu "assert eq"
+
+    with-env [PATH []] {
+        assert eq $env.PATH []
+
+        std path add "/foo/"
+        assert eq $env.PATH ["/foo/"]
+
+        std path add "/bar/" "/baz/"
+        assert eq $env.PATH ["/bar/", "/baz/", "/foo/"]
+
+        let-env PATH = []
+
+        std path add "foo"
+        std path add "bar" "baz" --append
+        assert eq $env.PATH ["foo", "bar", "baz"]
+
+        assert eq (std path add "fooooo" --ret) ["fooooo", "foo", "bar", "baz"]
+        assert eq $env.PATH ["fooooo", "foo", "bar", "baz"]
+    }
+}
+
 def main [] {
     test_assert
     tests
+    test_path_add
 }


### PR DESCRIPTION
# Description
this PR adds the `path add` command to `crates/nu-utils/standard_library/std.nu`
- this comes from frequent questions over on the discord server, about how to add directories to the `PATH`
- this is greatly inspired from the [original `path-add`](https://discord.com/channels/601130461678272522/615253963645911060/1081206660816699402) from @melMass 
- allows to prepend and append a variable number of directories to the `PATH`
- i've added a description with an example
- i've added tests in `crates/nu-utils/standard_library/tests.nu` that hopefully covers all the features

# User-Facing Changes
`path add` can now be used from `std.nu`

# Tests + Formatting
the tests pass with
```bash
nu crates/nu-utils/standard_library/tests.nu
```

# After Submitting
```bash
$nothing
```
