### PR TITLE
Aliasing math expression shows error earlier

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -113,3 +113,15 @@ fn alias_wont_recurse2() {
         assert!(actual.err.is_empty());
     })
 }
+
+#[test]
+fn alias_invalid_expression() {
+    let actual = nu!(r#" alias spam = 'foo' "#);
+    assert!(actual.err.contains("cant_alias_expression"));
+
+    let actual = nu!(r#" alias spam = (ls -l) "#);
+    assert!(actual.err.contains("cant_alias_expression"));
+
+    let actual = nu!(r#" alias spam = 0..12 "#);
+    assert!(actual.err.contains("cant_alias_expression"));
+}

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -259,8 +259,8 @@ fn help_module_sorted_aliases() {
             "spam.nu",
             r#"
                 module SPAM {
-                    export alias z = 'z'
-                    export alias a = 'a'
+                    export alias z = echo 'z'
+                    export alias a = echo 'a'
                 }
             "#,
         )]);

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -274,9 +274,9 @@ fn source_env_is_scoped() {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
-                    def no-name-similar-to-this [] { 'no-name-similar-to-this' }
-                    alias nor-similar-to-this = 'nor-similar-to-this'
-                "#,
+                def no-name-similar-to-this [] { 'no-name-similar-to-this' }
+                alias nor-similar-to-this = echo 'nor-similar-to-this'
+            "#,
         )]);
 
         let inp = &[r#"source-env spam.nu"#, r#"no-name-similar-to-this"#];

--- a/crates/nu-parser/src/errors.rs
+++ b/crates/nu-parser/src/errors.rs
@@ -109,6 +109,13 @@ pub enum ParseError {
     )]
     CantAliasKeyword(String, #[label("not supported in alias")] Span),
 
+    #[error("Can't create alias to expression.")]
+    #[diagnostic(
+        code(nu::parser::cant_alias_expression),
+        help("Only command calls can be aliased.")
+    )]
+    CantAliasExpression(String, #[label("aliasing {0} is not supported")] Span),
+
     #[error("Unknown operator")]
     #[diagnostic(code(nu::parser::unknown_operator), help("{1}"))]
     UnknownOperator(
@@ -434,6 +441,7 @@ impl ParseError {
             ParseError::ExpectedKeyword(_, s) => *s,
             ParseError::UnexpectedKeyword(_, s) => *s,
             ParseError::CantAliasKeyword(_, s) => *s,
+            ParseError::CantAliasExpression(_, s) => *s,
             ParseError::BuiltinCommandInPipeline(_, s) => *s,
             ParseError::AssignInPipeline(_, _, _, s) => *s,
             ParseError::LetBuiltinVar(_, s) => *s,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -18,13 +18,14 @@ pub const PLUGIN_DIRS_VAR: &str = "NU_PLUGIN_DIRS";
 
 use crate::{
     eval::{eval_constant, value_as_string},
+    is_math_expression_like,
     known_external::KnownExternal,
     lex,
     lite_parser::{lite_parse, LiteCommand, LiteElement},
     parser::{
-        check_call, check_name, garbage, garbage_pipeline, parse, parse_call, parse_import_pattern,
-        parse_internal_call, parse_multispan_value, parse_signature, parse_string, parse_value,
-        parse_var_with_opt_type, trim_quotes, ParsedInternalCall,
+        check_call, check_name, garbage, garbage_pipeline, parse, parse_call, parse_expression,
+        parse_import_pattern, parse_internal_call, parse_multispan_value, parse_signature,
+        parse_string, parse_value, parse_var_with_opt_type, trim_quotes, ParsedInternalCall,
     },
     unescape_unquote_string, ParseError, Token, TokenContents,
 };
@@ -788,6 +789,27 @@ pub fn parse_alias(
             let _equals = working_set.get_span_contents(spans[split_id + 1]);
 
             let replacement_spans = &spans[(split_id + 2)..];
+
+            if is_math_expression_like(working_set, replacement_spans[0], expand_aliases_denylist) {
+                // TODO: Maybe we need to implement a Display trait for Expression?
+                let (expr, _) = parse_expression(
+                    working_set,
+                    replacement_spans,
+                    expand_aliases_denylist,
+                    false,
+                );
+
+                let msg = format!("{:?}", expr.expr);
+                let msg_parts: Vec<&str> = msg.split('(').collect();
+
+                return (
+                    alias_pipeline,
+                    Some(ParseError::CantAliasExpression(
+                        msg_parts[0].to_string(),
+                        replacement_spans[0],
+                    )),
+                );
+            }
 
             let (expr, err) = parse_call(
                 working_set,


### PR DESCRIPTION
# Description

Previously, if attempting to alias a non-call expression, it would result in strange error messages when trying to use the alias. Now, if we're aliasing a math expression, we throw an error early.

Before:
```
> alias spam = 'foo'

> spam
Error: nu::shell::external_command

  × External command failed
   ╭─[entry #4:1:1]
 1 │ spam
   · ──┬─
   ·   ╰── did you mean 'foo'?
   ╰────
  help: No such file or directory (os error 2)
```

After:
```
> alias spam = 'foo'
Error: nu::parser::cant_alias_expression

  × Can't create alias to expression.
   ╭─[entry #1:1:1]
 1 │ alias spam = 'foo'
   ·              ──┬──
   ·                ╰── aliasing String is not supported
   ╰────
  help: Only command calls can be aliased.
```

Fixes https://github.com/nushell/nushell/issues/8760
Fixes https://github.com/nushell/nushell/issues/8249

# User-Facing Changes

Better error messages. Might break some existing code that previously failed silently.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
