### PR TITLE
remove patch version from most dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -317,6 +317,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -2184,9 +2185,9 @@ checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "libproc"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b799ad155d75ce914c467ee5627b62247c20d4aedbd446f821484cebf3cded7"
+checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
 dependencies = [
  "bindgen",
  "errno 0.2.8",
@@ -2272,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
 dependencies = [
  "hashbrown 0.13.2",
 ]
@@ -2759,7 +2760,6 @@ dependencies = [
  "reedline",
  "rstest",
  "sysinfo 0.28.2",
- "thiserror",
 ]
 
 [[package]]
@@ -2880,7 +2880,6 @@ dependencies = [
  "sysinfo 0.28.2",
  "tabled",
  "terminal_size 0.2.1",
- "thiserror",
  "titlecase",
  "toml 0.7.2",
  "trash",
@@ -4951,9 +4950,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db67dc6ef36edb658196c3fef0464a80b53dbbc194a904e81f9bd4190f9ecc5b"
+checksum = "0366f270dbabb5cc2e4c88427dc4c08bba144f81e32fbd459a013f26a4d16aa0"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,6 @@ members = [
 ]
 
 [dependencies]
-chrono = { version = "0.4.23", features = ["serde"] }
-crossterm = "0.24.0"
-ctrlc = "3.2.1"
-log = "0.4"
-miette = { version = "5.5.0", features = ["fancy-no-backtrace"] }
 nu-ansi-term = "0.46.0"
 nu-cli = { path = "./crates/nu-cli", version = "0.76.1" }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.76.1" }
@@ -62,19 +57,22 @@ nu-system = { path = "./crates/nu-system", version = "0.76.1" }
 nu-table = { path = "./crates/nu-table", version = "0.76.1" }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.76.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.76.1" }
-
 reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
-rayon = "1.7.0"
-is_executable = "1.0.1"
-simplelog = "0.12.0"
-time = "0.3.12"
+chrono = { version = "0.4", features = ["serde"] }
+crossterm = "0.24"
+ctrlc = "3.2"
+is_executable = "1.0"
+log = "0.4"
+miette = { version = "5.5", features = ["fancy-no-backtrace"] }
+rayon = "1.7"
+simplelog = "0.12"
+time = "0.3"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Our dependencies don't use OpenSSL on Windows
-openssl = { version = "0.10.38", features = ["vendored"], optional = true }
-signal-hook = { version = "0.3.14", default-features = false }
-
+openssl = { version = "0.10", features = ["vendored"], optional = true }
+signal-hook = { version = "0.3", default-features = false }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
@@ -90,14 +88,14 @@ atty = "0.2"
 
 [dev-dependencies]
 nu-test-support = { path = "./crates/nu-test-support", version = "0.76.1" }
-tempfile = "3.4.0"
-assert_cmd = "2.0.2"
+tempfile = "3.4"
+assert_cmd = "2.0"
 criterion = "0.4"
-pretty_assertions = "1.0.0"
-serial_test = "1.0.0"
-hamcrest2 = "0.3.0"
-rstest = { version = "0.16.0", default-features = false }
-itertools = "0.10.3"
+pretty_assertions = "1.3"
+serial_test = "1.0"
+hamcrest2 = "0.3"
+rstest = { version = "0.16", default-features = false }
+itertools = "0.10"
 
 [features]
 plugin = [

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 [dev-dependencies]
 nu-test-support = { path = "../nu-test-support", version = "0.76.1" }
 nu-command = { path = "../nu-command", version = "0.76.1" }
-rstest = { version = "0.16.0", default-features = false }
+rstest = { version = "0.16", default-features = false }
 
 [dependencies]
 nu-engine = { path = "../nu-engine", version = "0.76.1" }
@@ -23,21 +23,19 @@ nu-protocol = { path = "../nu-protocol", version = "0.76.1" }
 nu-utils = { path = "../nu-utils", version = "0.76.1" }
 nu-ansi-term = "0.46.0"
 nu-color-config = { path = "../nu-color-config", version = "0.76.1" }
-
 reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
-atty = "0.2.14"
-chrono = { default-features = false, features = ["std"], version = "0.4.23" }
+atty = "0.2"
+chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.24.0"
-fancy-regex = "0.11.0"
-fuzzy-matcher = "0.3.7"
-is_executable = "1.0.1"
-once_cell = "1.17.0"
+fancy-regex = "0.11"
+fuzzy-matcher = "0.3"
+is_executable = "1.0"
+once_cell = "1.17"
 log = "0.4"
-miette = { version = "5.5.0", features = ["fancy-no-backtrace"] }
-percent-encoding = "2"
-sysinfo = "0.28.2"
-thiserror = "1.0.31"
+miette = { version = "5.5", features = ["fancy-no-backtrace"] }
+percent-encoding = "2.2"
+sysinfo = "0.28"
 
 [features]
 plugin = []

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -19,13 +19,13 @@ nu-parser = { path = "../nu-parser", version = "0.76.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.76.1"  }
 nu-utils = { path = "../nu-utils", version = "0.76.1" }
 
-fancy-regex = "0.11.0"
-itertools = "0.10.0"
-log = "0.4.14"
-shadow-rs = { version = "0.21.0", default-features = false }
+fancy-regex = "0.11"
+itertools = "0.10"
+log = "0.4"
+shadow-rs = { version = "0.21", default-features = false }
 
 [build-dependencies]
-shadow-rs = { version = "0.21.0", default-features = false }
+shadow-rs = { version = "0.21", default-features = false }
 
 [dev-dependencies]
 nu-test-support = { path="../nu-test-support", version = "0.76.1"  }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -11,9 +11,9 @@ version = "0.76.1"
 bench = false
 
 [dependencies]
-serde = { version="1.0.123", features=["derive"] }
+serde = { version="1.0", features=["derive"] }
 # used only for text_style Alignments
-tabled = { version = "0.10.0", features = ["color"], default-features = false }
+tabled = { version = "0.10", features = ["color"], default-features = false }
 
 nu-protocol = { path = "../nu-protocol", version = "0.76.1"  }
 nu-ansi-term = "0.46.0"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -28,89 +28,88 @@ nu-system = { path = "../nu-system", version = "0.76.1" }
 nu-table = { path = "../nu-table", version = "0.76.1" }
 nu-term-grid = { path = "../nu-term-grid", version = "0.76.1" }
 nu-utils = { path = "../nu-utils", version = "0.76.1" }
-num-format = { version = "0.4.3" }
+reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
 # Potential dependencies for extras
 Inflector = "0.11"
-alphanumeric-sort = "1.4.4"
-atty = "0.2.14"
-base64 = "0.21.0"
-byteorder = "1.4.3"
-bytesize = "1.2.0"
-calamine = "0.19.1"
-chrono = { version = "0.4.23", features = ["std", "unstable-locales"], default-features = false }
-chrono-humanize = "0.2.1"
-chrono-tz = "0.8.1"
+alphanumeric-sort = "1.4"
+atty = "0.2"
+base64 = "0.21"
+byteorder = "1.4"
+bytesize = "1.2"
+calamine = "0.19"
+chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
+chrono-humanize = "0.2"
+chrono-tz = "0.8"
 crossterm = "0.24.0"
-csv = "1.2.0"
-dialoguer = { default-features = false, version = "0.10.3" }
-digest = { default-features = false, version = "0.10.0" }
-dtparse = "1.2.0"
-encoding_rs = "0.8.30"
-fancy-regex = "0.11.0"
-filesize = "0.2.0"
-filetime = "0.2.15"
-fs_extra = "1.3.0"
-htmlescape = "0.3.1"
-indexmap = { version = "1.7", features = ["serde-1"] }
-indicatif = "0.17.2"
-is-root = "0.1.2"
-itertools = "0.10.0"
-log = "0.4.14"
-lscolors = { version = "0.12.0", features = ["crossterm"], default-features = false }
-md5 = { package = "md-5", version = "0.10.0" }
-mime = "0.3.16"
-mime_guess = "2.0.4"
+csv = "1.2"
+dialoguer = { default-features = false, version = "0.10" }
+digest = { default-features = false, version = "0.10" }
+dtparse = "1.3"
+encoding_rs = "0.8"
+fancy-regex = "0.11"
+filesize = "0.2"
+filetime = "0.2"
+fs_extra = "1.3"
+htmlescape = "0.3"
+indexmap = { version = "1.9", features = ["serde-1"] }
+indicatif = "0.17"
+is-root = "0.1"
+itertools = "0.10"
+log = "0.4"
+lscolors = { version = "0.12", features = ["crossterm"], default-features = false }
+md5 = { package = "md-5", version = "0.10" }
+mime = "0.3"
+mime_guess = "2.0"
 notify = "4.0.17"
-num = { version = "0.4.0", optional = true }
-num-traits = "0.2.14"
+num = { version = "0.4", optional = true }
+num-format = { version = "0.4" }
+num-traits = "0.2"
 once_cell = "1.17"
 open = "3.2.0"
-pathdiff = "0.2.1"
-powierza-coefficient = "1.0.2"
+pathdiff = "0.2"
+powierza-coefficient = "1.0"
 quick-xml = "0.27"
 rand = "0.8"
-rayon = "1.7.0"
-regex = "1.7.1"
-ureq = { version = "2.6.2", default-features = false, features = ["json", "charset", "native-tls", "gzip"] }
-native-tls = "0.2.11"
-roxmltree = "0.18.0"
-rust-embed = "6.6.0"
-same-file = "1.0.6"
-serde = { version = "1.0.123", features = ["derive"] }
-serde_urlencoded = "0.7.0"
-serde_yaml = "0.9.4"
-sha2 = "0.10.0"
+rayon = "1.7"
+regex = "1.7"
+ureq = { version = "2.6", default-features = false, features = ["json", "charset", "native-tls", "gzip"] }
+native-tls = "0.2"
+roxmltree = "0.18"
+rust-embed = "6.6"
+same-file = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_urlencoded = "0.7"
+serde_yaml = "0.9"
+sha2 = "0.10"
 # Disable default features b/c the default features build Git (very slow to compile)
-percent-encoding = "2.2.0"
-reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
-rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
-sqlparser = { version = "0.30.0", features = ["serde"], optional = true }
-sysinfo = "0.28.2"
-tabled = "0.10.0"
-terminal_size = "0.2.1"
-thiserror = "1.0.31"
-titlecase = "2.0.0"
-toml = "0.7.1"
-unicode-segmentation = "1.10.0"
-unicode-width = "0.1.10"
-url = "2.2.1"
-uuid = { version = "1.3.0", features = ["v4"] }
-wax = { version = "0.5.0" }
-which = { version = "4.4.0", optional = true }
-print-positions = "0.6.1"
+percent-encoding = "2.2"
+rusqlite = { version = "0.28", features = ["bundled"], optional = true }
+sqlparser = { version = "0.32", features = ["serde"], optional = true }
+sysinfo = "0.28"
+tabled = "0.10"
+terminal_size = "0.2"
+titlecase = "2.2"
+toml = "0.7"
+unicode-segmentation = "1.10"
+unicode-width = "0.1"
+url = "2.3"
+uuid = { version = "1.3", features = ["v4"] }
+wax = { version = "0.5" }
+which = { version = "4.4", optional = true }
+print-positions = "0.6"
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.11.0"
+winreg = "0.11"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-umask = "2.0.0"
-users = "0.11.0"
+umask = "2.0"
+users = "0.11"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
 optional = true
-version = "3.0.1"
+version = "3.0"
 
 [dependencies.polars]
 features = [
@@ -141,11 +140,11 @@ features = [
 	"to_dummies",
 ]
 optional = true
-version = "0.27.2"
+version = "0.27"
 
 [target.'cfg(windows)'.dependencies.windows]
 features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_SystemServices"]
-version = "0.44.0"
+version = "0.44"
 
 [features]
 dataframe = ["num", "polars", "sqlparser"]
@@ -156,11 +155,10 @@ which-support = ["which"]
 
 [dev-dependencies]
 nu-test-support = { path = "../nu-test-support", version = "0.76.1" }
-mockito = "0.32.3"
-
-dirs-next = "2.0.0"
-hamcrest2 = "0.3.0"
-proptest = "1.1.0"
-quickcheck = "1.0.3"
-quickcheck_macros = "1.0.0"
-rstest = { version = "0.16.0", default-features = false }
+mockito = "0.32"
+dirs-next = "2.0"
+hamcrest2 = "0.3"
+proptest = "1.1"
+quickcheck = "1.0"
+quickcheck_macros = "1.0"
+rstest = { version = "0.16", default-features = false }

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -16,9 +16,9 @@ nu-path = { path = "../nu-path", version = "0.76.1"  }
 nu-glob = { path = "../nu-glob", version = "0.76.1" }
 nu-utils = { path = "../nu-utils", version = "0.76.1"  }
 
-chrono = { version="0.4.23", features = ["std"], default-features = false }
-serde = {version = "1.0.143", default-features = false }
-sysinfo ="0.28.2"
+chrono = { version="0.4", features = ["std"], default-features = false }
+serde = {version = "1.0", default-features = false }
+sysinfo ="0.28"
 
 [features]
 plugin = []

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -20,9 +20,9 @@ nu-table = { path = "../nu-table", version = "0.76.1" }
 nu-json = { path = "../nu-json", version = "0.76.1"  }
 nu-utils = { path = "../nu-utils", version = "0.76.1"  }
 
-terminal_size = "0.2.1"
-strip-ansi-escapes = "0.1.1"
+terminal_size = "0.2"
+strip-ansi-escapes = "0.1"
 crossterm = "0.24.0"
-tui = "0.19.0"
-ansi-str = "0.7.2"
-lscolors = { version = "0.12.0", features = ["crossterm"], default-features = false }
+tui = "0.19"
+ansi-str = "0.7"
+lscolors = { version = "0.12", features = ["crossterm"], default-features = false }

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -18,7 +18,7 @@ default = ["preserve_order"]
 
 [dependencies]
 linked-hash-map = { version="0.5", optional=true }
-num-traits = "0.2.14"
+num-traits = "0.2"
 serde = "1.0"
 
 [dev-dependencies]

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -11,17 +11,18 @@ version = "0.76.1"
 bench = false
 
 [dependencies]
-bytesize = "1.2.0"
-chrono = { default-features = false, features = ['std'], version = "0.4.23" }
-itertools = "0.10"
-miette = {version = "5.5.0", features = ["fancy-no-backtrace"]}
-thiserror = "1.0.31"
-serde_json = "1.0"
 nu-path = {path = "../nu-path", version = "0.76.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.76.1" }
 nu-plugin = { path = "../nu-plugin", optional = true, version = "0.76.1"  }
 nu-engine = { path = "../nu-engine", version = "0.76.1" }
+
+bytesize = "1.2"
+chrono = { default-features = false, features = ['std'], version = "0.4" }
+itertools = "0.10"
 log = "0.4"
+miette = {version = "5.5", features = ["fancy-no-backtrace"]}
+serde_json = "1.0"
+thiserror = "1.0"
 
 [features]
 plugin = ["nu-plugin"]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -11,10 +11,10 @@ version = "0.76.1"
 bench = false
 
 [dependencies]
-dirs-next = "2.0.0"
+dirs-next = "2.0"
 
 [target.'cfg(windows)'.dependencies]
-omnipath = "0.1.1"
+omnipath = "0.1"
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-pwd = "1.3.1"
+pwd = "1.4"

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -11,10 +11,11 @@ version = "0.76.1"
 bench = false
 
 [dependencies]
-bincode = "1.3.3"
 nu-protocol = { path = "../nu-protocol", version = "0.76.1"  }
 nu-engine = { path = "../nu-engine", version = "0.76.1"  }
-serde = { version = "1.0.143" }
+
+bincode = "1.3"
+rmp = "0.8"
+rmp-serde = "1.1"
+serde = { version = "1.0" }
 serde_json = { version = "1.0"}
-rmp = "0.8.11"
-rmp-serde = "1.1.0"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -17,6 +17,6 @@ bench = false
 nu-ansi-term = "0.46.0"
 
 [dev-dependencies]
-heapless = { version = "0.7.8", default-features = false }
-rand = "0.8.3"
+heapless = { version = "0.7", default-features = false }
+rand = "0.8"
 

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -16,24 +16,24 @@ bench = false
 nu-utils = { path = "../nu-utils", version = "0.76.1" }
 nu-json = { path = "../nu-json", version = "0.76.1" }
 
-byte-unit = "4.0.9"
-chrono = { version = "0.4.23", features = [
+byte-unit = "4.0"
+chrono = { version = "0.4", features = [
     "serde",
     "std",
 ], default-features = false }
-chrono-humanize = "0.2.1"
-fancy-regex = "0.11.0"
-indexmap = { version = "1.7" }
-lru = "0.9.0"
-miette = { version = "5.5.0", features = ["fancy-no-backtrace"] }
-num-format = "0.4.3"
-serde = { version = "1.0.143", default-features = false }
+chrono-humanize = "0.2"
+fancy-regex = "0.11"
+indexmap = { version = "1.9" }
+lru = "0.10"
+miette = { version = "5.5", features = ["fancy-no-backtrace"] }
+num-format = "0.4"
+serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", optional = true }
 strum = "0.24"
 strum_macros = "0.24"
-sys-locale = "0.2.0"
-thiserror = "1.0.31"
-typetag = "0.2.5"
+sys-locale = "0.2"
+thiserror = "1.0"
+typetag = "0.2"
 
 [features]
 plugin = ["serde_json"]

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -21,15 +21,15 @@ nix = { version = "0.25", default-features = false, features = ["fs", "term", "p
 atty = "0.2"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-procfs  = "0.15.1"
+procfs  = "0.15"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-libproc = "0.12.0"
+libproc = "0.13"
 errno = "0.3"
 mach2 = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.9", features = ["tlhelp32", "fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi", "std", "securitybaseapi"] }
-chrono = "0.4.23"
+winapi = { version = "0.3", features = ["tlhelp32", "fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi", "std", "securitybaseapi"] }
+chrono = "0.4"
 ntapi = "0.4"
 once_cell = "1.17"

--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -3,9 +3,10 @@ use libproc::libproc::bsd_info::BSDInfo;
 use libproc::libproc::file_info::{pidfdinfo, ListFDs, ProcFDType};
 use libproc::libproc::net_info::{InSockInfo, SocketFDInfo, SocketInfoKind, TcpSockInfo};
 use libproc::libproc::pid_rusage::{pidrusage, RUsageInfoV2};
-use libproc::libproc::proc_pid::{listpidinfo, listpids, pidinfo, ListThreads, ProcType};
+use libproc::libproc::proc_pid::{listpidinfo, pidinfo, ListThreads};
 use libproc::libproc::task_info::{TaskAllInfo, TaskInfo};
 use libproc::libproc::thread_info::ThreadInfo;
+use libproc::processes::{pids_by_type, ProcFilter};
 use mach2::mach_time;
 use std::cmp;
 use std::ffi::OsStr;
@@ -33,7 +34,7 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
     let mut ret = Vec::new();
     let arg_max = get_arg_max();
 
-    if let Ok(procs) = listpids(ProcType::ProcAllPIDS) {
+    if let Ok(procs) = pids_by_type(ProcFilter::All) {
         for p in procs {
             if let Ok(task) = pidinfo::<TaskAllInfo>(p as i32, 0) {
                 let res = pidrusage::<RUsageInfoV2>(p as i32).ok();

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -16,10 +16,11 @@ nu-protocol = { path = "../nu-protocol", version = "0.76.1" }
 nu-utils = { path = "../nu-utils", version = "0.76.1" }
 nu-engine = { path = "../nu-engine", version = "0.76.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.76.1" }
-atty = "0.2.14"
-tabled = { version = "0.10.0", features = ["color"], default-features = false }
-json_to_table = { version = "0.3.1", features = ["color"] }
-serde_json = "1"
+
+atty = "0.2"
+tabled = { version = "0.10", features = ["color"], default-features = false }
+json_to_table = { version = "0.3", features = ["color"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 # nu-test-support = { path="../nu-test-support", version = "0.76.1"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -11,6 +11,6 @@ version = "0.76.1"
 bench = false
 
 [dependencies]
-unicode-width = "0.1.9"
-
 nu-utils = { path = "../nu-utils", version = "0.76.1"  }
+
+unicode-width = "0.1"

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -15,10 +15,10 @@ bench = false
 nu-path = { path="../nu-path", version = "0.76.1"  }
 nu-glob = { path = "../nu-glob", version = "0.76.1" }
 nu-utils = { path="../nu-utils", version = "0.76.1"  }
-once_cell = "1.16.0"
-num-format = "0.4.3"
-which = "4.3.0"
 
-getset = "0.1.1"
-tempfile = "3.2.0"
-hamcrest2 = "0.3.0"
+once_cell = "1.17"
+num-format = "0.4"
+which = "4.4"
+getset = "0.1"
+tempfile = "3.4"
+hamcrest2 = "0.3"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -18,10 +18,10 @@ bench = false
 
 [dependencies]
 log = "0.4"
-lscolors = { version = "0.12.0", features = ["crossterm"], default-features = false }
-num-format = { version = "0.4.3" }
-strip-ansi-escapes = "0.1.1"
-sys-locale = "0.2.1"
+lscolors = { version = "0.12", features = ["crossterm"], default-features = false }
+num-format = { version = "0.4" }
+strip-ansi-escapes = "0.1"
+sys-locale = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-crossterm_winapi = "0.9.0"
+crossterm_winapi = "0.9"

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -12,8 +12,8 @@ version = "0.76.1"
 nu-plugin = { path = "../nu-plugin", version = "0.76.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.76.1", features = ["plugin"] }
 nu-engine = { path = "../nu-engine", version = "0.76.1" }
-indexmap = { version = "1.7", features = ["serde-1"] }
+indexmap = { version = "1.9", features = ["serde-1"] }
 
-eml-parser = "0.1.0"
-ical = "0.8.0"
-rust-ini = "0.18.0"
+eml-parser = "0.1"
+ical = "0.8"
+rust-ini = "0.18"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -20,4 +20,4 @@ nu-plugin = { path="../nu-plugin", version = "0.76.1" }
 nu-protocol = { path="../nu-protocol", version = "0.76.1" }
 nu-engine = { path="../nu-engine", version = "0.76.1" }
 
-git2 = "0.16.1"
+git2 = "0.16"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -19,4 +19,4 @@ bench = false
 nu-plugin = { path="../nu-plugin", version = "0.76.1" }
 nu-protocol = { path="../nu-protocol", version = "0.76.1", features = ["plugin"]}
 
-semver = "1.0.16"
+semver = "1.0"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -20,7 +20,8 @@ bench = false
 nu-plugin = { path="../nu-plugin", version = "0.76.1" }
 nu-protocol = { path="../nu-protocol", version = "0.76.1" }
 nu-engine = { path="../nu-engine", version = "0.76.1" }
-gjson = "0.8.0"
-scraper = { default-features = false, version = "0.15.0" }
-sxd-document = "0.3.2"
-sxd-xpath = "0.4.2"
+
+gjson = "0.8"
+scraper = { default-features = false, version = "0.15" }
+sxd-document = "0.3"
+sxd-xpath = "0.4"


### PR DESCRIPTION
# Description

I realize this may be controversial but I thought I'd put it out there. How about changing most of our dependencies to not have the patch version? This way, our dependencies stay mostly up to date as patches are released. There are some dependencies that will always need to be pinned to very specific versions but most probably don't need to be.

Thoughts?

# User-Facing Changes


# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
