### PR TITLE
standard library: fix the tests for the new closure parsing of `0.77.2`

### DIFF
--- a/crates/nu-utils/standard_library/test_std.nu
+++ b/crates/nu-utils/standard_library/test_std.nu
@@ -27,8 +27,8 @@ export def test_match [] {
     use std.nu assert
 
     let branches = {
-        1: { -1 }
-        2: { -2 }
+        1: {|| -1 }
+        2: {|| -2 }
     }
 
     assert ((std match 1 $branches) == -1)


### PR DESCRIPTION
# Description
as closures now need to have explicit parameters, this PR adds the empty `||` to the two closure of the `std match` test.

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
```
nu crates/nu-utils/standard_library/tests.nu
```
does not give the following anymore
```
Error: nu::parser::closure_missing_pipe

  × Missing || inside closure
    ╭─[/home/amtoine/.local/share/git/store/github.com/amtoine/nushell/crates/nu-utils/standard_library/test_std.nu:29:1]
 29 │     let branches = {
 30 │         1: { -1 }
    ·            ───┬──
    ·               ╰── Parsing as a closure, but || is missing
 31 │         2: { -2 }
    ╰────
  help: Try add || to the beginning of closure

Error: nu::shell::only_supports_this_input_type

  × Input type not supported.
    ╭─[/home/amtoine/.local/share/git/store/github.com/amtoine/nushell/crates/nu-utils/standard_library/tests.nu:7:1]
  7 │             nu -c $'use ($test_file) *; $nu.scope.commands | to nuon'
  8 │             | from nuon
    ·               ────┬────
    ·                   ╰── input type: nothing
  9 │             | where module_name == $module_name
    ·               ──┬──
    ·                 ╰── only list, binary, raw data or range input data is supported
 10 │             | where ($it.name | str starts-with "test_")
    ╰────
```

# After Submitting
```
$nothing
```