### PR TITLE
Fix `to json` for SQLite databases

### DIFF
--- a/crates/nu-command/src/dataframe/values/nu_dataframe/custom_value.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/custom_value.rs
@@ -33,10 +33,6 @@ impl CustomValue for NuDataFrame {
         Ok(Value::List { vals, span })
     }
 
-    fn to_json(&self) -> nu_json::Value {
-        nu_json::Value::Null
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/crates/nu-command/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu-command/src/dataframe/values/nu_expression/custom_value.rs
@@ -34,10 +34,6 @@ impl CustomValue for NuExpression {
         Ok(self.to_value(span))
     }
 
-    fn to_json(&self) -> nu_json::Value {
-        nu_json::Value::Null
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/crates/nu-command/src/dataframe/values/nu_lazyframe/custom_value.rs
+++ b/crates/nu-command/src/dataframe/values/nu_lazyframe/custom_value.rs
@@ -47,10 +47,6 @@ impl CustomValue for NuLazyFrame {
         Ok(Value::Record { cols, vals, span })
     }
 
-    fn to_json(&self) -> nu_json::Value {
-        nu_json::Value::Null
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/crates/nu-command/src/dataframe/values/nu_lazygroupby/custom_value.rs
+++ b/crates/nu-command/src/dataframe/values/nu_lazygroupby/custom_value.rs
@@ -38,10 +38,6 @@ impl CustomValue for NuLazyGroupBy {
         Ok(Value::Record { cols, vals, span })
     }
 
-    fn to_json(&self) -> nu_json::Value {
-        nu_json::Value::Null
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/crates/nu-command/src/dataframe/values/nu_when/custom_value.rs
+++ b/crates/nu-command/src/dataframe/values/nu_when/custom_value.rs
@@ -34,10 +34,6 @@ impl CustomValue for NuWhen {
         Ok(value)
     }
 
-    fn to_json(&self) -> nu_json::Value {
-        nu_json::Value::Null
-    }
-
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -142,7 +142,10 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
             let collected = val.collect()?;
             value_to_json_value(&collected)?
         }
-        Value::CustomValue { val, .. } => val.to_json(),
+        Value::CustomValue { val, span } => {
+            let collected = val.to_base_value(*span)?;
+            value_to_json_value(&collected)?
+        }
     })
 }
 

--- a/crates/nu-protocol/src/value/custom_value.rs
+++ b/crates/nu-protocol/src/value/custom_value.rs
@@ -17,11 +17,6 @@ pub trait CustomValue: fmt::Debug + Send + Sync {
     // That already exist in nushell
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError>;
 
-    // Json representation of custom value
-    fn to_json(&self) -> nu_json::Value {
-        nu_json::Value::Null
-    }
-
     // Any representation used to downcast object to its original type
     fn as_any(&self) -> &dyn std::any::Any;
 


### PR DESCRIPTION
Fixes #8341. 

The `CustomValue::to_json()` function is an odd duck; it defaults to returning `null`, and no `CustomValue` implementations override it to do anything useful. I forgot to implement `to_json()` for `SQLiteDatabase`, so `open foo.db | to json` was returning `null`.

To fix this, I've removed `CustomValue::to_json()` and now `to json` will collect a `CustomValue` into a regular `Value` before doing a JSON conversion.