### PR TITLE
Remove unused `nu-json` from `nu-protocol`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2973,7 +2973,6 @@ dependencies = [
  "indexmap",
  "lru",
  "miette",
- "nu-json",
  "nu-test-support",
  "nu-utils",
  "num-format",

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -14,7 +14,6 @@ bench = false
 
 [dependencies]
 nu-utils = { path = "../nu-utils", version = "0.76.1" }
-nu-json = { path = "../nu-json", version = "0.76.1" }
 
 byte-unit = "4.0.9"
 chrono = { version = "0.4.23", features = [


### PR DESCRIPTION
# Description

This dependency apears unnecessary and should remove a link in the crate
graph that could favor parallel compilation


# User-Facing Changes

None

# Tests + Formatting

During local testing I observed an unrelated link error when trying to build the tests including dataframes:

`cargo test --workspace --features dataframe --no-run`

This occurs for me even before the recent dependency bump in #8408
