### PR TITLE
bump rust-toolchain version and cargo.toml rust version to match

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.60"
+rust-version = "1.67"
 version = "0.76.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }"
 pkg-fmt = "tgz"
+pkg-url = "{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ archive-format }"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"
@@ -24,20 +24,20 @@ pkg-fmt = "zip"
 [workspace]
 members = [
 	"crates/nu-cli",
-	"crates/nu-engine",
-	"crates/nu-parser",
-	"crates/nu-system",
 	"crates/nu-cmd-lang",
 	"crates/nu-command",
-	"crates/nu-protocol",
+	"crates/nu-engine",
+	"crates/nu-parser",
 	"crates/nu-plugin",
-	"crates/nu_plugin_inc",
-	"crates/nu_plugin_gstat",
-	"crates/nu_plugin_example",
-	"crates/nu_plugin_query",
-	"crates/nu_plugin_custom_values",
-	"crates/nu_plugin_formats",
+	"crates/nu-protocol",
+	"crates/nu-system",
 	"crates/nu-utils",
+	"crates/nu_plugin_custom_values",
+	"crates/nu_plugin_example",
+	"crates/nu_plugin_formats",
+	"crates/nu_plugin_gstat",
+	"crates/nu_plugin_inc",
+	"crates/nu_plugin_query",
 ]
 
 [dependencies]
@@ -48,8 +48,8 @@ log = "0.4"
 miette = { version = "5.5.0", features = ["fancy-no-backtrace"] }
 nu-ansi-term = "0.46.0"
 nu-cli = { path = "./crates/nu-cli", version = "0.76.1" }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.76.1" }
 nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.76.1" }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.76.1" }
 nu-command = { path = "./crates/nu-command", version = "0.76.1" }
 nu-engine = { path = "./crates/nu-engine", version = "0.76.1" }
 nu-json = { path = "./crates/nu-json", version = "0.76.1" }
@@ -65,8 +65,8 @@ nu-utils = { path = "./crates/nu-utils", version = "0.76.1" }
 
 reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
-rayon = "1.7.0"
 is_executable = "1.0.1"
+rayon = "1.7.0"
 simplelog = "0.12.0"
 time = "0.3.12"
 
@@ -75,42 +75,29 @@ time = "0.3.12"
 openssl = { version = "0.10.38", features = ["vendored"], optional = true }
 signal-hook = { version = "0.3.14", default-features = false }
 
-
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.25", default-features = false, features = [
-	"signal",
-	"process",
-	"fs",
-	"term",
-] }
 atty = "0.2"
+nix = { version = "0.25", default-features = false, features = ["fs", "process", "signal", "term"] }
 
 [dev-dependencies]
-nu-test-support = { path = "./crates/nu-test-support", version = "0.76.1" }
-tempfile = "3.4.0"
 assert_cmd = "2.0.2"
 criterion = "0.4"
-pretty_assertions = "1.0.0"
-serial_test = "1.0.0"
 hamcrest2 = "0.3.0"
-rstest = { version = "0.16.0", default-features = false }
 itertools = "0.10.3"
+nu-test-support = { path = "./crates/nu-test-support", version = "0.76.1" }
+pretty_assertions = "1.0.0"
+rstest = { version = "0.16.0", default-features = false }
+serial_test = "1.0.0"
+tempfile = "3.4.0"
 
 [features]
-plugin = [
-	"nu-plugin",
-	"nu-cli/plugin",
-	"nu-parser/plugin",
-	"nu-command/plugin",
-	"nu-protocol/plugin",
-	"nu-engine/plugin",
-]
+plugin = ["nu-cli/plugin", "nu-command/plugin", "nu-engine/plugin", "nu-parser/plugin", "nu-plugin", "nu-protocol/plugin"]
 # extra used to be more useful but now it's the same as default. Leaving it in for backcompat with existing build scripts
+default = ["plugin", "sqlite", "trash-support", "which-support"]
 extra = ["default"]
-default = ["plugin", "which-support", "trash-support", "sqlite"]
 stable = ["default"]
 wasi = []
 
@@ -118,8 +105,8 @@ wasi = []
 static-link-openssl = ["dep:openssl"]
 
 # Stable (Default)
-which-support = ["nu-command/which-support"]
 trash-support = ["nu-command/trash-support"]
+which-support = ["nu-command/which-support"]
 
 # Extra
 
@@ -130,39 +117,39 @@ dataframe = ["nu-command/dataframe"]
 sqlite = ["nu-command/sqlite"]
 
 [profile.release]
+lto = "thin"
 opt-level = "s"     # Optimize for size
 strip = "debuginfo"
-lto = "thin"
 
 # build with `cargo build --profile profiling`
 # to analyze performance with tooling like linux perf
 [profile.profiling]
+debug = true
 inherits = "release"
 strip = false
-debug = true
 
 # build with `cargo build --profile ci`
 # to analyze performance with tooling like linux perf
 [profile.ci]
+debug = false
 inherits = "dev"
 strip = false
-debug = false
 
 # Main nu binary
 [[bin]]
+bench = false
 name = "nu"
 path = "src/main.rs"
-bench = false
 
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
+nu-ansi-term = { git = "https://github.com/nushell/nu-ansi-term.git", branch = "main" }
 reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
-nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Criterion benchmarking setup
 # Run all benchmarks with `cargo bench`
 # Run individual benchmarks like `cargo bench -- <regex>` e.g. `cargo bench -- parse`
 [[bench]]
-name = "benchmarks"
 harness = false
+name = "benchmarks"

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -125,7 +125,7 @@ fn registry_query(
                 vals: vec![
                     Value::string(name, call_span),
                     nu_value,
-                    Value::string(format!("{:?}", reg_type), call_span),
+                    Value::string(format!("{reg_type:?}"), call_span),
                 ],
                 span: *registry_key_span,
             })
@@ -143,7 +143,7 @@ fn registry_query(
                             vals: vec![
                                 Value::string(value.item, call_span),
                                 nu_value,
-                                Value::string(format!("{:?}", reg_type), call_span),
+                                Value::string(format!("{reg_type:?}"), call_span),
                             ],
                             span: value.span,
                         }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -226,7 +226,7 @@ impl ExternalCommand {
                                 if let Some(cwd) = self.env_vars.get("PWD") {
                                     // append cwd to PATH so `which-rs` looks in the cwd too.
                                     // this approximates what cmd.exe does.
-                                    let path_with_cwd = format!("{};{}", cwd, path);
+                                    let path_with_cwd = format!("{cwd};{path}");
                                     if let Ok(which_path) =
                                         which::which_in(&self.name.item, Some(path_with_cwd), cwd)
                                     {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1931,7 +1931,7 @@ fn create_empty_placeholder(
         return "".into();
     }
 
-    let empty_info_string = format!("empty {}", value_type_name);
+    let empty_info_string = format!("empty {value_type_name}");
     let cell = NuTable::create_cell(empty_info_string, TextStyle::default().dimmed());
     let data = vec![vec![cell]];
     let table = NuTable::new(data, (1, 1));

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1427,7 +1427,7 @@ pub fn parse_int(token: &[u8], span: Span) -> (Expression, Option<ParseError>) {
             (
                 garbage(span),
                 Some(ParseError::InvalidLiteral(
-                    format!("invalid digits for radix {}", radix),
+                    format!("invalid digits for radix {radix}"),
                     "int".into(),
                     span,
                 )),

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -252,7 +252,7 @@ fn set_privilege() -> bool {
         }
 
         let mut tps: TOKEN_PRIVILEGES = zeroed();
-        let se_debug_name: Vec<u16> = format!("{}\0", SE_DEBUG_NAME).encode_utf16().collect();
+        let se_debug_name: Vec<u16> = format!("{SE_DEBUG_NAME}\0").encode_utf16().collect();
         tps.PrivilegeCount = 1;
         let ret = LookupPrivilegeValueW(
             ptr::null(),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 3 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.66.1"
-
+channel = "1.67.0"

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -287,7 +287,7 @@ pub fn input_bytes_length() {
     let stdin = io::stdin();
     let count = stdin.lock().bytes().count();
 
-    println!("{}", count);
+    println!("{count}");
 }
 
 fn args() -> Vec<String> {


### PR DESCRIPTION
# Description

This PR bumps the rust-toolchain version and cargo.toml version to match. I really only changed one thing in the cargo.toml file and saved. I guess the cargo extension is doing some formatting or something?

Ran clippy like this 
```
cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err  
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
