### PR TITLE
Resolve Clippy warnings inside tests.

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -315,9 +315,12 @@ mod command_completions_tests {
                 working_set.render()
             };
 
-            if let Err(err) = engine_state.merge_delta(delta) {
-                assert!(false, "Merge delta has failed: {}", err);
-            }
+            let result = engine_state.merge_delta(delta);
+            assert!(
+                result.is_ok(),
+                "Merge delta has failed: {}",
+                result.err().unwrap()
+            );
 
             let is_passthrough_command = is_passthrough_command(engine_state.get_file_contents());
             assert_eq!(

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -596,9 +596,12 @@ mod completer_tests {
             working_set.render()
         };
 
-        if let Err(err) = engine_state.merge_delta(delta) {
-            assert!(false, "Error merging delta: {:?}", err);
-        }
+        let result = engine_state.merge_delta(delta);
+        assert!(
+            result.is_ok(),
+            "Error merging delta: {:?}",
+            result.err().unwrap()
+        );
 
         let mut completer = NuCompleter::new(engine_state.into(), Stack::new());
         let dataset = vec![
@@ -617,7 +620,7 @@ mod completer_tests {
         for (line, has_result, begins_with, expected_values) in dataset {
             let result = completer.completion_helper(line, line.len());
             // Test whether the result is empty or not
-            assert_eq!(result.len() > 0, has_result, "line: {}", line);
+            assert_eq!(!result.is_empty(), has_result, "line: {}", line);
 
             // Test whether the result begins with the expected value
             result
@@ -629,7 +632,7 @@ mod completer_tests {
                 result
                     .iter()
                     .map(|x| expected_values.contains(&x.value.as_str()))
-                    .filter(|x| *x == true)
+                    .filter(|x| *x)
                     .count(),
                 expected_values.len(),
                 "line: {}",

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -23,7 +23,7 @@ fn copies_a_file_impl(progress: bool) {
         let progress_flag = if progress { "-p" } else { "" };
 
         // Get the hash of the file content to check integrity after copy.
-        let first_hash = get_file_hash(&test_file.display());
+        let first_hash = get_file_hash(test_file.display());
 
         nu!(
             cwd: dirs.root(),
@@ -175,15 +175,15 @@ fn deep_copies_with_recursive_flag_impl(progress: bool) {
         assert!(expected_dir.exists());
         assert!(files_exist_at(
             vec![Path::new("errors.txt"), Path::new("multishells.txt")],
-            &jonathans_expected_copied_dir
+            jonathans_expected_copied_dir
         ));
         assert!(files_exist_at(
             vec![Path::new("coverage.txt"), Path::new("commands.txt")],
-            &andres_expected_copied_dir
+            andres_expected_copied_dir
         ));
         assert!(files_exist_at(
             vec![Path::new("defer-evaluation.txt")],
-            &yehudas_expected_copied_dir
+            yehudas_expected_copied_dir
         ));
     })
 }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -83,7 +83,7 @@ fn test_int(
             },
         ) = &expressions[0]
         {
-            compare_rhs_binaryOp(test_tag, &expected_val, &observed_val);
+            compare_rhs_binaryOp(test_tag, &expected_val, observed_val);
         }
     }
 }


### PR DESCRIPTION
# Description

Command: `cargo clippy --workspace --all-targets`

Resolve those warnings:

```
warning: this expression creates a reference which is immediately dereferenced by the compiler
  --> crates/nu-parser/tests/test_parser.rs:86:59
   |
86 |             compare_rhs_binaryOp(test_tag, &expected_val, &observed_val);
   |                                                           ^^^^^^^^^^^^^ help: change this to: `observed_val`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: `assert!(false, ..)` should probably be replaced
   --> crates/nu-cli/src/completions/command_completions.rs:319:17
    |
319 |                 assert!(false, "Merge delta has failed: {}", err);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `panic!(..)` or `unreachable!(..)`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
    = note: `#[warn(clippy::assertions_on_constants)]` on by default

warning: 1 warning emitted

warning: `assert!(false, ..)` should probably be replaced
   --> crates/nu-cli/src/completions/completer.rs:600:13
    |
600 |             assert!(false, "Error merging delta: {:?}", err);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use `panic!(..)` or `unreachable!(..)`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants

warning: length comparison to zero
   --> crates/nu-cli/src/completions/completer.rs:620:24
    |
620 |             assert_eq!(result.len() > 0, has_result, "line: {}", line);
    |                        ^^^^^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!result.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
    = note: `#[warn(clippy::len_zero)]` on by default

warning: equality checks against true are unnecessary
   --> crates/nu-cli/src/completions/completer.rs:632:33
    |
632 |                     .filter(|x| *x == true)
    |                                 ^^^^^^^^^^ help: try simplifying it as shown: `*x`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_comparison
    = note: `#[warn(clippy::bool_comparison)]` on by default

    Checking nu v0.76.1 (/home/jaudiger/Development/git-repositories/jaudiger/nushell)
warning: 4 warnings emitted

warning: the borrowed expression implements the required traits
  --> crates/nu-command/tests/commands/cp.rs:26:40
   |
26 |         let first_hash = get_file_hash(&test_file.display());
   |                                        ^^^^^^^^^^^^^^^^^^^^ help: change this to: `test_file.display()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `#[warn(clippy::needless_borrow)]` on by default

warning: the borrowed expression implements the required traits
   --> crates/nu-command/tests/commands/cp.rs:178:13
    |
178 |             &jonathans_expected_copied_dir
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `jonathans_expected_copied_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> crates/nu-command/tests/commands/cp.rs:182:13
    |
182 |             &andres_expected_copied_dir
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `andres_expected_copied_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> crates/nu-command/tests/commands/cp.rs:186:13
    |
186 |             &yehudas_expected_copied_dir
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `yehudas_expected_copied_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: 4 warnings emitted
```

# User-Facing Changes

None.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
