### PR TITLE
Fix quicktest-found parser crash

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2744,6 +2744,10 @@ pub fn parse_string(
 
     let bytes = working_set.get_span_contents(span);
 
+    if bytes.is_empty() {
+        return (Expression::garbage(span), Some(ParseError::Expected("String".into(), span)))
+    }
+
     // Check for bare word interpolation
     if bytes[0] != b'\'' && bytes[0] != b'"' && bytes[0] != b'`' && bytes.contains(&b'(') {
         return parse_string_interpolation(working_set, span, expand_aliases_denylist);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2745,7 +2745,10 @@ pub fn parse_string(
     let bytes = working_set.get_span_contents(span);
 
     if bytes.is_empty() {
-        return (Expression::garbage(span), Some(ParseError::Expected("String".into(), span)))
+        return (
+            Expression::garbage(span),
+            Some(ParseError::Expected("String".into(), span)),
+        );
     }
 
     // Check for bare word interpolation

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -477,3 +477,8 @@ fn or_and_xor() -> TestResult {
 fn unbalanced_delimiter() -> TestResult {
     fail_test(r#"{a:{b:5}}}"#, "unbalanced { and }")
 }
+
+#[test]
+fn unbalanced_delimiter2() -> TestResult {
+    fail_test(r#"{}#.}"#, "unbalanced { and }")
+}


### PR DESCRIPTION
# Description

Fixes the crash when handing `{}#.}`

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
