### PR TITLE
allow startup-time to be captured when starting nushell with `nu -c`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,7 @@ fn main() -> Result<()> {
             use_color,
             &commands,
             input,
+            entire_start_time,
         )
     } else if !script_name.is_empty() {
         run_file(

--- a/src/run.rs
+++ b/src/run.rs
@@ -16,6 +16,7 @@ pub(crate) fn run_commands(
     use_color: bool,
     commands: &nu_protocol::Spanned<String>,
     input: PipelineData,
+    entire_start_time: std::time::Instant,
 ) -> Result<(), miette::ErrReport> {
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
@@ -69,6 +70,8 @@ pub(crate) fn run_commands(
         use_color,
     );
 
+    // Before running commands, set up the startup time
+    engine_state.set_startup_time(entire_start_time.elapsed().as_nanos() as i64);
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_commands(
         commands,


### PR DESCRIPTION
# Description

This PR fixes a small bug where `$nu.startup-time` wasn't being stored when nushell was launched with `nu -c`.

# User-Facing Changes



# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
