### PR TITLE
fix: `bytes length` example description typo

### DIFF
--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -54,7 +54,7 @@ impl Command for BytesLen {
                 result: Some(Value::test_int(4)),
             },
             Example {
-                description: "Return the lengths of multiple binary",
+                description: "Return the lengths of multiple binaries",
                 example: "[0x[1F FF AA AB] 0x[1F]] | bytes length",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(4), Value::test_int(1)],


### PR DESCRIPTION

this pr fixes a typo