### PR TITLE
Put a lock around `cargo build` invocations for plugin tests

### DIFF
--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -252,7 +252,7 @@ macro_rules! nu_with_plugins {
         let temp_plugin_file = temp.path().join("plugin.nu");
         std::fs::File::create(&temp_plugin_file).expect("couldn't create temporary plugin file");
 
-        $($crate::commands::ensure_binary_present($plugin_name);)+
+        $crate::commands::ensure_plugins_built();
 
         // TODO: the `$format` is a dummy empty string, but `plugin_name` is repeatable
         // just keep it here for now.  Need to find a way to remove it.


### PR DESCRIPTION
I think this _might_ fix the issues we've been seeing with plugin tests.

In a nutshell, the plugin tests run `cargo build` to ensure that plugins have been built: https://github.com/nushell/nushell/blob/f6ca62384e6140c32894ba94a3d703c7b08ae67f/crates/nu-test-support/src/commands.rs#L6

This PR adds a mutex to ensure that we're never running `cargo build` concurrently. It also uses an atomic bool to signal when plugins have already been built, so we can avoid invoking `cargo build` multiple times unnecessarily.

I can't be certain yet, but I'm guessing the macOS CI problems we've been seeing come from plugin tests clobbering each other (something like: test 1 builds the `foo` plugin, then test2 invokes `cargo build` again and deletes the `foo` plugin from disk).