### PR TITLE
FIX: load the library before anything else

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -113,6 +113,9 @@ pub(crate) fn run_commands(
 ) -> Result<(), miette::ErrReport> {
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
+
+    load_standard_library(engine_state)?;
+
     #[cfg(feature = "plugin")]
     read_plugin_file(
         engine_state,
@@ -162,8 +165,6 @@ pub(crate) fn run_commands(
         column!(),
         use_color,
     );
-
-    load_standard_library(engine_state)?;
 
     // Before running commands, set up the startup time
     engine_state.set_startup_time(entire_start_time.elapsed().as_nanos() as i64);
@@ -202,6 +203,8 @@ pub(crate) fn run_file(
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
 
+    load_standard_library(engine_state)?;
+
     #[cfg(feature = "plugin")]
     read_plugin_file(
         engine_state,
@@ -251,8 +254,6 @@ pub(crate) fn run_file(
         column!(),
         use_color,
     );
-
-    load_standard_library(engine_state)?;
 
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_file(
@@ -301,6 +302,8 @@ pub(crate) fn run_repl(
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
 
+    load_standard_library(engine_state)?;
+
     if parsed_nu_cli_args.no_config_file.is_none() {
         setup_config(
             engine_state,
@@ -323,8 +326,6 @@ pub(crate) fn run_repl(
         column!(),
         use_color,
     );
-
-    load_standard_library(engine_state)?;
 
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_repl(


### PR DESCRIPTION
should close #8772.

# Description
okey, i think that was pretty easy in the end :relieved: 
i just move the library loading to the top of 
- the script branch
- the command branch
- the REPL branch

more precisely, the calls to `load_standard_library` now occurs BEFORE the loading of the config!

# User-Facing Changes
users will now be able to `use std ...` from their config.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :red_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```
