### PR TITLE
Fix record-to-JSON conversion for HTTP commands

### DIFF
--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -76,3 +76,21 @@ fn http_post_failed_due_to_unexpected_body() {
 
     assert!(actual.err.contains("Cannot make request"))
 }
+
+#[test]
+fn http_post_json_is_success() {
+    let mut server = Server::new();
+
+    let mock = server
+        .mock("POST", "/")
+        .match_body(r#"{"foo":"bar"}"#)
+        .create();
+
+    let actual = nu!(format!(
+        r#"http post -t 'application/json' {url} {{foo: 'bar'}}"#,
+        url = server.url()
+    ));
+
+    mock.assert();
+    assert!(actual.out.is_empty())
+}


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/nushell/nushell/pull/8571. 

We were accidentally converting a `Result<Value, ShellError>` to JSON instead of converting a `Value`. The upshot was that we were sending JSON like `{"Ok":{"foo":"bar"}}` instead of `{"foo":"bar"}`.

This was an easy bug to miss, because `ureq::send_json()` accepts any `impl serde::Serialize`. I've added a test to prevent regression.