### PR TITLE
fix `inspect` panic with large tables

### DIFF
--- a/crates/nu-command/src/debug/inspect_table.rs
+++ b/crates/nu-command/src/debug/inspect_table.rs
@@ -23,7 +23,11 @@ pub fn build_table(value: Value, description: String, termsize: usize) -> String
     let mut desc_table = Builder::from(desc).build();
     let desc_table_width = desc_table.total_width();
 
-    let width = val_table_width.clamp(desc_table_width, termsize);
+    let width = if desc_table_width > termsize {
+        val_table_width.clamp(termsize, desc_table_width)
+    } else {
+        val_table_width.clamp(desc_table_width, termsize)
+    };
 
     desc_table
         .with(Style::rounded().off_bottom())


### PR DESCRIPTION
# Description

This PR fixes a small bug where `inspect` was panicking because the data returned was larger than that terminal size.

Closes #8671

# User-Facing Changes

No more panic

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
