### PR TITLE
Fix parse of def with paren params

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -197,3 +197,15 @@ param: list = [one]
         assert!(actual.out.contains(r#"["one"]"#));
     })
 }
+
+#[test]
+fn def_with_paren_params() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def foo (x: int, y: int) { $x + $y }; foo 1 2
+        "#
+    ));
+
+    assert_eq!(actual.out, "3");
+}

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1698,10 +1698,13 @@ pub(crate) fn parse_dollar_expr(
 pub fn parse_paren_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
+    shape: &SyntaxShape,
     expand_aliases_denylist: &[usize],
 ) -> (Expression, Option<ParseError>) {
     if let (expr, None) = parse_range(working_set, span, expand_aliases_denylist) {
         (expr, None)
+    } else if matches!(shape, SyntaxShape::Signature) {
+        return parse_signature(working_set, span, expand_aliases_denylist);
     } else {
         parse_full_cell_path(working_set, None, span, expand_aliases_denylist)
     }
@@ -4567,7 +4570,7 @@ pub fn parse_value(
 
     match bytes[0] {
         b'$' => return parse_dollar_expr(working_set, span, expand_aliases_denylist),
-        b'(' => return parse_paren_expr(working_set, span, expand_aliases_denylist),
+        b'(' => return parse_paren_expr(working_set, span, shape, expand_aliases_denylist),
         b'{' => return parse_brace_expr(working_set, span, shape, expand_aliases_denylist),
         b'[' => match shape {
             SyntaxShape::Any


### PR DESCRIPTION
# Description

This adds back support for parens around params, eg `def foo (x: int) { ... }`

# User-Facing Changes

returns to the original support before the recent parser refactor

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
