### PR TITLE
give better error when a numberlike is used for strings

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1761,7 +1761,11 @@ pub fn parse_numberlike_expr(
         SyntaxShape::CellPath => parse_simple_cell_path(working_set, span, expand_aliases_denylist),
         SyntaxShape::String => (
             garbage(span),
-            Some(ParseError::Expected("string".into(), span)),
+            Some(ParseError::Mismatch(
+                "string".into(),
+                "number-like value (hint: use quotes or backticks)".into(),
+                span,
+            )),
         ),
         SyntaxShape::Any => {
             if bytes == b"0b" {

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -226,3 +226,13 @@ fn parse_export_env_missing_block() {
 
     assert!(actual.err.contains("missing block"));
 }
+
+#[test]
+fn numberlike_command_name() {
+    let actual = nu!(cwd: "tests/parsing/samples",
+        r#"
+            def 7zup [] {}
+        "#);
+
+    assert!(actual.err.contains("backticks"));
+}


### PR DESCRIPTION
# Description

Before:
```
  × Type mismatch during operation.
   ╭─[source:1:1]
 1 │               def 7zup [] {} 
   ·                   ──┬─
   ·                     ╰── expected string
   ╰────
```

Now:
```
  × Type mismatch during operation.
   ╭─[source:1:1]
 1 │               def 7zup [] {} 
   ·                   ──┬─
   ·                     ╰── expected string, found number-like value (hint: use quotes or backticks)
   ╰────
```

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
