### PR TITLE
FEATURE: better `ansi -e` error 

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -608,7 +608,12 @@ Format: #
             },
             Example {
                 description: "Use ansi to color text with a style (blue on red in bold)",
-                example: r#"$"(ansi -e { fg: '#0000ff' bg: '#ff0000' attr: b })Hello Nu World(ansi reset)""#,
+                example: r#"let format = {  # none of the following keys are mandatory, but any other key will be considered invalid
+        fg: '#0000ff'
+        bg: '#ff0000'
+        attr: b
+    }
+    $"(ansi -e $format)Hello Nu World(ansi reset)""#,
                 result: Some(Value::test_string(
                     "\u{1b}[1;48;2;255;0;0;38;2;0;0;255mHello Nu World\u{1b}[0m",
                 )),

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -608,7 +608,7 @@ Format: #
             },
             Example {
                 description: "Use ansi to color text with a style (blue on red in bold)",
-                example: r#"let format = {  # none of the following keys are mandatory, but any other key will be considered invalid
+                example: r#"let format = {  # `fg`, `bg`, `attr` are the acceptable keys, all other keys are considered invalid and will throw errors.
         fg: '#0000ff'
         bg: '#ff0000'
         attr: b

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -745,7 +745,7 @@ Format: #
                     "attr" => nu_style.attr = Some(v.as_string()?),
                     _ => {
                         return Err(ShellError::IncompatibleParametersSingle {
-                            msg: format!("problem with key: {k}"),
+                            msg: format!("unknown ANSI format key: expected one of ['fg', 'bg', 'attr'], found '{k}'"),
                             span: code.expect_span(),
                         })
                     }


### PR DESCRIPTION
Should close #8704.

# Description
this PR
- makes the error thrown by things like `ansi -e {invalid: "invalid"}` more explicit
- makes the `ansi -e` example more explicit about valid / invalid keys

# User-Facing Changes
the error
```bash
> ansi -e {invalid: "invalid"}
Error: nu::shell::incompatible_parameters

  × Incompatible parameters.
   ╭─[entry #1:1:1]
 1 │ ansi -e {invalid: "invalid"}
   ·         ──────────┬─────────
   ·                   ╰── unknown ANSI format key: expected one of ['fg', 'bg', 'attr'], found 'invalid'
   ╰────
```

the new `ansi -e` example
```bash
  Use structured escape codes
  > let bold_blue_on_red = {  # `fg`, `bg`, `attr` are the acceptable keys, all other keys are considered invalid and will throw errors.
        fg: '#0000ff'
        bg: '#ff0000'
        attr: b
    }
    $"(ansi -e $bold_blue_on_red)Hello Nu World(ansi reset)"
  Hello Nu World
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```