### PR TITLE
Add is-interactive and is-login to NuVariable and allow running scripts with -i

### DIFF
--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -524,13 +524,15 @@ fn variables_completions() {
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
 
-    assert_eq!(9, suggestions.len());
+    assert_eq!(11, suggestions.len());
 
     let expected: Vec<String> = vec![
         "config-path".into(),
         "env-path".into(),
         "history-path".into(),
         "home-path".into(),
+        "is-interactive".into(),
+        "is-login".into(),
         "loginshell-path".into(),
         "os-info".into(),
         "pid".into(),

--- a/crates/nu-engine/src/nu_variable.rs
+++ b/crates/nu-engine/src/nu_variable.rs
@@ -37,6 +37,9 @@ impl LazyRecord for NuVariable {
         cols.push("pid");
         cols.push("os-info");
 
+        cols.push("is-interactive");
+        cols.push("is-login");
+
         cols
     }
 
@@ -177,6 +180,14 @@ impl LazyRecord for NuVariable {
 
                 Ok(os_record)
             }
+            "is-interactive" => Ok(Value::Bool {
+                val: self.engine_state.is_interactive,
+                span: self.span,
+            }),
+            "is-login" => Ok(Value::Bool {
+                val: self.engine_state.is_login,
+                span: self.span,
+            }),
             _ => err(&format!("Could not find column '{column}'")),
         }
     }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -145,6 +145,8 @@ pub struct EngineState {
     // If Nushell was started, e.g., with `nu spam.nu`, the file's parent is stored here
     pub currently_parsed_cwd: Option<PathBuf>,
     pub regex_cache: Arc<Mutex<LruCache<String, Regex>>>,
+    pub is_interactive: bool,
+    pub is_login: bool,
 }
 
 // The max number of compiled regexes to keep around in a LRU cache, arbitrarily chosen
@@ -195,6 +197,8 @@ impl EngineState {
             regex_cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(REGEX_CACHE_SIZE).expect("tried to create cache of size zero"),
             ))),
+            is_interactive: false,
+            is_login: false,
         }
     }
 

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -199,3 +199,59 @@ fn run_export_extern() {
         assert!(actual.out.contains("Usage"));
     })
 }
+
+#[test]
+fn run_in_login_mode() {
+    let child_output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "{:?} -l -c 'echo $nu.is-login'",
+            nu_test_support::fs::executable_path()
+        ))
+        .output()
+        .expect("true");
+
+    assert!(child_output.stderr.is_empty());
+}
+
+#[test]
+fn run_in_not_login_mode() {
+    let child_output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "{:?} -c 'echo $nu.is-login'",
+            nu_test_support::fs::executable_path()
+        ))
+        .output()
+        .expect("false");
+
+    assert!(child_output.stderr.is_empty());
+}
+
+#[test]
+fn run_in_interactive_mode() {
+    let child_output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "{:?} -i -c 'echo $nu.is-interactive'",
+            nu_test_support::fs::executable_path()
+        ))
+        .output()
+        .expect("true");
+
+    assert!(child_output.stderr.is_empty());
+}
+
+#[test]
+fn run_in_noninteractive_mode() {
+    let child_output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "{:?} -c 'echo $nu.is-interactive'",
+            nu_test_support::fs::executable_path()
+        ))
+        .output()
+        .expect("false");
+
+    assert!(child_output.stderr.is_empty());
+}


### PR DESCRIPTION
Add two rows in `$nu`, `$nu.is-interactive` and `$nu.is-login`, which are true when nu is run in interactive and login mode respectively. 

The `-i` flag now behaves a bit more like that of bash's, where the any provided command or file is run without REPL but in "interactive mode". This should entail sourcing interactive-mode config files, but since we are planning on overhauling the config system soon, I'm holding off on that. For now, all `-i` does is set `$nu.is-interactive` to be true.

About testing, I can't seem to find where cli-args get tested, so I haven't written any new tests for this. Also I don't think there are any docs that need updating. However if I'm wrong please tell me. 