### PR TITLE
Add `math exp` command (issue #8661)

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -388,6 +388,7 @@ pub fn create_default_context() -> EngineState {
             MathPi,
             MathTau,
             MathEuler,
+            MathExp,
             MathLn,
             MathLog,
         };

--- a/crates/nu-command/src/math/exp.rs
+++ b/crates/nu-command/src/math/exp.rs
@@ -1,0 +1,92 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "math exp"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("math exp")
+            .input_output_types(vec![(Type::Number, Type::Float)])
+            .vectorizes_over_list(true)
+            .category(Category::Math)
+    }
+
+    fn usage(&self) -> &str {
+        "Returns e raised to the power of x."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["exponential", "exponentiation", "euler"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        // This doesn't match explicit nulls
+        if matches!(input, PipelineData::Empty) {
+            return Err(ShellError::PipelineEmpty { dst_span: head });
+        }
+        input.map(
+            move |value| operate(value, head),
+            engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Get e raised to the power of zero",
+            example: "0 | math exp",
+            result: Some(Value::test_float(1.0f64)),
+        }, Example {
+            description: "Get e (same as 'math e')",
+            example: "1 | math exp",
+            result: Some(Value::test_float(1.0f64.exp())),
+        }]
+    }
+}
+
+fn operate(value: Value, head: Span) -> Value {
+    match value {
+        numeric @ (Value::Int { .. } | Value::Float { .. }) => {
+            let (val, span) = match numeric {
+                Value::Int { val, span } => (val as f64, span),
+                Value::Float { val, span } => (val, span),
+                _ => unreachable!(),
+            };
+
+            Value::Float { val: val.exp(), span }
+        }
+        Value::Error { .. } => value,
+        other => Value::Error {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "numeric".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.expect_span(),
+            }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/math/exp.rs
+++ b/crates/nu-command/src/math/exp.rs
@@ -44,15 +44,18 @@ impl Command for SubCommand {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Get e raised to the power of zero",
-            example: "0 | math exp",
-            result: Some(Value::test_float(1.0f64)),
-        }, Example {
-            description: "Get e (same as 'math e')",
-            example: "1 | math exp",
-            result: Some(Value::test_float(1.0f64.exp())),
-        }]
+        vec![
+            Example {
+                description: "Get e raised to the power of zero",
+                example: "0 | math exp",
+                result: Some(Value::test_float(1.0f64)),
+            },
+            Example {
+                description: "Get e (same as 'math e')",
+                example: "1 | math exp",
+                result: Some(Value::test_float(1.0f64.exp())),
+            },
+        ]
     }
 }
 
@@ -65,7 +68,10 @@ fn operate(value: Value, head: Span) -> Value {
                 _ => unreachable!(),
             };
 
-            Value::Float { val: val.exp(), span }
+            Value::Float {
+                val: val.exp(),
+                span,
+            }
         }
         Value::Error { .. } => value,
         other => Value::Error {

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -10,6 +10,7 @@ mod ceil;
 mod cos;
 mod cosh;
 mod euler;
+mod exp;
 mod floor;
 mod ln;
 mod log;
@@ -69,3 +70,4 @@ pub use tau::SubCommand as MathTau;
 
 pub use self::log::SubCommand as MathLog;
 pub use ln::SubCommand as MathLn;
+pub use exp::SubCommand as MathExp;

--- a/crates/nu-command/src/math/mod.rs
+++ b/crates/nu-command/src/math/mod.rs
@@ -69,5 +69,5 @@ pub use pi::SubCommand as MathPi;
 pub use tau::SubCommand as MathTau;
 
 pub use self::log::SubCommand as MathLog;
-pub use ln::SubCommand as MathLn;
 pub use exp::SubCommand as MathExp;
+pub use ln::SubCommand as MathLn;


### PR DESCRIPTION
# Description
I copied the `math ln` command and replaced the relevant parts to implement `math exp`.

# User-Facing Changes

The `math exp` command was added. Now one can do `[1, 2, 3] | math exp` to get e to the power of these numbers.

# Tests + Formatting
I only wrote example tests, same as for `math ln`, which also does not have special tests. I have ran into an issue with the tests but it seems completely unrelated (see #8687)

# After Submitting

This PR was done in order to make the documentation complete, so I'm not adding any documentation except `math ln`.
