### PR TITLE
stdlib: add an automatic loading of "prelude" commands

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -232,45 +232,51 @@ pub(crate) fn run_repl(
         use_color,
     );
 
-    let name = "std".to_string();
-    let content = get_standard_library().as_bytes();
+    let delta = {
+        let name = "std".to_string();
+        let content = get_standard_library().as_bytes();
 
-    let mut working_set = StateWorkingSet::new(engine_state);
+        let mut working_set = StateWorkingSet::new(engine_state);
 
-    let start = working_set.next_span_start();
-    working_set.add_file(name.clone(), content);
-    let end = working_set.next_span_start();
+        let start = working_set.next_span_start();
+        working_set.add_file(name.clone(), content);
+        let end = working_set.next_span_start();
 
-    let (_, module, _, _) = parse_module_block(
-        &mut working_set,
-        Span::new(start, end),
-        name.as_bytes(),
-        &[],
-    );
+        let (_, module, _, _) = parse_module_block(
+            &mut working_set,
+            Span::new(start, end),
+            name.as_bytes(),
+            &[],
+        );
 
-    let prelude = vec![
-        ("assert", "assert"),
-    ];
+        let prelude = vec![
+            ("assert", "assert"),
+        ];
 
-    working_set.use_decls(
-        prelude
-            .iter()
-            .map(|(name, search_name)| {
-                (
-                    name.as_bytes().to_vec(),
-                    module
-                        .decls
-                        .get(&search_name.as_bytes().to_vec())
-                        .unwrap_or_else(|| {
-                            panic!("could not load `{}` from `std`.", search_name)
-                        })
-                        .to_owned(),
-                )
-            })
-            .collect(),
-    );
+        working_set.use_decls(
+            prelude
+                .iter()
+                .map(|(name, search_name)| {
+                    (
+                        name.as_bytes().to_vec(),
+                        module
+                            .decls
+                            .get(&search_name.as_bytes().to_vec())
+                            .unwrap_or_else(|| {
+                                panic!("could not load `{}` from `std`.", search_name)
+                            })
+                            .to_owned(),
+                    )
+                })
+                .collect(),
+        );
 
-    working_set.add_module(&name, module, Vec::new());
+        working_set.add_module(&name, module, Vec::new());
+
+        working_set.render()
+    };
+
+    engine_state.merge_delta(delta)?;
 
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_repl(

--- a/src/run.rs
+++ b/src/run.rs
@@ -77,7 +77,7 @@ fn load_standard_library(
                     "Unable to load the prelude of the standard library.".into(),
                     String::new(),
                     None,
-                    Some("this is a bug: please file an issue at <issue_tracker_url>".to_string()),
+                    Some("this is a bug: please file an issue in the [issue tracker](https://github.com/nushell/nushell/issues/new/choose)".to_string()),
                     errs,
                 ),
             );

--- a/src/run.rs
+++ b/src/run.rs
@@ -242,7 +242,7 @@ pub(crate) fn run_repl(
         working_set.add_file(name.clone(), content);
         let end = working_set.next_span_start();
 
-        let (_, module, comments, _) = parse_module_block(
+        let (block, module, comments, _) = parse_module_block(
             &mut working_set,
             Span::new(start, end),
             name.as_bytes(),
@@ -294,6 +294,7 @@ pub(crate) fn run_repl(
         working_set.use_decls(decls);
 
         working_set.add_module(&name, module, comments);
+        working_set.add_block(block);
 
         working_set.render()
     };

--- a/src/run.rs
+++ b/src/run.rs
@@ -249,8 +249,16 @@ pub(crate) fn run_repl(
             &[],
         );
 
+        // TODO: change this when #8505 is merged
+        // NOTE: remove the assert and uncomment the `help`s
         let prelude = vec![
             ("assert", "assert"),
+            // ("help", "help"),
+            // ("help commands", "help commands"),
+            // ("help aliases", "help aliases"),
+            // ("help modules", "help modules"),
+            // ("help externs", "help externs"),
+            // ("help operators", "help operators"),
         ];
 
         working_set.use_decls(

--- a/src/run.rs
+++ b/src/run.rs
@@ -196,6 +196,10 @@ pub(crate) fn run_file(
     ret_val
 }
 
+fn get_standard_library() -> &'static str {
+    include_str!("../crates/nu-utils/standard_library/std.nu")
+}
+
 pub(crate) fn run_repl(
     engine_state: &mut nu_protocol::engine::EngineState,
     parsed_nu_cli_args: command::NushellCliArgs,

--- a/src/run.rs
+++ b/src/run.rs
@@ -242,7 +242,7 @@ pub(crate) fn run_repl(
         working_set.add_file(name.clone(), content);
         let end = working_set.next_span_start();
 
-        let (_, module, _, _) = parse_module_block(
+        let (_, module, comments, _) = parse_module_block(
             &mut working_set,
             Span::new(start, end),
             name.as_bytes(),
@@ -279,7 +279,7 @@ pub(crate) fn run_repl(
                 .collect(),
         );
 
-        working_set.add_module(&name, module, Vec::new());
+        working_set.add_module(&name, module, comments);
 
         working_set.render()
     };

--- a/src/run.rs
+++ b/src/run.rs
@@ -35,7 +35,7 @@ fn load_standard_library(
             report_error(&working_set, &err);
         }
 
-        let (block, parse_error) = parse(&mut working_set, Some(&name), content, false, &[]);
+        let (_, parse_error) = parse(&mut working_set, Some(&name), content, false, &[]);
 
         if let Some(err) = parse_error {
             report_error(&working_set, &err);
@@ -86,7 +86,6 @@ fn load_standard_library(
         working_set.use_decls(decls);
 
         working_set.add_module(&name, module, comments);
-        working_set.add_block(block);
 
         working_set.render()
     };

--- a/src/run.rs
+++ b/src/run.rs
@@ -150,6 +150,8 @@ pub(crate) fn run_commands(
         use_color,
     );
 
+    load_standard_library(engine_state)?;
+
     // Before running commands, set up the startup time
     engine_state.set_startup_time(entire_start_time.elapsed().as_nanos() as i64);
     let start_time = std::time::Instant::now();
@@ -236,6 +238,8 @@ pub(crate) fn run_file(
         column!(),
         use_color,
     );
+
+    load_standard_library(engine_state)?;
 
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_file(

--- a/src/run.rs
+++ b/src/run.rs
@@ -11,6 +11,10 @@ use nu_parser::{parse, parse_module_block};
 use nu_protocol::{engine::StateWorkingSet, PipelineData, ShellError, Span};
 use nu_utils::utils::perf;
 
+fn get_standard_library() -> &'static str {
+    include_str!("../crates/nu-utils/standard_library/std.nu")
+}
+
 fn load_standard_library(
     engine_state: &mut nu_protocol::engine::EngineState,
 ) -> Result<(), miette::ErrReport> {
@@ -283,10 +287,6 @@ pub(crate) fn run_file(
     );
 
     ret_val
-}
-
-fn get_standard_library() -> &'static str {
-    include_str!("../crates/nu-utils/standard_library/std.nu")
 }
 
 pub(crate) fn run_repl(

--- a/src/run.rs
+++ b/src/run.rs
@@ -242,12 +242,16 @@ pub(crate) fn run_repl(
         working_set.add_file(name.clone(), content);
         let end = working_set.next_span_start();
 
-        let (block, module, comments, _) = parse_module_block(
+        let (block, module, comments, parse_error) = parse_module_block(
             &mut working_set,
             Span::new(start, end),
             name.as_bytes(),
             &[],
         );
+
+        if let Some(err) = parse_error {
+            report_error(&working_set, &err);
+        }
 
         // TODO: change this when #8505 is merged
         // NOTE: remove the assert and uncomment the `help`s

--- a/src/run.rs
+++ b/src/run.rs
@@ -35,7 +35,7 @@ fn load_standard_library(
             report_error(&working_set, &err);
         }
 
-        let (_, parse_error) = parse(&mut working_set, Some(&name), content, false, &[]);
+        let (_, parse_error) = parse(&mut working_set, Some(&name), content, true, &[]);
 
         if let Some(err) = parse_error {
             report_error(&working_set, &err);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,6 +16,7 @@ mod test_parser;
 mod test_ranges;
 mod test_regex;
 mod test_signatures;
+mod test_stdlib;
 mod test_strings;
 mod test_table_operations;
 mod test_type_check;

--- a/src/tests/test_stdlib.rs
+++ b/src/tests/test_stdlib.rs
@@ -1,0 +1,30 @@
+use crate::tests::{fail_test, run_test, TestResult};
+
+#[test]
+fn library_loaded() -> TestResult {
+    run_test(
+        "help std | lines | first 1 | to text",
+        "std.nu, `used` to load all standard library components",
+    )
+}
+
+#[test]
+fn prelude_loaded() -> TestResult {
+    run_test(
+        "help assert | lines | first 1 | to text",
+        "Universal assert command",
+    )
+}
+
+#[test]
+fn not_loaded() -> TestResult {
+    fail_test("help log info", "")
+}
+
+#[test]
+fn use_command() -> TestResult {
+    run_test(
+        "use std 'log info'; log info 'this is some information'",
+        "",
+    )
+}

--- a/src/tests/test_stdlib.rs
+++ b/src/tests/test_stdlib.rs
@@ -17,6 +17,11 @@ fn prelude_loaded() -> TestResult {
 }
 
 #[test]
+fn prelude_run() -> TestResult {
+    run_test("assert true; print 'it works'", "it works")
+}
+
+#[test]
 fn not_loaded() -> TestResult {
     fail_test("help log info", "")
 }


### PR DESCRIPTION
Should address some points in #8450.
Related to #8611.

# Description
- parse the `std.nu` module and add
  - the library as `std` to the main "namespace"
  - the top-level comments of the library to have a complete `help std`
  - all the commands in the library to the useable set of commands with `use`
- loads the prelude, i.e. a list of `(name, search_name)` to be added automatically
  - `name` is the name of the command that the user can use without `use`
  - `search_name` is the name of the command in the `std.nu` module
  - most of the time, `name` and `search_name` will be the same, but the `name` can be made `std ...` to make the difference with built-in commands
- finally merges the loaded library and imported prelude to the main engine state
- throws errors at each parsing / adding step without crashing the shell

:test_tube: tests have been added to test the bad behaviours and bug i have stumbled upon and the expected behaviour.

# User-Facing Changes
## normal behaviour
the user will have access, for free, to the commands listed in the prelude, e.g. the `help` implementations in `nushell` from #8611.

the standard library will be available, for free, as `std`.
the user can import any command from the standard library with
```bash
use std <command>
```
or the whole library with
```bash
use std
```
from anywhere, without having to have the `std.nu` file locally on disk.

## when the prelude can not be loaded
```bash
Error:
  × Unable to load the prelude of the standard library.
  help: this is a bug: please file an issue in the [issue tracker](https://github.com/nushell/nushell/issues/new/choose)

Error:
  × could not load `not an std command` from `std`.

Error:
  × could not load `not an valid command either` from `std`.


     __  ,
 .--()°'.' Welcome to Nushell,
'|, . ,'   based on the nu language,
 !_-(_\    where all data is structured!

Please join our Discord community at https://discord.gg/NtAbbGn
Our GitHub repository is at https://github.com/nushell/nushell
Our Documentation is located at https://nushell.sh
Tweet us at @nu_shell
Learn how to remove this at: https://nushell.sh/book/configuration.html#remove-welcome-message

It's been this long since Nushell's first commit:
3yr 10month 3wk 3day 15hr 8min 368ms 488µs 475ns

Startup Time: 129ms 949µs 70ns
```
> **Note**
> see how it does NOT crash `nushell`, simply does not load these commands :ok_hand: 


# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`

# After Submitting
this will make the annoucement of the standard library possible!
we will be able to land #8406 and #8415 and #8611 when we want :ok_hand: 