### PR TITLE
Better error message for `mv` when file not found

### DIFF
--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -87,8 +87,8 @@ impl Command for Mv {
 
         if sources.is_empty() {
             return Err(ShellError::GenericError(
-                "Invalid file or pattern".into(),
-                "invalid file or pattern".into(),
+                "File(s) not found".into(),
+                "could not find any files matching this glob pattern".into(),
                 Some(spanned_source.span),
                 None,
                 Vec::new(),

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -203,7 +203,7 @@ fn errors_if_source_doesnt_exist() {
             cwd: dirs.test(),
             "mv non-existing-file test_folder/"
         );
-        assert!(actual.err.contains("invalid file or pattern"));
+        assert!(actual.err.contains("File(s) not found"));
     })
 }
 


### PR DESCRIPTION
Closes #8546.

### Before:
```
> mv foo.txt bar.txt
Error:
  × Invalid file or pattern
   ╭─[entry #2:1:1]
 1 │ mv foo.txt bar.txt
   ·    ───┬───
   ·       ╰── invalid file or pattern
   ╰────
```

### After:
```
> mv foo.txt bar.txt
Error:
  × File(s) not found
   ╭─[entry #2:1:1]
 1 │ mv foo.txt bar.txt
   ·    ───┬───
   ·       ╰── could not find any files matching this glob pattern
   ╰────
```