### PR TITLE
nu-command::fs::touch: Remove the two examples with -d argument, as this argument does not exist anymore.

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -75,7 +75,7 @@ impl Command for Touch {
         let rest: Vec<String> = call.rest(engine_state, stack, 1)?;
 
         let mut date: Option<DateTime<Local>> = None;
-        let mut ref_date_atime: Option<DateTime<Local>> = None;
+        let mut ref_date_atime: Option<DateTime<Local>> = None;e make_docs.nu script in the repo root. so, this change will get overwritten by whatever the command generates.
 
         // Change both times if none is specified
         if !change_mtime && !change_atime {
@@ -213,21 +213,21 @@ impl Command for Touch {
                 example: "touch -m fixture.json",
                 result: None,
             },
-            Example {
-                description: "Changes the last modified time of files a, b and c to a date",
-                example: r#"touch -m -d "yesterday" a b c"#,
-                result: None,
-            },
+            // Example {
+            //     description: "Changes the last modified time of files a, b and c to a date",
+            //     example: r#"touch -m -d "yesterday" a b c"#,
+            //     result: None,
+            // },
             Example {
                 description: r#"Changes the last modified time of file d and e to "fixture.json"'s last modified time"#,
                 example: r#"touch -m -r fixture.json d e"#,
                 result: None,
             },
-            Example {
-                description: r#"Changes the last accessed time of "fixture.json" to a date"#,
-                example: r#"touch -a -d "August 24, 2019; 12:30:30" fixture.json"#,
-                result: None,
-            },
+            // Example {
+            //     description: r#"Changes the last accessed time of "fixture.json" to a date"#,
+            //     example: r#"touch -a -d "August 24, 2019; 12:30:30" fixture.json"#,
+            //     result: None,
+            // },
         ]
     }
 }

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -75,7 +75,7 @@ impl Command for Touch {
         let rest: Vec<String> = call.rest(engine_state, stack, 1)?;
 
         let mut date: Option<DateTime<Local>> = None;
-        let mut ref_date_atime: Option<DateTime<Local>> = None;e make_docs.nu script in the repo root. so, this change will get overwritten by whatever the command generates.
+        let mut ref_date_atime: Option<DateTime<Local>> = None;
 
         // Change both times if none is specified
         if !change_mtime && !change_atime {


### PR DESCRIPTION

# Description
nu-command::fs::touch: Remove the two examples with -d argument, as this argument does not exist anymore.

# User-Facing Changes

No

# Tests + Formatting

No tests needed

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
