### PR TITLE
Disable alias recursion

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -90,3 +90,17 @@ fn cant_alias_keyword() {
     ));
     assert!(actual.err.contains("cant_alias_keyword"));
 }
+
+#[test]
+fn alias_wont_recurse() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+            alias print = print -e;
+            print 'hello'
+        "#
+    ));
+
+    assert!(actual.out.is_empty());
+    assert_eq!(actual.err, "hello\n");
+}

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -96,11 +96,17 @@ fn alias_wont_recurse() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-            alias print = print -e;
-            print 'hello'
+            module myspamsymbol {
+                export def myfoosymbol [prefix: string, msg: string] {
+                    $prefix + $msg
+                }
+            };
+            use myspamsymbol myfoosymbol;
+            alias myfoosymbol = myfoosymbol 'hello';
+            myfoosymbol ' world'
         "#
     ));
 
-    assert!(actual.out.is_empty());
-    assert_eq!(actual.err, "hello\n");
+    assert_eq!(actual.out, "hello world");
+    assert!(actual.err.is_empty());
 }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -804,6 +804,13 @@ pub fn parse_alias(
 
             let replacement_spans = &spans[(split_id + 2)..];
 
+            // Temporarily hide the alias itself to prevent recursion
+            let predecl_id = working_set
+                .delta
+                .last_scope_frame_mut()
+                .predecls
+                .remove(&alias_name);
+
             let (expr, err) = parse_call(
                 working_set,
                 replacement_spans,
@@ -811,6 +818,14 @@ pub fn parse_alias(
                 expand_aliases_denylist,
                 false, // TODO: Should this be set properly???
             );
+
+            if let Some(id) = predecl_id {
+                working_set
+                    .delta
+                    .last_scope_frame_mut()
+                    .predecls
+                    .insert(alias_name.to_vec(), id);
+            }
 
             if let Some(e) = err {
                 if let ParseError::MissingPositional(..) = e {


### PR DESCRIPTION
# Description

Prevents alias from aliasing itself. It allows a commonly requested pattern similar to `alias ls = ls -l`.

One small issue is that the syntax highlighting is a bit off:
![alias_itself_no_color](https://user-images.githubusercontent.com/25571562/224545129-8a3ff535-347b-4a4e-b686-11493bb2a33b.png)

Fixes https://github.com/nushell/nushell/issues/8246

# User-Facing Changes

Shouldn't be a breaking change.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
