### PR TITLE
Don't localize integer to string

### DIFF
--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -6,8 +6,6 @@ use nu_protocol::{
     into_code, Category, Config, Example, IntoPipelineData, PipelineData, ShellError, Signature,
     Span, SyntaxShape, Type, Value,
 };
-use nu_utils::get_system_locale;
-use num_format::ToFormattedString;
 
 struct Arguments {
     decimals_value: Option<i64>,
@@ -199,7 +197,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
     match input {
         Value::Int { val, .. } => {
             let decimal_value = digits.unwrap_or(0) as usize;
-            let res = format_int(*val, false, decimal_value);
+            let res = format_int(*val, decimal_value);
             Value::String { val: res, span }
         }
         Value::Float { val, .. } => {
@@ -273,22 +271,13 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
     }
 }
 
-fn format_int(int: i64, group_digits: bool, decimals: usize) -> String {
-    let locale = get_system_locale();
-
-    let str = if group_digits {
-        int.to_formatted_string(&locale)
-    } else {
-        int.to_string()
-    };
+fn format_int(int: i64, decimals: usize) -> String {
+    let str = int.to_string();
 
     if decimals > 0 {
-        let decimal_point = locale.decimal();
-
         format!(
-            "{}{decimal_point}{dummy:0<decimals$}",
+            "{}.{dummy:0<decimals$}",
             str,
-            decimal_point = decimal_point,
             dummy = "",
             decimals = decimals
         )

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -227,8 +227,9 @@ fn int_into_string_decimals_10() {
 }
 
 #[test]
-fn int_into_string_decimals_respects_system_locale_de() {
+fn int_into_string_decimals_doesnt_respect_system_locale_de() {
     // Set locale to `de_DE`, which uses `,` (comma) as decimal separator
+    // But int to string, like float to string, always uses `.` (period)
     let actual = nu!(
         locale: "de_DE.UTF-8",
         pipeline(
@@ -238,7 +239,7 @@ fn int_into_string_decimals_respects_system_locale_de() {
         )
     );
 
-    assert_eq!(actual.out, "10,0");
+    assert_eq!(actual.out, "10.0");
 }
 
 #[test]


### PR DESCRIPTION
# Description

Fixes #8790 

# User-Facing Changes

`into string` now doesn't use `,` for formatting ints with decimals, which is consistent with formatting floats.

# Tests + Formatting

Fixes https://github.com/nushell/nushell/blob/a52386e837bc4cb74d93379f02facc932b4acde3/crates/nu-command/src/conversions/into/string.rs#L79-L83

I found that the thousands separator for file sizes is also localized, but checked on discord that this is expected behaviour. This means that fixing the locale in place when running tests is not the default. On further inspection I found this function: https://github.com/nushell/nushell/blob/41306aa7e0834892e72b1c93423bffb82fc21d4a/crates/nu-utils/src/locale.rs#L23-L28

I think that instead of using an env var, this should always use the en_US locale

# After Submitting

Example for `into string` now works on all locales