### PR TITLE
Fix SQLite table creation sql

### DIFF
--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -117,7 +117,7 @@ fn action(
 
             let table_columns_creation = columns
                 .iter()
-                .map(|(name, sql_type)| format!("`{name}` {sql_type}"))
+                .map(|(name, sql_type)| format!("\"{name}\" {sql_type}"))
                 .join(",");
 
             // get the values

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -117,7 +117,7 @@ fn action(
 
             let table_columns_creation = columns
                 .iter()
-                .map(|(name, sql_type)| format!("{name} {sql_type}"))
+                .map(|(name, sql_type)| format!("`{name}` {sql_type}"))
                 .join(",");
 
             // get the values


### PR DESCRIPTION
# Description

The "CREATE TABLE" statement in `into sqlite` does not add quotes to the column names, reproduction steps are below:

```
/home/xxx〉[[name,y/n];[a,y]] | into sqlite test.db
Error: 
  × Failed to prepare SQLite statement
   ╭─[entry #1:1:1]
 1 │ [[name,y/n];[a,y]] | into sqlite test.db
   ·                                                       ───┬───
   ·                                                             ╰── near "/": syntax error in CREATE TABLE IF NOT EXISTS main (name TEXT,y/n TEXT) at offset 44
   ╰────
```

# User-Facing Changes

None




