### PR TITLE
Fix(tests/nu-command): remove unnecessary cwd() and pipeline(), etc

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -6,7 +6,13 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn alias_simple() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", " alias bar = use sample_def.nu greet; bar; greet ");
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            alias bar = use sample_def.nu greet;
+            bar;
+            greet
+        "#
+    ));
 
     assert_eq!(actual.out, "hello");
 }

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -6,13 +6,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn alias_simple() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            alias bar = use sample_def.nu greet;
-            bar;
-            greet
-        "#
-    ));
+        cwd: "tests/fixtures/formats", " alias bar = use sample_def.nu greet; bar; greet ");
 
     assert_eq!(actual.out, "hello");
 }
@@ -49,47 +43,23 @@ fn alias_hiding_2() {
 #[test]
 fn alias_fails_with_invalid_name() {
     let err_msg = "name can't be a number, a filesize, or contain a hash # or caret ^";
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            alias 1234 = echo "test"
-        "#
-    ));
+    let actual = nu!(r#" alias 1234 = echo "test" "#);
+
     assert!(actual.err.contains(err_msg));
 
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            alias 5gib = echo "test"
-        "#
-    ));
+    let actual = nu!(r#" alias 5gib = echo "test" "#);
     assert!(actual.err.contains(err_msg));
 
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            alias "te#t" = echo "test"
-        "#
-    ));
+    let actual = nu!(r#" alias "te#t" = echo "test" "#);
     assert!(actual.err.contains(err_msg));
 
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            alias ^foo = echo "bar"
-        "#
-    ));
+    let actual = nu!(r#" alias ^foo = echo "bar" "#);
     assert!(actual.err.contains(err_msg));
 }
 
 #[test]
 fn cant_alias_keyword() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            alias ou = let
-        "#
-    ));
+    let actual = nu!(r#" alias ou = let "#);
     assert!(actual.err.contains("cant_alias_keyword"));
 }
 

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -2,8 +2,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn checks_all_rows_are_true() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
                 echo  [ "Andrés", "Andrés", "Andrés" ]
                 | all {|it| $it == "Andrés" }
@@ -15,32 +14,21 @@ fn checks_all_rows_are_true() {
 
 #[test]
 fn checks_all_rows_are_false_with_param() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-                [1, 2, 3, 4] | all { |a| $a >= 5 }
-        "#
-    ));
+    let actual = nu!(r#" [1, 2, 3, 4] | all { |a| $a >= 5 } "#);
 
     assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn checks_all_rows_are_true_with_param() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-                [1, 2, 3, 4] | all { |a| $a < 5 }
-        "#
-    ));
+    let actual = nu!(r#" [1, 2, 3, 4] | all { |a| $a < 5 } "#);
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn checks_all_columns_of_a_table_is_true() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
                 echo [
                         [  first_name, last_name,   rusty_at, likes  ];
@@ -59,8 +47,7 @@ fn checks_all_columns_of_a_table_is_true() {
 #[test]
 fn checks_if_all_returns_error_with_invalid_command() {
     // Using `with-env` to remove `st` possibly being an external program
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             with-env {PATH: ""} {
                 [red orange yellow green blue purple] | all {|it| ($it | st length) > 4 }
@@ -73,50 +60,35 @@ fn checks_if_all_returns_error_with_invalid_command() {
 
 #[test]
 fn works_with_1_param_blocks() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | all {|e| print $e | true }"#
-    ));
+    let actual = nu!(r#"[1 2 3] | all {|e| print $e | true }"#);
 
     assert_eq!(actual.out, "123true");
 }
 
 #[test]
 fn works_with_0_param_blocks() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | all {|| print $in | true }"#
-    ));
+    let actual = nu!(r#"[1 2 3] | all {|| print $in | true }"#);
 
     assert_eq!(actual.out, "123true");
 }
 
 #[test]
 fn early_exits_with_1_param_blocks() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | all {|e| print $e | false }"#
-    ));
+    let actual = nu!(r#"[1 2 3] | all {|e| print $e | false }"#);
 
     assert_eq!(actual.out, "1false");
 }
 
 #[test]
 fn early_exits_with_0_param_blocks() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | all {|| print $in | false }"#
-    ));
+    let actual = nu!(r#"[1 2 3] | all {|| print $in | false }"#);
 
     assert_eq!(actual.out, "1false");
 }
 
 #[test]
 fn all_uses_enumerate_index() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[7 8 9] | enumerate | all {|el| print $el.index | true }"#
-    ));
+    let actual = nu!(r#"[7 8 9] | enumerate | all {|el| print $el.index | true }"#);
 
     assert_eq!(actual.out, "012true");
 }

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -2,8 +2,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn checks_any_row_is_true() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
                 echo  [ "Ecuador", "USA", "New Zealand" ]
                 | any {|it| $it == "New Zealand" }
@@ -15,8 +14,7 @@ fn checks_any_row_is_true() {
 
 #[test]
 fn checks_any_column_of_a_table_is_true() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
                 echo [
                         [  first_name, last_name,   rusty_at, likes  ];
@@ -35,8 +33,7 @@ fn checks_any_column_of_a_table_is_true() {
 #[test]
 fn checks_if_any_returns_error_with_invalid_command() {
     // Using `with-env` to remove `st` possibly being an external program
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             with-env {PATH: ""} {
                 [red orange yellow green blue purple] | any {|it| ($it | st length) > 4 }
@@ -49,50 +46,35 @@ fn checks_if_any_returns_error_with_invalid_command() {
 
 #[test]
 fn works_with_1_param_blocks() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | any {|e| print $e | false }"#
-    ));
+    let actual = nu!(r#"[1 2 3] | any {|e| print $e | false }"#);
 
     assert_eq!(actual.out, "123false");
 }
 
 #[test]
 fn works_with_0_param_blocks() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | any {|| print $in | false }"#
-    ));
+    let actual = nu!(r#"[1 2 3] | any {|| print $in | false }"#);
 
     assert_eq!(actual.out, "123false");
 }
 
 #[test]
 fn early_exits_with_1_param_blocks() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | any {|e| print $e | true }"#
-    ));
+    let actual = nu!(r#"[1 2 3] | any {|e| print $e | true }"#);
 
     assert_eq!(actual.out, "1true");
 }
 
 #[test]
 fn early_exits_with_0_param_blocks() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | any {|| print $in | true }"#
-    ));
+    let actual = nu!(r#"[1 2 3] | any {|| print $in | true }"#);
 
     assert_eq!(actual.out, "1true");
 }
 
 #[test]
 fn any_uses_enumerate_index() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[7 8 9] | enumerate | any {|el| print $el.index | false }"#
-    ));
+    let actual = nu!(r#"[7 8 9] | enumerate | any {|el| print $el.index | false }"#);
 
     assert_eq!(actual.out, "012false");
 }

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -24,13 +24,7 @@ fn fetches_a_row() {
             "#,
         )]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.toml
-                | get nu_party_venue
-            "#
-        ));
+        let actual = nu!( cwd: dirs.test(), "open sample.toml | get nu_party_venue");
 
         assert_eq!(actual.out, "zion");
     })
@@ -50,13 +44,7 @@ fn fetches_by_index() {
             "#,
         )]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.toml
-                | get package.authors.2
-            "#
-        ));
+        let actual = nu!( cwd: dirs.test(), "open sample.toml | get package.authors.2");
 
         assert_eq!(actual.out, "Andrés N. Robalino <andres@androbtech.com>");
     })
@@ -73,13 +61,7 @@ fn fetches_by_column_path() {
             "#,
         )]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.toml
-                | get package.name
-            "#
-        ));
+        let actual = nu!( cwd: dirs.test(), "open sample.toml | get package.name");
 
         assert_eq!(actual.out, "nu");
     })
@@ -97,14 +79,7 @@ fn column_paths_are_either_double_quoted_or_regular_unquoted_words_separated_by_
             "#,
         )]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.toml
-                | get package."9999"
-                | length
-            "#
-        ));
+        let actual = nu!( cwd: dirs.test(), r#"open sample.toml | get package."9999" | length"#);
 
         assert_eq!(actual.out, "3");
     })
@@ -132,11 +107,11 @@ fn fetches_more_than_one_column_path() {
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            "
                 open sample.toml
                 | get fortune_tellers.2.name fortune_tellers.0.name fortune_tellers.1.name
                 | get 2
-            "#
+            "
         ));
 
         assert_eq!(actual.out, "JT");
@@ -156,13 +131,7 @@ fn errors_fetching_by_column_not_present() {
             "#,
         )]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.toml
-                | get taco
-            "#
-        ));
+        let actual = nu!( cwd: dirs.test(), "open sample.toml | get taco");
 
         assert!(actual.err.contains("Name not found"),);
         assert!(actual.err.contains("did you mean 'tacos'"),);
@@ -180,13 +149,7 @@ fn errors_fetching_by_column_using_a_number() {
             "#,
         )]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.toml
-                | get spanish_lesson.0
-            "#
-        ));
+        let actual = nu!( cwd: dirs.test(), "open sample.toml | get spanish_lesson.0");
 
         assert!(actual.err.contains("Type mismatch"),);
     })
@@ -204,12 +167,7 @@ fn errors_fetching_by_index_out_of_bounds() {
         )]);
 
         let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.toml
-                | get spanish_lesson.sentence_words.3
-            "#
-        ));
+            cwd: dirs.test(), " open sample.toml | get spanish_lesson.sentence_words.3 ");
 
         assert!(actual.err.contains("Row number too large (max: 2)"),);
         assert!(actual.err.contains("too large"),);
@@ -234,23 +192,14 @@ fn quoted_column_access() {
 
 #[test]
 fn get_does_not_delve_too_deep_in_nested_lists() {
-    let actual = nu!(
-        cwd: ".",
-        r#"[[{foo: bar}]] | get foo"#
-    );
+    let actual = nu!(r#"[[{foo: bar}]] | get foo"#);
 
     assert!(actual.err.contains("cannot find column"));
 }
 
 #[test]
 fn ignore_errors_works() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
-        let path = "foo";
-        {} | get -i $path | to nuon
-        "#
-    );
+    let actual = nu!(r#" let path = "foo"; {} | get -i $path | to nuon "#);
 
     assert_eq!(actual.out, "null");
 }


### PR DESCRIPTION
# Description

This PR aims to cover the tests under nu-command as part of this issue #8670 to clean up any unnecessary wrapping funcs like `cwd(".")` or `pipeline()`, etc. 

This PR is still WIP and opening as draft to get first impressions and feedback on a few tests before I go on changing more.


# User-Facing Changes

None

# Tests + Formatting

None

# After Submitting

None