### PR TITLE
Allow NU_LIBS_DIR and friends to be const

### DIFF
--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -6,7 +6,7 @@ use nu_protocol::{
     PipelineData, Span, Type, Value,
 };
 use reedline::Suggestion;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use super::completer::map_value_completions;
 
@@ -66,7 +66,7 @@ impl Completer for CustomCompletion {
                 ],
                 redirect_stdout: true,
                 redirect_stderr: true,
-                parser_info: vec![],
+                parser_info: HashMap::new(),
             },
             PipelineData::empty(),
         );

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -66,23 +66,24 @@ impl Command for OverlayUse {
         let mut name_arg: Spanned<String> = call.req(engine_state, caller_stack, 0)?;
         name_arg.item = trim_quotes_str(&name_arg.item).to_string();
 
-        let maybe_origin_module_id = if let Some(overlay_expr) = call.parser_info_nth(0) {
-            if let Expr::Overlay(module_id) = overlay_expr.expr {
-                module_id
+        let maybe_origin_module_id =
+            if let Some(overlay_expr) = call.get_parser_info("overlay_expr") {
+                if let Expr::Overlay(module_id) = overlay_expr.expr {
+                    module_id
+                } else {
+                    return Err(ShellError::NushellFailedSpanned(
+                        "Not an overlay".to_string(),
+                        "requires an overlay (path or a string)".to_string(),
+                        overlay_expr.span,
+                    ));
+                }
             } else {
                 return Err(ShellError::NushellFailedSpanned(
-                    "Not an overlay".to_string(),
-                    "requires an overlay (path or a string)".to_string(),
-                    overlay_expr.span,
+                    "Missing positional".to_string(),
+                    "missing required overlay".to_string(),
+                    call.head,
                 ));
-            }
-        } else {
-            return Err(ShellError::NushellFailedSpanned(
-                "Missing positional".to_string(),
-                "missing required overlay".to_string(),
-                call.head,
-            ));
-        };
+            };
 
         let overlay_name = if let Some(name) = call.opt(engine_state, caller_stack, 1)? {
             name
@@ -113,7 +114,12 @@ impl Command for OverlayUse {
 
             // Evaluate the export-env block (if any) and keep its environment
             if let Some(block_id) = module.env_block {
-                let maybe_path = find_in_dirs_env(&name_arg.item, engine_state, caller_stack)?;
+                let maybe_path = find_in_dirs_env(
+                    &name_arg.item,
+                    engine_state,
+                    caller_stack,
+                    call.get_parser_info("dirs_var").map(|x| &x.expr),
+                )?;
 
                 let block = engine_state.get_block(block_id);
                 let mut callee_stack = caller_stack.gather_captures(&block.captures);

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -48,7 +48,7 @@ impl Command for Use {
         let import_pattern = if let Some(Expression {
             expr: Expr::ImportPattern(pat),
             ..
-        }) = call.parser_info_nth(0)
+        }) = call.get_parser_info("import_pattern")
         {
             pat
         } else {
@@ -72,9 +72,12 @@ impl Command for Use {
                 let module_arg_str = String::from_utf8_lossy(
                     engine_state.get_span_contents(&import_pattern.head.span),
                 );
-                let maybe_parent = if let Some(path) =
-                    find_in_dirs_env(&module_arg_str, engine_state, caller_stack)?
-                {
+                let maybe_parent = if let Some(path) = find_in_dirs_env(
+                    &module_arg_str,
+                    engine_state,
+                    caller_stack,
+                    call.get_parser_info("dirs_var").map(|x| &x.expr),
+                )? {
                     path.parent().map(|p| p.to_path_buf()).or(None)
                 } else {
                     None

--- a/crates/nu-command/src/deprecated/source.rs
+++ b/crates/nu-command/src/deprecated/source.rs
@@ -45,7 +45,7 @@ impl Command for Source {
     ) -> Result<PipelineData, ShellError> {
         // Note: this hidden positional is the block_id that corresponded to the 0th position
         // it is put here by the parser
-        let block_id: i64 = call.req_parser_info(engine_state, stack, 0)?;
+        let block_id: i64 = call.req_parser_info(engine_state, stack, "block_id")?;
 
         let block = engine_state.get_block(block_id as usize).clone();
         eval_block_with_early_return(

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -42,12 +42,15 @@ impl Command for SourceEnv {
 
         // Note: this hidden positional is the block_id that corresponded to the 0th position
         // it is put here by the parser
-        let block_id: i64 = call.req_parser_info(engine_state, caller_stack, 0)?;
+        let block_id: i64 = call.req_parser_info(engine_state, caller_stack, "block_id")?;
 
         // Set the currently evaluated directory (file-relative PWD)
-        let mut parent = if let Some(path) =
-            find_in_dirs_env(&source_filename.item, engine_state, caller_stack)?
-        {
+        let mut parent = if let Some(path) = find_in_dirs_env(
+            &source_filename.item,
+            engine_state,
+            caller_stack,
+            call.get_parser_info("dirs_var").map(|x| &x.expr),
+        )? {
             PathBuf::from(&path)
         } else {
             return Err(ShellError::FileNotFound(source_filename.span));

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -106,7 +106,12 @@ impl Command for NuCheck {
             _ => {
                 if let Some(path_str) = path {
                     // look up the path as relative to FILE_PWD or inside NU_LIB_DIRS (same process as source-env)
-                    let path = match find_in_dirs_env(&path_str.item, engine_state, stack) {
+                    let path = match find_in_dirs_env(
+                        &path_str.item,
+                        engine_state,
+                        stack,
+                        call.get_parser_info("dirs_var").map(|x| &x.expr),
+                    ) {
                         Ok(path) => {
                             if let Some(path) = path {
                                 path

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -39,7 +39,7 @@ pub trait CallExt {
         &self,
         engine_state: &EngineState,
         stack: &mut Stack,
-        pos: usize,
+        name: &str,
     ) -> Result<T, ShellError>;
 }
 
@@ -111,9 +111,9 @@ impl CallExt for Call {
         &self,
         engine_state: &EngineState,
         stack: &mut Stack,
-        pos: usize,
+        name: &str,
     ) -> Result<T, ShellError> {
-        if let Some(expr) = self.parser_info_nth(pos) {
+        if let Some(expr) = self.get_parser_info(name) {
             let result = eval_expression(engine_state, stack, expr)?;
             FromValue::from_value(&result)
         } else if self.parser_info.is_empty() {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -831,7 +831,7 @@ pub fn eval_element_with_input(
                             ],
                             redirect_stdout: false,
                             redirect_stderr: false,
-                            parser_info: vec![],
+                            parser_info: HashMap::new(),
                         },
                         input,
                     )
@@ -902,7 +902,7 @@ pub fn eval_element_with_input(
                             ],
                             redirect_stdout: false,
                             redirect_stderr: false,
-                            parser_info: vec![],
+                            parser_info: HashMap::new(),
                         },
                         input,
                     )

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::Expression;
@@ -19,7 +21,7 @@ pub struct Call {
     pub redirect_stdout: bool,
     pub redirect_stderr: bool,
     /// this field is used by the parser to pass additional command-specific information
-    pub parser_info: Vec<Expression>,
+    pub parser_info: HashMap<String, Expression>,
 }
 
 impl Call {
@@ -30,7 +32,7 @@ impl Call {
             arguments: vec![],
             redirect_stdout: true,
             redirect_stderr: false,
-            parser_info: vec![],
+            parser_info: HashMap::new(),
         }
     }
 
@@ -70,10 +72,6 @@ impl Call {
         self.arguments.push(Argument::Positional(positional));
     }
 
-    pub fn add_parser_info(&mut self, info: Expression) {
-        self.parser_info.push(info);
-    }
-
     pub fn add_unknown(&mut self, unknown: Expression) {
         self.arguments.push(Argument::Unknown(unknown));
     }
@@ -106,8 +104,12 @@ impl Call {
         self.positional_iter().count()
     }
 
-    pub fn parser_info_nth(&self, i: usize) -> Option<&Expression> {
-        self.parser_info.get(i)
+    pub fn get_parser_info(&self, name: &str) -> Option<&Expression> {
+        self.parser_info.get(name)
+    }
+
+    pub fn set_parser_info(&mut self, name: String, val: Expression) -> Option<Expression> {
+        self.parser_info.insert(name, val)
     }
 
     pub fn has_flag(&self, flag_name: &str) -> bool {


### PR DESCRIPTION
# Description

Allow NU_LIBS_DIR and friends to be const they can be updated within the same parse pass. This will allow us to remove having multiple config files eventually. 

Small implementation detail: I've changed `call.parser_info` to a hashmap with string keys, so the information can have names rather than indices, and we don't have to worry too much about the order in which we put things into it.

# User-Facing Changes

In a single file, users can now do stuff like
```
const NU_LIBS_DIR = ['/some/path/here']
source script.nu
```
and the source statement will use the value of NU_LIBS_DIR declared the line before. 

Currently, if there is no `NU_LIBS_DIR` const, then we fallback to using the value of the `NU_LIBS_DIR` env-var, so there are no breaking changes (unless someone named a const NU_LIBS_DIR for some reason). 

# Tests + Formatting

TODO

# After Submitting

TODO
