### PR TITLE
When running external command, expand tilde when pass back-quoted word

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -778,7 +778,8 @@ fn trim_enclosing_quotes(input: &str) -> (String, bool, bool) {
     match (chars.next(), chars.next_back()) {
         (Some('"'), Some('"')) => (chars.collect(), false, true),
         (Some('\''), Some('\'')) => (chars.collect(), false, true),
-        (Some('`'), Some('`')) => (chars.collect(), true, true),
+        // we treat back quoted string as a bare word, so don't need ot keep it as raw string
+        (Some('`'), Some('`')) => (chars.collect(), true, false),
         _ => (input.to_string(), true, false),
     }
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -778,7 +778,7 @@ fn trim_enclosing_quotes(input: &str) -> (String, bool, bool) {
     match (chars.next(), chars.next_back()) {
         (Some('"'), Some('"')) => (chars.collect(), false, true),
         (Some('\''), Some('\'')) => (chars.collect(), false, true),
-        // we treat back quoted string as a bare word, so don't need ot keep it as raw string
+        // We treat back-quoted strings as bare words, so there's no need to keep them as raw strings
         (Some('`'), Some('`')) => (chars.collect(), true, false),
         _ => (input.to_string(), true, false),
     }

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -214,6 +214,17 @@ fn external_command_not_expand_tilde_with_quotes() {
 }
 
 #[test]
+fn external_command_expand_tilde_with_back_quotes() {
+    Playground::setup(
+        "external command not expand tilde with quotes",
+        |dirs, _| {
+            let actual = nu!(cwd: dirs.test(), pipeline(r#"nu --testbin nonu `~`"#));
+            assert!(!actual.out.contains("~"));
+        },
+    )
+}
+
+#[test]
 fn external_command_receives_raw_binary_data() {
     Playground::setup("external command receives raw binary data", |dirs, _| {
         let actual =


### PR DESCRIPTION
# Description

Fixes: #8542

# User-Facing Changes

## Previous
```
❯ cat `~/TE ST/bug`
cat: ~/TE ST/bug: No such file or directory
```

## After
```
❯ cat `~/TE ST/bug`
a
```

This should be ok because We treat back-quoted strings as bare words

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
