### PR TITLE
Change default config to display failed LAST_EXIT_CODE

### DIFF
--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -26,10 +26,18 @@ def create_left_prompt [] {
 
 def create_right_prompt [] {
     let time_segment = ([
+        (ansi reset)
+        (ansi magenta)
         (date now | date format '%m/%d/%Y %r')
     ] | str join)
 
-    $time_segment
+    let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
+        (ansi rb)
+        ($env.LAST_EXIT_CODE)
+    ] | str join)
+    } else { "" }
+
+    ([$last_exit_code, (char space), $time_segment] | str join)
 }
 
 # Use nushell functions to define your right and left prompt


### PR DESCRIPTION
# Description

fixed #8655 
Change default nushell configuration file `default_env.nu` to display LAST_EXIT_CODE in the prompt. For this change, users can quickly know that a previous command failed.

# User-Facing Changes

This change affects only users who use the default configuration.
When a command fails, the exit code is displayed in the prompt like these figures.
* before
![image](https://user-images.githubusercontent.com/37319612/229782830-45bc6b0d-75e4-459f-ae1d-46877f740239.png)
* after
![image](https://user-images.githubusercontent.com/37319612/229784089-e68b5d14-499b-4448-b764-e6b30ca64714.png)


# Tests + Formatting

When I ran tests, `test.nu` failed with the following error.
The error also occurs in the master branch, so it's probably unrelated to these changes.
Do I need to address it?

* `cargo fmt --all -- --check`: passed
* `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect`: passed
* `cargo test --workspace`: passed
* `cargo run -- crates/nu-utils/standard_library/tests.nu`: ~failed~ passed
```
~/oss_dev/nushell> cargo run -- crates/nu-utils/standard_library/tests.nu
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/nu crates/nu-utils/standard_library/tests.nu`
Error: nu::shell::external_command

  × External command failed
    ╭─[/home/hiroki/oss_dev/nushell/crates/nu-utils/standard_library/tests.nu:73:1]
 73 │         | upsert test {|module|
 74 │             nu -c $'use ($module.file) *; $nu.scope.commands | select name module_name | to nuon'
    ·             ─┬
    ·              ╰── did you mean 'du'?
 75 │             | from nuon
    ╰────
  help: No such file or directory (os error 2)
  ```

# After Submitting

nothing