### PR TITLE
`cp` progress bar - cleaner version

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -284,7 +284,7 @@ impl Command for Cp {
                 let mut n_file = 0;
 
                 for (s, d) in sources {
-                    n_file = n_file + 1;
+                    n_file += 1;
                     overall_pb.update_bar(n_file);
 
                     // Check if the user has pressed ctrl+c before copying a file
@@ -523,9 +523,7 @@ fn copy_file_with_progressbar(
 
     // With this I am able to update the overall progress bar.
     let mut stdout = stdout();
-    stdout
-        .execute(cursor::MoveToPreviousLine(0))
-        .unwrap_or_default();
+    let _tmp_pos = stdout.execute(cursor::MoveToPreviousLine(0));
 
     Value::String { val: msg, span }
 }

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -363,7 +363,11 @@ fn stream_to_file(
     // It looks a bit messy but I am doing it this way to avoid
     // creating the bar when is not needed
     let (mut bar_opt, bar_opt_clone) = if progress {
-        let tmp_bar = progress_bar::NuProgressBar::new(file_total_size);
+        let tmp_bar = progress_bar::NuProgressBar::new(
+            progress_bar::ProgressType::ProgressBytes,
+            file_total_size,
+            "".to_string(),
+        );
         let tmp_bar_clone = tmp_bar.clone();
 
         (Some(tmp_bar), Some(tmp_bar_clone))

--- a/crates/nu-command/src/progress_bar.rs
+++ b/crates/nu-command/src/progress_bar.rs
@@ -1,4 +1,4 @@
-use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
+use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use std::fmt;
 
 // This module includes the progress bar used to show the progress when using the command `save`

--- a/crates/nu-command/src/progress_bar.rs
+++ b/crates/nu-command/src/progress_bar.rs
@@ -1,4 +1,4 @@
-use indicatif::{ProgressBar, ProgressState, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressState, ProgressStyle};
 use std::fmt;
 
 // This module includes the progress bar used to show the progress when using the command `save`
@@ -10,25 +10,62 @@ pub struct NuProgressBar {
     total_bytes: Option<u64>,
 }
 
+#[derive(PartialEq)]
+pub enum ProgressType {
+    ProgressBytes,
+    ProgressItems,
+}
+
 impl NuProgressBar {
-    pub fn new(total_bytes: Option<u64>) -> NuProgressBar {
+    pub fn new(
+        progress_type: ProgressType,
+        total_progress: Option<u64>,
+        msg: String,
+    ) -> NuProgressBar {
+        let (progress_flag_current, progress_flag_goal) = match progress_type {
+            ProgressType::ProgressBytes => ("{bytes}", "{total_bytes}"),
+            ProgressType::ProgressItems => ("{pos}", "{len}"),
+        };
+
+        let progress_flag_eta = if progress_type == ProgressType::ProgressBytes {
+            "({eta})"
+        } else {
+            ""
+        };
+        let progress_flag_bytes_per_sec = if progress_type == ProgressType::ProgressBytes {
+            "{binary_bytes_per_sec}"
+        } else {
+            ""
+        };
+
         // Let's create the progress bar template.
-        let template = match total_bytes {
+        let template = match total_progress {
             Some(_) => {
+                let str_template = format!(
+                    "{{spinner:.green}} [{{elapsed_precise}}] [{{bar:30.cyan/blue}}] [{}/{}] {} {} {{wide_msg}}",
+                    progress_flag_current,
+                    progress_flag_goal,
+                    progress_flag_bytes_per_sec,
+                    progress_flag_eta
+                );
+
                 // We will use a progress bar if we know the total bytes of the stream
-                ProgressStyle::with_template("{spinner:.green} [{elapsed_precise}] [{bar:30.cyan/blue}] [{bytes}/{total_bytes}] {binary_bytes_per_sec} ({eta}) {wide_msg}")
+                ProgressStyle::with_template(&str_template)
             }
             _ => {
+                let str_template = format!(
+                    "{{spinner:.green}} [{{elapsed_precise}}] {} {} {{wide_msg}}",
+                    progress_flag_current, progress_flag_bytes_per_sec
+                );
+
                 // But if we don't know the total then we just show the stats progress
-                ProgressStyle::with_template(
-                    "{spinner:.green} [{elapsed_precise}] {bytes} {binary_bytes_per_sec} {wide_msg}",
-                )
+                ProgressStyle::with_template(&str_template)
             }
         };
 
-        let total_bytes = total_bytes.unwrap_or_default();
+        let total_progress = total_progress.unwrap_or_default();
 
-        let new_progress_bar = ProgressBar::new(total_bytes);
+        let new_progress_bar = ProgressBar::new(total_progress);
         new_progress_bar.set_style(
             template
                 .unwrap_or_else(|_| ProgressStyle::default_bar())
@@ -37,6 +74,8 @@ impl NuProgressBar {
                 })
                 .progress_chars("#>-"),
         );
+
+        new_progress_bar.set_message(msg);
 
         NuProgressBar {
             pb: new_progress_bar,
@@ -49,8 +88,12 @@ impl NuProgressBar {
         self.pb.set_position(bytes_processed);
     }
 
-    pub fn finished_msg(&self, msg: String) {
-        self.pb.finish_with_message(msg);
+    pub fn finished_msg(&self, msg: String, clear: bool) {
+        if clear {
+            self.pb.finish_and_clear();
+        } else {
+            self.pb.finish_with_message(msg);
+        }
     }
 
     pub fn abandoned_msg(&self, msg: String) {


### PR DESCRIPTION
# Description

Cleaner version for the `cp` progress bar. discussed [here](https://github.com/nushell/nushell/pull/8012#pullrequestreview-1294839180) and [here](https://github.com/nushell/nushell/pull/8012#issuecomment-1427313054)

![nu_pb04](https://user-images.githubusercontent.com/38369407/222989305-7a35d19d-40fb-4b8b-ae79-11ab3226f2a4.jpg)

# User-Facing Changes
NONE

# Tests + Formatting

Check - `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
Check - `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
Check - `cargo test --workspace` to check that all tests pass
