### PR TITLE
fix unhelpful error message with extra characters in list annotations

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3129,6 +3129,17 @@ fn parse_list_shape(
         // overflows with spans
         let end = if bytes.ends_with(b">") {
             span.end - 1
+        // extra characters after the >
+        } else if bytes.contains(&b'>') {
+            let angle_start = bytes.split(|it| it == &b'>').collect::<Vec<_>>()[0].len() + 1;
+            let span = Span::new(span.start + angle_start, span.end);
+
+            let err = ParseError::LabeledError(
+                "Extra characters in the parameter name".into(),
+                "extra characters".into(),
+                span,
+            );
+            return (SyntaxShape::Any, Some(err));
         } else {
             let err = ParseError::Unclosed(">".into(), span);
             return (SyntaxShape::List(Box::new(SyntaxShape::Any)), Some(err));

--- a/src/tests/test_signatures.rs
+++ b/src/tests/test_signatures.rs
@@ -125,3 +125,10 @@ fn list_annotations_with_default_val_2() -> TestResult {
     let expected = "Default value wrong type";
     fail_test(input, expected)
 }
+
+#[test]
+fn list_annotations_with_extra_characters() -> TestResult {
+    let input = "def run [list: list<int>extra] {$list | length}; run [1 2 3]";
+    let expected = "Extra characters in the parameter name";
+    fail_test(input, expected)
+}


### PR DESCRIPTION
# Description

with such a line
```nu
def err [list: list<>extra] {}
```
this pr changes the error message from 
```nu
Error: nu::parser::unclosed_delimiter

  × Unclosed delimiter.
   ╭─[entry #69:1:1]
 1 │ def err [list: list<>extra] {}
   ·                ─────┬─────
   ·                      ╰── unclosed >
   ╰────
```
to
```nu
  × Extra characters in the parameter name.
   ╭─[entry #69:1:1]
 1 │ def err [list: list<>extra] {}
   ·                      ──┬──
   ·                        ╰── extra characters
   ╰────
```