### PR TITLE
Additional flags for commands `from csv` and `from tsv`

### DIFF
--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -27,7 +27,7 @@ impl Command for FromCsv {
             .named(
                 "comment",
                 SyntaxShape::String,
-                "a comment character to ignore lines starting with it, defaults to '#'",
+                "a comment character to ignore lines starting with it",
                 Some('c'),
             )
             .named(
@@ -99,27 +99,27 @@ impl Command for FromCsv {
                 result: None,
             },
             Example {
-                description: "Convert comma-separated data to a table, ignoring headers",
-                example: "open data.txt | from csv -n",
-                result: None,
-            },
-            Example {
                 description: "Convert semicolon-separated data to a table",
                 example: "open data.txt | from csv --separator ';'",
                 result: None,
             },
             Example {
-                description: "Convert semicolon-separated data to a table, dropping all possible whitespaces around header names and field values",
+                description: "Convert comma-separated data to a table, ignoring lines starting with '#'",
+                example: "open data.txt | from csv --comment '#'",
+                result: None,
+            },
+            Example {
+                description: "Convert comma-separated data to a table, dropping all possible whitespaces around header names and field values",
                 example: "open data.txt | from csv --trim all",
                 result: None,
             },
             Example {
-                description: "Convert semicolon-separated data to a table, dropping all possible whitespaces around header names",
+                description: "Convert comma-separated data to a table, dropping all possible whitespaces around header names",
                 example: "open data.txt | from csv --trim headers",
                 result: None,
             },
             Example {
-                description: "Convert semicolon-separated data to a table, dropping all possible whitespaces around field values",
+                description: "Convert comma-separated data to a table, dropping all possible whitespaces around field values",
                 example: "open data.txt | from csv --trim fields",
                 result: None,
             },
@@ -143,8 +143,7 @@ fn from_csv(
     let comment = call
         .get_flag(engine_state, stack, "comment")?
         .map(|v: Value| v.as_char())
-        .transpose()?
-        .unwrap_or('#');
+        .transpose()?;
     let quote = call
         .get_flag(engine_state, stack, "quote")?
         .map(|v: Value| v.as_char())

--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -39,7 +39,7 @@ impl Command for FromCsv {
             .named(
                 "escape",
                 SyntaxShape::String,
-                "an escape character for strings containing the quote character, defaults to '\"'",
+                "an escape character for strings containing the quote character",
                 Some('e'),
             )
             .switch(
@@ -152,8 +152,7 @@ fn from_csv(
     let escape = call
         .get_flag(engine_state, stack, "escape")?
         .map(|v: Value| v.as_char())
-        .transpose()?
-        .unwrap_or('"');
+        .transpose()?;
     let no_infer = call.has_flag("no-infer");
     let noheaders = call.has_flag("noheaders");
     let flexible = call.has_flag("flexible");

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -21,7 +21,7 @@ fn from_delimited_string_to_value(
         .delimiter(separator as u8)
         .comment(comment.map(|c| c as u8))
         .quote(quote as u8)
-        .escape(Some(escape as u8))
+        .escape(escape.map(|c| c as u8))
         .trim(trim)
         .from_reader(s.as_bytes());
 
@@ -70,7 +70,7 @@ pub(super) struct DelimitedReaderConfig {
     pub separator: char,
     pub comment: Option<char>,
     pub quote: char,
-    pub escape: char,
+    pub escape: Option<char>,
     pub noheaders: bool,
     pub flexible: bool,
     pub no_infer: bool,

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -19,7 +19,7 @@ fn from_delimited_string_to_value(
         .has_headers(!noheaders)
         .flexible(flexible)
         .delimiter(separator as u8)
-        .comment(Some(comment as u8))
+        .comment(comment.map(|c| c as u8))
         .quote(quote as u8)
         .escape(Some(escape as u8))
         .trim(trim)
@@ -68,7 +68,7 @@ fn from_delimited_string_to_value(
 
 pub(super) struct DelimitedReaderConfig {
     pub separator: char,
-    pub comment: char,
+    pub comment: Option<char>,
     pub quote: char,
     pub escape: char,
     pub noheaders: bool,

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -2,16 +2,26 @@ use csv::{ReaderBuilder, Trim};
 use nu_protocol::{IntoPipelineData, PipelineData, ShellError, Span, Value};
 
 fn from_delimited_string_to_value(
+    DelimitedReaderConfig {
+        separator,
+        comment,
+        quote,
+        escape,
+        noheaders,
+        flexible,
+        no_infer,
+        trim,
+    }: DelimitedReaderConfig,
     s: String,
-    noheaders: bool,
-    no_infer: bool,
-    separator: char,
-    trim: Trim,
     span: Span,
 ) -> Result<Value, csv::Error> {
     let mut reader = ReaderBuilder::new()
         .has_headers(!noheaders)
+        .flexible(flexible)
         .delimiter(separator as u8)
+        .comment(Some(comment as u8))
+        .quote(quote as u8)
+        .escape(Some(escape as u8))
         .trim(trim)
         .from_reader(s.as_bytes());
 
@@ -56,24 +66,30 @@ fn from_delimited_string_to_value(
     Ok(Value::List { vals: rows, span })
 }
 
-pub fn from_delimited_data(
-    noheaders: bool,
-    no_infer: bool,
-    sep: char,
-    trim: Trim,
+pub(super) struct DelimitedReaderConfig {
+    pub separator: char,
+    pub comment: char,
+    pub quote: char,
+    pub escape: char,
+    pub noheaders: bool,
+    pub flexible: bool,
+    pub no_infer: bool,
+    pub trim: Trim,
+}
+
+pub(super) fn from_delimited_data(
+    config: DelimitedReaderConfig,
     input: PipelineData,
     name: Span,
 ) -> Result<PipelineData, ShellError> {
     let (concat_string, _span, metadata) = input.collect_string_strict(name)?;
 
-    Ok(
-        from_delimited_string_to_value(concat_string, noheaders, no_infer, sep, trim, name)
-            .map_err(|x| ShellError::DelimiterError {
-                msg: x.to_string(),
-                span: name,
-            })?
-            .into_pipeline_data_with_metadata(metadata),
-    )
+    Ok(from_delimited_string_to_value(config, concat_string, name)
+        .map_err(|x| ShellError::DelimiterError {
+            msg: x.to_string(),
+            span: name,
+        })?
+        .into_pipeline_data_with_metadata(metadata))
 }
 
 pub fn trim_from_str(trim: Option<Value>) -> Result<Trim, ShellError> {

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -21,7 +21,7 @@ impl Command for FromTsv {
             .named(
                 "comment",
                 SyntaxShape::String,
-                "a comment character to ignore lines starting with it, defaults to '#'",
+                "a comment character to ignore lines starting with it",
                 Some('c'),
             )
             .named(
@@ -127,8 +127,7 @@ fn from_tsv(
     let comment = call
         .get_flag(engine_state, stack, "comment")?
         .map(|v: Value| v.as_char())
-        .transpose()?
-        .unwrap_or('#');
+        .transpose()?;
     let quote = call
         .get_flag(engine_state, stack, "quote")?
         .map(|v: Value| v.as_char())

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -33,7 +33,7 @@ impl Command for FromTsv {
             .named(
                 "escape",
                 SyntaxShape::String,
-                "an escape character for strings containing the quote character, defaults to '\"'",
+                "an escape character for strings containing the quote character",
                 Some('e'),
             )
             .switch(
@@ -136,8 +136,7 @@ fn from_tsv(
     let escape = call
         .get_flag(engine_state, stack, "escape")?
         .map(|v: Value| v.as_char())
-        .transpose()?
-        .unwrap_or('"');
+        .transpose()?;
     let no_infer = call.has_flag("no-infer");
     let noheaders = call.has_flag("noheaders");
     let flexible = call.has_flag("flexible");

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -321,7 +321,7 @@ fn from_csv_text_with_missing_columns_to_table() {
 }
 
 #[test]
-fn from_csv_text_with_multiple_char_seperator() {
+fn from_csv_text_with_multiple_char_separator() {
     Playground::setup("filter_from_csv_test_10", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
@@ -346,7 +346,7 @@ fn from_csv_text_with_multiple_char_seperator() {
 }
 
 #[test]
-fn from_csv_text_with_wrong_type_seperator() {
+fn from_csv_text_with_wrong_type_separator() {
     Playground::setup("filter_from_csv_test_11", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -183,8 +183,92 @@ fn from_csv_text_with_tab_separator_to_table() {
 }
 
 #[test]
-fn from_csv_text_skipping_headers_to_table() {
+fn from_csv_text_with_comments_to_table() {
     Playground::setup("filter_from_csv_test_5", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                # This is a comment
+                first_name,last_name,rusty_luck
+                # This one too
+                Andrés,Robalino,1
+                Jonathan,Turner,1
+                Yehuda,Katz,1
+                # This one also
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r##"
+                open los_tres_caballeros.txt
+                | from csv --comment "#"
+                | get rusty_luck
+                | length
+            "##
+        ));
+
+        assert_eq!(actual.out, "3");
+    })
+}
+
+#[test]
+fn from_csv_text_with_custom_quotes_to_table() {
+    Playground::setup("filter_from_csv_test_6", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                first_name,last_name,rusty_luck
+                'And''rés',Robalino,1
+                Jonathan,Turner,1
+                Yehuda,Katz,1
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open los_tres_caballeros.txt
+                | from csv --quote "'"
+                | first
+                | get first_name
+            "#
+        ));
+
+        assert_eq!(actual.out, "And'rés");
+    })
+}
+
+#[test]
+fn from_csv_text_with_custom_escapes_to_table() {
+    Playground::setup("filter_from_csv_test_7", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                first_name,last_name,rusty_luck
+                "And\"rés",Robalino,1
+                Jonathan,Turner,1
+                Yehuda,Katz,1
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open los_tres_caballeros.txt
+                | from csv --escape '\'
+                | first
+                | get first_name
+            "#
+        ));
+
+        assert_eq!(actual.out, "And\"rés");
+    })
+}
+
+#[test]
+fn from_csv_text_skipping_headers_to_table() {
+    Playground::setup("filter_from_csv_test_8", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "los_tres_amigos.txt",
             r#"
@@ -205,6 +289,34 @@ fn from_csv_text_skipping_headers_to_table() {
         ));
 
         assert_eq!(actual.out, "3");
+    })
+}
+
+#[test]
+fn from_csv_text_with_missing_columns_to_table() {
+    Playground::setup("filter_from_csv_test_9", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                first_name,last_name,rusty_luck
+                Andrés,Robalino
+                Jonathan,Turner,1
+                Yehuda,Katz,1
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open los_tres_caballeros.txt
+                | from csv --flexible
+                | get -i rusty_luck
+                | compact
+                | length
+            "#
+        ));
+
+        assert_eq!(actual.out, "2");
     })
 }
 

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -321,6 +321,56 @@ fn from_csv_text_with_missing_columns_to_table() {
 }
 
 #[test]
+fn from_csv_text_with_multiple_char_seperator() {
+    Playground::setup("filter_from_csv_test_10", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                first_name,last_name,rusty_luck
+                Andrés,Robalino,1
+                Jonathan,Turner,1
+                Yehuda,Katz,1
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open los_tres_caballeros.txt
+                | from csv --separator "li"
+            "#
+        ));
+
+        assert!(actual.err.contains("single character separator"));
+    })
+}
+
+#[test]
+fn from_csv_text_with_wrong_type_seperator() {
+    Playground::setup("filter_from_csv_test_11", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                first_name,last_name,rusty_luck
+                Andrés,Robalino,1
+                Jonathan,Turner,1
+                Yehuda,Katz,1
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open los_tres_caballeros.txt
+                | from csv --separator ('123' | into int)
+            "#
+        ));
+
+        assert!(actual.err.contains("can't convert int to char"));
+    })
+}
+
+#[test]
 fn table_with_record_error() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -16,7 +16,7 @@ fn table_to_tsv_text_and_from_tsv_text_back_into_table() {
 fn table_to_tsv_text_and_from_tsv_text_back_into_table_using_csv_separator() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        r"open caco3_plastics.tsv | to tsv | from csv --separator '\t' | first | get origin"
+        r#"open caco3_plastics.tsv | to tsv | from csv --separator "\t" | first | get origin"#
     );
 
     assert_eq!(actual.out, "SPAIN");

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -242,3 +242,53 @@ fn from_tsv_text_with_missing_columns_to_table() {
         assert_eq!(actual.out, "2");
     })
 }
+
+#[test]
+fn from_tsv_text_with_multiple_char_comment() {
+    Playground::setup("filter_from_tsv_test_7", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                first_name	last_name	rusty_luck
+                Andrés	Robalino	1
+                Jonathan	Turner	1
+                Yehuda	Katz	1
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open los_tres_caballeros.txt
+                | from csv --comment "li"
+            "#
+        ));
+
+        assert!(actual.err.contains("single character separator"));
+    })
+}
+
+#[test]
+fn from_tsv_text_with_wrong_type_comment() {
+    Playground::setup("filter_from_csv_test_8", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "los_tres_caballeros.txt",
+            r#"
+                first_name	last_name	rusty_luck
+                Andrés	Robalino	1
+                Jonathan	Turner	1
+                Yehuda	Katz	1
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open los_tres_caballeros.txt
+                | from csv --comment ('123' | into int)
+            "#
+        ));
+
+        assert!(actual.err.contains("can't convert int to char"));
+    })
+}

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -188,6 +188,27 @@ impl Clone for Value {
 }
 
 impl Value {
+    pub fn as_char(&self) -> Result<char, ShellError> {
+        match self {
+            Value::String { val, span } => {
+                let mut chars = val.chars();
+                match (chars.next(), chars.next()) {
+                    (Some(c), None) => Ok(c),
+                    _ => Err(ShellError::MissingParameter {
+                        param_name: "single character separator".into(),
+                        span: *span,
+                    }),
+                }
+            }
+            x => Err(ShellError::CantConvert {
+                to_type: "char".into(),
+                from_type: x.get_type().to_string(),
+                span: self.span()?,
+                help: None,
+            }),
+        }
+    }
+
     /// Converts into string values that can be changed into string natively
     pub fn as_string(&self) -> Result<String, ShellError> {
         match self {


### PR DESCRIPTION
# Description

Resolves issue #8370

Adds the following flags to commands `from csv` and `from tsv`:
- `--flexible`: allow the number of fields in records to be variable
- `-c --comment`: a comment character to ignore lines starting with it
- `-q --quote`: a quote character to ignore separators in strings, defaults to '\"'
- `-e --escape`: an escape character for strings containing the quote character

Internally, the `Value` struct has an additional helper function `as_char` which converts it to a single `char`

# User-Facing Changes

The single quoted string `'\t'` can no longer be used as a parameter for the flag `--separator '\t'` as it is interpreted as a two-character string. One needs to use from now on the flag with a double quoted string like so: `-s "\t"` which correctly interprets the string as a single `char`.
