### PR TITLE
Require that values that look like numbers parse as numberlike

### DIFF
--- a/crates/nu-command/src/bits/not.rs
+++ b/crates/nu-command/src/bits/not.rs
@@ -90,7 +90,7 @@ impl Command for SubCommand {
             Example {
                 description:
                     "Apply logical negation to a list of numbers, treat input as 2 bytes number",
-                example: "[4 3 2] | bits not -n 2",
+                example: "[4 3 2] | bits not -n '2'",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_int(65531),

--- a/crates/nu-command/src/bits/rotate_right.rs
+++ b/crates/nu-command/src/bits/rotate_right.rs
@@ -85,7 +85,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Rotate right a list of numbers of one byte",
-                example: "[15 33 92] | bits ror 2 -n 1",
+                example: "[15 33 92] | bits ror 2 -n '1'",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_int(195),

--- a/crates/nu-command/src/bits/shift_left.rs
+++ b/crates/nu-command/src/bits/shift_left.rs
@@ -85,7 +85,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Shift left a number with 1 byte by 7 bits",
-                example: "2 | bits shl 7 -n 1",
+                example: "2 | bits shl 7 -n '1'",
                 result: Some(Value::test_int(0)),
             },
             Example {

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -105,7 +105,7 @@ impl Command for Fill {
             Example {
                 description:
                     "Fill a number on the left side to a width of 5 with the character '0'",
-                example: "1 | fill --alignment right --character 0 --width 5",
+                example: "1 | fill --alignment right --character '0' --width 5",
                 result: Some(Value::String {
                     val: "00001".into(),
                     span: Span::test_data(),
@@ -113,7 +113,7 @@ impl Command for Fill {
             },
             Example {
                 description: "Fill a number on both sides to a width of 5 with the character '0'",
-                example: "1.1 | fill --alignment center --character 0 --width 5",
+                example: "1.1 | fill --alignment center --character '0' --width 5",
                 result: Some(Value::String {
                     val: "01.10".into(),
                     span: Span::test_data(),
@@ -122,7 +122,7 @@ impl Command for Fill {
             Example {
                 description:
                     "Fill a filesize on the left side to a width of 5 with the character '0'",
-                example: "1kib | fill --alignment middle --character 0 --width 10",
+                example: "1kib | fill --alignment middle --character '0' --width 10",
                 result: Some(Value::String {
                     val: "0001024000".into(),
                     span: Span::test_data(),

--- a/crates/nu-command/src/debug/debug_.rs
+++ b/crates/nu-command/src/debug/debug_.rs
@@ -76,7 +76,8 @@ impl Command for Debug {
             },
             Example {
                 description: "Debug print a table",
-                example: "[[version patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | debug",
+                example:
+                    "[[version patch]; ['0.1.0' false] ['0.1.1' true] ['0.2.0' false]] | debug",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_string("{version: 0.1.0, patch: false}"),

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -119,7 +119,7 @@ impl Command for Find {
             },
             Example {
                 description: "Find value in records",
-                example: r#"[[version name]; [0.1.0 nushell] [0.1.1 fish] [0.2.0 zsh]] | find -r "nu""#,
+                example: r#"[[version name]; ['0.1.0' nushell] ['0.1.1' fish] ['0.2.0' zsh]] | find -r "nu""#,
                 result: Some(Value::List {
                     vals: vec![Value::test_record(
                         vec!["version", "name"],

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -197,7 +197,7 @@ impl Command for Char {
             },
             Example {
                 description: "Output Unicode character",
-                example: r#"char -u 1f378"#,
+                example: r#"char -u '1f378'"#,
                 result: Some(Value::test_string("\u{1f378}")),
             },
             Example {
@@ -207,7 +207,7 @@ impl Command for Char {
             },
             Example {
                 description: "Output multi-byte Unicode character",
-                example: r#"char -u 1F468 200D 1F466 200D 1F466"#,
+                example: r#"char -u '1F468' '200D' '1F466' '200D' '1F466'"#,
                 result: Some(Value::test_string(
                     "\u{1F468}\u{200D}\u{1F466}\u{200D}\u{1F466}",
                 )),

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -160,7 +160,7 @@ prints out the list properly."#
             },
             Example {
                 description: "Render a table with 'name' column in it to a grid",
-                example: "[[name patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | grid",
+                example: "[[name patch]; ['0.1.0' false] ['0.1.1' true] ['0.2.0' false]] | grid",
                 result: Some(Value::test_string("0.1.0 │ 0.1.1 │ 0.2.0\n")),
             },
         ]

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -44,10 +44,10 @@ fn checks_all_columns_of_a_table_is_true() {
         r#"
                 echo [
                         [  first_name, last_name,   rusty_at, likes  ];
-                        [      Andrés,  Robalino, 10/11/2013,   1    ]
-                        [    JT,    Turner, 10/12/2013,   1    ]
-                        [      Darren, Schroeder, 10/11/2013,   1    ]
-                        [      Yehuda,      Katz, 10/11/2013,   1    ]
+                        [      Andrés,  Robalino, '10/11/2013',   1    ]
+                        [    JT,    Turner, '10/12/2013',   1    ]
+                        [      Darren, Schroeder, '10/11/2013',   1    ]
+                        [      Yehuda,      Katz, '10/11/2013',   1    ]
                 ]
                 | all {|x| $x.likes > 0 }
         "#

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -20,12 +20,12 @@ fn checks_any_column_of_a_table_is_true() {
         r#"
                 echo [
                         [  first_name, last_name,   rusty_at, likes  ];
-                        [      Andrés,  Robalino, 10/11/2013,   1    ]
-                        [    JT,    Turner, 10/12/2013,   1    ]
-                        [      Darren, Schroeder, 10/11/2013,   1    ]
-                        [      Yehuda,      Katz, 10/11/2013,   1    ]
+                        [      Andrés,  Robalino, '10/11/2013',   1    ]
+                        [    JT,    Turner, '10/12/2013',   1    ]
+                        [      Darren, Schroeder, '10/11/2013',   1    ]
+                        [      Yehuda,      Katz, '10/11/2013',   1    ]
                 ]
-                | any {|x| $x.rusty_at == 10/12/2013 }
+                | any {|x| $x.rusty_at == '10/12/2013' }
         "#
     ));
 

--- a/crates/nu-command/tests/commands/cal.rs
+++ b/crates/nu-command/tests/commands/cal.rs
@@ -33,7 +33,7 @@ fn cal_friday_the_thirteenths_in_2015() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        cal --full-year 2015 | default friday 0 | where friday == 13 | length
+        cal --full-year 2015 | default friday '0' | where friday == 13 | length
         "#
     ));
 

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -367,7 +367,7 @@ fn does_not_error_when_some_file_is_moving_into_itself() {
 
         let original_dir = dirs.test().join("11");
         let expected = dirs.test().join("12/11");
-        nu!(cwd: dirs.test(), "mv 1* 12");
+        nu!(cwd: dirs.test(), "mv `1*` `12`");
 
         assert!(!original_dir.exists());
         assert!(expected.exists());

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -7,9 +7,9 @@ fn regular_columns() {
             echo [
                 [first_name, last_name, rusty_at, type];
 
-                [Andrés Robalino 10/11/2013 A]
-                [JT Turner 10/12/2013 B]
-                [Yehuda Katz 10/11/2013 A]
+                [Andrés Robalino '10/11/2013' A]
+                [JT Turner '10/12/2013' B]
+                [Yehuda Katz '10/11/2013' A]
             ]
             | reject type first_name
             | columns

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -219,7 +219,7 @@ fn external_command_expand_tilde_with_back_quotes() {
         "external command not expand tilde with quotes",
         |dirs, _| {
             let actual = nu!(cwd: dirs.test(), pipeline(r#"nu --testbin nonu `~`"#));
-            assert!(!actual.out.contains("~"));
+            assert!(!actual.out.contains('~'));
         },
     )
 }

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -9,9 +9,9 @@ fn regular_columns() {
             echo [
                 [first_name, last_name, rusty_at, type];
 
-                [Andrés Robalino 10/11/2013 A]
-                [JT Turner 10/12/2013 B]
-                [Yehuda Katz 10/11/2013 A]
+                [Andrés Robalino '10/11/2013' A]
+                [JT Turner '10/12/2013' B]
+                [Yehuda Katz '10/11/2013' A]
             ]
             | select rusty_at last_name
             | get 0
@@ -72,9 +72,9 @@ fn fails_if_given_unknown_column_name() {
             echo [
                 [first_name, last_name, rusty_at, type];
 
-                [Andrés Robalino 10/11/2013 A]
-                [JT Turner 10/12/2013 B]
-                [Yehuda Katz 10/11/2013 A]
+                [Andrés Robalino '10/11/2013' A]
+                [JT Turner '10/12/2013' B]
+                [Yehuda Katz '10/11/2013' A]
             ]
             | select rrusty_at first_name
             | length

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -234,7 +234,7 @@ fn substrings_the_input() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring 6,14 fortune.teller.phone
+                 | str substring '6,14' fortune.teller.phone
                  | get fortune.teller.phone
              "#
         ));
@@ -258,7 +258,7 @@ fn substring_errors_if_start_index_is_greater_than_end_index() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring 6,5 fortune.teller.phone
+                 | str substring '6,5' fortune.teller.phone
              "#
         ));
 
@@ -283,7 +283,7 @@ fn substrings_the_input_and_returns_the_string_if_end_index_exceeds_length() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring 0,999 package.name
+                 | str substring '0,999' package.name
                  | get package.name
              "#
         ));
@@ -307,7 +307,7 @@ fn substrings_the_input_and_returns_blank_if_start_index_exceeds_length() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring 50,999 package.name
+                 | str substring '50,999' package.name
                  | get package.name
              "#
         ));
@@ -331,7 +331,7 @@ fn substrings_the_input_and_treats_start_index_as_zero_if_blank_start_index_give
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring ,2 package.name
+                 | str substring ',2' package.name
                  | get package.name
              "#
         ));
@@ -355,7 +355,7 @@ fn substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given(
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring 3, package.name
+                 | str substring '3,' package.name
                  | get package.name
              "#
         ));

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -194,7 +194,7 @@ pub fn multi_test_parse_int() {
         ),
         Test(
             "semver data not confused for int",
-            b"1.0.1",
+            b"'1.0.1'",
             Expr::String("1.0.1".into()),
             None,
         ),


### PR DESCRIPTION
# Description

Require that any value that looks like it might be a number (starts with a digit, or a '-' + digit, or a '+' + digits, or a special form float like `-inf`, `inf`, or `NaN` must now be treated as a number-like value. Number-like syntax can only parse into number-like values. Number-like values include: durations, ints, floats, ranges, filesizes, binary data, etc.

# User-Facing Changes

BREAKING CHANGE
BREAKING CHANGE
BREAKING CHANGE
BREAKING CHANGE
BREAKING CHANGE
BREAKING CHANGE
BREAKING CHANGE
BREAKING CHANGE

Just making sure we see this for release notes 😅 

This breaks any and all numberlike values that were treated as strings before. Example, we used to allow `3,` as a bare word.  Anything like this would now require quotes or backticks to be treated as a string or bare word, respectively.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
