### PR TITLE
Support passing an empty list to sort, uniq, sort-by, and uniq-by (issue #5957)

### DIFF
--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -271,22 +271,12 @@ pub fn sort(
     insensitive: bool,
     natural: bool,
 ) -> Result<(), ShellError> {
-    if vec.is_empty() {
-        return Err(ShellError::GenericError(
-            "no values to work with".to_string(),
-            "".to_string(),
-            None,
-            Some("no values to work with".to_string()),
-            Vec::new(),
-        ));
-    }
-
-    match &vec[0] {
-        Value::Record {
+    match vec.first() {
+        Some(Value::Record {
             cols,
             vals: _input_vals,
             ..
-        } => {
+        }) => {
             let columns = cols.clone();
             vec.sort_by(|a, b| process(a, b, &columns, span, insensitive, natural));
         }

--- a/crates/nu-command/src/filters/uniq_by.rs
+++ b/crates/nu-command/src/filters/uniq_by.rs
@@ -107,21 +107,11 @@ impl Command for UniqBy {
 }
 
 fn validate(vec: Vec<Value>, columns: &Vec<String>, span: Span) -> Result<(), ShellError> {
-    if vec.is_empty() {
-        return Err(ShellError::GenericError(
-            "no values to work with".to_string(),
-            "".to_string(),
-            None,
-            Some("no values to work with".to_string()),
-            Vec::new(),
-        ));
-    }
-
-    if let Value::Record {
+    if let Some(Value::Record {
         cols,
         vals: _input_vals,
         span: val_span,
-    } = &vec[0]
+    }) = vec.first()
     {
         if columns.is_empty() {
             // This uses the same format as the 'requires a column name' error in split_by.rs

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -61,22 +61,12 @@ pub fn sort(
     insensitive: bool,
     natural: bool,
 ) -> Result<(), ShellError> {
-    if vec.is_empty() {
-        return Err(ShellError::GenericError(
-            "no values to work with".to_string(),
-            "".to_string(),
-            None,
-            Some("no values to work with".to_string()),
-            Vec::new(),
-        ));
-    }
-
-    match &vec[0] {
-        Value::Record {
+    match vec.first() {
+        Some(Value::Record {
             cols,
             vals: _input_vals,
             span: val_span,
-        } => {
+        }) => {
             if sort_columns.is_empty() {
                 // This uses the same format as the 'requires a column name' error in split_by.rs
                 return Err(ShellError::GenericError(

--- a/crates/nu-command/tests/commands/sort.rs
+++ b/crates/nu-command/tests/commands/sort.rs
@@ -121,13 +121,7 @@ fn sort_record_values_insensitive_reverse() {
 
 #[test]
 fn sort_empty() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [] | sort
-            | to json --raw
-        "#
-    ));
+    let actual = nu!("[] | sort | to nuon");
 
     assert_eq!(actual.out, "[]");
 }

--- a/crates/nu-command/tests/commands/sort.rs
+++ b/crates/nu-command/tests/commands/sort.rs
@@ -118,3 +118,16 @@ fn sort_record_values_insensitive_reverse() {
 
     assert_eq!(actual.out, r#"{"2": zed, "3": ABE, "1": abe}"#);
 }
+
+#[test]
+fn sort_empty() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [] | sort
+            | to json --raw
+        "#
+    ));
+
+    assert_eq!(actual.out, "[]");
+}

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -45,13 +45,7 @@ fn by_invalid_column() {
 
 #[test]
 fn sort_by_empty() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [] | sort-by foo
-            | to json --raw
-        "#
-    ));
+    let actual = nu!("[] | sort-by foo | to nuon");
 
     assert_eq!(actual.out, "[]");
 }

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -44,6 +44,19 @@ fn by_invalid_column() {
 }
 
 #[test]
+fn sort_by_empty() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [] | sort-by foo
+            | to json --raw
+        "#
+    ));
+
+    assert_eq!(actual.out, "[]");
+}
+
+#[test]
 fn ls_sort_by_name_sensitive() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -62,6 +62,19 @@ fn uniq_values() {
 }
 
 #[test]
+fn uniq_empty() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [] | uniq
+            | to json --raw
+        "#
+    ));
+
+    assert_eq!(actual.out, "[]");
+}
+
+#[test]
 fn nested_json_structures() {
     Playground::setup("uniq_test_3", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -63,13 +63,7 @@ fn uniq_values() {
 
 #[test]
 fn uniq_empty() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [] | uniq
-            | to json --raw
-        "#
-    ));
+    let actual = nu!("[] | uniq | to nuon");
 
     assert_eq!(actual.out, "[]");
 }

--- a/crates/nu-command/tests/commands/uniq_by.rs
+++ b/crates/nu-command/tests/commands/uniq_by.rs
@@ -127,6 +127,19 @@ fn table() {
 }
 
 #[test]
+fn uniq_by_empty() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [] | uniq-by foo
+            | to json --raw
+        "#
+    ));
+
+    assert_eq!(actual.out, "[]");
+}
+
+#[test]
 fn uniq_by_multiple_columns() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/commands/uniq_by.rs
+++ b/crates/nu-command/tests/commands/uniq_by.rs
@@ -128,13 +128,7 @@ fn table() {
 
 #[test]
 fn uniq_by_empty() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [] | uniq-by foo
-            | to json --raw
-        "#
-    ));
+    let actual = nu!("[] | uniq-by foo | to nuon");
 
     assert_eq!(actual.out, "[]");
 }


### PR DESCRIPTION
# Description

Currently, all four of these commands return a (rather-confusing) spanless error when passed an empty list:

```
> [] | sort
Error: 
  × no values to work with
  help: no values to work with
```

This PR changes these commands to always output `[]` if the input is `[]`.

```
> [] | sort
╭────────────╮
│ empty list │
╰────────────╯
> [] | uniq-by foo
╭────────────╮
│ empty list │
╰────────────╯
```

I'm not sure what the original logic was here, but in the case of `sort` and `uniq`, I think the current behavior is straightforwardly wrong.

`sort-by` and `uniq-by` are a bit more complicated, since they currently try to perform some validation that the specified column name is present in the input (see #8667 for problems with this validation, where a possible outcome is removing the validation entirely). When passed `[]`, it's not possible to do any validation because there are no records. This opens up the possibility for situations like the following:

```
> [[foo]; [5] [6]] | where foo < 3 | sort-by bar
╭────────────╮
│ empty list │
╰────────────╯
```

I think there's a strong argument that `[]` is the best output for these commands as well, since it makes pipelines like `$table | filter $condition | sort-by $column` more predictable. Currently, this pipeline will throw an error if `filter` evaluates to `[]`, but work fine otherwise. This makes it difficult to write reliable code, especially since users are not likely to encounter the `filter -> []` case in testing (issue #5957). The only workaround is to insert manual checks for an empty result. IMO, this is significantly worse than the "you can typo a column name without getting an error" problem shown above.

Other commands that take column arguments (`get`, `select`, `rename`, etc) already have `[] -> []`, so there's existing precedent for this behavior.

The core question here is "what columns does `[]` have"? The current behavior of `sort-by` is "no columns", while the current behavior of `select` is "all possible columns". Both answers lead to accepting some likely-buggy code without throwing on error, but in order to do better here we would need something like `Value::Table` that tracks columns on empty tables.

If other people disagree with this logic, I'm happy to split out the `sort-by` and `uniq-by` changes into another PR.

# User-Facing Changes

`sort`, `uniq`, `sort-by`, and `uniq-by` now return `[]` instead of throwing an error when input is `[]`.

# After Submitting

> If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.

The existing behavior was not documented, and the new behavior is what you would expect by default, so I don't think we need to update documentation.
