### PR TITLE
Make HTTP requests cancellable when trying to connect

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -255,11 +255,11 @@ fn send_cancellable_request(
             ));
         }
 
-        if let Ok(result) = rx.try_recv() {
+        // 100ms wait time chosen arbitrarily
+        if let Ok(result) = rx.recv_timeout(Duration::from_millis(100)) {
             return result
                 .map_err(|e| ShellErrorOrRequestError::RequestError(request_url.to_string(), e));
         }
-        std::thread::sleep(Duration::from_millis(100)); // arbitrarily chosen interval
     }
 }
 

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -184,6 +184,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span()?;
+    let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
     let client = http_client(args.insecure);
@@ -193,7 +194,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, args.data, args.content_type);
+    let response = send_request(request, args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -163,6 +163,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span()?;
+    let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
     let client = http_client(args.insecure);
@@ -172,7 +173,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, None, None);
+    let response = send_request(request, None, None, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -126,13 +129,18 @@ fn run_head(
         password: call.get_flag(engine_state, stack, "password")?,
         timeout: call.get_flag(engine_state, stack, "max-time")?,
     };
+    let ctrl_c = engine_state.ctrlc.clone();
 
-    helper(call, args)
+    helper(call, args, ctrl_c)
 }
 
 // Helper function that actually goes to retrieve the resource from the url given
 // The Option<String> return a possible file extension which can be used in AutoConvert commands
-fn helper(call: &Call, args: Arguments) -> Result<PipelineData, ShellError> {
+fn helper(
+    call: &Call,
+    args: Arguments,
+    ctrlc: Option<Arc<AtomicBool>>,
+) -> Result<PipelineData, ShellError> {
     let span = args.url.span()?;
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
@@ -143,7 +151,7 @@ fn helper(call: &Call, args: Arguments) -> Result<PipelineData, ShellError> {
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, None, None);
+    let response = send_request(request, None, None, ctrlc);
     request_handle_response_headers(span, response)
 }
 

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -174,6 +174,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span()?;
+    let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
     let client = http_client(args.insecure);
@@ -183,7 +184,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, Some(args.data), args.content_type);
+    let response = send_request(request, Some(args.data), args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -174,6 +174,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span()?;
+    let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
     let client = http_client(args.insecure);
@@ -183,7 +184,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, Some(args.data), args.content_type);
+    let response = send_request(request, Some(args.data), args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -174,6 +174,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span()?;
+    let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
     let client = http_client(args.insecure);
@@ -183,7 +184,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, Some(args.data), args.content_type);
+    let response = send_request(request, Some(args.data), args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1056,6 +1056,13 @@ pub enum ShellError {
         #[label("Could not access '{column_name}' on this record")]
         span: Span,
     },
+
+    /// Operation interrupted by user
+    #[error("Operation interrupted by user")]
+    InterruptedByUser {
+        #[label("This operation was interrupted")]
+        span: Option<Span>,
+    },
 }
 
 impl From<std::io::Error> for ShellError {


### PR DESCRIPTION
Closes #8585.

Prior to this change, the `http` commands could get stuck for 30s while attempting to make a connection to a remote server. After this change, `ctrl+c` works as expected:

![image](https://user-images.githubusercontent.com/26268125/227395505-c2d5b19d-6228-4eac-836f-c0c3426b0c19.png)

To make this work, we perform blocking `ureq` calls in a background thread and poll the channel while checking `ctrl+c`.