### PR TITLE
Add ppid to ps command

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -86,6 +86,12 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
             span,
         });
 
+        cols.push("ppid".to_string());
+        vals.push(Value::Int {
+            val: proc.ppid() as i64,
+            span,
+        });
+
         cols.push("name".to_string());
         vals.push(Value::String {
             val: proc.name(),

--- a/crates/nu-system/src/linux.rs
+++ b/crates/nu-system/src/linux.rs
@@ -131,6 +131,11 @@ impl ProcessInfo {
         self.pid
     }
 
+    /// PPID of process
+    pub fn ppid(&self) -> i32 {
+        self.ppid
+    }
+
     /// Name of command
     pub fn name(&self) -> String {
         self.command()

--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -302,6 +302,11 @@ impl ProcessInfo {
         self.pid
     }
 
+    /// Parent PID of process
+    pub fn ppid(&self) -> i32 {
+        self.ppid
+    }
+
     /// Name of command
     pub fn name(&self) -> String {
         if let Some(path) = &self.curr_path {

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -1006,6 +1006,11 @@ impl ProcessInfo {
         self.pid
     }
 
+    /// Parent PID of process
+    pub fn ppid(&self) -> i32 {
+        self.ppid
+    }
+
     /// Name of command
     pub fn name(&self) -> String {
         self.command.clone()


### PR DESCRIPTION
# Description

Adds the `ppid` field that's available on all supported platforms to the `ps` command. This would be useful in my scripts.

# User-Facing Changes

- ps output now contains an extra column

# Tests + Formatting

Not sure if I need to add a test for this

# After Submitting

Update https://www.nushell.sh/book/quick_tour.html#quick-tour to show the new table
