### PR TITLE
Remove `-t`/`--threads` flag from nu

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -107,7 +107,6 @@ pub(crate) fn parse_commandline_args(
             let log_level: Option<Expression> = call.get_flag_expr("log-level");
             let log_target: Option<Expression> = call.get_flag_expr("log-target");
             let execute: Option<Expression> = call.get_flag_expr("execute");
-            let threads: Option<Value> = call.get_flag(engine_state, &mut stack, "threads")?;
             let table_mode: Option<Value> =
                 call.get_flag(engine_state, &mut stack, "table-mode")?;
 
@@ -181,7 +180,6 @@ pub(crate) fn parse_commandline_args(
                 log_level,
                 log_target,
                 execute,
-                threads,
                 table_mode,
             });
         }
@@ -213,7 +211,6 @@ pub(crate) struct NushellCliArgs {
     pub(crate) log_level: Option<Spanned<String>>,
     pub(crate) log_target: Option<Spanned<String>>,
     pub(crate) execute: Option<Spanned<String>>,
-    pub(crate) threads: Option<Value>,
     pub(crate) table_mode: Option<Value>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,24 +137,6 @@ fn main() -> Result<()> {
     );
 
     start_time = std::time::Instant::now();
-    if let Some(t) = parsed_nu_cli_args.threads.clone() {
-        // 0 means to let rayon decide how many threads to use
-        let threads = t.as_i64().unwrap_or(0);
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(threads as usize)
-            .build_global()
-            .expect("error setting number of threads");
-    }
-    perf(
-        "set rayon threads",
-        start_time,
-        file!(),
-        line!(),
-        column!(),
-        use_color,
-    );
-
-    start_time = std::time::Instant::now();
     if let Some(testbin) = &parsed_nu_cli_args.testbin {
         // Call out to the correct testbin
         match testbin.item.as_str() {


### PR DESCRIPTION
### What?

This PR removes the `--threads` flag from nu.exe:

![image](https://user-images.githubusercontent.com/26268125/229021408-bf78ce64-11f7-4354-a410-ed905b96bb5a.png)

### Why?

Darren added a `--threads` flag to `par-each` in https://github.com/nushell/nushell/pull/8679, so it no longer respects the global `--threads` flag. Now the only place `rayon` is used is [the `table` renderer](https://github.com/nushell/nushell/blob/3db0aed9f739fd929f8dff287fafd60883649c07/crates/nu-command/src/viewers/table.rs#L15).

I don't think anyone will actually want to specify the number of threads used in `table`, and it would be confusing to leave this flag around when it no longer does anything useful.

### Notes

Relevant `rayon` docs: https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.build_global