### PR TITLE
make std.nu tests work on mac

### DIFF
--- a/crates/nu-utils/standard_library/test_dirs.nu
+++ b/crates/nu-utils/standard_library/test_dirs.nu
@@ -9,13 +9,18 @@ def clean [path: path] {
 
 export def test_dirs_command [] {
     # need some directories to play with
-    let base_path = (($nu.temp-path) | path join $"test_dirs_(random uuid)" | path expand )
-    let path_a = ($base_path | path expand | path join "a")
-    let path_b = ($base_path | path expand | path join "b")
+    let base_path = ($nu.temp-path | path join $"test_dirs_(random uuid)")
+    let path_a = ($base_path | path join "a")
+    let path_b = ($base_path | path join "b")
 
     try {
-        mkdir ($base_path | path expand) $path_a $path_b
-        cd ($base_path | path expand)
+        mkdir $base_path $path_a $path_b
+        # Now that we've created the directories, we need to expand them to include symlinks
+        let base_path = ($base_path | path expand)
+        let path_a = ($path_a | path expand)
+        let path_b = ($path_b | path expand)
+
+        cd $base_path
         use std.nu "dirs next"
         use std.nu "dirs prev"
         use std.nu "dirs add"
@@ -23,13 +28,13 @@ export def test_dirs_command [] {
         use std.nu "dirs show"
 
         assert length $env.DIRS_LIST 1 "list is just pwd after initialization"
-        assert equal ($base_path | path expand) $env.DIRS_LIST.0 "list is just pwd after initialization"
+        assert equal $base_path $env.DIRS_LIST.0 "list is just pwd after initialization"
 
         dirs next
-        assert equal ($base_path | path expand) $env.DIRS_LIST.0 "next wraps at end of list"
+        assert equal $base_path $env.DIRS_LIST.0 "next wraps at end of list"
 
         dirs prev
-        assert equal ($base_path | path expand) $env.DIRS_LIST.0 "prev wraps at top of list"
+        assert equal $base_path $env.DIRS_LIST.0 "prev wraps at top of list"
 
         dirs add $path_b $path_a
         assert equal $path_b $env.PWD "add changes PWD to first added dir"
@@ -37,7 +42,7 @@ export def test_dirs_command [] {
         assert equal $path_a $env.DIRS_LIST.2 "add in fact adds to list"
 
         dirs next 2
-        assert equal ($base_path | path expand) $env.PWD "next wraps at end of list"
+        assert equal $base_path $env.PWD "next wraps at end of list"
 
         dirs prev 1
         assert equal $path_a $env.PWD "prev wraps at start of list"
@@ -46,9 +51,9 @@ export def test_dirs_command [] {
         assert length $env.DIRS_LIST 2 "drop removes from list"
         assert equal ($base_path | path expand) $env.PWD "drop changes PWD to next in list (after dropped element)"
 
-        assert equal (dirs show) [[active path]; [true ($base_path | path expand)] [false $path_b]] "show table contains expected information"
+        assert equal (dirs show) [[active path]; [true $base_path] [false $path_b]] "show table contains expected information"
     } catch { |error|
-        clean ($base_path | path expand)
+        clean $base_path
 
         let error = (
             $error
@@ -69,5 +74,5 @@ export def test_dirs_command [] {
         }
     }
 
-    try { clean ($base_path | path expand) }
+    try { clean $base_path }
 }


### PR DESCRIPTION
# Description

This PR is to make test_dirs.nu work better on macos.

closes #8528

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
