### PR TITLE
remove unused imports: `Deserialize`, `Serialize` compiler warning for nu-protocol/src/example.rs

### DIFF
--- a/crates/nu-protocol/src/example.rs
+++ b/crates/nu-protocol/src/example.rs
@@ -1,4 +1,5 @@
 use crate::Value;
+#[allow(unused_imports)]
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]


### PR DESCRIPTION

when running the tests inside nu-protocol we were getting a compiler warning...
this PR removes the compiler warning from nu-protocol.
by adding
```rust
#[allow(unused_imports)]
```