### PR TITLE
Fix two stable `clippy` lints

### DIFF
--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -35,10 +35,7 @@ pub(crate) fn get_editor(
     if let Some((a, b)) = editor.split_once(' ') {
         Ok((
             a.to_string(),
-            b.split(' ')
-                .into_iter()
-                .map(|s| s.to_string())
-                .collect::<Vec<String>>(),
+            b.split(' ').map(|s| s.to_string()).collect::<Vec<String>>(),
         ))
     } else {
         Ok((editor, Vec::new()))

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -141,7 +141,6 @@ fn element_to_value(n: &roxmltree::Node, info: &ParsingInfo) -> Value {
 
     let content: Vec<Value> = n
         .children()
-        .into_iter()
         .filter_map(|node| from_node_to_value(&node, info))
         .collect();
     let content = Value::list(content, span);


### PR DESCRIPTION
# Description

Unnecessary calls to `.into_iter()`


# User-Facing Changes

None

# Tests + Formatting

Only visible on stable toolchain
