### PR TITLE
Don't use 'spam' as module name as it isn't unique

### DIFF
--- a/src/tests/test_hiding.rs
+++ b/src/tests/test_hiding.rs
@@ -3,20 +3,26 @@ use crate::tests::{fail_test, run_test, TestResult};
 // TODO: Test the use/hide tests also as separate lines in REPL (i.e., with  merging the delta in between)
 #[test]
 fn hides_def() -> TestResult {
-    fail_test(r#"def foo [] { "foo" }; hide foo; foo"#, "external_command")
+    fail_test(
+        r#"def myfoosymbol [] { "myfoosymbol" }; hide myfoosymbol; myfoosymbol"#,
+        "external_command",
+    )
 }
 
 #[test]
 fn hides_alias() -> TestResult {
     fail_test(
-        r#"alias foo = echo "foo"; hide foo; foo"#,
+        r#"alias myfoosymbol = echo "myfoosymbol"; hide myfoosymbol; myfoosymbol"#,
         "external_command",
     )
 }
 
 #[test]
 fn hides_env() -> TestResult {
-    fail_test(r#"let-env foo = "foo"; hide-env foo; $env.foo"#, "")
+    fail_test(
+        r#"let-env myfoosymbol = "myfoosymbol"; hide-env myfoosymbol; $env.myfoosymbol"#,
+        "",
+    )
 }
 
 #[test]
@@ -24,7 +30,7 @@ fn hides_def_then_redefines() -> TestResult {
     // this one should fail because of predecl -- cannot have more defs with the same name in a
     // block
     fail_test(
-        r#"def foo [] { "foo" }; hide foo; def foo [] { "bar" }; foo"#,
+        r#"def myfoosymbol [] { "myfoosymbol" }; hide myfoosymbol; def myfoosymbol [] { "bar" }; myfoosymbol"#,
         "defined more than once",
     )
 }
@@ -33,15 +39,15 @@ fn hides_def_then_redefines() -> TestResult {
 #[test]
 fn hides_alias_then_redefines() -> TestResult {
     run_test(
-        r#"alias foo = echo "foo"; hide foo; alias foo = echo "foo"; foo"#,
-        "foo",
+        r#"alias myfoosymbol = echo "myfoosymbol"; hide myfoosymbol; alias myfoosymbol = echo "myfoosymbol"; myfoosymbol"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hides_env_then_redefines() -> TestResult {
     run_test(
-        r#"let-env foo = "foo"; hide-env foo; let-env foo = "bar"; $env.foo"#,
+        r#"let-env myfoosymbol = "myfoosymbol"; hide-env myfoosymbol; let-env myfoosymbol = "bar"; $env.myfoosymbol"#,
         "bar",
     )
 }
@@ -49,7 +55,7 @@ fn hides_env_then_redefines() -> TestResult {
 #[test]
 fn hides_def_in_scope_1() -> TestResult {
     fail_test(
-        r#"def foo [] { "foo" }; do { hide foo; foo }"#,
+        r#"def myfoosymbol [] { "myfoosymbol" }; do { hide myfoosymbol; myfoosymbol }"#,
         "external_command",
     )
 }
@@ -57,15 +63,15 @@ fn hides_def_in_scope_1() -> TestResult {
 #[test]
 fn hides_def_in_scope_2() -> TestResult {
     run_test(
-        r#"def foo [] { "foo" }; do { def foo [] { "bar" }; hide foo; foo }"#,
-        "foo",
+        r#"def myfoosymbol [] { "myfoosymbol" }; do { def myfoosymbol [] { "bar" }; hide myfoosymbol; myfoosymbol }"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hides_def_in_scope_3() -> TestResult {
     fail_test(
-        r#"def foo [] { "foo" }; do { hide foo; def foo [] { "bar" }; hide foo; foo }"#,
+        r#"def myfoosymbol [] { "myfoosymbol" }; do { hide myfoosymbol; def myfoosymbol [] { "bar" }; hide myfoosymbol; myfoosymbol }"#,
         "external_command",
     )
 }
@@ -73,7 +79,7 @@ fn hides_def_in_scope_3() -> TestResult {
 #[test]
 fn hides_def_in_scope_4() -> TestResult {
     fail_test(
-        r#"def foo [] { "foo" }; do { def foo [] { "bar" }; hide foo; hide foo; foo }"#,
+        r#"def myfoosymbol [] { "myfoosymbol" }; do { def myfoosymbol [] { "bar" }; hide myfoosymbol; hide myfoosymbol; myfoosymbol }"#,
         "external_command",
     )
 }
@@ -81,7 +87,7 @@ fn hides_def_in_scope_4() -> TestResult {
 #[test]
 fn hides_alias_in_scope_1() -> TestResult {
     fail_test(
-        r#"alias foo = echo "foo"; do { hide foo; foo }"#,
+        r#"alias myfoosymbol = echo "myfoosymbol"; do { hide myfoosymbol; myfoosymbol }"#,
         "external_command",
     )
 }
@@ -89,15 +95,15 @@ fn hides_alias_in_scope_1() -> TestResult {
 #[test]
 fn hides_alias_in_scope_2() -> TestResult {
     run_test(
-        r#"alias foo = echo "foo"; do { alias foo = echo "bar"; hide foo; foo }"#,
-        "foo",
+        r#"alias myfoosymbol = echo "myfoosymbol"; do { alias myfoosymbol = echo "bar"; hide myfoosymbol; myfoosymbol }"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hides_alias_in_scope_3() -> TestResult {
     fail_test(
-        r#"alias foo = echo "foo"; do { hide foo; alias foo = echo "bar"; hide foo; foo }"#,
+        r#"alias myfoosymbol = echo "myfoosymbol"; do { hide myfoosymbol; alias myfoosymbol = echo "bar"; hide myfoosymbol; myfoosymbol }"#,
         "external_command",
     )
 }
@@ -105,7 +111,7 @@ fn hides_alias_in_scope_3() -> TestResult {
 #[test]
 fn hides_alias_in_scope_4() -> TestResult {
     fail_test(
-        r#"alias foo = echo "foo"; do { alias foo = echo "bar"; hide foo; hide foo; foo }"#,
+        r#"alias myfoosymbol = echo "myfoosymbol"; do { alias myfoosymbol = echo "bar"; hide myfoosymbol; hide myfoosymbol; myfoosymbol }"#,
         "external_command",
     )
 }
@@ -113,7 +119,7 @@ fn hides_alias_in_scope_4() -> TestResult {
 #[test]
 fn hides_env_in_scope_1() -> TestResult {
     fail_test(
-        r#"let-env foo = "foo"; do { hide-env foo; $env.foo }"#,
+        r#"let-env myfoosymbol = "myfoosymbol"; do { hide-env myfoosymbol; $env.myfoosymbol }"#,
         "not_found",
     )
 }
@@ -121,15 +127,15 @@ fn hides_env_in_scope_1() -> TestResult {
 #[test]
 fn hides_env_in_scope_2() -> TestResult {
     run_test(
-        r#"let-env foo = "foo"; do { let-env foo = "bar"; hide-env foo; $env.foo }"#,
-        "foo",
+        r#"let-env myfoosymbol = "myfoosymbol"; do { let-env myfoosymbol = "bar"; hide-env myfoosymbol; $env.myfoosymbol }"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hides_env_in_scope_3() -> TestResult {
     fail_test(
-        r#"let-env foo = "foo"; do { hide-env foo; let-env foo = "bar"; hide-env foo; $env.foo }"#,
+        r#"let-env myfoosymbol = "myfoosymbol"; do { hide-env myfoosymbol; let-env myfoosymbol = "bar"; hide-env myfoosymbol; $env.myfoosymbol }"#,
         "",
     )
 }
@@ -137,7 +143,7 @@ fn hides_env_in_scope_3() -> TestResult {
 #[test]
 fn hides_env_in_scope_4() -> TestResult {
     fail_test(
-        r#"let-env foo = "foo"; do { let-env foo = "bar"; hide-env foo; hide-env foo; $env.foo }"#,
+        r#"let-env myfoosymbol = "myfoosymbol"; do { let-env myfoosymbol = "bar"; hide-env myfoosymbol; hide-env myfoosymbol; $env.myfoosymbol }"#,
         "",
     )
 }
@@ -146,7 +152,7 @@ fn hides_env_in_scope_4() -> TestResult {
 #[ignore]
 fn hide_def_twice_not_allowed() -> TestResult {
     fail_test(
-        r#"def foo [] { "foo" }; hide foo; hide foo"#,
+        r#"def myfoosymbol [] { "myfoosymbol" }; hide myfoosymbol; hide myfoosymbol"#,
         "did not find",
     )
 }
@@ -155,20 +161,23 @@ fn hide_def_twice_not_allowed() -> TestResult {
 #[ignore]
 fn hide_alias_twice_not_allowed() -> TestResult {
     fail_test(
-        r#"alias foo = echo "foo"; hide foo; hide foo"#,
+        r#"alias myfoosymbol = echo "myfoosymbol"; hide myfoosymbol; hide myfoosymbol"#,
         "did not find",
     )
 }
 
 #[test]
 fn hide_env_twice_not_allowed() -> TestResult {
-    fail_test(r#"let-env foo = "foo"; hide-env foo; hide-env foo"#, "")
+    fail_test(
+        r#"let-env myfoosymbol = "myfoosymbol"; hide-env myfoosymbol; hide-env myfoosymbol"#,
+        "",
+    )
 }
 
 #[test]
 fn hide_env_twice_allowed() -> TestResult {
     fail_test(
-        r#"let-env foo = "foo"; hide-env foo; hide-env -i foo; $env.foo"#,
+        r#"let-env myfoosymbol = "myfoosymbol"; hide-env myfoosymbol; hide-env -i myfoosymbol; $env.myfoosymbol"#,
         "",
     )
 }
@@ -176,7 +185,7 @@ fn hide_env_twice_allowed() -> TestResult {
 #[test]
 fn hides_def_runs_env() -> TestResult {
     run_test(
-        r#"let-env foo = "bar"; def foo [] { "foo" }; hide foo; $env.foo"#,
+        r#"let-env myfoosymbol = "bar"; def myfoosymbol [] { "myfoosymbol" }; hide myfoosymbol; $env.myfoosymbol"#,
         "bar",
     )
 }
@@ -184,7 +193,7 @@ fn hides_def_runs_env() -> TestResult {
 #[test]
 fn hides_def_import_1() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam foo; spam foo"#,
+        r#"module myspammodule { export def myfoosymbol [] { "myfoosymbol" } }; use myspammodule; hide myspammodule myfoosymbol; myspammodule myfoosymbol"#,
         "external_command",
     )
 }
@@ -192,7 +201,7 @@ fn hides_def_import_1() -> TestResult {
 #[test]
 fn hides_def_import_2() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam; spam foo"#,
+        r#"module myspammodule { export def myfoosymbol [] { "myfoosymbol" } }; use myspammodule; hide myspammodule; myspammodule myfoosymbol"#,
         "external_command",
     )
 }
@@ -200,7 +209,7 @@ fn hides_def_import_2() -> TestResult {
 #[test]
 fn hides_def_import_3() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam; hide spam [foo]; spam foo"#,
+        r#"module myspammodule { export def myfoosymbol [] { "myfoosymbol" } }; use myspammodule; hide myspammodule [myfoosymbol]; myspammodule myfoosymbol"#,
         "external_command",
     )
 }
@@ -208,7 +217,7 @@ fn hides_def_import_3() -> TestResult {
 #[test]
 fn hides_def_import_4() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam foo; hide foo; foo"#,
+        r#"module myspammodule { export def myfoosymbol [] { "myfoosymbol" } }; use myspammodule myfoosymbol; hide myfoosymbol; myfoosymbol"#,
         "external_command",
     )
 }
@@ -216,7 +225,7 @@ fn hides_def_import_4() -> TestResult {
 #[test]
 fn hides_def_import_5() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam *; hide foo; foo"#,
+        r#"module myspammodule { export def myfoosymbol [] { "myfoosymbol" } }; use myspammodule *; hide myfoosymbol; myfoosymbol"#,
         "external_command",
     )
 }
@@ -224,7 +233,7 @@ fn hides_def_import_5() -> TestResult {
 #[test]
 fn hides_def_import_6() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam *; hide spam *; foo"#,
+        r#"module myspammodule { export def myfoosymbol [] { "myfoosymbol" } }; use myspammodule *; hide myspammodule *; myfoosymbol"#,
         "external_command",
     )
 }
@@ -232,15 +241,15 @@ fn hides_def_import_6() -> TestResult {
 #[test]
 fn hides_def_import_then_reimports() -> TestResult {
     run_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam foo; hide foo; use spam foo; foo"#,
-        "foo",
+        r#"module myspammodule { export def myfoosymbol [] { "myfoosymbol" } }; use myspammodule myfoosymbol; hide myfoosymbol; use myspammodule myfoosymbol; myfoosymbol"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hides_alias_import_1() -> TestResult {
     fail_test(
-        r#"module spam { export alias foo = echo "foo" }; use spam; hide spam foo; spam foo"#,
+        r#"module myspammodule { export alias myfoosymbol = echo "myfoosymbol" }; use myspammodule; hide myspammodule myfoosymbol; myspammodule myfoosymbol"#,
         "external_command",
     )
 }
@@ -248,7 +257,7 @@ fn hides_alias_import_1() -> TestResult {
 #[test]
 fn hides_alias_import_2() -> TestResult {
     fail_test(
-        r#"module spam { export alias foo = echo "foo" }; use spam; hide spam; spam foo"#,
+        r#"module myspammodule { export alias myfoosymbol = echo "myfoosymbol" }; use myspammodule; hide myspammodule; myspammodule myfoosymbol"#,
         "external_command",
     )
 }
@@ -256,7 +265,7 @@ fn hides_alias_import_2() -> TestResult {
 #[test]
 fn hides_alias_import_3() -> TestResult {
     fail_test(
-        r#"module spam { export alias foo = echo "foo" }; use spam; hide spam [foo]; spam foo"#,
+        r#"module myspammodule { export alias myfoosymbol = echo "myfoosymbol" }; use myspammodule; hide myspammodule [myfoosymbol]; myspammodule myfoosymbol"#,
         "external_command",
     )
 }
@@ -264,7 +273,7 @@ fn hides_alias_import_3() -> TestResult {
 #[test]
 fn hides_alias_import_4() -> TestResult {
     fail_test(
-        r#"module spam { export alias foo = echo "foo" }; use spam foo; hide foo; foo"#,
+        r#"module myspammodule { export alias myfoosymbol = echo "myfoosymbol" }; use myspammodule myfoosymbol; hide myfoosymbol; myfoosymbol"#,
         "external_command",
     )
 }
@@ -272,7 +281,7 @@ fn hides_alias_import_4() -> TestResult {
 #[test]
 fn hides_alias_import_5() -> TestResult {
     fail_test(
-        r#"module spam { export alias foo = echo "foo" }; use spam *; hide foo; foo"#,
+        r#"module myspammodule { export alias myfoosymbol = echo "myfoosymbol" }; use myspammodule *; hide myfoosymbol; myfoosymbol"#,
         "external_command",
     )
 }
@@ -280,7 +289,7 @@ fn hides_alias_import_5() -> TestResult {
 #[test]
 fn hides_alias_import_6() -> TestResult {
     fail_test(
-        r#"module spam { export alias foo = echo "foo" }; use spam *; hide spam *; foo"#,
+        r#"module myspammodule { export alias myfoosymbol = echo "myfoosymbol" }; use myspammodule *; hide myspammodule *; myfoosymbol"#,
         "external_command",
     )
 }
@@ -288,15 +297,15 @@ fn hides_alias_import_6() -> TestResult {
 #[test]
 fn hides_alias_import_then_reimports() -> TestResult {
     run_test(
-        r#"module spam { export alias foo = echo "foo" }; use spam foo; hide foo; use spam foo; foo"#,
-        "foo",
+        r#"module myspammodule { export alias myfoosymbol = echo "myfoosymbol" }; use myspammodule myfoosymbol; hide myfoosymbol; use myspammodule myfoosymbol; myfoosymbol"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hides_env_import_1() -> TestResult {
     fail_test(
-        r#"module spam { export-env { let-env foo = "foo" } }; use spam; hide-env foo; $env.foo"#,
+        r#"module myspammodule { export-env { let-env myfoosymbol = "myfoosymbol" } }; use myspammodule; hide-env myfoosymbol; $env.myfoosymbol"#,
         "",
     )
 }
@@ -304,15 +313,15 @@ fn hides_env_import_1() -> TestResult {
 #[test]
 fn hides_def_runs_env_import() -> TestResult {
     run_test(
-        r#"module spam { export-env { let-env foo = "foo" }; export def foo [] { "bar" } }; use spam foo; hide foo; $env.foo"#,
-        "foo",
+        r#"module myspammodule { export-env { let-env myfoosymbol = "myfoosymbol" }; export def myfoosymbol [] { "bar" } }; use myspammodule myfoosymbol; hide myfoosymbol; $env.myfoosymbol"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hides_def_and_env_import_1() -> TestResult {
     fail_test(
-        r#"module spam { export-env { let-env foo = "foo" }; export def foo [] { "bar" } }; use spam foo; hide foo; hide-env foo; $env.foo"#,
+        r#"module myspammodule { export-env { let-env myfoosymbol = "myfoosymbol" }; export def myfoosymbol [] { "bar" } }; use myspammodule myfoosymbol; hide myfoosymbol; hide-env myfoosymbol; $env.myfoosymbol"#,
         "",
     )
 }
@@ -320,39 +329,39 @@ fn hides_def_and_env_import_1() -> TestResult {
 #[test]
 fn use_def_import_after_hide() -> TestResult {
     run_test(
-        r#"module spam { export def foo [] { "foo" } }; use spam foo; hide foo; use spam foo; foo"#,
-        "foo",
+        r#"module myspammodule { export def myfoosymbol [] { "myfoosymbol" } }; use myspammodule myfoosymbol; hide myfoosymbol; use myspammodule myfoosymbol; myfoosymbol"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn use_env_import_after_hide() -> TestResult {
     run_test(
-        r#"module spam { export-env { let-env foo = "foo" } }; use spam; hide-env foo; use spam; $env.foo"#,
-        "foo",
+        r#"module myspammodule { export-env { let-env myfoosymbol = "myfoosymbol" } }; use myspammodule; hide-env myfoosymbol; use myspammodule; $env.myfoosymbol"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hide_shadowed_decl() -> TestResult {
     run_test(
-        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; do { use spam foo; hide foo; foo }"#,
-        "foo",
+        r#"module myspammodule { export def myfoosymbol [] { "bar" } }; def myfoosymbol [] { "myfoosymbol" }; do { use myspammodule myfoosymbol; hide myfoosymbol; myfoosymbol }"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hide_shadowed_env() -> TestResult {
     run_test(
-        r#"module spam { export-env { let-env foo = "bar" } }; let-env foo = "foo"; do { use spam; hide-env foo; $env.foo }"#,
-        "foo",
+        r#"module myspammodule { export-env { let-env myfoosymbol = "bar" } }; let-env myfoosymbol = "myfoosymbol"; do { use myspammodule; hide-env myfoosymbol; $env.myfoosymbol }"#,
+        "myfoosymbol",
     )
 }
 
 #[test]
 fn hides_all_decls_within_scope() -> TestResult {
     fail_test(
-        r#"module spam { export def foo [] { "bar" } }; def foo [] { "foo" }; use spam foo; hide foo; foo"#,
+        r#"module myspammodule { export def myfoosymbol [] { "bar" } }; def myfoosymbol [] { "myfoosymbol" }; use myspammodule myfoosymbol; hide myfoosymbol; myfoosymbol"#,
         "external_command",
     )
 }
@@ -360,7 +369,7 @@ fn hides_all_decls_within_scope() -> TestResult {
 #[test]
 fn hides_all_envs_within_scope() -> TestResult {
     fail_test(
-        r#"module spam { export-env { let-env foo = "bar" } }; let-env foo = "foo"; use spam; hide-env foo; $env.foo"#,
+        r#"module myspammodule { export-env { let-env myfoosymbol = "bar" } }; let-env myfoosymbol = "myfoosymbol"; use myspammodule; hide-env myfoosymbol; $env.myfoosymbol"#,
         "",
     )
 }
@@ -368,7 +377,7 @@ fn hides_all_envs_within_scope() -> TestResult {
 #[test]
 fn hides_main_import_1() -> TestResult {
     fail_test(
-        r#"module spam { export def main [] { "foo" } }; use spam; hide spam; spam"#,
+        r#"module myspammodule { export def main [] { "myfoosymbol" } }; use myspammodule; hide myspammodule; myspammodule"#,
         "external_command",
     )
 }
@@ -376,7 +385,7 @@ fn hides_main_import_1() -> TestResult {
 #[test]
 fn hides_main_import_2() -> TestResult {
     fail_test(
-        r#"module spam { export def main [] { "foo" } }; use spam; hide spam main; spam"#,
+        r#"module myspammodule { export def main [] { "myfoosymbol" } }; use myspammodule; hide myspammodule main; myspammodule"#,
         "external_command",
     )
 }
@@ -384,7 +393,7 @@ fn hides_main_import_2() -> TestResult {
 #[test]
 fn hides_main_import_3() -> TestResult {
     fail_test(
-        r#"module spam { export def main [] { "foo" } }; use spam; hide spam [ main ]; spam"#,
+        r#"module myspammodule { export def main [] { "myfoosymbol" } }; use myspammodule; hide myspammodule [ main ]; myspammodule"#,
         "external_command",
     )
 }
@@ -392,7 +401,7 @@ fn hides_main_import_3() -> TestResult {
 #[test]
 fn hides_main_import_4() -> TestResult {
     fail_test(
-        r#"module spam { export def main [] { "foo" } }; use spam; hide spam *; spam"#,
+        r#"module myspammodule { export def main [] { "myfoosymbol" } }; use myspammodule; hide myspammodule *; myspammodule"#,
         "external_command",
     )
 }


### PR DESCRIPTION
# Description

The `spam` command is not always going to be missing, as is the case with this sgml tool: https://linux.die.net/man/1/spam

Rename `spam` and `foo` to something more unique so we have a lower chance of colliding with other names on the system.

fixes #8404

# User-Facing Changes

No impact. This only impacts testing

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
