### PR TITLE
Add SSL tests for `http get`

### DIFF
--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -38,3 +38,30 @@ fn http_get_failed_due_to_server_error() {
 
     assert!(actual.err.contains("Bad request (400)"))
 }
+
+// These tests require network access; they use badssl.com which is a Google-affiliated site for testing various SSL errors.
+// Revisit this if these tests prove to be flaky or unstable.
+
+#[test]
+fn http_get_expired_cert_fails() {
+    let actual = nu!("http get https://expired.badssl.com/");
+    assert!(actual.err.contains("network_failure"));
+}
+
+#[test]
+fn http_get_expired_cert_override() {
+    let actual = nu!("http get --insecure https://expired.badssl.com/");
+    assert!(actual.out.contains("<html>"));
+}
+
+#[test]
+fn http_get_self_signed_fails() {
+    let actual = nu!("http get https://self-signed.badssl.com/");
+    assert!(actual.err.contains("network_failure"));
+}
+
+#[test]
+fn http_get_self_signed_override() {
+    let actual = nu!("http get --insecure https://self-signed.badssl.com/");
+    assert!(actual.out.contains("<html>"));
+}


### PR DESCRIPTION
This PR adds tests to confirm that:
1. `http get` does the right thing (bail) when it encounters common SSL errors
2. the `--insecure` flag works to ignore SSL errors

It's prompted by #8098, where `--insecure` stopped working and we didn't notice until it was reported by a user.

## Deets + considerations

This PR uses [badssl.com](https://badssl.com/), a very handy website affiliated with the Google Chrome team. The badssl authors mention that stability is not guaranteed:

> Most subdomains are likely to have stable functionality, but anything could change without notice. 

I suspect that the badssl.com subdomains I've chosen will be stable enough in practice. Can revisit this if the tests end up being flaky.

This PR does mean our tests are now making an external network call... which I _think_ is OK. Our CI isn't exactly designed for offline machines; test runners already have to download a bunch of crates etc. I think the new tests are quick enough:

![image](https://user-images.githubusercontent.com/26268125/222992751-a9f0d8ff-b776-4ea5-908a-7d11607487fe.png)