### PR TITLE
FIX: do not allow *start > end* in `error make` spans

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -138,7 +138,7 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                         if start > end {
                             Some(ShellError::GenericError(
                                 "invalid error format.".into(),
-                                "`$.label.start` is strictly bigger than `$.label.end`".into(),
+                                "`$.label.start` should be smaller than `$.label.end`".into(),
                                 label_span,
                                 Some(format!("{} > {}", start, end)),
                                 Vec::new(),

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -134,13 +134,25 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                         Some(Value::String {
                             val: label_text, ..
                         }),
-                    ) => Some(ShellError::GenericError(
-                        message,
-                        label_text,
-                        Some(Span::new(start as usize, end as usize)),
-                        None,
-                        Vec::new(),
-                    )),
+                    ) => {
+                        if start > end {
+                            Some(ShellError::GenericError(
+                                "invalid error format.".into(),
+                                "`$.label.start` is stricly bigger than `$.label.end`".into(),
+                                label_span,
+                                Some(format!("{} > {}", start, end)),
+                                Vec::new(),
+                            ))
+                        } else {
+                            Some(ShellError::GenericError(
+                                message,
+                                label_text,
+                                Some(Span::new(start as usize, end as usize)),
+                                None,
+                                Vec::new(),
+                            ))
+                        }
+                    }
                     (
                         None,
                         None,

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -138,7 +138,7 @@ fn make_error(value: &Value, throw_span: Option<Span>) -> Option<ShellError> {
                         if start > end {
                             Some(ShellError::GenericError(
                                 "invalid error format.".into(),
-                                "`$.label.start` is stricly bigger than `$.label.end`".into(),
+                                "`$.label.start` is strictly bigger than `$.label.end`".into(),
                                 label_span,
                                 Some(format!("{} > {}", start, end)),
                                 Vec::new(),

--- a/crates/nu-command/tests/commands/error_make.rs
+++ b/crates/nu-command/tests/commands/error_make.rs
@@ -37,5 +37,5 @@ fn error_start_bigger_than_end_should_fail() {
     assert!(!actual.err.contains("invalid error format"));
     assert!(!actual
         .err
-        .contains("`$.label.start` is stricly bigger than `$.label.end`"));
+        .contains("`$.label.start` should be smaller than `$.label.end`"));
 }

--- a/crates/nu-command/tests/commands/error_make.rs
+++ b/crates/nu-command/tests/commands/error_make.rs
@@ -24,3 +24,16 @@ fn no_span_if_unspanned() {
 
     assert!(!actual.err.contains("unseen"));
 }
+
+#[test]
+fn error_start_bigger_than_end_should_fail() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        error make {msg: foo label: {text: bar start 456 end 123}}
+        "#
+    ));
+
+    assert!(!actual.err.contains("invalid error format"));
+    assert!(!actual.err.contains("`$.label.start` is stricly bigger than `$.label.end`"));
+}

--- a/crates/nu-command/tests/commands/error_make.rs
+++ b/crates/nu-command/tests/commands/error_make.rs
@@ -35,5 +35,7 @@ fn error_start_bigger_than_end_should_fail() {
     ));
 
     assert!(!actual.err.contains("invalid error format"));
-    assert!(!actual.err.contains("`$.label.start` is stricly bigger than `$.label.end`"));
+    assert!(!actual
+        .err
+        .contains("`$.label.start` is stricly bigger than `$.label.end`"));
 }


### PR DESCRIPTION
This should close #8567.

# Description
this PR throws an error when `start > end` in the most complete branch of `ErrorMake::run`, i.e. when `$.msg`, `$.label.text`, `$.label.start` and `$.label.end` are defined.

i've also added a `error_start_bigger_than_end_should_fail` test to check that it does indeed return the right error.

# User-Facing Changes
no more crash when manipulating span bounds and a clear error, e.g.
```bash
>_ error make {msg: "msg" label: {text: "text" start: 1010 end: 1000}}
Error:
  × invalid error format.
   ╭─[entry #3:1:1]
 1 │ error make {msg: "msg" label: {text: "text" start: 1010 end: 1000}}
   ·                               ──────────────────┬─────────────────
   ·                                                 ╰── `$.label.start` is stricly bigger than `$.label.end`
   ╰────
  help: 1010 > 1000
```
or
```bash
>_ error make {
:::     msg: "msg"
:::     label: {
:::         text: "text"
:::         start: ($nu.scope.engine_state.source_bytes - 90)
:::         end: ($nu.scope.engine_state.source_bytes - 100)
:::     }
::: }
Error:
  × invalid error format.
   ╭─[entry #4:2:1]
 2 │         msg: "msg"
 3 │ ╭─▶     label: {
 4 │ │           text: "text"
 5 │ │           start: ($nu.scope.engine_state.source_bytes - 90)
 6 │ │           end: ($nu.scope.engine_state.source_bytes - 100)
 7 │ ├─▶     }
   · ╰──── `$.label.start` is stricly bigger than `$.label.end`
 8 │     }
   ╰────
  help: 204525 > 204515
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :red_circle: `toolkit test`

# After Submitting
```
$nothing
```