### PR TITLE
Remove once_cell dependency from nu-test-support create.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,6 @@ dependencies = [
  "nu-path",
  "nu-utils",
  "num-format",
- "once_cell",
  "tempfile",
  "which",
 ]

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -15,7 +15,6 @@ bench = false
 nu-path = { path="../nu-path", version = "0.77.2"  }
 nu-glob = { path = "../nu-glob", version = "0.77.2" }
 nu-utils = { path="../nu-utils", version = "0.77.2"  }
-once_cell = "1.16.0"
 num-format = "0.4.3"
 which = "4.3.0"
 

--- a/crates/nu-test-support/src/locale_override.rs
+++ b/crates/nu-test-support/src/locale_override.rs
@@ -1,11 +1,10 @@
 #![cfg(debug_assertions)]
 
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use nu_utils::locale::LOCALE_OVERRIDE_ENV_VAR;
-use once_cell::sync::Lazy;
 
-static LOCALE_OVERRIDE_MUTEX: Lazy<Arc<Mutex<()>>> = Lazy::new(Default::default);
+static LOCALE_OVERRIDE_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Run a closure in a fake locale environment.
 ///


### PR DESCRIPTION
# Description

I was looking where we could remove the usage of once-cell dependency. As for now, I only found one place. Not a terrible improvement, but at least, it removes a dependency nu-test-support crate.

# User-Facing Changes

None.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
