### PR TITLE
print pipeline contents in `print`

### DIFF
--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -54,13 +54,13 @@ Since this command has no output, there is no point in piping it with other comm
         let to_stderr = call.has_flag("stderr");
 
         // This will allow for easy printing of pipelines as well
-        if !input.is_nothing() {
+        if !args.is_empty() {
+            for arg in args {
+                arg.into_pipeline_data()
+                    .print(engine_state, stack, no_newline, to_stderr)?;
+            }
+        } else if !input.is_nothing() {
             input.print(engine_state, stack, no_newline, to_stderr)?;
-        }
-
-        for arg in args {
-            arg.into_pipeline_data()
-                .print(engine_state, stack, no_newline, to_stderr)?;
         }
 
         Ok(PipelineData::empty())

--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -47,11 +47,16 @@ Since this command has no output, there is no point in piping it with other comm
         engine_state: &EngineState,
         stack: &mut Stack,
         call: &Call,
-        _input: PipelineData,
+        input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let args: Vec<Value> = call.rest(engine_state, stack, 0)?;
         let no_newline = call.has_flag("no-newline");
         let to_stderr = call.has_flag("stderr");
+
+        // This will allow for easy printing of pipelines as well
+        if !input.is_nothing() {
+            input.print(engine_state, stack, no_newline, to_stderr)?;
+        }
 
         for arg in args {
             arg.into_pipeline_data()


### PR DESCRIPTION
# Description

Have `print` print it's input, so it's easier to print a pipeline (esp after we land #8292 and related)

# User-Facing Changes

`print` will now print its input, if there are no args given

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
