### PR TITLE
Escape will now escape paths with '=' in them

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5103,7 +5103,7 @@ pub fn parse_expression(
 
         let split = name.splitn(2, |x| *x == b'=');
         let split: Vec<_> = split.collect();
-        if split.len() == 2 && !split[0].is_empty() {
+        if !name.starts_with(b"^") && split.len() == 2 && !split[0].is_empty() {
             let point = split[0].len() + 1;
 
             let lhs = parse_string_strict(

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -72,6 +72,13 @@ fn correctly_escape_external_arguments() {
 }
 
 #[test]
+fn escape_also_escapes_equals() {
+    let actual = nu!(cwd: ".", r#"^MYFOONAME=MYBARVALUE"#);
+
+    assert!(actual.err.contains("executable was not found"));
+}
+
+#[test]
 fn execute_binary_in_string() {
     let actual = nu!(
     cwd: ".",


### PR DESCRIPTION
# Description

Fixes the issue where there is no way to escape `FOO=BAR` in a way that treats it as a file path/executable name. Previously `^FOO=BAR` would be handled as an environment shorthand. Now, environment shorthands are not allowed to start with `^`. To create an environment shorthand value that uses `^` as the first character of the environment variable name, use quotes, eg `"^FOO"=BAR`

# User-Facing Changes

This should enable `=` being in paths and external command names in command position.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
