### PR TITLE
FIX: redirect to `encode base64` as `hash bash64` is deprecated

### DIFF
--- a/crates/nu-command/src/strings/encode_decode/base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/base64.rs
@@ -93,7 +93,7 @@ fn action(
         not_valid => return Value::Error { error:ShellError::GenericError(
             "value is not an accepted character set".to_string(),
             format!(
-                "{not_valid} is not a valid character-set.\nPlease use `help hash base64` to see a list of valid character sets."
+                "{not_valid} is not a valid character-set.\nPlease use `help encode base64` to see a list of valid character sets."
             ),
             Some(config_character_set.span),
             None,


### PR DESCRIPTION
# Description
i tried yesterday to `encode` with an invalid character set and this is what i got
```bash
>_ {alg: "HS256", type: "JWT"} | to json -r | encode base64 --character-set invalid-character-set
Error:
  × value is not an accepted character set
   ╭─[entry #11:1:1]
 1 │ {alg: "HS256", type: "JWT"} | to json -r | encode base64 --character-set invalid-character-set
   ·                                                                          ──────────┬──────────
   ·                                                                                    ╰── invalid-character-set is not a valid character-set.
Please use `help hash base64` to see a list of valid character sets.
   ╰────
```

but `hash base64` is now a deprecated command, see `help hash base64`.

=> **this PR changes the error message to mention `help encode base64`, where the list of valid character sets is, instead**

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
- :green_circle: `cargo fmt --all`
- :green_circle: `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect`
- :green_circle: `cargo test --workspace`

# After Submitting
```
$nothing
```