### PR TITLE
Bump version to `0.77.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "assert_cmd",
  "atty",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "atty",
  "chrono",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "fancy-regex",
  "itertools",
@@ -2750,7 +2750,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "Inflector",
  "alphanumeric-sort",
@@ -2868,7 +2868,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "chrono",
  "nu-glob",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "nu-explore"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "ansi-str 0.7.2",
  "crossterm 0.24.0",
@@ -2901,14 +2901,14 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "doc-comment",
 ]
 
 [[package]]
 name = "nu-json"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "linked-hash-map",
  "num-traits",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "bincode",
  "nu-engine",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "heapless",
  "nu-ansi-term",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -2988,7 +2988,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "atty",
  "chrono",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "atty",
  "json_to_table",
@@ -3021,7 +3021,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "nu-utils",
  "unicode-width",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "getset",
  "hamcrest2",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3074,7 +3074,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_formats"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "eml-parser",
  "ical",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "git2",
  "nu-engine",
@@ -3097,7 +3097,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3106,7 +3106,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.76.1"
+version = "0.77.0"
 dependencies = [
  "gjson",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.60"
-version = "0.76.1"
+version = "0.77.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -47,21 +47,21 @@ ctrlc = "3.2.1"
 log = "0.4"
 miette = { version = "5.5.0", features = ["fancy-no-backtrace"] }
 nu-ansi-term = "0.47.0"
-nu-cli = { path = "./crates/nu-cli", version = "0.76.1" }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.76.1" }
-nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.76.1" }
-nu-command = { path = "./crates/nu-command", version = "0.76.1" }
-nu-engine = { path = "./crates/nu-engine", version = "0.76.1" }
-nu-json = { path = "./crates/nu-json", version = "0.76.1" }
-nu-parser = { path = "./crates/nu-parser", version = "0.76.1" }
-nu-path = { path = "./crates/nu-path", version = "0.76.1" }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.76.1" }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.76.1" }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.76.1" }
-nu-system = { path = "./crates/nu-system", version = "0.76.1" }
-nu-table = { path = "./crates/nu-table", version = "0.76.1" }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.76.1" }
-nu-utils = { path = "./crates/nu-utils", version = "0.76.1" }
+nu-cli = { path = "./crates/nu-cli", version = "0.77.0" }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.77.0" }
+nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.77.0" }
+nu-command = { path = "./crates/nu-command", version = "0.77.0" }
+nu-engine = { path = "./crates/nu-engine", version = "0.77.0" }
+nu-json = { path = "./crates/nu-json", version = "0.77.0" }
+nu-parser = { path = "./crates/nu-parser", version = "0.77.0" }
+nu-path = { path = "./crates/nu-path", version = "0.77.0" }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.77.0" }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.77.0" }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.77.0" }
+nu-system = { path = "./crates/nu-system", version = "0.77.0" }
+nu-table = { path = "./crates/nu-table", version = "0.77.0" }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.77.0" }
+nu-utils = { path = "./crates/nu-utils", version = "0.77.0" }
 
 reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
@@ -89,7 +89,7 @@ nix = { version = "0.26", default-features = false, features = [
 atty = "0.2"
 
 [dev-dependencies]
-nu-test-support = { path = "./crates/nu-test-support", version = "0.76.1" }
+nu-test-support = { path = "./crates/nu-test-support", version = "0.77.0" }
 tempfile = "3.4.0"
 assert_cmd = "2.0.2"
 criterion = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ crossterm = "0.24.0"
 ctrlc = "3.2.1"
 log = "0.4"
 miette = { version = "5.5.0", features = ["fancy-no-backtrace"] }
-nu-ansi-term = "0.47.0"
 nu-cli = { path = "./crates/nu-cli", version = "0.77.0" }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.77.0" }
 nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.77.0" }
@@ -63,6 +62,7 @@ nu-table = { path = "./crates/nu-table", version = "0.77.0" }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.77.0" }
 nu-utils = { path = "./crates/nu-utils", version = "0.77.0" }
 
+nu-ansi-term = "0.47.0"
 reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
 rayon = "1.7.0"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -21,9 +21,9 @@ nu-path = { path = "../nu-path", version = "0.77.0" }
 nu-parser = { path = "../nu-parser", version = "0.77.0" }
 nu-protocol = { path = "../nu-protocol", version = "0.77.0" }
 nu-utils = { path = "../nu-utils", version = "0.77.0" }
-nu-ansi-term = "0.47.0"
 nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
 
+nu-ansi-term = "0.47.0"
 reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 
 atty = "0.2.14"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -5,24 +5,24 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.76.1" }
-nu-command = { path = "../nu-command", version = "0.76.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.77.0" }
+nu-command = { path = "../nu-command", version = "0.77.0" }
 rstest = { version = "0.16.0", default-features = false }
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.76.1" }
-nu-path = { path = "../nu-path", version = "0.76.1" }
-nu-parser = { path = "../nu-parser", version = "0.76.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.76.1" }
-nu-utils = { path = "../nu-utils", version = "0.76.1" }
+nu-engine = { path = "../nu-engine", version = "0.77.0" }
+nu-path = { path = "../nu-path", version = "0.77.0" }
+nu-parser = { path = "../nu-parser", version = "0.77.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0" }
+nu-utils = { path = "../nu-utils", version = "0.77.0" }
 nu-ansi-term = "0.47.0"
-nu-color-config = { path = "../nu-color-config", version = "0.76.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
 
 reedline = { version = "0.16.0", features = ["bashisms", "sqlite"] }
 

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -6,18 +6,18 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-lang"
 edition = "2021"
 license = "MIT"
 name = "nu-cmd-lang"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
 
 [dependencies]
 nu-ansi-term = "0.47.0"
-nu-color-config = { path = "../nu-color-config", version = "0.76.1" }
-nu-engine = { path = "../nu-engine", version = "0.76.1" }
-nu-parser = { path = "../nu-parser", version = "0.76.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.76.1"  }
-nu-utils = { path = "../nu-utils", version = "0.76.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
+nu-engine = { path = "../nu-engine", version = "0.77.0" }
+nu-parser = { path = "../nu-parser", version = "0.77.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0"  }
+nu-utils = { path = "../nu-utils", version = "0.77.0" }
 
 fancy-regex = "0.11.0"
 itertools = "0.10.0"
@@ -28,4 +28,4 @@ shadow-rs = { version = "0.21.0", default-features = false }
 shadow-rs = { version = "0.21.0", default-features = false }
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.76.1"  }
+nu-test-support = { path="../nu-test-support", version = "0.77.0"  }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -12,12 +12,13 @@ version = "0.77.0"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.47.0"
 nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
 nu-engine = { path = "../nu-engine", version = "0.77.0" }
 nu-parser = { path = "../nu-parser", version = "0.77.0" }
 nu-protocol = { path = "../nu-protocol", version = "0.77.0"  }
 nu-utils = { path = "../nu-utils", version = "0.77.0" }
+
+nu-ansi-term = "0.47.0"
 
 fancy-regex = "0.11.0"
 itertools = "0.10.0"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-confi
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
@@ -15,11 +15,11 @@ serde = { version="1.0.123", features=["derive"] }
 # used only for text_style Alignments
 tabled = { version = "0.10.0", features = ["color"], default-features = false }
 
-nu-protocol = { path = "../nu-protocol", version = "0.76.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0"  }
 nu-ansi-term = "0.47.0"
-nu-utils = { path = "../nu-utils", version = "0.76.1" }
-nu-engine = { path = "../nu-engine", version = "0.76.1" }
-nu-json = { path="../nu-json", version = "0.76.1"  }
+nu-utils = { path = "../nu-utils", version = "0.77.0" }
+nu-engine = { path = "../nu-engine", version = "0.77.0" }
+nu-json = { path="../nu-json", version = "0.77.0"  }
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.76.1"  }
+nu-test-support = { path="../nu-test-support", version = "0.77.0"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.77.0"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.47.0"
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.77.0" }
 nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
 nu-engine = { path = "../nu-engine", version = "0.77.0" }
@@ -29,6 +28,8 @@ nu-table = { path = "../nu-table", version = "0.77.0" }
 nu-term-grid = { path = "../nu-term-grid", version = "0.77.0" }
 nu-utils = { path = "../nu-utils", version = "0.77.0" }
 num-format = { version = "0.4.3" }
+
+nu-ansi-term = "0.47.0"
 
 # Potential dependencies for extras
 Inflector = "0.11"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-command"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
-version = "0.76.1"
+version = "0.77.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,20 +14,20 @@ bench = false
 
 [dependencies]
 nu-ansi-term = "0.47.0"
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.76.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.76.1" }
-nu-engine = { path = "../nu-engine", version = "0.76.1" }
-nu-explore = { path = "../nu-explore", version = "0.76.1" }
-nu-glob = { path = "../nu-glob", version = "0.76.1" }
-nu-json = { path = "../nu-json", version = "0.76.1" }
-nu-parser = { path = "../nu-parser", version = "0.76.1" }
-nu-path = { path = "../nu-path", version = "0.76.1" }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.76.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.76.1" }
-nu-system = { path = "../nu-system", version = "0.76.1" }
-nu-table = { path = "../nu-table", version = "0.76.1" }
-nu-term-grid = { path = "../nu-term-grid", version = "0.76.1" }
-nu-utils = { path = "../nu-utils", version = "0.76.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.77.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
+nu-engine = { path = "../nu-engine", version = "0.77.0" }
+nu-explore = { path = "../nu-explore", version = "0.77.0" }
+nu-glob = { path = "../nu-glob", version = "0.77.0" }
+nu-json = { path = "../nu-json", version = "0.77.0" }
+nu-parser = { path = "../nu-parser", version = "0.77.0" }
+nu-path = { path = "../nu-path", version = "0.77.0" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.77.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0" }
+nu-system = { path = "../nu-system", version = "0.77.0" }
+nu-table = { path = "../nu-table", version = "0.77.0" }
+nu-term-grid = { path = "../nu-term-grid", version = "0.77.0" }
+nu-utils = { path = "../nu-utils", version = "0.77.0" }
 num-format = { version = "0.4.3" }
 
 # Potential dependencies for extras
@@ -155,7 +155,7 @@ trash-support = ["trash"]
 which-support = ["which"]
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.76.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.77.0" }
 mockito = "0.32.3"
 
 dirs-next = "2.0.0"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.76.1"  }
-nu-path = { path = "../nu-path", version = "0.76.1"  }
-nu-glob = { path = "../nu-glob", version = "0.76.1" }
-nu-utils = { path = "../nu-utils", version = "0.76.1"  }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.77.0"  }
+nu-path = { path = "../nu-path", version = "0.77.0"  }
+nu-glob = { path = "../nu-glob", version = "0.77.0" }
+nu-utils = { path = "../nu-utils", version = "0.77.0"  }
 
 chrono = { version="0.4.23", features = ["std"], default-features = false }
 serde = {version = "1.0.143", default-features = false }

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -5,20 +5,20 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-explore"
 edition = "2021"
 license = "MIT"
 name = "nu-explore"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
 
 [dependencies]
 nu-ansi-term = "0.47.0"
-nu-protocol = { path = "../nu-protocol", version = "0.76.1" }
-nu-parser = { path = "../nu-parser", version = "0.76.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.76.1" }
-nu-engine = { path = "../nu-engine", version = "0.76.1" }
-nu-table = { path = "../nu-table", version = "0.76.1" }
-nu-json = { path = "../nu-json", version = "0.76.1"  }
-nu-utils = { path = "../nu-utils", version = "0.76.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0" }
+nu-parser = { path = "../nu-parser", version = "0.77.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
+nu-engine = { path = "../nu-engine", version = "0.77.0" }
+nu-table = { path = "../nu-table", version = "0.77.0" }
+nu-json = { path = "../nu-json", version = "0.77.0"  }
+nu-utils = { path = "../nu-utils", version = "0.77.0"  }
 
 terminal_size = "0.2.1"
 strip-ansi-escapes = "0.1.1"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.76.1"
+version = "0.77.0"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.76.1"
+version = "0.77.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,5 +22,5 @@ num-traits = "0.2.14"
 serde = "1.0"
 
 [dev-dependencies]
-# nu-path = { path="../nu-path", version = "0.76.1" }
+# nu-path = { path="../nu-path", version = "0.77.0" }
 # serde_json = "1.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
@@ -17,10 +17,10 @@ itertools = "0.10"
 miette = {version = "5.5.0", features = ["fancy-no-backtrace"]}
 thiserror = "1.0.31"
 serde_json = "1.0"
-nu-path = {path = "../nu-path", version = "0.76.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.76.1" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.76.1"  }
-nu-engine = { path = "../nu-engine", version = "0.76.1" }
+nu-path = {path = "../nu-path", version = "0.77.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0" }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.77.0"  }
+nu-engine = { path = "../nu-engine", version = "0.77.0" }
 log = "0.4"
 
 [features]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -5,15 +5,15 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
 
 [dependencies]
 bincode = "1.3.3"
-nu-protocol = { path = "../nu-protocol", version = "0.76.1"  }
-nu-engine = { path = "../nu-engine", version = "0.76.1"  }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0"  }
+nu-engine = { path = "../nu-engine", version = "0.77.0"  }
 serde = { version = "1.0.143" }
 serde_json = { version = "1.0"}
 rmp = "0.8.11"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.76.1"
+version = "0.77.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +13,7 @@ version = "0.76.1"
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.76.1" }
+nu-utils = { path = "../nu-utils", version = "0.77.0" }
 
 byte-unit = "4.0.9"
 chrono = { version = "0.4.23", features = [
@@ -39,4 +39,4 @@ plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = "1.0"
-nu-test-support = { path = "../nu-test-support", version = "0.76.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.77.0" }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.76.1"
+version = "0.77.0"
 edition = "2021"
 license = "MIT"
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -11,11 +11,13 @@ version = "0.77.0"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.47.0"
 nu-protocol = { path = "../nu-protocol", version = "0.77.0" }
 nu-utils = { path = "../nu-utils", version = "0.77.0" }
 nu-engine = { path = "../nu-engine", version = "0.77.0" }
 nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
+
+nu-ansi-term = "0.47.0"
+
 atty = "0.2.14"
 tabled = { version = "0.10.0", features = ["color"], default-features = false }
 json_to_table = { version = "0.3.1", features = ["color"] }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -5,21 +5,21 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
 
 [dependencies]
 nu-ansi-term = "0.47.0"
-nu-protocol = { path = "../nu-protocol", version = "0.76.1" }
-nu-utils = { path = "../nu-utils", version = "0.76.1" }
-nu-engine = { path = "../nu-engine", version = "0.76.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.76.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0" }
+nu-utils = { path = "../nu-utils", version = "0.77.0" }
+nu-engine = { path = "../nu-engine", version = "0.77.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.77.0" }
 atty = "0.2.14"
 tabled = { version = "0.10.0", features = ["color"], default-features = false }
 json_to_table = { version = "0.3.1", features = ["color"] }
 serde_json = "1"
 
 [dev-dependencies]
-# nu-test-support = { path="../nu-test-support", version = "0.76.1"  }
+# nu-test-support = { path="../nu-test-support", version = "0.77.0"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 bench = false
@@ -13,4 +13,4 @@ bench = false
 [dependencies]
 unicode-width = "0.1.9"
 
-nu-utils = { path = "../nu-utils", version = "0.76.1"  }
+nu-utils = { path = "../nu-utils", version = "0.77.0"  }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-suppor
 edition = "2021"
 license = "MIT"
 name = "nu-test-support"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 doctest = false
 bench = false
 
 [dependencies]
-nu-path = { path="../nu-path", version = "0.76.1"  }
-nu-glob = { path = "../nu-glob", version = "0.76.1" }
-nu-utils = { path="../nu-utils", version = "0.76.1"  }
+nu-path = { path="../nu-path", version = "0.77.0"  }
+nu-glob = { path = "../nu-glob", version = "0.77.0" }
+nu-utils = { path="../nu-utils", version = "0.77.0"  }
 once_cell = "1.16.0"
 num-format = "0.4.3"
 which = "4.3.0"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-utils"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
-version = "0.76.1"
+version = "0.77.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -10,7 +10,7 @@ name = "nu_plugin_custom_values"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.76.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.76.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.77.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0", features = ["plugin"] }
 serde = { version = "1.0", default-features = false }
 typetag = "0.2.5"

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_exam
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.76.1"
+version = "0.77.0"
 
 [[bin]]
 name = "nu_plugin_example"
@@ -15,5 +15,5 @@ bench = false
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.76.1" }
-nu-protocol = { path="../nu-protocol", version = "0.76.1", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.77.0" }
+nu-protocol = { path="../nu-protocol", version = "0.77.0", features = ["plugin"]}

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -5,13 +5,13 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_form
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_formats"
-version = "0.76.1"
+version = "0.77.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.76.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.76.1", features = ["plugin"] }
-nu-engine = { path = "../nu-engine", version = "0.76.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.77.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.77.0", features = ["plugin"] }
+nu-engine = { path = "../nu-engine", version = "0.77.0" }
 indexmap = { version = "1.7", features = ["serde-1"] }
 
 eml-parser = "0.1.0"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gsta
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 doctest = false
@@ -16,8 +16,8 @@ name = "nu_plugin_gstat"
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.76.1" }
-nu-protocol = { path="../nu-protocol", version = "0.76.1" }
-nu-engine = { path="../nu-engine", version = "0.76.1" }
+nu-plugin = { path="../nu-plugin", version = "0.77.0" }
+nu-protocol = { path="../nu-protocol", version = "0.77.0" }
+nu-engine = { path="../nu-engine", version = "0.77.0" }
 
 git2 = "0.16.1"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_inc"
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.76.1" }
-nu-protocol = { path="../nu-protocol", version = "0.76.1", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.77.0" }
+nu-protocol = { path="../nu-protocol", version = "0.77.0", features = ["plugin"]}
 
 semver = "1.0.16"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_quer
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.76.1"
+version = "0.77.0"
 
 [lib]
 doctest = false
@@ -17,9 +17,9 @@ bench = false
 
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.76.1" }
-nu-protocol = { path="../nu-protocol", version = "0.76.1" }
-nu-engine = { path="../nu-engine", version = "0.76.1" }
+nu-plugin = { path="../nu-plugin", version = "0.77.0" }
+nu-protocol = { path="../nu-protocol", version = "0.77.0" }
+nu-engine = { path="../nu-engine", version = "0.77.0" }
 gjson = "0.8.0"
 scraper = { default-features = false, version = "0.15.0" }
 sxd-document = "0.3.2"


### PR DESCRIPTION
# Description

Preparations for the upcoming release.


## Checklist:

- [x] `nu-ansi-term` is released
- [x] `reedline` uses the new `nu-ansi-term`
- [x] `reedline` is released and pinned
- [x] `nu-ansi-term` is pinned to the same new version 
- [x] [`nu_release.nu`](https://github.com/nushell/nu_scripts/blob/main/make_release/nu_release.nu) script is updated to reflect the crate graph after cratification
- [ ] breaking changes are mentioned in the [release notes](https://github.com/nushell/nushell.github.io/pull/800)
