### PR TITLE
Remove old alias implementation

### DIFF
--- a/crates/nu-cli/src/commands.rs
+++ b/crates/nu-cli/src/commands.rs
@@ -34,7 +34,7 @@ pub fn evaluate_commands(
 
         let mut working_set = StateWorkingSet::new(engine_state);
 
-        let output = parse(&mut working_set, None, commands.item.as_bytes(), false, &[]);
+        let output = parse(&mut working_set, None, commands.item.as_bytes(), false);
         if let Some(err) = working_set.parse_errors.first() {
             report_error(&working_set, err);
 

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -88,7 +88,7 @@ impl CommandCompletion {
 
         let filter_predicate = |command: &[u8]| match_algorithm.matches_u8(command, partial);
 
-        let results = working_set
+        let mut results = working_set
             .find_commands_by_predicate(filter_predicate)
             .into_iter()
             .map(move |x| Suggestion {
@@ -97,20 +97,8 @@ impl CommandCompletion {
                 extra: None,
                 span: reedline::Span::new(span.start - offset, span.end - offset),
                 append_whitespace: true,
-            });
-
-        let results_aliases = working_set
-            .find_aliases_by_predicate(filter_predicate)
-            .into_iter()
-            .map(move |x| Suggestion {
-                value: String::from_utf8_lossy(&x).to_string(),
-                description: None,
-                extra: None,
-                span: reedline::Span::new(span.start - offset, span.end - offset),
-                append_whitespace: true,
-            });
-
-        let mut results = results.chain(results_aliases).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
 
         let partial = working_set.get_span_contents(span);
         let partial = String::from_utf8_lossy(partial).to_string();

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -113,14 +113,13 @@ impl NuCompleter {
     fn completion_helper(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         let mut working_set = StateWorkingSet::new(&self.engine_state);
         let offset = working_set.next_span_start();
-        let (mut new_line, alias_offset) = try_find_alias(line.as_bytes(), &working_set);
         let initial_line = line.to_string();
-        let alias_total_offset: usize = alias_offset.iter().sum();
-        new_line.insert(alias_total_offset + pos, b'a');
+        let mut line = line.to_string();
+        line.insert(pos, 'a');
         let pos = offset + pos;
         let config = self.engine_state.get_config();
 
-        let output = parse(&mut working_set, Some("completer"), &new_line, false, &[]);
+        let output = parse(&mut working_set, Some("completer"), line.as_bytes(), false);
 
         for pipeline in output.pipelines.into_iter() {
             for pipeline_element in pipeline.elements {
@@ -131,7 +130,6 @@ impl NuCompleter {
                     | PipelineElement::Or(_, expr)
                     | PipelineElement::SeparateRedirection { out: (_, expr), .. } => {
                         let flattened: Vec<_> = flatten_expression(&working_set, &expr);
-                        let span_offset: usize = alias_offset.iter().sum();
                         let mut spans: Vec<String> = vec![];
 
                         for (flat_idx, flat) in flattened.iter().enumerate() {
@@ -154,24 +152,17 @@ impl NuCompleter {
                             }
 
                             // Complete based on the last span
-                            if pos + span_offset >= flat.0.start && pos + span_offset < flat.0.end {
+                            if pos >= flat.0.start && pos < flat.0.end {
                                 // Context variables
                                 let most_left_var =
                                     most_left_variable(flat_idx, &working_set, flattened.clone());
 
                                 // Create a new span
-                                let new_span = if flat_idx == 0 {
-                                    Span::new(flat.0.start, flat.0.end - 1 - span_offset)
-                                } else {
-                                    Span::new(
-                                        flat.0.start - span_offset,
-                                        flat.0.end - 1 - span_offset,
-                                    )
-                                };
+                                let new_span = Span::new(flat.0.start, flat.0.end - 1);
 
                                 // Parses the prefix. Completion should look up to the cursor position, not after.
                                 let mut prefix = working_set.get_span_contents(flat.0).to_vec();
-                                let index = pos - (flat.0.start - span_offset);
+                                let index = pos - flat.0.start;
                                 prefix.drain(index..);
 
                                 // Variables completion
@@ -388,85 +379,6 @@ impl NuCompleter {
 impl ReedlineCompleter for NuCompleter {
     fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
         self.completion_helper(line, pos)
-    }
-}
-
-type MatchedAlias = Vec<(Vec<u8>, Vec<u8>)>;
-
-// Handler the completion when giving lines contains at least one alias. (e.g: `g checkout`)
-// that `g` is an alias of `git`
-fn try_find_alias(line: &[u8], working_set: &StateWorkingSet) -> (Vec<u8>, Vec<usize>) {
-    // An vector represents the offsets of alias
-    // e.g: the offset is 2 for the alias `g` of `git`
-    let mut alias_offset = vec![];
-    let mut output = vec![];
-    if let Some(matched_alias) = search_alias(line, working_set) {
-        let mut lens = matched_alias.len();
-        for (input_vec, line_vec) in matched_alias {
-            alias_offset.push(line_vec.len() - input_vec.len());
-            output.extend(line_vec);
-            if lens > 1 {
-                output.push(b' ');
-                lens -= 1;
-            }
-        }
-
-        if !line.is_empty() {
-            let last = line.last().expect("input is empty");
-            if last == &b' ' {
-                output.push(b' ');
-            }
-        }
-    } else {
-        output = line.to_vec();
-    }
-
-    (output, alias_offset)
-}
-
-fn search_alias(input: &[u8], working_set: &StateWorkingSet) -> Option<MatchedAlias> {
-    let mut vec_names = vec![];
-    let mut vec_alias = vec![];
-    let mut pos = 0;
-    let mut is_alias = false;
-    for (index, character) in input.iter().enumerate() {
-        if *character == b' ' {
-            let range = &input[pos..index];
-            vec_names.push(range.to_owned());
-            pos = index + 1;
-        }
-    }
-    // Push the rest to names vector.
-    if pos < input.len() {
-        vec_names.push(input[pos..].to_owned());
-    }
-
-    for name in &vec_names {
-        if let Some(alias_id) = working_set.find_alias(&name[..]) {
-            let alias_span = working_set.get_alias(alias_id);
-            let mut span_vec = vec![];
-            is_alias = true;
-            for alias in alias_span {
-                let name = working_set.get_span_contents(*alias);
-                if !name.is_empty() {
-                    span_vec.push(name);
-                }
-            }
-            // Join span of vector together for complex alias, e.g: `f` is an alias for `git remote -v`
-            let full_aliases = span_vec.join(&[b' '][..]);
-            vec_alias.push(full_aliases);
-        } else {
-            vec_alias.push(name.to_owned());
-        }
-    }
-
-    if is_alias {
-        // Zip names and alias vectors, the original inputs and its aliases mapping.
-        // e.g:(['g'], ['g','i','t'])
-        let output = vec_names.into_iter().zip(vec_alias).collect();
-        Some(output)
-    } else {
-        None
     }
 }
 

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -96,7 +96,7 @@ pub fn evaluate_file(
 
     let mut working_set = StateWorkingSet::new(engine_state);
     trace!("parsing file: {}", file_path_str);
-    let _ = parse(&mut working_set, Some(file_path_str), &file, false, &[]);
+    let _ = parse(&mut working_set, Some(file_path_str), &file, false);
 
     if working_set.find_decl(b"main", &Type::Any).is_some() {
         let args = format!("main {}", args.join(" "));

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -102,7 +102,6 @@ pub(crate) fn add_menus(
                     Some(name), // format!("entry #{}", entry_num)
                     definition.as_bytes(),
                     true,
-                    &[],
                 );
 
                 (output, working_set.render())

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -789,7 +789,7 @@ pub fn eval_string_with_input(
 ) -> Result<Value, ShellError> {
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);
-        let output = parse(&mut working_set, None, source.as_bytes(), false, &[]);
+        let output = parse(&mut working_set, None, source.as_bytes(), false);
 
         (output, working_set.render())
     };

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -18,7 +18,7 @@ impl Highlighter for NuHighlighter {
         trace!("highlighting: {}", line);
 
         let mut working_set = StateWorkingSet::new(&self.engine_state);
-        let block = parse(&mut working_set, None, line.as_bytes(), false, &[]);
+        let block = parse(&mut working_set, None, line.as_bytes(), false);
         let (shapes, global_span_offset) = {
             let shapes = flatten_block(&working_set, &block);
             (shapes, self.engine_state.next_span_start())

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -222,7 +222,6 @@ pub fn eval_source(
             Some(fname), // format!("entry #{}", entry_num)
             source,
             false,
-            &[],
         );
         if let Some(err) = working_set.parse_errors.first() {
             set_last_exit_code(stack, 1);

--- a/crates/nu-cli/src/validation.rs
+++ b/crates/nu-cli/src/validation.rs
@@ -13,7 +13,7 @@ pub struct NuValidator {
 impl Validator for NuValidator {
     fn validate(&self, line: &str) -> ValidationResult {
         let mut working_set = StateWorkingSet::new(&self.engine_state);
-        parse(&mut working_set, None, line.as_bytes(), false, &[]);
+        parse(&mut working_set, None, line.as_bytes(), false);
 
         if matches!(
             working_set.parse_errors.first(),

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -663,7 +663,7 @@ fn run_external_completion(block: &str, input: &str) -> Vec<Suggestion> {
     let (dir, _, mut engine_state, mut stack) = new_engine();
     let (_, delta) = {
         let mut working_set = StateWorkingSet::new(&engine_state);
-        let block = parse(&mut working_set, None, block.as_bytes(), false, &[]);
+        let block = parse(&mut working_set, None, block.as_bytes(), false);
         assert!(working_set.parse_errors.is_empty());
 
         (block, working_set.render())

--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -146,7 +146,7 @@ pub fn merge_input(
     let (block, delta) = {
         let mut working_set = StateWorkingSet::new(engine_state);
 
-        let block = parse(&mut working_set, None, input, false, &[]);
+        let block = parse(&mut working_set, None, input, false);
 
         assert!(working_set.parse_errors.is_empty());
 

--- a/crates/nu-cmd-lang/src/core_commands/help_modules.rs
+++ b/crates/nu-cmd-lang/src/core_commands/help_modules.rs
@@ -4,8 +4,8 @@ use nu_engine::{scope::ScopeData, CallExt};
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    span, AliasId, Category, DeclId, Example, IntoInterruptiblePipelineData, IntoPipelineData,
-    PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
+    span, Category, DeclId, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
+    ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -152,9 +152,16 @@ pub fn help_modules(
         long_desc.push_str("\n\n");
 
         if !module.decls.is_empty() || module.main.is_some() {
-            let commands: Vec<(Vec<u8>, DeclId)> = engine_state.get_decls_sorted(false).collect();
+            let commands: Vec<(Vec<u8>, DeclId)> = engine_state
+                .get_decls_sorted(false)
+                .filter(|(_, id)| !engine_state.get_decl(*id).is_alias())
+                .collect();
 
-            let mut module_commands = module.decls();
+            let mut module_commands: Vec<(Vec<u8>, DeclId)> = module
+                .decls()
+                .into_iter()
+                .filter(|(_, id)| !engine_state.get_decl(*id).is_alias())
+                .collect();
             module_commands.sort_by(|a, b| a.0.cmp(&b.0));
 
             let commands_str = module_commands
@@ -181,15 +188,18 @@ pub fn help_modules(
             long_desc.push_str("\n\n");
         }
 
-        if !module.aliases.is_empty() {
-            let aliases: Vec<(Vec<u8>, AliasId)> = engine_state.get_aliases_sorted(false).collect();
-
-            let mut module_aliases: Vec<(&[u8], AliasId)> = module
-                .aliases
-                .iter()
-                .map(|(name, id)| (name.as_ref(), *id))
+        if !module.decls.is_empty() {
+            let aliases: Vec<(Vec<u8>, DeclId)> = engine_state
+                .get_decls_sorted(false)
+                .filter(|(_, id)| engine_state.get_decl(*id).is_alias())
                 .collect();
-            module_aliases.sort_by(|a, b| a.0.cmp(b.0));
+
+            let mut module_aliases: Vec<(Vec<u8>, DeclId)> = module
+                .decls()
+                .into_iter()
+                .filter(|(_, id)| engine_state.get_decl(*id).is_alias())
+                .collect();
+            module_aliases.sort_by(|a, b| a.0.cmp(&b.0));
 
             let aliases_str = module_aliases
                 .iter()
@@ -198,7 +208,7 @@ pub fn help_modules(
                     if let Some((used_name_bytes, _)) =
                         aliases.iter().find(|(_, alias_id)| id == alias_id)
                     {
-                        if engine_state.find_alias(name.as_bytes(), &[]).is_some() {
+                        if engine_state.find_decl(name.as_bytes(), &[]).is_some() {
                             format!("{CB}{name}{RESET}")
                         } else {
                             let alias_name = String::from_utf8_lossy(used_name_bytes);

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -126,7 +126,7 @@ fn eval_pipeline_without_terminal_expression(
 
 pub fn parse(contents: &str, engine_state: &EngineState) -> (Block, StateDelta) {
     let mut working_set = StateWorkingSet::new(engine_state);
-    let output = nu_parser::parse(&mut working_set, None, contents.as_bytes(), false, &[]);
+    let output = nu_parser::parse(&mut working_set, None, contents.as_bytes(), false);
 
     if let Some(err) = working_set.parse_errors.first() {
         panic!("test parse error in `{contents}`: {err:?}")

--- a/crates/nu-command/src/dataframe/test_dataframe.rs
+++ b/crates/nu-command/src/dataframe/test_dataframe.rs
@@ -50,13 +50,7 @@ pub fn test_dataframe(cmds: Vec<Box<dyn Command + 'static>>) {
 
         let (block, delta) = {
             let mut working_set = StateWorkingSet::new(&engine_state);
-            let output = parse(
-                &mut working_set,
-                None,
-                example.example.as_bytes(),
-                false,
-                &[],
-            );
+            let output = parse(&mut working_set, None, example.example.as_bytes(), false);
 
             if let Some(err) = working_set.parse_errors.first() {
                 panic!("test parse error in `{}`: {:?}", example.example, err)

--- a/crates/nu-command/src/debug/ast.rs
+++ b/crates/nu-command/src/debug/ast.rs
@@ -41,7 +41,7 @@ impl Command for Ast {
         let pipeline: Spanned<String> = call.req(engine_state, stack, 0)?;
         let mut working_set = StateWorkingSet::new(engine_state);
 
-        let block_output = parse(&mut working_set, None, pipeline.item.as_bytes(), false, &[]);
+        let block_output = parse(&mut working_set, None, pipeline.item.as_bytes(), false);
 
         let error_output = working_set.parse_errors.first();
 

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -133,15 +132,6 @@ impl Command for ViewSource {
                             Vec::new(),
                         ))
                     }
-                } else if let Some(alias_id) = engine_state.find_alias(val.as_bytes(), &[]) {
-                    let contents = &mut engine_state.get_alias(alias_id).iter().map(|span| {
-                        String::from_utf8_lossy(engine_state.get_span_contents(span)).to_string()
-                    });
-                    Ok(Value::String {
-                        val: contents.join(" "),
-                        span: call.head,
-                    }
-                    .into_pipeline_data())
                 } else {
                     Err(ShellError::GenericError(
                         "Cannot view value".to_string(),

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -65,8 +65,7 @@ impl Command for FromNuon {
 
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let mut block =
-            nu_parser::parse(&mut working_set, None, string_input.as_bytes(), false, &[]);
+        let mut block = nu_parser::parse(&mut working_set, None, string_input.as_bytes(), false);
 
         if let Some(pipeline) = block.pipelines.get(1) {
             if let Some(element) = pipeline.elements.get(0) {

--- a/crates/nu-command/src/hook.rs
+++ b/crates/nu-command/src/hook.rs
@@ -167,7 +167,7 @@ pub fn eval_hook(
                             }
 
                             let output =
-                                parse(&mut working_set, Some("hook"), val.as_bytes(), false, &[]);
+                                parse(&mut working_set, Some("hook"), val.as_bytes(), false);
                             if let Some(err) = working_set.parse_errors.first() {
                                 report_error(&working_set, err);
 

--- a/crates/nu-command/src/strings/format/command.rs
+++ b/crates/nu-command/src/strings/format/command.rs
@@ -290,7 +290,7 @@ fn format_record(
                 }
             }
             FormatOperation::ValueNeedEval(_col_name, span) => {
-                let exp = parse_expression(working_set, &[*span], &[], false);
+                let exp = parse_expression(working_set, &[*span], false);
                 match working_set.parse_errors.first() {
                     None => {
                         let parsed_result = eval_expression(engine_state, stack, &exp);

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -320,7 +320,7 @@ fn parse_module(
 
     let new_span = Span::new(start, end);
     let starting_error_count = working_set.parse_errors.len();
-    parse_module_block(working_set, new_span, filename.as_bytes(), &[]);
+    parse_module_block(working_set, new_span, filename.as_bytes());
 
     if starting_error_count != working_set.parse_errors.len() {
         if is_debug {
@@ -354,7 +354,7 @@ fn parse_script(
     span: Span,
 ) -> Result<PipelineData, ShellError> {
     let starting_error_count = working_set.parse_errors.len();
-    parse(working_set, filename, contents, false, &[]);
+    parse(working_set, filename, contents, false);
     if starting_error_count != working_set.parse_errors.len() {
         let msg = format!(
             r#"Found : {}"#,

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use log::trace;
 use nu_engine::env;
 use nu_engine::CallExt;
@@ -74,27 +73,6 @@ fn entry(arg: impl Into<String>, path: impl Into<String>, builtin: bool, span: S
     Value::Record { cols, vals, span }
 }
 
-fn get_entry_in_aliases(engine_state: &EngineState, name: &str, span: Span) -> Option<Value> {
-    if let Some(alias_id) = engine_state.find_alias(name.as_bytes(), &[]) {
-        let alias = engine_state.get_alias(alias_id);
-        let alias_str = alias
-            .iter()
-            .map(|alias_span| String::from_utf8_lossy(engine_state.get_span_contents(alias_span)))
-            .join(" ");
-
-        trace!("Found alias: {}", name);
-
-        Some(entry(
-            name,
-            format!("Nushell alias: {alias_str}"),
-            false,
-            span,
-        ))
-    } else {
-        None
-    }
-}
-
 fn get_entry_in_commands(engine_state: &EngineState, name: &str, span: Span) -> Option<Value> {
     if let Some(decl_id) = engine_state.find_decl(name.as_bytes(), &[]) {
         let (msg, is_builtin) = if engine_state.get_decl(decl_id).is_custom_command() {
@@ -118,10 +96,6 @@ fn get_entries_in_nu(
     skip_after_first_found: bool,
 ) -> Vec<Value> {
     let mut all_entries = vec![];
-
-    if let Some(ent) = get_entry_in_aliases(engine_state, name, span) {
-        all_entries.push(ent);
-    }
 
     if !all_entries.is_empty() && skip_after_first_found {
         return all_entries;

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -5,8 +5,6 @@ use quickcheck_macros::quickcheck;
 mod commands;
 mod format_conversions;
 
-// use nu_engine::EvaluationContext;
-
 #[quickcheck]
 fn quickcheck_parse(data: String) -> bool {
     let (tokens, err) = nu_parser::lex(data.as_bytes(), 0, b"", b"", true);
@@ -17,7 +15,7 @@ fn quickcheck_parse(data: String) -> bool {
             let mut working_set = StateWorkingSet::new(&context);
             working_set.add_file("quickcheck".into(), data.as_bytes());
 
-            let _ = nu_parser::parse_block(&mut working_set, &tokens, false, &[], false);
+            let _ = nu_parser::parse_block(&mut working_set, &tokens, false, false);
         }
     }
     true

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -52,8 +52,7 @@ pub struct ScopeData<'e, 's> {
     engine_state: &'e EngineState,
     stack: &'s Stack,
     vars_map: HashMap<&'e Vec<u8>, &'e usize>,
-    commands_map: HashMap<&'e (Vec<u8>, Type), &'e usize>,
-    aliases_map: HashMap<&'e Vec<u8>, &'e usize>,
+    decls_map: HashMap<&'e (Vec<u8>, Type), &'e usize>,
     modules_map: HashMap<&'e Vec<u8>, &'e usize>,
     visibility: Visibility,
 }
@@ -64,8 +63,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             engine_state,
             stack,
             vars_map: HashMap::new(),
-            commands_map: HashMap::new(),
-            aliases_map: HashMap::new(),
+            decls_map: HashMap::new(),
             modules_map: HashMap::new(),
             visibility: Visibility::new(),
         }
@@ -74,16 +72,9 @@ impl<'e, 's> ScopeData<'e, 's> {
     pub fn populate_all(&mut self) {
         for overlay_frame in self.engine_state.active_overlays(&[]) {
             self.vars_map.extend(&overlay_frame.vars);
-            self.commands_map.extend(&overlay_frame.decls);
-            self.aliases_map.extend(&overlay_frame.aliases);
+            self.decls_map.extend(&overlay_frame.decls);
             self.modules_map.extend(&overlay_frame.modules);
             self.visibility.merge_with(overlay_frame.visibility.clone());
-        }
-    }
-
-    pub fn populate_aliases(&mut self) {
-        for overlay_frame in self.engine_state.active_overlays(&[]) {
-            self.aliases_map.extend(&overlay_frame.aliases);
         }
     }
 
@@ -117,8 +108,10 @@ impl<'e, 's> ScopeData<'e, 's> {
 
     pub fn collect_commands(&self, span: Span) -> Vec<Value> {
         let mut commands = vec![];
-        for ((command_name, _), decl_id) in &self.commands_map {
-            if self.visibility.is_decl_id_visible(decl_id) {
+        for ((command_name, _), decl_id) in &self.decls_map {
+            if self.visibility.is_decl_id_visible(decl_id)
+                && !self.engine_state.get_decl(**decl_id).is_alias()
+            {
                 let mut cols = vec![];
                 let mut vals = vec![];
 
@@ -465,7 +458,7 @@ impl<'e, 's> ScopeData<'e, 's> {
 
     pub fn collect_externs(&self, span: Span) -> Vec<Value> {
         let mut externals = vec![];
-        for ((command_name, _), decl_id) in &self.commands_map {
+        for ((command_name, _), decl_id) in &self.decls_map {
             let decl = self.engine_state.get_decl(**decl_id);
 
             if decl.is_known_external() {
@@ -511,36 +504,6 @@ impl<'e, 's> ScopeData<'e, 's> {
 
     pub fn collect_aliases(&self, span: Span) -> Vec<Value> {
         let mut aliases = vec![];
-        for (alias_name, alias_id) in &self.aliases_map {
-            if self.visibility.is_alias_id_visible(alias_id) {
-                let alias = self.engine_state.get_alias(**alias_id);
-                let mut alias_text = String::new();
-
-                for span in alias {
-                    let contents = self.engine_state.get_span_contents(span);
-                    if !alias_text.is_empty() {
-                        alias_text.push(' ');
-                    }
-                    alias_text.push_str(&String::from_utf8_lossy(contents));
-                }
-
-                let alias_usage = self
-                    .engine_state
-                    .build_alias_usage(**alias_id)
-                    .map(|(usage, _)| usage)
-                    .unwrap_or_default();
-
-                aliases.push(Value::Record {
-                    cols: vec!["name".into(), "expansion".into(), "usage".into()],
-                    vals: vec![
-                        Value::string(String::from_utf8_lossy(alias_name), span),
-                        Value::string(alias_text, span),
-                        Value::string(alias_usage, span),
-                    ],
-                    span,
-                });
-            }
-        }
         for (name_bytes, decl_id) in self.engine_state.get_decls_sorted(false) {
             if self.visibility.is_decl_id_visible(&decl_id) {
                 let decl = self.engine_state.get_decl(decl_id);
@@ -585,13 +548,21 @@ impl<'e, 's> ScopeData<'e, 's> {
             let export_commands: Vec<Value> = module
                 .decls()
                 .iter()
+                .filter(|(_, id)| {
+                    self.visibility.is_decl_id_visible(id)
+                        && !self.engine_state.get_decl(*id).is_alias()
+                })
                 .map(|(bytes, _)| Value::string(String::from_utf8_lossy(bytes), span))
                 .collect();
 
             let export_aliases: Vec<Value> = module
-                .aliases
-                .keys()
-                .map(|bytes| Value::string(String::from_utf8_lossy(bytes), span))
+                .decls()
+                .iter()
+                .filter(|(_, id)| {
+                    self.visibility.is_decl_id_visible(id)
+                        && self.engine_state.get_decl(*id).is_alias()
+                })
+                .map(|(bytes, _)| Value::string(String::from_utf8_lossy(bytes), span))
                 .collect();
 
             let export_env_block = module.env_block.map_or_else(
@@ -640,8 +611,7 @@ impl<'e, 's> ScopeData<'e, 's> {
         let engine_state_cols = vec![
             "source_bytes".to_string(),
             "num_vars".to_string(),
-            "num_commands".to_string(),
-            "num_aliases".to_string(),
+            "num_decls".to_string(),
             "num_blocks".to_string(),
             "num_modules".to_string(),
             "num_env_vars".to_string(),
@@ -651,7 +621,6 @@ impl<'e, 's> ScopeData<'e, 's> {
             Value::int(self.engine_state.next_span_start() as i64, span),
             Value::int(self.engine_state.num_vars() as i64, span),
             Value::int(self.engine_state.num_decls() as i64, span),
-            Value::int(self.engine_state.num_aliases() as i64, span),
             Value::int(self.engine_state.num_blocks() as i64, span),
             Value::int(self.engine_state.num_modules() as i64, span),
             Value::int(

--- a/crates/nu-explore/src/nu_common/command.rs
+++ b/crates/nu-explore/src/nu_common/command.rs
@@ -60,7 +60,6 @@ fn eval_source2(
             Some(fname), // format!("entry #{}", entry_num)
             source,
             false,
-            &[],
         );
 
         if let Some(err) = working_set.parse_errors.first() {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3,7 +3,7 @@ use nu_path::canonicalize_with;
 use nu_protocol::{
     ast::{
         Argument, Block, Call, Expr, Expression, ImportPattern, ImportPatternHead,
-        ImportPatternMember, PathMember, Pipeline, PipelineElement,
+        ImportPatternMember, Pipeline, PipelineElement,
     },
     engine::{StateWorkingSet, DEFAULT_OVERLAY_NAME},
     span, Alias, BlockId, Exportable, Module, ParseError, PositionalArg, Span, Spanned,
@@ -82,14 +82,12 @@ pub fn is_unaliasable_parser_keyword(working_set: &StateWorkingSet, spans: &[Spa
 pub fn parse_keyword(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
-    expand_aliases_denylist: &[usize],
     is_subexpression: bool,
 ) -> Pipeline {
     let call_expr = parse_call(
         working_set,
         &lite_command.parts,
         lite_command.parts[0],
-        expand_aliases_denylist,
         is_subexpression,
     );
 
@@ -108,7 +106,7 @@ pub fn parse_keyword(
         match cmd.name() {
             "overlay hide" => parse_overlay_hide(working_set, call),
             "overlay new" => parse_overlay_new(working_set, call),
-            "overlay use" => parse_overlay_use(working_set, call, expand_aliases_denylist),
+            "overlay use" => parse_overlay_use(working_set, call),
             _ => Pipeline::from_vec(vec![call_expr]),
         }
     } else {
@@ -116,11 +114,7 @@ pub fn parse_keyword(
     }
 }
 
-pub fn parse_def_predecl(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) {
+pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     let name = working_set.get_span_contents(spans[0]);
 
     // handle "export def" same as "def"
@@ -132,8 +126,6 @@ pub fn parse_def_predecl(
 
     if (name == b"def" || name == b"def-env") && spans.len() >= 4 {
         let starting_error_count = working_set.parse_errors.len();
-        // let name_expr = parse_string(working_set, spans[1], expand_aliases_denylist);
-        // let name = name_expr.as_string();
         let name = working_set.get_span_contents(spans[1]);
         let name = trim_quotes(name);
         let name = String::from_utf8_lossy(name).to_string();
@@ -145,7 +137,7 @@ pub fn parse_def_predecl(
         // The second time is when we actually parse the body itworking_set.
         // We can't reuse the first time because the variables that are created during parse_signature
         // are lost when we exit the scope below.
-        let sig = parse_signature(working_set, spans[2], expand_aliases_denylist);
+        let sig = parse_signature(working_set, spans[2]);
         working_set.parse_errors.truncate(starting_error_count);
 
         let signature = sig.as_signature();
@@ -168,7 +160,7 @@ pub fn parse_def_predecl(
             }
         }
     } else if name == b"extern" && spans.len() == 3 {
-        let name_expr = parse_string(working_set, spans[1], expand_aliases_denylist);
+        let name_expr = parse_string(working_set, spans[1]);
         let name = name_expr.as_string();
 
         working_set.enter_scope();
@@ -178,7 +170,7 @@ pub fn parse_def_predecl(
         // The second time is when we actually parse the body itworking_set.
         // We can't reuse the first time because the variables that are created during parse_signature
         // are lost when we exit the scope below.
-        let sig = parse_signature(working_set, spans[2], expand_aliases_denylist);
+        let sig = parse_signature(working_set, spans[2]);
         let signature = sig.as_signature();
         working_set.exit_scope();
 
@@ -207,11 +199,7 @@ pub fn parse_def_predecl(
     }
 }
 
-pub fn parse_for(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_for(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {
     // Checking that the function is used with the correct name
     // Maybe this is not necessary but it is a sanity check
     if working_set.get_span_contents(spans[0]) != b"for" {
@@ -235,13 +223,8 @@ pub fn parse_for(
         }
         Some(decl_id) => {
             working_set.enter_scope();
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                spans[0],
-                &spans[1..],
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
             working_set.exit_scope();
 
@@ -314,7 +297,6 @@ pub fn parse_def(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
     module_name: Option<&[u8]>,
-    expand_aliases_denylist: &[usize],
 ) -> Pipeline {
     let spans = &lite_command.parts[..];
 
@@ -355,13 +337,8 @@ pub fn parse_def(
             working_set.enter_scope();
             let (command_spans, rest_spans) = spans.split_at(split_id);
             let starting_error_count = working_set.parse_errors.len();
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                span(command_spans),
-                rest_spans,
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, span(command_spans), rest_spans, decl_id);
             // This is to preserve the order of the errors so that
             // the check errors below come first
             let mut new_errors = working_set.parse_errors[starting_error_count..].to_vec();
@@ -513,7 +490,6 @@ pub fn parse_extern(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
     module_name: Option<&[u8]>,
-    expand_aliases_denylist: &[usize],
 ) -> Pipeline {
     let spans = &lite_command.parts;
 
@@ -554,13 +530,8 @@ pub fn parse_extern(
 
             let (command_spans, rest_spans) = spans.split_at(split_id);
 
-            let ParsedInternalCall { call, .. } = parse_internal_call(
-                working_set,
-                span(command_spans),
-                rest_spans,
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, .. } =
+                parse_internal_call(working_set, span(command_spans), rest_spans, decl_id);
             working_set.exit_scope();
 
             let call_span = span(spans);
@@ -647,7 +618,6 @@ pub fn parse_alias(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
     module_name: Option<&[u8]>,
-    expand_aliases_denylist: &[usize],
 ) -> Pipeline {
     let spans = &lite_command.parts;
 
@@ -681,13 +651,7 @@ pub fn parse_alias(
             call: alias_call,
             output,
             ..
-        } = parse_internal_call(
-            working_set,
-            span(command_spans),
-            rest_spans,
-            decl_id,
-            expand_aliases_denylist,
-        );
+        } = parse_internal_call(working_set, span(command_spans), rest_spans, decl_id);
         working_set
             .parse_errors
             .truncate(original_starting_error_count);
@@ -756,20 +720,11 @@ pub fn parse_alias(
 
             if first_bytes != b"if"
                 && first_bytes != b"match"
-                && is_math_expression_like(
-                    working_set,
-                    replacement_spans[0],
-                    expand_aliases_denylist,
-                )
+                && is_math_expression_like(working_set, replacement_spans[0])
             {
                 // TODO: Maybe we need to implement a Display trait for Expression?
                 let starting_error_count = working_set.parse_errors.len();
-                let expr = parse_expression(
-                    working_set,
-                    replacement_spans,
-                    expand_aliases_denylist,
-                    false,
-                );
+                let expr = parse_expression(working_set, replacement_spans, false);
                 working_set.parse_errors.truncate(starting_error_count);
 
                 let msg = format!("{:?}", expr.expr);
@@ -787,7 +742,6 @@ pub fn parse_alias(
                 working_set,
                 replacement_spans,
                 replacement_spans[0],
-                expand_aliases_denylist,
                 false, // TODO: Should this be set properly???
             );
 
@@ -868,186 +822,17 @@ pub fn parse_alias(
     garbage_pipeline(spans)
 }
 
-pub fn parse_old_alias(
-    working_set: &mut StateWorkingSet,
-    lite_command: &LiteCommand,
-    module_name: Option<&[u8]>,
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
-    let spans = &lite_command.parts;
-
-    // if the call is "alias", turn it into "print $nu.scope.aliases"
-    if spans.len() == 1 {
-        let head = Expression {
-            expr: Expr::Var(nu_protocol::NU_VARIABLE_ID),
-            span: Span::new(0, 0),
-            ty: Type::Any,
-            custom_completion: None,
-        };
-        let tail = vec![
-            PathMember::String {
-                val: "scope".to_string(),
-                span: Span::new(0, 0),
-                optional: false,
-            },
-            PathMember::String {
-                val: "aliases".to_string(),
-                span: Span::new(0, 0),
-                optional: false,
-            },
-        ];
-        let expr = Expression {
-            ty: Type::Any,
-            expr: Expr::FullCellPath(Box::new(nu_protocol::ast::FullCellPath { head, tail })),
-            span: Span::new(0, 0),
-            custom_completion: None,
-        };
-        if let Some(decl_id) = working_set.find_decl(b"print", &Type::Any) {
-            let print_call = Expr::Call(Box::new(Call {
-                head: spans[0],
-                arguments: vec![Argument::Positional(expr)],
-                decl_id,
-                redirect_stdout: true,
-                redirect_stderr: false,
-                parser_info: HashMap::new(),
-            }));
-            return Pipeline::from_vec(vec![Expression {
-                expr: print_call,
-                span: spans[0],
-                ty: Type::Any,
-                custom_completion: None,
-            }]);
-        }
-        return Pipeline::from_vec(vec![expr]);
-    }
-
-    let (name_span, split_id) =
-        if spans.len() > 1 && working_set.get_span_contents(spans[0]) == b"export" {
-            (spans[1], 2)
-        } else {
-            (spans[0], 1)
-        };
-
-    let name = working_set.get_span_contents(name_span);
-
-    if name == b"old-alias" {
-        if let Some(span) = check_name(working_set, spans) {
-            return Pipeline::from_vec(vec![garbage(*span)]);
-        }
-
-        if let Some(decl_id) = working_set.find_decl(b"alias", &Type::Any) {
-            let (command_spans, rest_spans) = spans.split_at(split_id);
-
-            let ParsedInternalCall { call, output, .. } = parse_internal_call(
-                working_set,
-                span(command_spans),
-                rest_spans,
-                decl_id,
-                expand_aliases_denylist,
-            );
-
-            if call.has_flag("help") {
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: span(spans),
-                    ty: output,
-                    custom_completion: None,
-                }]);
-            }
-
-            if spans.len() >= split_id + 3 {
-                let alias_name = working_set.get_span_contents(spans[split_id]);
-
-                let alias_name = if alias_name.starts_with(b"\"")
-                    && alias_name.ends_with(b"\"")
-                    && alias_name.len() > 1
-                {
-                    alias_name[1..(alias_name.len() - 1)].to_vec()
-                } else {
-                    alias_name.to_vec()
-                };
-
-                if let Some(mod_name) = module_name {
-                    if alias_name == mod_name {
-                        working_set.error(ParseError::NamedAsModule(
-                            "alias".to_string(),
-                            String::from_utf8_lossy(&alias_name).to_string(),
-                            spans[split_id],
-                        ));
-                        return Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call),
-                            span: span(spans),
-                            ty: output,
-                            custom_completion: None,
-                        }]);
-                    }
-
-                    if &alias_name == b"main" {
-                        working_set.error(ParseError::ExportMainAliasNotAllowed(spans[split_id]));
-                        return Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call),
-                            span: span(spans),
-                            ty: output,
-                            custom_completion: None,
-                        }]);
-                    }
-                }
-
-                let _equals = working_set.get_span_contents(spans[split_id + 1]);
-
-                let replacement = spans[(split_id + 2)..].to_vec();
-
-                let checked_name = String::from_utf8_lossy(&alias_name);
-                if checked_name.contains('#')
-                    || checked_name.contains('^')
-                    || checked_name.parse::<bytesize::ByteSize>().is_ok()
-                    || checked_name.parse::<f64>().is_ok()
-                {
-                    working_set.error(ParseError::AliasNotValid(name_span));
-                    return Pipeline::from_vec(vec![garbage(name_span)]);
-                }
-
-                working_set.add_alias(alias_name, replacement, lite_command.comments.clone());
-            }
-
-            if spans.len() < 4 {
-                working_set.error(ParseError::IncorrectValue(
-                    "Incomplete alias".into(),
-                    span(&spans[..split_id]),
-                    "incomplete alias".into(),
-                ))
-            }
-
-            return Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: span(spans),
-                ty: Type::Any,
-                custom_completion: None,
-            }]);
-        }
-    }
-
-    working_set.error(ParseError::InternalError(
-        "Alias statement unparsable".into(),
-        span(spans),
-    ));
-    garbage_pipeline(spans)
-}
-
 // This one will trigger if `export` appears during eval, e.g., in a script
 pub fn parse_export_in_block(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
-    expand_aliases_denylist: &[usize],
 ) -> Pipeline {
     let call_span = span(&lite_command.parts);
 
     let full_name = if lite_command.parts.len() > 1 {
         let sub = working_set.get_span_contents(lite_command.parts[1]);
         match sub {
-            b"old-alias" | b"alias" | b"def" | b"def-env" | b"extern" | b"use" => {
-                [b"export ", sub].concat()
-            }
+            b"alias" | b"def" | b"def-env" | b"extern" | b"use" => [b"export ", sub].concat(),
             _ => b"export".to_vec(),
         }
     } else {
@@ -1068,7 +853,6 @@ pub fn parse_export_in_block(
                 &lite_command.parts[2..]
             },
             decl_id,
-            expand_aliases_denylist,
         );
 
         let decl = working_set.get_decl(decl_id);
@@ -1104,19 +888,13 @@ pub fn parse_export_in_block(
     }
 
     match full_name.as_slice() {
-        b"export old-alias" => {
-            parse_old_alias(working_set, lite_command, None, expand_aliases_denylist)
-        }
-        b"export alias" => parse_alias(working_set, lite_command, None, expand_aliases_denylist),
-        b"export def" | b"export def-env" => {
-            parse_def(working_set, lite_command, None, expand_aliases_denylist)
-        }
+        b"export alias" => parse_alias(working_set, lite_command, None),
+        b"export def" | b"export def-env" => parse_def(working_set, lite_command, None),
         b"export use" => {
-            let (pipeline, _) =
-                parse_use(working_set, &lite_command.parts, expand_aliases_denylist);
+            let (pipeline, _) = parse_use(working_set, &lite_command.parts);
             pipeline
         }
-        b"export extern" => parse_extern(working_set, lite_command, None, expand_aliases_denylist),
+        b"export extern" => parse_extern(working_set, lite_command, None),
         _ => {
             working_set.error(ParseError::UnexpectedKeyword(
                 String::from_utf8_lossy(&full_name).to_string(),
@@ -1133,7 +911,6 @@ pub fn parse_export_in_module(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
     module_name: &[u8],
-    expand_aliases_denylist: &[usize],
 ) -> (Pipeline, Vec<Exportable>) {
     let spans = &lite_command.parts[..];
 
@@ -1182,12 +959,7 @@ pub fn parse_export_in_module(
                     comments: lite_command.comments.clone(),
                     parts: spans[1..].to_vec(),
                 };
-                let pipeline = parse_def(
-                    working_set,
-                    &lite_command,
-                    Some(module_name),
-                    expand_aliases_denylist,
-                );
+                let pipeline = parse_def(working_set, &lite_command, Some(module_name));
 
                 let export_def_decl_id =
                     if let Some(id) = working_set.find_decl(b"export def", &Type::Any) {
@@ -1246,12 +1018,7 @@ pub fn parse_export_in_module(
                     comments: lite_command.comments.clone(),
                     parts: spans[1..].to_vec(),
                 };
-                let pipeline = parse_def(
-                    working_set,
-                    &lite_command,
-                    Some(module_name),
-                    expand_aliases_denylist,
-                );
+                let pipeline = parse_def(working_set, &lite_command, Some(module_name));
 
                 let export_def_decl_id =
                     if let Some(id) = working_set.find_decl(b"export def-env", &Type::Any) {
@@ -1311,12 +1078,7 @@ pub fn parse_export_in_module(
                     comments: lite_command.comments.clone(),
                     parts: spans[1..].to_vec(),
                 };
-                let pipeline = parse_extern(
-                    working_set,
-                    &lite_command,
-                    Some(module_name),
-                    expand_aliases_denylist,
-                );
+                let pipeline = parse_extern(working_set, &lite_command, Some(module_name));
 
                 let export_def_decl_id =
                     if let Some(id) = working_set.find_decl(b"export extern", &Type::Any) {
@@ -1371,82 +1133,12 @@ pub fn parse_export_in_module(
 
                 result
             }
-            b"old-alias" => {
-                let lite_command = LiteCommand {
-                    comments: lite_command.comments.clone(),
-                    parts: spans[1..].to_vec(),
-                };
-                let pipeline = parse_old_alias(
-                    working_set,
-                    &lite_command,
-                    Some(module_name),
-                    expand_aliases_denylist,
-                );
-
-                let export_alias_decl_id =
-                    if let Some(id) = working_set.find_decl(b"export old-alias", &Type::Any) {
-                        id
-                    } else {
-                        working_set.error(ParseError::InternalError(
-                            "missing 'export old-alias' command".into(),
-                            export_span,
-                        ));
-                        return (garbage_pipeline(spans), vec![]);
-                    };
-
-                // Trying to warp the 'old-alias' call into the 'export old-alias' in a very clumsy way
-                if let Some(PipelineElement::Expression(
-                    _,
-                    Expression {
-                        expr: Expr::Call(ref alias_call),
-                        ..
-                    },
-                )) = pipeline.elements.get(0)
-                {
-                    call = alias_call.clone();
-
-                    call.head = span(&spans[0..=1]);
-                    call.decl_id = export_alias_decl_id;
-                } else {
-                    working_set.error(ParseError::InternalError(
-                        "unexpected output from parsing a definition".into(),
-                        span(&spans[1..]),
-                    ));
-                };
-
-                let mut result = vec![];
-
-                let alias_name = match spans.get(2) {
-                    Some(span) => working_set.get_span_contents(*span),
-                    None => &[],
-                };
-                let alias_name = trim_quotes(alias_name);
-
-                if let Some(alias_id) = working_set.find_alias(alias_name) {
-                    result.push(Exportable::Alias {
-                        name: alias_name.to_vec(),
-                        id: alias_id,
-                    });
-                } else {
-                    working_set.error(ParseError::InternalError(
-                        "failed to find added alias".into(),
-                        span(&spans[1..]),
-                    ));
-                }
-
-                result
-            }
             b"alias" => {
                 let lite_command = LiteCommand {
                     comments: lite_command.comments.clone(),
                     parts: spans[1..].to_vec(),
                 };
-                let pipeline = parse_alias(
-                    working_set,
-                    &lite_command,
-                    Some(module_name),
-                    expand_aliases_denylist,
-                );
+                let pipeline = parse_alias(working_set, &lite_command, Some(module_name));
 
                 let export_alias_decl_id =
                     if let Some(id) = working_set.find_decl(b"export alias", &Type::Any) {
@@ -1506,8 +1198,7 @@ pub fn parse_export_in_module(
                     comments: lite_command.comments.clone(),
                     parts: spans[1..].to_vec(),
                 };
-                let (pipeline, exportables) =
-                    parse_use(working_set, &lite_command.parts, expand_aliases_denylist);
+                let (pipeline, exportables) = parse_use(working_set, &lite_command.parts);
 
                 let export_use_decl_id =
                     if let Some(id) = working_set.find_decl(b"export use", &Type::Any) {
@@ -1545,7 +1236,7 @@ pub fn parse_export_in_module(
             _ => {
                 working_set.error(ParseError::Expected(
                     // TODO: Fill in more keywords as they come
-                    "def, def-env, alias, use, or env keyword".into(),
+                    "def, def-env, alias, use, or extern keyword".into(),
                     spans[1],
                 ));
 
@@ -1554,9 +1245,9 @@ pub fn parse_export_in_module(
         }
     } else {
         working_set.error(ParseError::MissingPositional(
-            "def, def-env, alias, or env keyword".into(), // TODO: keep filling more keywords as they come
+            "def, def-env, alias, use, or extern keyword".into(), // TODO: keep filling more keywords as they come
             Span::new(export_span.end, export_span.end),
-            "'def', `def-env`, `alias`, or 'env' keyword.".to_string(),
+            "`def`, `def-env`, `alias`, use, or `extern` keyword.".to_string(),
         ));
 
         vec![]
@@ -1576,7 +1267,6 @@ pub fn parse_export_in_module(
 pub fn parse_export_env(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
-    expand_aliases_denylist: &[usize],
 ) -> (Pipeline, Option<BlockId>) {
     if !spans.is_empty() && working_set.get_span_contents(spans[0]) != b"export-env" {
         working_set.error(ParseError::UnknownState(
@@ -1597,13 +1287,8 @@ pub fn parse_export_env(
 
     let call = match working_set.find_decl(b"export-env", &Type::Any) {
         Some(decl_id) => {
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                spans[0],
-                &[spans[1]],
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, spans[0], &[spans[1]], decl_id);
             let decl = working_set.get_decl(decl_id);
 
             let call_span = span(spans);
@@ -1695,7 +1380,6 @@ pub fn parse_module_block(
     working_set: &mut StateWorkingSet,
     span: Span,
     module_name: &[u8],
-    expand_aliases_denylist: &[usize],
 ) -> (Block, Module, Vec<Span>) {
     working_set.enter_scope();
 
@@ -1716,7 +1400,7 @@ pub fn parse_module_block(
     for pipeline in &output.block {
         if pipeline.commands.len() == 1 {
             if let LiteElement::Command(_, command) = &pipeline.commands[0] {
-                parse_def_predecl(working_set, &command.parts, expand_aliases_denylist);
+                parse_def_predecl(working_set, &command.parts);
             }
         }
     }
@@ -1738,41 +1422,24 @@ pub fn parse_module_block(
                                     working_set,
                                     command,
                                     None, // using commands named as the module locally is OK
-                                    expand_aliases_denylist,
                                 )
                             }
-                            b"extern" => {
-                                parse_extern(working_set, command, None, expand_aliases_denylist)
-                            }
-                            b"old-alias" => {
-                                parse_old_alias(
-                                    working_set,
-                                    command,
-                                    None, // using aliases named as the module locally is OK
-                                    expand_aliases_denylist,
-                                )
-                            }
+                            b"extern" => parse_extern(working_set, command, None),
                             b"alias" => {
                                 parse_alias(
                                     working_set,
                                     command,
                                     None, // using aliases named as the module locally is OK
-                                    expand_aliases_denylist,
                                 )
                             }
                             b"use" => {
-                                let (pipeline, _) =
-                                    parse_use(working_set, &command.parts, expand_aliases_denylist);
+                                let (pipeline, _) = parse_use(working_set, &command.parts);
 
                                 pipeline
                             }
                             b"export" => {
-                                let (pipe, exportables) = parse_export_in_module(
-                                    working_set,
-                                    command,
-                                    module_name,
-                                    expand_aliases_denylist,
-                                );
+                                let (pipe, exportables) =
+                                    parse_export_in_module(working_set, command, module_name);
 
                                 for exportable in exportables {
                                     match exportable {
@@ -1783,20 +1450,14 @@ pub fn parse_module_block(
                                                 module.add_decl(name, id);
                                             }
                                         }
-                                        Exportable::Alias { name, id } => {
-                                            module.add_alias(name, id);
-                                        }
                                     }
                                 }
 
                                 pipe
                             }
                             b"export-env" => {
-                                let (pipe, maybe_env_block) = parse_export_env(
-                                    working_set,
-                                    &command.parts,
-                                    expand_aliases_denylist,
-                                );
+                                let (pipe, maybe_env_block) =
+                                    parse_export_env(working_set, &command.parts);
 
                                 if let Some(block_id) = maybe_env_block {
                                     module.add_env_block(block_id);
@@ -1831,11 +1492,7 @@ pub fn parse_module_block(
     (block, module, module_comments)
 }
 
-pub fn parse_module(
-    working_set: &mut StateWorkingSet,
-    lite_command: &LiteCommand,
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
+pub fn parse_module(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
     // TODO: Currently, module is closing over its parent scope (i.e., defs in the parent scope are
     // visible and usable in this module's scope). We want to disable that for files.
 
@@ -1845,7 +1502,7 @@ pub fn parse_module(
     let bytes = working_set.get_span_contents(spans[0]);
 
     if bytes == b"module" && spans.len() >= 3 {
-        let module_name_expr = parse_string(working_set, spans[1], expand_aliases_denylist);
+        let module_name_expr = parse_string(working_set, spans[1]);
 
         let module_name = module_name_expr
             .as_string()
@@ -1871,12 +1528,8 @@ pub fn parse_module(
 
         let block_span = Span::new(start, end);
 
-        let (block, module, inner_comments) = parse_module_block(
-            working_set,
-            block_span,
-            module_name.as_bytes(),
-            expand_aliases_denylist,
-        );
+        let (block, module, inner_comments) =
+            parse_module_block(working_set, block_span, module_name.as_bytes());
 
         let block_id = working_set.add_block(block);
 
@@ -1922,11 +1575,7 @@ pub fn parse_module(
     }
 }
 
-pub fn parse_use(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> (Pipeline, Vec<Exportable>) {
+pub fn parse_use(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeline, Vec<Exportable>) {
     let (name_span, split_id) =
         if spans.len() > 1 && working_set.get_span_contents(spans[0]) == b"export" {
             (spans[1], 2)
@@ -1955,13 +1604,8 @@ pub fn parse_use(
         Some(decl_id) => {
             let (command_spans, rest_spans) = spans.split_at(split_id);
 
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                span(command_spans),
-                rest_spans,
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, span(command_spans), rest_spans, decl_id);
             let decl = working_set.get_decl(decl_id);
 
             let call_span = span(spans);
@@ -1991,8 +1635,7 @@ pub fn parse_use(
         }
     };
 
-    let import_pattern_expr =
-        parse_import_pattern(working_set, args_spans, expand_aliases_denylist);
+    let import_pattern_expr = parse_import_pattern(working_set, args_spans);
 
     let import_pattern = if let Expression {
         expr: Expr::ImportPattern(import_pattern),
@@ -2099,7 +1742,6 @@ pub fn parse_use(
                         working_set,
                         Span::new(span_start, span_end),
                         module_name.as_bytes(),
-                        expand_aliases_denylist,
                     );
 
                     // Remove the file from the stack of parsed module files
@@ -2155,17 +1797,13 @@ pub fn parse_use(
         }
     };
 
-    let (decls_to_use, aliases_to_use) = if import_pattern.members.is_empty() {
-        (
-            module.decls_with_head(&import_pattern.head.name),
-            module.aliases_with_head(&import_pattern.head.name),
-        )
+    let decls_to_use = if import_pattern.members.is_empty() {
+        module.decls_with_head(&import_pattern.head.name)
     } else {
         match &import_pattern.members[0] {
-            ImportPatternMember::Glob { .. } => (module.decls(), module.aliases()),
+            ImportPatternMember::Glob { .. } => module.decls(),
             ImportPatternMember::Name { name, span } => {
                 let mut decl_output = vec![];
-                let mut alias_output = vec![];
 
                 if name == b"main" {
                     if let Some(id) = &module.main {
@@ -2175,17 +1813,14 @@ pub fn parse_use(
                     }
                 } else if let Some(id) = module.get_decl_id(name) {
                     decl_output.push((name.clone(), id));
-                } else if let Some(id) = module.get_alias_id(name) {
-                    alias_output.push((name.clone(), id));
                 } else {
                     working_set.error(ParseError::ExportNotFound(*span));
                 }
 
-                (decl_output, alias_output)
+                decl_output
             }
             ImportPatternMember::List { names } => {
                 let mut decl_output = vec![];
-                let mut alias_output = vec![];
 
                 for (name, span) in names {
                     if name == b"main" {
@@ -2196,15 +1831,13 @@ pub fn parse_use(
                         }
                     } else if let Some(id) = module.get_decl_id(name) {
                         decl_output.push((name.clone(), id));
-                    } else if let Some(id) = module.get_alias_id(name) {
-                        alias_output.push((name.clone(), id));
                     } else {
                         working_set.error(ParseError::ExportNotFound(*span));
                         break;
                     }
                 }
 
-                (decl_output, alias_output)
+                decl_output
             }
         }
     };
@@ -2215,19 +1848,10 @@ pub fn parse_use(
             name: name.clone(),
             id: *decl_id,
         })
-        .chain(
-            aliases_to_use
-                .iter()
-                .map(|(name, alias_id)| Exportable::Alias {
-                    name: name.clone(),
-                    id: *alias_id,
-                }),
-        )
         .collect();
 
     // Extend the current scope with the module's exportables
     working_set.use_decls(decls_to_use);
-    working_set.use_aliases(aliases_to_use);
 
     // Create a new Use command call to pass the new import pattern
     let import_pattern_expr = Expression {
@@ -2251,11 +1875,7 @@ pub fn parse_use(
     )
 }
 
-pub fn parse_hide(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
+pub fn parse_hide(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
     if working_set.get_span_contents(spans[0]) != b"hide" {
         working_set.error(ParseError::UnknownState(
             "internal error: Wrong call name for 'hide' command".into(),
@@ -2266,13 +1886,8 @@ pub fn parse_hide(
 
     let (call, args_spans) = match working_set.find_decl(b"hide", &Type::Any) {
         Some(decl_id) => {
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                spans[0],
-                &spans[1..],
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
             let decl = working_set.get_decl(decl_id);
 
             let call_span = span(spans);
@@ -2299,8 +1914,7 @@ pub fn parse_hide(
         }
     };
 
-    let import_pattern_expr =
-        parse_import_pattern(working_set, args_spans, expand_aliases_denylist);
+    let import_pattern_expr = parse_import_pattern(working_set, args_spans);
 
     let import_pattern = if let Expression {
         expr: Expr::ImportPattern(import_pattern),
@@ -2320,52 +1934,41 @@ pub fn parse_hide(
 
     if bytes == b"hide" && spans.len() >= 2 {
         for span in spans[1..].iter() {
-            parse_string(working_set, *span, expand_aliases_denylist);
+            parse_string(working_set, *span);
         }
 
         // module used only internally, not saved anywhere
-        let (is_module, module) = if let Some(module_id) =
-            working_set.find_module(&import_pattern.head.name)
-        {
-            (true, working_set.get_module(module_id).clone())
-        } else if import_pattern.members.is_empty() {
-            // The pattern head can be:
-            if let Some(id) = working_set.find_alias(&import_pattern.head.name) {
-                // an alias,
-                let mut module = Module::new(b"tmp".to_vec());
-                module.add_alias(import_pattern.head.name.clone(), id);
+        let (is_module, module) =
+            if let Some(module_id) = working_set.find_module(&import_pattern.head.name) {
+                (true, working_set.get_module(module_id).clone())
+            } else if import_pattern.members.is_empty() {
+                // The pattern head can be:
+                if let Some(id) = working_set.find_decl(&import_pattern.head.name, &Type::Any) {
+                    // a custom command,
+                    let mut module = Module::new(b"tmp".to_vec());
+                    module.add_decl(import_pattern.head.name.clone(), id);
 
-                (false, module)
-            } else if let Some(id) = working_set.find_decl(&import_pattern.head.name, &Type::Any) {
-                // a custom command,
-                let mut module = Module::new(b"tmp".to_vec());
-                module.add_decl(import_pattern.head.name.clone(), id);
-
-                (false, module)
+                    (false, module)
+                } else {
+                    // , or it could be an env var (handled by the engine)
+                    (false, Module::new(b"tmp".to_vec()))
+                }
             } else {
-                // , or it could be an env var (handled by the engine)
-                (false, Module::new(b"tmp".to_vec()))
-            }
-        } else {
-            working_set.error(ParseError::ModuleNotFound(spans[1]));
-            return garbage_pipeline(spans);
-        };
+                working_set.error(ParseError::ModuleNotFound(spans[1]));
+                return garbage_pipeline(spans);
+            };
 
         // This kind of inverts the import pattern matching found in parse_use()
-        let (aliases_to_hide, decls_to_hide) = if import_pattern.members.is_empty() {
+        let decls_to_hide = if import_pattern.members.is_empty() {
             if is_module {
-                (
-                    module.alias_names_with_head(&import_pattern.head.name),
-                    module.decl_names_with_head(&import_pattern.head.name),
-                )
+                module.decl_names_with_head(&import_pattern.head.name)
             } else {
-                (module.alias_names(), module.decl_names())
+                module.decl_names()
             }
         } else {
             match &import_pattern.members[0] {
-                ImportPatternMember::Glob { .. } => (module.alias_names(), module.decl_names()),
+                ImportPatternMember::Glob { .. } => module.decl_names(),
                 ImportPatternMember::Name { name, span } => {
-                    let mut aliases = vec![];
                     let mut decls = vec![];
 
                     if name == b"main" {
@@ -2375,10 +1978,6 @@ pub fn parse_hide(
                             working_set.error(ParseError::ExportNotFound(*span));
                         }
                     } else if let Some(item) =
-                        module.alias_name_with_head(name, &import_pattern.head.name)
-                    {
-                        aliases.push(item);
-                    } else if let Some(item) =
                         module.decl_name_with_head(name, &import_pattern.head.name)
                     {
                         decls.push(item);
@@ -2386,10 +1985,9 @@ pub fn parse_hide(
                         working_set.error(ParseError::ExportNotFound(*span));
                     }
 
-                    (aliases, decls)
+                    decls
                 }
                 ImportPatternMember::List { names } => {
-                    let mut aliases = vec![];
                     let mut decls = vec![];
 
                     for (name, span) in names {
@@ -2401,10 +1999,6 @@ pub fn parse_hide(
                                 break;
                             }
                         } else if let Some(item) =
-                            module.alias_name_with_head(name, &import_pattern.head.name)
-                        {
-                            aliases.push(item);
-                        } else if let Some(item) =
                             module.decl_name_with_head(name, &import_pattern.head.name)
                         {
                             decls.push(item);
@@ -2414,22 +2008,20 @@ pub fn parse_hide(
                         }
                     }
 
-                    (aliases, decls)
+                    decls
                 }
             }
         };
 
         let import_pattern = {
-            let aliases: HashSet<Vec<u8>> = aliases_to_hide.iter().cloned().collect();
             let decls: HashSet<Vec<u8>> = decls_to_hide.iter().cloned().collect();
 
-            import_pattern.with_hidden(decls.union(&aliases).cloned().collect())
+            import_pattern.with_hidden(decls)
         };
 
         // TODO: `use spam; use spam foo; hide foo` will hide both `foo` and `spam foo` since
         // they point to the same DeclId. Do we want to keep it that way?
         working_set.hide_decls(&decls_to_hide);
-        working_set.hide_aliases(&aliases_to_hide);
 
         // Create a new Use command call to pass the new import pattern
         let import_pattern_expr = Expression {
@@ -2495,22 +2087,12 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         vec![],
     );
 
-    working_set.add_overlay(
-        overlay_name.as_bytes().to_vec(),
-        module_id,
-        vec![],
-        vec![],
-        false,
-    );
+    working_set.add_overlay(overlay_name.as_bytes().to_vec(), module_id, vec![], false);
 
     pipeline
 }
 
-pub fn parse_overlay_use(
-    working_set: &mut StateWorkingSet,
-    call: Box<Call>,
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
+pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
 
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
@@ -2684,7 +2266,6 @@ pub fn parse_overlay_use(
                                 working_set,
                                 Span::new(span_start, span_end),
                                 overlay_name.as_bytes(),
-                                expand_aliases_denylist,
                             );
 
                             // Restore the currently parsed directory back
@@ -2719,24 +2300,20 @@ pub fn parse_overlay_use(
             }
         };
 
-    let (decls_to_lay, aliases_to_lay) = if is_module_updated {
+    let decls_to_lay = if is_module_updated {
         if has_prefix {
-            (
-                origin_module.decls_with_head(final_overlay_name.as_bytes()),
-                origin_module.aliases_with_head(final_overlay_name.as_bytes()),
-            )
+            origin_module.decls_with_head(final_overlay_name.as_bytes())
         } else {
-            (origin_module.decls(), origin_module.aliases())
+            origin_module.decls()
         }
     } else {
-        (vec![], vec![])
+        vec![]
     };
 
     working_set.add_overlay(
         final_overlay_name.as_bytes().to_vec(),
         origin_module_id,
         decls_to_lay,
-        aliases_to_lay,
         has_prefix,
     );
 
@@ -2824,11 +2401,7 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
     pipeline
 }
 
-pub fn parse_let_or_const(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
+pub fn parse_let_or_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
     let name = working_set.get_span_contents(spans[0]);
 
     if name == b"let" || name == b"const" {
@@ -2859,7 +2432,6 @@ pub fn parse_let_or_const(
                                 b"=".to_vec(),
                                 Box::new(SyntaxShape::MathExpression),
                             ),
-                            expand_aliases_denylist,
                         );
 
                         if idx < (spans.len() - 1) {
@@ -2925,13 +2497,8 @@ pub fn parse_let_or_const(
                     }
                 }
             }
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                spans[0],
-                &spans[1..],
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
             return Pipeline::from_vec(vec![Expression {
                 expr: Expr::Call(call),
@@ -2950,11 +2517,7 @@ pub fn parse_let_or_const(
     garbage_pipeline(spans)
 }
 
-pub fn parse_mut(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
+pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
     let name = working_set.get_span_contents(spans[0]);
 
     if name == b"mut" {
@@ -2981,7 +2544,6 @@ pub fn parse_mut(
                                 b"=".to_vec(),
                                 Box::new(SyntaxShape::MathExpression),
                             ),
-                            expand_aliases_denylist,
                         );
 
                         if idx < (spans.len() - 1) {
@@ -3033,13 +2595,8 @@ pub fn parse_mut(
                     }
                 }
             }
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                spans[0],
-                &spans[1..],
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
             return Pipeline::from_vec(vec![Expression {
                 expr: Expr::Call(call),
@@ -3057,11 +2614,7 @@ pub fn parse_mut(
     garbage_pipeline(spans)
 }
 
-pub fn parse_source(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
+pub fn parse_source(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
     let name = working_set.get_span_contents(spans[0]);
 
     if name == b"source" || name == b"source-env" {
@@ -3072,13 +2625,8 @@ pub fn parse_source(
 
             // Is this the right call to be using here?
             // Some of the others (`parse_let`) use it, some of them (`parse_hide`) don't.
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                spans[0],
-                &spans[1..],
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
             if call.has_flag("help") {
                 return Pipeline::from_vec(vec![Expression {
@@ -3091,12 +2639,7 @@ pub fn parse_source(
 
             // Command and one file name
             if spans.len() >= 2 {
-                let expr = parse_value(
-                    working_set,
-                    spans[1],
-                    &SyntaxShape::Any,
-                    expand_aliases_denylist,
-                );
+                let expr = parse_value(working_set, spans[1], &SyntaxShape::Any);
 
                 let val = match eval_constant(working_set, &expr) {
                     Ok(val) => val,
@@ -3144,7 +2687,6 @@ pub fn parse_source(
                             path.file_name().and_then(|x| x.to_str()),
                             &contents,
                             scoped,
-                            expand_aliases_denylist,
                         );
 
                         // Restore the currently parsed directory back
@@ -3193,11 +2735,7 @@ pub fn parse_source(
     garbage_pipeline(spans)
 }
 
-pub fn parse_where_expr(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {
     trace!("parsing: where");
 
     if !spans.is_empty() && working_set.get_span_contents(spans[0]) != b"where" {
@@ -3219,13 +2757,8 @@ pub fn parse_where_expr(
 
     let call = match working_set.find_decl(b"where", &Type::Any) {
         Some(decl_id) => {
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                spans[0],
-                &spans[1..],
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
             let decl = working_set.get_decl(decl_id);
 
             let call_span = span(spans);
@@ -3260,21 +2793,13 @@ pub fn parse_where_expr(
     }
 }
 
-pub fn parse_where(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
-    let expression = parse_where_expr(working_set, spans, expand_aliases_denylist);
+pub fn parse_where(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
+    let expression = parse_where_expr(working_set, spans);
     Pipeline::from_vec(vec![expression])
 }
 
 #[cfg(feature = "plugin")]
-pub fn parse_register(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Pipeline {
+pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
     use nu_plugin::{get_signature, PluginDeclaration};
     use nu_protocol::{engine::Stack, PluginSignature};
 
@@ -3302,13 +2827,8 @@ pub fn parse_register(
             return garbage_pipeline(spans);
         }
         Some(decl_id) => {
-            let ParsedInternalCall { call, output } = parse_internal_call(
-                working_set,
-                spans[0],
-                &spans[1..],
-                decl_id,
-                expand_aliases_denylist,
-            );
+            let ParsedInternalCall { call, output } =
+                parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
             let decl = working_set.get_decl(decl_id);
 
             let call_span = span(spans);

--- a/crates/nu-parser/src/parse_patterns.rs
+++ b/crates/nu-parser/src/parse_patterns.rs
@@ -49,7 +49,7 @@ pub fn parse_pattern(working_set: &mut StateWorkingSet, span: Span) -> MatchPatt
         }
     } else {
         // Literal value
-        let value = parse_value(working_set, span, &SyntaxShape::Any, &[]);
+        let value = parse_value(working_set, span, &SyntaxShape::Any);
 
         MatchPattern {
             pattern: Pattern::Value(value),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -23,8 +23,8 @@ use nu_protocol::{
 use crate::parse_keywords::{
     find_dirs_var, is_unaliasable_parser_keyword, parse_alias, parse_def, parse_def_predecl,
     parse_export_in_block, parse_extern, parse_for, parse_hide, parse_keyword, parse_let_or_const,
-    parse_module, parse_old_alias, parse_overlay_hide, parse_overlay_new, parse_overlay_use,
-    parse_source, parse_use, parse_where, parse_where_expr, LIB_DIRS_VAR,
+    parse_module, parse_overlay_hide, parse_overlay_new, parse_overlay_use, parse_source,
+    parse_use, parse_where, parse_where_expr, LIB_DIRS_VAR,
 };
 
 use itertools::Itertools;
@@ -63,11 +63,7 @@ fn is_identifier_byte(b: u8) -> bool {
         && b != b'|'
 }
 
-pub fn is_math_expression_like(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> bool {
+pub fn is_math_expression_like(working_set: &mut StateWorkingSet, span: Span) -> bool {
     let bytes = working_set.get_span_contents(span);
     if bytes.is_empty() {
         return false;
@@ -123,7 +119,7 @@ pub fn is_math_expression_like(
     }
     working_set.parse_errors.truncate(starting_error_count);
 
-    parse_range(working_set, span, expand_aliases_denylist);
+    parse_range(working_set, span);
 
     if working_set.parse_errors.len() == starting_error_count {
         return true;
@@ -270,22 +266,13 @@ pub fn check_name<'a>(working_set: &mut StateWorkingSet, spans: &'a [Span]) -> O
     }
 }
 
-fn parse_external_arg(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+fn parse_external_arg(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     let contents = working_set.get_span_contents(span);
 
     if contents.starts_with(b"$") || contents.starts_with(b"(") {
-        parse_dollar_expr(working_set, span, expand_aliases_denylist)
+        parse_dollar_expr(working_set, span)
     } else if contents.starts_with(b"[") {
-        parse_list_expression(
-            working_set,
-            span,
-            &SyntaxShape::Any,
-            expand_aliases_denylist,
-        )
+        parse_list_expression(working_set, span, &SyntaxShape::Any)
     } else {
         // Eval stage trims the quotes, so we don't have to do the same thing when parsing.
         let contents = if contents.starts_with(b"\"") {
@@ -310,7 +297,6 @@ fn parse_external_arg(
 pub fn parse_external_call(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
-    expand_aliases_denylist: &[usize],
     is_subexpression: bool,
 ) -> Expression {
     trace!("parse external");
@@ -329,7 +315,7 @@ pub fn parse_external_call(
 
     let head = if head_contents.starts_with(b"$") || head_contents.starts_with(b"(") {
         // the expression is inside external_call, so it's a subexpression
-        let arg = parse_expression(working_set, &[head_span], expand_aliases_denylist, true);
+        let arg = parse_expression(working_set, &[head_span], true);
         Box::new(arg)
     } else {
         let (contents, err) = unescape_unquote_string(&head_contents, head_span);
@@ -346,7 +332,7 @@ pub fn parse_external_call(
     };
 
     for span in &spans[1..] {
-        let arg = parse_external_arg(working_set, *span, expand_aliases_denylist);
+        let arg = parse_external_arg(working_set, *span);
         args.push(arg);
     }
 
@@ -363,7 +349,6 @@ fn parse_long_flag(
     spans: &[Span],
     spans_idx: &mut usize,
     sig: &Signature,
-    expand_aliases_denylist: &[usize],
 ) -> (Option<Spanned<String>>, Option<Expression>) {
     let arg_span = spans[*spans_idx];
     let arg_contents = working_set.get_span_contents(arg_span);
@@ -382,8 +367,7 @@ fn parse_long_flag(
                         let mut span = arg_span;
                         span.start += long_name_len + 3; //offset by long flag and '='
 
-                        let arg =
-                            parse_value(working_set, span, arg_shape, expand_aliases_denylist);
+                        let arg = parse_value(working_set, span, arg_shape);
 
                         (
                             Some(Spanned {
@@ -393,8 +377,7 @@ fn parse_long_flag(
                             Some(arg),
                         )
                     } else if let Some(arg) = spans.get(*spans_idx + 1) {
-                        let arg =
-                            parse_value(working_set, *arg, arg_shape, expand_aliases_denylist);
+                        let arg = parse_value(working_set, *arg, arg_shape);
 
                         *spans_idx += 1;
                         (
@@ -614,7 +597,6 @@ pub fn parse_multispan_value(
     spans: &[Span],
     spans_idx: &mut usize,
     shape: &SyntaxShape,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     match shape {
         SyntaxShape::VarWithOptType => {
@@ -624,8 +606,7 @@ pub fn parse_multispan_value(
         }
         SyntaxShape::RowCondition => {
             trace!("parsing: row condition");
-            let arg =
-                parse_row_condition(working_set, &spans[*spans_idx..], expand_aliases_denylist);
+            let arg = parse_row_condition(working_set, &spans[*spans_idx..]);
             *spans_idx = spans.len() - 1;
 
             arg
@@ -633,12 +614,7 @@ pub fn parse_multispan_value(
         SyntaxShape::MathExpression => {
             trace!("parsing: math expression");
 
-            let arg = parse_math_expression(
-                working_set,
-                &spans[*spans_idx..],
-                None,
-                expand_aliases_denylist,
-            );
+            let arg = parse_math_expression(working_set, &spans[*spans_idx..], None);
             *spans_idx = spans.len() - 1;
 
             arg
@@ -648,13 +624,7 @@ pub fn parse_multispan_value(
             //let block_then_exp = shapes.as_slice() == [SyntaxShape::Block, SyntaxShape::Expression];
             for shape in shapes.iter() {
                 let starting_error_count = working_set.parse_errors.len();
-                let s = parse_multispan_value(
-                    working_set,
-                    spans,
-                    spans_idx,
-                    shape,
-                    expand_aliases_denylist,
-                );
+                let s = parse_multispan_value(working_set, spans, spans_idx, shape);
 
                 if starting_error_count == working_set.parse_errors.len() {
                     return s;
@@ -699,12 +669,7 @@ pub fn parse_multispan_value(
 
             // is it subexpression?
             // Not sure, but let's make it not, so the behavior is the same as previous version of nushell.
-            let arg = parse_expression(
-                working_set,
-                &spans[*spans_idx..],
-                expand_aliases_denylist,
-                false,
-            );
+            let arg = parse_expression(working_set, &spans[*spans_idx..], false);
             *spans_idx = spans.len() - 1;
 
             arg
@@ -749,8 +714,7 @@ pub fn parse_multispan_value(
                 };
             }
             let keyword_span = spans[*spans_idx - 1];
-            let expr =
-                parse_multispan_value(working_set, spans, spans_idx, arg, expand_aliases_denylist);
+            let expr = parse_multispan_value(working_set, spans, spans_idx, arg);
             let ty = expr.ty.clone();
 
             Expression {
@@ -764,7 +728,7 @@ pub fn parse_multispan_value(
             // All other cases are single-span values
             let arg_span = spans[*spans_idx];
 
-            parse_value(working_set, arg_span, shape, expand_aliases_denylist)
+            parse_value(working_set, arg_span, shape)
         }
     }
 }
@@ -798,7 +762,6 @@ pub fn parse_internal_call(
     command_span: Span,
     spans: &[Span],
     decl_id: usize,
-    expand_aliases_denylist: &[usize],
 ) -> ParsedInternalCall {
     trace!("parsing: internal call (decl id: {})", decl_id);
 
@@ -855,13 +818,7 @@ pub fn parse_internal_call(
 
         let starting_error_count = working_set.parse_errors.len();
         // Check if we're on a long flag, if so, parse
-        let (long_name, arg) = parse_long_flag(
-            working_set,
-            spans,
-            &mut spans_idx,
-            &signature,
-            expand_aliases_denylist,
-        );
+        let (long_name, arg) = parse_long_flag(working_set, spans, &mut spans_idx, &signature);
 
         if let Some(long_name) = long_name {
             // We found a long flag, like --bar
@@ -871,12 +828,7 @@ pub fn parse_internal_call(
                 && signature.allows_unknown_args
             {
                 working_set.parse_errors.truncate(starting_error_count);
-                let arg = parse_value(
-                    working_set,
-                    arg_span,
-                    &SyntaxShape::Any,
-                    expand_aliases_denylist,
-                );
+                let arg = parse_value(working_set, arg_span, &SyntaxShape::Any);
 
                 call.add_unknown(arg);
             } else {
@@ -918,20 +870,14 @@ pub fn parse_internal_call(
                 && signature.allows_unknown_args
             {
                 working_set.parse_errors.truncate(starting_error_count);
-                let arg = parse_value(
-                    working_set,
-                    arg_span,
-                    &SyntaxShape::Any,
-                    expand_aliases_denylist,
-                );
+                let arg = parse_value(working_set, arg_span, &SyntaxShape::Any);
 
                 call.add_unknown(arg);
             } else {
                 for flag in short_flags {
                     if let Some(arg_shape) = flag.arg {
                         if let Some(arg) = spans.get(spans_idx + 1) {
-                            let arg =
-                                parse_value(working_set, *arg, &arg_shape, expand_aliases_denylist);
+                            let arg = parse_value(working_set, *arg, &arg_shape);
 
                             if flag.long.is_empty() {
                                 if let Some(short) = flag.short {
@@ -1020,7 +966,6 @@ pub fn parse_internal_call(
                 &spans[..end],
                 &mut spans_idx,
                 &positional.shape,
-                expand_aliases_denylist,
             );
 
             let arg = if !type_compatible(&positional.shape.to_type(), &arg.ty) {
@@ -1036,12 +981,7 @@ pub fn parse_internal_call(
             call.add_positional(arg);
             positional_idx += 1;
         } else if signature.allows_unknown_args {
-            let arg = parse_value(
-                working_set,
-                arg_span,
-                &SyntaxShape::Any,
-                expand_aliases_denylist,
-            );
+            let arg = parse_value(working_set, arg_span, &SyntaxShape::Any);
 
             call.add_unknown(arg);
         } else {
@@ -1071,7 +1011,6 @@ pub fn parse_call(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
     head: Span,
-    expand_aliases_denylist: &[usize],
     is_subexpression: bool,
 ) -> Expression {
     trace!("parsing: call");
@@ -1092,13 +1031,6 @@ pub fn parse_call(
     for word_span in spans[cmd_start..].iter() {
         // Find the longest group of words that could form a command
 
-        // if is_math_expression_like(working_set, *word_span, expand_aliases_denylist) {
-        //     let bytes = working_set.get_span_contents(*word_span);
-        //     if bytes != b"true" && bytes != b"false" && bytes != b"null" && bytes != b"not" {
-        //         break;
-        //     }
-        // }
-
         name_spans.push(*word_span);
 
         let name_part = working_set.get_span_contents(*word_span);
@@ -1107,52 +1039,6 @@ pub fn parse_call(
         } else {
             name.push(b' ');
             name.extend(name_part);
-        }
-
-        // If the word is an alias, expand it and re-parse the expression
-        if let Some(alias_id) = working_set.find_alias(&name) {
-            if !expand_aliases_denylist.contains(&alias_id) {
-                trace!("expanding alias");
-
-                let expansion = working_set.get_alias(alias_id);
-
-                let expansion_span = span(expansion);
-
-                let orig_span = span(&[spans[cmd_start], spans[pos]]);
-                let mut new_spans: Vec<Span> = vec![];
-                new_spans.extend(&spans[0..cmd_start]);
-                new_spans.extend(expansion);
-                // TODO: This seems like it should be `pos + 1`. `pos` starts as 0
-                if spans.len() > pos {
-                    new_spans.extend(&spans[(pos + 1)..]);
-                }
-
-                let mut expand_aliases_denylist = expand_aliases_denylist.to_vec();
-                expand_aliases_denylist.push(alias_id);
-
-                let lite_command = LiteCommand {
-                    comments: vec![],
-                    parts: new_spans.clone(),
-                };
-
-                let mut result = parse_builtin_commands(
-                    working_set,
-                    &lite_command,
-                    &expand_aliases_denylist,
-                    is_subexpression,
-                );
-
-                let result = result.elements.remove(0);
-
-                // If this is the first element in a pipeline, we know it has to be an expression
-                if let PipelineElement::Expression(_, mut result) = result {
-                    result.replace_span(working_set, expansion_span, orig_span);
-
-                    return result;
-                } else {
-                    panic!("Internal error: first element of pipeline not an expression")
-                }
-            }
         }
 
         pos += 1;
@@ -1217,7 +1103,7 @@ pub fn parse_call(
                 let mut final_args = args.clone();
 
                 for arg_span in spans.iter().skip(1) {
-                    let arg = parse_external_arg(working_set, *arg_span, expand_aliases_denylist);
+                    let arg = parse_external_arg(working_set, *arg_span);
                     final_args.push(arg);
                 }
 
@@ -1237,7 +1123,6 @@ pub fn parse_call(
                     span(&spans[cmd_start..pos]),
                     &spans[pos..],
                     decl_id,
-                    expand_aliases_denylist,
                 )
             }
         } else {
@@ -1247,7 +1132,6 @@ pub fn parse_call(
                 span(&spans[cmd_start..pos]),
                 &spans[pos..],
                 decl_id,
-                expand_aliases_denylist,
             )
         };
 
@@ -1265,7 +1149,7 @@ pub fn parse_call(
             trace!("-- found leading range indicator");
             let starting_error_count = working_set.parse_errors.len();
 
-            let range_expr = parse_range(working_set, spans[0], expand_aliases_denylist);
+            let range_expr = parse_range(working_set, spans[0]);
             if working_set.parse_errors.len() == starting_error_count {
                 trace!("-- successfully parsed range");
                 return range_expr;
@@ -1275,12 +1159,7 @@ pub fn parse_call(
         trace!("parsing: external call");
 
         // Otherwise, try external command
-        parse_external_call(
-            working_set,
-            spans,
-            expand_aliases_denylist,
-            is_subexpression,
-        )
+        parse_external_call(working_set, spans, is_subexpression)
     }
 }
 
@@ -1491,11 +1370,7 @@ pub fn parse_number(working_set: &mut StateWorkingSet, span: Span) -> Expression
     garbage(span)
 }
 
-pub fn parse_range(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     trace!("parsing: range");
 
     // Range follows the following syntax: [<from>][<next_operator><next>]<range_operator>[<to>]
@@ -1573,7 +1448,6 @@ pub fn parse_range(
             working_set,
             from_span,
             &SyntaxShape::Number,
-            expand_aliases_denylist,
         )))
     };
 
@@ -1585,7 +1459,6 @@ pub fn parse_range(
             working_set,
             to_span,
             &SyntaxShape::Number,
-            expand_aliases_denylist,
         )))
     };
 
@@ -1608,7 +1481,6 @@ pub fn parse_range(
                 working_set,
                 next_span,
                 &SyntaxShape::Number,
-                expand_aliases_denylist,
             ))),
             next_op_span,
         )
@@ -1630,31 +1502,23 @@ pub fn parse_range(
     }
 }
 
-pub(crate) fn parse_dollar_expr(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub(crate) fn parse_dollar_expr(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     trace!("parsing: dollar expression");
     let contents = working_set.get_span_contents(span);
 
     if contents.starts_with(b"$\"") || contents.starts_with(b"$'") {
-        parse_string_interpolation(working_set, span, expand_aliases_denylist)
+        parse_string_interpolation(working_set, span)
     } else if contents.starts_with(b"$.") {
-        parse_simple_cell_path(
-            working_set,
-            Span::new(span.start + 2, span.end),
-            expand_aliases_denylist,
-        )
+        parse_simple_cell_path(working_set, Span::new(span.start + 2, span.end))
     } else {
         let starting_error_count = working_set.parse_errors.len();
 
-        let expr = parse_range(working_set, span, expand_aliases_denylist);
+        let expr = parse_range(working_set, span);
         if starting_error_count == working_set.parse_errors.len() {
             expr
         } else {
             working_set.parse_errors.truncate(starting_error_count);
-            parse_full_cell_path(working_set, None, span, expand_aliases_denylist)
+            parse_full_cell_path(working_set, None, span)
         }
     }
 }
@@ -1663,11 +1527,10 @@ pub fn parse_paren_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     let starting_error_count = working_set.parse_errors.len();
 
-    let expr = parse_range(working_set, span, expand_aliases_denylist);
+    let expr = parse_range(working_set, span);
 
     if starting_error_count == working_set.parse_errors.len() {
         expr
@@ -1675,9 +1538,9 @@ pub fn parse_paren_expr(
         working_set.parse_errors.truncate(starting_error_count);
 
         if matches!(shape, SyntaxShape::Signature) {
-            parse_signature(working_set, span, expand_aliases_denylist)
+            parse_signature(working_set, span)
         } else {
-            parse_full_cell_path(working_set, None, span, expand_aliases_denylist)
+            parse_full_cell_path(working_set, None, span)
         }
     }
 }
@@ -1686,7 +1549,6 @@ pub fn parse_numberlike_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     match shape {
         SyntaxShape::Binary => parse_binary(working_set, span),
@@ -1696,8 +1558,8 @@ pub fn parse_numberlike_expr(
         SyntaxShape::Duration => parse_duration(working_set, span),
         SyntaxShape::DateTime => parse_datetime(working_set, span),
         SyntaxShape::Filesize => parse_filesize(working_set, span),
-        SyntaxShape::Range => parse_range(working_set, span, expand_aliases_denylist),
-        SyntaxShape::CellPath => parse_simple_cell_path(working_set, span, expand_aliases_denylist),
+        SyntaxShape::Range => parse_range(working_set, span),
+        SyntaxShape::CellPath => parse_simple_cell_path(working_set, span),
         SyntaxShape::String => {
             working_set.error(ParseError::Mismatch(
                 "string".into(),
@@ -1734,7 +1596,7 @@ pub fn parse_numberlike_expr(
                 ] {
                     let starting_error_count = working_set.parse_errors.len();
 
-                    let result = parse_value(working_set, span, shape, expand_aliases_denylist);
+                    let result = parse_value(working_set, span, shape);
 
                     if starting_error_count == working_set.parse_errors.len() {
                         return result;
@@ -1764,7 +1626,6 @@ pub fn parse_brace_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     // Try to detect what kind of value we're about to parse
     // FIXME: In the future, we should work over the token stream so we only have to do this once
@@ -1798,30 +1659,30 @@ pub fn parse_brace_expr(
     if matches!(second_token, None) {
         // If we're empty, that means an empty record or closure
         if matches!(shape, SyntaxShape::Closure(None)) {
-            parse_closure_expression(working_set, shape, span, expand_aliases_denylist, false)
+            parse_closure_expression(working_set, shape, span, false)
         } else if matches!(shape, SyntaxShape::Closure(Some(_))) {
-            parse_closure_expression(working_set, shape, span, expand_aliases_denylist, true)
+            parse_closure_expression(working_set, shape, span, true)
         } else if matches!(shape, SyntaxShape::Block) {
-            parse_block_expression(working_set, span, expand_aliases_denylist)
+            parse_block_expression(working_set, span)
         } else if matches!(shape, SyntaxShape::MatchBlock) {
-            parse_match_block_expression(working_set, span, expand_aliases_denylist)
+            parse_match_block_expression(working_set, span)
         } else {
-            parse_record(working_set, span, expand_aliases_denylist)
+            parse_record(working_set, span)
         }
     } else if matches!(second_token_contents, Some(TokenContents::Pipe))
         || matches!(second_token_contents, Some(TokenContents::PipePipe))
     {
-        parse_closure_expression(working_set, shape, span, expand_aliases_denylist, true)
+        parse_closure_expression(working_set, shape, span, true)
     } else if matches!(third_token, Some(b":")) {
-        parse_full_cell_path(working_set, None, span, expand_aliases_denylist)
+        parse_full_cell_path(working_set, None, span)
     } else if matches!(shape, SyntaxShape::Closure(None)) {
-        parse_closure_expression(working_set, shape, span, expand_aliases_denylist, false)
+        parse_closure_expression(working_set, shape, span, false)
     } else if matches!(shape, SyntaxShape::Closure(Some(_))) || matches!(shape, SyntaxShape::Any) {
-        parse_closure_expression(working_set, shape, span, expand_aliases_denylist, true)
+        parse_closure_expression(working_set, shape, span, true)
     } else if matches!(shape, SyntaxShape::Block) {
-        parse_block_expression(working_set, span, expand_aliases_denylist)
+        parse_block_expression(working_set, span)
     } else if matches!(shape, SyntaxShape::MatchBlock) {
-        parse_match_block_expression(working_set, span, expand_aliases_denylist)
+        parse_match_block_expression(working_set, span)
     } else {
         working_set.error(ParseError::Expected(
             format!("non-block value: {shape}"),
@@ -1832,11 +1693,7 @@ pub fn parse_brace_expr(
     }
 }
 
-pub fn parse_string_interpolation(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     #[derive(PartialEq, Eq, Debug)]
     enum InterpolationMode {
         String,
@@ -1950,8 +1807,7 @@ pub fn parse_string_interpolation(
                     if token_start < b {
                         let span = Span::new(token_start, b + 1);
 
-                        let expr =
-                            parse_full_cell_path(working_set, None, span, expand_aliases_denylist);
+                        let expr = parse_full_cell_path(working_set, None, span);
                         output.push(expr);
                     }
 
@@ -1990,7 +1846,7 @@ pub fn parse_string_interpolation(
             if token_start < end {
                 let span = Span::new(token_start, end);
 
-                let expr = parse_full_cell_path(working_set, None, span, expand_aliases_denylist);
+                let expr = parse_full_cell_path(working_set, None, span);
                 output.push(expr);
             }
         }
@@ -2056,7 +1912,6 @@ pub fn parse_cell_path(
     working_set: &mut StateWorkingSet,
     tokens: impl Iterator<Item = Token>,
     expect_dot: bool,
-    expand_aliases_denylist: &[usize],
 ) -> Vec<PathMember> {
     enum TokenType {
         Dot,           // .
@@ -2121,8 +1976,7 @@ pub fn parse_cell_path(
                         optional: false,
                     }),
                     _ => {
-                        let result =
-                            parse_string(working_set, path_element.span, expand_aliases_denylist);
+                        let result = parse_string(working_set, path_element.span);
                         match result {
                             Expression {
                                 expr: Expr::String(string),
@@ -2153,11 +2007,7 @@ pub fn parse_cell_path(
     tail
 }
 
-pub fn parse_simple_cell_path(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_simple_cell_path(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     let source = working_set.get_span_contents(span);
 
     let (tokens, err) = lex(source, span.start, &[b'\n', b'\r'], &[b'.', b'?'], true);
@@ -2167,7 +2017,7 @@ pub fn parse_simple_cell_path(
 
     let tokens = tokens.into_iter().peekable();
 
-    let cell_path = parse_cell_path(working_set, tokens, false, expand_aliases_denylist);
+    let cell_path = parse_cell_path(working_set, tokens, false);
 
     Expression {
         expr: Expr::CellPath(CellPath { members: cell_path }),
@@ -2181,7 +2031,6 @@ pub fn parse_full_cell_path(
     working_set: &mut StateWorkingSet,
     implicit_head: Option<VarId>,
     span: Span,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     trace!("parsing: full cell path");
     let full_cell_span = span;
@@ -2222,7 +2071,7 @@ pub fn parse_full_cell_path(
 
             // Creating a Type scope to parse the new block. This will keep track of
             // the previous input type found in that block
-            let output = parse_block(working_set, &output, true, expand_aliases_denylist, true);
+            let output = parse_block(working_set, &output, true, true);
             working_set
                 .type_scope
                 .add_type(working_set.type_scope.get_last_output());
@@ -2262,14 +2111,14 @@ pub fn parse_full_cell_path(
         } else if bytes.starts_with(b"[") {
             trace!("parsing: table head of full cell path");
 
-            let output = parse_table_expression(working_set, head.span, expand_aliases_denylist);
+            let output = parse_table_expression(working_set, head.span);
 
             tokens.next();
 
             (output, true)
         } else if bytes.starts_with(b"{") {
             trace!("parsing: record head of full cell path");
-            let output = parse_record(working_set, head.span, expand_aliases_denylist);
+            let output = parse_record(working_set, head.span);
 
             tokens.next();
 
@@ -2302,7 +2151,7 @@ pub fn parse_full_cell_path(
             return garbage(span);
         };
 
-        let tail = parse_cell_path(working_set, tokens, expect_dot, expand_aliases_denylist);
+        let tail = parse_cell_path(working_set, tokens, expect_dot);
 
         Expression {
             // FIXME: Get the type of the data at the tail using follow_cell_path() (or something)
@@ -2865,11 +2714,7 @@ pub fn unescape_unquote_string(bytes: &[u8], span: Span) -> (String, Option<Pars
     }
 }
 
-pub fn parse_string(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_string(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     trace!("parsing: string");
 
     let bytes = working_set.get_span_contents(span);
@@ -2881,7 +2726,7 @@ pub fn parse_string(
 
     // Check for bare word interpolation
     if bytes[0] != b'\'' && bytes[0] != b'"' && bytes[0] != b'`' && bytes.contains(&b'(') {
-        return parse_string_interpolation(working_set, span, expand_aliases_denylist);
+        return parse_string_interpolation(working_set, span);
     }
 
     let (s, err) = unescape_unquote_string(bytes, span);
@@ -3107,11 +2952,7 @@ pub fn parse_type(_working_set: &StateWorkingSet, bytes: &[u8]) -> Type {
     }
 }
 
-pub fn parse_import_pattern(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {
     let head_span = if let Some(head_span) = spans.get(0) {
         head_span
     } else {
@@ -3119,12 +2960,7 @@ pub fn parse_import_pattern(
         return garbage(span(spans));
     };
 
-    let head_expr = parse_value(
-        working_set,
-        *head_span,
-        &SyntaxShape::Any,
-        expand_aliases_denylist,
-    );
+    let head_expr = parse_value(working_set, *head_span, &SyntaxShape::Any);
 
     let (maybe_module_id, head_name) = match eval_constant(working_set, &head_expr) {
         Ok(val) => match value_as_string(val, head_expr.span) {
@@ -3157,12 +2993,7 @@ pub fn parse_import_pattern(
                 None,
             )
         } else if tail.starts_with(b"[") {
-            let result = parse_list_expression(
-                working_set,
-                *tail_span,
-                &SyntaxShape::String,
-                expand_aliases_denylist,
-            );
+            let result = parse_list_expression(working_set, *tail_span, &SyntaxShape::String);
 
             let mut output = vec![];
 
@@ -3342,7 +3173,6 @@ pub fn expand_to_cell_path(
     working_set: &mut StateWorkingSet,
     expression: &mut Expression,
     var_id: VarId,
-    expand_aliases_denylist: &[usize],
 ) {
     trace!("parsing: expanding to cell path");
     if let Expression {
@@ -3352,21 +3182,15 @@ pub fn expand_to_cell_path(
     } = expression
     {
         // Re-parse the string as if it were a cell-path
-        let new_expression =
-            parse_full_cell_path(working_set, Some(var_id), *span, expand_aliases_denylist);
+        let new_expression = parse_full_cell_path(working_set, Some(var_id), *span);
 
         *expression = new_expression;
     }
 }
 
-pub fn parse_row_condition(
-    working_set: &mut StateWorkingSet,
-    spans: &[Span],
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_row_condition(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expression {
     let var_id = working_set.add_variable(b"$it".to_vec(), span(spans), Type::Any, false);
-    let expression =
-        parse_math_expression(working_set, spans, Some(var_id), expand_aliases_denylist);
+    let expression = parse_math_expression(working_set, spans, Some(var_id));
     let span = span(spans);
 
     let block_id = match expression.expr {
@@ -3402,11 +3226,7 @@ pub fn parse_row_condition(
     }
 }
 
-pub fn parse_signature(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_signature(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     let bytes = working_set.get_span_contents(span);
 
     let mut start = span.start;
@@ -3433,7 +3253,7 @@ pub fn parse_signature(
         working_set.error(ParseError::Unclosed("] or )".into(), Span::new(end, end)));
     }
 
-    let sig = parse_signature_helper(working_set, Span::new(start, end), expand_aliases_denylist);
+    let sig = parse_signature_helper(working_set, Span::new(start, end));
 
     Expression {
         expr: Expr::Signature(sig),
@@ -3443,11 +3263,7 @@ pub fn parse_signature(
     }
 }
 
-pub fn parse_signature_helper(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Box<Signature> {
+pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> Box<Signature> {
     #[allow(clippy::enum_variant_names)]
     enum ParseMode {
         ArgMode,
@@ -3830,12 +3646,7 @@ pub fn parse_signature_helper(
                         }
                         ParseMode::DefaultValueMode => {
                             if let Some(last) = args.last_mut() {
-                                let expression = parse_value(
-                                    working_set,
-                                    span,
-                                    &SyntaxShape::Any,
-                                    expand_aliases_denylist,
-                                );
+                                let expression = parse_value(working_set, span, &SyntaxShape::Any);
 
                                 //TODO check if we're replacing a custom parameter already
                                 match last {
@@ -4035,7 +3846,6 @@ pub fn parse_list_expression(
     working_set: &mut StateWorkingSet,
     span: Span,
     element_shape: &SyntaxShape,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     let bytes = working_set.get_span_contents(span);
 
@@ -4079,7 +3889,6 @@ pub fn parse_list_expression(
                         &command.parts,
                         &mut spans_idx,
                         element_shape,
-                        expand_aliases_denylist,
                     );
 
                     if let Some(ref ctype) = contained_type {
@@ -4113,7 +3922,6 @@ pub fn parse_list_expression(
 pub fn parse_table_expression(
     working_set: &mut StateWorkingSet,
     original_span: Span,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     let bytes = working_set.get_span_contents(original_span);
 
@@ -4152,12 +3960,7 @@ pub fn parse_table_expression(
         },
         1 => {
             // List
-            parse_list_expression(
-                working_set,
-                original_span,
-                &SyntaxShape::Any,
-                expand_aliases_denylist,
-            )
+            parse_list_expression(working_set, original_span, &SyntaxShape::Any)
         }
         _ => {
             match &output.block[0].commands[0] {
@@ -4172,7 +3975,6 @@ pub fn parse_table_expression(
                         working_set,
                         command.parts[0],
                         &SyntaxShape::List(Box::new(SyntaxShape::Any)),
-                        expand_aliases_denylist,
                     );
 
                     if let Expression {
@@ -4195,7 +3997,6 @@ pub fn parse_table_expression(
                                     working_set,
                                     *part,
                                     &SyntaxShape::List(Box::new(SyntaxShape::Any)),
-                                    expand_aliases_denylist,
                                 );
                                 if let Expression {
                                     expr: Expr::List(values),
@@ -4234,11 +4035,7 @@ pub fn parse_table_expression(
     }
 }
 
-pub fn parse_block_expression(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     trace!("parsing: block expression");
 
     let bytes = working_set.get_span_contents(span);
@@ -4284,13 +4081,7 @@ pub fn parse_block_expression(
         _ => (None, 0),
     };
 
-    let mut output = parse_block(
-        working_set,
-        &output[amt_to_skip..],
-        false,
-        expand_aliases_denylist,
-        false,
-    );
+    let mut output = parse_block(working_set, &output[amt_to_skip..], false, false);
 
     if let Some(signature) = signature {
         output.signature = signature.0;
@@ -4324,11 +4115,7 @@ pub fn parse_block_expression(
     }
 }
 
-pub fn parse_match_block_expression(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     let bytes = working_set.get_span_contents(span);
 
     let mut start = span.start;
@@ -4464,7 +4251,6 @@ pub fn parse_match_block_expression(
             &[output[position].span],
             &mut 0,
             &SyntaxShape::OneOf(vec![SyntaxShape::Block, SyntaxShape::Expression]),
-            expand_aliases_denylist,
         );
         position += 1;
         working_set.exit_scope();
@@ -4484,7 +4270,6 @@ pub fn parse_closure_expression(
     working_set: &mut StateWorkingSet,
     shape: &SyntaxShape,
     span: Span,
-    expand_aliases_denylist: &[usize],
     require_pipe: bool,
 ) -> Expression {
     trace!("parsing: closure expression");
@@ -4548,8 +4333,7 @@ pub fn parse_closure_expression(
             };
 
             let signature_span = Span::new(start_point, end_point);
-            let signature =
-                parse_signature_helper(working_set, signature_span, expand_aliases_denylist);
+            let signature = parse_signature_helper(working_set, signature_span);
 
             (Some((signature, signature_span)), amt_to_skip)
         }
@@ -4600,13 +4384,7 @@ pub fn parse_closure_expression(
         }
     }
 
-    let mut output = parse_block(
-        working_set,
-        &output[amt_to_skip..],
-        false,
-        expand_aliases_denylist,
-        false,
-    );
+    let mut output = parse_block(working_set, &output[amt_to_skip..], false, false);
 
     if let Some(signature) = signature {
         output.signature = signature.0;
@@ -4644,7 +4422,6 @@ pub fn parse_value(
     working_set: &mut StateWorkingSet,
     span: Span,
     shape: &SyntaxShape,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     let bytes = working_set.get_span_contents(span);
 
@@ -4690,7 +4467,7 @@ pub fn parse_value(
             };
         }
         b"-inf" | b"inf" | b"NaN" => {
-            return parse_numberlike_expr(working_set, span, shape, expand_aliases_denylist);
+            return parse_numberlike_expr(working_set, span, shape);
         }
         _ => {}
     }
@@ -4700,9 +4477,9 @@ pub fn parse_value(
     }
 
     match bytes[0] {
-        b'$' => return parse_dollar_expr(working_set, span, expand_aliases_denylist),
-        b'(' => return parse_paren_expr(working_set, span, shape, expand_aliases_denylist),
-        b'{' => return parse_brace_expr(working_set, span, shape, expand_aliases_denylist),
+        b'$' => return parse_dollar_expr(working_set, span),
+        b'(' => return parse_paren_expr(working_set, span, shape),
+        b'{' => return parse_brace_expr(working_set, span, shape),
         b'[' => match shape {
             SyntaxShape::Any
             | SyntaxShape::List(_)
@@ -4717,14 +4494,14 @@ pub fn parse_value(
             // Anything that starts with a number now has to be a number-like value
             // These include values like ints, floats, dates, durations, etc
             // To create a string, wrap in quotes, to create a bare word, wrap in backticks
-            return parse_numberlike_expr(working_set, span, shape, expand_aliases_denylist);
+            return parse_numberlike_expr(working_set, span, shape);
         }
         b'-' | b'+' => {
             if bytes.len() > 1 && bytes[1].is_ascii_digit() {
                 // Anything that starts with a negative number now has to be a number-like value
                 // These include values like ints, floats, dates, durations, etc
                 // To create a string, wrap in quotes, to create a bare word, wrap in backticks
-                return parse_numberlike_expr(working_set, span, shape, expand_aliases_denylist);
+                return parse_numberlike_expr(working_set, span, shape);
             }
         }
         _ => {}
@@ -4732,20 +4509,20 @@ pub fn parse_value(
 
     match shape {
         SyntaxShape::Custom(shape, custom_completion) => {
-            let mut expression = parse_value(working_set, span, shape, expand_aliases_denylist);
+            let mut expression = parse_value(working_set, span, shape);
             expression.custom_completion = Some(*custom_completion);
             expression
         }
-        SyntaxShape::Range => parse_range(working_set, span, expand_aliases_denylist),
+        SyntaxShape::Range => parse_range(working_set, span),
         SyntaxShape::Filepath => parse_filepath(working_set, span),
         SyntaxShape::Directory => parse_directory(working_set, span),
         SyntaxShape::GlobPattern => parse_glob_pattern(working_set, span),
-        SyntaxShape::String => parse_string(working_set, span, expand_aliases_denylist),
+        SyntaxShape::String => parse_string(working_set, span),
         SyntaxShape::Binary => parse_binary(working_set, span),
         SyntaxShape::MatchPattern => parse_match_pattern(working_set, span),
         SyntaxShape::Signature => {
             if bytes.starts_with(b"[") {
-                parse_signature(working_set, span, expand_aliases_denylist)
+                parse_signature(working_set, span)
             } else {
                 working_set.error(ParseError::Expected("signature".into(), span));
 
@@ -4754,7 +4531,7 @@ pub fn parse_value(
         }
         SyntaxShape::List(elem) => {
             if bytes.starts_with(b"[") {
-                parse_list_expression(working_set, span, elem, expand_aliases_denylist)
+                parse_list_expression(working_set, span, elem)
             } else {
                 working_set.error(ParseError::Expected("list".into(), span));
 
@@ -4763,14 +4540,14 @@ pub fn parse_value(
         }
         SyntaxShape::Table => {
             if bytes.starts_with(b"[") {
-                parse_table_expression(working_set, span, expand_aliases_denylist)
+                parse_table_expression(working_set, span)
             } else {
                 working_set.error(ParseError::Expected("table".into(), span));
 
                 Expression::garbage(span)
             }
         }
-        SyntaxShape::CellPath => parse_simple_cell_path(working_set, span, expand_aliases_denylist),
+        SyntaxShape::CellPath => parse_simple_cell_path(working_set, span),
         SyntaxShape::Boolean => {
             // Redundant, though we catch bad boolean parses here
             if bytes == b"true" || bytes == b"false" {
@@ -4801,7 +4578,7 @@ pub fn parse_value(
         SyntaxShape::Any => {
             if bytes.starts_with(b"[") {
                 //parse_value(working_set, span, &SyntaxShape::Table)
-                parse_full_cell_path(working_set, None, span, expand_aliases_denylist)
+                parse_full_cell_path(working_set, None, span)
             } else {
                 let shapes = [
                     SyntaxShape::Range,
@@ -4813,7 +4590,7 @@ pub fn parse_value(
                 for shape in shapes.iter() {
                     let starting_error_count = working_set.parse_errors.len();
 
-                    let s = parse_value(working_set, span, shape, expand_aliases_denylist);
+                    let s = parse_value(working_set, span, shape);
 
                     if starting_error_count == working_set.parse_errors.len() {
                         return s;
@@ -4984,7 +4761,6 @@ pub fn parse_math_expression(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
     lhs_row_var_id: Option<VarId>,
-    expand_aliases_denylist: &[usize],
 ) -> Expression {
     trace!("parsing: math expression");
 
@@ -5008,7 +4784,7 @@ pub fn parse_math_expression(
     if first_span == b"if" || first_span == b"match" {
         // If expression
         if spans.len() > 1 {
-            return parse_call(working_set, spans, spans[0], expand_aliases_denylist, false);
+            return parse_call(working_set, spans, spans[0], false);
         } else {
             working_set.error(ParseError::Expected(
                 "expression".into(),
@@ -5018,12 +4794,7 @@ pub fn parse_math_expression(
         }
     } else if first_span == b"not" {
         if spans.len() > 1 {
-            let remainder = parse_math_expression(
-                working_set,
-                &spans[1..],
-                lhs_row_var_id,
-                expand_aliases_denylist,
-            );
+            let remainder = parse_math_expression(working_set, &spans[1..], lhs_row_var_id);
             return Expression {
                 expr: Expr::UnaryNot(Box::new(remainder)),
                 span: span(spans),
@@ -5039,18 +4810,13 @@ pub fn parse_math_expression(
         }
     }
 
-    let mut lhs = parse_value(
-        working_set,
-        spans[0],
-        &SyntaxShape::Any,
-        expand_aliases_denylist,
-    );
+    let mut lhs = parse_value(working_set, spans[0], &SyntaxShape::Any);
     idx += 1;
 
     if idx >= spans.len() {
         // We already found the one part of our expression, so let's expand
         if let Some(row_var_id) = lhs_row_var_id {
-            expand_to_cell_path(working_set, &mut lhs, row_var_id, expand_aliases_denylist);
+            expand_to_cell_path(working_set, &mut lhs, row_var_id);
         }
     }
 
@@ -5073,12 +4839,7 @@ pub fn parse_math_expression(
             break;
         }
 
-        let rhs = parse_value(
-            working_set,
-            spans[idx],
-            &SyntaxShape::Any,
-            expand_aliases_denylist,
-        );
+        let rhs = parse_value(working_set, spans[idx], &SyntaxShape::Any);
 
         while op_prec <= last_prec && expr_stack.len() > 1 {
             // Collapse the right associated operations first
@@ -5103,7 +4864,7 @@ pub fn parse_math_expression(
                 .expect("internal error: expression stack empty");
 
             if let Some(row_var_id) = lhs_row_var_id {
-                expand_to_cell_path(working_set, &mut lhs, row_var_id, expand_aliases_denylist);
+                expand_to_cell_path(working_set, &mut lhs, row_var_id);
             }
 
             let (result_ty, err) = math_result_type(working_set, &mut lhs, &mut op, &mut rhs);
@@ -5139,7 +4900,7 @@ pub fn parse_math_expression(
             .expect("internal error: expression stack empty");
 
         if let Some(row_var_id) = lhs_row_var_id {
-            expand_to_cell_path(working_set, &mut lhs, row_var_id, expand_aliases_denylist);
+            expand_to_cell_path(working_set, &mut lhs, row_var_id);
         }
 
         let (result_ty, err) = math_result_type(working_set, &mut lhs, &mut op, &mut rhs);
@@ -5164,7 +4925,6 @@ pub fn parse_math_expression(
 pub fn parse_expression(
     working_set: &mut StateWorkingSet,
     spans: &[Span],
-    expand_aliases_denylist: &[usize],
     is_subexpression: bool,
 ) -> Expression {
     trace!("parsing: expression");
@@ -5191,7 +4951,7 @@ pub fn parse_expression(
                 let rhs_span = Span::new(spans[pos].start + point, spans[pos].end);
 
                 if working_set.get_span_contents(rhs_span).starts_with(b"$") {
-                    parse_dollar_expr(working_set, rhs_span, expand_aliases_denylist)
+                    parse_dollar_expr(working_set, rhs_span)
                 } else {
                     parse_string_strict(working_set, rhs_span)
                 }
@@ -5221,28 +4981,22 @@ pub fn parse_expression(
         return garbage(span(spans));
     }
 
-    let output = if is_math_expression_like(working_set, spans[pos], expand_aliases_denylist) {
-        parse_math_expression(working_set, &spans[pos..], None, expand_aliases_denylist)
+    let output = if is_math_expression_like(working_set, spans[pos]) {
+        parse_math_expression(working_set, &spans[pos..], None)
     } else {
         let bytes = working_set.get_span_contents(spans[pos]).to_vec();
 
         // For now, check for special parses of certain keywords
         match bytes.as_slice() {
-            b"def" | b"extern" | b"for" | b"module" | b"use" | b"source" | b"old-alias"
-            | b"alias" | b"export" | b"hide" => {
+            b"def" | b"extern" | b"for" | b"module" | b"use" | b"source" | b"alias" | b"export"
+            | b"hide" => {
                 working_set.error(ParseError::BuiltinCommandInPipeline(
                     String::from_utf8(bytes)
                         .expect("builtin commands bytes should be able to convert to string"),
                     spans[0],
                 ));
 
-                parse_call(
-                    working_set,
-                    &spans[pos..],
-                    spans[0],
-                    expand_aliases_denylist,
-                    is_subexpression,
-                )
+                parse_call(working_set, &spans[pos..], spans[0], is_subexpression)
             }
             b"let" | b"const" | b"mut" => {
                 working_set.error(ParseError::AssignInPipeline(
@@ -5260,40 +5014,22 @@ pub fn parse_expression(
                     .to_string(),
                     spans[0],
                 ));
-                parse_call(
-                    working_set,
-                    &spans[pos..],
-                    spans[0],
-                    expand_aliases_denylist,
-                    is_subexpression,
-                )
+                parse_call(working_set, &spans[pos..], spans[0], is_subexpression)
             }
             b"overlay" => {
                 if spans.len() > 1 && working_set.get_span_contents(spans[1]) == b"list" {
                     // whitelist 'overlay list'
-                    parse_call(
-                        working_set,
-                        &spans[pos..],
-                        spans[0],
-                        expand_aliases_denylist,
-                        is_subexpression,
-                    )
+                    parse_call(working_set, &spans[pos..], spans[0], is_subexpression)
                 } else {
                     working_set.error(ParseError::BuiltinCommandInPipeline(
                         "overlay".into(),
                         spans[0],
                     ));
 
-                    parse_call(
-                        working_set,
-                        &spans[pos..],
-                        spans[0],
-                        expand_aliases_denylist,
-                        is_subexpression,
-                    )
+                    parse_call(working_set, &spans[pos..], spans[0], is_subexpression)
                 }
             }
-            b"where" => parse_where_expr(working_set, &spans[pos..], expand_aliases_denylist),
+            b"where" => parse_where_expr(working_set, &spans[pos..]),
             #[cfg(feature = "plugin")]
             b"register" => {
                 working_set.error(ParseError::BuiltinCommandInPipeline(
@@ -5301,22 +5037,10 @@ pub fn parse_expression(
                     spans[0],
                 ));
 
-                parse_call(
-                    working_set,
-                    &spans[pos..],
-                    spans[0],
-                    expand_aliases_denylist,
-                    is_subexpression,
-                )
+                parse_call(working_set, &spans[pos..], spans[0], is_subexpression)
             }
 
-            _ => parse_call(
-                working_set,
-                &spans[pos..],
-                spans[0],
-                expand_aliases_denylist,
-                is_subexpression,
-            ),
+            _ => parse_call(working_set, &spans[pos..], spans[0], is_subexpression),
         }
     };
 
@@ -5396,10 +5120,9 @@ pub fn parse_variable(working_set: &mut StateWorkingSet, span: Span) -> Option<V
 pub fn parse_builtin_commands(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
-    expand_aliases_denylist: &[usize],
     is_subexpression: bool,
 ) -> Pipeline {
-    if !is_math_expression_like(working_set, lite_command.parts[0], expand_aliases_denylist)
+    if !is_math_expression_like(working_set, lite_command.parts[0])
         && !is_unaliasable_parser_keyword(working_set, &lite_command.parts)
     {
         let name = working_set.get_span_contents(lite_command.parts[0]);
@@ -5412,7 +5135,6 @@ pub fn parse_builtin_commands(
                     working_set,
                     &lite_command.parts,
                     lite_command.parts[0],
-                    expand_aliases_denylist,
                     is_subexpression,
                 );
 
@@ -5426,9 +5148,7 @@ pub fn parse_builtin_commands(
                     match cmd.name() {
                         "overlay hide" => return parse_overlay_hide(working_set, call),
                         "overlay new" => return parse_overlay_new(working_set, call),
-                        "overlay use" => {
-                            return parse_overlay_use(working_set, call, expand_aliases_denylist)
-                        }
+                        "overlay use" => return parse_overlay_use(working_set, call),
                         _ => { /* this alias is not a parser keyword */ }
                     }
                 }
@@ -5439,56 +5159,36 @@ pub fn parse_builtin_commands(
     let name = working_set.get_span_contents(lite_command.parts[0]);
 
     match name {
-        b"def" | b"def-env" => parse_def(working_set, lite_command, None, expand_aliases_denylist),
-        b"extern" => parse_extern(working_set, lite_command, None, expand_aliases_denylist),
-        b"let" | b"const" => {
-            parse_let_or_const(working_set, &lite_command.parts, expand_aliases_denylist)
-        }
-        b"mut" => parse_mut(working_set, &lite_command.parts, expand_aliases_denylist),
+        b"def" | b"def-env" => parse_def(working_set, lite_command, None),
+        b"extern" => parse_extern(working_set, lite_command, None),
+        b"let" | b"const" => parse_let_or_const(working_set, &lite_command.parts),
+        b"mut" => parse_mut(working_set, &lite_command.parts),
         b"for" => {
-            let expr = parse_for(working_set, &lite_command.parts, expand_aliases_denylist);
+            let expr = parse_for(working_set, &lite_command.parts);
             Pipeline::from_vec(vec![expr])
         }
-        b"old-alias" => parse_old_alias(working_set, lite_command, None, expand_aliases_denylist),
-        b"alias" => parse_alias(working_set, lite_command, None, expand_aliases_denylist),
-        b"module" => parse_module(working_set, lite_command, expand_aliases_denylist),
+        b"alias" => parse_alias(working_set, lite_command, None),
+        b"module" => parse_module(working_set, lite_command),
         b"use" => {
-            let (pipeline, _) =
-                parse_use(working_set, &lite_command.parts, expand_aliases_denylist);
+            let (pipeline, _) = parse_use(working_set, &lite_command.parts);
             pipeline
         }
-        b"overlay" => parse_keyword(
-            working_set,
-            lite_command,
-            expand_aliases_denylist,
-            is_subexpression,
-        ),
-        b"source" | b"source-env" => {
-            parse_source(working_set, &lite_command.parts, expand_aliases_denylist)
-        }
-        b"export" => parse_export_in_block(working_set, lite_command, expand_aliases_denylist),
-        b"hide" => parse_hide(working_set, &lite_command.parts, expand_aliases_denylist),
-        b"where" => parse_where(working_set, &lite_command.parts, expand_aliases_denylist),
+        b"overlay" => parse_keyword(working_set, lite_command, is_subexpression),
+        b"source" | b"source-env" => parse_source(working_set, &lite_command.parts),
+        b"export" => parse_export_in_block(working_set, lite_command),
+        b"hide" => parse_hide(working_set, &lite_command.parts),
+        b"where" => parse_where(working_set, &lite_command.parts),
         #[cfg(feature = "plugin")]
-        b"register" => parse_register(working_set, &lite_command.parts, expand_aliases_denylist),
+        b"register" => parse_register(working_set, &lite_command.parts),
         _ => {
-            let expr = parse_expression(
-                working_set,
-                &lite_command.parts,
-                expand_aliases_denylist,
-                is_subexpression,
-            );
+            let expr = parse_expression(working_set, &lite_command.parts, is_subexpression);
 
             Pipeline::from_vec(vec![expr])
         }
     }
 }
 
-pub fn parse_record(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    expand_aliases_denylist: &[usize],
-) -> Expression {
+pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     let bytes = working_set.get_span_contents(span);
 
     let mut start = span.start;
@@ -5523,12 +5223,7 @@ pub fn parse_record(
 
     let mut field_types = Some(vec![]);
     while idx < tokens.len() {
-        let field = parse_value(
-            working_set,
-            tokens[idx].span,
-            &SyntaxShape::Any,
-            expand_aliases_denylist,
-        );
+        let field = parse_value(working_set, tokens[idx].span, &SyntaxShape::Any);
 
         idx += 1;
         if idx == tokens.len() {
@@ -5542,12 +5237,7 @@ pub fn parse_record(
             working_set.error(ParseError::Expected("record".into(), span));
             return garbage(span);
         }
-        let value = parse_value(
-            working_set,
-            tokens[idx].span,
-            &SyntaxShape::Any,
-            expand_aliases_denylist,
-        );
+        let value = parse_value(working_set, tokens[idx].span, &SyntaxShape::Any);
         idx += 1;
 
         if let Some(field) = field.as_string() {
@@ -5578,7 +5268,6 @@ pub fn parse_block(
     working_set: &mut StateWorkingSet,
     tokens: &[Token],
     scoped: bool,
-    expand_aliases_denylist: &[usize],
     is_subexpression: bool,
 ) -> Block {
     let (lite_block, err) = lite_parse(tokens);
@@ -5602,7 +5291,7 @@ pub fn parse_block(
                 | LiteElement::Redirection(_, _, command)
                 | LiteElement::SeparateRedirection {
                     out: (_, command), ..
-                } => parse_def_predecl(working_set, &command.parts, expand_aliases_denylist),
+                } => parse_def_predecl(working_set, &command.parts),
             }
         }
     }
@@ -5619,23 +5308,15 @@ pub fn parse_block(
                     .map(|command| match command {
                         LiteElement::Command(span, command) => {
                             trace!("parsing: pipeline element: command");
-                            let expr = parse_expression(
-                                working_set,
-                                &command.parts,
-                                expand_aliases_denylist,
-                                is_subexpression,
-                            );
+                            let expr =
+                                parse_expression(working_set, &command.parts, is_subexpression);
                             working_set.type_scope.add_type(expr.ty.clone());
 
                             PipelineElement::Expression(*span, expr)
                         }
                         LiteElement::Redirection(span, redirection, command) => {
                             trace!("parsing: pipeline element: redirection");
-                            let expr = parse_string(
-                                working_set,
-                                command.parts[0],
-                                expand_aliases_denylist,
-                            );
+                            let expr = parse_string(working_set, command.parts[0]);
 
                             working_set.type_scope.add_type(expr.ty.clone());
 
@@ -5646,19 +5327,11 @@ pub fn parse_block(
                             err: (err_span, err_command),
                         } => {
                             trace!("parsing: pipeline element: separate redirection");
-                            let out_expr = parse_string(
-                                working_set,
-                                out_command.parts[0],
-                                expand_aliases_denylist,
-                            );
+                            let out_expr = parse_string(working_set, out_command.parts[0]);
 
                             working_set.type_scope.add_type(out_expr.ty.clone());
 
-                            let err_expr = parse_string(
-                                working_set,
-                                err_command.parts[0],
-                                expand_aliases_denylist,
-                            );
+                            let err_expr = parse_string(working_set, err_command.parts[0]);
 
                             working_set.type_scope.add_type(err_expr.ty.clone());
 
@@ -5692,12 +5365,8 @@ pub fn parse_block(
                     | LiteElement::SeparateRedirection {
                         out: (_, command), ..
                     } => {
-                        let mut pipeline = parse_builtin_commands(
-                            working_set,
-                            command,
-                            expand_aliases_denylist,
-                            is_subexpression,
-                        );
+                        let mut pipeline =
+                            parse_builtin_commands(working_set, command, is_subexpression);
 
                         if idx == 0 {
                             if let Some(let_decl_id) = working_set.find_decl(b"let", &Type::Any) {
@@ -6219,7 +5888,6 @@ pub fn parse(
     fname: Option<&str>,
     contents: &[u8],
     scoped: bool,
-    expand_aliases_denylist: &[usize],
 ) -> Block {
     let span_offset = working_set.next_span_start();
 
@@ -6235,7 +5903,7 @@ pub fn parse(
         working_set.error(err)
     }
 
-    let mut output = parse_block(working_set, &output, scoped, expand_aliases_denylist, false);
+    let mut output = parse_block(working_set, &output, scoped, false);
 
     let mut seen = vec![];
     let mut seen_blocks = HashMap::new();

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1723,7 +1723,7 @@ mod input_types {
         let mut working_set = StateWorkingSet::new(&engine_state);
         let input = r#"ls | group-by name"#;
 
-        let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+        let block = parse(&mut working_set, None, input.as_bytes(), true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1768,7 +1768,7 @@ mod input_types {
         let (block, delta) = {
             let mut working_set = StateWorkingSet::new(&engine_state);
             let input = r#"ls | to-custom | group-by name other | agg ("b" | min)"#;
-            let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+            let block = parse(&mut working_set, None, input.as_bytes(), true);
 
             (block, working_set.render())
         };
@@ -1829,7 +1829,7 @@ mod input_types {
         let mut working_set = StateWorkingSet::new(&engine_state);
         let input = r#"[[a b]; [1 2] [3 4]] | to-custom | with-column [ ("a" | min) ("b" | min) ] | collect"#;
 
-        let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+        let block = parse(&mut working_set, None, input.as_bytes(), true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1883,7 +1883,7 @@ mod input_types {
         ];
 
         for input in inputs {
-            let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+            let block = parse(&mut working_set, None, input.as_bytes(), true);
 
             assert!(working_set.parse_errors.is_empty());
             assert_eq!(block.len(), 2, "testing: {input}");
@@ -1901,7 +1901,6 @@ mod input_types {
             None,
             b"if false { 'a' } else { $foo }",
             true,
-            &[],
         );
 
         assert!(matches!(
@@ -1921,7 +1920,6 @@ mod input_types {
             None,
             b"if false { 'a' } else $foo { 'b' }",
             true,
-            &[],
         );
 
         assert!(matches!(

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -52,7 +52,7 @@ fn test_int(
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, test, true, &[]);
+    let block = parse(&mut working_set, None, test, true);
 
     let err = working_set.parse_errors.first();
 
@@ -266,7 +266,7 @@ fn test_parse_any() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, test, true, &[]);
+    let block = parse(&mut working_set, None, test, true);
 
     match (block, working_set.parse_errors.first()) {
         (_, Some(e)) => {
@@ -282,7 +282,7 @@ pub fn parse_int() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"3", true, &[]);
+    let block = parse(&mut working_set, None, b"3", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -305,7 +305,7 @@ pub fn parse_int_with_underscores() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"420_69_2023", true, &[]);
+    let block = parse(&mut working_set, None, b"420_69_2023", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -335,7 +335,7 @@ pub fn parse_cell_path() {
         false,
     );
 
-    let block = parse(&mut working_set, None, b"$foo.bar.baz", true, &[]);
+    let block = parse(&mut working_set, None, b"$foo.bar.baz", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -389,7 +389,7 @@ pub fn parse_cell_path_optional() {
         false,
     );
 
-    let block = parse(&mut working_set, None, b"$foo.bar?.baz", true, &[]);
+    let block = parse(&mut working_set, None, b"$foo.bar?.baz", true);
 
     assert!(working_set.parse_errors.is_empty());
 
@@ -437,7 +437,7 @@ pub fn parse_binary_with_hex_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"0x[13]", true, &[]);
+    let block = parse(&mut working_set, None, b"0x[13]", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -455,7 +455,7 @@ pub fn parse_binary_with_incomplete_hex_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"0x[3]", true, &[]);
+    let block = parse(&mut working_set, None, b"0x[3]", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -473,7 +473,7 @@ pub fn parse_binary_with_binary_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"0b[1010 1000]", true, &[]);
+    let block = parse(&mut working_set, None, b"0b[1010 1000]", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -491,7 +491,7 @@ pub fn parse_binary_with_incomplete_binary_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"0b[10]", true, &[]);
+    let block = parse(&mut working_set, None, b"0b[10]", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -509,7 +509,7 @@ pub fn parse_binary_with_octal_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"0o[250]", true, &[]);
+    let block = parse(&mut working_set, None, b"0o[250]", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -527,7 +527,7 @@ pub fn parse_binary_with_incomplete_octal_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"0o[2]", true, &[]);
+    let block = parse(&mut working_set, None, b"0o[2]", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -545,7 +545,7 @@ pub fn parse_binary_with_invalid_octal_format() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, b"0b[90]", true, &[]);
+    let block = parse(&mut working_set, None, b"0b[90]", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -565,7 +565,7 @@ pub fn parse_binary_with_multi_byte_char() {
 
     // found using fuzzing, Rust can panic if you slice into this string
     let contents = b"0x[\xEF\xBF\xBD]";
-    let block = parse(&mut working_set, None, contents, true, &[]);
+    let block = parse(&mut working_set, None, contents, true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -586,7 +586,7 @@ pub fn parse_call() {
     let sig = Signature::build("foo").named("--jazz", SyntaxShape::Int, "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
 
-    let block = parse(&mut working_set, None, b"foo", true, &[]);
+    let block = parse(&mut working_set, None, b"foo", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -614,7 +614,7 @@ pub fn parse_call_missing_flag_arg() {
     let sig = Signature::build("foo").named("jazz", SyntaxShape::Int, "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
 
-    parse(&mut working_set, None, b"foo --jazz", true, &[]);
+    parse(&mut working_set, None, b"foo --jazz", true);
     assert!(matches!(
         working_set.parse_errors.first(),
         Some(ParseError::MissingFlagParam(..))
@@ -629,7 +629,7 @@ pub fn parse_call_missing_short_flag_arg() {
     let sig = Signature::build("foo").named("--jazz", SyntaxShape::Int, "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
 
-    parse(&mut working_set, None, b"foo -j", true, &[]);
+    parse(&mut working_set, None, b"foo -j", true);
     assert!(matches!(
         working_set.parse_errors.first(),
         Some(ParseError::MissingFlagParam(..))
@@ -645,7 +645,7 @@ pub fn parse_call_too_many_shortflag_args() {
         .named("--jazz", SyntaxShape::Int, "jazz!!", Some('j'))
         .named("--math", SyntaxShape::Int, "math!!", Some('m'));
     working_set.add_decl(sig.predeclare());
-    parse(&mut working_set, None, b"foo -mj", true, &[]);
+    parse(&mut working_set, None, b"foo -mj", true);
     assert!(matches!(
         working_set.parse_errors.first(),
         Some(ParseError::ShortFlagBatchCantTakeArg(..))
@@ -659,7 +659,7 @@ pub fn parse_call_unknown_shorthand() {
 
     let sig = Signature::build("foo").switch("--jazz", "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
-    parse(&mut working_set, None, b"foo -mj", true, &[]);
+    parse(&mut working_set, None, b"foo -mj", true);
     assert!(matches!(
         working_set.parse_errors.first(),
         Some(ParseError::UnknownFlag(..))
@@ -673,7 +673,7 @@ pub fn parse_call_extra_positional() {
 
     let sig = Signature::build("foo").switch("--jazz", "jazz!!", Some('j'));
     working_set.add_decl(sig.predeclare());
-    parse(&mut working_set, None, b"foo -j 100", true, &[]);
+    parse(&mut working_set, None, b"foo -j 100", true);
     assert!(matches!(
         working_set.parse_errors.first(),
         Some(ParseError::ExtraPositional(..))
@@ -687,7 +687,7 @@ pub fn parse_call_missing_req_positional() {
 
     let sig = Signature::build("foo").required("jazz", SyntaxShape::Int, "jazz!!");
     working_set.add_decl(sig.predeclare());
-    parse(&mut working_set, None, b"foo", true, &[]);
+    parse(&mut working_set, None, b"foo", true);
     assert!(matches!(
         working_set.parse_errors.first(),
         Some(ParseError::MissingPositional(..))
@@ -701,7 +701,7 @@ pub fn parse_call_missing_req_flag() {
 
     let sig = Signature::build("foo").required_named("--jazz", SyntaxShape::Int, "jazz!!", None);
     working_set.add_decl(sig.predeclare());
-    parse(&mut working_set, None, b"foo", true, &[]);
+    parse(&mut working_set, None, b"foo", true);
     assert!(matches!(
         working_set.parse_errors.first(),
         Some(ParseError::MissingRequiredFlag(..))
@@ -712,7 +712,7 @@ pub fn parse_call_missing_req_flag() {
 fn test_nothing_comparison_eq() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
-    let block = parse(&mut working_set, None, b"2 == null", true, &[]);
+    let block = parse(&mut working_set, None, b"2 == null", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -735,7 +735,7 @@ fn test_nothing_comparison_eq() {
 fn test_nothing_comparison_neq() {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
-    let block = parse(&mut working_set, None, b"2 != null", true, &[]);
+    let block = parse(&mut working_set, None, b"2 != null", true);
 
     assert!(working_set.parse_errors.is_empty());
     assert_eq!(block.len(), 1);
@@ -762,7 +762,7 @@ mod string {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"\"hello nushell\"", true, &[]);
+        let block = parse(&mut working_set, None, b"\"hello nushell\"", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -785,7 +785,7 @@ mod string {
             let engine_state = EngineState::new();
             let mut working_set = StateWorkingSet::new(&engine_state);
 
-            let block = parse(&mut working_set, None, b"$\"hello (39 + 3)\"", true, &[]);
+            let block = parse(&mut working_set, None, b"$\"hello (39 + 3)\"", true);
 
             assert!(working_set.parse_errors.is_empty());
             assert_eq!(block.len(), 1);
@@ -817,7 +817,7 @@ mod string {
             let engine_state = EngineState::new();
             let mut working_set = StateWorkingSet::new(&engine_state);
 
-            let block = parse(&mut working_set, None, b"$\"hello \\(39 + 3)\"", true, &[]);
+            let block = parse(&mut working_set, None, b"$\"hello \\(39 + 3)\"", true);
 
             assert!(working_set.parse_errors.is_empty());
 
@@ -848,13 +848,7 @@ mod string {
             let engine_state = EngineState::new();
             let mut working_set = StateWorkingSet::new(&engine_state);
 
-            let block = parse(
-                &mut working_set,
-                None,
-                b"$\"hello \\\\(39 + 3)\"",
-                true,
-                &[],
-            );
+            let block = parse(&mut working_set, None, b"$\"hello \\\\(39 + 3)\"", true);
 
             assert!(working_set.parse_errors.is_empty());
 
@@ -887,13 +881,7 @@ mod string {
             let engine_state = EngineState::new();
             let mut working_set = StateWorkingSet::new(&engine_state);
 
-            let block = parse(
-                &mut working_set,
-                None,
-                b"$\"\\(1 + 3)\\(7 - 5)\"",
-                true,
-                &[],
-            );
+            let block = parse(&mut working_set, None, b"$\"\\(1 + 3)\\(7 - 5)\"", true);
 
             assert!(working_set.parse_errors.is_empty());
 
@@ -937,7 +925,6 @@ mod string {
                 $"(($foo))"
                 "#,
                 true,
-                &[],
             );
 
             assert!(working_set.parse_errors.is_empty());
@@ -962,7 +949,6 @@ mod string {
                 $"Hello ($foo.bar)"
                 "#,
                 true,
-                &[],
             );
 
             assert!(working_set.parse_errors.is_empty());
@@ -979,7 +965,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"0..10", true, &[]);
+        let block = parse(&mut working_set, None, b"0..10", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1011,7 +997,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"0..<10", true, &[]);
+        let block = parse(&mut working_set, None, b"0..<10", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1043,7 +1029,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"10..0", true, &[]);
+        let block = parse(&mut working_set, None, b"10..0", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1075,7 +1061,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"(3 - 3)..<(8 + 2)", true, &[]);
+        let block = parse(&mut working_set, None, b"(3 - 3)..<(8 + 2)", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1109,7 +1095,7 @@ mod range {
 
         working_set.add_decl(Box::new(Let));
 
-        let block = parse(&mut working_set, None, b"let a = 2; $a..10", true, &[]);
+        let block = parse(&mut working_set, None, b"let a = 2; $a..10", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 2);
@@ -1143,13 +1129,7 @@ mod range {
 
         working_set.add_decl(Box::new(Let));
 
-        let block = parse(
-            &mut working_set,
-            None,
-            b"let a = 2; $a..<($a + 10)",
-            true,
-            &[],
-        );
+        let block = parse(&mut working_set, None, b"let a = 2; $a..<($a + 10)", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 2);
@@ -1181,7 +1161,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"0..", true, &[]);
+        let block = parse(&mut working_set, None, b"0..", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1213,7 +1193,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"..10", true, &[]);
+        let block = parse(&mut working_set, None, b"..10", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1245,7 +1225,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"-10..-3", true, &[]);
+        let block = parse(&mut working_set, None, b"-10..-3", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1277,7 +1257,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        let block = parse(&mut working_set, None, b"2.0..4.0..10.0", true, &[]);
+        let block = parse(&mut working_set, None, b"2.0..4.0..10.0", true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1309,7 +1289,7 @@ mod range {
         let engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
 
-        parse(&mut working_set, None, b"(0)..\"a\"", true, &[]);
+        parse(&mut working_set, None, b"(0)..\"a\"", true);
 
         assert!(!working_set.parse_errors.is_empty());
     }
@@ -1632,7 +1612,7 @@ mod input_types {
         let mut working_set = StateWorkingSet::new(&engine_state);
         let input = r#"ls | to-custom | group-by name other"#;
 
-        let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+        let block = parse(&mut working_set, None, input.as_bytes(), true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1696,7 +1676,7 @@ mod input_types {
         let input =
             r#"let a = (ls | to-custom | group-by name other); let b = (1+3); $a | agg sum"#;
 
-        let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+        let block = parse(&mut working_set, None, input.as_bytes(), true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 3);
@@ -1727,7 +1707,7 @@ mod input_types {
         let mut working_set = StateWorkingSet::new(&engine_state);
         let input = r#"let a = (ls | to-custom | group-by name other); ($a + $a) | agg sum"#;
 
-        let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+        let block = parse(&mut working_set, None, input.as_bytes(), true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 2);
@@ -1759,7 +1739,7 @@ mod input_types {
         let input = r#"
         let a = (ls | to-custom | group-by name other); [1 2 3] | to-custom; [1 2 3] | to-custom"#;
 
-        let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+        let block = parse(&mut working_set, None, input.as_bytes(), true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 3);
@@ -1803,7 +1783,7 @@ mod input_types {
         let mut working_set = StateWorkingSet::new(&engine_state);
         let input = r#"ls | group-by name"#;
 
-        let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+        let block = parse(&mut working_set, None, input.as_bytes(), true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1848,7 +1828,7 @@ mod input_types {
         let (block, delta) = {
             let mut working_set = StateWorkingSet::new(&engine_state);
             let input = r#"ls | to-custom | group-by name other | agg ("b" | min)"#;
-            let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+            let block = parse(&mut working_set, None, input.as_bytes(), true);
 
             (block, working_set.render())
         };
@@ -1909,7 +1889,7 @@ mod input_types {
         let mut working_set = StateWorkingSet::new(&engine_state);
         let input = r#"[[a b]; [1 2] [3 4]] | to-custom | with-column [ ("a" | min) ("b" | min) ] | collect"#;
 
-        let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+        let block = parse(&mut working_set, None, input.as_bytes(), true);
 
         assert!(working_set.parse_errors.is_empty());
         assert_eq!(block.len(), 1);
@@ -1963,7 +1943,7 @@ mod input_types {
         ];
 
         for input in inputs {
-            let block = parse(&mut working_set, None, input.as_bytes(), true, &[]);
+            let block = parse(&mut working_set, None, input.as_bytes(), true);
 
             assert!(working_set.parse_errors.is_empty());
             assert_eq!(block.len(), 2, "testing: {input}");
@@ -1981,7 +1961,6 @@ mod input_types {
             None,
             b"if false { 'a' } else { $foo }",
             true,
-            &[],
         );
 
         assert!(matches!(
@@ -2001,7 +1980,6 @@ mod input_types {
             None,
             b"if false { 'a' } else $foo { 'b' }",
             true,
-            &[],
         );
 
         assert!(matches!(

--- a/crates/nu-parser/tests/test_parser_unicode_escapes.rs
+++ b/crates/nu-parser/tests/test_parser_unicode_escapes.rs
@@ -14,7 +14,7 @@ pub fn do_test(test: &[u8], expected: &str, error_contains: Option<&str>) {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
 
-    let block = parse(&mut working_set, None, test, true, &[]);
+    let block = parse(&mut working_set, None, test, true);
 
     match working_set.parse_errors.first() {
         None => {

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -1,22 +1,20 @@
-use crate::{AliasId, DeclId, ModuleId, OverlayId, Type, Value, VarId};
+use crate::{DeclId, ModuleId, OverlayId, Type, Value, VarId};
 use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 pub static DEFAULT_OVERLAY_NAME: &str = "zero";
 
-/// Tells whether a decl or alias is visible or not
+/// Tells whether a decl is visible or not
 #[derive(Debug, Clone)]
 pub struct Visibility {
     decl_ids: HashMap<DeclId, bool>,
-    alias_ids: HashMap<AliasId, bool>,
 }
 
 impl Visibility {
     pub fn new() -> Self {
         Visibility {
             decl_ids: HashMap::new(),
-            alias_ids: HashMap::new(),
         }
     }
 
@@ -24,30 +22,17 @@ impl Visibility {
         *self.decl_ids.get(decl_id).unwrap_or(&true) // by default it's visible
     }
 
-    pub fn is_alias_id_visible(&self, alias_id: &AliasId) -> bool {
-        *self.alias_ids.get(alias_id).unwrap_or(&true) // by default it's visible
-    }
-
     pub fn hide_decl_id(&mut self, decl_id: &DeclId) {
         self.decl_ids.insert(*decl_id, false);
-    }
-
-    pub fn hide_alias_id(&mut self, alias_id: &AliasId) {
-        self.alias_ids.insert(*alias_id, false);
     }
 
     pub fn use_decl_id(&mut self, decl_id: &DeclId) {
         self.decl_ids.insert(*decl_id, true);
     }
 
-    pub fn use_alias_id(&mut self, alias_id: &AliasId) {
-        self.alias_ids.insert(*alias_id, true);
-    }
-
     /// Overwrite own values with the other
     pub fn merge_with(&mut self, other: Visibility) {
         self.decl_ids.extend(other.decl_ids);
-        self.alias_ids.extend(other.alias_ids);
     }
 
     /// Take new values from the other but keep own values
@@ -55,12 +40,6 @@ impl Visibility {
         for (decl_id, visible) in other.decl_ids.iter() {
             if !self.decl_ids.contains_key(decl_id) {
                 self.decl_ids.insert(*decl_id, *visible);
-            }
-        }
-
-        for (alias_id, visible) in other.alias_ids.iter() {
-            if !self.alias_ids.contains_key(alias_id) {
-                self.alias_ids.insert(*alias_id, *visible);
             }
         }
     }
@@ -198,7 +177,6 @@ pub struct OverlayFrame {
     pub constants: HashMap<VarId, Value>,
     pub predecls: HashMap<Vec<u8>, DeclId>, // temporary storage for predeclarations
     pub decls: HashMap<(Vec<u8>, Type), DeclId>,
-    pub aliases: HashMap<Vec<u8>, AliasId>,
     pub modules: HashMap<Vec<u8>, ModuleId>,
     pub visibility: Visibility,
     pub origin: ModuleId, // The original module the overlay was created from
@@ -212,7 +190,6 @@ impl OverlayFrame {
             constants: HashMap::new(),
             predecls: HashMap::new(),
             decls: HashMap::new(),
-            aliases: HashMap::new(),
             modules: HashMap::new(),
             visibility: Visibility::new(),
             origin,

--- a/crates/nu-protocol/src/exportable.rs
+++ b/crates/nu-protocol/src/exportable.rs
@@ -1,6 +1,5 @@
-use crate::{AliasId, DeclId};
+use crate::DeclId;
 
 pub enum Exportable {
     Decl { name: Vec<u8>, id: DeclId },
-    Alias { name: Vec<u8>, id: AliasId },
 }

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -1,6 +1,5 @@
 pub type VarId = usize;
 pub type DeclId = usize;
-pub type AliasId = usize;
 pub type BlockId = usize;
 pub type ModuleId = usize;
 pub type OverlayId = usize;

--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -1,4 +1,4 @@
-use crate::{AliasId, BlockId, DeclId, Span};
+use crate::{BlockId, DeclId, Span};
 
 use indexmap::IndexMap;
 
@@ -7,7 +7,6 @@ use indexmap::IndexMap;
 pub struct Module {
     pub name: Vec<u8>,
     pub decls: IndexMap<Vec<u8>, DeclId>,
-    pub aliases: IndexMap<Vec<u8>, AliasId>,
     pub env_block: Option<BlockId>, // `export-env { ... }` block
     pub main: Option<DeclId>,       // `export def main`
     pub span: Option<Span>,
@@ -18,7 +17,6 @@ impl Module {
         Module {
             name,
             decls: IndexMap::new(),
-            aliases: IndexMap::new(),
             env_block: None,
             main: None,
             span: None,
@@ -29,7 +27,6 @@ impl Module {
         Module {
             name,
             decls: IndexMap::new(),
-            aliases: IndexMap::new(),
             env_block: None,
             main: None,
             span: Some(span),
@@ -40,29 +37,20 @@ impl Module {
         self.decls.insert(name, decl_id)
     }
 
-    pub fn add_alias(&mut self, name: Vec<u8>, alias_id: AliasId) -> Option<AliasId> {
-        self.aliases.insert(name, alias_id)
-    }
-
     pub fn add_env_block(&mut self, block_id: BlockId) {
         self.env_block = Some(block_id);
     }
 
     pub fn extend(&mut self, other: &Module) {
         self.decls.extend(other.decls.clone());
-        self.aliases.extend(other.aliases.clone());
     }
 
     pub fn is_empty(&self) -> bool {
-        self.decls.is_empty() && self.aliases.is_empty()
+        self.decls.is_empty()
     }
 
     pub fn get_decl_id(&self, name: &[u8]) -> Option<DeclId> {
         self.decls.get(name).copied()
-    }
-
-    pub fn get_alias_id(&self, name: &[u8]) -> Option<AliasId> {
-        self.aliases.get(name).copied()
     }
 
     pub fn has_decl(&self, name: &[u8]) -> bool {
@@ -73,23 +61,8 @@ impl Module {
         self.decls.contains_key(name)
     }
 
-    pub fn has_alias(&self, name: &[u8]) -> bool {
-        self.aliases.contains_key(name)
-    }
-
     pub fn decl_name_with_head(&self, name: &[u8], head: &[u8]) -> Option<Vec<u8>> {
         if self.has_decl(name) {
-            let mut new_name = head.to_vec();
-            new_name.push(b' ');
-            new_name.extend(name);
-            Some(new_name)
-        } else {
-            None
-        }
-    }
-
-    pub fn alias_name_with_head(&self, name: &[u8], head: &[u8]) -> Option<Vec<u8>> {
-        if self.has_alias(name) {
             let mut new_name = head.to_vec();
             new_name.push(b' ');
             new_name.extend(name);
@@ -137,30 +110,6 @@ impl Module {
         result
     }
 
-    pub fn aliases_with_head(&self, head: &[u8]) -> Vec<(Vec<u8>, AliasId)> {
-        self.aliases
-            .iter()
-            .map(|(name, id)| {
-                let mut new_name = head.to_vec();
-                new_name.push(b' ');
-                new_name.extend(name);
-                (new_name, *id)
-            })
-            .collect()
-    }
-
-    pub fn alias_names_with_head(&self, head: &[u8]) -> Vec<Vec<u8>> {
-        self.aliases
-            .keys()
-            .map(|name| {
-                let mut new_name = head.to_vec();
-                new_name.push(b' ');
-                new_name.extend(name);
-                new_name
-            })
-            .collect()
-    }
-
     pub fn decls(&self) -> Vec<(Vec<u8>, DeclId)> {
         let mut result: Vec<(Vec<u8>, DeclId)> = self
             .decls
@@ -183,16 +132,5 @@ impl Module {
         }
 
         result
-    }
-
-    pub fn alias_names(&self) -> Vec<Vec<u8>> {
-        self.aliases.keys().cloned().collect()
-    }
-
-    pub fn aliases(&self) -> Vec<(Vec<u8>, AliasId)> {
-        self.aliases
-            .iter()
-            .map(|(name, id)| (name.clone(), *id))
-            .collect()
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -64,13 +64,7 @@ pub(crate) fn parse_commandline_args(
         let mut working_set = StateWorkingSet::new(engine_state);
         working_set.add_decl(Box::new(Nu));
 
-        let output = parse(
-            &mut working_set,
-            None,
-            commandline_args.as_bytes(),
-            false,
-            &[],
-        );
+        let output = parse(&mut working_set, None, commandline_args.as_bytes(), false);
         if let Some(err) = working_set.parse_errors.first() {
             report_error(&working_set, err);
 

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -22,7 +22,7 @@ fn find_id(
     location: &Value,
 ) -> Option<(Id, usize, Span)> {
     let offset = working_set.next_span_start();
-    let block = parse(working_set, Some(file_path), file, false, &[]);
+    let block = parse(working_set, Some(file_path), file, false);
 
     let flattened = flatten_block(working_set, &block);
 
@@ -78,7 +78,7 @@ pub fn check(engine_state: &mut EngineState, file_path: &String) {
 
     if let Ok(contents) = file {
         let offset = working_set.next_span_start();
-        let block = parse(&mut working_set, Some(file_path), &contents, false, &[]);
+        let block = parse(&mut working_set, Some(file_path), &contents, false);
 
         for err in &working_set.parse_errors {
             let mut span = err.span();

--- a/src/run.rs
+++ b/src/run.rs
@@ -62,18 +62,14 @@ fn load_standard_library(
         working_set.add_file(name.clone(), content);
         let end = working_set.next_span_start();
 
-        let (_, module, comments) = parse_module_block(
-            &mut working_set,
-            Span::new(start, end),
-            name.as_bytes(),
-            &[],
-        );
+        let (_, module, comments) =
+            parse_module_block(&mut working_set, Span::new(start, end), name.as_bytes());
 
         if let Some(err) = working_set.parse_errors.first() {
             report_error(&working_set, err);
         }
 
-        parse(&mut working_set, Some(&name), content, true, &[]);
+        parse(&mut working_set, Some(&name), content, true);
 
         if let Some(err) = working_set.parse_errors.first() {
             report_error(&working_set, err);

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -229,7 +229,6 @@ pub fn nu_repl() {
                 Some(&format!("line{i}")),
                 line.as_bytes(),
                 false,
-                &[],
             );
 
             if let Some(err) = working_set.parse_errors.first() {


### PR DESCRIPTION
# Description

Removes the old alias implementation.

The only remaining issues with the new alias implementation is missing completions with external completers and no support for aliasing a call with env shorthand (`alias foo = FOO=bar run-something`). Also some presentation issues, like `which` and wrong `usage`. I think these are not deal breakers and we can go ahead with the removal.

# User-Facing Changes

`old-alias` is no longer available.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
