### PR TITLE
updates a test to use testbin versus external echo

### DIFF
--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -22,7 +22,7 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
         r#"
             open nu_times.csv
             | get origin
-            | each { |it| ^echo $it | nu --testbin chop }
+            | each { |it| nu --testbin cococo $it | nu --testbin chop }
             | get 2
             "#
         ));


### PR DESCRIPTION
# Description

In the past, I've seen this test `takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external` fail more than a few times. My only guess was that running external commands in a cross-platform way can be tricky. This is the main reason we have some `--testbin` commands, to avoid this situation. With that in mind, this removes the `^echo` command from this one test and replaces it with `nu --testbin cococo`, which I believe is our equivalent of echo.

Please comment below if you think this is the wrong strategy. There are other `^echo` tests but I'm not sure if we can change all of them.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
