### PR TITLE
Add `hmac` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1750,6 +1751,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "html5ever"
@@ -2807,6 +2817,7 @@ dependencies = [
  "filetime",
  "fs_extra",
  "hamcrest2",
+ "hmac",
  "htmlescape",
  "indexmap",
  "indicatif",
@@ -4972,6 +4983,12 @@ dependencies = [
  "rustversion",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "supports-color"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -83,6 +83,7 @@ serde = { version = "1.0.123", features = ["derive"] }
 serde_urlencoded = "0.7.0"
 serde_yaml = "0.9.4"
 sha2 = "0.10.0"
+hmac = "0.12.1"
 # Disable default features b/c the default features build Git (very slow to compile)
 percent-encoding = "2.2.0"
 reedline = { version = "0.17.0", features = ["bashisms", "sqlite"] }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -435,6 +435,12 @@ pub fn create_default_context() -> EngineState {
             HashSha256::default(),
         };
 
+        // Hmac
+        bind_command! {
+            Hmac,
+            HmacSha256::default(),
+        };
+
         // Experimental
         bind_command! {
             IsAdmin,

--- a/crates/nu-command/src/hmac/generic_digest.rs
+++ b/crates/nu-command/src/hmac/generic_digest.rs
@@ -1,0 +1,167 @@
+use crate::input_handler::{operate, CmdArgument};
+use nu_engine::CallExt;
+use nu_protocol::ast::{Call, CellPath};
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::Span;
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+};
+use std::marker::PhantomData;
+
+pub trait HmacDigest: digest::Mac + digest::KeyInit + Clone {
+    fn name() -> &'static str;
+    fn examples() -> Vec<Example<'static>>;
+}
+
+#[derive(Clone)]
+pub struct GenericDigest<D: HmacDigest> {
+    name: String,
+    usage: String,
+    phantom: PhantomData<D>,
+}
+
+impl<D: HmacDigest> Default for GenericDigest<D> {
+    fn default() -> Self {
+        Self {
+            name: format!("hmac {}", D::name()),
+            usage: format!(
+                "Hmac a value with a secret key using the {} hash algorithm",
+                D::name()
+            ),
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub(super) struct Arguments<D> {
+    pub(super) cell_paths: Option<Vec<CellPath>>,
+    pub(super) binary: bool,
+    pub(super) mac: D,
+}
+
+impl<D> CmdArgument for Arguments<D> {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        self.cell_paths.take()
+    }
+}
+
+impl<D> Command for GenericDigest<D>
+where
+    D: HmacDigest + Send + Sync + 'static,
+    digest::Output<D>: core::fmt::LowerHex,
+{
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .category(Category::Hash)
+            .input_output_types(vec![
+                (Type::String, Type::String),
+                (Type::String, Type::Binary),
+            ])
+            .required_named("key", SyntaxShape::String, "secret key", None)
+            .switch(
+                "binary",
+                "Output binary instead of hexadecimal representation",
+                Some('b'),
+            )
+            .rest(
+                "rest",
+                SyntaxShape::CellPath,
+                format!("optionally {} hmac data by cell path", D::name()),
+            )
+    }
+
+    fn usage(&self) -> &str {
+        &self.usage
+    }
+
+    fn examples(&self) -> Vec<Example<'static>> {
+        D::examples()
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let binary = call.has_flag("binary");
+        let key: String =
+            call.get_flag(engine_state, stack, "key")?
+                .ok_or(ShellError::MissingParameter {
+                    param_name: "key".to_string(),
+                    span: call.head,
+                })?;
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+        let args = Arguments {
+            binary,
+            cell_paths,
+            mac: <D as digest::Mac>::new_from_slice(key.as_bytes()).map_err(|e| {
+                ShellError::IncorrectValue {
+                    msg: e.to_string(),
+                    span: call.head,
+                }
+            })?,
+        };
+        operate(
+            action::<D>,
+            args,
+            input,
+            call.head,
+            engine_state.ctrlc.clone(),
+        )
+    }
+}
+
+pub(super) fn action<D>(input: &Value, args: &Arguments<D>, _span: Span) -> Value
+where
+    D: HmacDigest,
+    digest::Output<D>: core::fmt::LowerHex,
+{
+    let (bytes, span) = match input {
+        Value::String { val, span } => (val.as_bytes(), *span),
+        Value::Binary { val, span } => (val.as_slice(), *span),
+        // Propagate existing errors
+        Value::Error { .. } => return input.clone(),
+        other => {
+            let span = match input.span() {
+                Ok(span) => span,
+                Err(error) => {
+                    return Value::Error {
+                        error: Box::new(error),
+                    }
+                }
+            };
+
+            return Value::Error {
+                error: Box::new(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "string or binary".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: span,
+                    src_span: other.expect_span(),
+                }),
+            };
+        }
+    };
+
+    let mut mac = args.mac.clone();
+    mac.update(bytes);
+    let digest = mac.finalize().into_bytes();
+
+    if args.binary {
+        Value::Binary {
+            val: digest.to_vec(),
+            span,
+        }
+    } else {
+        Value::String {
+            val: format!("{digest:x}"),
+            span,
+        }
+    }
+}

--- a/crates/nu-command/src/hmac/hmac_.rs
+++ b/crates/nu-command/src/hmac/hmac_.rs
@@ -1,0 +1,47 @@
+use nu_engine::get_full_help;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value};
+
+#[derive(Clone)]
+pub struct Hmac;
+
+impl Command for Hmac {
+    fn name(&self) -> &str {
+        "hmac"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("hmac")
+            .category(Category::Hash)
+            .input_output_types(vec![(Type::Nothing, Type::String)])
+    }
+
+    fn usage(&self) -> &str {
+        "Apply hmac function."
+    }
+
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(Value::String {
+            val: get_full_help(
+                &Self.signature(),
+                &Self.examples(),
+                engine_state,
+                stack,
+                self.is_parser_keyword(),
+            ),
+            span: call.head,
+        }
+        .into_pipeline_data())
+    }
+}

--- a/crates/nu-command/src/hmac/mod.rs
+++ b/crates/nu-command/src/hmac/mod.rs
@@ -1,0 +1,6 @@
+mod generic_digest;
+mod hmac_;
+mod sha256;
+
+pub use self::hmac_::Hmac;
+pub use self::sha256::HmacSha256;

--- a/crates/nu-command/src/hmac/sha256.rs
+++ b/crates/nu-command/src/hmac/sha256.rs
@@ -1,0 +1,100 @@
+use super::generic_digest::{GenericDigest, HmacDigest};
+use ::sha2::Sha256;
+use nu_protocol::{Example, Span, Value};
+
+pub type HmacSha256 = GenericDigest<::hmac::Hmac<Sha256>>;
+
+impl HmacDigest for ::hmac::Hmac<Sha256> {
+    fn name() -> &'static str {
+        "sha256"
+    }
+
+    fn examples() -> Vec<Example<'static>> {
+        vec![
+            Example {
+                description: "Return the sha256 hmac of a string, hex-encoded",
+                example: "'abcdefghijklmnopqrstuvwxyz' | hmac sha256 --key 'mysecretkey'",
+                result: Some(Value::String {
+                    val: "87935cc95c18048a2060d02dc4296271669eb63ea247129892fbd1919303edb9"
+                        .to_owned(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Return the sha256 hmac of a string, as binary",
+                example: "'abcdefghijklmnopqrstuvwxyz' | hmac sha256 --key 'mysecretkey' --binary",
+                result: Some(Value::Binary {
+                    val: vec![
+                        0x87, 0x93, 0x5c, 0xc9, 0x5c, 0x18, 0x04, 0x8a, 0x20, 0x60, 0xd0, 0x2d,
+                        0xc4, 0x29, 0x62, 0x71, 0x66, 0x9e, 0xb6, 0x3e, 0xa2, 0x47, 0x12, 0x98,
+                        0x92, 0xfb, 0xd1, 0x91, 0x93, 0x03, 0xed, 0xb9,
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Return the sha256 hmac of a file's contents",
+                example: "open ./nu_0_24_1_windows.zip | hmac sha256 --key 'mysecretkey'",
+                result: None,
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hmac::generic_digest::{self, Arguments};
+    use digest::KeyInit;
+
+    #[test]
+    fn test_examples() {
+        crate::test_examples(HmacSha256::default())
+    }
+
+    #[test]
+    fn hmac_string() {
+        let binary = Value::String {
+            val: "abcdefghijklmnopqrstuvwxyz".to_owned(),
+            span: Span::test_data(),
+        };
+        let key = "mysecretkey";
+        let expected = Value::String {
+            val: "87935cc95c18048a2060d02dc4296271669eb63ea247129892fbd1919303edb9".to_owned(),
+            span: Span::test_data(),
+        };
+        let actual = generic_digest::action::<::hmac::Hmac<Sha256>>(
+            &binary,
+            &Arguments {
+                cell_paths: None,
+                binary: false,
+                mac: ::hmac::Hmac::<Sha256>::new_from_slice(key.as_bytes()).unwrap(),
+            },
+            Span::test_data(),
+        );
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn hash_bytes() {
+        let binary = Value::Binary {
+            val: vec![0xC0, 0xFF, 0xEE],
+            span: Span::test_data(),
+        };
+        let key = "mysecretkey";
+        let expected = Value::String {
+            val: "f7dc525fcdfafcb39459b7c83d29f302f952cd0a0d2c82cfa95031d965620b7c".to_owned(),
+            span: Span::test_data(),
+        };
+        let actual = generic_digest::action::<::hmac::Hmac<Sha256>>(
+            &binary,
+            &Arguments {
+                cell_paths: None,
+                binary: false,
+                mac: ::hmac::Hmac::<Sha256>::new_from_slice(key.as_bytes()).unwrap(),
+            },
+            Span::test_data(),
+        );
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -14,6 +14,7 @@ mod filters;
 mod formats;
 mod generators;
 mod hash;
+mod hmac;
 pub mod hook;
 mod input_handler;
 mod math;
@@ -30,6 +31,7 @@ mod system;
 pub mod util;
 mod viewers;
 
+pub use self::hmac::*;
 pub use bits::*;
 pub use bytes::*;
 pub use charting::*;


### PR DESCRIPTION
# Description
Add `hmac` command, which is very useful when using open api.

<img width="656" alt="image" src="https://user-images.githubusercontent.com/11287532/227732302-1079ec1c-c107-4013-b7c5-64933a024f6e.png">


# User-Facing Changes
None

# Tests + Formatting

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass
