### PR TITLE
Exit successfully from `nu --help` for compatibility with halp

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -155,7 +155,7 @@ pub(crate) fn parse_commandline_args(
 
                 let _ = std::panic::catch_unwind(move || stdout_write_all_and_flush(full_help));
 
-                std::process::exit(1);
+                std::process::exit(0);
             }
 
             if call.has_flag("version") {


### PR DESCRIPTION
https://github.com/orhun/halp finds the correct help command
by checking if `cmd --help` succeeds.

All standard utilities I've tried exit successfully on `--help`,
but not nushell.
