### PR TITLE
Remove underflow panic on `[] | inspect`

### DIFF
--- a/crates/nu-command/src/debug/inspect_table.rs
+++ b/crates/nu-command/src/debug/inspect_table.rs
@@ -311,7 +311,7 @@ mod global_horizontal_char {
             let is_last_line = self.line == (shape.0 * 2);
             let mut row = self.line;
             if is_last_line {
-                row = self.line - 1;
+                row = self.line.saturating_sub(1);
             }
 
             let mut evaluator = WidthEstimator::default();


### PR DESCRIPTION
# Description

When I run `[] | inspect` on latest main, I get an underflow panic. This removes the panic, although the output is still a little ugly:

```
╭─────────────┬───────────╮
│ description │ list<any> │


╭────────────╮
│ empty list │
╰────────────╯
```

This particular panic is triggered when `[] | inspect` is executed in a terminal. There's a different panic when you run `nu -c '[] | inspect' | cat`, see #8671/#8673. 

# User-Facing Changes

Fewer panics