### PR TITLE
Hack around bad binary viewing logic

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -718,7 +718,9 @@ impl PipelineData {
                 return self.write_all_and_flush(engine_state, config, no_newline, to_stderr);
             }
 
-            let table = command.run(engine_state, stack, &Call::new(Span::new(0, 0)), self)?;
+            let mut call = Call::new(Span::new(0, 0));
+            call.redirect_stdout = false;
+            let table = command.run(engine_state, stack, &call, self)?;
 
             table.write_all_and_flush(engine_state, config, no_newline, to_stderr)?;
         } else {


### PR DESCRIPTION
# Description

This works around a bug introduced by #8058 

We should revisit the original fix, as it makes some assumptions about how stdout redirection is used by `table`. We use the stdout by default for table regularly during a repl session, so we should instead special-case case for handling externals.

# User-Facing Changes

Restores the original default `table` behaviour for binary data

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
