### PR TITLE
standard library: fix the readme

### DIFF
--- a/crates/nu-utils/standard_library/README.md
+++ b/crates/nu-utils/standard_library/README.md
@@ -52,7 +52,7 @@ use /path/to/standard_library/std.nu
 
 ## :pencil2: contribute to the standard library
 ### :wrench: add new commands
-- add new standard commands to [`std.nu`](std.nu), or preferably create a new submodule.
+- add new standard commands by appending to [`std.nu`](std.nu)
 - add associated tests to [`test_std.nu`](tests_std.nu) or preferably to `test_<submodule>.nu`.
     - define a new exported (!) `test_<feature>` command
     - import the `assert` functions you need at the top of the functions, e.g. `use std.nu "assert eq"`

--- a/crates/nu-utils/standard_library/README.md
+++ b/crates/nu-utils/standard_library/README.md
@@ -51,6 +51,10 @@ use /path/to/standard_library/std.nu
 > ```
 
 ## :pencil2: contribute to the standard library
+- all the commands of the standard_library are located in [`std.nu`](std.nu)
+- the tests are located in files that have a name starting with "test_", e.g. [`test_std.nu`](test_std.nu)
+- a test runner, at [`tests.nu`](tests.nu), allows to run all the tests automatically
+
 ### :wrench: add new commands
 - add new standard commands by appending to [`std.nu`](std.nu)
 - add associated tests to [`test_std.nu`](tests_std.nu) or preferably to `test_<submodule>.nu`.


### PR DESCRIPTION
# Description
as we now want to put all the library in `std.nu` alone, this PR removes the mentions to "creating a separate submodule from `std.nu`" from the `README` of the standard library and adds a few clarifications about the structure of the library.

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
```
$nothing
```

# After Submitting
```
$nothing
```