### PR TITLE
[experiment] Disable all property-based tests

### DIFF
--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -1,5 +1,5 @@
 use nu_test_support::{nu, pipeline};
-use proptest::prelude::*;
+// use proptest::prelude::*;
 
 #[test]
 fn to_nuon_correct_compaction() {
@@ -504,38 +504,38 @@ fn read_code_should_fail_rather_than_panic() {
     assert!(actual.err.contains("error when parsing"))
 }
 
-proptest! {
-    #[test]
-    fn to_nuon_from_nuon(c: char) {
-        if c != '\0' && c!='\r' {
-        let actual = nu!(
-            cwd: "tests/fixtures/formats", pipeline(
-                format!(r#"
-             {{"prop{c}test": "sam"}} | to nuon | from nuon;
-             [ [ "prop{c}test" ]; [ 'test' ] ] | to nuon | from nuon;
-             [ [ "{c}" ]; [ 'test' ] ] | to nuon | from nuon;
-             {{"{c}": "sam"}} | to nuon | from nuon;
-        "#).as_ref()
-        ));
-        assert!(actual.err.is_empty() || actual.err.contains("Unexpected end of code") || actual.err.contains("only strings can be keys") || actual.err.contains("unbalanced { and }"));
-        // The second is for weird escapes due to backslashes
-        // The third is for chars like '0'
-        }
-    }
-    #[test]
-    fn to_nuon_from_nuon_string(s: String) {
-        if s != "\\0" && !s.is_empty() && !s.contains('\\') && !s.contains('"'){
-        let actual = nu!(
-            cwd: "tests/fixtures/formats", pipeline(
-                format!(r#"
-             {{"prop{s}test": "sam"}} | to nuon | from nuon;
-             [ [ "prop{s}test" ]; [ 'test' ] ] | to nuon | from nuon;
-             [ [ "{s}" ]; [ 'test' ] ] | to nuon | from nuon;
-             {{"{s}": "sam"}} | to nuon | from nuon;
-        "#).as_ref()
-        ));
-        assert!(actual.err.is_empty() || actual.err.contains("only strings can be keys") || actual.err.contains("unknown command"));
-        // TODO: fix parser error for "unknown command" when '=$' is the name
-    }
-    }
-}
+// proptest! {
+//     #[test]
+//     fn to_nuon_from_nuon(c: char) {
+//         if c != '\0' && c!='\r' {
+//         let actual = nu!(
+//             cwd: "tests/fixtures/formats", pipeline(
+//                 format!(r#"
+//              {{"prop{c}test": "sam"}} | to nuon | from nuon;
+//              [ [ "prop{c}test" ]; [ 'test' ] ] | to nuon | from nuon;
+//              [ [ "{c}" ]; [ 'test' ] ] | to nuon | from nuon;
+//              {{"{c}": "sam"}} | to nuon | from nuon;
+//         "#).as_ref()
+//         ));
+//         assert!(actual.err.is_empty() || actual.err.contains("Unexpected end of code") || actual.err.contains("only strings can be keys") || actual.err.contains("unbalanced { and }"));
+//         // The second is for weird escapes due to backslashes
+//         // The third is for chars like '0'
+//         }
+//     }
+//     #[test]
+//     fn to_nuon_from_nuon_string(s: String) {
+//         if s != "\\0" && !s.is_empty() && !s.contains('\\') && !s.contains('"'){
+//         let actual = nu!(
+//             cwd: "tests/fixtures/formats", pipeline(
+//                 format!(r#"
+//              {{"prop{s}test": "sam"}} | to nuon | from nuon;
+//              [ [ "prop{s}test" ]; [ 'test' ] ] | to nuon | from nuon;
+//              [ [ "{s}" ]; [ 'test' ] ] | to nuon | from nuon;
+//              {{"{s}": "sam"}} | to nuon | from nuon;
+//         "#).as_ref()
+//         ));
+//         assert!(actual.err.is_empty() || actual.err.contains("only strings can be keys") || actual.err.contains("unknown command"));
+//         // TODO: fix parser error for "unknown command" when '=$' is the name
+//     }
+//     }
+// }

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -1,27 +1,27 @@
 use nu_command::create_default_context;
 use nu_protocol::{engine::StateWorkingSet, Category};
-use quickcheck_macros::quickcheck;
+// use quickcheck_macros::quickcheck;
 
 mod commands;
 mod format_conversions;
 
 // use nu_engine::EvaluationContext;
 
-#[quickcheck]
-fn quickcheck_parse(data: String) -> bool {
-    let (tokens, err) = nu_parser::lex(data.as_bytes(), 0, b"", b"", true);
-
-    if err.is_none() {
-        let context = create_default_context();
-        {
-            let mut working_set = StateWorkingSet::new(&context);
-            working_set.add_file("quickcheck".into(), data.as_bytes());
-
-            let _ = nu_parser::parse_block(&mut working_set, &tokens, false, &[], false);
-        }
-    }
-    true
-}
+// #[quickcheck]
+// fn quickcheck_parse(data: String) -> bool {
+//     let (tokens, err) = nu_parser::lex(data.as_bytes(), 0, b"", b"", true);
+//
+//     if err.is_none() {
+//         let context = create_default_context();
+//         {
+//             let mut working_set = StateWorkingSet::new(&context);
+//             working_set.add_file("quickcheck".into(), data.as_bytes());
+//
+//             let _ = nu_parser::parse_block(&mut working_set, &tokens, false, &[], false);
+//         }
+//     }
+//     true
+// }
 
 #[test]
 fn signature_name_matches_command_name() {

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -1,5 +1,5 @@
 use nu_command::create_default_context;
-use nu_protocol::{engine::StateWorkingSet, Category};
+use nu_protocol::Category;
 // use quickcheck_macros::quickcheck;
 
 mod commands;

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -1,27 +1,27 @@
 use nu_command::create_default_context;
-use nu_protocol::Category;
-// use quickcheck_macros::quickcheck;
+use nu_protocol::{engine::StateWorkingSet, Category};
+use quickcheck_macros::quickcheck;
 
 mod commands;
 mod format_conversions;
 
 // use nu_engine::EvaluationContext;
 
-// #[quickcheck]
-// fn quickcheck_parse(data: String) -> bool {
-//     let (tokens, err) = nu_parser::lex(data.as_bytes(), 0, b"", b"", true);
-//
-//     if err.is_none() {
-//         let context = create_default_context();
-//         {
-//             let mut working_set = StateWorkingSet::new(&context);
-//             working_set.add_file("quickcheck".into(), data.as_bytes());
-//
-//             let _ = nu_parser::parse_block(&mut working_set, &tokens, false, &[], false);
-//         }
-//     }
-//     true
-// }
+#[quickcheck]
+fn quickcheck_parse(data: String) -> bool {
+    let (tokens, err) = nu_parser::lex(data.as_bytes(), 0, b"", b"", true);
+
+    if err.is_none() {
+        let context = create_default_context();
+        {
+            let mut working_set = StateWorkingSet::new(&context);
+            working_set.add_file("quickcheck".into(), data.as_bytes());
+
+            let _ = nu_parser::parse_block(&mut working_set, &tokens, false, &[], false);
+        }
+    }
+    true
+}
 
 #[test]
 fn signature_name_matches_command_name() {


### PR DESCRIPTION
# Description

Primarily to study the impact on the coverage I disabled the
property-based tests.
Touches `quickcheck` and `proptest` tests (do the same thing slightly
differently under the hood.)
For now just commented out. If we can stop the flukes and keep the
general coverage we would want to move the proptests into a separate
scheduled fuzz run.


# User-Facing Changes

None

# Tests + Formatting

Yeet the proptests from the earth (or the regularly run CI/coverage tests)
