### PR TITLE
FEATURE: add a pretty output to `toolkit check pr`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,10 +25,6 @@ Make sure you've run and fixed any issues with these commands:
 > use toolkit.nu  # or use an `env_change` hook to activate it automatically
 > toolkit check pr
 > ```
-> you can replace this whole "Tests + Formatting" section by the list output of
-> ```bash
-> toolkit check pr --pretty
-> ```
 
 # After Submitting
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,10 @@ Make sure you've run and fixed any issues with these commands:
 > use toolkit.nu  # or use an `env_change` hook to activate it automatically
 > toolkit check pr
 > ```
+> you can replace this whole "Tests + Formatting" section by the list output of
+> ```bash
+> toolkit check pr --pretty
+> ```
 
 # After Submitting
 

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -35,6 +35,11 @@ export def test [
     }
 }
 
+# print the pipe input inside backticks, dimmed and italic, as a pretty command
+def pretty-print-command [] {
+    $"`(ansi default_dimmed)(ansi default_italic)($in)(ansi reset)`"
+}
+
 # run all the necessary checks and tests to submit a perfect PR
 #
 # # Example
@@ -125,7 +130,7 @@ export def test [
 export def "check pr" [
     --fast: bool  # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
 ] {
-    print "running `toolkit fmt`"
+    print $"running ('toolkit fmt' | pretty-print-command)"
     try {
         fmt --check
     } catch {
@@ -133,9 +138,9 @@ export def "check pr" [
         return
     }
 
-    print "running `toolkit clippy`"
+    print $"running ('toolkit clippy' | pretty-print-command)"
     clippy
 
-    print "running `toolkit test`"
+    print $"running ('toolkit test' | pretty-print-command)"
     if $fast { test --fast } else { test }
 }


### PR DESCRIPTION
when i write a PR, i run the tests and i like to have a pretty output to make extra clear which one of the tests did run, which one did not, etc, etc...

this always end up a variation of the template
> - `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
> - `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
> - `cargo test --workspace` to check that all tests pass

but with emojis and without the descriptions

> - :green_circle: `cargo fmt --all`
> - :red_circle: `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect`
> - :yellow_circle: `cargo test --workspace`
>
> and a :black_circle: (`:black_circle:`) when i did not have the time or the resources to run the check stage

in this PR, i came up with a way to do that automatically with the `toolkit` introduced in #8152 :yum: 

# Description
this PR
- adds `toolkit::pretty-print-command` to print the command names being run with backticks and some colors
- adds `toolkit::report` to return a "report" of the PR check stages => see `help toolkit check pr`
- adds the `--pretty` option to `toolkit check pr` to return a list-with-emojis version of the check report, i.e. a *GitHub*-friendly list to drop in place in the "Tests + Formatting" section
- adds a clear mention to `toolkit check pr --pretty` in the PR template to make it easily visible to anyone

hope you'll like it, that's not a huge deal but that's my attempt to encourage developers to show that they run the tests, what stages did pass and which one did not :relieved: :wave: 

# User-Facing Changes
the developer can now use `toolkit check pr --pretty` to have a ready-to-use output for *GitHub*

# Tests + Formatting
```
$nothing
```

# After Submitting
```
$nothing
```