### PR TITLE
`update` command: make `$in`(in closure body) takes cell path

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -2,8 +2,8 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::{Call, CellPath, PathMember};
 use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, FromValue, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
-    ShellError, Signature, Span, SyntaxShape, Type, Value,
+    Category, Example, FromValue, IntoInterruptiblePipelineData, PipelineData, ShellError,
+    Signature, Span, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -122,7 +122,10 @@ fn update(
                     &engine_state,
                     &mut stack,
                     &block,
-                    input.clone().into_pipeline_data(),
+                    input
+                        .clone()
+                        .follow_cell_path(&cell_path.members, false)
+                        .into_pipeline_data(None),
                     redirect_stdout,
                     redirect_stderr,
                 );

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -76,8 +76,8 @@ impl Command for Update {
                 result: Some(Value::List { vals: vec![Value::Record { cols: vec!["project".into(), "authors".into()], vals: vec![Value::test_string("nu"), Value::test_string("Andrés,JT,Yehuda")], span: Span::test_data()}], span: Span::test_data()}),
             },
             Example {
-                description: "Use `$in` to update 'authors' to use a single string",
-                example: "[[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors {|| $in | str join ','}",
+                description: "You can also use a simple command to update 'authors' to a single string",
+                example: "[[project, authors]; ['nu', ['Andrés', 'JT', 'Yehuda']]] | update authors {|| str join ','}",
                 result: Some(Value::List { vals: vec![Value::Record { cols: vec!["project".into(), "authors".into()], vals: vec![Value::test_string("nu"), Value::test_string("Andrés,JT,Yehuda")], span: Span::test_data()}], span: Span::test_data()}),
             }
         ]

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -48,7 +48,6 @@ impl Command for StrJoin {
         // Hmm, not sure what we actually want. If you don't use debug_string, Date comes out as human readable
         // which feels funny
         let mut strings: Vec<String> = vec![];
-        println!("input in str join command: {:?}", input);
 
         for value in input {
             match value {

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -48,6 +48,7 @@ impl Command for StrJoin {
         // Hmm, not sure what we actually want. If you don't use debug_string, Date comes out as human readable
         // which feels funny
         let mut strings: Vec<String> = vec![];
+        println!("input in str join command: {:?}", input);
 
         for value in input {
             match value {


### PR DESCRIPTION
# Description

Make `$in` takes cell path in `update` command

The reason behind the change: https://discord.com/channels/601130461678272522/615329862395101194/1088405671080370196
> when i use update on some cell path, it's almost always because i want to start with its previous value and change it.

cc @amtoine 

# User-Facing Changes

## Before
```
open Cargo.toml | get package | update metadata.binstall.pkg-fmt {|| $in.metadata.binstall.pkg-fmt | str replace "g" "FOO"}
```

## After
```
open Cargo.toml | get package | update metadata.binstall.pkg-fmt {|| str replace "g" "FOO"}
```

If use want to access original raw, it can be accessed by parameters in closure:
```
open Cargo.toml | get package | update metadata.binstall.pkg-fmt {|$it| $it.metadata.binstall.pkg-fmt | str replace "g" "FOO"}
```
For this reason, I don't think we need to add a flag like `--whole`

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
