### PR TITLE
Fix `config {nu,env}` to open `$nu.{config,env}-file`

### DIFF
--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -42,8 +42,8 @@ impl Command for ConfigEnv {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let env_vars_str = env_to_strings(engine_state, stack)?;
-        let mut config_path = match nu_path::config_dir() {
-            Some(path) => path,
+        let nu_config = match engine_state.get_config_path("env-path") {
+            Some(path) => path.clone(),
             None => {
                 return Err(ShellError::GenericError(
                     "Could not find nu env path".to_string(),
@@ -54,9 +54,6 @@ impl Command for ConfigEnv {
                 ));
             }
         };
-        config_path.push("nushell");
-        let mut nu_config = config_path.clone();
-        nu_config.push("env.nu");
 
         let (item, config_args) = get_editor(engine_state, stack, call.head)?;
 

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -46,8 +46,8 @@ impl Command for ConfigEnv {
             Some(path) => path.clone(),
             None => {
                 return Err(ShellError::GenericError(
-                    "Could not find nu env path".to_string(),
-                    "Could not find nu env path".to_string(),
+                    "Could not find $nu.env-path".to_string(),
+                    "Could not find $nu.env-path".to_string(),
                     None,
                     None,
                     Vec::new(),

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -42,21 +42,18 @@ impl Command for ConfigNu {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let env_vars_str = env_to_strings(engine_state, stack)?;
-        let mut config_path = match nu_path::config_dir() {
-            Some(path) => path,
+        let nu_config = match engine_state.get_config_path("config-path") {
+            Some(path) => path.clone(),
             None => {
                 return Err(ShellError::GenericError(
-                    "Could not find nu config path".to_string(),
-                    "Could not find nu config path".to_string(),
+                    "Could not find $nu.config-path".to_string(),
+                    "Could not find $nu.config-path".to_string(),
                     None,
                     None,
                     Vec::new(),
                 ));
             }
         };
-        config_path.push("nushell");
-        let mut nu_config = config_path.clone();
-        nu_config.push("config.nu");
 
         let (item, config_args) = get_editor(engine_state, stack, call.head)?;
 


### PR DESCRIPTION
# Description

fixed #8755
Now, command `config {nu,env}` opens default file `.config/nushell/{config,env}.nu`.
This behavior is inappropriate when `nu` is launched with option `--config` or `--env-config`.
This PR changes the file that the command opens to `$nu.{config,env}-file`.

# User-Facing Changes

`config {nu,env}` opens `$nu.{config,env}-file`.

# Tests + Formatting

```
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :red_circle: `toolkit test stdlib`
```

I got these errors, but the errors are probably caused by my environment.
```
INF|2023-04-07T23:30:00.382|Running tests in test_asserts
Error:
  × ASSERT:SKIP
    ╭─[std.nu:75:1]
 75 │ export def "assert skip" [] {
 76 │     error make {msg: "ASSERT:SKIP"}
    ·     ─────┬────
    ·          ╰── originates from here
 77 │ }
    ╰────


INF|2023-04-07T23:30:00.642|Running tests in test_dirs
INF|2023-04-07T23:30:00.819|Running tests in test_logger
INF|2023-04-07T23:30:01.125|Running tests in test_std
INF|2023-04-07T23:30:01.186|Running tests in test_xml
Error: nu::shell::deprecated_command

  × Deprecated command match
     ╭─[std.nu:421:1]
 421 │     for $step in ($path) {
 422 │         match ($step | describe) {
     ·         ──┬──
     ·           ╰── 'match' is deprecated. Please use 'find' instead.
 423 │             'string' => {
     ╰────

Error: nu::shell::deprecated_command

  × Deprecated command match
     ╭─[std.nu:518:1]
 518 │
 519 │         match ($step | describe) {
     ·         ──┬──
     ·           ╰── 'match' is deprecated. Please use 'find' instead.
 520 │             'string' => {
     ╰────

Error: nu::shell::deprecated_command

  × Deprecated command match
     ╭─[std.nu:518:1]
 518 │
 519 │         match ($step | describe) {
     ·         ──┬──
     ·           ╰── 'match' is deprecated. Please use 'find' instead.
 520 │             'string' => {
     ╰────
```

# After Submitting

nothing