### PR TITLE
standard library: use the standard assert and fix test output

### DIFF
--- a/crates/nu-utils/standard_library/test_dirs.nu
+++ b/crates/nu-utils/standard_library/test_dirs.nu
@@ -41,8 +41,7 @@ export def test_dirs_command [] {
 
         assert ((dirs show) == [[active path]; [true $base_path] [false $path_b]]) "show table contains expected information"
     } catch { |error|
-        $error | debug
-        true
+        print $error
     }
 
     cd $base_path

--- a/crates/nu-utils/standard_library/test_dirs.nu
+++ b/crates/nu-utils/standard_library/test_dirs.nu
@@ -1,5 +1,11 @@
 use std.nu assert
 
+def clean [path: path] {
+    cd $path
+    cd ..
+    rm -r $path
+}
+
 export def test_dirs_command [] {
     # need some directories to play with
     let base_path = (($nu.temp-path) | path join $"test_dirs_(random uuid)" | path expand )
@@ -42,9 +48,8 @@ export def test_dirs_command [] {
         assert ((dirs show) == [[active path]; [true $base_path] [false $path_b]]) "show table contains expected information"
     } catch { |error|
         print $error
+        clean $base_path
     }
 
-    cd $base_path
-    cd ..
-    rm -r $base_path
+    try { clean $base_path }
 }

--- a/crates/nu-utils/standard_library/test_dirs.nu
+++ b/crates/nu-utils/standard_library/test_dirs.nu
@@ -47,8 +47,25 @@ export def test_dirs_command [] {
 
         assert ((dirs show) == [[active path]; [true $base_path] [false $path_b]]) "show table contains expected information"
     } catch { |error|
-        print $error
         clean $base_path
+
+        let error = (
+            $error
+            | get debug
+            | str replace "{" "("
+            | str replace "}" ")"
+            | parse 'GenericError("{msg}", "{text}", Some(Span ( start: {start}, end: {end} )), {rest})'
+            | reject rest
+            | get 0
+        )
+        error make {
+            msg: $error.msg
+            label: {
+                text: $error.text
+                start: ($error.start | into int)
+                end: ($error.end | into int)
+            }
+        }
     }
 
     try { clean $base_path }

--- a/crates/nu-utils/standard_library/test_dirs.nu
+++ b/crates/nu-utils/standard_library/test_dirs.nu
@@ -1,20 +1,4 @@
-use std.nu
-
-def "myassert" [
-    predicate: bool
-    msg?:string = "..."
-    --verbose = false (-v)  # enable to see successful tests
-] {
-    if not $predicate {
-        let span = (metadata $predicate).span
-        error make {msg: $"Assertion failed checking ($msg)",
-                    label: {text: "Condition not true" start: $span.start end: $span.end}}
-    } else {
-        if $verbose {
-            echo $"check succeeded: ($msg)"
-        }
-    }
-}
+use std.nu assert
 
 export def test_dirs_command [] {
     # need some directories to play with
@@ -31,31 +15,31 @@ export def test_dirs_command [] {
         use std.nu "dirs drop"
         use std.nu "dirs show"
 
-        myassert (1 == ($env.DIRS_LIST | length)) "list is just pwd after initialization"
-        myassert ($base_path == $env.DIRS_LIST.0) "list is just pwd after initialization"
+        assert (1 == ($env.DIRS_LIST | length)) "list is just pwd after initialization"
+        assert ($base_path == $env.DIRS_LIST.0) "list is just pwd after initialization"
 
         dirs next
-        myassert ($base_path == $env.DIRS_LIST.0) "next wraps at end of list"
+        assert ($base_path == $env.DIRS_LIST.0) "next wraps at end of list"
 
         dirs prev
-        myassert ($base_path == $env.DIRS_LIST.0) "prev wraps at top of list"
+        assert ($base_path == $env.DIRS_LIST.0) "prev wraps at top of list"
 
         dirs add $path_b $path_a
-        myassert ($path_b == $env.PWD) "add changes PWD to first added dir"
-        myassert (3 == ($env.DIRS_LIST | length)) "add in fact adds to list"
-        myassert ($path_a == $env.DIRS_LIST.2) "add in fact adds to list"
+        assert ($path_b == $env.PWD) "add changes PWD to first added dir"
+        assert (3 == ($env.DIRS_LIST | length)) "add in fact adds to list"
+        assert ($path_a == $env.DIRS_LIST.2) "add in fact adds to list"
 
         dirs next 2
-        myassert ($base_path == $env.PWD) "next wraps at end of list"
+        assert ($base_path == $env.PWD) "next wraps at end of list"
 
         dirs prev 1
-        myassert ($path_a == $env.PWD) "prev wraps at start of list"
+        assert ($path_a == $env.PWD) "prev wraps at start of list"
 
         dirs drop
-        myassert (2 == ($env.DIRS_LIST | length)) "drop removes from list"
-        myassert ($base_path == $env.PWD) "drop changes PWD to next in list (after dropped element)"
+        assert (2 == ($env.DIRS_LIST | length)) "drop removes from list"
+        assert ($base_path == $env.PWD) "drop changes PWD to next in list (after dropped element)"
 
-        myassert ((dirs show) == [[active path]; [true $base_path] [false $path_b]]) "show table contains expected information"
+        assert ((dirs show) == [[active path]; [true $base_path] [false $path_b]]) "show table contains expected information"
     } catch { |error|
         $error | debug
         true

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -2,7 +2,7 @@ def main [] {
     for test_file in (ls ($env.FILE_PWD | path join "test_*.nu") -f | get name) {
         let $module_name = ($test_file | path parse).stem
 
-        print $"(ansi default)INFO  Run tests in ($module_name)(ansi reset)"
+        echo $"(ansi default)INFO  Run tests in ($module_name)(ansi reset)"
         let tests = (
             nu -c $'use ($test_file) *; $nu.scope.commands | to nuon'
             | from nuon
@@ -12,7 +12,7 @@ def main [] {
         )
 
         for test_case in $tests {
-            print $"(ansi default_dimmed)DEBUG Run test ($module_name)/($test_case)(ansi reset)"
+            echo $"(ansi default_dimmed)DEBUG Run test ($module_name)/($test_case)(ansi reset)"
             nu -c $'use ($test_file) ($test_case); ($test_case)'
         }
     }

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -2,7 +2,7 @@ def main [] {
     for test_file in (ls ($env.FILE_PWD | path join "test_*.nu") -f | get name) {
         let $module_name = ($test_file | path parse).stem
 
-        echo $"(ansi default)INFO  Run tests in ($module_name)(ansi reset)"
+        print $"(ansi default)INFO  Run tests in ($module_name)(ansi reset)"
         let tests = (
             nu -c $'use ($test_file) *; $nu.scope.commands | to nuon'
             | from nuon
@@ -12,7 +12,7 @@ def main [] {
         )
 
         for test_case in $tests {
-            echo $"(ansi default_dimmed)DEBUG Run test ($module_name)/($test_case)(ansi reset)"
+            print $"(ansi default_dimmed)DEBUG Run test ($module_name)/($test_case)(ansi reset)"
             nu -c $'use ($test_file) ($test_case); ($test_case)'
         }
     }


### PR DESCRIPTION
# Description
## in the `test_dirs` test module
- use the `std assert` function in the `test_dirs` module instead of `myassert`
- refactor the "test cleaning" in the `clean` command
  - allows to clean the tests and then throw a real error in the `catch` block in case there is an error
  - the test still "try"s to `clean` the test directory after the `catch`, like in a "finally" block
- parse the `catch` error and `error make` a proper one instead of `debug`ging it => because the `catch` will be triggered as soon as one error occurs, there will always only be a single error in the tests, so this does not change the behaviour of failing `dirs` tests!

> **Note**
> i'm not particularly happy with the parsing stage in the `catch` block.
> however that's the simplest i found to both keep the `try` / `catch` construct that allows to clean the test directory and have a proper error at the same time!

## in the global `tests` module
- use `print` instead of `echo` to make sure the log statements show up during the tests

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
```bash
nu crates/nu-utils/standard_library/tests.nu
```
passes but now with
- proper log statements
- proper error when a `dirs` error occurs => try with `sd 'assert \(1' "assert (10" crates/nu-utils/standard_library/test_dirs.nu` :wink: 

# After Submitting
```
$nothing
```