### PR TITLE
FEATURE: make the link in the `ansi` extra usage an ANSI link

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -533,7 +533,7 @@ impl Command for AnsiCommand {
 
     fn extra_usage(&self) -> &str {
         "An introduction to what ANSI escape sequences are can be found in the
-[*ANSI escape code*](https://en.wikipedia.org/wiki/ANSI_escape_code) Wikipedia page.
+\u{1b}]8;;https://en.wikipedia.org/wiki/ANSI_escape_code\u{1b}\\ANSI escape code\u{1b}]8;;\u{1b}\\ Wikipedia page.
 
 Escape sequences usual values:
 ╭────┬────────────┬────────┬────────┬─────────╮


### PR DESCRIPTION
# Description
this addresses the comments of @fdncred from https://github.com/nushell/nushell/issues/8713#issuecomment-1498206087

the exact ANSI link has been generated with
```bash
"https://en.wikipedia.org/wiki/ANSI_escape_code" | ansi link --text "ANSI escape code" | debug -r
```

# User-Facing Changes
there is now an ANSI link in the `ansi` help page instead of a markdown link.

# Tests + Formatting
```
$nothing
```

# After Submitting
```
$nothing
```