### PR TITLE
Fix CPU usage info in `sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
  "percent-encoding",
  "reedline",
  "rstest",
- "sysinfo 0.28.0",
+ "sysinfo 0.28.2",
  "thiserror",
 ]
 
@@ -2757,7 +2757,7 @@ dependencies = [
  "sha2",
  "shadow-rs",
  "sqlparser",
- "sysinfo 0.28.0",
+ "sysinfo 0.28.2",
  "tabled",
  "terminal_size 0.2.1",
  "thiserror",
@@ -2786,7 +2786,7 @@ dependencies = [
  "nu-protocol",
  "nu-utils",
  "serde",
- "sysinfo 0.28.0",
+ "sysinfo 0.28.2",
 ]
 
 [[package]]
@@ -5060,9 +5060,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.28.0"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727220a596b4ca0af040a07091e49f5c105ec8f2592674339a5bf35be592f76e"
+checksum = "d3e847e2de7a137c8c2cede5095872dbb00f4f9bf34d061347e36b43322acd56"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -36,7 +36,7 @@ once_cell = "1.17.0"
 log = "0.4"
 miette = { version = "5.5.0", features = ["fancy-no-backtrace"] }
 percent-encoding = "2"
-sysinfo = "0.28.0"
+sysinfo = "0.28.2"
 thiserror = "1.0.31"
 
 [features]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -86,7 +86,7 @@ reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 shadow-rs = { version = "0.20.0", default-features = false }
 sqlparser = { version = "0.30.0", features = ["serde"], optional = true }
-sysinfo = "0.28.0"
+sysinfo = "0.28.2"
 tabled = "0.10.0"
 terminal_size = "0.2.1"
 thiserror = "1.0.31"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -18,7 +18,7 @@ nu-utils = { path = "../nu-utils", version = "0.76.1"  }
 
 chrono = { version="0.4.23", features = ["std"], default-features = false }
 serde = {version = "1.0.143", default-features = false }
-sysinfo ="0.28.0"
+sysinfo ="0.28.2"
 
 [features]
 plugin = []


### PR DESCRIPTION
Closes #8264. This PR does a few things to fix the `usage` column in `sys.cpu`:

1. Sleep a while (~400ms) between calls to `sys.refresh_cpu()`, [as required by `sysinfo`](https://docs.rs/sysinfo/latest/sysinfo/trait.SystemExt.html#method.refresh_cpu)
2. Change `sys` to return a `LazyRecord` (so you can do things like `sys | get host` instantly without waiting for CPU info)
3. Update our `sysinfo` dependency to [fix CPU usage calculations on Linux](https://github.com/GuillaumeGomez/sysinfo/pull/946)

CPU usage is no longer always reported as zero:

![image](https://user-images.githubusercontent.com/26268125/222929775-5e9cbe18-95d9-4ecb-baf8-1e843f5c7086.png)