### PR TITLE
parser: Fix panic that happens when you type a single `{`

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1724,6 +1724,16 @@ pub fn parse_brace_expr(
     // the parse is ambiguous. We'll need to update the parts of the grammar where this is ambiguous
     // and then revisit the parsing.
 
+    if span.end <= (span.start + 1) {
+        return (
+            Expression::garbage(span),
+            Some(ParseError::Expected(
+                format!("non-block value: {shape}"),
+                span,
+            )),
+        );
+    }
+
     let bytes = working_set.get_span_contents(Span::new(span.start + 1, span.end - 1));
     let (tokens, _) = lex(bytes, span.start + 1, &[b'\r', b'\n', b'\t'], &[b':'], true);
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -482,3 +482,8 @@ fn unbalanced_delimiter() -> TestResult {
 fn unbalanced_delimiter2() -> TestResult {
     fail_test(r#"{}#.}"#, "unbalanced { and }")
 }
+
+#[test]
+fn unbalanced_delimiter3() -> TestResult {
+    fail_test(r#"{"#, "Unexpected end of code")
+}


### PR DESCRIPTION
# Description

Fix the recent parser panic with a single `{`

Introduced by https://github.com/nushell/nushell/pull/8470

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
