### PR TITLE
Correction bug multiple dots mkdir and touch

### DIFF
--- a/crates/nu-command/tests/commands/mkdir.rs
+++ b/crates/nu-command/tests/commands/mkdir.rs
@@ -84,3 +84,45 @@ fn print_created_paths() {
         assert!(actual.err.contains("dir_3"));
     })
 }
+
+#[test]
+fn creates_directory_three_dots() {
+    Playground::setup("mkdir_test_1", |dirs, _| {
+        nu!(
+            cwd: dirs.test(),
+            "mkdir test..."
+        );
+
+        let expected = dirs.test().join("test...");
+
+        assert!(expected.exists());
+    })
+}
+
+#[test]
+fn creates_directory_four_dots() {
+    Playground::setup("mkdir_test_1", |dirs, _| {
+        nu!(
+            cwd: dirs.test(),
+            "mkdir test...."
+        );
+
+        let expected = dirs.test().join("test....");
+
+        assert!(expected.exists());
+    })
+}
+
+#[test]
+fn creates_directory_three_dots_quotation_marks() {
+    Playground::setup("mkdir_test_1", |dirs, _| {
+        nu!(
+            cwd: dirs.test(),
+            "mkdir 'test...'"
+        );
+
+        let expected = dirs.test().join("test...");
+
+        assert!(expected.exists());
+    })
+}

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -122,3 +122,42 @@ fn not_create_file_if_it_not_exists() {
         assert!(!path.exists());
     })
 }
+
+#[test]
+fn creates_file_three_dots() {
+    Playground::setup("create_test_1", |dirs, _sandbox| {
+        nu!(
+            cwd: dirs.test(),
+            "touch file..."
+        );
+
+        let path = dirs.test().join("file...");
+        assert!(path.exists());
+    })
+}
+
+#[test]
+fn creates_file_four_dots() {
+    Playground::setup("create_test_1", |dirs, _sandbox| {
+        nu!(
+            cwd: dirs.test(),
+            "touch file...."
+        );
+
+        let path = dirs.test().join("file....");
+        assert!(path.exists());
+    })
+}
+
+#[test]
+fn creates_file_four_dots_quotation_marks() {
+    Playground::setup("create_test_1", |dirs, _sandbox| {
+        nu!(
+            cwd: dirs.test(),
+            "touch 'file....'"
+        );
+
+        let path = dirs.test().join("file....");
+        assert!(path.exists());
+    })
+}

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -33,6 +33,7 @@ pub fn expand_ndots(path: impl AsRef<Path>) -> PathBuf {
 
     // find if we need to expand any >2 dot paths and early exit if not
     let mut dots_count = 0u8;
+    let mut not_separator_before_dot = false;
     let ndots_present = {
         for chr in path_str.chars() {
             if chr == '.' {
@@ -42,7 +43,7 @@ pub fn expand_ndots(path: impl AsRef<Path>) -> PathBuf {
                     // this path component had >2 dots
                     break;
                 }
-
+                not_separator_before_dot = !is_separator(chr);
                 dots_count = 0;
             }
         }
@@ -50,7 +51,7 @@ pub fn expand_ndots(path: impl AsRef<Path>) -> PathBuf {
         dots_count > 2
     };
 
-    if !ndots_present {
+    if !ndots_present || not_separator_before_dot {
         return path.as_ref().into();
     }
 

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -43,7 +43,7 @@ pub fn expand_ndots(path: impl AsRef<Path>) -> PathBuf {
                     // this path component had >2 dots
                     break;
                 }
-                not_separator_before_dot = !is_separator(chr);
+                not_separator_before_dot = !(is_separator(chr) || chr.is_whitespace());
                 dots_count = 0;
             }
         }


### PR DESCRIPTION
# Description

As described in #8386, there was a problem in creating files and folders with more than two consecutive dots (`..`) in their name. This came from the specific management of nushell points in paths (for example, `...` is automatically transformed into `../..`). But this should not happen when the user wants to create a file/folder with several points (for example `test...`). In this case, the given file/folder should be created as requested by the user.

# Proposed change

To this end, I proposed to modify a little bit the `expand_ndots` function by checking if the character just before the dots is a separator/whitespace or not. If it is a separator or a whitespace, then the classic rule (`...` to `../..`) applies. Otherwise, the user must be free to do what he wants when handling paths.

This results in:

```rust
// find if we need to expand any >2 dot paths and early exit if not
let mut dots_count = 0u8;
let mut not_separator_before_dot = false;
let ndots_present = {
for chr in path_str.chars() {
    if chr == '.' {
        dots_count += 1;
    } else {
        if is_separator(chr) && (dots_count > 2) {
            // this path component had >2 dots
            break;
        }
        not_separator_before_dot = !(is_separator(chr) || chr.is_whitespace())
        dots_count = 0;
    }
}

dots_count > 2
};

if !ndots_present || not_separator_before_dot {
    return path.as_ref().into();
}
```


# Tests

The corresponding tests are added in the `mkdir.rs` and `touch.rs` test files.