### PR TITLE
Fix a bug with `us` not outputting as `µs` with the `into duration` command

### DIFF
--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -161,6 +161,14 @@ impl Command for SubCommand {
                     span,
                 }),
             },
+            Example {
+                description: "Convert duration to µs as a string if unit asked for was us",
+                example: "1sec | into duration --convert us",
+                result: Some(Value::String {
+                    val: "1000000 µs".to_string(),
+                    span,
+                }),
+            },
         ]
     }
 }
@@ -439,7 +447,7 @@ fn string_to_unit_duration(
             if let Expr::Int(x) = value.expr {
                 match unit.item {
                     Unit::Nanosecond => return Ok(("ns", x)),
-                    Unit::Microsecond => return Ok(("us", x)),
+                    Unit::Microsecond => return Ok(("µs", x)),
                     Unit::Millisecond => return Ok(("ms", x)),
                     Unit::Second => return Ok(("sec", x)),
                     Unit::Minute => return Ok(("min", x)),
@@ -488,14 +496,19 @@ fn action(
                     *value_span,
                 ) {
                     Ok(d) => {
+                        let unit = if &to_unit.item == "us" {
+                            "µs"
+                        } else {
+                            &to_unit.item
+                        };
                         if d.fract() == 0.0 {
                             Value::String {
-                                val: format!("{} {}", d, &to_unit.item),
+                                val: format!("{} {}", d, unit),
                                 span: *value_span,
                             }
                         } else {
                             Value::String {
-                                val: format!("{:.float_precision$} {}", d, &to_unit.item),
+                                val: format!("{:.float_precision$} {}", d, unit),
                                 span: *value_span,
                             }
                         }
@@ -522,14 +535,19 @@ fn action(
                         *value_span,
                     ) {
                         Ok(d) => {
+                            let unit = if &to_unit.item == "us" {
+                                "µs"
+                            } else {
+                                &to_unit.item
+                            };
                             if d.fract() == 0.0 {
                                 Value::String {
-                                    val: format!("{} {}", d, &to_unit.item),
+                                    val: format!("{} {}", d, unit),
                                     span: *value_span,
                                 }
                             } else {
                                 Value::String {
-                                    val: format!("{:.float_precision$} {}", d, &to_unit.item),
+                                    val: format!("{:.float_precision$} {}", d, unit),
                                     span: *value_span,
                                 }
                             }


### PR DESCRIPTION
# Description

Whilst working on [Allow parsing of mu (µ) character for durations](https://github.com/nushell/nushell/pull/8647), I found a bug where, if you use `into duration --convert us`,  it outputs with the unit as `us` rather than `µs`
![image](https://user-images.githubusercontent.com/44570273/229141818-37f97071-7f8e-451c-9baa-3c292290e6e7.png)

After this change, it now outputs the correct symbol:
![image](https://user-images.githubusercontent.com/44570273/229142720-6e67d49a-e88f-44a8-a742-92fa5220e54b.png)

# User-Facing Changes

User will now see correct unit when converting into microseconds.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
