### PR TITLE
make inlays show type instead of shape

### DIFF
--- a/src/ide.rs
+++ b/src/ide.rs
@@ -110,7 +110,7 @@ pub fn check(engine_state: &mut EngineState, file_path: &String) {
                     "{}",
                     json!({
                         "type": "hint",
-                        "typename": var.ty,
+                        "typename": var.ty.to_string(),
                         "position": {
                             "start": flat.0.start - offset,
                             "end": flat.0.end - offset

--- a/src/tests/test_ide.rs
+++ b/src/tests/test_ide.rs
@@ -5,6 +5,6 @@ fn parser_recovers() -> TestResult {
     test_ide_contains(
         "3 + \"bob\"\nlet x = \"fred\"\n",
         &["--ide-check"],
-        "\"typename\":\"String\"",
+        "\"typename\":\"string\"",
     )
 }


### PR DESCRIPTION
# Description

This tiny change fixes how inlays are shown.
![image](https://user-images.githubusercontent.com/343840/230671454-8adc7e69-4f4e-421f-b0e5-c9563a501c4b.png)


# User-Facing Changes



# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-utils/standard_library/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
