### PR TITLE
stdlib: add `assert skip` command to skip test case

### DIFF
--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -67,6 +67,16 @@ export def "assert error" [
     }
 }
 
+# Skip the current test case
+#
+# # Examples
+#
+# if $condition { assert skip }
+export def "assert skip" [] {
+    error make {msg: "ASSERT:SKIP"}
+}
+
+
 # Assert $left == $right
 #
 # For more documentation see the assert command

--- a/crates/nu-utils/standard_library/test_asserts.nu
+++ b/crates/nu-utils/standard_library/test_asserts.nu
@@ -57,8 +57,6 @@ export def test_assert_length [] {
     assert error { assert length [0, 0] 3 }
 }
 
-# export def test_assert_§ [] {
-#     assert §
-#     assert error { assert § }
-# }
-
+export def test_assert_skip [] {
+    assert skip # This test case is skipped on purpose
+}

--- a/crates/nu-utils/standard_library/tests.nu
+++ b/crates/nu-utils/standard_library/tests.nu
@@ -118,13 +118,11 @@ def main [
                     use ($test.file) ($test.name)
                     try {
                         ($test.name)
-                    } catch { |e|
-                        if $e.msg == "ASSERT:SKIP" {
+                    } catch { |err|
+                        if $err.msg == "ASSERT:SKIP" {
                             exit 2
                         } else {
-                            # Run again to print the error message and make an error,
-                            # since in Nushell 0.78 it is not available in $e.
-                            ($test.name)
+                            $err | get raw
                         }
                     }
                 '


### PR DESCRIPTION
Add `assert skip` command to skip test case.

![image](https://user-images.githubusercontent.com/282320/230009039-47bd5b4b-5753-4625-bc3a-e270c5c47753.png)
