### PR TITLE
feature: add the standard library tests to the PR template and the toolkit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ Make sure you've run and fixed any issues with these commands:
 - `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
 - `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
 - `cargo test --workspace` to check that all tests pass
+- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library
 
 > **Note**
 > from `nushell` you can also use the `toolkit` as follows

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -35,6 +35,11 @@ export def test [
     }
 }
 
+# run the tests for the standard library
+export def "test stdlib" [] {
+    cargo run -- crates/nu-utils/standard_library/tests.nu
+}
+
 # print the pipe input inside backticks, dimmed and italic, as a pretty command
 def pretty-print-command [] {
     $"`(ansi default_dimmed)(ansi default_italic)($in)(ansi reset)`"


### PR DESCRIPTION
Related to #8525.

# Description
With #8525, the tests for the standard library have been enabled in the CI.
The only places where these tests are missing are
- the PR template
- the toolkit

This PR adds
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to the PR template
- the same command as `toolkit test stdlib`
- the `test stdlib` command to `toolkit check pr`

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
the new output of `toolkit check pr`, with the same color code:
> - :green_circle: `toolkit fmt`
> - :green_circle: `toolkit clippy`
> - :green_circle: `toolkit test`
> - :green_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```