### PR TITLE
prevent redefining fields in a record

### DIFF
--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -85,7 +85,7 @@ fn reject_record_from_raw_eval() {
     let actual = nu!(
         cwd: ".", pipeline(
             r#"
-            {"a": 3, "a": 4} | reject a | describe
+            {"a": 3} | reject a | describe
             "#
         )
     );
@@ -98,7 +98,7 @@ fn reject_table_from_raw_eval() {
     let actual = nu!(
         cwd: ".", pipeline(
             r#"
-            [{"a": 3, "a": 4}] | reject a
+            [{"a": 3}] | reject a
             "#
         )
     );

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -560,7 +560,10 @@ pub fn eval_expression(
                 let pos = cols.iter().position(|c| c == &col_name);
                 match pos {
                     Some(index) => {
-                        vals[index] = eval_expression(engine_state, stack, val)?;
+                        return Err(ShellError::ColumnDefinedTwice {
+                            second_use: col.span,
+                            first_use: fields[index].0.span,
+                        })
                     }
                     None => {
                         cols.push(col_name);

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -597,6 +597,20 @@ pub enum ShellError {
         src_span: Span,
     },
 
+    /// Fields can only be defined once
+    ///
+    /// ## Resolution
+    ///
+    /// Check the record to ensure you aren't reusing the same field name
+    #[error("Record field used twice")]
+    #[diagnostic(code(nu::shell::not_a_list))]
+    ColumnDefinedTwice {
+        #[label = "field redefined here"]
+        second_use: Span,
+        #[label = "field first defined here"]
+        first_use: Span,
+    },
+
     /// An error happened while performing an external command.
     ///
     /// ## Resolution

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -1,0 +1,10 @@
+use nu_test_support::nu;
+
+#[test]
+fn source_file_relative_to_file() {
+    let actual = nu!(cwd: "tests/eval", r#"
+        {x: 1, x: 2}
+        "#);
+
+    assert!(actual.err.contains("redefined"));
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,7 @@
 extern crate nu_test_support;
 
 mod const_;
+mod eval;
 mod hooks;
 mod modules;
 mod overlays;


### PR DESCRIPTION
# Description

Prevents redefining fields in a record, for example `{a: 1, a: 2}` would now error.

fixes https://github.com/nushell/nushell/issues/8699

# User-Facing Changes

Is technically a breaking change. If you relied on this behaviour to give you the last value, your code will now error.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
