### PR TITLE
DEV: make all "comments" real md comments in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,16 @@
 
 # Description
+<!--
+Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.
 
-_(Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.)_
-
-_(Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.)_
+Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
+-->
 
 # User-Facing Changes
-
-_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_
+<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
 
 # Tests + Formatting
-
+<!--
 Don't forget to add tests that cover your changes.
 
 Make sure you've run and fixed any issues with these commands:
@@ -26,7 +26,7 @@ Make sure you've run and fixed any issues with these commands:
 > use toolkit.nu  # or use an `env_change` hook to activate it automatically
 > toolkit check pr
 > ```
+-->
 
 # After Submitting
-
-If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
+<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->


### PR DESCRIPTION
# Description
i sometimes see some sections of the PR template being left untouched by contributors :thinking: 
this is not a big deal at all, but i thought we could hide them in the final PR by making the italic hints real markdown comments with the `<!-- ... -->` syntax.

this has the effect of 
- still showing the guidelines to the contributor in the PR creation window
- not show these guidelines in the visible PR body

> **Warning**
> limitations
> - this won't remove the comments from the squashed commit when the PR lands :thinking: 
> - we might need to use a more structured template for this, like in the [feature requests](https://github.com/nushell/nushell/issues/new?assignees=&labels=enhancement&template=feature_request.yml) but i'm not sure this works with PR templates :confused: 

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
```
$nothing
```

# After Submitting
```
$nothing
```