### PR TITLE
make better usage of error value in `catch` block

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -143,7 +143,7 @@ fn intercept_block_control(error: ShellError) -> Result<ShellError, ShellError> 
 
 /// Convert from `error` to [`Value::Record`] so the error information can be easily accessed in catch.
 fn err_to_record(error: ShellError, head: Span) -> Value {
-    let cols = vec!["msg".to_string(), "detail".to_string(), "raw".to_string()];
+    let cols = vec!["msg".to_string(), "debug".to_string(), "raw".to_string()];
     let vals = vec![
         Value::string(error.to_string(), head),
         Value::string(format!("{error:?}"), head),

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -2,8 +2,8 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Block, Closure, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type,
-    Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    Type, Value,
 };
 
 #[derive(Clone)]
@@ -59,17 +59,13 @@ impl Command for Try {
         match result {
             Err(error) => {
                 let error = intercept_block_control(error)?;
-                let err_value = Value::Error {
-                    error: Box::new(error),
-                };
-                handle_catch(err_value, catch_block, engine_state, stack)
+                let err_record = err_to_record(error, call.head);
+                handle_catch(err_record, catch_block, engine_state, stack)
             }
             Ok(PipelineData::Value(Value::Error { error }, ..)) => {
                 let error = intercept_block_control(*error)?;
-                let err_value = Value::Error {
-                    error: Box::new(error),
-                };
-                handle_catch(err_value, catch_block, engine_state, stack)
+                let err_record = err_to_record(error, call.head);
+                handle_catch(err_record, catch_block, engine_state, stack)
             }
             // external command may fail to run
             Ok(pipeline) => {
@@ -143,6 +139,19 @@ fn intercept_block_control(error: ShellError) -> Result<ShellError, ShellError> 
         nu_protocol::ShellError::Return(_, _) => Err(error),
         _ => Ok(error),
     }
+}
+
+/// Convert from `error` to [`Value::Record`] so the error information can be easily accessed in catch.
+fn err_to_record(error: ShellError, head: Span) -> Value {
+    let cols = vec!["msg".to_string(), "detail".to_string(), "raw".to_string()];
+    let vals = vec![
+        Value::string(error.to_string(), head),
+        Value::string(format!("{error:?}"), head),
+        Value::Error {
+            error: Box::new(error),
+        },
+    ];
+    Value::record(cols, vals, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -106,7 +106,7 @@ fn loop_try_break_on_command_should_show_successful() {
 fn catch_block_can_use_error_object() {
     let output = nu!(
         cwd: ".",
-        "try {1 / 0} catch {|err| print ($err | get msg})"
+        "try {1 / 0} catch {|err| print ($err | get msg)}"
     );
     assert_eq!(output.out, "division by zero")
 }

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -101,3 +101,12 @@ fn loop_try_break_on_command_should_show_successful() {
 
     assert!(!output.out.contains("failed"));
 }
+
+#[test]
+fn catch_block_can_use_error_object() {
+    let output = nu!(
+        cwd: ".",
+        "try {1 / 0} catch {|err| print ($err | get msg})"
+    );
+    assert_eq!(output.out, "division by zero")
+}

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -24,7 +24,7 @@ fn try_catch() {
 fn catch_can_access_error() {
     let output = nu!(
         cwd: ".",
-        "try { foobarbaz } catch { |err| $err }"
+        "try { foobarbaz } catch { |err| $err | get raw }"
     );
 
     assert!(output.err.contains("External command failed"));
@@ -34,7 +34,7 @@ fn catch_can_access_error() {
 fn catch_can_access_error_as_dollar_in() {
     let output = nu!(
         cwd: ".",
-        "try { foobarbaz } catch { $in }"
+        "try { foobarbaz } catch { $in | get raw }"
     );
 
     assert!(output.err.contains("External command failed"));

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -108,5 +108,5 @@ fn catch_block_can_use_error_object() {
         cwd: ".",
         "try {1 / 0} catch {|err| print ($err | get msg)}"
     );
-    assert_eq!(output.out, "division by zero")
+    assert_eq!(output.out, "Division by zero")
 }

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -108,5 +108,5 @@ fn catch_block_can_use_error_object() {
         cwd: ".",
         "try {1 / 0} catch {|err| print ($err | get msg)}"
     );
-    assert_eq!(output.out, "Division by zero")
+    assert_eq!(output.out, "Division by zero.")
 }


### PR DESCRIPTION
# Description

Fixes: #8402  #8391

The cause of these issue if when we want to evaluate a expression with `Value::Error`, nushell show error immediately.  To fix the issue, we can wrap the `Value::Error` into a `Value::Record`.  So user can see the message he want.

# User-Facing Changes

Before
```
❯ try { 1 / 0 } catch {|e| echo $"error is ($e)"}
Error: nu::shell::division_by_zero

  × Division by zero.
   ╭─[entry #2:1:1]
 1 │ try { 1 / 0 } catch {|e| echo $"error is ($e)"}
   ·         ┬
   ·         ╰── division by zero
   ╰────
```

After
```
❯ try { 1 / 0 } catch {|e| echo $"error is ($e)"}
error is {msg: Division by zero., debug: DivisionByZero { span: Span { start: 43104, end: 43105 } }, raw: DivisionByZero { sp
an: Span { start: 43104, end: 43105 } }}
```

As we can see, error becomes a record with `msg`, `debug`, `raw` columns.
1. msg column is a user friendly message.
2. debug column is more about `Value::Error` information as a string.
3. raw column is a `Value::Error` itself, if user want to re-raise the error, just use `$e | get raw`

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
