### PR TITLE
Stdlib: use default color for info log level

### DIFF
--- a/crates/nu-utils/standard_library/std.nu
+++ b/crates/nu-utils/standard_library/std.nu
@@ -376,7 +376,7 @@ export def "log warning" [message: string] {
 export def "log info" [message: string] {
     if (current-log-level) > (INFO_LEVEL) { return }
 
-    print --stderr $"(ansi white)INF|(now)|($message)(ansi reset)"
+    print --stderr $"(ansi default)INF|(now)|($message)(ansi reset)"
 }
 # Log debug message
 export def "log debug" [message: string] {

--- a/crates/nu-utils/standard_library/test_logger.nu
+++ b/crates/nu-utils/standard_library/test_logger.nu
@@ -37,3 +37,10 @@ export def test_debug [] {
     assert no message INFO debug 
     assert message DEBUG debug DBG
 }
+export def example [] {
+    log debug "Debug message"
+    log info "Info message"
+    log warning "Warning message"
+    log error "Error message"
+    log critical "Critical message"
+}


### PR DESCRIPTION
To make it work with a light theme, as well. The dark theme is not affected, since the default color is white there. 

## Before

![image](https://user-images.githubusercontent.com/282320/230329663-6fae7b7d-7062-459c-ad80-8da3a243d606.png)

## After

![image](https://user-images.githubusercontent.com/282320/230329784-c40bf93e-0740-4b87-ae19-84fd7983898a.png)

Also, I added back the example command to the test script which is very useful in these cases...