### PR TITLE
Box `ShellError` in `Value::Error`

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -145,7 +145,7 @@ pub(crate) fn print_table_or_error(
 
     if let PipelineData::Value(Value::Error { error }, ..) = &pipeline_data {
         let working_set = StateWorkingSet::new(engine_state);
-        report_error(&working_set, error);
+        report_error(&working_set, &**error);
         std::process::exit(1);
     }
 
@@ -193,7 +193,7 @@ fn print_or_exit(pipeline_data: PipelineData, engine_state: &mut EngineState, co
         if let Value::Error { error } = item {
             let working_set = StateWorkingSet::new(engine_state);
 
-            report_error(&working_set, &error);
+            report_error(&working_set, &*error);
 
             std::process::exit(1);
         }

--- a/crates/nu-cli/src/nu_highlight.rs
+++ b/crates/nu-cli/src/nu_highlight.rs
@@ -53,7 +53,9 @@ impl Command for NuHighlight {
                         span: head,
                     }
                 }
-                Err(err) => Value::Error { error: err },
+                Err(err) => Value::Error {
+                    error: Box::new(err),
+                },
             },
             ctrlc,
         )

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -1121,7 +1121,7 @@ fn run_hook_block(
         eval_block_with_early_return(engine_state, &mut callee_stack, block, input, false, false)?;
 
     if let PipelineData::Value(Value::Error { error }, _) = pipeline_data {
-        return Err(error);
+        return Err(*error);
     }
 
     // If all went fine, preserve the environment of the called block

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -57,66 +57,29 @@ impl Command for Try {
         let result = eval_block(engine_state, stack, try_block, input, false, false);
 
         match result {
-            Err(error) | Ok(PipelineData::Value(Value::Error { error }, ..)) => {
-                if let nu_protocol::ShellError::Break(_) = error {
-                    return Err(error);
-                } else if let nu_protocol::ShellError::Continue(_) = error {
-                    return Err(error);
-                } else if let nu_protocol::ShellError::Return(_, _) = error {
-                    return Err(error);
-                }
-                if let Some(catch_block) = catch_block {
-                    let catch_block = engine_state.get_block(catch_block.block_id);
-                    let err_value = Value::Error { error };
-                    // Put the error value in the positional closure var
-                    if let Some(var) = catch_block.signature.get_positional(0) {
-                        if let Some(var_id) = &var.var_id {
-                            stack.add_var(*var_id, err_value.clone());
-                        }
-                    }
-
-                    eval_block(
-                        engine_state,
-                        stack,
-                        catch_block,
-                        // Make the error accessible with $in, too
-                        err_value.into_pipeline_data(),
-                        false,
-                        false,
-                    )
-                } else {
-                    Ok(PipelineData::empty())
-                }
+            Err(error) => {
+                let error = intercept_block_control(error)?;
+                let err_value = Value::Error {
+                    error: Box::new(error),
+                };
+                handle_catch(err_value, catch_block, engine_state, stack)
+            }
+            Ok(PipelineData::Value(Value::Error { error }, ..)) => {
+                let error = intercept_block_control(*error)?;
+                let err_value = Value::Error {
+                    error: Box::new(error),
+                };
+                handle_catch(err_value, catch_block, engine_state, stack)
             }
             // external command may fail to run
             Ok(pipeline) => {
                 let (pipeline, external_failed) = pipeline.is_external_failed();
                 if external_failed {
-                    if let Some(catch_block) = catch_block {
-                        let catch_block = engine_state.get_block(catch_block.block_id);
-
-                        if let Some(var) = catch_block.signature.get_positional(0) {
-                            if let Some(var_id) = &var.var_id {
-                                // Because external command errors aren't "real" errors,
-                                // (unless do -c is in effect)
-                                // they can't be passed in as Nushell values.
-                                let err_value = Value::nothing(call.head);
-                                stack.add_var(*var_id, err_value);
-                            }
-                        }
-
-                        eval_block(
-                            engine_state,
-                            stack,
-                            catch_block,
-                            // The same null as in the above block is set as the $in value.
-                            Value::nothing(call.head).into_pipeline_data(),
-                            false,
-                            false,
-                        )
-                    } else {
-                        Ok(PipelineData::empty())
-                    }
+                    // Because external command errors aren't "real" errors,
+                    // (unless do -c is in effect)
+                    // they can't be passed in as Nushell values.
+                    let err_value = Value::nothing(call.head);
+                    handle_catch(err_value, catch_block, engine_state, stack)
                 } else {
                     Ok(pipeline)
                 }
@@ -137,6 +100,48 @@ impl Command for Try {
                 result: Some(Value::test_string("missing")),
             },
         ]
+    }
+}
+
+fn handle_catch(
+    err_value: Value,
+    catch_block: Option<Closure>,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+) -> Result<PipelineData, ShellError> {
+    if let Some(catch_block) = catch_block {
+        let catch_block = engine_state.get_block(catch_block.block_id);
+        // Put the error value in the positional closure var
+        if let Some(var) = catch_block.signature.get_positional(0) {
+            if let Some(var_id) = &var.var_id {
+                stack.add_var(*var_id, err_value.clone());
+            }
+        }
+
+        eval_block(
+            engine_state,
+            stack,
+            catch_block,
+            // Make the error accessible with $in, too
+            err_value.into_pipeline_data(),
+            false,
+            false,
+        )
+    } else {
+        Ok(PipelineData::empty())
+    }
+}
+
+/// The flow control commands `break`/`continue`/`return` emit their own [`ShellError`] variants
+/// We need to ignore those in `try` and bubble them through
+///
+/// `Err` when flow control to bubble up with `?`
+fn intercept_block_control(error: ShellError) -> Result<ShellError, ShellError> {
+    match error {
+        nu_protocol::ShellError::Break(_) => Err(error),
+        nu_protocol::ShellError::Continue(_) => Err(error),
+        nu_protocol::ShellError::Return(_, _) => Err(error),
+        _ => Ok(error),
     }
 }
 

--- a/crates/nu-command/src/bits/and.rs
+++ b/crates/nu-command/src/bits/and.rs
@@ -81,12 +81,12 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -150,12 +150,12 @@ fn operate(value: Value, head: Span, signed: bool, number_size: NumberBytes) -> 
             // Propagate errors inside the value
             Value::Error { .. } => other,
             _ => Value::Error {
-                error: ShellError::OnlySupportsThisInputType {
+                error: Box::new(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "integer".into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.expect_span(),
-                },
+                }),
             },
         },
     }

--- a/crates/nu-command/src/bits/or.rs
+++ b/crates/nu-command/src/bits/or.rs
@@ -81,12 +81,12 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bits/rotate_left.rs
+++ b/crates/nu-command/src/bits/rotate_left.rs
@@ -103,7 +103,7 @@ where
     match rotate_result {
         Ok(val) => Value::Int { val, span },
         Err(_) => Value::Error {
-            error: ShellError::GenericError(
+            error: Box::new(ShellError::GenericError(
                 "Rotate left result beyond the range of 64 bit signed number".to_string(),
                 format!(
                     "{val} of the specified number of bytes rotate left {bits} bits exceed limit"
@@ -111,7 +111,7 @@ where
                 Some(span),
                 None,
                 Vec::new(),
-            ),
+            )),
         },
     }
 }
@@ -137,12 +137,12 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bits/rotate_right.rs
+++ b/crates/nu-command/src/bits/rotate_right.rs
@@ -107,7 +107,7 @@ where
     match rotate_result {
         Ok(val) => Value::Int { val, span },
         Err(_) => Value::Error {
-            error: ShellError::GenericError(
+            error: Box::new(ShellError::GenericError(
                 "Rotate right result beyond the range of 64 bit signed number".to_string(),
                 format!(
                     "{val} of the specified number of bytes rotate right {bits} bits exceed limit"
@@ -115,7 +115,7 @@ where
                 Some(span),
                 None,
                 Vec::new(),
-            ),
+            )),
         },
     }
 }
@@ -141,12 +141,12 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -115,7 +115,7 @@ where
             match shift_result {
                 Ok(val) => Value::Int { val, span },
                 Err(_) => Value::Error {
-                    error: ShellError::GenericError(
+                    error: Box::new(ShellError::GenericError(
                         "Shift left result beyond the range of 64 bit signed number".to_string(),
                         format!(
                             "{val} of the specified number of bytes shift left {bits} bits exceed limit"
@@ -123,18 +123,18 @@ where
                         Some(span),
                         None,
                         Vec::new(),
-                    ),
+                    )),
                 },
             }
         }
         None => Value::Error {
-            error: ShellError::GenericError(
+            error: Box::new(ShellError::GenericError(
                 "Shift left failed".to_string(),
                 format!("{val} shift left {bits} bits failed, you may shift too many bits"),
                 Some(span),
                 None,
                 Vec::new(),
-            ),
+            )),
         },
     }
 }
@@ -160,12 +160,12 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bits/shift_right.rs
+++ b/crates/nu-command/src/bits/shift_right.rs
@@ -105,7 +105,7 @@ where
             match shift_result {
                 Ok(val) => Value::Int { val, span },
                 Err(_) => Value::Error {
-                    error: ShellError::GenericError(
+                    error: Box::new(ShellError::GenericError(
                         "Shift right result beyond the range of 64 bit signed number".to_string(),
                         format!(
                             "{val} of the specified number of bytes shift right {bits} bits exceed limit"
@@ -113,18 +113,18 @@ where
                         Some(span),
                         None,
                         Vec::new(),
-                    ),
+                    )),
                 },
             }
         }
         None => Value::Error {
-            error: ShellError::GenericError(
+            error: Box::new(ShellError::GenericError(
                 "Shift right failed".to_string(),
                 format!("{val} shift right {bits} bits failed, you may shift too many bits"),
                 Some(span),
                 None,
                 Vec::new(),
-            ),
+            )),
         },
     }
 }
@@ -150,12 +150,12 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bits/xor.rs
+++ b/crates/nu-command/src/bits/xor.rs
@@ -80,12 +80,12 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -125,12 +125,12 @@ fn add(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bytes/build_.rs
+++ b/crates/nu-command/src/bytes/build_.rs
@@ -53,7 +53,7 @@ impl Command for BytesBuild {
             match val {
                 Value::Binary { mut val, .. } => output.append(&mut val),
                 // Explicitly propagate errors instead of dropping them.
-                Value::Error { error } => return Err(error),
+                Value::Error { error } => return Err(*error),
                 other => {
                     return Err(ShellError::TypeMismatch {
                         err_message: "only binary data arguments are supported".to_string(),

--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -55,7 +55,7 @@ impl Command for BytesCollect {
                     }
                 }
                 // Explicitly propagate errors instead of dropping them.
-                Value::Error { error } => return Err(error),
+                Value::Error { error } => return Err(*error),
                 other => {
                     return Err(ShellError::OnlySupportsThisInputType {
                         exp_input_type: "binary".into(),

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -93,12 +93,12 @@ fn ends_with(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -135,12 +135,12 @@ fn index_of(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -74,12 +74,12 @@ fn length(val: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -142,12 +142,12 @@ fn remove(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -133,12 +133,12 @@ fn replace(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bytes/reverse.rs
+++ b/crates/nu-command/src/bytes/reverse.rs
@@ -84,12 +84,12 @@ fn reverse(val: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -80,12 +80,12 @@ impl Command for BytesStartsWith {
                         // Unsupported data
                         Ok(other) => {
                             return Ok(Value::Error {
-                                error: ShellError::OnlySupportsThisInputType {
+                                error: Box::new(ShellError::OnlySupportsThisInputType {
                                     exp_input_type: "string and binary".into(),
                                     wrong_type: other.get_type().to_string(),
                                     dst_span: span,
                                     src_span: other.expect_span(),
-                                },
+                                }),
                             }
                             .into_pipeline_data());
                         }
@@ -149,12 +149,12 @@ fn starts_with(val: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -79,7 +79,7 @@ impl HashableValue {
             Value::Binary { val, span } => Ok(HashableValue::Binary { val, span }),
 
             // Explicitly propagate errors instead of dropping them.
-            Value::Error { error } => Err(error),
+            Value::Error { error } => Err(*error),
             _ => Err(ShellError::UnsupportedInput(
                 "input value is not hashable".into(),
                 format!("input type: {:?}", value.get_type()),
@@ -236,7 +236,7 @@ mod test {
             },
             Value::Nothing { span },
             Value::Error {
-                error: ShellError::DidYouMean("what?".to_string(), span),
+                error: Box::new(ShellError::DidYouMean("what?".to_string(), span)),
             },
             Value::CellPath {
                 val: CellPath {

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -160,7 +160,7 @@ fn run_histogram(
             for v in values {
                 match v {
                     // Propagate existing errors.
-                    Value::Error { error } => return Err(error),
+                    Value::Error { error } => return Err(*error),
                     _ => {
                         let t = v.get_type();
                         let span = v.expect_span();
@@ -198,7 +198,7 @@ fn run_histogram(
                         }
                     }
                     // Propagate existing errors.
-                    Value::Error { error } => return Err(error),
+                    Value::Error { error } => return Err(*error),
                     _ => continue,
                 }
             }

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -193,12 +193,12 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "int, filesize, float, string".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/conversions/fmt.rs
+++ b/crates/nu-command/src/conversions/fmt.rs
@@ -87,12 +87,12 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer or filesize".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -188,13 +188,13 @@ pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "integer, float, filesize, string, date, duration, binary or bool"
                     .into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -161,17 +161,19 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         },
         Value::String { val, .. } => match string_to_boolean(val, span) {
             Ok(val) => Value::Bool { val, span },
-            Err(error) => Value::Error { error },
+            Err(error) => Value::Error {
+                error: Box::new(error),
+            },
         },
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "bool, integer, float or string".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -88,12 +88,12 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
             match other.parse::<f64>() {
                 Ok(x) => Value::float(x, head),
                 Err(reason) => Value::Error {
-                    error: ShellError::CantConvert {
+                    error: Box::new(ShellError::CantConvert {
                         to_type: "float".to_string(),
                         from_type: reason.to_string(),
                         span: *span,
                         help: None,
-                    },
+                    }),
                 },
             }
         }
@@ -108,12 +108,12 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string, integer or bool".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -174,7 +174,9 @@ fn into_duration(
                         Box::new(move |old| action(old, &d, float_precision, head)),
                     );
                     if let Err(error) = r {
-                        return Value::Error { error };
+                        return Value::Error {
+                            error: Box::new(error),
+                        };
                     }
                 }
 
@@ -430,7 +432,7 @@ fn action(
                             }
                         }
                     }
-                    Err(e) => Value::Error { error: e },
+                    Err(e) => Value::Error { error: Box::new(e) },
                 }
             } else {
                 input.clone()
@@ -464,34 +466,36 @@ fn action(
                                 }
                             }
                         }
-                        Err(e) => Value::Error { error: e },
+                        Err(e) => Value::Error { error: Box::new(e) },
                     }
                 } else {
                     Value::Error {
-                        error: ShellError::CantConvert {
+                        error: Box::new(ShellError::CantConvert {
                             to_type: "string".into(),
                             from_type: "duration".into(),
                             span,
                             help: None,
-                        },
+                        }),
                     }
                 }
             } else {
                 match string_to_duration(val, span, *value_span) {
                     Ok(val) => Value::Duration { val, span },
-                    Err(error) => Value::Error { error },
+                    Err(error) => Value::Error {
+                        error: Box::new(error),
+                    },
                 }
             }
         }
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string or duration".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -110,19 +110,21 @@ pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
                     val,
                     span: value_span,
                 },
-                Err(error) => Value::Error { error },
+                Err(error) => Value::Error {
+                    error: Box::new(error),
+                },
             },
             Value::Nothing { .. } => Value::Filesize {
                 val: 0,
                 span: value_span,
             },
             other => Value::Error {
-                error: ShellError::OnlySupportsThisInputType {
+                error: Box::new(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "string and integer".into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: span,
                     src_span: value_span,
-                },
+                }),
             },
         }
     } else {

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -185,12 +185,12 @@ fn into_record(
         Value::Record { cols, vals, span } => Value::Record { cols, vals, span },
         Value::Error { .. } => input,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: call.head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     };
     Ok(res.into_pipeline_data())

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -247,28 +247,28 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             span: _,
         } => Value::Error {
             // Watch out for CantConvert's argument order
-            error: ShellError::CantConvert {
+            error: Box::new(ShellError::CantConvert {
                 to_type: "string".into(),
                 from_type: "record".into(),
                 span,
                 help: Some("try using the `to nuon` command".into()),
-            },
+            }),
         },
         Value::Binary { .. } => Value::Error {
-            error: ShellError::CantConvert {
+            error: Box::new(ShellError::CantConvert {
                 to_type: "string".into(),
                 from_type: "binary".into(),
                 span,
                 help: Some("try using the `decode` command".into()),
-            },
+            }),
         },
         x => Value::Error {
-            error: ShellError::CantConvert {
+            error: Box::new(ShellError::CantConvert {
                 to_type: String::from("string"),
                 from_type: x.get_type().to_string(),
                 span,
                 help: None,
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -217,7 +217,7 @@ fn action(
             Ok(Value::Nothing { span: *span })
         }
         // Propagate errors by explicitly matching them before the final case.
-        Value::Error { error } => Err(error.clone()),
+        Value::Error { error } => Err(*error.clone()),
         other => Err(ShellError::OnlySupportsThisInputType {
             exp_input_type: "list".into(),
             wrong_type: other.get_type().to_string(),

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -463,7 +463,7 @@ pub fn convert_sqlite_value_to_nu_value(value: ValueRef, span: Span) -> Value {
                 Ok(v) => v,
                 Err(_) => {
                     return Value::Error {
-                        error: ShellError::NonUtf8(span),
+                        error: Box::new(ShellError::NonUtf8(span)),
                     }
                 }
             };

--- a/crates/nu-command/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-command/src/dataframe/values/nu_dataframe/conversion.rs
@@ -461,13 +461,13 @@ pub fn create_column(
                             Some(val) => val,
                             None => {
                                 return Value::Error {
-                                    error: ShellError::UnsupportedInput(
+                                    error: Box::new(ShellError::UnsupportedInput(
                                         "The given local datetime representation is invalid."
                                             .to_string(),
                                         format!("timestamp is {a:?}"),
                                         span,
                                         Span::unknown(),
-                                    ),
+                                    )),
                                 }
                             }
                         };
@@ -476,13 +476,13 @@ pub fn create_column(
                             Some(val) => val,
                             None => {
                                 return Value::Error {
-                                    error: ShellError::UnsupportedInput(
+                                    error: Box::new(ShellError::UnsupportedInput(
                                         "The given local datetime representation is invalid."
                                             .to_string(),
                                         format!("timestamp is {a:?}"),
                                         span,
                                         Span::unknown(),
-                                    ),
+                                    )),
                                 }
                             }
                         };
@@ -526,13 +526,13 @@ pub fn create_column(
                             Some(val) => val,
                             None => {
                                 return Value::Error {
-                                    error: ShellError::UnsupportedInput(
+                                    error: Box::new(ShellError::UnsupportedInput(
                                         "The given local datetime representation is invalid."
                                             .to_string(),
                                         format!("timestamp is {a:?}"),
                                         span,
                                         Span::unknown(),
-                                    ),
+                                    )),
                                 }
                             }
                         };
@@ -541,13 +541,13 @@ pub fn create_column(
                             Some(val) => val,
                             None => {
                                 return Value::Error {
-                                    error: ShellError::UnsupportedInput(
+                                    error: Box::new(ShellError::UnsupportedInput(
                                         "The given local datetime representation is invalid."
                                             .to_string(),
                                         format!("timestamp is {a:?}"),
                                         span,
                                         Span::unknown(),
-                                    ),
+                                    )),
                                 }
                             }
                         };

--- a/crates/nu-command/src/date/format.rs
+++ b/crates/nu-command/src/date/format.rs
@@ -132,10 +132,10 @@ where
             span,
         },
         Err(_) => Value::Error {
-            error: ShellError::TypeMismatch {
+            error: Box::new(ShellError::TypeMismatch {
                 err_message: "invalid format".to_string(),
                 span,
-            },
+            }),
         },
     }
 }
@@ -152,7 +152,10 @@ fn format_helper(value: Value, formatter: &str, formatter_span: Span, head_span:
             }
         }
         _ => Value::Error {
-            error: ShellError::DatetimeParseError(value.debug_value(), head_span),
+            error: Box::new(ShellError::DatetimeParseError(
+                value.debug_value(),
+                head_span,
+            )),
         },
     }
 }
@@ -177,7 +180,7 @@ fn format_helper_rfc2822(value: Value, span: Span) -> Value {
             }
         }
         _ => Value::Error {
-            error: ShellError::DatetimeParseError(value.debug_value(), span),
+            error: Box::new(ShellError::DatetimeParseError(value.debug_value(), span)),
         },
     }
 }

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -90,7 +90,7 @@ fn helper(value: Value, head: Span) -> Value {
             span: head,
         },
         _ => Value::Error {
-            error: ShellError::DatetimeParseError(value.debug_value(), head),
+            error: Box::new(ShellError::DatetimeParseError(value.debug_value(), head)),
         },
     }
 }

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -156,7 +156,7 @@ fn helper(val: Value, head: Span) -> Value {
         }
         Value::Date { val, span: _ } => parse_date_into_table(Ok(val), head),
         _ => Value::Error {
-            error: DatetimeParseError(val.debug_value(), head),
+            error: Box::new(DatetimeParseError(val.debug_value(), head)),
         },
     }
 }

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -161,7 +161,7 @@ fn helper(val: Value, head: Span) -> Value {
         }
         Value::Date { val, span: _ } => parse_date_into_table(Ok(val), head),
         _ => Value::Error {
-            error: DatetimeParseError(val.debug_value(), head),
+            error: Box::new(DatetimeParseError(val.debug_value(), head)),
         },
     }
 }

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -128,7 +128,7 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
             _to_timezone(dt.with_timezone(dt.offset()), timezone, head)
         }
         _ => Value::Error {
-            error: ShellError::DatetimeParseError(value.debug_value(), head),
+            error: Box::new(ShellError::DatetimeParseError(value.debug_value(), head)),
         },
     }
 }
@@ -137,10 +137,10 @@ fn _to_timezone(dt: DateTime<FixedOffset>, timezone: &Spanned<String>, span: Spa
     match datetime_in_timezone(&dt, timezone.item.as_str()) {
         Ok(dt) => Value::Date { val: dt, span },
         Err(_) => Value::Error {
-            error: ShellError::TypeMismatch {
+            error: Box::new(ShellError::TypeMismatch {
                 err_message: String::from("invalid time zone"),
                 span: timezone.span,
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -15,12 +15,12 @@ pub(crate) fn parse_date_from_string(
                 LocalResult::Single(d) => Ok(d),
                 LocalResult::Ambiguous(d, _) => Ok(d),
                 LocalResult::None => Err(Value::Error {
-                    error: ShellError::DatetimeParseError(input.to_string(), span),
+                    error: Box::new(ShellError::DatetimeParseError(input.to_string(), span)),
                 }),
             }
         }
         Err(_) => Err(Value::Error {
-            error: ShellError::DatetimeParseError(input.to_string(), span),
+            error: Box::new(ShellError::DatetimeParseError(input.to_string(), span)),
         }),
     }
 }

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -279,7 +279,9 @@ fn get_expression_as_value(
 ) -> Value {
     match eval_expression(engine_state, stack, inner_expr) {
         Ok(v) => v,
-        Err(error) => Value::Error { error },
+        Err(error) => Value::Error {
+            error: Box::new(error),
+        },
     }
 }
 

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -379,13 +379,13 @@ fn interactive_copy(
     );
     if let Err(e) = interaction {
         Value::Error {
-            error: ShellError::GenericError(
+            error: Box::new(ShellError::GenericError(
                 e.to_string(),
                 e.to_string(),
                 Some(span),
                 None,
                 Vec::new(),
-            ),
+            )),
         }
     } else if !confirmed {
         let msg = format!("{:} not copied to {:}", src.display(), dst.display());
@@ -518,13 +518,13 @@ fn copy_symlink(
         Ok(p) => p,
         Err(err) => {
             return Value::Error {
-                error: ShellError::GenericError(
+                error: Box::new(ShellError::GenericError(
                     err.to_string(),
                     err.to_string(),
                     Some(span),
                     None,
                     vec![],
-                ),
+                )),
             }
         }
     };
@@ -551,7 +551,13 @@ fn copy_symlink(
             Value::String { val: msg, span }
         }
         Err(e) => Value::Error {
-            error: ShellError::GenericError(e.to_string(), e.to_string(), Some(span), None, vec![]),
+            error: Box::new(ShellError::GenericError(
+                e.to_string(),
+                e.to_string(),
+                Some(span),
+                None,
+                vec![],
+            )),
         },
     }
 }
@@ -593,5 +599,7 @@ fn convert_io_error(error: std::io::Error, src: PathBuf, dst: PathBuf, span: Spa
         _ => ShellError::IOErrorSpanned(message_src, span),
     };
 
-    Value::Error { error: shell_error }
+    Value::Error {
+        error: Box::new(shell_error),
+    }
 }

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -255,10 +255,14 @@ impl Command for Ls {
                             );
                             match entry {
                                 Ok(value) => Some(value),
-                                Err(err) => Some(Value::Error { error: err }),
+                                Err(err) => Some(Value::Error {
+                                    error: Box::new(err),
+                                }),
                             }
                         }
-                        Err(err) => Some(Value::Error { error: err }),
+                        Err(err) => Some(Value::Error {
+                            error: Box::new(err),
+                        }),
                     }
                 }
                 _ => Some(Value::Nothing { span: call_span }),

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -193,7 +193,9 @@ impl Command for Mv {
                     interactive,
                 );
                 if let Err(error) = result {
-                    Some(Value::Error { error })
+                    Some(Value::Error {
+                        error: Box::new(error),
+                    })
                 } else if verbose {
                     let val = match result {
                         Ok(true) => format!(

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -405,13 +405,13 @@ fn rm(
                     if let Err(e) = result {
                         let msg = format!("Could not delete because: {e:}");
                         Value::Error {
-                            error: ShellError::GenericError(
+                            error: Box::new(ShellError::GenericError(
                                 msg,
                                 e.to_string(),
                                 Some(span),
                                 None,
                                 Vec::new(),
-                            ),
+                            )),
                         }
                     } else if verbose {
                         let msg = if interactive && !confirmed {
@@ -427,25 +427,25 @@ fn rm(
                 } else {
                     let msg = format!("Cannot remove {:}. try --recursive", f.to_string_lossy());
                     Value::Error {
-                        error: ShellError::GenericError(
+                        error: Box::new(ShellError::GenericError(
                             msg,
                             "cannot remove non-empty directory".into(),
                             Some(span),
                             None,
                             Vec::new(),
-                        ),
+                        )),
                     }
                 }
             } else {
                 let msg = format!("no such file or directory: {:}", f.to_string_lossy());
                 Value::Error {
-                    error: ShellError::GenericError(
+                    error: Box::new(ShellError::GenericError(
                         msg,
                         "no such file or directory".into(),
                         Some(span),
                         None,
                         Vec::new(),
-                    ),
+                    )),
                 }
             }
         })

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -250,7 +250,7 @@ fn value_to_bytes(value: Value) -> Result<Vec<u8>, ShellError> {
             Ok(val.into_bytes())
         }
         // Propagate errors by explicitly matching them before the final case.
-        Value::Error { error } => Err(error),
+        Value::Error { error } => Err(*error),
         other => Ok(other.as_string()?.into_bytes()),
     }
 }
@@ -376,7 +376,7 @@ fn stream_to_file(
                     Value::String { val, .. } => val.into_bytes(),
                     Value::Binary { val, .. } => val,
                     // Propagate errors by explicitly matching them before the final case.
-                    Value::Error { error } => return Err(error),
+                    Value::Error { error } => return Err(*error),
                     other => {
                         return Err(ShellError::OnlySupportsThisInputType {
                             exp_input_type: "string or binary".into(),

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -137,7 +137,7 @@ fn getcol(
             .into_pipeline_data(ctrlc)
             .set_metadata(metadata)),
         // Propagate errors
-        PipelineData::Value(Value::Error { error }, ..) => Err(error),
+        PipelineData::Value(Value::Error { error }, ..) => Err(*error),
         PipelineData::Value(other, ..) => Err(ShellError::OnlySupportsThisInputType {
             exp_input_type: "record or table".into(),
             wrong_type: other.get_type().to_string(),

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -167,7 +167,9 @@ with 'transpose' first."#
                         Err(ShellError::Break(_)) => None,
                         Err(error) => {
                             let error = chain_error_with_input(error, input_span);
-                            Some(Value::Error { error })
+                            Some(Value::Error {
+                                error: Box::new(error),
+                            })
                         }
                     }
                 })
@@ -187,7 +189,11 @@ with 'transpose' first."#
                     let x = match x {
                         Ok(x) => x,
                         Err(ShellError::Break(_)) => return None,
-                        Err(err) => return Some(Value::Error { error: err }),
+                        Err(err) => {
+                            return Some(Value::Error {
+                                error: Box::new(err),
+                            })
+                        }
                     };
 
                     if let Some(var) = block.signature.get_positional(0) {
@@ -208,7 +214,7 @@ with 'transpose' first."#
                         Ok(v) => Some(v.into_value(span)),
                         Err(ShellError::Break(_)) => None,
                         Err(error) => {
-                            let error = chain_error_with_input(error, input_span);
+                            let error = Box::new(chain_error_with_input(error, input_span));
                             Some(Value::Error { error })
                         }
                     }

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -101,7 +101,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                             }
                         }
                         Err(error) => Some(Value::Error {
-                            error: chain_error_with_input(error, x.span()),
+                            error: Box::new(chain_error_with_input(error, x.span())),
                         }),
                     }
                 })
@@ -118,7 +118,11 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
 
                     let x = match x {
                         Ok(x) => x,
-                        Err(err) => return Some(Value::Error { error: err }),
+                        Err(err) => {
+                            return Some(Value::Error {
+                                error: Box::new(err),
+                            })
+                        }
                     };
 
                     if let Some(var) = block.signature.get_positional(0) {
@@ -144,7 +148,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                             }
                         }
                         Err(error) => Some(Value::Error {
-                            error: chain_error_with_input(error, x.span()),
+                            error: Box::new(chain_error_with_input(error, x.span())),
                         }),
                     }
                 })
@@ -177,7 +181,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                         }
                     }
                     Err(error) => Some(Value::Error {
-                        error: chain_error_with_input(error, x.span()),
+                        error: Box::new(chain_error_with_input(error, x.span())),
                     }),
                 }
                 .into_pipeline_data(ctrlc))

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -522,7 +522,7 @@ fn find_with_rest_and_highlight(
                             }
                         }
                         // Propagate errors by explicitly matching them before the final case.
-                        Value::Error { error } => return Err(error),
+                        Value::Error { error } => return Err(*error),
                         other => {
                             return Err(ShellError::UnsupportedInput(
                                 "unsupported type from raw stream".into(),

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -141,7 +141,7 @@ fn first_helper(
                 }
             }
             // Propagate errors by explicitly matching them before the final case.
-            Value::Error { error } => Err(error),
+            Value::Error { error } => Err(*error),
             other => Err(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "list, binary or range".into(),
                 wrong_type: other.get_type().to_string(),

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -154,7 +154,7 @@ enum TableInside<'a> {
 fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) -> Vec<Value> {
     let tag = match item.span() {
         Ok(x) => x,
-        Err(e) => return vec![Value::Error { error: e }],
+        Err(e) => return vec![Value::Error { error: Box::new(e) }],
     };
 
     let res = {
@@ -172,19 +172,19 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                 Value::Error { .. } => return vec![item.clone()],
                 other => {
                     return vec![Value::Error {
-                        error: ShellError::OnlySupportsThisInputType {
+                        error: Box::new(ShellError::OnlySupportsThisInputType {
                             exp_input_type: "record".into(),
                             wrong_type: other.get_type().to_string(),
                             dst_span: _name_tag,
                             src_span: other.expect_span(),
-                        },
+                        }),
                     }];
                 }
             };
 
             let s = match item.span() {
                 Ok(x) => x,
-                Err(e) => return vec![Value::Error { error: e }],
+                Err(e) => return vec![Value::Error { error: Box::new(e) }],
             };
 
             let records_iterator = {
@@ -229,12 +229,12 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                         if all && vals.iter().all(|f| f.as_record().is_ok()) =>
                     {
                         if need_flatten && inner_table.is_some() {
-                            return vec![Value::Error{ error: ShellError::UnsupportedInput(
+                            return vec![Value::Error{ error: Box::new(ShellError::UnsupportedInput(
                                     "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(),
                                     "value originates from here".into(),
                                     s,
                                     *span
-                                )}
+                                ))}
                             ];
                         }
                         // it's a table (a list of record, we can flatten inner record)
@@ -267,12 +267,12 @@ fn flat_value(columns: &[CellPath], item: &Value, _name_tag: Span, all: bool) ->
                     }
                     Value::List { vals: values, span } => {
                         if need_flatten && inner_table.is_some() {
-                            return vec![Value::Error{ error: ShellError::UnsupportedInput(
+                            return vec![Value::Error{ error: Box::new(ShellError::UnsupportedInput(
                                     "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(),
                                     "value originates from here".into(),
                                     s,
                                     *span
-                                )}
+                                ))}
                             ];
                         }
 

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -244,7 +244,7 @@ pub fn group(
         Grouper::ByColumn(Some(column_name)) => {
             let block = Box::new(move |_, row: &Value| {
                 if let Value::Error { error } = row {
-                    return Err(error.clone());
+                    return Err(*error.clone());
                 };
                 match row.get_data_by_key(&column_name.item) {
                     Some(group_key) => Ok(group_key.as_string()?),

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -163,12 +163,12 @@ fn insert(
                             pd.into_value(span),
                             span,
                         ) {
-                            return Value::Error { error: e };
+                            return Value::Error { error: Box::new(e) };
                         }
 
                         input
                     }
-                    Err(e) => Value::Error { error: e },
+                    Err(e) => Value::Error { error: Box::new(e) },
                 }
             },
             ctrlc,
@@ -199,7 +199,7 @@ fn insert(
                 if let Err(e) =
                     input.insert_data_at_cell_path(&cell_path.members, replacement, span)
                 {
-                    return Value::Error { error: e };
+                    return Value::Error { error: Box::new(e) };
                 }
 
                 input

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -86,7 +86,7 @@ fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellErr
             // Check for and propagate errors
             for value in input.into_iter() {
                 if let Value::Error { error } = value {
-                    return Err(error);
+                    return Err(*error);
                 }
                 count += 1
             }

--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -125,11 +125,15 @@ repeating this process with row 1, and so on."#
                                             span: call.head,
                                         }
                                     }
-                                    Err(error) => Value::Error { error },
+                                    Err(error) => Value::Error {
+                                        error: Box::new(error),
+                                    },
                                 }
                             }
                             (_, None) => inp,
-                            (Err(error), _) => Value::Error { error },
+                            (Err(error), _) => Value::Error {
+                                error: Box::new(error),
+                            },
                         });
 
                 if let Some(md) = metadata {

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -158,9 +158,13 @@ impl Command for Move {
                         call.head,
                     ) {
                         Ok(val) => val,
-                        Err(error) => Value::Error { error },
+                        Err(error) => Value::Error {
+                            error: Box::new(error),
+                        },
                     },
-                    Err(error) => Value::Error { error },
+                    Err(error) => Value::Error {
+                        error: Box::new(error),
+                    },
                 });
 
                 if let Some(md) = metadata {

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -121,7 +121,7 @@ impl Command for ParEach {
                     ) {
                         Ok(v) => v,
                         Err(error) => Value::Error {
-                            error: chain_error_with_input(error, val_span),
+                            error: Box::new(chain_error_with_input(error, val_span)),
                         }
                         .into_pipeline_data(),
                     }
@@ -155,7 +155,7 @@ impl Command for ParEach {
                     ) {
                         Ok(v) => v,
                         Err(error) => Value::Error {
-                            error: chain_error_with_input(error, val_span),
+                            error: Box::new(chain_error_with_input(error, val_span)),
                         }
                         .into_pipeline_data(),
                     }
@@ -188,7 +188,7 @@ impl Command for ParEach {
                     ) {
                         Ok(v) => v,
                         Err(error) => Value::Error {
-                            error: chain_error_with_input(error, val_span),
+                            error: Box::new(chain_error_with_input(error, val_span)),
                         }
                         .into_pipeline_data(),
                     }
@@ -206,7 +206,12 @@ impl Command for ParEach {
                 .map(move |x| {
                     let x = match x {
                         Ok(x) => x,
-                        Err(err) => return Value::Error { error: err }.into_pipeline_data(),
+                        Err(err) => {
+                            return Value::Error {
+                                error: Box::new(err),
+                            }
+                            .into_pipeline_data()
+                        }
                     };
 
                     let block = engine_state.get_block(block_id);
@@ -228,7 +233,10 @@ impl Command for ParEach {
                         redirect_stderr,
                     ) {
                         Ok(v) => v,
-                        Err(error) => Value::Error { error }.into_pipeline_data(),
+                        Err(error) => Value::Error {
+                            error: Box::new(error),
+                        }
+                        .into_pipeline_data(),
                     }
                 })
                 .collect::<Vec<_>>()

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -141,7 +141,7 @@ fn rename(
                             // check if the specified column to be renamed exists
                             if !cols.contains(&c[0]) {
                                 return Value::Error {
-                                    error: ShellError::UnsupportedInput(
+                                    error: Box::new(ShellError::UnsupportedInput(
                                         format!(
                                             "The column '{}' does not exist in the input",
                                             &c[0]
@@ -151,7 +151,7 @@ fn rename(
                                         specified_col_span.unwrap_or(head_span),
                                         // Arrow 2 points at the input value.
                                         span,
-                                    ),
+                                    )),
                                 };
                             }
                             for (idx, val) in cols.iter_mut().enumerate() {
@@ -177,12 +177,12 @@ fn rename(
                 // Propagate errors by explicitly matching them before the final case.
                 Value::Error { .. } => item.clone(),
                 other => Value::Error {
-                    error: ShellError::OnlySupportsThisInputType {
+                    error: Box::new(ShellError::OnlySupportsThisInputType {
                         exp_input_type: "record".into(),
                         wrong_type: other.get_type().to_string(),
                         dst_span: head_span,
                         src_span: other.expect_span(),
-                    },
+                    }),
                 },
             },
             engine_state.ctrlc.clone(),

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -73,7 +73,7 @@ impl Command for Take {
                     .into_pipeline_data(ctrlc)
                     .set_metadata(metadata)),
                 // Propagate errors by explicitly matching them before the final case.
-                Value::Error { error } => Err(error),
+                Value::Error { error } => Err(*error),
                 other => Err(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "list, binary or range".into(),
                     wrong_type: other.get_type().to_string(),

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -132,12 +132,12 @@ fn update(
                         if let Err(e) =
                             input.update_data_at_cell_path(&cell_path.members, pd.into_value(span))
                         {
-                            return Value::Error { error: e };
+                            return Value::Error { error: Box::new(e) };
                         }
 
                         input
                     }
-                    Err(e) => Value::Error { error: e },
+                    Err(e) => Value::Error { error: Box::new(e) },
                 }
             },
             ctrlc,
@@ -174,7 +174,7 @@ fn update(
                 let replacement = replacement.clone();
 
                 if let Err(e) = input.update_data_at_cell_path(&cell_path.members, replacement) {
-                    return Value::Error { error: e };
+                    return Value::Error { error: Box::new(e) };
                 }
 
                 input

--- a/crates/nu-command/src/filters/update_cells.rs
+++ b/crates/nu-command/src/filters/update_cells.rs
@@ -253,7 +253,7 @@ fn process_cell(
         redirect_stderr,
     ) {
         Ok(pd) => pd.into_value(span),
-        Err(e) => Value::Error { error: e },
+        Err(e) => Value::Error { error: Box::new(e) },
     }
 }
 

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -154,12 +154,12 @@ fn upsert(
                         if let Err(e) =
                             input.upsert_data_at_cell_path(&cell_path.members, pd.into_value(span))
                         {
-                            return Value::Error { error: e };
+                            return Value::Error { error: Box::new(e) };
                         }
 
                         input
                     }
-                    Err(e) => Value::Error { error: e },
+                    Err(e) => Value::Error { error: Box::new(e) },
                 }
             },
             ctrlc,
@@ -195,7 +195,7 @@ fn upsert(
                 let replacement = replacement.clone();
 
                 if let Err(e) = input.upsert_data_at_cell_path(&cell_path.members, replacement) {
-                    return Value::Error { error: e };
+                    return Value::Error { error: Box::new(e) };
                 }
 
                 input

--- a/crates/nu-command/src/filters/values.rs
+++ b/crates/nu-command/src/filters/values.rs
@@ -119,7 +119,7 @@ pub fn get_values<'a>(
                     }
                 }
             }
-            Value::Error { error } => return Err(error.clone()),
+            Value::Error { error } => return Err(*error.clone()),
             _ => {
                 return Err(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "record or table".into(),
@@ -176,7 +176,7 @@ fn values(
             Ok(vals.into_pipeline_data(ctrlc).set_metadata(metadata))
         }
         // Propagate errors
-        PipelineData::Value(Value::Error { error }, ..) => Err(error),
+        PipelineData::Value(Value::Error { error }, ..) => Err(*error),
         PipelineData::Value(other, ..) => Err(ShellError::OnlySupportsThisInputType {
             exp_input_type: "record or table".into(),
             wrong_type: other.get_type().to_string(),

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -97,7 +97,9 @@ not supported."#
                             None
                         }
                     }
-                    Err(err) => Some(Value::Error { error: err }),
+                    Err(err) => Some(Value::Error {
+                        error: Box::new(err),
+                    }),
                 }
             })
             .into_pipeline_data(ctrlc)

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -77,7 +77,9 @@ impl Command for FromJson {
                     } else {
                         match convert_string_to_value(x.to_string(), span) {
                             Ok(v) => Some(v),
-                            Err(error) => Some(Value::Error { error }),
+                            Err(error) => Some(Value::Error {
+                                error: Box::new(error),
+                            }),
                         }
                     }
                 })
@@ -119,12 +121,12 @@ fn convert_nujson_to_value(value: &nu_json::Value, span: Span) -> Value {
         nu_json::Value::U64(u) => {
             if *u > i64::MAX as u64 {
                 Value::Error {
-                    error: ShellError::CantConvert {
+                    error: Box::new(ShellError::CantConvert {
                         to_type: "i64 sized integer".into(),
                         from_type: "value larger than i64".into(),
                         span,
                         help: None,
-                    },
+                    }),
                 }
             } else {
                 Value::Int {

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -93,7 +93,7 @@ fn collect_binary(input: PipelineData, span: Span) -> Result<Vec<u8>, ShellError
             Some(Value::Binary { val: b, .. }) => {
                 bytes.extend_from_slice(&b);
             }
-            Some(Value::Error { error }) => return Err(error),
+            Some(Value::Error { error }) => return Err(*error),
             Some(x) => {
                 return Err(ShellError::UnsupportedInput(
                     "Expected binary from pipeline".to_string(),

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -16,7 +16,7 @@ fn from_value_to_delimited_string(
         }
         Value::List { vals, span } => table_to_delimited(vals, span, separator, config, head),
         // Propagate errors by explicitly matching them before the final case.
-        Value::Error { error } => Err(error.clone()),
+        Value::Error { error } => Err(*error.clone()),
         v => Err(make_unsupported_input_error(v, head, v.expect_span())),
     }
 }
@@ -122,7 +122,7 @@ fn to_string_tagged_value(
         Value::Date { val, .. } => Ok(val.to_string()),
         Value::Nothing { .. } => Ok(String::new()),
         // Propagate existing errors
-        Value::Error { error } => Err(error.clone()),
+        Value::Error { error } => Err(*error.clone()),
         _ => Err(make_unsupported_input_error(v, head, span)),
     }
 }

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -70,12 +70,12 @@ impl Command for ToJson {
             }
             .into_pipeline_data()),
             _ => Ok(Value::Error {
-                error: ShellError::CantConvert {
+                error: Box::new(ShellError::CantConvert {
                     to_type: "JSON".into(),
                     from_type: value.get_type().to_string(),
                     span,
                     help: None,
-                },
+                }),
             }
             .into_pipeline_data()),
         }
@@ -126,7 +126,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
         ),
 
         Value::List { vals, .. } => nu_json::Value::Array(json_list(vals)?),
-        Value::Error { error } => return Err(error.clone()),
+        Value::Error { error } => return Err(*error.clone()),
         Value::Closure { .. } | Value::Block { .. } | Value::Range { .. } => nu_json::Value::Null,
         Value::Binary { val, .. } => {
             nu_json::Value::Array(val.iter().map(|x| nu_json::Value::U64(*x as u64)).collect())

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -101,7 +101,7 @@ pub fn value_to_string(v: &Value, span: Span) -> Result<String, ShellError> {
         // FIXME: make durations use the shortest lossless representation.
         Value::Duration { val, .. } => Ok(format!("{}ns", *val)),
         // Propagate existing errors
-        Value::Error { error } => Err(error.clone()),
+        Value::Error { error } => Err(*error.clone()),
         // FIXME: make filesizes use the shortest lossless representation.
         Value::Filesize { val, .. } => Ok(format!("{}b", *val)),
         Value::Float { val, .. } => {

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -77,7 +77,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
             toml::Value::String(code)
         }
         Value::Nothing { .. } => toml::Value::String("<Nothing>".to_string()),
-        Value::Error { error } => return Err(error.clone()),
+        Value::Error { error } => return Err(*error.clone()),
         Value::Binary { val, .. } => toml::Value::Array(
             val.iter()
                 .map(|x| toml::Value::Integer(*x as i64))
@@ -118,12 +118,12 @@ fn toml_into_pipeline_data(
         }
         .into_pipeline_data()),
         _ => Ok(Value::Error {
-            error: ShellError::CantConvert {
+            error: Box::new(ShellError::CantConvert {
                 to_type: "TOML".into(),
                 from_type: value_type.to_string(),
                 span,
                 help: None,
-            },
+            }),
         }
         .into_pipeline_data()),
     }
@@ -137,7 +137,7 @@ fn value_to_toml_value(
     match v {
         Value::Record { .. } => helper(engine_state, v),
         // Propagate existing errors
-        Value::Error { error } => Err(error.clone()),
+        Value::Error { error } => Err(*error.clone()),
         _ => Err(ShellError::UnsupportedInput(
             format!("{:?} is not valid top-level TOML", v.get_type()),
             "value originates from here".into(),

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -79,7 +79,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
         Value::Block { .. } => serde_yaml::Value::Null,
         Value::Closure { .. } => serde_yaml::Value::Null,
         Value::Nothing { .. } => serde_yaml::Value::Null,
-        Value::Error { error } => return Err(error.clone()),
+        Value::Error { error } => return Err(*error.clone()),
         Value::Binary { val, .. } => serde_yaml::Value::Sequence(
             val.iter()
                 .map(|x| serde_yaml::Value::Number(serde_yaml::Number::from(*x)))
@@ -111,12 +111,12 @@ fn to_yaml(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> 
         }
         .into_pipeline_data()),
         _ => Ok(Value::Error {
-            error: ShellError::CantConvert {
+            error: Box::new(ShellError::CantConvert {
                 to_type: "YAML".into(),
                 from_type: value.get_type().to_string(),
                 span: head,
                 help: None,
-            },
+            }),
         }
         .into_pipeline_data()),
     }

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -111,16 +111,20 @@ where
         other => {
             let span = match input.span() {
                 Ok(span) => span,
-                Err(error) => return Value::Error { error },
+                Err(error) => {
+                    return Value::Error {
+                        error: Box::new(error),
+                    }
+                }
             };
 
             return Value::Error {
-                error: ShellError::OnlySupportsThisInputType {
+                error: Box::new(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "string or binary".into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: span,
                     src_span: other.expect_span(),
-                },
+                }),
             };
         }
     };

--- a/crates/nu-command/src/input_handler.rs
+++ b/crates/nu-command/src/input_handler.rs
@@ -76,7 +76,9 @@ where
                             }),
                         );
                         if let Err(error) = r {
-                            return Value::Error { error };
+                            return Value::Error {
+                                error: Box::new(error),
+                            };
                         }
                     }
                     v

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -68,12 +68,12 @@ fn abs_helper(val: Value, head: Span) -> Value {
         },
         Value::Error { .. } => val,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/arccos.rs
+++ b/crates/nu-command/src/math/arccos.rs
@@ -77,23 +77,23 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
                 Value::Float { val, span }
             } else {
                 Value::Error {
-                    error: ShellError::UnsupportedInput(
+                    error: Box::new(ShellError::UnsupportedInput(
                         "'arccos' undefined for values outside the closed interval [-1, 1].".into(),
                         "value originates from here".into(),
                         head,
                         span,
-                    ),
+                    )),
                 }
             }
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/arccosh.rs
+++ b/crates/nu-command/src/math/arccosh.rs
@@ -67,23 +67,23 @@ fn operate(value: Value, head: Span) -> Value {
                 Value::Float { val, span }
             } else {
                 Value::Error {
-                    error: ShellError::UnsupportedInput(
+                    error: Box::new(ShellError::UnsupportedInput(
                         "'arccosh' undefined for values below 1.".into(),
                         "value originates from here".into(),
                         head,
                         span,
-                    ),
+                    )),
                 }
             }
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/arcsin.rs
+++ b/crates/nu-command/src/math/arcsin.rs
@@ -78,23 +78,23 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
                 Value::Float { val, span }
             } else {
                 Value::Error {
-                    error: ShellError::UnsupportedInput(
+                    error: Box::new(ShellError::UnsupportedInput(
                         "'arcsin' undefined for values outside the closed interval [-1, 1].".into(),
                         "value originates from here".into(),
                         head,
                         span,
-                    ),
+                    )),
                 }
             }
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/arcsinh.rs
+++ b/crates/nu-command/src/math/arcsinh.rs
@@ -67,12 +67,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/arctan.rs
+++ b/crates/nu-command/src/math/arctan.rs
@@ -78,12 +78,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/arctanh.rs
+++ b/crates/nu-command/src/math/arctanh.rs
@@ -67,23 +67,23 @@ fn operate(value: Value, head: Span) -> Value {
                 Value::Float { val, span }
             } else {
                 Value::Error {
-                    error: ShellError::UnsupportedInput(
+                    error: Box::new(ShellError::UnsupportedInput(
                         "'arctanh' undefined for values outside the open interval (-1, 1).".into(),
                         "value originates from here".into(),
                         head,
                         span,
-                    ),
+                    )),
                 }
             }
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -64,12 +64,12 @@ fn operate(value: Value, head: Span) -> Value {
         },
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/cos.rs
+++ b/crates/nu-command/src/math/cos.rs
@@ -88,12 +88,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/cosh.rs
+++ b/crates/nu-command/src/math/cosh.rs
@@ -69,12 +69,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -64,12 +64,12 @@ fn operate(value: Value, head: Span) -> Value {
         },
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/ln.rs
+++ b/crates/nu-command/src/math/ln.rs
@@ -67,23 +67,23 @@ fn operate(value: Value, head: Span) -> Value {
                 Value::Float { val, span }
             } else {
                 Value::Error {
-                    error: ShellError::UnsupportedInput(
+                    error: Box::new(ShellError::UnsupportedInput(
                         "'ln' undefined for values outside the open interval (0, Inf).".into(),
                         "value originates from here".into(),
                         head,
                         span,
-                    ),
+                    )),
                 }
             }
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -96,13 +96,13 @@ fn operate(value: Value, head: Span, base: f64) -> Value {
 
             if val <= 0.0 {
                 return Value::Error {
-                    error: ShellError::UnsupportedInput(
+                    error: Box::new(ShellError::UnsupportedInput(
                         "'math log' undefined for values outside the open interval (0, Inf)."
                             .into(),
                         "value originates from here".into(),
                         head,
                         span,
-                    ),
+                    )),
                 };
             }
             // Specialize for better precision/performance
@@ -118,12 +118,12 @@ fn operate(value: Value, head: Span, base: f64) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -132,7 +132,7 @@ pub fn mode(values: &[Value], _span: Span, head: &Span) -> Result<Value, ShellEr
             Value::Filesize { val, .. } => {
                 Ok(HashableType::new(val.to_ne_bytes(), NumberTypes::Filesize))
             }
-            Value::Error { error } => Err(error.clone()),
+            Value::Error { error } => Err(*error.clone()),
             other => Err(ShellError::UnsupportedInput(
                 "Unable to give a result with this input".to_string(),
                 "value originates from here".into(),

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -112,7 +112,7 @@ pub fn sum(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
             | Value::Duration { .. } => {
                 acc = acc.add(head, value, head)?;
             }
-            Value::Error { error } => return Err(error.clone()),
+            Value::Error { error } => return Err(*error.clone()),
             other => {
                 return Err(ShellError::UnsupportedInput(
                     "Attempted to compute the sum of a value that cannot be summed".to_string(),
@@ -145,7 +145,7 @@ pub fn product(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellE
             Value::Int { .. } | Value::Float { .. } => {
                 acc = acc.mul(head, value, head)?;
             }
-            Value::Error { error } => return Err(error.clone()),
+            Value::Error { error } => return Err(*error.clone()),
             other => {
                 return Err(ShellError::UnsupportedInput(
                     "Attempted to compute the product of a value that cannot be multiplied"

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -95,12 +95,12 @@ fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
         Value::Int { .. } => value,
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/sin.rs
+++ b/crates/nu-command/src/math/sin.rs
@@ -88,12 +88,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/sinh.rs
+++ b/crates/nu-command/src/math/sinh.rs
@@ -69,12 +69,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -73,24 +73,24 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }
 
 fn error_negative_sqrt(head: Span, span: Span) -> Value {
     Value::Error {
-        error: ShellError::UnsupportedInput(
+        error: Box::new(ShellError::UnsupportedInput(
             String::from("Can't square root a negative number"),
             "value originates from here".into(),
             head,
             span,
-        ),
+        )),
     }
 }
 

--- a/crates/nu-command/src/math/tan.rs
+++ b/crates/nu-command/src/math/tan.rs
@@ -86,12 +86,12 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/tanh.rs
+++ b/crates/nu-command/src/math/tanh.rs
@@ -68,12 +68,12 @@ fn operate(value: Value, head: Span) -> Value {
         }
         Value::Error { .. } => value,
         other => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -34,7 +34,7 @@ fn helper_for_tables(
                         .or_insert_with(|| vec![value.clone()]);
                 }
             }
-            Value::Error { error } => return Err(error.clone()),
+            Value::Error { error } => return Err(*error.clone()),
             _ => {
                 //Turns out we are not dealing with a table
                 return mf(values, val.expect_span(), &name);

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -64,7 +64,7 @@ fn sum_of_squares(values: &[Value], span: &Span) -> Result<Value, ShellError> {
     for value in values {
         let v = match &value {
             Value::Int { .. } | Value::Float { .. } => Ok(value),
-            Value::Error { error } => Err(error.clone()),
+            Value::Error { error } => Err(*error.clone()),
             _ => Err(ShellError::UnsupportedInput(
                 "Attempted to compute the sum of squares of a non-integer, non-float value"
                     .to_string(),

--- a/crates/nu-command/src/network/url/build_query.rs
+++ b/crates/nu-command/src/network/url/build_query.rs
@@ -98,7 +98,7 @@ fn to_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> {
                 }
             }
             // Propagate existing errors
-            Value::Error { error } => Err(error),
+            Value::Error { error } => Err(*error),
             other => Err(ShellError::UnsupportedInput(
                 "Expected a table from pipeline".to_string(),
                 "value originates from here".into(),

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -100,12 +100,12 @@ fn action_all(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }
@@ -121,12 +121,12 @@ fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -106,7 +106,7 @@ impl Command for SubCommand {
 
                     url_components?.to_url(span)
                 }
-                Value::Error { error } => Err(error),
+                Value::Error { error } => Err(*error),
                 other => Err(ShellError::UnsupportedInput(
                     "Expected a record from pipeline".to_string(),
                     "value originates from here".into(),
@@ -164,7 +164,7 @@ impl UrlComponents {
                     port: Some(val),
                     ..self
                 }),
-                Value::Error { error } => Err(error),
+                Value::Error { error } => Err(*error),
                 other => Err(ShellError::IncompatibleParametersSingle {
                     msg: String::from(
                         "Port parameter should be an unsigned integer or a string representing it",
@@ -211,7 +211,7 @@ impl UrlComponents {
                         ..self
                     })
                 }
-                Value::Error { error } => Err(error),
+                Value::Error { error } => Err(*error),
                 other => Err(ShellError::IncompatibleParametersSingle {
                     msg: String::from("Key params has to be a record"),
                     span: other.expect_span(),

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -111,7 +111,7 @@ fn exists(path: &Path, span: Span, args: &Arguments) -> Value {
             Ok(exists) => exists,
             Err(err) => {
                 return Value::Error {
-                    error: ShellError::IOErrorSpanned(err.to_string(), span),
+                    error: Box::new(ShellError::IOErrorSpanned(err.to_string(), span)),
                 }
             }
         },

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -136,7 +136,7 @@ fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
                 }
             }
             Err(_) => Value::Error {
-                error: ShellError::GenericError(
+                error: Box::new(ShellError::GenericError(
                     "Could not expand path".into(),
                     "could not be expanded (path might not exist, non-final \
                             component is not a directory, or other cause)"
@@ -144,7 +144,7 @@ fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
                     Some(span),
                     None,
                     Vec::new(),
-                ),
+                )),
             },
         }
     } else if args.not_follow_symlink {

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -197,11 +197,11 @@ fn join_list(parts: &[Value], head: Span, span: Span, args: &Arguments) -> Value
                     Value::List { vals, span }
                 }
                 Err(_) => Value::Error {
-                    error: ShellError::PipelineMismatch {
+                    error: Box::new(ShellError::PipelineMismatch {
                         exp_input_type: "string or record".into(),
                         dst_span: head,
                         src_span: span,
-                    },
+                    }),
                 },
             }
         }
@@ -223,7 +223,9 @@ fn join_record(cols: &[String], vals: &[Value], head: Span, span: Span, args: &A
     } else {
         match merge_record(cols, vals, head, span) {
             Ok(p) => join_single(p.as_path(), head, args),
-            Err(error) => Value::Error { error },
+            Err(error) => Value::Error {
+                error: Box::new(error),
+            },
         }
     }
 }

--- a/crates/nu-command/src/path/mod.rs
+++ b/crates/nu-command/src/path/mod.rs
@@ -48,12 +48,12 @@ where
             };
             if col.is_empty() {
                 return Value::Error {
-                    error: ShellError::UnsupportedInput(
+                    error: Box::new(ShellError::UnsupportedInput(
                         String::from("when the input is a table, you must specify the columns"),
                         "value originates from here".into(),
                         name,
                         span,
-                    ),
+                    )),
                 };
             }
 
@@ -85,7 +85,7 @@ where
 
 fn handle_invalid_values(rest: Value, name: Span) -> Value {
     Value::Error {
-        error: err_from_value(&rest, name),
+        error: Box::new(err_from_value(&rest, name)),
     }
 }
 

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -128,12 +128,12 @@ fn relative_to(path: &Path, span: Span, args: &Arguments) -> Value {
     match lhs.strip_prefix(&rhs) {
         Ok(p) => Value::string(p.to_string_lossy(), span),
         Err(e) => Value::Error {
-            error: ShellError::CantConvert {
+            error: Box::new(ShellError::CantConvert {
                 to_type: e.to_string(),
                 from_type: "string".into(),
                 span,
                 help: None,
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/platform/ansi/gradient.rs
@@ -134,7 +134,9 @@ fn operate(
                         Box::new(move |old| action(old, fgs_hex, fge_hex, bgs_hex, bge_hex, &head)),
                     );
                     if let Err(error) = r {
-                        return Value::Error { error };
+                        return Value::Error {
+                            error: Box::new(error),
+                        };
                     }
                 }
                 ret
@@ -158,11 +160,11 @@ fn action(
                 (None, None, None, None) => {
                     // Error - no colors
                     Value::Error {
-                        error: ShellError::MissingParameter {
+                        error: Box::new(ShellError::MissingParameter {
                             param_name:
                                 "please supply foreground and/or background color parameters".into(),
                             span: *command_span,
-                        },
+                        }),
                     }
                 }
                 (None, None, None, Some(bg_end)) => {
@@ -286,10 +288,10 @@ fn action(
             let got = format!("value is {}, not string", other.get_type());
 
             Value::Error {
-                error: ShellError::TypeMismatch {
+                error: Box::new(ShellError::TypeMismatch {
                     err_message: got,
                     span: other.span().unwrap_or(*command_span),
-                },
+                }),
             }
         }
     }

--- a/crates/nu-command/src/platform/ansi/link.rs
+++ b/crates/nu-command/src/platform/ansi/link.rs
@@ -122,7 +122,9 @@ fn process_each_path(
             Box::new(|v| process_value(v, text, command_span)),
         );
         if let Err(error) = ret {
-            return Value::Error { error };
+            return Value::Error {
+                error: Box::new(error),
+            };
         }
     }
     value
@@ -139,10 +141,10 @@ fn process_value(value: &Value, text: &Option<String>, command_span: &Span) -> V
             let got = format!("value is {}, not string", other.get_type());
 
             Value::Error {
-                error: ShellError::TypeMismatch {
+                error: Box::new(ShellError::TypeMismatch {
                     err_message: got,
                     span: other.span().unwrap_or(*command_span),
-                },
+                }),
             }
         }
     }

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -58,10 +58,10 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, command_span: Span) -> Value 
             let got = format!("value is {}, not string", other.get_type());
 
             Value::Error {
-                error: ShellError::TypeMismatch {
+                error: Box::new(ShellError::TypeMismatch {
                     err_message: got,
                     span: other.span().unwrap_or(command_span),
-                },
+                }),
             }
         }
     }

--- a/crates/nu-command/src/platform/du.rs
+++ b/crates/nu-command/src/platform/du.rs
@@ -179,7 +179,7 @@ impl Command for Du {
                     }
                 }
                 Err(e) => {
-                    output.push(Value::Error { error: e });
+                    output.push(Value::Error { error: Box::new(e) });
                 }
             }
         }

--- a/crates/nu-command/src/strings/encode_decode/base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/base64.rs
@@ -90,7 +90,8 @@ fn action(
         "binhex" => GeneralPurpose::new(&alphabet::BIN_HEX, NO_PAD),
         "crypt" => GeneralPurpose::new(&alphabet::CRYPT, NO_PAD),
         "mutf7" => GeneralPurpose::new(&alphabet::IMAP_MUTF7, NO_PAD),
-        not_valid => return Value::Error { error:ShellError::GenericError(
+        not_valid => return Value::Error { error:
+            Box::new(ShellError::GenericError(
             "value is not an accepted character set".to_string(),
             format!(
                 "{not_valid} is not a valid character-set.\nPlease use `help encode base64` to see a list of valid character sets."
@@ -98,7 +99,7 @@ fn action(
             Some(config_character_set.span),
             None,
             Vec::new(),
-        )}
+        ))}
     };
     match input {
         // Propagate existing errors.
@@ -111,13 +112,13 @@ fn action(
                     Ok(bytes_written) => bytes_written,
                     Err(err) => {
                         return Value::Error {
-                            error: ShellError::GenericError(
+                            error: Box::new(ShellError::GenericError(
                                 "Error encoding data".into(),
                                 err.to_string(),
                                 Some(Span::unknown()),
                                 None,
                                 Vec::new(),
-                            ),
+                            )),
                         }
                     }
                 };
@@ -125,13 +126,13 @@ fn action(
                 Value::string(std::str::from_utf8(&enc_vec).unwrap_or(""), command_span)
             }
             ActionType::Decode => Value::Error {
-                error: ShellError::UnsupportedInput(
+                error: Box::new(ShellError::UnsupportedInput(
                     "Binary data can only be encoded".to_string(),
                     "value originates from here".into(),
                     command_span,
                     // This line requires the Value::Error {} match above.
                     input.expect_span(),
-                ),
+                )),
             },
         },
         Value::String {
@@ -158,20 +159,20 @@ fn action(
                                 match String::from_utf8(decoded_value) {
                                     Ok(string_value) => Value::string(string_value, command_span),
                                     Err(e) => Value::Error {
-                                        error: ShellError::GenericError(
+                                        error: Box::new(ShellError::GenericError(
                                             "base64 payload isn't a valid utf-8 sequence"
                                                 .to_owned(),
                                             e.to_string(),
                                             Some(*value_span),
                                             Some("consider using the `--binary` flag".to_owned()),
                                             Vec::new(),
-                                        ),
+                                        )),
                                     },
                                 }
                             }
                         }
                         Err(_) => Value::Error {
-                            error: ShellError::GenericError(
+                            error: Box::new(ShellError::GenericError(
                                 "value could not be base64 decoded".to_string(),
                                 format!(
                                     "invalid base64 input for character set {}",
@@ -180,17 +181,17 @@ fn action(
                                 Some(command_span),
                                 None,
                                 Vec::new(),
-                            ),
+                            )),
                         },
                     }
                 }
             }
         }
         other => Value::Error {
-            error: ShellError::TypeMismatch {
+            error: Box::new(ShellError::TypeMismatch {
                 err_message: format!("string or binary, not {}", other.get_type()),
                 span: other.span().unwrap_or(command_span),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/encode_decode/decode.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode.rs
@@ -77,7 +77,7 @@ documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#
             PipelineData::Value(v, ..) => match v {
                 Value::Binary { val: bytes, .. } => super::encoding::decode(head, encoding, &bytes)
                     .map(|val| val.into_pipeline_data()),
-                Value::Error { error } => Err(error),
+                Value::Error { error } => Err(*error),
                 _ => Err(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "binary".into(),
                     wrong_type: v.get_type().to_string(),

--- a/crates/nu-command/src/strings/encode_decode/encode.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode.rs
@@ -100,7 +100,7 @@ documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#
                     super::encoding::encode(head, encoding, &s, span, ignore_errors)
                         .map(|val| val.into_pipeline_data())
                 }
-                Value::Error { error } => Err(error),
+                Value::Error { error } => Err(*error),
                 _ => Err(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "string".into(),
                     wrong_type: v.get_type().to_string(),

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -230,7 +230,7 @@ fn format(
                             }
                         }
                     }
-                    Value::Error { error } => return Err(error.clone()),
+                    Value::Error { error } => return Err(*error.clone()),
                     _ => {
                         return Err(ShellError::OnlySupportsThisInputType {
                             exp_input_type: "record".to_string(),
@@ -249,7 +249,7 @@ fn format(
         }
         // Unwrapping this ShellError is a bit unfortunate.
         // Ideally, its Span would be preserved.
-        Value::Error { error } => Err(error),
+        Value::Error { error } => Err(*error),
         _ => Err(ShellError::OnlySupportsThisInputType {
             exp_input_type: "record".to_string(),
             wrong_type: data_as_value.get_type().to_string(),

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -106,12 +106,12 @@ fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
         },
         Value::Error { .. } => val.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "filesize".into(),
                 wrong_type: val.get_type().to_string(),
                 dst_span: span,
                 src_span: val.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -346,11 +346,11 @@ impl Iterator for ParseStreamer {
                     &mut self.excess,
                 ),
                 Err(_) => Some(Value::Error {
-                    error: ShellError::PipelineMismatch {
+                    error: Box::new(ShellError::PipelineMismatch {
                         exp_input_type: "string".into(),
                         dst_span: self.span,
                         src_span: v.span().unwrap_or(self.span),
-                    },
+                    }),
                 }),
             }
         } else {
@@ -386,15 +386,17 @@ impl Iterator for ParseStreamerExternal {
                     &mut self.excess,
                 ),
                 Err(_) => Some(Value::Error {
-                    error: ShellError::PipelineMismatch {
+                    error: Box::new(ShellError::PipelineMismatch {
                         exp_input_type: "string".into(),
                         dst_span: self.span,
                         src_span: self.span,
-                    },
+                    }),
                 }),
             }
         } else if let Some(Err(err)) = v {
-            Some(Value::Error { error: err })
+            Some(Value::Error {
+                error: Box::new(err),
+            })
         } else {
             None
         }
@@ -416,13 +418,13 @@ fn stream_helper(
             Ok(c) => c,
             Err(e) => {
                 return Some(Value::Error {
-                    error: ShellError::GenericError(
+                    error: Box::new(ShellError::GenericError(
                         "Error with regular expression captures".into(),
                         e.to_string(),
                         None,
                         None,
                         Vec::new(),
-                    ),
+                    )),
                 })
             }
         };

--- a/crates/nu-command/src/strings/size.rs
+++ b/crates/nu-command/src/strings/size.rs
@@ -124,18 +124,18 @@ fn size(
         move |v| {
             // First, obtain the span. If this fails, propagate the error that results.
             let value_span = match v.span() {
-                Err(v) => return Value::Error { error: v },
+                Err(v) => return Value::Error { error: Box::new(v) },
                 Ok(v) => v,
             };
             // Now, check if it's a string.
             match v.as_string() {
                 Ok(s) => counter(&s, span),
                 Err(_) => Value::Error {
-                    error: ShellError::PipelineMismatch {
+                    error: Box::new(ShellError::PipelineMismatch {
                         exp_input_type: "string".into(),
                         dst_span: span,
                         src_span: value_span,
-                    },
+                    }),
                 },
             }
         },

--- a/crates/nu-command/src/strings/split/chars.rs
+++ b/crates/nu-command/src/strings/split/chars.rs
@@ -110,15 +110,17 @@ fn split_chars_helper(v: &Value, name: Span, graphemes: bool) -> Vec<Value> {
                 }
             } else {
                 vec![Value::Error {
-                    error: ShellError::PipelineMismatch {
+                    error: Box::new(ShellError::PipelineMismatch {
                         exp_input_type: "string".into(),
                         dst_span: name,
                         src_span: v_span,
-                    },
+                    }),
                 }]
             }
         }
-        Err(error) => vec![Value::Error { error }],
+        Err(error) => vec![Value::Error {
+            error: Box::new(error),
+        }],
     }
 }
 

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -182,13 +182,15 @@ fn split_column_helper(
     } else {
         match v.span() {
             Ok(span) => vec![Value::Error {
-                error: ShellError::PipelineMismatch {
+                error: Box::new(ShellError::PipelineMismatch {
                     exp_input_type: "string".into(),
                     dst_span: head,
                     src_span: span,
-                },
+                }),
             }],
-            Err(error) => vec![Value::Error { error }],
+            Err(error) => vec![Value::Error {
+                error: Box::new(error),
+            }],
         }
     }
 }

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -132,15 +132,17 @@ fn split_row_helper(
                 }
             } else {
                 vec![Value::Error {
-                    error: ShellError::PipelineMismatch {
+                    error: Box::new(ShellError::PipelineMismatch {
                         exp_input_type: "string".into(),
                         dst_span: name,
                         src_span: v_span,
-                    },
+                    }),
                 }]
             }
         }
-        Err(error) => vec![Value::Error { error }],
+        Err(error) => vec![Value::Error {
+            error: Box::new(error),
+        }],
     }
 }
 

--- a/crates/nu-command/src/strings/split/words.rs
+++ b/crates/nu-command/src/strings/split/words.rs
@@ -185,15 +185,17 @@ fn split_words_helper(
                     .collect::<Vec<Value>>()
             } else {
                 vec![Value::Error {
-                    error: ShellError::PipelineMismatch {
+                    error: Box::new(ShellError::PipelineMismatch {
                         exp_input_type: "string".into(),
                         dst_span: span,
                         src_span: v_span,
-                    },
+                    }),
                 }]
             }
         }
-        Err(error) => vec![Value::Error { error }],
+        Err(error) => vec![Value::Error {
+            error: Box::new(error),
+        }],
     }
 }
 

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -89,7 +89,9 @@ fn operate(
                     let r =
                         ret.update_cell_path(&path.members, Box::new(move |old| action(old, head)));
                     if let Err(error) = r {
-                        return Value::Error { error };
+                        return Value::Error {
+                            error: Box::new(error),
+                        };
                     }
                 }
                 ret
@@ -107,12 +109,12 @@ fn action(input: &Value, head: Span) -> Value {
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -101,7 +101,9 @@ fn operate(
                     let r =
                         ret.update_cell_path(&path.members, Box::new(move |old| action(old, head)));
                     if let Err(error) = r {
-                        return Value::Error { error };
+                        return Value::Error {
+                            error: Box::new(error),
+                        };
                     }
                 }
                 ret
@@ -119,12 +121,12 @@ fn action(input: &Value, head: Span) -> Value {
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/case/mod.rs
+++ b/crates/nu-command/src/strings/str_/case/mod.rs
@@ -69,12 +69,12 @@ where
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -68,7 +68,9 @@ fn operate(
                     let r =
                         ret.update_cell_path(&path.members, Box::new(move |old| action(old, head)));
                     if let Err(error) = r {
-                        return Value::Error { error };
+                        return Value::Error {
+                            error: Box::new(error),
+                        };
                     }
                 }
                 ret
@@ -86,12 +88,12 @@ fn action(input: &Value, head: Span) -> Value {
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/collect.rs
+++ b/crates/nu-command/src/strings/str_/collect.rs
@@ -48,7 +48,7 @@ impl Command for StrCollect {
         for value in input {
             match value {
                 Value::Error { error } => {
-                    return Err(error);
+                    return Err(*error);
                 }
                 value => {
                     strings.push(value.debug_string("\n", config));

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -183,12 +183,12 @@ fn action(
         ),
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -99,12 +99,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -98,12 +98,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -155,7 +155,7 @@ fn action(
         Value::String { val: s, .. } => {
             let (start_index, end_index) = match r {
                 Ok(r) => (r.0 as usize, r.1 as usize),
-                Err(e) => return Value::Error { error: e },
+                Err(e) => return Value::Error { error: Box::new(e) },
             };
 
             // When the -e flag is present, search using rfind instead of find.s
@@ -186,12 +186,12 @@ fn action(
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }
@@ -235,7 +235,7 @@ fn process_range(
                 Ok((start_index, end_index))
             }
         }
-        Value::Error { error } => Err(error.clone()),
+        Value::Error { error } => Err(*error.clone()),
         _ => Err(ShellError::OnlySupportsThisInputType {
             exp_input_type: "string".into(),
             wrong_type: input.get_type().to_string(),

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -52,7 +52,7 @@ impl Command for StrJoin {
         for value in input {
             match value {
                 Value::Error { error } => {
-                    return Err(error);
+                    return Err(*error);
                 }
                 value => {
                     strings.push(value.debug_string("\n", config));

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -108,12 +108,12 @@ fn action(input: &Value, arg: &Arguments, head: Span) -> Value {
         ),
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -209,22 +209,22 @@ fn action(
                         }
                     }
                     Err(e) => Value::Error {
-                        error: ShellError::IncorrectValue {
+                        error: Box::new(ShellError::IncorrectValue {
                             msg: format!("Regex error: {e}"),
                             span: find.span,
-                        },
+                        }),
                     },
                 }
             }
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -77,12 +77,12 @@ fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
         },
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -114,12 +114,12 @@ fn action(
         }
         Value::Error { .. } => input.clone(),
         _ => Value::Error {
-            error: ShellError::OnlySupportsThisInputType {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "string".into(),
                 wrong_type: input.get_type().to_string(),
                 dst_span: head,
                 src_span: input.expect_span(),
-            },
+            }),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -155,10 +155,10 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                 match start.cmp(&end) {
                     Ordering::Equal => Value::string("", head),
                     Ordering::Greater => Value::Error {
-                        error: ShellError::TypeMismatch {
+                        error: Box::new(ShellError::TypeMismatch {
                             err_message: "End must be greater than or equal to Start".to_string(),
                             span: head,
-                        },
+                        }),
                     },
                     Ordering::Less => Value::String {
                         val: {
@@ -200,13 +200,13 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::Error {
-            error: ShellError::UnsupportedInput(
+            error: Box::new(ShellError::UnsupportedInput(
                 "Only string values are supported".into(),
                 format!("input type: {:?}", other.get_type()),
                 head,
                 // This line requires the Value::Error match above.
                 other.expect_span(),
-            ),
+            )),
         },
     }
 }

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -191,13 +191,13 @@ fn action(input: &Value, arg: &Arguments, head: Span) -> Value {
             },
             ActionMode::Local => {
                 Value::Error {
-                    error: ShellError::UnsupportedInput(
+                    error: Box::new(ShellError::UnsupportedInput(
                         "Only string values are supported".into(),
                         format!("input type: {:?}", other.get_type()),
                         head,
                         // This line requires the Value::Error match above.
                         other.expect_span(),
-                    ),
+                    )),
                 }
             }
         },

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -445,7 +445,7 @@ impl ExternalCommand {
                                         ))
                                     );
                                     let _ = exit_code_tx.send(Value::Error {
-                                        error: ShellError::ExternalCommand { label: "core dumped".to_string(), help: format!("{cause}: child process '{commandname}' core dumped"), span: head },
+                                        error: Box::new(ShellError::ExternalCommand { label: "core dumped".to_string(), help: format!("{cause}: child process '{commandname}' core dumped"), span: head }),
                                     });
                                     return Ok(());
                                 }

--- a/crates/nu-command/src/viewers/explore.rs
+++ b/crates/nu-command/src/viewers/explore.rs
@@ -98,7 +98,9 @@ impl Command for Explore {
             Ok(Some(value)) => Ok(PipelineData::Value(value, None)),
             Ok(None) => Ok(PipelineData::Value(Value::default(), None)),
             Err(err) => Ok(PipelineData::Value(
-                Value::Error { error: err.into() },
+                Value::Error {
+                    error: Box::new(err.into()),
+                },
                 None,
             )),
         }

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -305,7 +305,7 @@ fn handle_table_command(
         PipelineData::Value(Value::Error { error }, ..) => {
             // Propagate this error outward, so that it goes to stderr
             // instead of stdout.
-            Err(error)
+            Err(*error)
         }
         PipelineData::Value(Value::CustomValue { val, span }, ..) => {
             let base_pipeline = val.to_base_value(span)?.into_pipeline_data();
@@ -904,7 +904,7 @@ fn convert_to_table(
         }
 
         if let Value::Error { error } = item {
-            return Err(error.clone());
+            return Err(*error.clone());
         }
 
         let mut row = vec![];
@@ -1043,7 +1043,7 @@ fn convert_to_table2<'a>(
             }
 
             if let Value::Error { error } = item {
-                return Err(error.clone());
+                return Err(*error.clone());
             }
 
             let index = row + row_offset;
@@ -1085,7 +1085,7 @@ fn convert_to_table2<'a>(
             }
 
             if let Value::Error { error } = item {
-                return Err(error.clone());
+                return Err(*error.clone());
             }
 
             let mut value = convert_to_table2_entry(
@@ -1184,7 +1184,7 @@ fn convert_to_table2<'a>(
             }
 
             if let Value::Error { error } = item {
-                return Err(error.clone());
+                return Err(*error.clone());
             }
 
             let mut value = create_table2_entry(

--- a/crates/nu-explore/src/nu_common/table.rs
+++ b/crates/nu-explore/src/nu_common/table.rs
@@ -347,7 +347,7 @@ fn convert_to_table2<'a>(
             }
 
             if let Value::Error { error } = item {
-                return Err(error.clone());
+                return Err(*error.clone());
             }
 
             let index = row + row_offset;
@@ -382,7 +382,7 @@ fn convert_to_table2<'a>(
             }
 
             if let Value::Error { error } = item {
-                return Err(error.clone());
+                return Err(*error.clone());
             }
 
             let value = convert_to_table2_entry(
@@ -444,7 +444,7 @@ fn convert_to_table2<'a>(
             }
 
             if let Value::Error { error } = item {
-                return Err(error.clone());
+                return Err(*error.clone());
             }
 
             let value = create_table2_entry(

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -52,7 +52,9 @@ fn collect_external_stream(
     let mut data = vec![];
     if let Some(stdout) = stdout {
         let value = stdout.into_string().map_or_else(
-            |error| Value::Error { error },
+            |error| Value::Error {
+                error: Box::new(error),
+            },
             |string| Value::string(string.item, span),
         );
 
@@ -61,7 +63,9 @@ fn collect_external_stream(
     }
     if let Some(stderr) = stderr {
         let value = stderr.into_string().map_or_else(
-            |error| Value::Error { error },
+            |error| Value::Error {
+                error: Box::new(error),
+            },
             |string| Value::string(string.item, span),
         );
 

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -145,7 +145,7 @@ impl PipelineData {
                             items.push(val);
                         }
                         Err(e) => {
-                            return Value::Error { error: e };
+                            return Value::Error { error: Box::new(e) };
                         }
                     }
                 }
@@ -165,7 +165,9 @@ impl PipelineData {
                                 output.extend(item);
                             }
                             Err(err) => {
-                                return Value::Error { error: err };
+                                return Value::Error {
+                                    error: Box::new(err),
+                                };
                             }
                         }
                     }
@@ -180,7 +182,9 @@ impl PipelineData {
                         match item.as_string() {
                             Ok(s) => output.push_str(&s),
                             Err(err) => {
-                                return Value::Error { error: err };
+                                return Value::Error {
+                                    error: Box::new(err),
+                                };
                             }
                         }
                     }
@@ -227,7 +231,7 @@ impl PipelineData {
                     Err(error) => Err(error),
                 },
                 // Propagate errors by explicitly matching them before the final case.
-                Value::Error { error } => Err(error),
+                Value::Error { error } => Err(*error),
                 other => Err(ShellError::OnlySupportsThisInputType {
                     exp_input_type: "list, binary, raw data or range".into(),
                     wrong_type: other.get_type().to_string(),
@@ -397,7 +401,7 @@ impl PipelineData {
                 .map(f)
                 .into_pipeline_data(ctrlc)),
             PipelineData::Value(v, ..) => match f(v) {
-                Value::Error { error } => Err(error),
+                Value::Error { error } => Err(*error),
                 v => Ok(v.into_pipeline_data()),
             },
         }
@@ -768,7 +772,7 @@ impl PipelineData {
                 let working_set = StateWorkingSet::new(engine_state);
                 // Value::Errors must always go to stderr, not stdout.
                 is_err = true;
-                format_error(&working_set, &error)
+                format_error(&working_set, &*error)
             } else if no_newline {
                 item.into_string("", config)
             } else {
@@ -819,7 +823,9 @@ impl IntoIterator for PipelineData {
                     )),
                     Err(error) => PipelineIterator(PipelineData::ListStream(
                         ListStream {
-                            stream: Box::new(std::iter::once(Value::Error { error })),
+                            stream: Box::new(std::iter::once(Value::Error {
+                                error: Box::new(error),
+                            })),
                             ctrlc: None,
                         },
                         metadata,
@@ -861,7 +867,7 @@ pub fn print_if_stream(
         let mut exit_codes: Vec<_> = exit_code.into_iter().collect();
         return match exit_codes.pop() {
             #[cfg(unix)]
-            Some(Value::Error { error }) => Err(error),
+            Some(Value::Error { error }) => Err(*error),
             Some(Value::Int { val, .. }) => Ok(val),
             _ => Ok(0),
         };
@@ -885,7 +891,9 @@ impl Iterator for PipelineIterator {
                 ..
             } => stream.next().map(|x| match x {
                 Ok(x) => x,
-                Err(err) => Value::Error { error: err },
+                Err(err) => Value::Error {
+                    error: Box::new(err),
+                },
             }),
         }
     }

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -218,7 +218,7 @@ impl Iterator for RangeIterator {
         } else {
             self.done = true;
             return Some(Value::Error {
-                error: ShellError::CannotCreateRange { span: self.span },
+                error: Box::new(ShellError::CannotCreateRange { span: self.span }),
             });
         };
 
@@ -237,7 +237,9 @@ impl Iterator for RangeIterator {
 
                 Err(error) => {
                     self.done = true;
-                    return Some(Value::Error { error });
+                    return Some(Value::Error {
+                        error: Box::new(error),
+                    });
                 }
             };
             std::mem::swap(&mut self.curr, &mut next);

--- a/crates/nu_plugin_formats/src/from/ics.rs
+++ b/crates/nu_plugin_formats/src/from/ics.rs
@@ -28,12 +28,12 @@ pub fn from_ics_call(call: &EvaluatedCall, input: &Value) -> Result<Value, Label
         match calendar {
             Ok(c) => output.push(calendar_to_value(c, head)),
             Err(e) => output.push(Value::Error {
-                error: ShellError::UnsupportedInput(
+                error: Box::new(ShellError::UnsupportedInput(
                     format!("input cannot be parsed as .ics ({e})"),
                     "value originates from here".into(),
                     head,
                     span,
-                ),
+                )),
             }),
         }
     }

--- a/crates/nu_plugin_formats/src/from/vcf.rs
+++ b/crates/nu_plugin_formats/src/from/vcf.rs
@@ -24,12 +24,12 @@ pub fn from_vcf_call(call: &EvaluatedCall, input: &Value) -> Result<Value, Label
     let iter = parser.map(move |contact| match contact {
         Ok(c) => contact_to_value(c, head),
         Err(e) => Value::Error {
-            error: ShellError::UnsupportedInput(
+            error: Box::new(ShellError::UnsupportedInput(
                 format!("input cannot be parsed as .vcf ({e})"),
                 "value originates from here".into(),
                 head,
                 span,
-            ),
+            )),
         },
     });
 


### PR DESCRIPTION
# Description

Our `ShellError` at the moment has a `std::mem::size_of<ShellError>` of 136 bytes (on AMD64).  As a result `Value` directly storing the struct also required 136 bytes (thanks to alignment requirements).

This change stores the `Value::Error` `ShellError` on the heap.

Pro:
- Value now needs just 80 bytes
- Should be 1 cacheline less (still at least 2 cachelines)

Con:
- More small heap allocations when dealing with `Value::Error`
  - More heap fragmentation
  - Potential for additional required memcopies

# Further code changes

Includes a small refactor of `try` due to a type mismatch in its large match.

# User-Facing Changes

None for regular users.

Plugin authors may have to update their matches on `Value` if they use `nu-protocol`

Needs benchmarking to see if there is a benefit in real world workloads.
**Update** small improvements in runtime for workloads with high volume of values. Significant reduction in maximum resident set size, when many values are held in memory.

# Tests + Formatting

