### PR TITLE
remove `match` from the standard library

### DIFF
--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -199,47 +199,6 @@ export def "assert str contains" [left: string, right: string, message?: string]
     }
 }
 
-# ```nushell
-# >_ let branches = {
-# )))     1: { print "this is the 1st branch"}
-# )))     2: { print "this is the 2nd branch" }
-# )))     3: { print "this is the 3rd branch" }
-# )))     4: { print "this is the 4th branch" }
-# ))) }
-#
-# >_ match 1 $branches
-# ))) match 2 $branches
-# ))) match 3 $branches
-# ))) match 4 $branches
-# ))) match 5 $branches
-# this is the 1st branch
-# this is the 2nd branch
-# this is the 3rd branch
-# this is the 4th branch
-#
-# >_ match 1 $branches { "this is the default branch" }
-# ))) match 2 $branches { "this is the default branch" }
-# ))) match 3 $branches { "this is the default branch" }
-# ))) match 4 $branches { "this is the default branch" }
-# ))) match 5 $branches { "this is the default branch" }
-# this is the 1st branch
-# this is the 2nd branch
-# this is the 3rd branch
-# this is the 4th branch
-# this is the default branch
-# ```
-export def match [
-    input:string
-    matchers:record
-    default?: block
-] {
-    if (($matchers | get -i $input) != null) {
-         $matchers | get $input | do $in
-    } else if ($default != null) {
-        do $default
-    }
-}
-
 # Add the given paths to the PATH.
 #
 # # Example

--- a/crates/nu-utils/standard_library/test_std.nu
+++ b/crates/nu-utils/standard_library/test_std.nu
@@ -1,22 +1,5 @@
 use std.nu
 
-export def test_match [] {
-    use std.nu assert
-
-    let branches = {
-        1: {|| -1 }
-        2: {|| -2 }
-    }
-
-    assert ((std match 1 $branches) == -1)
-    assert ((std match 2 $branches) == -2)
-    assert ((std match 3 $branches) == $nothing)
-
-    assert ((std match 1 $branches { 0 }) == -1)
-    assert ((std match 2 $branches { 0 }) == -2)
-    assert ((std match 3 $branches { 0 }) == 0)
-}
-
 export def test_path_add [] {
     use std.nu "assert equal"
 


### PR DESCRIPTION
Should close #8616.
Related to #8590.

# Description
With the new builtin `match` command introduced in the `rust` source in #8590, there is no need to have a custom `match` in the standard library.
This PR removes the `match` command from `std.nu` and the associated test.

# User-Facing Changes
Users can not access `match` from `std.nu`.

# Tests + Formatting
```
nu crates/nu-utils/standard_library/tests.nu  --path crates/nu-utils/standard_library/ out+err> /dev/null; ($env.LAST_EXIT_CODE == 0)
```
gives `true`

# After Submitting
```
$nothing
```