### PR TITLE
enable error reporting from enable_vt_processing

### DIFF
--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -18,11 +18,10 @@ pub fn enable_vt_processing() -> Result<()> {
         // enable_processed_output and enable_virtual_terminal_processing should be used
 
         if old_mode & mask == 0 {
-            match console_mode
+            if let Err(err) = console_mode
                 .set_mode(old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
             {
-                Ok(_) => (),
-                Err(err) => return Err(err),
+                return Err(err);
             }
         }
     }

--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -18,11 +18,8 @@ pub fn enable_vt_processing() -> Result<()> {
         // enable_processed_output and enable_virtual_terminal_processing should be used
 
         if old_mode & mask == 0 {
-            if let Err(err) = console_mode
-                .set_mode(old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
-            {
-                return Err(err);
-            }
+            console_mode
+                .set_mode(old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING)?
         }
     }
     Ok(())

--- a/crates/nu-utils/src/utils.rs
+++ b/crates/nu-utils/src/utils.rs
@@ -9,19 +9,22 @@ pub fn enable_vt_processing() -> Result<()> {
 
         pub const ENABLE_PROCESSED_OUTPUT: u32 = 0x0001;
         pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: u32 = 0x0004;
-        // let mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+        let mask = ENABLE_VIRTUAL_TERMINAL_PROCESSING;
 
         let console_mode = ConsoleMode::from(Handle::current_out_handle()?);
         let old_mode = console_mode.mode()?;
 
         // researching odd ansi behavior in windows terminal repo revealed that
         // enable_processed_output and enable_virtual_terminal_processing should be used
-        // also, instead of checking old_mode & mask, just set the mode already
 
-        // if old_mode & mask == 0 {
-        console_mode
-            .set_mode(old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING)?;
-        // }
+        if old_mode & mask == 0 {
+            match console_mode
+                .set_mode(old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+            {
+                Ok(_) => (),
+                Err(err) => return Err(err),
+            }
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
# Description

This PR tweaks the enable_vt_processing() function with more verbose error handling. This is related to #8344.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
