### PR TITLE
better error message if plugin name doesn't starts with `nu_plugin_`

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3765,7 +3765,7 @@ pub fn parse_register(
             } else {
                 Err(ParseError::LabeledError(
                     "Register plugin failed".into(),
-                    "plugin name must starts with nu_plugin_".into(),
+                    "plugin name must start with nu_plugin_".into(),
                     path_span,
                 ))
             }
@@ -3800,7 +3800,7 @@ pub fn parse_register(
             } else {
                 Err(ParseError::LabeledError(
                     "Register plugin failed".into(),
-                    "plugin name must starts with nu_plugin_".into(),
+                    "plugin name must start with nu_plugin_".into(),
                     path_span,
                 ))
             }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3680,7 +3680,7 @@ pub fn parse_register(
                 };
 
                 if path.exists() & path.is_file() {
-                    Ok(path)
+                    Ok((path, expr.span))
                 } else {
                     Err(ParseError::RegisteredFileNotFound(
                         format!("{path:?}"),
@@ -3750,29 +3750,33 @@ pub fn parse_register(
     let current_envs =
         nu_engine::env::env_to_strings(working_set.permanent_state, &stack).unwrap_or_default();
     let error = match signature {
-        Some(signature) => arguments.and_then(|path| {
+        Some(signature) => arguments.and_then(|(path, path_span)| {
             // restrict plugin file name starts with `nu_plugin_`
-            let f_name = path
+            let valid_plugin_name = path
                 .file_name()
                 .map(|s| s.to_string_lossy().starts_with("nu_plugin_"));
 
-            if let Some(true) = f_name {
+            if let Some(true) = valid_plugin_name {
                 signature.map(|signature| {
                     let plugin_decl = PluginDeclaration::new(path, signature, shell);
                     working_set.add_decl(Box::new(plugin_decl));
                     working_set.mark_plugins_file_dirty();
                 })
             } else {
-                Ok(())
+                Err(ParseError::LabeledError(
+                    "Register plugin failed".into(),
+                    "plugin name must starts with nu_plugin_".into(),
+                    path_span,
+                ))
             }
         }),
-        None => arguments.and_then(|path| {
+        None => arguments.and_then(|(path, path_span)| {
             // restrict plugin file name starts with `nu_plugin_`
-            let f_name = path
+            let valid_plugin_name = path
                 .file_name()
                 .map(|s| s.to_string_lossy().starts_with("nu_plugin_"));
 
-            if let Some(true) = f_name {
+            if let Some(true) = valid_plugin_name {
                 get_signature(path.as_path(), &shell, &current_envs)
                     .map_err(|err| {
                         ParseError::LabeledError(
@@ -3794,7 +3798,11 @@ pub fn parse_register(
                         working_set.mark_plugins_file_dirty();
                     })
             } else {
-                Ok(())
+                Err(ParseError::LabeledError(
+                    "Register plugin failed".into(),
+                    "plugin name must starts with nu_plugin_".into(),
+                    path_span,
+                ))
             }
         }),
     }


### PR DESCRIPTION
# Description

Fixes: #8548 

# User-Facing Changes
```
❯ register target/debug/formats
Error:
  × Register plugin failed
   ╭─[entry #1:1:1]
 1 │ register target/debug/formats
   ·          ──────────┬─────────
   ·                    ╰── plugin name must starts with nu_plugin_
   ╰────

```
# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
