### PR TITLE
Improve number-like error if expecting a string

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1761,6 +1761,10 @@ pub fn parse_numberlike_expr(
         SyntaxShape::Filesize => parse_filesize(working_set, span),
         SyntaxShape::Range => parse_range(working_set, span, expand_aliases_denylist),
         SyntaxShape::CellPath => parse_simple_cell_path(working_set, span, expand_aliases_denylist),
+        SyntaxShape::String => (
+            garbage(span),
+            Some(ParseError::Expected("string".into(), span)),
+        ),
         SyntaxShape::Any => {
             if bytes == b"0b" {
                 // FIXME: having to work around this filesize that also looks like a binary value


### PR DESCRIPTION
# Description

This should give a slightly better error if a position expects a string and the user writes a number-like value.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
