### PR TITLE
stdlib: optimize test search and add better errors

### DIFF
--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -34,8 +34,11 @@ def main [
         extension: nu
     } | path join)
 
+
+    let path = ($path | default $env.FILE_PWD)
+
     let tests = (
-        ls ($path | default $env.FILE_PWD | path join $module_search_pattern)
+        ls ($path | path join $module_search_pattern)
         | each {|row| {file: $row.name name: ($row.name | path parse | get stem)}}
         | upsert test {|module|
             nu -c $'use ($module.file) *; $nu.scope.commands | select name module_name | to nuon'

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -29,8 +29,13 @@ def main [
     --command: string, # Test command to run. Default: all test command found in the files.
     --list, # list the selected tests without running them.
 ] {
+    let module_search_pattern = ({
+        stem: ($module | default "test_*")
+        extension: nu
+    } | path join)
+
     let tests = (
-        ls ($path | default $env.FILE_PWD | path join "test_*.nu")
+        ls ($path | default $env.FILE_PWD | path join $module_search_pattern)
         | each {|row| {file: $row.name name: ($row.name | path parse | get stem)}}
         | upsert test {|module|
             nu -c $'use ($module.file) *; $nu.scope.commands | select name module_name | to nuon'

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -94,7 +94,7 @@ def main [
     }
 
     if ($tests_to_run | is-empty) {
-        error make -u {msg: "no test to run"}
+        error make --unspanned {msg: "no test to run"}
     }
 
     let tests = (

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -20,6 +20,17 @@ def show-pretty-test [indent: int = 4] {
     ] | str join
 }
 
+def throw-error [error: record] {
+    error make {
+        msg: $"(ansi red)($error.msg)(ansi reset)"
+        label: {
+            text: ($error.label)
+            start: $error.span.start
+            end: $error.span.end
+        }
+    }
+}
+
 # Test executor
 #
 # It executes exported "test_*" commands in "test_*" modules
@@ -36,14 +47,10 @@ def main [
 
     if not ($module | is-empty) {
         if not ($path | path exists) {
-            let span = (metadata $path | get span)
-            error make {
-                msg: $"(ansi red)directory_not_found(ansi reset)"
-                label: {
-                    text: $"no such directory"
-                    start: $span.start
-                    end: $span.end
-                }
+            throw-error {
+                msg: "directory_not_found"
+                label: "no such directory"
+                span: (metadata $path | get span)
             }
         }
     }
@@ -52,14 +59,10 @@ def main [
 
     if not ($module | is-empty) {
         if not ($path | path join $module_search_pattern | path exists) {
-            let span = (metadata $module | get span)
-            error make {
-                msg: $"(ansi red)module_not_found(ansi reset)"
-                label: {
-                    text: $"no such module in ($path)"
-                    start: $span.start
-                    end: $span.end
-                }
+            throw-error {
+                msg: "module_not_found"
+                label: $"no such module in ($path)"
+                span: (metadata $module | get span)
             }
         }
     }

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -34,8 +34,35 @@ def main [
         extension: nu
     } | path join)
 
+    if not ($module | is-empty) {
+        if not ($path | path exists) {
+            let span = (metadata $path | get span)
+            error make {
+                msg: $"(ansi red)directory_not_found(ansi reset)"
+                label: {
+                    text: $"no such directory"
+                    start: $span.start
+                    end: $span.end
+                }
+            }
+        }
+    }
 
     let path = ($path | default $env.FILE_PWD)
+
+    if not ($module | is-empty) {
+        if not ($path | path join $module_search_pattern | path exists) {
+            let span = (metadata $module | get span)
+            error make {
+                msg: $"(ansi red)module_not_found(ansi reset)"
+                label: {
+                    text: $"no such module in ($path)"
+                    start: $span.start
+                    end: $span.end
+                }
+            }
+        }
+    }
 
     let tests = (
         ls ($path | path join $module_search_pattern)

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -45,7 +45,7 @@ def main [
         extension: nu
     } | path join)
 
-    if not ($module | is-empty) {
+    if not ($path | is-empty) {
         if not ($path | path exists) {
             throw-error {
                 msg: "directory_not_found"

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -90,6 +90,10 @@ def main [
         return ($tests_to_run | select module name file)
     }
 
+    if ($tests_to_run | is-empty) {
+        error make -u {msg: "no test to run"}
+    }
+
     let tests = (
         $tests_to_run
         | group-by module


### PR DESCRIPTION
the first part of this PR comes from a request from @presidento in #8525.
the second one is an improvement of the error support.

# Description
this PR
- computes `module_search_pattern` to only `ls` the selected modules => the goal is to save search time in the future with more tests
- gives better errors when
  - the `--path` is invalid
  - the `--module` does not exist
  - the search is too strict

### examples
```bash
>_ nu crates/nu-utils/standard_library/tests.nu --path does-not-exist
Error: 
  × directory_not_found
   ╭─[<commandline>:1:1]
 1 │ main --path does-not-exist
   ·             ───────┬──────
   ·                    ╰── no such directory
   ╰────
```

```bash
>_ nu crates/nu-utils/standard_library/tests.nu --module does-not-exist
Error: 
  × module_not_found
   ╭─[<commandline>:1:1]
 1 │ main --module does-not-exist
   ·               ───────┬──────
   ·                      ╰── no such module in /home/amtoine/.local/share/git/store/github.com/amtoine/nushell/crates/nu-utils/standard_library/
   ╰────
```

```bash
>_ nu crates/nu-utils/standard_library/tests.nu --command does_not_exist
Error: 
  × no test to run
```

instead of the previous

```bash
>_ nu crates/nu-utils/standard_library/tests.nu --path does-not-exist
Error: 
  × No matches found for /home/amtoine/.local/share/git/store/github.com/amtoine/nushell/does-not-exist/test_*.nu
    ╭─[/home/amtoine/.local/share/git/store/github.com/amtoine/nushell/crates/nu-utils/standard_library/tests.nu:32:1]
 32 │     let tests = (
 33 │         ls ($path | default $env.FILE_PWD | path join "test_*.nu")
    ·            ───────────────────────────┬───────────────────────────
    ·                                       ╰── Pattern, file or folder not found
 34 │         | each {|row| {file: $row.name name: ($row.name | path parse | get stem)}}
    ╰────
  help: no matches found
```

```bash
>_ nu crates/nu-utils/standard_library/tests.nu --module does-not-exist
Error: 
  × expected table from pipeline
    ╭─[/home/amtoine/.local/share/git/store/github.com/amtoine/nushell/crates/nu-utils/standard_library/tests.nu:59:1]
 59 │         $tests_to_run
 60 │         | group-by module
    ·           ────┬───
    ·               ╰── requires a table input
 61 │         | transpose name tests
    ╰────
```

```bash
>_ nu crates/nu-utils/standard_library/tests.nu --command does-not-exist
Error: 
  × expected table from pipeline
    ╭─[/home/amtoine/.local/share/git/store/github.com/amtoine/nushell/crates/nu-utils/standard_library/tests.nu:59:1]
 59 │         $tests_to_run
 60 │         | group-by module
    ·           ────┬───
    ·               ╰── requires a table input
 61 │         | transpose name tests
    ╰────
```

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
```
$nothing
```

# After Submitting
```
$nothing
```