### PR TITLE
Add section on removing ANSI sequences with find command

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -133,7 +133,7 @@ impl Command for Find {
             },
             Example {
                 description: "Remove ANSI sequences from result",
-                example: "ls | find Car | get 0.name | ansi strip",
+                example: "[[foo bar]; [abc 123] [def 456]] | find 123 | get bar | ansi strip",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -132,7 +132,7 @@ impl Command for Find {
                 }),
             },
             Example {
-                description: "Remove ANSI sequence from result",
+                description: "Remove ANSI sequences from result",
                 example: "ls | find Car | get 0.name | ansi strip",
                 result: None,
             },

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -131,6 +131,11 @@ impl Command for Find {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Remove ANSI sequence from result",
+                example: "ls | find Car | get 0.name | ansi strip",
+                result: None,
+            },
         ]
     }
 


### PR DESCRIPTION
# Description

Add example at the end 

![Capture d’écran du 2023-03-18 22-55-54](https://user-images.githubusercontent.com/1321367/226142422-5ae171f4-d3c0-4e53-8e75-894cd327d700.png)

# User-Facing Changes

None

# Tests + Formatting

-  [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x]  `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass



