### PR TITLE
Fix docs building error caused by missing end tag

### DIFF
--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -37,7 +37,7 @@ To represent different types of entries different values must be written to this
 1. Tag entry: `{tag: <tag name> attrs: {<attr name>: "<string value>" ...} content: [<entries>]}`
 2. Comment entry: `{tag: '!' attrs: null content: "<comment string>"}`
 3. Processing instruction (PI): `{tag: '?<pi name>' attrs: null content: "<pi content string>"}`
-4. Text: `{tag: null attrs: null content: "<text>"}`. Or as plain "<text>" instead of record.
+4. Text: `{tag: null attrs: null content: "<text>"}`. Or as plain `<text>` instead of record.
 
 Additionally any field which is: empty record, empty list or null, can be omitted."#
     }

--- a/crates/nu_plugin_query/src/nu/mod.rs
+++ b/crates/nu_plugin_query/src/nu/mod.rs
@@ -73,7 +73,7 @@ impl Plugin for Query {
 pub fn web_examples() -> Vec<PluginExample> {
     vec![PluginExample {
         example: "http get https://phoronix.com | query web -q 'header'".into(),
-        description: "Retrieve all <header> elements from phoronix.com website".into(),
+        description: "Retrieve all `<header>` elements from phoronix.com website".into(),
         result: None,
     }, PluginExample {
         example: "http get https://en.wikipedia.org/wiki/List_of_cities_in_India_by_population


### PR DESCRIPTION
# Description

Fix docs building error caused by missing end tag, for more detail here: https://github.com/nushell/nushell.github.io/actions/runs/4434104047/jobs/7779764472

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
