### PR TITLE
Fix the SQLite feature name in `version`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -164,7 +164,7 @@ fn features_enabled() -> Vec<String> {
 
     #[cfg(feature = "sqlite")]
     {
-        names.push("database".to_string());
+        names.push("sqlite".to_string());
     }
 
     #[cfg(feature = "dataframe")]


### PR DESCRIPTION
A tiny fix: make the naming of the `sqlite` feature consistent across both `Cargo.toml` and the `version` command's output. Previously `version` displayed it as `database`, a user was asking about that the other day.