### PR TITLE
Add ppid example for ps

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -67,6 +67,11 @@ impl Command for Ps {
                 example: "ps | where name =~ 'nu'",
                 result: None,
             },
+            Example {
+                description: "Get the parent process id of the current nu process",
+                example: "ps | where pid == $nu.pid | get ppid",
+                result: None,
+            },
         ]
     }
 }


### PR DESCRIPTION
# Description

Add an extra example for the `ps` command

# User-Facing Changes

Only adds this example:

![image](https://user-images.githubusercontent.com/1576660/230374829-dc957b89-0a76-451d-baba-5e4463b150c3.png)

# Tests + Formatting

N/A

# After Submitting

This is related to https://github.com/nushell/nushell.github.io/pull/864