### PR TITLE
Remove body parameters from `http get`

### DIFF
--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -39,13 +39,6 @@ impl Command for SubCommand {
                 "the password when authenticating",
                 Some('p'),
             )
-            .named("data", SyntaxShape::Any, "the content to post", Some('d'))
-            .named(
-                "content-type",
-                SyntaxShape::Any,
-                "the MIME type of content to post",
-                Some('t'),
-            )
             .named(
                 "max-time",
                 SyntaxShape::Int,
@@ -113,16 +106,6 @@ impl Command for SubCommand {
                 example: "http get -H [my-header-key my-header-value] https://www.example.com",
                 result: None,
             },
-            Example {
-                description: "Get content from example.com, with body",
-                example: "http get -d 'body' https://www.example.com",
-                result: None,
-            },
-            Example {
-                description: "Get content from example.com, with JSON body",
-                example: "http get -t application/json -d { field: value } https://www.example.com",
-                result: None,
-            },
         ]
     }
 }
@@ -130,8 +113,6 @@ impl Command for SubCommand {
 struct Arguments {
     url: Value,
     headers: Option<Value>,
-    data: Option<Value>,
-    content_type: Option<String>,
     raw: bool,
     insecure: bool,
     user: Option<String>,
@@ -148,8 +129,6 @@ fn run_get(
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,
         headers: call.get_flag(engine_state, stack, "headers")?,
-        data: call.get_flag(engine_state, stack, "data")?,
-        content_type: call.get_flag(engine_state, stack, "content-type")?,
         raw: call.has_flag("raw"),
         insecure: call.has_flag("insecure"),
         user: call.get_flag(engine_state, stack, "user")?,
@@ -177,7 +156,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, span, args.data, args.content_type);
+    let response = send_request(request, span, None, None);
     request_handle_response(
         engine_state,
         stack,


### PR DESCRIPTION
`http get` has 2 parameters which are used for setting the body of the HTTP request. They don't make sense because [GET requests should have no body](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET):

![image](https://user-images.githubusercontent.com/26268125/223032130-764d0313-df00-48a6-80a5-0d8ff296b8ae.png)