### PR TITLE
allow register to accept a const argument

### DIFF
--- a/crates/nu-parser/src/eval.rs
+++ b/crates/nu-parser/src/eval.rs
@@ -19,6 +19,10 @@ pub fn eval_constant(
             val: b.clone(),
             span: expr.span,
         }),
+        Expr::Filepath(path) => Ok(Value::String {
+            val: path.clone(),
+            span: expr.span,
+        }),
         Expr::Var(var_id) => match working_set.find_constant(*var_id) {
             Some(val) => Ok(val.clone()),
             None => Err(ParseError::NotAConstant(expr.span)),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2853,25 +2853,24 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
     let arguments = call
         .positional_nth(0)
         .map(|expr| {
-            let name_expr = working_set.get_span_contents(expr.span);
-            let (name, err) = unescape_unquote_string(name_expr, expr.span);
-            if let Some(err) = err {
-                working_set.error(err)
-            }
-
-            let path = if let Some(p) = find_in_dirs(&name, working_set, &cwd, PLUGIN_DIRS_VAR) {
-                p
-            } else {
-                return Err(ParseError::RegisteredFileNotFound(name, expr.span));
+            let val = match eval_constant(working_set, expr) {
+                Ok(val) => val,
+                Err(err) =>return Err(err),
             };
 
-            if path.exists() & path.is_file() {
+            let filename = match value_as_string(val, expr.span) {
+                Ok(str) => str,
+                Err(err) => return Err(err), 
+            };
+
+            let Some(path) = find_in_dirs(&filename, working_set, &cwd, PLUGIN_DIRS_VAR) else {
+                return Err(ParseError::RegisteredFileNotFound(filename, expr.span))
+            };
+
+            if path.exists() && path.is_file() {
                 Ok((path, expr.span))
             } else {
-                Err(ParseError::RegisteredFileNotFound(
-                    format!("{path:?}"),
-                    expr.span,
-                ))
+                Err(ParseError::RegisteredFileNotFound(filename, expr.span))
             }
         })
         .expect("required positional has being checked");

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2855,12 +2855,12 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
         .map(|expr| {
             let val = match eval_constant(working_set, expr) {
                 Ok(val) => val,
-                Err(err) =>return Err(err),
+                Err(err) => return Err(err),
             };
 
             let filename = match value_as_string(val, expr.span) {
                 Ok(str) => str,
-                Err(err) => return Err(err), 
+                Err(err) => return Err(err),
             };
 
             let Some(path) = find_in_dirs(&filename, working_set, &cwd, PLUGIN_DIRS_VAR) else {

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -487,3 +487,36 @@ fn unbalanced_delimiter2() -> TestResult {
 fn unbalanced_delimiter3() -> TestResult {
     fail_test(r#"{"#, "Unexpected end of code")
 }
+
+#[test]
+fn register_with_string_literal() -> TestResult {
+    fail_test(r#"register 'nu-plugin-math'"#, "File not found")
+}
+
+#[test]
+fn register_with_string_constant() -> TestResult {
+    let input = "\
+const file = 'nu-plugin-math'
+register $file
+";
+    // should not fail with `not a constant`
+    fail_test(input, "File not found")
+}
+
+#[test]
+fn register_with_string_variable() -> TestResult {
+    let input = "\
+let file = 'nu-plugin-math'
+register $file
+";
+    fail_test(input, "Value is not a parse-time constant")
+}
+
+#[test]
+fn register_with_non_string_constant() -> TestResult {
+    let input = "\
+const file = 6
+register $file
+";
+    fail_test(input, "expected string, found int")
+}


### PR DESCRIPTION
# Description

this pr allows `register` to be used with const variables
```nu
const math_plugin = "~/.config/nushell/plugins/nu_plugin_math"
register $math_plugin
```

should close #8208, previous work #8435
