### PR TITLE
DRAFT: Record and list shape updates

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -16,7 +16,11 @@ impl Command for ErrorMake {
     fn signature(&self) -> Signature {
         Signature::build("error make")
             .input_output_types(vec![(Type::Nothing, Type::Error)])
-            .required("error_struct", SyntaxShape::Record, "the error to create")
+            .required(
+                "error_struct",
+                SyntaxShape::Record(vec![]),
+                "the error to create",
+            )
             .switch(
                 "unspanned",
                 "remove the origin label from the error",

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -23,7 +23,7 @@ impl Command for LoadEnv {
             .allow_variants_without_examples(true)
             .optional(
                 "update",
-                SyntaxShape::Record,
+                SyntaxShape::Record(vec![]),
                 "the record to use for updates",
             )
             .category(Category::FileSystem)

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -155,7 +155,7 @@ fn def_with_list() {
     Playground::setup("def_with_list", |dirs, _| {
         let data = r#"
 def e [
-param: list
+param: [any]
 ] {echo $param};
             "#;
         fs::write(dirs.root().join("def_test"), data).expect("Unable to write file");
@@ -173,7 +173,7 @@ fn def_with_default_list() {
     Playground::setup("def_with_default_list", |dirs, _| {
         let data = r#"
 def f [
-param: list = [one]
+param: [string] = [one]
 ] {echo $param};
             "#;
         fs::write(dirs.root().join("def_test"), data).expect("Unable to write file");

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -77,7 +77,7 @@ fn gets_first_row_as_list_when_amount_given() {
             "#
     ));
 
-    assert_eq!(actual.out, "list<int> (stream)");
+    assert_eq!(actual.out, "[int] (stream)");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -76,7 +76,7 @@ fn gets_last_row_as_list_when_amount_given() {
             "#
     ));
 
-    assert_eq!(actual.out, "list<int> (stream)");
+    assert_eq!(actual.out, "[int] (stream)");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/seq.rs
+++ b/crates/nu-command/tests/commands/seq.rs
@@ -9,7 +9,7 @@ fn float_in_seq_leads_to_lists_of_floats() {
         "#
     ));
 
-    assert_eq!(actual.out, "list<float> (stream)");
+    assert_eq!(actual.out, "[float] (stream)");
 }
 
 #[test]
@@ -21,5 +21,5 @@ fn ints_in_seq_leads_to_lists_of_ints() {
         "#
     ));
 
-    assert_eq!(actual.out, "list<int> (stream)");
+    assert_eq!(actual.out, "[int] (stream)");
 }

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -493,7 +493,7 @@ fn quotes_some_strings_necessarily() {
         "#
     ));
 
-    assert_eq!(actual.out, "list<string>");
+    assert_eq!(actual.out, "[string]");
 }
 
 #[test]

--- a/crates/nu-parser/tests/test_lex.rs
+++ b/crates/nu-parser/tests/test_lex.rs
@@ -24,7 +24,7 @@ fn lex_newline() {
 
 #[test]
 fn lex_annotations_list() {
-    let file = b"items: list<string>";
+    let file = b"items: [string]";
 
     let (output, err) = lex_signature(file, 0, &[b'\n', b'\r'], &[b':', b'=', b','], false);
 
@@ -34,7 +34,7 @@ fn lex_annotations_list() {
 
 #[test]
 fn lex_annotations_record() {
-    let file = b"config: record<name: string>";
+    let file = b"config: {name: string}";
 
     let (output, err) = lex_signature(file, 0, &[b'\n', b'\r'], &[b':', b'=', b','], false);
 
@@ -44,7 +44,7 @@ fn lex_annotations_record() {
 
 #[test]
 fn lex_annotations_empty() {
-    let file = b"items: list<>";
+    let file = b"items: []";
 
     let (output, err) = lex_signature(file, 0, &[b'\n', b'\r'], &[b':', b'=', b','], false);
 
@@ -88,7 +88,7 @@ fn lex_annotations_space_within_annotations() {
 
 #[test]
 fn lex_annotations_nested() {
-    let file = b"items: list<record<name: string>>";
+    let file = b"items: [{name: string}]";
 
     let (output, err) = lex_signature(file, 0, &[b'\n', b'\r'], &[b':', b'=', b','], false);
 
@@ -98,7 +98,7 @@ fn lex_annotations_nested() {
 
 #[test]
 fn lex_annotations_nested_unterminated() {
-    let file = b"items: list<record<name: string>";
+    let file = b"items: [{name: string}]";
 
     let (output, err) = lex_signature(file, 0, &[b'\n', b'\r'], &[b':', b'=', b','], false);
 

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -155,7 +155,7 @@ impl Display for Type {
                 } else {
                     write!(
                         f,
-                        "record<{}>",
+                        "{{{}}}",
                         fields
                             .iter()
                             .map(|(x, y)| format!("{x}: {y}"))
@@ -179,7 +179,7 @@ impl Display for Type {
                     )
                 }
             }
-            Type::List(l) => write!(f, "list<{l}>"),
+            Type::List(l) => write!(f, "[{l}]"),
             Type::Nothing => write!(f, "nothing"),
             Type::Number => write!(f, "number"),
             Type::String => write!(f, "string"),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -87,7 +87,13 @@ impl Type {
             Type::List(x) => SyntaxShape::List(Box::new(x.to_shape())),
             Type::Number => SyntaxShape::Number,
             Type::Nothing => SyntaxShape::Nothing,
-            Type::Record(_) => SyntaxShape::Record,
+            Type::Record(fields) => {
+                let mut shape_fields = vec![];
+                for field in fields {
+                    shape_fields.push((field.0.clone(), field.1.to_shape()));
+                }
+                SyntaxShape::Record(shape_fields)
+            }
             Type::Table(_) => SyntaxShape::Table,
             Type::ListStream => SyntaxShape::List(Box::new(SyntaxShape::Any)),
             Type::Any => SyntaxShape::Any,

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -2,7 +2,7 @@ use std.nu *
 
 # show a test record in a pretty way
 #
-# `$in` must be a `record<file: string, module: string, name: string, pass: bool>`.
+# `$in` must be a `{file: string, module: string, name: string, pass: bool}`.
 #
 # the output would be like
 # - "<indentation> x <module> <test>" all in red if failed

--- a/src/tests/test_signatures.rs
+++ b/src/tests/test_signatures.rs
@@ -2,133 +2,126 @@ use crate::tests::{fail_test, run_test, TestResult};
 
 #[test]
 fn list_annotations() -> TestResult {
-    let input = "def run [list: list<int>] {$list | length}; run [2 5 4]";
+    let input = "def run [list: [int]] {$list | length}; run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_unknown_prefix() -> TestResult {
-    let input = "def run [list: listint>] {$list | length}; run [2 5 4]";
+    let input = "def run [list: int]] {$list | length}; run [2 5 4]";
     let expected = "unknown type";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_empty_1() -> TestResult {
-    let input = "def run [list: list] {$list | length}; run [2 5 4]";
+    let input = "def run [list: []] {$list | length}; run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_empty_2() -> TestResult {
-    let input = "def run [list: list<>] {$list | length}; run [2 5 4]";
+    let input = "def run [list: []] {$list | length}; run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_empty_3() -> TestResult {
-    let input = "def run [list: list< >] {$list | length}; run [2 5 4]";
+    let input = "def run [list: [ ]] {$list | length}; run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_empty_4() -> TestResult {
-    let input = "def run [list: list<\n>] {$list | length}; run [2 5 4]";
+    let input = "def run [list: [\n]] {$list | length}; run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_nested() -> TestResult {
-    let input = "def run [list: list<list<float>>] {$list | length}; run [ [2.0] [5.0] [4.0]]";
+    let input = "def run [list: [[float]]] {$list | length}; run [ [2.0] [5.0] [4.0]]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_unknown_inner_type() -> TestResult {
-    let input = "def run [list: list<str>] {$list | length}; run ['nushell' 'nunu' 'nana']";
+    let input = "def run [list: [str]] {$list | length}; run ['nushell' 'nunu' 'nana']";
     let expected = "unknown type";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_nested_unknown_inner() -> TestResult {
-    let input = "def run [list: list<list<str>>] {$list | length}; run [ [nushell] [nunu] [nana]]";
+    let input = "def run [list: [[str]]] {$list | length}; run [ [nushell] [nunu] [nana]]";
     let expected = "unknown type";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_unterminated() -> TestResult {
-    let input = "def run [list: list<string] {$list | length}; run [nu she ll]";
-    let expected = "expected closing >";
+    let input = "def run [list: [string] {$list | length}; run [nu she ll]";
+    let expected = "eof";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_nested_unterminated() -> TestResult {
-    let input = "def run [list: list<list<>] {$list | length}; run [2 5 4]";
-    let expected = "expected closing >";
+    let input = "def run [list: [[]] {$list | length}; run [2 5 4]";
+    let expected = "eof";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_space_within_1() -> TestResult {
-    let input = "def run [list: list< range>] {$list | length}; run [2..32 5..<64 4..128]";
+    let input = "def run [list: [ range]] {$list | length}; run [2..32 5..<64 4..128]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_space_within_2() -> TestResult {
-    let input = "def run [list: list<number >] {$list | length}; run [2 5 4]";
+    let input = "def run [list: [number ]] {$list | length}; run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_space_within_3() -> TestResult {
-    let input = "def run [list: list< int >] {$list | length}; run [2 5 4]";
+    let input = "def run [list: [ int ]] {$list | length}; run [2 5 4]";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
-fn list_annotations_space_before() -> TestResult {
-    let input = "def run [list: list <int>] {$list | length}; run [2 5 4]";
-    let expected = "expected valid variable name for this parameter";
-    fail_test(input, expected)
-}
-
-#[test]
 fn list_annotations_unknown_separators() -> TestResult {
-    let input = "def run [list: list<int, string>] {$list | length}; run [2 5 4]";
+    let input = "def run [list: [int, string]] {$list | length}; run [2 5 4]";
     let expected = "unknown type";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_with_default_val_1() -> TestResult {
-    let input = "def run [list: list<int> = [2 5 4]] {$list | length}; run";
+    let input = "def run [list: [int] = [2 5 4]] {$list | length}; run";
     let expected = "3";
     run_test(input, expected)
 }
 
 #[test]
 fn list_annotations_with_default_val_2() -> TestResult {
-    let input = "def run [list: list<string> = [2 5 4]] {$list | length}; run";
+    let input = "def run [list: [string] = [2 5 4]] {$list | length}; run";
     let expected = "Default value wrong type";
     fail_test(input, expected)
 }
 
 #[test]
 fn list_annotations_with_extra_characters() -> TestResult {
-    let input = "def run [list: list<int>extra] {$list | length}; run [1 2 3]";
-    let expected = "Extra characters in the parameter name";
+    let input = "def run [list: [int]extra] {$list | length}; run [1 2 3]";
+    let expected = "unknown type";
     fail_test(input, expected)
 }

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -51,7 +51,7 @@ fn const_list() {
 
     let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
 
-    assert_eq!(actual.out, "list<string>");
+    assert_eq!(actual.out, "[string]");
 }
 
 #[test]
@@ -60,7 +60,7 @@ fn const_record() {
 
     let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
 
-    assert_eq!(actual.out, "record<a: int, b: int, c: int>");
+    assert_eq!(actual.out, "{a: int, b: int, c: int}");
 }
 
 #[test]


### PR DESCRIPTION
# Description

This updates the list shape from `list<int>` to `[int]`

And also updates the record shape from `record` to `{x: int}` (as one example)

**update:** in the design meeting today, we talked about this as another possible syntax:

`list(int)`, `record(field: type)`, and `table(field: type)`

# User-Facing Changes

Breaks the shape names for records and lists.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
