### PR TITLE
feat!: use `~/.config/nushell` as the primary config directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,27 +1009,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dlv-list"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1148,17 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2707,13 +2697,13 @@ dependencies = [
  "csv",
  "dialoguer",
  "digest",
- "dirs-next",
  "dtparse",
  "encoding_rs",
  "fancy-regex",
  "filesize",
  "filetime",
  "fs_extra",
+ "home",
  "htmlescape",
  "indexmap 2.0.0",
  "indicatif",
@@ -2856,8 +2846,9 @@ dependencies = [
 name = "nu-path"
 version = "0.82.1"
 dependencies = [
- "dirs-next",
+ "etcetera",
  "omnipath",
+ "once_cell",
  "pwd",
 ]
 
@@ -4148,17 +4139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -128,7 +128,7 @@ which-support = ["which"]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.82.1" }
 nu-test-support = { path = "../nu-test-support", version = "0.82.1" }
 
-dirs-next = "2.0"
+home = "0.5"
 mockito = { version = "1.1", default-features = false }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -124,7 +124,7 @@ fn filesystem_change_to_home_directory() {
             "
         );
 
-        assert_eq!(Some(PathBuf::from(actual.out)), dirs_next::home_dir());
+        assert_eq!(Some(PathBuf::from(actual.out)), home::home_dir());
     })
 }
 

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -11,7 +11,8 @@ version = "0.82.1"
 bench = false
 
 [dependencies]
-dirs-next = "2.0"
+etcetera = "0.8"
+once_cell = "1.18"
 
 [target.'cfg(windows)'.dependencies]
 omnipath = "0.1"

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -9,10 +9,13 @@ static CONFIG_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
     let default = if let Some(mut config_dir) = home_dir() {
         config_dir.push(".config");
         if config_dir.join("nushell").is_dir() {
+            // `~/.config/nushell` exists, so we'll use that
             return Some(config_dir);
         }
+        // `~/.config/nushell` doesn't exist, but we'll use it if the "native" folder doesn't exist either
         Some(config_dir)
     } else {
+        // `~` not found, so we'll return `None` if the "native" folder doesn't exist either
         None
     };
 
@@ -23,17 +26,32 @@ static CONFIG_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
             basedirs.config_dir()
         };
         if config_home.join("nushell").is_dir() {
+            // "native" config folder exists, so we'll use that
             return Some(config_home);
         }
     }
 
+    // fresh install, so we'll use the default defined above
     default
 });
 
+/// Returns the home directory of the current user.
+///
+/// Uses the `HOME` environment variable on Linux and macOS, if set, otherwise `getpwuid_r`.
+/// Uses the `USERPROFILE` environment variable on Windows, if set, otherwise `SHGetKnownFolderPath` with `CSIDL_PROFILE`.
 pub fn home_dir() -> Option<PathBuf> {
     HOME_DIR.clone()
 }
 
+/// Returns the path where the `nushell` folder should be located.
+///
+/// If `~/.config/nushell` exists, returns `~/.config`.
+/// Checks the following path based on the OS:
+///   - Linux: `~/.config/`
+///   - macOS: `~/Library/Application Support/`
+///   - Windows: `{FOLDERID_RoamingAppData}`
+/// If the `nushell` folder exists in the path, returns the path.
+/// Otherwise, returns `~/.config'.
 pub fn config_dir() -> Option<PathBuf> {
     CONFIG_DIR.clone()
 }

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -1,13 +1,41 @@
+use etcetera::BaseStrategy;
 #[cfg(windows)]
 use omnipath::WinPathExt;
+use once_cell::sync::Lazy;
 use std::path::PathBuf;
 
+static HOME_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| etcetera::home_dir().ok());
+static CONFIG_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
+    let default = if let Some(mut config_dir) = home_dir() {
+        config_dir.push(".config");
+        if config_dir.join("nushell").is_dir() {
+            return Some(config_dir);
+        }
+        Some(config_dir)
+    } else {
+        None
+    };
+
+    if let Ok(basedirs) = etcetera::base_strategy::choose_native_strategy() {
+        let config_home = if cfg!(target_os = "macos") {
+            basedirs.data_dir()
+        } else {
+            basedirs.config_dir()
+        };
+        if config_home.join("nushell").is_dir() {
+            return Some(config_home);
+        }
+    }
+
+    default
+});
+
 pub fn home_dir() -> Option<PathBuf> {
-    dirs_next::home_dir()
+    HOME_DIR.clone()
 }
 
 pub fn config_dir() -> Option<PathBuf> {
-    dirs_next::config_dir()
+    CONFIG_DIR.clone()
 }
 
 #[cfg(windows)]

--- a/crates/nu-path/src/tilde.rs
+++ b/crates/nu-path/src/tilde.rs
@@ -2,6 +2,8 @@
 use pwd::Passwd;
 use std::path::{Path, PathBuf};
 
+use crate::helpers;
+
 fn expand_tilde_with_home(path: impl AsRef<Path>, home: Option<PathBuf>) -> PathBuf {
     let path = path.as_ref();
 
@@ -62,7 +64,7 @@ fn user_home_dir(username: &str) -> PathBuf {
 
 #[cfg(target_os = "macos")]
 fn user_home_dir(username: &str) -> PathBuf {
-    match dirs_next::home_dir() {
+    match helpers::home_dir() {
         None => {
             let mut expected_path = String::from("/Users/");
             expected_path.push_str(username);
@@ -91,7 +93,7 @@ fn user_home_dir(username: &str) -> PathBuf {
 
 #[cfg(target_os = "windows")]
 fn user_home_dir(username: &str) -> PathBuf {
-    match dirs_next::home_dir() {
+    match helpers::home_dir() {
         None => {
             let mut expected_path = String::from("C:\\Users\\");
             expected_path.push_str(username);
@@ -146,7 +148,7 @@ fn expand_tilde_with_another_user_home(path: &Path) -> PathBuf {
 /// Expand tilde ("~") into a home directory if it is the first path component
 pub fn expand_tilde(path: impl AsRef<Path>) -> PathBuf {
     // TODO: Extend this to work with "~user" style of home paths
-    expand_tilde_with_home(path, dirs_next::home_dir())
+    expand_tilde_with_home(path, helpers::home_dir())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

Use `~/.config/nushell` as the primary location on all platforms & allow fallback to the existing os-specific locations.

Fixes #893.
Fixes #8256.
Resolves #2918.
Resolves #8263.

# User-Facing Changes

This is a very minor breaking change for macOS/Windows users. If `~/.config/nushell` exists, then the old os-specific locations won't be used.