### PR TITLE
Revert "Allow NU_LIBS_DIR and friends to be const"

### DIFF
--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -6,7 +6,7 @@ use nu_protocol::{
     PipelineData, Span, Type, Value,
 };
 use reedline::Suggestion;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use super::completer::map_value_completions;
 
@@ -66,7 +66,7 @@ impl Completer for CustomCompletion {
                 ],
                 redirect_stdout: true,
                 redirect_stderr: true,
-                parser_info: HashMap::new(),
+                parser_info: vec![],
             },
             PipelineData::empty(),
         );

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -1,4 +1,4 @@
-use nu_engine::{eval_block, find_in_dirs_env, get_dirs_var_from_call, redirect_env};
+use nu_engine::{eval_block, find_in_dirs_env, redirect_env};
 use nu_protocol::ast::{Call, Expr, Expression};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -48,7 +48,7 @@ impl Command for Use {
         let import_pattern = if let Some(Expression {
             expr: Expr::ImportPattern(pat),
             ..
-        }) = call.get_parser_info("import_pattern")
+        }) = call.parser_info_nth(0)
         {
             pat
         } else {
@@ -72,12 +72,9 @@ impl Command for Use {
                 let module_arg_str = String::from_utf8_lossy(
                     engine_state.get_span_contents(&import_pattern.head.span),
                 );
-                let maybe_parent = if let Some(path) = find_in_dirs_env(
-                    &module_arg_str,
-                    engine_state,
-                    caller_stack,
-                    get_dirs_var_from_call(call),
-                )? {
+                let maybe_parent = if let Some(path) =
+                    find_in_dirs_env(&module_arg_str, engine_state, caller_stack)?
+                {
                     path.parent().map(|p| p.to_path_buf()).or(None)
                 } else {
                     None

--- a/crates/nu-command/src/deprecated/source.rs
+++ b/crates/nu-command/src/deprecated/source.rs
@@ -45,7 +45,7 @@ impl Command for Source {
     ) -> Result<PipelineData, ShellError> {
         // Note: this hidden positional is the block_id that corresponded to the 0th position
         // it is put here by the parser
-        let block_id: i64 = call.req_parser_info(engine_state, stack, "block_id")?;
+        let block_id: i64 = call.req_parser_info(engine_state, stack, 0)?;
 
         let block = engine_state.get_block(block_id as usize).clone();
         eval_block_with_early_return(

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -1,8 +1,6 @@
 use std::path::PathBuf;
 
-use nu_engine::{
-    eval_block_with_early_return, find_in_dirs_env, get_dirs_var_from_call, redirect_env, CallExt,
-};
+use nu_engine::{eval_block_with_early_return, find_in_dirs_env, redirect_env, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -44,15 +42,12 @@ impl Command for SourceEnv {
 
         // Note: this hidden positional is the block_id that corresponded to the 0th position
         // it is put here by the parser
-        let block_id: i64 = call.req_parser_info(engine_state, caller_stack, "block_id")?;
+        let block_id: i64 = call.req_parser_info(engine_state, caller_stack, 0)?;
 
         // Set the currently evaluated directory (file-relative PWD)
-        let mut parent = if let Some(path) = find_in_dirs_env(
-            &source_filename.item,
-            engine_state,
-            caller_stack,
-            get_dirs_var_from_call(call),
-        )? {
+        let mut parent = if let Some(path) =
+            find_in_dirs_env(&source_filename.item, engine_state, caller_stack)?
+        {
             PathBuf::from(&path)
         } else {
             return Err(ShellError::FileNotFound(source_filename.span));

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -1,4 +1,4 @@
-use nu_engine::{find_in_dirs_env, get_dirs_var_from_call, CallExt};
+use nu_engine::{find_in_dirs_env, CallExt};
 use nu_parser::{parse, parse_module_block, unescape_unquote_string};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack, StateWorkingSet};
@@ -106,12 +106,7 @@ impl Command for NuCheck {
             _ => {
                 if let Some(path_str) = path {
                     // look up the path as relative to FILE_PWD or inside NU_LIB_DIRS (same process as source-env)
-                    let path = match find_in_dirs_env(
-                        &path_str.item,
-                        engine_state,
-                        stack,
-                        get_dirs_var_from_call(call),
-                    ) {
+                    let path = match find_in_dirs_env(&path_str.item, engine_state, stack) {
                         Ok(path) => {
                             if let Some(path) = path {
                                 path

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -39,7 +39,7 @@ pub trait CallExt {
         &self,
         engine_state: &EngineState,
         stack: &mut Stack,
-        name: &str,
+        pos: usize,
     ) -> Result<T, ShellError>;
 }
 
@@ -111,9 +111,9 @@ impl CallExt for Call {
         &self,
         engine_state: &EngineState,
         stack: &mut Stack,
-        name: &str,
+        pos: usize,
     ) -> Result<T, ShellError> {
-        if let Some(expr) = self.get_parser_info(name) {
+        if let Some(expr) = self.parser_info_nth(pos) {
             let result = eval_expression(engine_state, stack, expr)?;
             FromValue::from_value(&result)
         } else if self.parser_info.is_empty() {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -828,7 +828,7 @@ pub fn eval_element_with_input(
                             ],
                             redirect_stdout: false,
                             redirect_stderr: false,
-                            parser_info: HashMap::new(),
+                            parser_info: vec![],
                         },
                         input,
                     )
@@ -899,7 +899,7 @@ pub fn eval_element_with_input(
                             ],
                             redirect_stdout: false,
                             redirect_stderr: false,
-                            parser_info: HashMap::new(),
+                            parser_info: vec![],
                         },
                         input,
                     )

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use super::Expression;
@@ -21,7 +19,7 @@ pub struct Call {
     pub redirect_stdout: bool,
     pub redirect_stderr: bool,
     /// this field is used by the parser to pass additional command-specific information
-    pub parser_info: HashMap<String, Expression>,
+    pub parser_info: Vec<Expression>,
 }
 
 impl Call {
@@ -32,7 +30,7 @@ impl Call {
             arguments: vec![],
             redirect_stdout: true,
             redirect_stderr: false,
-            parser_info: HashMap::new(),
+            parser_info: vec![],
         }
     }
 
@@ -72,6 +70,10 @@ impl Call {
         self.arguments.push(Argument::Positional(positional));
     }
 
+    pub fn add_parser_info(&mut self, info: Expression) {
+        self.parser_info.push(info);
+    }
+
     pub fn add_unknown(&mut self, unknown: Expression) {
         self.arguments.push(Argument::Unknown(unknown));
     }
@@ -104,12 +106,8 @@ impl Call {
         self.positional_iter().count()
     }
 
-    pub fn get_parser_info(&self, name: &str) -> Option<&Expression> {
-        self.parser_info.get(name)
-    }
-
-    pub fn set_parser_info(&mut self, name: String, val: Expression) -> Option<Expression> {
-        self.parser_info.insert(name, val)
+    pub fn parser_info_nth(&self, i: usize) -> Option<&Expression> {
+        self.parser_info.get(i)
     }
 
     pub fn has_flag(&self, flag_name: &str) -> bool {

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -140,34 +140,6 @@ fn nu_lib_dirs_relative_repl() {
     })
 }
 
-// TODO: add absolute path tests after we expand const capabilities (see #8310)
-#[test]
-fn const_nu_lib_dirs_relative() {
-    Playground::setup("const_nu_lib_dirs_relative", |dirs, sandbox| {
-        sandbox
-            .mkdir("scripts")
-            .with_files(vec![FileWithContentToBeTrimmed(
-                "scripts/foo.nu",
-                r#"
-                    let-env FOO = "foo"
-                "#,
-            )])
-            .with_files(vec![FileWithContentToBeTrimmed(
-                "main.nu",
-                r#"
-                    const NU_LIB_DIRS = [ 'scripts' ]
-                    source-env foo.nu
-                    $env.FOO
-                "#,
-            )]);
-
-        let outcome = nu!(cwd: dirs.test(), "source main.nu");
-
-        assert!(outcome.err.is_empty());
-        assert_eq!(outcome.out, "foo");
-    })
-}
-
 #[test]
 fn nu_lib_dirs_relative_script() {
     Playground::setup("nu_lib_dirs_relative_script", |dirs, sandbox| {


### PR DESCRIPTION
Reverts nushell/nushell#8310

In anticipation that we may want to revert this PR. I'm starting the process because of this issue.

This stopped working
```
let-env NU_LIB_DIRS = [
    ($nu.config-path | path dirname | path join 'scripts')
    'C:\Users\username\source\repos\forks\nu_scripts'
    ($nu.config-path | path dirname)
]
```
You have to do this now instead.
```
const NU_LIB_DIRS = [
    'C:\Users\username\AppData\Roaming\nushell\scripts'
    'C:\Users\username\source\repos\forks\nu_scripts'
    'C:\Users\username\AppData\Roaming\nushell'
]
```

In talking with @kubouch, he was saying that the `let-env` version should keep working. Hopefully it's a small change.