### PR TITLE
Fix CI tests that landed after no-implicit-echo

### DIFF
--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -11,7 +11,7 @@ fn commandline_test_append() -> TestResult {
         "commandline --replace '0👩‍❤️‍👩2'\n\
         commandline --cursor '2'\n\
         commandline --append 'ab'\n\
-        commandline\n\
+        print (commandline)\n\
         commandline --cursor",
         "0👩‍❤️‍👩2ab\n\
         2",
@@ -24,7 +24,7 @@ fn commandline_test_insert() -> TestResult {
         "commandline --replace '0👩‍❤️‍👩2'\n\
         commandline --cursor '2'\n\
         commandline --insert 'ab'\n\
-        commandline\n\
+        print (commandline)\n\
         commandline --cursor",
         "0👩‍❤️‍👩ab2\n\
         4",
@@ -36,7 +36,7 @@ fn commandline_test_replace() -> TestResult {
     run_test(
         "commandline --replace '0👩‍❤️‍👩2'\n\
         commandline --replace 'ab'\n\
-        commandline\n\
+        print (commandline)\n\
         commandline --cursor",
         "ab\n\
         2",

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -329,13 +329,13 @@ fn pre_execution_block_preserve_env_var() {
 fn pre_execution_commandline() {
     let inp = &[
         &pre_execution_hook_code(r#"{ let-env repl_commandline = (commandline) }"#),
-        "echo foo!; $env.repl_commandline",
+        "$env.repl_commandline",
     ];
 
     let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
-    assert_eq!(actual_repl.out, "foo!echo foo!; $env.repl_commandline");
+    assert_eq!(actual_repl.out, "$env.repl_commandline");
 }
 
 #[test]


### PR DESCRIPTION
# Description

Turning off implicit echo got tested before some of these changes, so bring a few tests in-line with that functionality.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
