### PR TITLE
fixed an error message that popped up after landing

### DIFF
--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -523,7 +523,7 @@ mod test {
             Span::test_data(),
         );
         if let Value::Error {
-            error: ShellError::IncorrectValue(e, ..),
+            error: ShellError::IncorrectValue { msg: e, .. },
         } = actual
         {
             assert!(

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -232,9 +232,10 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
                         .unwrap()
             {
                 Value::Error {
-                    error: ShellError::IncorrectValue(
-                        "DateTime out of range for timestamp: 1677-09-21T00:12:43Z to 2262-04-11T23:47:16".to_string(),
-                span),
+                    error: ShellError::IncorrectValue {
+                        msg: "DateTime out of range for timestamp: 1677-09-21T00:12:43Z to 2262-04-11T23:47:16".to_string(),
+                        span
+                    },
                 }
             } else {
                 Value::Int {


### PR DESCRIPTION
# Description

This PR fixes an error message that popped up after landing a PR #8337. I guess there were too many changes since the PR was submitted?

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
