### PR TITLE
Remove CI coverage until we can figure out why it's broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,40 +169,40 @@ jobs:
         run: cargo test --profile ci --package nu_plugin_*
 
 
-  nu-coverage:
-    needs: nu-tests
-    env:
-      NUSHELL_CARGO_TARGET: ci
+  # nu-coverage:
+  #   needs: nu-tests
+  #   env:
+  #     NUSHELL_CARGO_TARGET: ci
 
-    strategy:
-      fail-fast: true
-      matrix:
-        # disabled mac due to problems with merging coverage and similarity to linux
-        # disabled windows due to running out of disk space when having too many crates or tests
-        platform: [ubuntu-20.04] # windows-latest
-        rust:
-          - stable
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       # disabled mac due to problems with merging coverage and similarity to linux
+  #       # disabled windows due to running out of disk space when having too many crates or tests
+  #       platform: [ubuntu-20.04] # windows-latest
+  #       rust:
+  #         - stable
 
-    runs-on: ${{ matrix.platform }}
+  #   runs-on: ${{ matrix.platform }}
 
-    steps:
-      - uses: actions/checkout@v3
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: Setup Rust toolchain and cache
-        uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
-      - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+  #     - name: Setup Rust toolchain and cache
+  #       uses: actions-rust-lang/setup-rust-toolchain@v1.4.4
+  #     - name: Install cargo-llvm-cov
+  #       uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Tests
-        shell: bash
-        run: |
-          source <(cargo llvm-cov show-env --export-prefix) # Set the environment variables needed to get coverage.
-          cargo llvm-cov clean --workspace # Remove artifacts that may affect the coverage results.
-          cargo build --workspace --profile ci
-          cargo test --workspace --profile ci
-          cargo llvm-cov report --profile ci --lcov --output-path lcov.info
+  #     - name: Tests
+  #       shell: bash
+  #       run: |
+  #         source <(cargo llvm-cov show-env --export-prefix) # Set the environment variables needed to get coverage.
+  #         cargo llvm-cov clean --workspace # Remove artifacts that may affect the coverage results.
+  #         cargo build --workspace --profile ci
+  #         cargo test --workspace --profile ci
+  #         cargo llvm-cov report --profile ci --lcov --output-path lcov.info
 
-      - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v3
-        with:
-          files: lcov.info
+  #     - name: Upload coverage reports to Codecov with GitHub Action
+  #       uses: codecov/codecov-action@v3
+  #       with:
+  #         files: lcov.info

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![@nu_shell](https://img.shields.io/badge/twitter-@nu_shell-1DA1F3?style=flat-square)](https://twitter.com/nu_shell)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/nushell/nushell)](https://github.com/nushell/nushell/graphs/commit-activity)
 [![GitHub contributors](https://img.shields.io/github/contributors/nushell/nushell)](https://github.com/nushell/nushell/graphs/contributors)
-[![codecov](https://codecov.io/gh/nushell/nushell/branch/main/graph/badge.svg?token=JheS8qu2II)](https://codecov.io/gh/nushell/nushell)
+<!-- [![codecov](https://codecov.io/gh/nushell/nushell/branch/main/graph/badge.svg?token=JheS8qu2II)](https://codecov.io/gh/nushell/nushell) -->
 
 A new type of shell.
 


### PR DESCRIPTION
# Description

The coverage testing on CI has been broken for at least a week. It looks like we might have to do some work, but for now, disabling it so we don't give bad stability info to contributors.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
