### PR TITLE
move the `show_banner` config field to the top

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -176,6 +176,8 @@ let light_theme = {
 
 # The default config record. This is where much of your global configuration is setup.
 let-env config = {
+  # true or false to enable or disable the welcome banner at startup
+  show_banner: true
   ls: {
     use_ls_colors: true # use the LS_COLORS environment variable to colorize output
     clickable_links: true # enable or disable clickable links. Your terminal has to support links.
@@ -287,8 +289,6 @@ let-env config = {
   use_ansi_coloring: true
   edit_mode: emacs # emacs, vi
   shell_integration: true # enables terminal markers and a workaround to arrow keys stop working issue
-  # true or false to enable or disable the welcome banner at startup
-  show_banner: true
   render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
 
   hooks: {


### PR DESCRIPTION
Should close https://github.com/nushell/nushell/issues/8698 and similar issues.

# Description
simply moves the `show_banner` field and its comment to the top of the default config file.

# User-Facing Changes
this should make the setting easier to see and encourage people to modify the line instead of adding another line before the default `show_banner: true`, which would overwrite the setting.

# Tests + Formatting
```
$nothing
```

# After Submitting
the default banner links to https://www.nushell.sh/book/configuration.html#remove-welcome-message, which does not mention this issue => this will have to be updated