### PR TITLE
Add regex separators for split row/list/column

### DIFF
--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Type,
     Value,
 };
-
+use regex::Regex;
 #[derive(Clone)]
 pub struct SubCommand;
 
@@ -21,7 +21,7 @@ impl Command for SubCommand {
             .required(
                 "separator",
                 SyntaxShape::String,
-                "the character that denotes what separates rows",
+                "a character or regex that denotes what separates rows",
             )
             .named(
                 "number",
@@ -29,6 +29,7 @@ impl Command for SubCommand {
                 "Split into maximum number of items",
                 Some('n'),
             )
+            .switch("regex", "use regex syntax for separator", Some('r'))
             .category(Category::Strings)
     }
 
@@ -92,6 +93,18 @@ impl Command for SubCommand {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Split a string by regex",
+                example: r"'a   b       c' | split row -r '\s+'",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_string("a"),
+                        Value::test_string("b"),
+                        Value::test_string("c"),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }
@@ -104,30 +117,40 @@ fn split_row(
 ) -> Result<PipelineData, ShellError> {
     let name_span = call.head;
     let separator: Spanned<String> = call.req(engine_state, stack, 0)?;
+    let regex = if call.has_flag("regex") {
+        Regex::new(&separator.item)
+    } else {
+        let escaped = regex::escape(&separator.item);
+        Regex::new(&escaped)
+    }
+    .map_err(|err| {
+        ShellError::GenericError(
+            "Error with regular expression".into(),
+            err.to_string(),
+            Some(separator.span),
+            None,
+            Vec::new(),
+        )
+    })?;
     let max_split: Option<usize> = call.get_flag(engine_state, stack, "number")?;
     input.flat_map(
-        move |x| split_row_helper(&x, &separator, max_split, name_span),
+        move |x| split_row_helper(&x, &regex, max_split, name_span),
         engine_state.ctrlc.clone(),
     )
 }
 
-fn split_row_helper(
-    v: &Value,
-    separator: &Spanned<String>,
-    max_split: Option<usize>,
-    name: Span,
-) -> Vec<Value> {
+fn split_row_helper(v: &Value, regex: &Regex, max_split: Option<usize>, name: Span) -> Vec<Value> {
     match v.span() {
         Ok(v_span) => {
             if let Ok(s) = v.as_string() {
                 match max_split {
-                    Some(max_split) => s
-                        .splitn(max_split, &separator.item)
-                        .map(|s| Value::string(s, v_span))
+                    Some(max_split) => regex
+                        .splitn(&s, max_split)
+                        .map(|x: &str| Value::string(x, v_span))
                         .collect(),
-                    None => s
-                        .split(&separator.item)
-                        .map(|s| Value::string(s, v_span))
+                    None => regex
+                        .split(&s)
+                        .map(|x: &str| Value::string(x, v_span))
                         .collect(),
                 }
             } else {

--- a/crates/nu-command/tests/commands/split_column.rs
+++ b/crates/nu-command/tests/commands/split_column.rs
@@ -5,12 +5,20 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn to_column() {
     Playground::setup("split_column_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "sample.txt",
-            r#"
+        sandbox.with_files(vec![
+            FileWithContentToBeTrimmed(
+                "sample.txt",
+                r#"
                 importer,shipper,tariff_item,name,origin
             "#,
-        )]);
+            ),
+            FileWithContentToBeTrimmed(
+                "sample2.txt",
+                r#"
+                importer , shipper  , tariff_item  ,   name  ,  origin
+            "#,
+            ),
+        ]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -19,6 +27,19 @@ fn to_column() {
                 | lines
                 | str trim
                 | split column ","
+                | get column2
+            "#
+        ));
+
+        assert!(actual.out.contains("shipper"));
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open sample2.txt
+                | lines
+                | str trim
+                | split column -r '\s*,\s*'
                 | get column2
             "#
         ));

--- a/crates/nu-command/tests/commands/split_row.rs
+++ b/crates/nu-command/tests/commands/split_row.rs
@@ -5,12 +5,20 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn to_row() {
     Playground::setup("split_row_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "sample.txt",
-            r#"
+        sandbox.with_files(vec![
+            FileWithContentToBeTrimmed(
+                "sample.txt",
+                r#"
                 importer,shipper,tariff_item,name,origin
             "#,
-        )]);
+            ),
+            FileWithContentToBeTrimmed(
+                "sample2.txt",
+                r#"
+                importer      ,   shipper      ,  tariff_item,name      ,    origin
+            "#,
+            ),
+        ]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -19,6 +27,19 @@ fn to_row() {
                 | lines
                 | str trim
                 | split row ","
+                | length
+            "#
+        ));
+
+        assert!(actual.out.contains('5'));
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open sample2.txt
+                | lines
+                | str trim
+                | split row -r '\s*,\s*'
                 | length
             "#
         ));


### PR DESCRIPTION
# Description

Verified on discord with maintainer

Change adds regex separators in split rows/column/list.  The primary motivating reason was to make it easier to split on separators with unbounded whitespace without requiring a lot of trim jiggery.  But, secondary motivation is the same as the set of all motivations for adding split regex features to most languages.

# User-Facing Changes

Adds -r option to split rows/column/list.

# Tests + Formatting

Ran tests, however tests.nu fails with unrelated errors:

```
~/src/nushell> cargo run -- crates/nu-utils/standard_library/tests.nu                                                                                                                                                          04/02/2023 02:07:25 AM
    Finished dev [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/nu crates/nu-utils/standard_library/tests.nu`
INF|2023-04-02T02:07:27.060|Running tests in test_asserts
INF|2023-04-02T02:07:27.141|Running tests in test_dirs
Error:
  × list is just pwd after initialization

INF|2023-04-02T02:07:27.167|Running tests in test_logger
INF|2023-04-02T02:07:27.286|Running tests in test_std
Error:
  × some tests did not pass (see complete errors above):
  │
  │       test_asserts test_assert
  │       test_asserts test_assert_equal
  │       test_asserts test_assert_error
  │       test_asserts test_assert_greater
  │       test_asserts test_assert_greater_or_equal
  │       test_asserts test_assert_length
  │       test_asserts test_assert_less
  │       test_asserts test_assert_less_or_equal
  │       test_asserts test_assert_not_equal
  │     ⨯ test_dirs test_dirs_command
  │       test_logger test_critical
  │       test_logger test_debug
  │       test_logger test_error
  │       test_logger test_info
  │       test_logger test_warning
  │       test_std test_path_add
  │
```

Upon investigating seeing this difference:

```
╭───┬─────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ 0 │ /var/folders/1f/ltbr1m8s5s1811k6n1rhpc0r0000gn/T/test_dirs_c1ed89d6-19f7-47c7-9e1f-74c39f3623b5         │
│ 1 │ /private/var/folders/1f/ltbr1m8s5s1811k6n1rhpc0r0000gn/T/test_dirs_c1ed89d6-19f7-47c7-9e1f-74c39f3623b5 │
╰───┴─────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

This seems unrelated to my changes, but can investigate further if desired.

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
