### PR TITLE
FEATURE: write better errors for `error make` and complete the doc

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -89,6 +89,13 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                 let label_text = label.get_data_by_key("text");
 
                 match (label_start, label_end, label_text) {
+                    (_, _, None) => Some(ShellError::GenericError(
+                        "Unable to parse error format.".into(),
+                        "missing required member `$.label.text`".into(),
+                        None,
+                        None,
+                        Vec::new(),
+                    )),
                     (
                         Some(Value::Int { val: start, .. }),
                         Some(Value::Int { val: end, .. }),
@@ -115,6 +122,20 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                         None,
                         Vec::new(),
                     )),
+                    (Some(Value::Int { .. }), None, _) => Some(ShellError::GenericError(
+                        "Unable to parse error format.".into(),
+                        "missing required member `$.label.end`".into(),
+                        None,
+                        Some("required because `$.label.start` is set".to_string()),
+                        Vec::new(),
+                    )),
+                    (None, Some(Value::Int { .. }), _) => Some(ShellError::GenericError(
+                        "Unable to parse error format.".into(),
+                        "missing required member `$.label.start`".into(),
+                        None,
+                        Some("required because `$.label.end` is set".to_string()),
+                        Vec::new(),
+                    )),
                     _ => None,
                 }
             }
@@ -122,6 +143,13 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                 message,
                 "originates from here".to_string(),
                 throw_span,
+                None,
+                Vec::new(),
+            )),
+            (None, _) => Some(ShellError::GenericError(
+                "Unable to parse error format.".into(),
+                "missing required member `$.msg`".into(),
+                None,
                 None,
                 Vec::new(),
             )),

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -91,13 +91,6 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                 let label_span = label.span().unwrap();
 
                 match (label_start, label_end, label_text) {
-                    (_, _, None) => Some(ShellError::GenericError(
-                        "Unable to parse error format.".into(),
-                        "missing required member `$.label.text`".into(),
-                        Some(label_span),
-                        None,
-                        Vec::new(),
-                    )),
                     (
                         Some(Value::Int { val: start, .. }),
                         Some(Value::Int { val: end, .. }),
@@ -121,6 +114,13 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                         message,
                         label_text,
                         throw_span,
+                        None,
+                        Vec::new(),
+                    )),
+                    (_, _, None) => Some(ShellError::GenericError(
+                        "Unable to parse error format.".into(),
+                        "missing required member `$.label.text`".into(),
+                        Some(label_span),
                         None,
                         Vec::new(),
                     )),

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -92,10 +92,18 @@ impl Command for ErrorMake {
                 }),
             },
             Example {
-                description: "Create a custom error for a custom command",
+                description:
+                    "Create a custom error for a custom command that shows the span of the argument",
                 example: r#"def foo [x] {
         let span = (metadata $x).span;
-        error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
+        error make {
+            msg: "this is fishy"
+            label: {
+                text: "fish right here"
+                start: $span.start
+                end: $span.end
+            }
+        }
     }"#,
                 result: None,
             },

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -44,27 +44,16 @@ impl Command for ErrorMake {
         let arg: Value = call.req(engine_state, stack, 0)?;
         let unspanned = call.has_flag("unspanned");
 
-        if unspanned {
-            Err(make_error(&arg, None).unwrap_or_else(|| {
-                ShellError::GenericError(
-                    "Creating error value not supported.".into(),
-                    "unsupported error format".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            }))
-        } else {
-            Err(make_error(&arg, Some(span)).unwrap_or_else(|| {
-                ShellError::GenericError(
-                    "Creating error value not supported.".into(),
-                    "unsupported error format".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            }))
-        }
+        let throw_error = if unspanned { None } else { Some(span) };
+        Err(make_error(&arg, throw_error).unwrap_or_else(|| {
+            ShellError::GenericError(
+                "Creating error value not supported.".into(),
+                "unsupported error format".into(),
+                Some(span),
+                None,
+                Vec::new(),
+            )
+        }))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -59,18 +59,18 @@ impl Command for ErrorMake {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
+                description: "Create a simple custom error",
+                example: r#"error make {msg: "my custom error message"}"#,
+                result: None,
+            },
+            Example {
                 description: "Create a custom error for a custom command",
                 example: r#"def foo [x] {
         let span = (metadata $x).span;
         error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
-    }"#,
-                result: None,
-            },
-            Example {
-                description: "Create a simple custom error for a custom command",
-                example: r#"def foo [x] {
-        error make {msg: "this is fishy"}
-    }"#,
+    }
+
+    foo "i am fishy...""#,
                 result: None,
             },
         ]

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -68,9 +68,7 @@ impl Command for ErrorMake {
                 example: r#"def foo [x] {
         let span = (metadata $x).span;
         error make {msg: "this is fishy", label: {text: "fish right here", start: $span.start, end: $span.end } }
-    }
-
-    foo "i am fishy...""#,
+    }"#,
                 result: None,
             },
         ]

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -61,7 +61,15 @@ impl Command for ErrorMake {
             Example {
                 description: "Create a simple custom error",
                 example: r#"error make {msg: "my custom error message"}"#,
-                result: None,
+                result: Some(Value::Error {
+                    error: Box::new(ShellError::GenericError(
+                        "my custom error message".to_string(),
+                        "".to_string(),
+                        None,
+                        None,
+                        Vec::new(),
+                    )),
+                }),
             },
             Example {
                 description: "Create a more complex custom error",
@@ -73,6 +81,15 @@ impl Command for ErrorMake {
             end: 456  # not mandatory unless $.label.start is set
         }
     }"#,
+                result: Some(Value::Error {
+                    error: Box::new(ShellError::GenericError(
+                        "my custom error message".to_string(),
+                        "my custom label text".to_string(),
+                        Some(Span::new(123, 456)),
+                        None,
+                        Vec::new(),
+                    )),
+                }),
             },
             Example {
                 description: "Create a custom error for a custom command",

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -64,6 +64,17 @@ impl Command for ErrorMake {
                 result: None,
             },
             Example {
+                description: "Create a more complex custom error",
+                example: r#"error make {
+        msg: "my custom error message"
+        label: {
+            text: "my custom label text"  # not mandatory unless $.label exists
+            start: 123  # not mandatory unless $.label.end is set
+            end: 456  # not mandatory unless $.label.start is set
+        }
+    }"#,
+            },
+            Example {
                 description: "Create a custom error for a custom command",
                 example: r#"def foo [x] {
         let span = (metadata $x).span;

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -88,7 +88,10 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                 let label_end = label.get_data_by_key("end");
                 let label_text = label.get_data_by_key("text");
 
-                let label_span = label.span().unwrap();
+                let label_span = match label.span() {
+                    Ok(lspan) => Some(lspan),
+                    Err(_) => None,
+                };
 
                 match (label_start, label_end, label_text) {
                     (
@@ -120,21 +123,21 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                     (_, _, None) => Some(ShellError::GenericError(
                         "Unable to parse error format.".into(),
                         "missing required member `$.label.text`".into(),
-                        Some(label_span),
+                        label_span,
                         None,
                         Vec::new(),
                     )),
                     (Some(Value::Int { .. }), None, _) => Some(ShellError::GenericError(
                         "Unable to parse error format.".into(),
                         "missing required member `$.label.end`".into(),
-                        Some(label_span),
+                        label_span,
                         Some("required because `$.label.start` is set".to_string()),
                         Vec::new(),
                     )),
                     (None, Some(Value::Int { .. }), _) => Some(ShellError::GenericError(
                         "Unable to parse error format.".into(),
                         "missing required member `$.label.start`".into(),
-                        Some(label_span),
+                        label_span,
                         Some("required because `$.label.end` is set".to_string()),
                         Vec::new(),
                     )),


### PR DESCRIPTION
# Description
this PR
- refactors `ErrorMake::run` to avoid duplicate branches depending on the value of `--unspanned`
- completes the examples
  1. show a really simple `error make` call, without any command definition
  2. show a complete error format with all possible fields
  3. the command definition but with indentation and slightly better description
- adds results to the first two examples
- gives meaningful error messages for all known "bad" error formats, using the span of the error format or the span of `$format.label` to better explain why the format is bad

# User-Facing Changes
users have now the following help
```bash
Examples:
  Create a simple custom error
  > error make {msg: "my custom error message"}

  Create a more complex custom error
  > error make {
        msg: "my custom error message"
        label: {
            text: "my custom label text"  # not mandatory unless $.label exists
            start: 123  # not mandatory unless $.label.end is set
            end: 456  # not mandatory unless $.label.start is set
        }
    }

  Create a custom error for a custom command that shows the span of the argument
  > def foo [x] {
        let span = (metadata $x).span;
        error make {
            msg: "this is fishy"
            label: {
                text: "fish right here"
                start: $span.start
                end: $span.end
            }
        }
    }
```
and the following error messages when the error format is bad https://asciinema.org/a/568107 :partying_face: 

# Tests + Formatting
- :green_circle: `cargo fmt --all`
- :green_circle: `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect`
- :red_circle: `cargo test --workspace`
=> the tests do not pass but they do not pass on latest `main` either => i should `cargo clean`, but that's an expensive operation on my machine...

# After Submitting
the documentation would have to be regenerated over on the website