### PR TITLE
Fix rest of license year ranges

### DIFF
--- a/crates/nu-cli/LICENSE
+++ b/crates/nu-cli/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-cmd-lang/LICENSE
+++ b/crates/nu-cmd-lang/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-color-config/LICENSE
+++ b/crates/nu-color-config/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-command/LICENSE
+++ b/crates/nu-command/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-engine/LICENSE
+++ b/crates/nu-engine/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-explore/LICENSE
+++ b/crates/nu-explore/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-json/LICENSE
+++ b/crates/nu-json/LICENSE
@@ -2,7 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2014 The Rust Project Developers
 Copyright (c) 2016 Christian Zangl
-Copyright (c) 2020-2022 The Nushell Project Developers
+Copyright (c) 2020-2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/crates/nu-parser/LICENSE
+++ b/crates/nu-parser/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-path/LICENSE
+++ b/crates/nu-path/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-plugin/LICENSE
+++ b/crates/nu-plugin/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-pretty-hex/LICENSE
+++ b/crates/nu-pretty-hex/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Andrei Volnin
-Copyright (c) 2021-2022 The Nushell Project Developers
+Copyright (c) 2021-2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-protocol/LICENSE
+++ b/crates/nu-protocol/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-table/LICENSE
+++ b/crates/nu-table/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-test-support/LICENSE
+++ b/crates/nu-test-support/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/nu-utils/LICENSE
+++ b/crates/nu-utils/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 - 2022 The Nushell Project Developers
+Copyright (c) 2019 - 2023 The Nushell Project Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Description

In theory we don't need to include the end of the year range for a
proper MIT license.


