### PR TITLE
IMPORTANT(?): add codeowners to `nushell`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @nushell/core-team
+/crates/nu-utils/standard_library/ @amtoine


### PR DESCRIPTION
inspired by https://github.com/nushell/nu_scripts/pull/419 and as @fdncred did not look against the project, here is the `CODEOWNERS` file:

- the core team is responsible of the entire source base
- i'd be responsible for the standard library

## important notes
- i'll let this as a draft until all the "administrative" stuff has been sorted out in https://github.com/nushell/nu_scripts/pull/419
- the @nushell/core-team and myself, @amtoine, would have to have write permissions
- that could be handled quite well with branch protection rules

i just had the changes available, i'll wait for https://github.com/nushell/nu_scripts/pull/419 to be sorted out, and if giving write access like this is not an option, you can close this :+1: :relieved: 