### PR TITLE
nu-table/ skip some unicode chars

### DIFF
--- a/crates/nu-table/src/nu_protocol_table.rs
+++ b/crates/nu-table/src/nu_protocol_table.rs
@@ -154,7 +154,15 @@ fn nu_protocol_value_to_json(value: Value, config: &Config, with_footer: bool) -
 
             Json::Array(map)
         }
-        val => Json::String(val.into_abbreviated_string(config)),
+        val => {
+            let is_string = matches!(val, Value::String { .. });
+            let mut val = val.into_abbreviated_string(config);
+            if is_string {
+                val = crate::util::normalize_whitespace(val);
+            }
+
+            Json::String(val)
+        }
     }
 }
 

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -55,18 +55,18 @@ impl Table {
         text: impl Into<String>,
         style: TextStyle,
     ) -> TCell<CellInfo<'static>, TextStyle> {
-        TCell::new(CellInfo::new(text.into(), CfgWidthFunction::new(4)), style)
+        let text = crate::util::normalize_whitespace(text);
+        TCell::new(CellInfo::new(text, CfgWidthFunction::new(4)), style)
     }
 
     pub fn truncate(&mut self, width: usize, theme: &TableTheme) -> bool {
         let mut truncated = false;
         while self.data.count_rows() > 0 && self.data.count_columns() > 0 {
-            let total;
-            {
+            let total = {
                 let mut table = Builder::custom(self.data.clone()).build();
                 load_theme(&mut table, theme, false, false, None);
-                total = table.total_width();
-            }
+                table.total_width()
+            };
 
             if total > width {
                 truncated = true;

--- a/crates/nu-table/src/util.rs
+++ b/crates/nu-table/src/util.rs
@@ -43,3 +43,28 @@ pub fn string_truncate(text: &str, width: usize) -> String {
         .with(Width::truncate(width))
         .to_string()
 }
+
+// https://github.com/rust-lang/rust/blob/8a73f50d875840b8077b8ec080fa41881d7ce40d/compiler/rustc_errors/src/emitter.rs#L2477-L2497
+const OUTPUT_REPLACEMENTS: &[(char, &str)] = &[
+    ('\t', "    "),
+    ('\r', ""),
+    ('\u{200D}', ""),
+    ('\u{202A}', ""),
+    ('\u{202B}', ""),
+    ('\u{202D}', ""),
+    ('\u{202E}', ""),
+    ('\u{2066}', ""),
+    ('\u{2067}', ""),
+    ('\u{2068}', ""),
+    ('\u{202C}', ""),
+    ('\u{2069}', ""),
+];
+
+pub fn normalize_whitespace(str: impl Into<String>) -> String {
+    let mut s = str.into();
+    for (c, replacement) in OUTPUT_REPLACEMENTS {
+        s = s.replace(*c, replacement);
+    }
+
+    s
+}

--- a/crates/nu-table/tests/common.rs
+++ b/crates/nu-table/tests/common.rs
@@ -52,6 +52,7 @@ pub fn create_table(data: VecCells, config: TableConfig, termwidth: usize) -> Op
     table.draw(config, termwidth)
 }
 
+#[allow(unused)]
 pub fn create_row(count_columns: usize) -> Vec<TCell<CellInfo<'static>, TextStyle>> {
     let mut row = Vec::with_capacity(count_columns);
 

--- a/crates/nu-table/tests/replacement.rs
+++ b/crates/nu-table/tests/replacement.rs
@@ -1,8 +1,8 @@
 mod common;
 
-use common::{create_table};
+use common::create_table;
 
-use nu_table::{TableConfig, TableTheme as theme, Table};
+use nu_table::{Table, TableConfig, TableTheme as theme};
 
 #[test]
 fn replace_tab() {

--- a/crates/nu-table/tests/replacement.rs
+++ b/crates/nu-table/tests/replacement.rs
@@ -1,0 +1,43 @@
+mod common;
+
+use common::{create_table};
+
+use nu_table::{TableConfig, TableTheme as theme, Table};
+
+#[test]
+fn replace_tab() {
+    let table = create_table(
+        vec![vec![Table::create_cell("123\t345", Default::default())]; 3],
+        TableConfig::new(theme::rounded(), true, false, false).expand(),
+        50,
+    );
+
+    assert_eq!(
+        table.unwrap(),
+        "╭────────────────────────────────────────────────╮\n\
+         │                   123    345                   │\n\
+         ├────────────────────────────────────────────────┤\n\
+         │ 123    345                                     │\n\
+         │ 123    345                                     │\n\
+         ╰────────────────────────────────────────────────╯"
+    );
+}
+
+#[test]
+fn replace_u202e_tab() {
+    let table = create_table(
+        vec![vec![Table::create_cell("123\u{202E}345", Default::default())]; 3],
+        TableConfig::new(theme::rounded(), true, false, false).expand(),
+        50,
+    );
+
+    assert_eq!(
+        table.unwrap(),
+        "╭────────────────────────────────────────────────╮\n\
+         │                     123345                     │\n\
+         ├────────────────────────────────────────────────┤\n\
+         │ 123345                                         │\n\
+         │ 123345                                         │\n\
+         ╰────────────────────────────────────────────────╯"
+    );
+}


### PR DESCRIPTION
close #8411 

So I just did what you've described @fdncred.
Seems like it stay unchanged in `alacritty`, `VS Code` still has broken columns.
Please could you verify it your self as I am not sure what the end goal of this was.