### PR TITLE
Pin `reedline` to `0.18.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,8 +4258,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.17.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#9d6e22dd06d79b3f5ece716ef560148714c5489c"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9be1b4ddfacccf35ea8b4a8d3f7ec9e494ea22969c4156d4b2a393c1b9cef"
 dependencies = [
  "chrono",
  "crossterm 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.77.2" }
 nu-utils = { path = "./crates/nu-utils", version = "0.77.2" }
 
 nu-ansi-term = "0.47.0"
-reedline = { version = "0.17.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.18.0", features = ["bashisms", "sqlite"] }
 
 rayon = "1.7.0"
 is_executable = "1.0.1"
@@ -157,7 +157,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Criterion benchmarking setup

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -24,7 +24,7 @@ nu-utils = { path = "../nu-utils", version = "0.77.2" }
 nu-color-config = { path = "../nu-color-config", version = "0.77.2" }
 
 nu-ansi-term = "0.47.0"
-reedline = { version = "0.17.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.18.0", features = ["bashisms", "sqlite"] }
 
 atty = "0.2.14"
 chrono = { default-features = false, features = ["std"], version = "0.4.23" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -85,7 +85,7 @@ serde_yaml = "0.9.4"
 sha2 = "0.10.0"
 # Disable default features b/c the default features build Git (very slow to compile)
 percent-encoding = "2.2.0"
-reedline = { version = "0.17.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.18.0", features = ["bashisms", "sqlite"] }
 rusqlite = { version = "0.28.0", features = ["bundled"], optional = true }
 sqlparser = { version = "0.32.0", features = ["serde"], optional = true }
 sysinfo = "0.28.2"


### PR DESCRIPTION
# Description

see release notes:

https://github.com/nushell/reedline/releases/tag/v0.18.0


