### PR TITLE
Fix ls behaviour when directory is empty

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -129,7 +129,7 @@ impl Command for Ls {
                         ));
                     }
                     if is_empty_dir(&expanded) {
-                        return Ok(Value::nothing(call_span).into_pipeline_data());
+                        return Ok(Value::list(vec![], call_span).into_pipeline_data());
                     }
                     p.push("*");
                 }
@@ -141,7 +141,7 @@ impl Command for Ls {
                 if directory {
                     (PathBuf::from("."), call_span, false)
                 } else if is_empty_dir(current_dir(engine_state, stack)?) {
-                    return Ok(Value::nothing(call_span).into_pipeline_data());
+                    return Ok(Value::list(vec![], call_span).into_pipeline_data());
                 } else {
                     (PathBuf::from("./*"), call_span, false)
                 }


### PR DESCRIPTION
Prior to this PR, `ls` would return `nothing` in an empty directory. After this PR, it returns an empty `List`. This makes the behaviour of `ls` more consistent and easier to reason about (IMO).

This was prompted by a user noticing that `ls | where size == 0KB and type == file` breaks when run in an empty directory:

```
  × Input type not supported.
   ╭─[entry #12:1:1]
 1 │ ls | where size == 0KB and type == file
   · ─┬   ──┬──
   ·  │     ╰── only list, binary, raw data or range input data is supported
   ·  ╰── input type: nothing
   ╰────
```

If people agree with this change, let's wait until after the 0.77 release so we have a bit more time to test it.