### PR TITLE
type-check default values of list annotations

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3996,15 +3996,14 @@ pub fn parse_signature_helper(
                                                 );
                                             }
                                             Type::List(param_ty) => {
-                                                if var_type.is_list() && expression.ty.is_list() {
-                                                    if let Type::List(expr_ty) = &expression.ty {
-                                                        if param_ty == expr_ty {
-                                                            working_set.set_variable_type(
-                                                                var_id,
-                                                                expression.ty.clone(),
-                                                            );
-                                                        } else {
-                                                            error = error.or_else(|| {
+                                                if let Type::List(expr_ty) = &expression.ty {
+                                                    if param_ty == expr_ty {
+                                                        working_set.set_variable_type(
+                                                            var_id,
+                                                            expression.ty.clone(),
+                                                        );
+                                                    } else {
+                                                        error = error.or_else(|| {
                                                                 Some(
                                                                     ParseError::AssignmentMismatch(
                                                                         "Default value wrong type"
@@ -4016,7 +4015,6 @@ pub fn parse_signature_helper(
                                                                     ),
                                                                 )
                                                             })
-                                                        }
                                                     }
                                                 } else {
                                                     error = error.or_else(|| {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4010,8 +4010,7 @@ pub fn parse_signature_helper(
                                                                         "Default value wrong type"
                                                                             .into(),
                                                                         format!(
-                                                                            "expected default value to be `{}` but found `{}`",
-                                                                            var_type, expression.ty,
+                                                                            "expected default value to be `{var_type}`",
                                                                         ),
                                                                         expression.span,
                                                                     ),
@@ -4024,8 +4023,7 @@ pub fn parse_signature_helper(
                                                         Some(ParseError::AssignmentMismatch(
                                                             "Default value wrong type".into(),
                                                             format!(
-                                                                "expected default value to be `{}` but found `{}`",
-                                                                var_type, expression.ty,
+                                                                "expected default value to be `{var_type}`",
                                                             ),
                                                             expression.span,
                                                         ))
@@ -4037,7 +4035,7 @@ pub fn parse_signature_helper(
                                                     error = error.or_else(|| {
                                                         Some(ParseError::AssignmentMismatch(
                                                             "Default value wrong type".into(),
-                                                            format!("expected default value to be `{t}` but found `{}`", expression.ty),
+                                                            format!("expected default value to be `{t}`"),
                                                             expression.span,
                                                         ))
                                                     })

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3995,19 +3995,37 @@ pub fn parse_signature_helper(
                                                     expression.ty.clone(),
                                                 );
                                             }
-                                            Type::List(_) => {
+                                            Type::List(param_ty) => {
                                                 if var_type.is_list() && expression.ty.is_list() {
-                                                    working_set.set_variable_type(
-                                                        var_id,
-                                                        expression.ty.clone(),
-                                                    );
+                                                    if let Type::List(expr_ty) = &expression.ty {
+                                                        if param_ty == expr_ty {
+                                                            working_set.set_variable_type(
+                                                                var_id,
+                                                                expression.ty.clone(),
+                                                            );
+                                                        } else {
+                                                            error = error.or_else(|| {
+                                                                Some(
+                                                                    ParseError::AssignmentMismatch(
+                                                                        "Default value wrong type"
+                                                                            .into(),
+                                                                        format!(
+                                                                            "expected default value to be `{}` but found `{}`",
+                                                                            var_type, expression.ty,
+                                                                        ),
+                                                                        expression.span,
+                                                                    ),
+                                                                )
+                                                            })
+                                                        }
+                                                    }
                                                 } else {
                                                     error = error.or_else(|| {
                                                         Some(ParseError::AssignmentMismatch(
                                                             "Default value wrong type".into(),
                                                             format!(
-                                                                "default value not {0}",
-                                                                expression.ty
+                                                                "expected default value to be `{}` but found `{}`",
+                                                                var_type, expression.ty,
                                                             ),
                                                             expression.span,
                                                         ))
@@ -4019,7 +4037,7 @@ pub fn parse_signature_helper(
                                                     error = error.or_else(|| {
                                                         Some(ParseError::AssignmentMismatch(
                                                             "Default value wrong type".into(),
-                                                            format!("default value not {t}"),
+                                                            format!("expected default value to be `{t}` but found `{}`", expression.ty),
                                                             expression.span,
                                                         ))
                                                     })

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3997,7 +3997,9 @@ pub fn parse_signature_helper(
                                             }
                                             Type::List(param_ty) => {
                                                 if let Type::List(expr_ty) = &expression.ty {
-                                                    if param_ty == expr_ty {
+                                                    if param_ty == expr_ty
+                                                        || **param_ty == Type::Any
+                                                    {
                                                         working_set.set_variable_type(
                                                             var_id,
                                                             expression.ty.clone(),

--- a/src/tests/test_signatures.rs
+++ b/src/tests/test_signatures.rs
@@ -111,3 +111,17 @@ fn list_annotations_unknown_separators() -> TestResult {
     let expected = "unknown type";
     fail_test(input, expected)
 }
+
+#[test]
+fn list_annotations_with_default_val_1() -> TestResult {
+    let input = "def run [list: list<int> = [2 5 4]] {$list | length}; run";
+    let expected = "3";
+    run_test(input, expected)
+}
+
+#[test]
+fn list_annotations_with_default_val_2() -> TestResult {
+    let input = "def run [list: list<string> = [2 5 4]] {$list | length}; run";
+    let expected = "Default value wrong type";
+    fail_test(input, expected)
+}


### PR DESCRIPTION
# Description

@fdncred noticed an [issue](https://github.com/nushell/nushell/pull/8529#issuecomment-1482770636) with list annotations that while i was trying to find a fix found another issue.

innitially, this was accepted by the parser
```nu
def err [list: list<int> = ['a' 'b' 'c']] {}
```

but now an error is raised
```nu
Error: nu::parser::assignment_mismatch

  × Default value wrong type
   ╭─[entry #1:1:1]
 1 │ def err [list: list<int> = ['a' 'b' 'c']] {}
   ·                            ──────┬────
   ·                                   ╰── expected default value to be `list<int>`
   ╰────
```

# User-Facing Changes

none

# Tests + Formatting

done
