### PR TITLE
add `dirs` command to std lib

### DIFF
--- a/crates/nu-utils/standard_library/dirs.nu
+++ b/crates/nu-utils/standard_library/dirs.nu
@@ -3,7 +3,8 @@
 # todo:
 # * expand relative to absolute paths (or relative to some prefix?)
 # * what if user does `cd` by hand?
-# * things I learned: let foo = (pipeline) + <expression> is devil's playground.
+# * fix dirs show to use active: true/false
+
 
 # the directory stack
 export-env {

--- a/crates/nu-utils/standard_library/dirs.nu
+++ b/crates/nu-utils/standard_library/dirs.nu
@@ -1,0 +1,81 @@
+# module dirs.nu -- maintain list of remembered directories + navigate them
+#
+# todo:
+# * expand relative to absolute paths (or relative to some prefix?)
+# * what if user does `cd` by hand?
+# * things I learned: let foo = (pipeline) + <expression> is devil's playground.
+
+# the directory stack
+export-env {
+    let-env DIRS_POSITION = 0
+    let-env DIRS_LIST = [$env.PWD]
+}
+
+# Add one or more directories to the list.
+# PWD becomes first of the newly added directories.
+export def-env "add" [
+    ...paths: string    # directory or directories to add to remembered list
+    ] {
+    let-env DIRS_LIST = ($env.DIRS_LIST | insert ($env.DIRS_POSITION + 1) $paths | flatten)
+    let-env DIRS_POSITION = $env.DIRS_POSITION + 1
+
+    _fetch 0
+}
+
+# Advance to the next directory in the list or wrap to beginning.
+export def-env "next" [
+    N:int = 1 # number of positions to move.
+] {
+    _fetch $N    
+}
+
+# Back up to the previous directory or wrap to the end.
+export def-env "prev" [
+    N:int = 1 # number of positions to move.
+] {
+    _fetch (-1 * $N)    
+}
+
+# Drop the current directory from the list, if it's not the only one.
+# PWD becomes the next remembered directory
+export def-env "drop" [] {
+    if ($env.DIRS_LIST | length) > 1 {
+        let-env DIRS_LIST = (($env.DIRS_LIST | take $env.DIRS_POSITION) | append ($env.DIRS_LIST | skip ($env.DIRS_POSITION + 1)))
+    }
+
+    _fetch 0
+}
+
+# display current remembered directories
+export def-env "show" [] {
+    mut out = []
+    for $p in ($env.DIRS_LIST | enumerate) {
+        $out = ($out | append [
+            [current, path]; 
+            [(if ($p.index == $env.DIRS_POSITION) {
+                    "==>"
+                } else {
+                    ""
+                })
+            , $p.item]
+        ])
+    }
+
+    $out
+}
+
+
+
+# fetch item helper
+def-env  _fetch [
+    offset: int,            # signed change to position
+] {
+    # nushell 'mod' operator is really 'remainder', can return negative values.
+    # see: https://stackoverflow.com/questions/13683563/whats-the-difference-between-mod-and-remainder    
+    let pos = ($env.DIRS_POSITION + $offset + ($env.DIRS_LIST | length)) mod ($env.DIRS_LIST | length)
+    # echo $"at ($pos); item is: ($env.DIRS_LIST |  get $pos)"
+    let-env DIRS_POSITION = $pos
+
+    cd ($env.DIRS_LIST | get $pos )
+}
+            

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -3,7 +3,6 @@
 # ----------- sub modules to be loaded as part of stdlib ------------------
 # (choose flavor of import that puts your functions in the right namespace)
 # This imports into std top-level namespace: std <subcommand>
-# (not what I want for a new subcommand.)
 # export use dirs.nu *
 # This imports into std *sub* namespace: std dirs <subcommand>
 # export use dirs.nu
@@ -11,6 +10,11 @@
 # to put the subcommands at the top level: dirs <subcommand>
 
 export use dirs.nu
+# the directory stack -- export-env from submodule doesn't work?
+export-env {
+    let-env DIRS_POSITION = 0
+    let-env DIRS_LIST = [($env.PWD | path expand)]
+}
 
 # ---------------- builtin std functions --------------------
 

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -1,3 +1,19 @@
+# std.nu, `used` to load all standard library components
+
+# ----------- sub modules to be loaded as part of stdlib ------------------
+# (choose flavor of import that puts your functions in the right namespace)
+# This imports into std top-level namespace: std <subcommand>
+# (not what I want for a new subcommand.)
+# export use dirs.nu *
+# This imports into std *sub* namespace: std dirs <subcommand>
+# export use dirs.nu
+# You could also advise the user to `use` your submodule directly
+# to put the subcommands at the top level: dirs <subcommand>
+
+export use dirs.nu
+
+# ---------------- builtin std functions --------------------
+
 def _assert [
     cond: bool
     msg: string

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -63,8 +63,76 @@ def test_path_add [] {
     }
 }
 
+
+def test_dirs [] {
+
+    def "myassert eq" [
+        left:any 
+        right:any 
+        msg?:string = "..."
+        --verbose = false (-v)  # enable to see successful tests and values of unequal tests
+    ] {
+        if $left != $right {
+            let start_span = (metadata $left).span.start
+            let end_span = (metadata $right).span.end
+            let fail_msg = (if $verbose {
+                                $"\n    left: ($left|debug)\n   right: ($right|debug)"
+                            } else {""})
+            error make {msg: $"Assertion failed checking ($msg)($fail_msg)", label: {text: "Values not equal" start: $start_span end: $end_span}}
+        } else {
+            if $verbose {
+                echo $"check succeeded: ($msg)"
+            }
+        }
+    }
+    
+    # need some directories to play with
+    let base_path = ($"tmp_(random uuid)" | path expand )
+
+    try {
+        mkdir $base_path ($base_path | path join "a") ($base_path | path join "b")
+        cd $base_path
+        use dirs.nu
+
+        myassert eq 1 ($env.DIRS_LIST | length) "list is just pwd after initialization"
+        myassert eq $base_path $env.DIRS_LIST.0 "list is just pwd after initialization"
+
+        dirs next
+        myassert eq $base_path $env.DIRS_LIST.0 "next wraps at end of list"
+
+        dirs prev
+        myassert eq $base_path $env.DIRS_LIST.0 "prev wraps at top of list"
+
+        dirs add ($base_path | path join "b") ($base_path | path join "a")
+        myassert eq ($base_path | path join "b") $env.PWD "add changes PWD to first added dir"
+        myassert eq 3 ($env.DIRS_LIST | length) "add in fact adds to list"
+        myassert eq ($base_path | path join "a") $env.DIRS_LIST.2 "add in fact adds to list"
+        
+        dirs next 2
+        myassert eq $base_path $env.PWD "next wraps at end of list"
+
+        dirs prev 1 
+        myassert eq ($base_path | path join "a") $env.PWD "prev wraps at start of list"
+
+        dirs drop
+        myassert eq 2 ($env.DIRS_LIST | length) "drop removes from list"    
+        myassert eq $base_path $env.PWD "drop changes PWD to next in list (after dropped element)"
+
+        let show_tab = (dirs show)
+        myassert eq $show_tab [[active path]; [true $base_path] [false ($base_path | path join "b")]] "show table contains expected information"
+    } catch { |error|
+        $error | debug
+        true
+    }
+
+    cd $base_path
+    cd ..
+    rm -r $base_path
+}
+
 def main [] {
     test_assert
     tests
     test_path_add
+    test_dirs
 }


### PR DESCRIPTION
# Description

Prototype replacement for `enter`, `n`, `p`, `exit` built-ins implemented as scripts in standard library.
MVP-level capabilities (rough hack), for feedback please.  Not intended to merge and ship as is.

_(Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.)_

# User-Facing Changes
New command in standard library

```nushell
〉use ~/src/rust/nushell/crates/nu-utils/standard_library/dirs.nu
---------------------------------------------- /home/bobhy ----------------------------------------------
〉help dirs
module dirs.nu -- maintain list of remembered directories + navigate them

todo:
* expand relative to absolute paths (or relative to some prefix?)
* what if user does `cd` by hand?

Module: dirs

Exported commands:
  add (dirs add), drop, next (dirs next), prev (dirs prev), show (dirs show)

This module exports environment.
---------------------------------------------- /home/bobhy ----------------------------------------------
〉dirs add ~/src/rust/nushell /etc ~/.cargo
-------------------------------------- /home/bobhy/src/rust/nushell --------------------------------------
〉dirs next 2
------------------------------------------- /home/bobhy/.cargo -------------------------------------------
〉dirs show
╭───┬─────────┬────────────────────╮
│ # │ current │        path        │
├───┼─────────┼────────────────────┤
│ 0 │         │ /home/bobhy        │
│ 1 │         │ ~/src/rust/nushell │
│ 2 │         │ /etc               │
│ 3 │ ==>     │ ~/.cargo           │
╰───┴─────────┴────────────────────╯
------------------------------------------- /home/bobhy/.cargo -------------------------------------------
〉dirs drop
---------------------------------------------- /home/bobhy ----------------------------------------------
〉dirs show
╭───┬─────────┬────────────────────╮
│ # │ current │        path        │
├───┼─────────┼────────────────────┤
│ 0 │ ==>     │ /home/bobhy        │
│ 1 │         │ ~/src/rust/nushell │
│ 2 │         │ /etc               │
╰───┴─────────┴────────────────────╯
---------------------------------------------- /home/bobhy ----------------------------------------------
〉
```
# Tests + Formatting

Haven't even looked at stdlib `tests.nu` yet.

Other todos:
* address module todos.
* integrate into std lib, rather than as standalone module. Somehow arrange for `use .../standard_library/std.nu` to load this module without having to put all the source in `std.nu`?
*  Maybe command should be `std dirs ...`?   
* what else do `enter` and `exit` do that this should do? Then deprecate those commands.

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
