### PR TITLE
Clean up unnecessary macro use

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -79,29 +79,27 @@ impl Highlighter for NuHighlighter {
                 }};
             }
 
-            macro_rules! add_colored_token {
-                ($shape:expr, $text:expr) => {
-                    output.push((get_shape_color($shape.to_string(), &self.config), $text))
-                };
-            }
+            let mut add_colored_token = |shape: &FlatShape, text: String| {
+                output.push((get_shape_color(shape.to_string(), &self.config), text));
+            };
 
             match shape.1 {
-                FlatShape::Garbage => add_colored_token!(shape.1, next_token),
-                FlatShape::Nothing => add_colored_token!(shape.1, next_token),
-                FlatShape::Binary => add_colored_token!(shape.1, next_token),
-                FlatShape::Bool => add_colored_token!(shape.1, next_token),
-                FlatShape::Int => add_colored_token!(shape.1, next_token),
-                FlatShape::Float => add_colored_token!(shape.1, next_token),
-                FlatShape::Range => add_colored_token!(shape.1, next_token),
-                FlatShape::InternalCall => add_colored_token!(shape.1, next_token),
-                FlatShape::External => add_colored_token!(shape.1, next_token),
-                FlatShape::ExternalArg => add_colored_token!(shape.1, next_token),
-                FlatShape::Literal => add_colored_token!(shape.1, next_token),
-                FlatShape::Operator => add_colored_token!(shape.1, next_token),
-                FlatShape::Signature => add_colored_token!(shape.1, next_token),
-                FlatShape::String => add_colored_token!(shape.1, next_token),
-                FlatShape::StringInterpolation => add_colored_token!(shape.1, next_token),
-                FlatShape::DateTime => add_colored_token!(shape.1, next_token),
+                FlatShape::Garbage => add_colored_token(&shape.1, next_token),
+                FlatShape::Nothing => add_colored_token(&shape.1, next_token),
+                FlatShape::Binary => add_colored_token(&shape.1, next_token),
+                FlatShape::Bool => add_colored_token(&shape.1, next_token),
+                FlatShape::Int => add_colored_token(&shape.1, next_token),
+                FlatShape::Float => add_colored_token(&shape.1, next_token),
+                FlatShape::Range => add_colored_token(&shape.1, next_token),
+                FlatShape::InternalCall => add_colored_token(&shape.1, next_token),
+                FlatShape::External => add_colored_token(&shape.1, next_token),
+                FlatShape::ExternalArg => add_colored_token(&shape.1, next_token),
+                FlatShape::Literal => add_colored_token(&shape.1, next_token),
+                FlatShape::Operator => add_colored_token(&shape.1, next_token),
+                FlatShape::Signature => add_colored_token(&shape.1, next_token),
+                FlatShape::String => add_colored_token(&shape.1, next_token),
+                FlatShape::StringInterpolation => add_colored_token(&shape.1, next_token),
+                FlatShape::DateTime => add_colored_token(&shape.1, next_token),
                 FlatShape::List => {
                     add_colored_token_with_bracket_highlight!(shape.1, shape.0, next_token)
                 }
@@ -116,17 +114,17 @@ impl Highlighter for NuHighlighter {
                     add_colored_token_with_bracket_highlight!(shape.1, shape.0, next_token)
                 }
 
-                FlatShape::Filepath => add_colored_token!(shape.1, next_token),
-                FlatShape::Directory => add_colored_token!(shape.1, next_token),
-                FlatShape::GlobPattern => add_colored_token!(shape.1, next_token),
-                FlatShape::Variable => add_colored_token!(shape.1, next_token),
-                FlatShape::Flag => add_colored_token!(shape.1, next_token),
-                FlatShape::Pipe => add_colored_token!(shape.1, next_token),
-                FlatShape::And => add_colored_token!(shape.1, next_token),
-                FlatShape::Or => add_colored_token!(shape.1, next_token),
-                FlatShape::Redirection => add_colored_token!(shape.1, next_token),
-                FlatShape::Custom(..) => add_colored_token!(shape.1, next_token),
-                FlatShape::MatchPattern => add_colored_token!(shape.1, next_token),
+                FlatShape::Filepath => add_colored_token(&shape.1, next_token),
+                FlatShape::Directory => add_colored_token(&shape.1, next_token),
+                FlatShape::GlobPattern => add_colored_token(&shape.1, next_token),
+                FlatShape::Variable => add_colored_token(&shape.1, next_token),
+                FlatShape::Flag => add_colored_token(&shape.1, next_token),
+                FlatShape::Pipe => add_colored_token(&shape.1, next_token),
+                FlatShape::And => add_colored_token(&shape.1, next_token),
+                FlatShape::Or => add_colored_token(&shape.1, next_token),
+                FlatShape::Redirection => add_colored_token(&shape.1, next_token),
+                FlatShape::Custom(..) => add_colored_token(&shape.1, next_token),
+                FlatShape::MatchPattern => add_colored_token(&shape.1, next_token),
             }
             last_seen_span = shape.0.end;
         }

--- a/crates/nu-color-config/src/nu_style.rs
+++ b/crates/nu-color-config/src/nu_style.rs
@@ -20,22 +20,26 @@ impl From<Style> for NuStyle {
 }
 
 fn style_get_attr(s: Style) -> Option<String> {
-    macro_rules! check {
-        ($attrs:expr, $b:expr, $c:expr) => {
-            if $b {
-                $attrs.push($c);
-            }
-        };
-    }
-
     let mut attrs = String::new();
 
-    check!(attrs, s.is_blink, 'l');
-    check!(attrs, s.is_bold, 'b');
-    check!(attrs, s.is_dimmed, 'd');
-    check!(attrs, s.is_reverse, 'r');
-    check!(attrs, s.is_strikethrough, 's');
-    check!(attrs, s.is_underline, 'u');
+    if s.is_blink {
+        attrs.push('l');
+    };
+    if s.is_bold {
+        attrs.push('b');
+    };
+    if s.is_dimmed {
+        attrs.push('d');
+    };
+    if s.is_reverse {
+        attrs.push('r');
+    };
+    if s.is_strikethrough {
+        attrs.push('s');
+    };
+    if s.is_underline {
+        attrs.push('u');
+    };
 
     if attrs.is_empty() {
         None

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -21,13 +21,6 @@ pub enum ComputableStyle {
     Closure(Value),
 }
 
-// macro used for adding initial values to the style hashmap
-macro_rules! initial {
-    ($a:expr, $b:expr) => {
-        ($a.to_string(), ComputableStyle::Static($b))
-    };
-}
-
 // An alias for the mapping used internally by StyleComputer.
 pub type StyleMapping = HashMap<String, ComputableStyle>;
 //
@@ -152,6 +145,12 @@ impl<'a> StyleComputer<'a> {
     // The main constructor.
     pub fn from_config(engine_state: &'a EngineState, stack: &'a Stack) -> StyleComputer<'a> {
         let config = engine_state.get_config();
+
+        macro_rules! initial {
+            ($a:expr, $b:expr) => {
+                ($a.to_string(), ComputableStyle::Static($b))
+            };
+        }
 
         // Create the hashmap
         let mut map: StyleMapping = HashMap::from([

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -187,10 +187,8 @@ fn help_frame_data(
 }
 
 fn help_manual_data(manual: &HelpManual, aliases: &[String]) -> (Vec<String>, Vec<Vec<Value>>) {
-    macro_rules! nu_str {
-        ($text:expr) => {
-            Value::string($text.to_string(), NuSpan::unknown())
-        };
+    fn nu_str(s: &impl ToString) -> Value {
+        Value::string(s.to_string(), NuSpan::unknown())
     }
 
     let arguments = manual
@@ -198,7 +196,7 @@ fn help_manual_data(manual: &HelpManual, aliases: &[String]) -> (Vec<String>, Ve
         .iter()
         .map(|e| Value::Record {
             cols: vec![String::from("example"), String::from("description")],
-            vals: vec![nu_str!(e.example), nu_str!(e.description)],
+            vals: vec![nu_str(&e.example), nu_str(&e.description)],
             span: NuSpan::unknown(),
         })
         .collect();
@@ -213,7 +211,7 @@ fn help_manual_data(manual: &HelpManual, aliases: &[String]) -> (Vec<String>, Ve
         .iter()
         .map(|e| Value::Record {
             cols: vec![String::from("example"), String::from("description")],
-            vals: vec![nu_str!(e.example), nu_str!(e.description)],
+            vals: vec![nu_str(&e.example), nu_str(&e.description)],
             span: NuSpan::unknown(),
         })
         .collect();
@@ -231,7 +229,7 @@ fn help_manual_data(manual: &HelpManual, aliases: &[String]) -> (Vec<String>, Ve
                 String::from("context"),
                 String::from("description"),
             ],
-            vals: vec![nu_str!(e.code), nu_str!(e.context), nu_str!(e.description)],
+            vals: vec![nu_str(&e.code), nu_str(&e.context), nu_str(&e.description)],
             span: NuSpan::unknown(),
         })
         .collect();
@@ -249,7 +247,7 @@ fn help_manual_data(manual: &HelpManual, aliases: &[String]) -> (Vec<String>, Ve
                 .iter()
                 .map(|v| Value::Record {
                     cols: vec![String::from("example"), String::from("description")],
-                    vals: vec![nu_str!(v.example), nu_str!(v.description)],
+                    vals: vec![nu_str(&v.example), nu_str(&v.description)],
                     span: NuSpan::unknown(),
                 })
                 .collect();
@@ -266,9 +264,9 @@ fn help_manual_data(manual: &HelpManual, aliases: &[String]) -> (Vec<String>, Ve
                     String::from("values"),
                 ],
                 vals: vec![
-                    nu_str!(o.group),
-                    nu_str!(o.key),
-                    nu_str!(o.description),
+                    nu_str(&o.group),
+                    nu_str(&o.key),
+                    nu_str(&o.description),
                     values,
                 ],
                 span: NuSpan::unknown(),
@@ -280,9 +278,9 @@ fn help_manual_data(manual: &HelpManual, aliases: &[String]) -> (Vec<String>, Ve
         span: NuSpan::unknown(),
     };
 
-    let name = nu_str!(manual.name);
-    let aliases = nu_str!(aliases.join(", "));
-    let desc = nu_str!(manual.description);
+    let name = nu_str(&manual.name);
+    let aliases = nu_str(&aliases.join(", "));
+    let desc = nu_str(&manual.description);
 
     let headers = vec![
         String::from("name"),


### PR DESCRIPTION
Some minor code cleanup.

We've accumulated a few macros over the years that arguably don't need to be macros. This PR removes 4 macros by either:
1. Inlining the macro
2. Replacing the macro with a local function
3. Replacing the macro with a closure