### PR TITLE
Move timeit to use blocks. Make match vars immutable

### DIFF
--- a/crates/nu-parser/src/parse_patterns.rs
+++ b/crates/nu-parser/src/parse_patterns.rs
@@ -88,7 +88,7 @@ pub fn parse_variable_pattern(
                 None,
             )
         } else {
-            let var_id = working_set.add_variable(bytes.to_vec(), span, Type::Any, true);
+            let var_id = working_set.add_variable(bytes.to_vec(), span, Type::Any, false);
 
             (
                 MatchPattern {


### PR DESCRIPTION
# Description

This does a couple random changes/fixes:

* Moves `timeit` to use a block instead of a closure. This makes it a bit more flexible.
* Moves var bindings in patterns to be immutable

# User-Facing Changes

`timeit` now takes a block and no arguments.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
