### PR TITLE
Fix parser recovery after error

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4646,6 +4646,8 @@ pub fn parse_value(
     shape: &SyntaxShape,
     expand_aliases_denylist: &[usize],
 ) -> Expression {
+    trace!("parsing: value: {}", shape);
+
     let bytes = working_set.get_span_contents(span);
 
     if bytes.is_empty() {
@@ -4818,7 +4820,7 @@ pub fn parse_value(
                     if starting_error_count == working_set.parse_errors.len() {
                         return s;
                     } else {
-                        match working_set.parse_errors.first() {
+                        match working_set.parse_errors.get(starting_error_count) {
                             Some(ParseError::Expected(_, _)) => {
                                 working_set.parse_errors.truncate(starting_error_count);
                                 continue;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -8,6 +8,7 @@ mod test_custom_commands;
 mod test_engine;
 mod test_env;
 mod test_hiding;
+mod test_ide;
 mod test_iteration;
 mod test_known_external;
 mod test_math;
@@ -82,6 +83,34 @@ pub fn run_test_contains(input: &str, expected: &str) -> TestResult {
     let name = file.path();
 
     let mut cmd = Command::cargo_bin("nu")?;
+    cmd.arg(name);
+
+    writeln!(file, "{input}")?;
+
+    let output = cmd.output()?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+
+    println!("stdout: {stdout}");
+    println!("stderr: {stderr}");
+
+    assert!(output.status.success());
+
+    assert!(stdout.contains(expected));
+
+    Ok(())
+}
+
+#[cfg(test)]
+pub fn test_ide_contains(input: &str, ide_commands: &[&str], expected: &str) -> TestResult {
+    let mut file = NamedTempFile::new()?;
+    let name = file.path();
+
+    let mut cmd = Command::cargo_bin("nu")?;
+    for ide_command in ide_commands {
+        cmd.arg(ide_command);
+    }
     cmd.arg(name);
 
     writeln!(file, "{input}")?;

--- a/src/tests/test_ide.rs
+++ b/src/tests/test_ide.rs
@@ -1,0 +1,10 @@
+use crate::tests::{test_ide_contains, TestResult};
+
+#[test]
+fn parser_recovers() -> TestResult {
+    test_ide_contains(
+        "3 + \"bob\"\nlet x = \"fred\"\n",
+        &["--ide-check"],
+        "\"typename\":\"String\"",
+    )
+}


### PR DESCRIPTION
# Description

This fixes the parser recovery after the first error (at least the main culprit), where `parse_value` was not able to properly parse `any` values after the first error.

fixes #8796 

# User-Facing Changes

None

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
