### PR TITLE
add the standard `help` to the prelude as `std help ...`

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -79,16 +79,13 @@ fn load_standard_library(
             report_error(&working_set, &err);
         }
 
-        // TODO: change this when #8505 is merged
-        // NOTE: remove the assert and uncomment the `help`s
         let prelude = vec![
-            ("assert", "assert"),
-            // ("help", "help"),
-            // ("help commands", "help commands"),
-            // ("help aliases", "help aliases"),
-            // ("help modules", "help modules"),
-            // ("help externs", "help externs"),
-            // ("help operators", "help operators"),
+            ("std help", "help"),
+            ("std help commands", "help commands"),
+            ("std help aliases", "help aliases"),
+            ("std help modules", "help modules"),
+            ("std help externs", "help externs"),
+            ("std help operators", "help operators"),
         ];
 
         load_prelude(&mut working_set, prelude, &module);

--- a/src/tests/test_stdlib.rs
+++ b/src/tests/test_stdlib.rs
@@ -10,26 +10,15 @@ fn library_loaded() -> TestResult {
 
 #[test]
 fn prelude_loaded() -> TestResult {
-    run_test(
-        "help assert | lines | first 1 | to text",
-        "Universal assert command",
-    )
-}
-
-#[test]
-fn prelude_run() -> TestResult {
-    run_test("assert true; print 'it works'", "it works")
+    run_test("std help commands | length", "377")
 }
 
 #[test]
 fn not_loaded() -> TestResult {
-    fail_test("help log info", "")
+    fail_test("log info", "")
 }
 
 #[test]
 fn use_command() -> TestResult {
-    run_test(
-        "use std 'log info'; log info 'this is some information'",
-        "",
-    )
+    run_test("use std assert; assert true; print 'it works'", "it works")
 }

--- a/src/tests/test_stdlib.rs
+++ b/src/tests/test_stdlib.rs
@@ -10,7 +10,7 @@ fn library_loaded() -> TestResult {
 
 #[test]
 fn prelude_loaded() -> TestResult {
-    run_test("std help commands | length", "377")
+    run_test("std help commands | where name == open | length", "1")
 }
 
 #[test]


### PR DESCRIPTION
Related to #8505.

# Description
as #8505 has been landed, this PR fixes the prelude TODO and uses the `help` commands from the standard library in the prelude.

# User-Facing Changes
can now access `std help ...` to use the `help` implementations from the standard library

# Tests + Formatting
```
$nothing
```

# After Submitting
```
$nothing
```