### PR TITLE
Remove `get -i` from default env file

### DIFF
--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -1,7 +1,15 @@
 # Nushell Environment Config File
 
 def create_left_prompt [] {
-    let home = ($env | get -i (if $nu.os-info.name == "windows" { "USERPROFILE" } else { "HOME" }) | into string)
+    mut home = ""
+    try {
+        if $nu.os-info.name == "windows" {
+            $home = $env.USERPROFILE
+        } else {
+            $home = $env.HOME
+        }
+    }
+
     let dir = ([
         ($env.PWD | str substring 0..($home | str length) | str replace -s $home "~"),
         ($env.PWD | str substring ($home | str length)..)


### PR DESCRIPTION
This is a follow-up from https://github.com/nushell/nushell/pull/8173, which was merged shortly after the 0.76 release. That PR changed `default_env.nu` so that the user's home folder is displayed as `~` in the left prompt. It did so using `get -i`.

This PR just rewrites the Nu code from https://github.com/nushell/nushell/pull/8173 to use `try`/`catch` instead of `-i`, which will make it easier to remove the `-i` flags from `get` and `select` eventually (see https://github.com/nushell/nushell/pull/8379). 

I would like to merge this before the 0.77 release, so we don't end up with lots of `env.nu` files using `get -i` out in the wild.