### PR TITLE
docs: Add missing space in Filesystem/start's usage

### DIFF
--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -16,7 +16,7 @@ impl Command for Start {
     }
 
     fn usage(&self) -> &str {
-        "Open a folder,file or website in the default application or viewer."
+        "Open a folder, file or website in the default application or viewer."
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
In order to fix the selected text, below, in the documentation: 
<img width="1252" alt="Screenshot 2023-03-15 at 06 50 25" src="https://user-images.githubusercontent.com/3862051/225218941-7654803f-7b85-490a-9fb0-3de7d666935b.png">

PS: see https://github.com/nushell/nushell.github.io/pull/826 that was created before this pull request.