### PR TITLE
Loops return external stream when external command failed.

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -122,7 +122,9 @@ impl Command for For {
                         Ok(pipeline) => {
                             let exit_code = pipeline.print(&engine_state, stack, false, false)?;
                             if exit_code != 0 {
-                                break;
+                                return Ok(PipelineData::new_external_stream_with_only_exit_code(
+                                    exit_code,
+                                ));
                             }
                         }
                     }

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -164,7 +164,9 @@ impl Command for For {
                         Ok(pipeline) => {
                             let exit_code = pipeline.drain_with_exit_code()?;
                             if exit_code != 0 {
-                                break;
+                                return Ok(PipelineData::new_external_stream_with_only_exit_code(
+                                    exit_code,
+                                ));
                             }
                         }
                     }

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -69,7 +69,9 @@ impl Command for Loop {
                 Ok(pipeline) => {
                     let exit_code = pipeline.drain_with_exit_code()?;
                     if exit_code != 0 {
-                        break;
+                        return Ok(PipelineData::new_external_stream_with_only_exit_code(
+                            exit_code,
+                        ));
                     }
                 }
             }

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -79,7 +79,11 @@ impl Command for While {
                             Ok(pipeline) => {
                                 let exit_code = pipeline.drain_with_exit_code()?;
                                 if exit_code != 0 {
-                                    break;
+                                    return Ok(
+                                        PipelineData::new_external_stream_with_only_exit_code(
+                                            exit_code,
+                                        ),
+                                    );
                                 }
                             }
                         }

--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -40,4 +40,15 @@ fn failed_for_should_break_running() {
         print 3"#
     );
     assert!(!actual.out.contains('3'));
+
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        let x = [1 2]
+        for i in $x {
+            nu --testbin fail
+        }
+        print 3"#
+    );
+    assert!(!actual.out.contains('3'));
 }

--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -28,3 +28,16 @@ fn for_break_on_external_failed() {
     // so our output will be `1`
     assert_eq!(actual.out, "1");
 }
+
+#[test]
+fn failed_for_should_break_running() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        for i in 1..2 {
+            nu --testbin fail
+        }
+        print 3"#
+    );
+    assert!(!actual.out.contains('3'));
+}

--- a/crates/nu-command/tests/commands/loop_.rs
+++ b/crates/nu-command/tests/commands/loop_.rs
@@ -40,3 +40,22 @@ fn loop_break_on_external_failed() {
     // so our output will be `1`.
     assert_eq!(actual.out, "1");
 }
+
+#[test]
+fn failed_loop_should_break_running() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+        mut total = 0;
+        loop {
+            if $total == 3 {
+                break;
+            } else {
+                $total += 1;
+            }
+            nu --testbin fail;
+        }
+        print 3"#
+    );
+    assert!(!actual.out.contains('3'));
+}

--- a/crates/nu-command/tests/commands/while_.rs
+++ b/crates/nu-command/tests/commands/while_.rs
@@ -31,3 +31,12 @@ fn while_break_on_external_failed() {
     // so our output will be `1`
     assert_eq!(actual.out, "1");
 }
+
+#[test]
+fn failed_while_should_break_running() {
+    let actual = nu!(
+        cwd: ".",
+        "mut total = 0; while $total < 2 { $total = $total + 1; nu --testbin fail }; print 3"
+    );
+    assert!(!actual.out.contains('3'));
+}

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -72,6 +72,23 @@ impl PipelineData {
         PipelineData::Value(Value::Nothing { span }, metadata)
     }
 
+    /// create a `PipelineData::ExternalStream` with proper exit_code
+    ///
+    /// It's useful to break running without raising error at user level.
+    pub fn new_external_stream_with_only_exit_code(exit_code: i64) -> PipelineData {
+        PipelineData::ExternalStream {
+            stdout: None,
+            stderr: None,
+            exit_code: Some(ListStream::from_stream(
+                [Value::int(exit_code, Span::unknown())].into_iter(),
+                None,
+            )),
+            span: Span::unknown(),
+            metadata: None,
+            trim_end_newline: false,
+        }
+    }
+
     pub fn empty() -> PipelineData {
         PipelineData::Empty
     }


### PR DESCRIPTION
# Description

Fixes: #8644

# User-Facing Changes

For the following code:
```
for i in 1..2 {
    nu --testbin fail
}
print 3
```
Before this change, nu will print 3.  After this change, 3 won't be printed

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
