### PR TITLE
fixes the ability to have multiple modifiers on keybindings

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -626,9 +626,12 @@ fn add_parsed_keybinding(
         "shift" => KeyModifiers::SHIFT,
         "alt" => KeyModifiers::ALT,
         "none" => KeyModifiers::NONE,
-        "control | shift" => KeyModifiers::CONTROL | KeyModifiers::SHIFT,
-        "control | alt" => KeyModifiers::CONTROL | KeyModifiers::ALT,
-        "control | alt | shift" => KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT,
+        "shift_alt" | "alt_shift" => KeyModifiers::SHIFT | KeyModifiers::ALT,
+        "control_shift" | "shift_control" => KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        "control_alt" | "alt_control" => KeyModifiers::CONTROL | KeyModifiers::ALT,
+        "control_alt_shift" | "control_shift_alt" => {
+            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
+        }
         _ => {
             return Err(ShellError::UnsupportedConfigValue(
                 "CONTROL, SHIFT, ALT or NONE".to_string(),


### PR DESCRIPTION
# Description

This PR fixes a bug that prevented you from having multiple modifiers on your keybindings. 

TODO:
- The docs need to be fixed too https://www.nushell.sh/book/line_editor.html#keybindings. (https://github.com/nushell/nushell.github.io/pull/840)
- I think reedline needs to be changed to show this too since it provides the list of available modifiers. (https://github.com/nushell/reedline/pull/559)

Now you can do something like this where `shift` and `alt` are combined with an underscore.
```
  {
    name: fuzzy_history_fzf
    modifier: shift_alt
    keycode: char_r
    mode: [emacs , vi_normal, vi_insert]
    event: {
blah
}
```
Here's the list of available combinations
```rust
        "control" => KeyModifiers::CONTROL,
        "shift" => KeyModifiers::SHIFT,
        "alt" => KeyModifiers::ALT,
        "none" => KeyModifiers::NONE,
        "shift_alt" | "alt_shift" => KeyModifiers::SHIFT | KeyModifiers::ALT,
        "control_shift" | "shift_control" => KeyModifiers::CONTROL | KeyModifiers::SHIFT,
        "control_alt" | "alt_control" => KeyModifiers::CONTROL | KeyModifiers::ALT,
        "control_alt_shift" | "control_shift_alt" => {
            KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT
        }
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
