### PR TITLE
tweak logging format

### DIFF
--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -391,33 +391,37 @@ def current-log-level [] {
     }
 }
 
+def now [] {
+    date now | date format "%Y-%m-%dT%H:%M:%S%.3f"
+}
+
 # Log critical message
 export def "log critical" [message: string] {
     if (current-log-level) > (CRITICAL_LEVEL) { return }
 
-    print --stderr $"(ansi red_bold)CRIT  ($message)(ansi reset)"
+    print --stderr $"(ansi red_bold)CRT|(now)|($message)(ansi reset)"
 }
 # Log error message
 export def "log error" [message: string] {
     if (current-log-level) > (ERROR_LEVEL) { return }
 
-    print --stderr $"(ansi red)ERROR ($message)(ansi reset)"
+    print --stderr $"(ansi red)ERR|(now)|($message)(ansi reset)"
 }
 # Log warning message
 export def "log warning" [message: string] {
     if (current-log-level) > (WARNING_LEVEL) { return }
 
-    print --stderr $"(ansi yellow)WARN  ($message)(ansi reset)"
+    print --stderr $"(ansi yellow)WRN|(now)|($message)(ansi reset)"
 }
 # Log info message
 export def "log info" [message: string] {
     if (current-log-level) > (INFO_LEVEL) { return }
 
-    print --stderr $"(ansi white)INFO  ($message)(ansi reset)"
+    print --stderr $"(ansi white)INF|(now)|($message)(ansi reset)"
 }
 # Log debug message
 export def "log debug" [message: string] {
     if (current-log-level) > (DEBUG_LEVEL) { return }
 
-    print --stderr $"(ansi default_dimmed)DEBUG ($message)(ansi reset)"
+    print --stderr $"(ansi default_dimmed)DBG|(now)|($message)(ansi reset)"
 }

--- a/crates/nu-utils/standard_library/test_logger.nu
+++ b/crates/nu-utils/standard_library/test_logger.nu
@@ -19,21 +19,21 @@ def "assert message" [system_level, message_level, message_level_str] {
 
 export def test_critical [] {
     assert no message 99 critical
-    assert message CRITICAL critical CRIT
+    assert message CRITICAL critical CRT
 }
 export def test_error [] {
     assert no message CRITICAL error 
-    assert message ERROR error ERROR
+    assert message ERROR error ERR
 }
 export def test_warning [] {
     assert no message ERROR warning 
-    assert message  WARNING warning WARN
+    assert message WARNING warning WRN
 }
 export def test_info [] {
     assert no message WARNING info 
-    assert message  INFO info INFO
+    assert message INFO info "INF" #INF has to be quoted, otherwise it is the `inf` float
 }
 export def test_debug [] {
     assert no message INFO debug 
-    assert message  DEBUG debug DEBUG
+    assert message DEBUG debug DBG
 }


### PR DESCRIPTION
# Description

This PR just tweaks the std.nu logging a bit. It looks like this after this PR. I like the ability to have a parse-able file, which is why there are pipes, and I like to have a pretty granular time date stamp in order to get rough performance metrics.
```
nu crates\nu-utils\standard_library\tests.nu
INF|2023-03-23T15:02:00.284|Run test test_asserts test_assert
INF|2023-03-23T15:02:00.372|Run test test_asserts test_assert_equal
INF|2023-03-23T15:02:00.461|Run test test_asserts test_assert_error
INF|2023-03-23T15:02:00.585|Run test test_asserts test_assert_greater
INF|2023-03-23T15:02:00.674|Run test test_asserts test_assert_greater_or_equal
INF|2023-03-23T15:02:00.762|Run test test_asserts test_assert_length
INF|2023-03-23T15:02:00.847|Run test test_asserts test_assert_less
INF|2023-03-23T15:02:00.933|Run test test_asserts test_assert_less_or_equal
INF|2023-03-23T15:02:01.021|Run test test_asserts test_assert_not_equal
INF|2023-03-23T15:02:01.110|Run test test_dirs test_dirs_command
INF|2023-03-23T15:02:01.300|Run test test_logger test_critical
INF|2023-03-23T15:02:01.558|Run test test_logger test_debug
INF|2023-03-23T15:02:01.818|Run test test_logger test_error
INF|2023-03-23T15:02:02.074|Run test test_logger test_info
INF|2023-03-23T15:02:02.331|Run test test_logger test_warning
INF|2023-03-23T15:02:02.573|Run test test_std test_match
INF|2023-03-23T15:02:02.678|Run test test_std test_path_add
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
