### PR TITLE
std.nu: Rewrite assert method

### DIFF
--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -30,15 +30,14 @@ def _assertion-error [start, end, label, message?: string] {
 }
 
 # ```nushell
-# >_ let a = 3
-# >_ assert ($a == 3)
-# >_ assert ($a != 3)
+# >_ assert (3 == 3)
+# >_ assert (42 == 3)
 # Error:
 #   × Assertion failed: 
 #     ╭─[myscript.nu:11:1]
-#  11 │ assert ($a == 3)
-#  12 │ assert ($a != 3)
-#     ·         ───┬───
+#  11 │ assert (3 == 3)
+#  12 │ assert (42 == 3)
+#     ·         ───┬────
 #     ·            ╰── It is not true.
 #  13 │
 #     ╰────
@@ -50,31 +49,38 @@ export def assert [cond: bool, message?: string] {
 }
 
 # ```nushell
-# >_ let a = 3
-# >_ assert eq $a "a string"
+# ❯ assert eq 3 "a string"
 # Error:
-#   × Assertion failed: 
-#     ╭─[myscript.nu:76:1]
-#  76 │ let a = 3
-#  77 │ assert eq $a "a string"
-#     ·           ──────┬──────
-#     ·                 ╰── Different types cannot be equal: int <-> string.
-#  78 │
-#     ╰────
+#   × Assertion failed.
+#    ╭─[entry #13:1:1]
+#  1 │ assert eq 3 "a string"
+#    ·           ──────┬─────
+#    ·                 ╰── Different types cannot be equal: int <-> string.
+#    ╰────
 #
 #
-# >_ let a = 3
-# >_ assert eq $a 3
-# >_ assert eq $a 1
+# ❯ assert eq 3 3
+# ❯ assert eq 3 1
 # Error:
-#   × Assertion failed: 
-#     ╭─[myscript.nu:81:1]
-#  81 │ assert eq $a 3
-#  82 │ assert eq $a 1
-#     ·           ──┬─
-#     ·             ╰── They are not equal: 3 != 1
-#  83 │
-#     ╰────
+#   × Assertion failed.
+#    ╭─[entry #14:1:1]
+#  1 │ assert eq 3 1
+#    ·           ─┬─
+#    ·            ╰── They are not equal: 3 != 1
+#    ╰────
+#
+#
+# 👇👇👇 BE CAREFUL! 👇👇👇
+# ❯ assert ( 1 == 1.0) # passes
+# ❯ assert eq 1 1.0
+# Error:
+#   × Assertion failed.
+#    ╭─[entry #16:1:1]
+#  1 │ assert eq 1 1.0
+#    ·           ──┬──
+#    ·             ╰── Different types cannot be equal: int <-> float.
+#    ╰────
+# 
 # ```
 export def "assert eq" [left: any, right: any, message?: string] {
     let left_type = ($left | describe)
@@ -91,25 +97,39 @@ export def "assert eq" [left: any, right: any, message?: string] {
 }
 
 # ```nushell
-# >_ let a = 3
-# >_ assert ne $a 1
-# >_ assert ne $a 3
+# ❯ assert ne 1 3
+# ❯ assert ne 42 42
 # Error:
-#   × Assertion failed:
-#      ╭─[C:\Users\fm\git\nushell\crates\nu-utils\standard_library\std.nu:113:1]
-#  113 │ assert ne $a 1
-#  114 │ assert ne $a 3
-#      ·           ──┬─
-#      ·             ╰── They both are 3
-#  115 │
-#      ╰────
+#   × Assertion failed.
+#    ╭─[entry #23:1:1]
+#  1 │ assert ne 42 42
+#    ·           ──┬──
+#    ·             ╰── They both are 42
+#    ╰────
+# 
+#
+# 👇👇👇 BE CAREFUL! 👇👇👇
+# ❯ assert ( 1 != "a string" ) # passes
+# ❯ assert ne 1 "a string"
+# Error:
+#   × Assertion failed.
+#    ╭─[entry #20:1:1]
+#  1 │ assert ne 1 "a string"
+#    ·           ──────┬─────
+#    ·                 ╰── They are not equal, although they have different types: int <-> string.
+#    ╰────
 # ```
 export def "assert ne" [left: any, right: any, message?: string] {
+    let left_type = ($left | describe)
+    let right_type = ($right | describe)
     let left_start = (metadata $left).span.start
     let right_end = (metadata $right).span.end
 
     if ($left == $right) {
         _assertion-error $left_start $right_end $"They both are ($left)" $message
+    }
+    if ($left_type != $right_type) {
+        _assertion-error $left_start $right_end $"They are not equal, although they have different types: ($left_type) <-> ($right_type)." $message
     }
 }
 

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -125,14 +125,10 @@ export def "assert ne" [left: any, right: any, message?: string] {
     let left_start = (metadata $left).span.start
     let right_end = (metadata $right).span.end
 
-    if (($left | describe) == ($right | describe)) {
-        # We are happy, nothing to do.
-    } else {
+    if (($left | describe) != ($right | describe)) {
         _assertion-error $left_start $right_end $"They have different types: ($left_type) <-> ($right_type)." $message
     }
-    if ($left != $right) {
-        # We are happy, nothing to do.
-    } else {
+    if ($left == $right) {
         _assertion-error $left_start $right_end $"They both are ($left)" $message
     }
 }

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -61,6 +61,7 @@ export def "assert eq" [left: any, right: any, message?: string] {
     let right_type = ($right | describe)
     let left_start = (metadata $left).span.start
     let right_end = (metadata $right).span.end
+
     if ($left_type != $right_type) {
         _assertion-error $left_start $right_end $"Different types cannot be equal: ($left_type) <-> ($right_type)." $message
     }
@@ -86,6 +87,7 @@ export def "assert eq" [left: any, right: any, message?: string] {
 export def "assert ne" [left: any, right: any, message?: string] {
     let left_start = (metadata $left).span.start
     let right_end = (metadata $right).span.end
+
     if ($left == $right) {
         _assertion-error $left_start $right_end $"They both are ($left)" $message
     }

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -1,6 +1,6 @@
 def _assertion-error [start, end, label, message?: string] {
     error make {
-        msg: $"Assertion failed: ($message)",
+        msg: ($message | default "Assertion failed."),
         label: {
             text: $label,
             start: $start,

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -125,11 +125,15 @@ export def "assert ne" [left: any, right: any, message?: string] {
     let left_start = (metadata $left).span.start
     let right_end = (metadata $right).span.end
 
-    if ($left == $right) {
-        _assertion-error $left_start $right_end $"They both are ($left)" $message
+    if (($left | describe) == ($right | describe)) {
+        # We are happy, nothing to do.
+    } else {
+        _assertion-error $left_start $right_end $"They have different types: ($left_type) <-> ($right_type)." $message
     }
-    if ($left_type != $right_type) {
-        _assertion-error $left_start $right_end $"They are not equal, although they have different types: ($left_type) <-> ($right_type)." $message
+    if ($left != $right) {
+        # We are happy, nothing to do.
+    } else {
+        _assertion-error $left_start $right_end $"They both are ($left)" $message
     }
 }
 

--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -1,12 +1,3 @@
-def _assert [
-    cond: bool
-    msg: string
-] {
-    if not $cond {
-        error make {msg: $msg}
-    }
-}
-
 def _assertion-error [start, end, label, message?: string] {
     error make {
         msg: $"Assertion failed: ($message)",
@@ -37,8 +28,6 @@ export def assert [cond: bool, message?: string] {
     let span = (metadata $cond).span
     _assertion-error $span.start $span.end "It is not true." $message
 }
-
-assert eq 1 2
 
 # ```nushell
 # >_ let a = 3
@@ -81,32 +70,25 @@ export def "assert eq" [left: any, right: any, message?: string] {
 }
 
 # ```nushell
-# >_ assert_ne $a "a string"
+# >_ let a = 3
+# >_ assert ne $a 1
+# >_ assert ne $a 3
 # Error:
-#   × left and right operand of `assert eq` should have the same type
-#    ╭─[entry #12:5:1]
-#  5 │     if not $cond {
-#  6 │         error make {msg: $msg}
-#    ·         ─────┬────
-#    ·              ╰── originates from here
-#  7 │     }
-#    ╰────
-#
-# >_ assert_ne $a 1
-# >_ assert_ne $a 3
-# Error:
-#   × left is equal to right
-#    ╭─[entry #12:5:1]
-#  5 │     if not $cond {
-#  6 │         error make {msg: $msg}
-#    ·         ─────┬────
-#    ·              ╰── originates from here
-#  7 │     }
-#    ╰────
+#   × Assertion failed:
+#      ╭─[C:\Users\fm\git\nushell\crates\nu-utils\standard_library\std.nu:113:1]
+#  113 │ assert ne $a 1
+#  114 │ assert ne $a 3
+#      ·           ──┬─
+#      ·             ╰── They both are 3
+#  115 │
+#      ╰────
 # ```
-export def "assert ne" [left: any, right: any] {
-    _assert (($left | describe) == ($right | describe)) $"left and right operand of `assert eq` should have the same type"
-    _assert ($left != $right) "left is equal to right"
+export def "assert ne" [left: any, right: any, message?: string] {
+    let left_start = (metadata $left).span.start
+    let right_end = (metadata $right).span.end
+    if ($left == $right) {
+        _assertion-error $left_start $right_end $"They both are ($left)" $message
+    }
 }
 
 # ```nushell

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -19,8 +19,8 @@ def test_assert [] {
     test_failing { std assert eq (1 + 2) 4) }
 
     std assert ne (1 + 2) 4
-    std assert ne 1 "foo"
-    std assert ne (1 + 2) 3)
+    test_failing { std assert ne 1 "foo" }
+    test_failing { std assert ne (1 + 2) 3) }
 }
 
 def tests [] {

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -19,8 +19,8 @@ def test_assert [] {
     test_failing { std assert eq (1 + 2) 4) }
 
     std assert ne (1 + 2) 4
-    test_failing { std assert ne 1 "foo" }
-    test_failing { std assert ne (1 + 2) 3) }
+    std assert ne 1 "foo"
+    std assert ne (1 + 2) 3)
 }
 
 def tests [] {


### PR DESCRIPTION
It is a common pattern to add message to assert.
Also the error message was not so helpful. (See the difference in the documentation)