### PR TITLE
Add $nu.current-exe variable

### DIFF
--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -524,10 +524,11 @@ fn variables_completions() {
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
 
-    assert_eq!(12, suggestions.len());
+    assert_eq!(13, suggestions.len());
 
     let expected: Vec<String> = vec![
         "config-path".into(),
+        "current-exe".into(),
         "env-path".into(),
         "history-path".into(),
         "home-path".into(),

--- a/crates/nu-engine/src/nu_variable.rs
+++ b/crates/nu-engine/src/nu_variable.rs
@@ -42,6 +42,8 @@ impl LazyRecord for NuVariable {
         cols.push("is-interactive");
         cols.push("is-login");
 
+        cols.push("current-exe");
+
         cols
     }
 
@@ -213,6 +215,19 @@ impl LazyRecord for NuVariable {
                 val: self.engine_state.get_startup_time(),
                 span: self.span(),
             }),
+            "current-exe" => {
+                let exe = std::env::current_exe().map_err(|_| {
+                    err("Could not get current executable path")
+                        .expect_err("did not get err from err function")
+                })?;
+
+                let canon_exe = canonicalize_path(&self.engine_state, &exe);
+
+                Ok(Value::String {
+                    val: canon_exe.to_string_lossy().into(),
+                    span: self.span(),
+                })
+            }
             _ => err(&format!("Could not find column '{column}'")),
         }
     }


### PR DESCRIPTION
# Description

Part solving #8752

Adds an extra variable to the `nu` table `current-exe` which is the path to the running shell executable.

# User-Facing Changes

Adds a variable to the `nu` table.

# Tests + Formatting

Tests and formatting have been run. No new test added

# After Submitting

I could add documentation for this if wanted