### PR TITLE
move 'str substring' to only use ranges

### DIFF
--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -234,7 +234,7 @@ fn substrings_the_input() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring '6,14' fortune.teller.phone
+                 | str substring 6..14 fortune.teller.phone
                  | get fortune.teller.phone
              "#
         ));
@@ -258,7 +258,7 @@ fn substring_errors_if_start_index_is_greater_than_end_index() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring '6,5' fortune.teller.phone
+                 | str substring 6..5 fortune.teller.phone
              "#
         ));
 
@@ -283,7 +283,7 @@ fn substrings_the_input_and_returns_the_string_if_end_index_exceeds_length() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring '0,999' package.name
+                 | str substring 0..999 package.name
                  | get package.name
              "#
         ));
@@ -307,7 +307,7 @@ fn substrings_the_input_and_returns_blank_if_start_index_exceeds_length() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring '50,999' package.name
+                 | str substring 50..999 package.name
                  | get package.name
              "#
         ));
@@ -331,7 +331,7 @@ fn substrings_the_input_and_treats_start_index_as_zero_if_blank_start_index_give
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring ',2' package.name
+                 | str substring ..2 package.name
                  | get package.name
              "#
         ));
@@ -355,7 +355,7 @@ fn substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given(
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring '3,' package.name
+                 | str substring 3.. package.name
                  | get package.name
              "#
         ));

--- a/src/tests/test_strings.rs
+++ b/src/tests/test_strings.rs
@@ -3,7 +3,7 @@ use crate::tests::{fail_test, run_test, TestResult};
 #[test]
 fn cjk_in_substrings() -> TestResult {
     run_test(
-        r#"let s = '[Rust 程序设计语言](title-page.md)'; let start = ($s | str index-of '('); let end = ($s | str index-of ')'); echo ($s | str substring $"($start + 1),($end)")"#,
+        r#"let s = '[Rust 程序设计语言](title-page.md)'; let start = ($s | str index-of '('); let end = ($s | str index-of ')'); $s | str substring ($start + 1)..($end)"#,
         "title-page.md",
     )
 }


### PR DESCRIPTION
# Description

This removes all the old style of quasi-ranges before we had full range support from `str substring`. Functionality should otherwise work, but only with the official range syntax.

# User-Facing Changes

Removes the array and string forms of ranges from `str substring`. Leaves only the official range support for range values.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
