### PR TITLE
Cratification: Test Infrastructure Support Part One

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -101,6 +101,7 @@ pub(crate) fn parse_commandline_args(
             let testbin: Option<Expression> = call.get_flag_expr("testbin");
             #[cfg(feature = "plugin")]
             let plugin_file: Option<Expression> = call.get_flag_expr("plugin-config");
+            let no_config_file = call.get_named_arg("no-config-file");
             let config_file: Option<Expression> = call.get_flag_expr("config");
             let env_file: Option<Expression> = call.get_flag_expr("env-config");
             let log_level: Option<Expression> = call.get_flag_expr("log-level");
@@ -171,6 +172,7 @@ pub(crate) fn parse_commandline_args(
                 testbin,
                 #[cfg(feature = "plugin")]
                 plugin_file,
+                no_config_file,
                 config_file,
                 env_file,
                 log_level,
@@ -202,6 +204,7 @@ pub(crate) struct NushellCliArgs {
     pub(crate) testbin: Option<Spanned<String>>,
     #[cfg(feature = "plugin")]
     pub(crate) plugin_file: Option<Spanned<String>>,
+    pub(crate) no_config_file: Option<Spanned<String>>,
     pub(crate) config_file: Option<Spanned<String>>,
     pub(crate) env_file: Option<Spanned<String>>,
     pub(crate) log_level: Option<Spanned<String>>,
@@ -241,6 +244,11 @@ impl Command for Nu {
                 SyntaxShape::String,
                 "the table mode to use. rounded is default.",
                 Some('m'),
+            )
+            .switch(
+                "no-config-file",
+                "start with no config file and no env file",
+                Some('n'),
             )
             .named(
                 "threads",

--- a/src/run.rs
+++ b/src/run.rs
@@ -201,7 +201,7 @@ pub(crate) fn run_repl(
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
 
-    if !parsed_nu_cli_args.no_config_file.is_some() {
+    if parsed_nu_cli_args.no_config_file.is_none() {
         setup_config(
             &mut engine_state,
             &mut stack,

--- a/src/run.rs
+++ b/src/run.rs
@@ -201,15 +201,18 @@ pub(crate) fn run_repl(
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
 
-    setup_config(
-        &mut engine_state,
-        &mut stack,
-        #[cfg(feature = "plugin")]
-        parsed_nu_cli_args.plugin_file,
-        parsed_nu_cli_args.config_file,
-        parsed_nu_cli_args.env_file,
-        parsed_nu_cli_args.login_shell.is_some(),
-    );
+    if !parsed_nu_cli_args.no_config_file.is_some() {
+        setup_config(
+            &mut engine_state,
+            &mut stack,
+            #[cfg(feature = "plugin")]
+            parsed_nu_cli_args.plugin_file,
+            parsed_nu_cli_args.config_file,
+            parsed_nu_cli_args.env_file,
+            parsed_nu_cli_args.login_shell.is_some(),
+        );
+    }
+
     // Reload use_color from config in case it's different from the default value
     let use_color = engine_state.get_config().use_ansi_coloring;
     perf(


### PR DESCRIPTION

startup nushell with no config file or env file...


This PR gives the ability to start up nushell easily with no config or env config files
simply by passing in

```rust
nu -n
```

or

```rust
nu --no-config-file
```

A bonus is that startup times for nushell decreases FIVE fold...
From about > 50ms to less than < 10ms on average on my mac

This will enable Part II which will hopefully be the ability to
to send this flag into the nu! macro and turn off loading of the config files...

Remember when config files are enabled the nu-cmd-lang tests fail because the
commands in the config files are a superset of the commands in nu-cmd-lang...

In my preliminary tests before by zeroing out the config files the nu-cmd-lang tests passed...

Independent of the cratification efforts I have always wanted a way anyway to turn off loading
the config files when starting up nushell...  So this accomplishes that task...
