### PR TITLE
Add char --list example to char command docs

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -186,6 +186,11 @@ impl Command for Char {
                 result: Some(Value::test_string("\n")),
             },
             Example {
+                description: "List available characters",
+                example: r#"char --list"#,
+                result: None,
+            },
+            Example {
                 description: "Output prompt character, newline and a hamburger menu character",
                 example: r#"(char prompt) + (char newline) + (char hamburger)"#,
                 result: Some(Value::test_string("\u{25b6}\n\u{2261}")),


### PR DESCRIPTION
# Description

When using `char`, I somehow missed the `--list` flag (even though it's of course displayed in the help output). While it's maybe a bit redundant to have a usage of the flag in the examples, I suspect that I may not be alone in needing an extra nudge on getting that info 😄

# User-Facing Changes

Just an extra example in the `char` help output.
