### PR TITLE
Improve inferred record types and type compat

### DIFF
--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -307,7 +307,7 @@ pub enum ParseError {
 
     #[error("Type mismatch.")]
     #[diagnostic(code(nu::parser::type_mismatch))]
-    TypeMismatch(Type, Type, #[label("expected {0:?}, found {1:?}")] Span), // expected, found, span
+    TypeMismatch(Type, Type, #[label("expected {0}, found {1}")] Span), // expected, found, span
 
     #[error("Missing required flag.")]
     #[diagnostic(code(nu::parser::missing_required_flag))]

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -13,6 +13,22 @@ pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
         (Type::Closure, Type::Block) => true,
         (Type::Any, _) => true,
         (_, Type::Any) => true,
+        (Type::Record(fields_lhs), Type::Record(fields_rhs)) => {
+            // Structural subtyping
+            'outer: for field_lhs in fields_lhs {
+                for field_rhs in fields_rhs {
+                    if field_lhs.0 == field_rhs.0 {
+                        if type_compatible(&field_lhs.1, &field_rhs.1) {
+                            continue 'outer;
+                        } else {
+                            return false;
+                        }
+                    }
+                }
+                return false;
+            }
+            true
+        }
         (lhs, rhs) => lhs == rhs,
     }
 }

--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -21,6 +21,11 @@ fn number_int() -> TestResult {
 }
 
 #[test]
+fn int_record_mismatch() -> TestResult {
+    fail_test(r#"def foo [x:int] { $x }; foo {}"#, "expected int")
+}
+
+#[test]
 fn number_float() -> TestResult {
     run_test(r#"def foo [x:number] { $x }; foo 1.4"#, "1.4")
 }


### PR DESCRIPTION
# Description

This allows for type inference to infer record types in more cases. The only time we will now fall back to `Any` is when one of the fields has a computed value.

I also updated the type mismatch error and highlighting to be in-line with other errors.

# User-Facing Changes

This may result in stricter type checking. Previously `{}` had the inferred type `Any` but will now have the correct inferred type of `Record<>`. 

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
