### PR TITLE
Update some `help` examples

### DIFF
--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -81,7 +81,7 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Get the current date in UTC+05:00",
-                example: "date now | date to-timezone +0500",
+                example: "date now | date to-timezone '+0500'",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -51,7 +51,7 @@ impl Command for Explain {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Explain a command within a closure",
-            example: "explain { ls | sort-by name type -i | get name } | table -e",
+            example: "explain {|| ls | sort-by name type -i | get name } | table -e",
             result: None,
         }]
     }

--- a/crates/nu-command/src/debug/profile.rs
+++ b/crates/nu-command/src/debug/profile.rs
@@ -106,7 +106,7 @@ Current known limitations are:
         vec![Example {
             description:
                 "Profile some code, stepping into the `spam` command and collecting source.",
-            example: r#"def spam [] { "spam" }; profile { spam | str length } -d 2 --source"#,
+            example: r#"def spam [] { "spam" }; profile {|| spam | str length } -d 2 --source"#,
             result: None,
         }]
     }

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -166,7 +166,7 @@ impl Command for ViewSource {
         vec![
             Example {
                 description: "View the source of a code block",
-                example: r#"let abc = { echo 'hi' }; view source $abc"#,
+                example: r#"let abc = {|| echo 'hi' }; view source $abc"#,
                 result: Some(Value::test_string("{ echo 'hi' }")),
             },
             Example {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -315,7 +315,7 @@ impl Command for Ls {
             },
             Example {
                 description: "List given paths and show directories themselves",
-                example: "['/path/to/directory' '/path/to/file'] | each { ls -D $in } | flatten",
+                example: "['/path/to/directory' '/path/to/file'] | each {|| ls -D $in } | flatten",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -269,7 +269,7 @@ impl Command for Watch {
         vec![
             Example {
                 description: "Run `cargo test` whenever a Rust file changes",
-                example: r#"watch . --glob=**/*.rs { cargo test }"#,
+                example: r#"watch . --glob=**/*.rs {|| cargo test }"#,
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -47,7 +47,7 @@ impl Command for ParEach {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[1 2 3] | par-each { 2 * $in }",
+                example: "[1 2 3] | par-each {|| 2 * $in }",
                 description:
                     "Multiplies each number. Note that the list will become arbitrarily disordered.",
                 result: None,

--- a/crates/nu-command/src/filters/shuffle.rs
+++ b/crates/nu-command/src/filters/shuffle.rs
@@ -46,7 +46,7 @@ impl Command for Shuffle {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Shuffle rows randomly (execute it several times and see the difference)",
-            example: r#"[[version patch]; [1.0.0 false] [3.0.1 true] [2.0.0 false]] | shuffle"#,
+            example: r#"[[version patch]; ['1.0.0' false] ['3.0.1' true] ['2.0.0' false]] | shuffle"#,
             result: None,
         }]
     }

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -150,7 +150,7 @@ not supported."#
             },
             Example {
                 description: "Find files whose filenames don't begin with the correct sequential number",
-                example: "ls | where type == file | sort-by name -n | enumerate | where {|e| $e.item.name !~ $'^($e.index + 1)' } | each { get item }",
+                example: "ls | where type == file | sort-by name -n | enumerate | where {|e| $e.item.name !~ $'^($e.index + 1)' } | each {|| get item }",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -77,7 +77,7 @@ impl Command for Zip {
                 }),
             },
             Example {
-                example: "glob *.ogg | zip ['bang.ogg', 'fanfare.ogg', 'laser.ogg'] | each { mv $in.0 $in.1 }",
+                example: "glob *.ogg | zip ['bang.ogg', 'fanfare.ogg', 'laser.ogg'] | each {|| mv $in.0 $in.1 }",
                 description: "Rename .ogg files to match an existing list of filenames",
                 result: None,
             },

--- a/crates/nu-command/src/platform/ansi/gradient.rs
+++ b/crates/nu-command/src/platform/ansi/gradient.rs
@@ -72,25 +72,25 @@ impl Command for SubCommand {
             Example {
             description: "draw text in a gradient with foreground start and end colors",
             example:
-                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff --fgend 0xe81cff",
+                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart '0x40c9ff' --fgend '0xe81cff'",
             result: None,
         },
         Example {
             description: "draw text in a gradient with foreground start and end colors and background start and end colors",
             example:
-                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff --fgend 0xe81cff --bgstart 0xe81cff --bgend 0x40c9ff",
+                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart '0x40c9ff' --fgend '0xe81cff' --bgstart '0xe81cff' --bgend '0x40c9ff'",
             result: None,
         },
         Example {
             description: "draw text in a gradient by specifying foreground start color - end color is assumed to be black",
             example:
-                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart 0x40c9ff",
+                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgstart '0x40c9ff'",
             result: None,
         },
         Example {
             description: "draw text in a gradient by specifying foreground end color - start color is assumed to be black",
             example:
-                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgend 0xe81cff",
+                "'Hello, Nushell! This is a gradient.' | ansi gradient --fgend '0xe81cff'",
             result: None,
         },
         ]

--- a/crates/nu-command/src/viewers/explore.rs
+++ b/crates/nu-command/src/viewers/explore.rs
@@ -120,7 +120,7 @@ impl Command for Explore {
             },
             Example {
                 description: "Explore a list of Markdown files' contents, with row indexes",
-                example: r#"glob *.md | each { open } | explore -i"#,
+                example: r#"glob *.md | each {|| open } | explore -i"#,
                 result: None,
             },
             Example {


### PR DESCRIPTION
# Description

<!--
_(Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.)_

_(Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.)_
-->

Recently a few things changed, which now create issues:
- `1.0.0`, `+500`, and `0x000000` used to get parsed as string, but now just errors
- `each { print $in }` -> `each {|| print $in }`

I looked through all the help pages and fixed every highlighted (red background) error: `help commands | each {|i| help $i.name} | table | less`

# User-Facing Changes

<!--
_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_
-->

The examples work again and no longer contain error syntax-highlighting

# Tests + Formatting

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting

<!--
If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
-->