### PR TITLE
Pick up fix in dtparse for nanosec truncation noted at bottom of #8337

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "dtparse"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8293d8a873beeaf3daaf818f3f218b30aafcdb8cd7ed6d4b860e09868af790ab"
+checksum = "dbd3b6a23c50eb90a80bdb748042620328617e76276b99dc5c97906e47f807c3"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -4468,9 +4468,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.28.1"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13cf35f7140155d02ba4ec3294373d513a3c7baa8364c162b030e33c61520a8"
+checksum = "26bd36b60561ee1fb5ec2817f198b6fd09fa571c897a5e86d1487cfc2b096dfc"
 dependencies = [
  "arrayvec 0.7.2",
  "num-traits",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -46,7 +46,7 @@ crossterm = "0.24.0"
 csv = "1.2.0"
 dialoguer = { default-features = false, version = "0.10.3" }
 digest = { default-features = false, version = "0.10.0" }
-dtparse = "1.2.0"
+dtparse = "1.4.0"
 encoding_rs = "0.8.30"
 fancy-regex = "0.11.0"
 filesize = "0.2.0"


### PR DESCRIPTION
# Description

Pick up [enhancement in `dtparse`](https://github.com/bspeice/dtparse/pull/41), to preserve nanoseconds in string-to-date conversions.

# User-Facing Changes

An especially eagle-eyed user might notice that prior versions of nushell were losing nanosecond precision when converting string format date/time to datetime.

Before:
```nushell
〉'2023-03-02T01:02:03.987654321' | into datetime | date to-record
╭────────────┬───────────╮
│ year       │ 2023      │
│ month      │ 3         │
│ day        │ 2         │
│ hour       │ 1         │
│ minute     │ 2         │
│ second     │ 3         │
│ nanosecond │ 987654000 │
│ timezone   │ -04:00    │
╰────────────┴───────────╯
```
Now, it just works(tm)
```nushell
〉'2023-03-02T01:02:03.987654321' | into datetime | date to-record
╭────────────┬───────────╮
│ year       │ 2023      │
│ month      │ 3         │
│ day        │ 2         │
│ hour       │ 1         │
│ minute     │ 2         │
│ second     │ 3         │
│ nanosecond │ 987654321 │
│ timezone   │ -04:00    │
╰────────────┴───────────╯
```

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass  
Some (unrelated) tests did fail [^err]
- [x] `cargo run -- crates/nu-std/tests.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.

# (Unrelated) test failures noted
[^err]: Several tests are failing, unrelated to this PR

```
failures:

---- modules::module_import_env_1 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env main.nu; use main.nu foo; foo
   ·            ───┬───
   ·               ╰── file not found
   ╰────


thread 'modules::module_import_env_1' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"foo"`', tests/modules/mod.rs:316:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- modules::module_import_env_2 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env main.nu; $env.FOO
   ·            ───┬───
   ·               ╰── file not found
   ╰────


thread 'modules::module_import_env_2' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"foo"`', tests/modules/mod.rs:341:9

---- overlays::overlay_use_do_cd_file_relative stdout ----
=== stderr

thread 'overlays::overlay_use_do_cd_file_relative' panicked at 'assertion failed: `(left == right)`
  left: `"nushell"`,
 right: `"test1"`', tests/overlays/mod.rs:919:9

---- overlays::overlay_use_dont_cd_overlay stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env test1/test2/spam.nu; $env.PWD | path basename
   ·            ─────────┬─────────
   ·                     ╰── file not found
   ╰────


thread 'overlays::overlay_use_dont_cd_overlay' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"overlay_use_dont_cd_overlay"`', tests/overlays/mod.rs:946:9

---- parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env lol/lol.nu; $env.FOO
   ·            ─────┬────
   ·                 ╰── file not found
   ╰────


thread 'parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"good"`', tests/parsing/mod.rs:177:9

---- parsing::parse_file_relative_to_parsed_file_simple stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env lol/lol/lol.nu; $env.LOL
   ·            ───────┬──────
   ·                   ╰── file not found
   ╰────


thread 'parsing::parse_file_relative_to_parsed_file_simple' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"lol"`', tests/parsing/mod.rs:99:9

---- shell::const_nu_lib_dirs_relative stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[main.nu:1:1]
 1 │ const NU_LIB_DIRS = [ 'scripts' ]
 2 │ source-env foo.nu
   ·            ───┬──

thread 'shell::const_nu_lib_dirs_relative' panicked at 'assertion failed: outcome.err.is_empty()', tests/shell/mod.rs:166:9

---- shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines stdout ----
=== stderr

thread 'shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"AndrásWithKitKat"`', tests/shell/pipeline/commands/external.rs:198:13

---- shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings stdout ----
=== stderr

thread 'shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"jt_likes_cake.txt"`', tests/shell/pipeline/commands/external.rs:173:13


failures:
    modules::module_import_env_1
    modules::module_import_env_2
    overlays::overlay_use_do_cd_file_relative
    overlays::overlay_use_dont_cd_overlay
    parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1
    parsing::parse_file_relative_to_parsed_file_simple
    shell::const_nu_lib_dirs_relative
    shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines
    shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings

test result: FAILED. 386 passed; 9 failed; 20 ignored; 0 measured; 0 filtered out; finished in 98.06s

error: test failed, to rerun pass `-p nu --test main`

failures:

---- modules::module_import_env_1 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env main.nu; use main.nu foo; foo
   ·            ───┬───
   ·               ╰── file not found
   ╰────


thread 'modules::module_import_env_1' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"foo"`', tests/modules/mod.rs:316:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- modules::module_import_env_2 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env main.nu; $env.FOO
   ·            ───┬───
   ·               ╰── file not found
   ╰────


thread 'modules::module_import_env_2' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"foo"`', tests/modules/mod.rs:341:9

---- overlays::overlay_use_do_cd_file_relative stdout ----
=== stderr

thread 'overlays::overlay_use_do_cd_file_relative' panicked at 'assertion failed: `(left == right)`
  left: `"nushell"`,
 right: `"test1"`', tests/overlays/mod.rs:919:9

---- overlays::overlay_use_dont_cd_overlay stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env test1/test2/spam.nu; $env.PWD | path basename
   ·            ─────────┬─────────
   ·                     ╰── file not found
   ╰────


thread 'overlays::overlay_use_dont_cd_overlay' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"overlay_use_dont_cd_overlay"`', tests/overlays/mod.rs:946:9

---- parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env lol/lol.nu; $env.FOO
   ·            ─────┬────
   ·                 ╰── file not found
   ╰────


thread 'parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"good"`', tests/parsing/mod.rs:177:9

---- parsing::parse_file_relative_to_parsed_file_simple stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env lol/lol/lol.nu; $env.LOL
   ·            ───────┬──────
   ·                   ╰── file not found
   ╰────


thread 'parsing::parse_file_relative_to_parsed_file_simple' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"lol"`', tests/parsing/mod.rs:99:9

---- shell::const_nu_lib_dirs_relative stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[main.nu:1:1]
 1 │ const NU_LIB_DIRS = [ 'scripts' ]
 2 │ source-env foo.nu
   ·            ───┬──

thread 'shell::const_nu_lib_dirs_relative' panicked at 'assertion failed: outcome.err.is_empty()', tests/shell/mod.rs:166:9

---- shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines stdout ----
=== stderr

thread 'shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"AndrásWithKitKat"`', tests/shell/pipeline/commands/external.rs:198:13

---- shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings stdout ----
=== stderr

thread 'shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"jt_likes_cake.txt"`', tests/shell/pipeline/commands/external.rs:173:13


failures:
    modules::module_import_env_1
    modules::module_import_env_2
    overlays::overlay_use_do_cd_file_relative
    overlays::overlay_use_dont_cd_overlay
    parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1
    parsing::parse_file_relative_to_parsed_file_simple
    shell::const_nu_lib_dirs_relative
    shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines
    shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings

test result: FAILED. 386 passed; 9 failed; 20 ignored; 0 measured; 0 filtered out; finished in 98.06s

error: test failed, to rerun pass `-p nu --test main`
failures:

---- modules::module_import_env_1 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env main.nu; use main.nu foo; foo
   ·            ───┬───
   ·               ╰── file not found
   ╰────


thread 'modules::module_import_env_1' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"foo"`', tests/modules/mod.rs:316:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- modules::module_import_env_2 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env main.nu; $env.FOO
   ·            ───┬───
   ·               ╰── file not found
   ╰────


thread 'modules::module_import_env_2' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"foo"`', tests/modules/mod.rs:341:9

---- overlays::overlay_use_do_cd_file_relative stdout ----
=== stderr

thread 'overlays::overlay_use_do_cd_file_relative' panicked at 'assertion failed: `(left == right)`
  left: `"nushell"`,
 right: `"test1"`', tests/overlays/mod.rs:919:9

---- overlays::overlay_use_dont_cd_overlay stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env test1/test2/spam.nu; $env.PWD | path basename
   ·            ─────────┬─────────
   ·                     ╰── file not found
   ╰────


thread 'overlays::overlay_use_dont_cd_overlay' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"overlay_use_dont_cd_overlay"`', tests/overlays/mod.rs:946:9

---- parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1 stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env lol/lol.nu; $env.FOO
   ·            ─────┬────
   ·                 ╰── file not found
   ╰────


thread 'parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"good"`', tests/parsing/mod.rs:177:9

---- parsing::parse_file_relative_to_parsed_file_simple stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[source:1:1]
 1 │ source-env lol/lol/lol.nu; $env.LOL
   ·            ───────┬──────
   ·                   ╰── file not found
   ╰────


thread 'parsing::parse_file_relative_to_parsed_file_simple' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"lol"`', tests/parsing/mod.rs:99:9

---- shell::const_nu_lib_dirs_relative stdout ----
=== stderr
Error: nu::shell::file_not_found

  × File not found
   ╭─[main.nu:1:1]
 1 │ const NU_LIB_DIRS = [ 'scripts' ]
 2 │ source-env foo.nu
   ·            ───┬──

thread 'shell::const_nu_lib_dirs_relative' panicked at 'assertion failed: outcome.err.is_empty()', tests/shell/mod.rs:166:9

---- shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines stdout ----
=== stderr

thread 'shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"AndrásWithKitKat"`', tests/shell/pipeline/commands/external.rs:198:13

---- shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings stdout ----
=== stderr

thread 'shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings' panicked at 'assertion failed: `(left == right)`
  left: `""`,
 right: `"jt_likes_cake.txt"`', tests/shell/pipeline/commands/external.rs:173:13


failures:
    modules::module_import_env_1
    modules::module_import_env_2
    overlays::overlay_use_do_cd_file_relative
    overlays::overlay_use_dont_cd_overlay
    parsing::parse_file_relative_to_parsed_file_dont_use_cwd_1
    parsing::parse_file_relative_to_parsed_file_simple
    shell::const_nu_lib_dirs_relative
    shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_lines
    shell::pipeline::commands::external::it_evaluation::takes_rows_of_nu_value_strings

test result: FAILED. 386 passed; 9 failed; 20 ignored; 0 measured; 0 filtered out; finished in 98.06s

error: test failed, to rerun pass `-p nu --test main`
```
