### PR TITLE
stdlib: fix the `assert equal` tests

### DIFF
--- a/crates/nu-utils/standard_library/test_asserts.nu
+++ b/crates/nu-utils/standard_library/test_asserts.nu
@@ -11,13 +11,13 @@ export def test_assert_equal [] {
     assert equal (1 + 2) 3
     assert equal (0.1 + 0.2 | into string | into decimal) 0.3 # 0.30000000000000004 == 0.3
     assert error { assert equal 1 "foo" }
-    assert error { assert equal (1 + 2) "4)" }
+    assert error { assert equal (1 + 2) 4 }
 }
 
 export def test_assert_not_equal [] {
     assert not equal (1 + 2) 4
     assert not equal 1 "foo"
-    assert not equal (1 + 2) "3)"
+    assert not equal (1 + 2) "3"
     assert error { assert not equal 1 1 }
 }
 


### PR DESCRIPTION
Related to #8150, #8635 and #8632.

# Description
i've introduced a bad set of tests for the `assert equal` command in #8150...

they should not compare `1 + 2` and `4)` or `3)` but the ints.

in this PR, i remove this spurious parentheses that were not planned at all :grimacing: :eyes: 


# User-Facing Changes
```
$nothing
```

# Tests + Formatting
```
>_ nu crates/nu-utils/standard_library/tests.nu
INF|2023-03-28T20:18:13.022|Running tests in test_asserts
INF|2023-03-28T20:18:13.173|Running tests in test_dirs
INF|2023-03-28T20:18:13.247|Running tests in test_logger
INF|2023-03-28T20:18:13.473|Running tests in test_std
```

# After Submitting
```
$nothing
```