### PR TITLE
stdlib: use the loaded library in tests and update `README`

### DIFF
--- a/crates/nu-std/README.md
+++ b/crates/nu-std/README.md
@@ -17,39 +17,6 @@ in order to "import" the standard library to either the interactive [*REPL*][REP
 use /path/to/standard_library/std.nu
 ```
 
-> ### :mag: a concrete example
-> - my name is @amtoine and i use the `ghq` tool to manage `git` projects
-> > **Note**  
-> > `ghq` stores any repository inside `$env.GHQ_ROOT` under `<host>/<owner>/<repo>/`
-> - the path to my local fork of `nushell` is then defined as
-> ```bash
-> let-env NUSHELL_REPO = ($env.GHQ_ROOT | path join "github.com" "amtoine" "nushell")
-> ```
-> - and the full path to the standard library is defined as
-> ```bash
-> let-env STD_LIB = ($env.NUSHELL_REPO | path join "crates" "nu-utils" "standard_library")
-> ```
-> > see the content of `$env.STD_LIB` :yum:
-> > ```bash
-> > >_ ls $env.STD_LIB | get name | str replace $env.STD_LIB "" | str trim -l -c "/"
-> > ╭───┬───────────╮
-> > │ 0 │ README.md │
-> > │ 1 │ std.nu    │
-> > │ 2 │ tests.nu  │
-> > ╰───┴───────────╯
-> > ```
-> - finally we can `use` the standard library and have access to the commands it exposes :thumbsup:
-> ```bash
-> >_ use std.nu
-> >_ help std
-> Module: std
->
-> Exported commands:
->   assert (std assert), assert eq (std assert eq), assert ne (std assert ne), match (std match)
->
-> This module does not export environment.
-> ```
-
 ## :pencil2: contribute to the standard library
 - all the commands of the standard_library are located in [`std.nu`](std.nu)
 - the tests are located in files that have a name starting with "test_", e.g. [`test_std.nu`](test_std.nu)
@@ -67,10 +34,3 @@ the following call should return no errors
 NU_LOG_LEVEL=DEBUG nu /path/to/standard_library/tests.nu
 ```
 
-> #### :mag: a concrete example
-> with `STD_LIB` defined as in the example above
-> ```bash
-> NU_LOG_LEVEL=DEBUG nu ($env.STD_LIB | path join "tests.nu")
-> ```
-
-[REPL]: https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop

--- a/crates/nu-std/README.md
+++ b/crates/nu-std/README.md
@@ -34,5 +34,5 @@ the following call should return no errors
 NU_LOG_LEVEL=DEBUG cargo run -- crates/nu-std/tests.nu
 ```
 
-> **Warning**
+> **Warning**  
 > the `cargo run --` part of this command is important to ensure the version of `nushell` and the version of the library are the same.

--- a/crates/nu-std/README.md
+++ b/crates/nu-std/README.md
@@ -14,7 +14,7 @@ in order to "import" the standard library to either the interactive [*REPL*][REP
 `nushell` or inside some `.nu` script, you might want to use the
 [`use`](https://nushell.sh/commands/docs/use.html) command!
 ```bash
-use /path/to/standard_library/std.nu
+use std
 ```
 
 ## :pencil2: contribute to the standard library

--- a/crates/nu-std/README.md
+++ b/crates/nu-std/README.md
@@ -31,6 +31,8 @@ use std
 ### :test_tube: run the tests
 the following call should return no errors
 ```bash
-NU_LOG_LEVEL=DEBUG nu /path/to/standard_library/tests.nu
+NU_LOG_LEVEL=DEBUG cargo nu -- crates/nu-std/tests.nu
 ```
 
+> **Warning**
+> the `cargo run --` part of this command is important to ensure the version of `nushell` and the version of the library are the same.

--- a/crates/nu-std/README.md
+++ b/crates/nu-std/README.md
@@ -31,7 +31,7 @@ use std
 ### :test_tube: run the tests
 the following call should return no errors
 ```bash
-NU_LOG_LEVEL=DEBUG cargo nu -- crates/nu-std/tests.nu
+NU_LOG_LEVEL=DEBUG cargo run -- crates/nu-std/tests.nu
 ```
 
 > **Warning**

--- a/crates/nu-std/test_asserts.nu
+++ b/crates/nu-std/test_asserts.nu
@@ -1,4 +1,4 @@
-use std.nu *
+use std *
 
 export def test_assert [] {
     assert true

--- a/crates/nu-std/test_dirs.nu
+++ b/crates/nu-std/test_dirs.nu
@@ -1,5 +1,5 @@
-use std.nu "assert length"
-use std.nu "assert equal"
+use std "assert length"
+use std "assert equal"
 
 def clean [path: path] {
     cd $path
@@ -17,11 +17,11 @@ export def test_dirs_command [] {
         mkdir $base_path $path_a $path_b
 
         cd $base_path
-        use std.nu "dirs next"
-        use std.nu "dirs prev"
-        use std.nu "dirs add"
-        use std.nu "dirs drop"
-        use std.nu "dirs show"
+        use std "dirs next"
+        use std "dirs prev"
+        use std "dirs add"
+        use std "dirs drop"
+        use std "dirs show"
 
         assert length $env.DIRS_LIST 1 "list is just pwd after initialization"
         assert equal $base_path $env.DIRS_LIST.0 "list is just pwd after initialization"

--- a/crates/nu-std/test_logger.nu
+++ b/crates/nu-std/test_logger.nu
@@ -1,9 +1,9 @@
-use std.nu *
+use std *
 
 def run [system_level, message_level] {
     cd $env.FILE_PWD
     do {
-        nu -c $'use std.nu; NU_LOG_LEVEL=($system_level) std log ($message_level) "test message"' 
+        nu -c $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) "test message"' 
     } | complete | get -i stderr
 }
 def "assert no message" [system_level, message_level] {

--- a/crates/nu-std/test_std.nu
+++ b/crates/nu-std/test_std.nu
@@ -1,7 +1,7 @@
-use std.nu
+use std
 
 export def test_path_add [] {
-    use std.nu "assert equal"
+    use std "assert equal"
 
     with-env [PATH []] {
         assert equal $env.PATH []

--- a/crates/nu-std/test_xml.nu
+++ b/crates/nu-std/test_xml.nu
@@ -1,7 +1,7 @@
-use std.nu "xaccess"
-use std.nu "xupdate"
-use std.nu "xinsert"
-use std.nu "assert equal"
+use std "xaccess"
+use std "xupdate"
+use std "xinsert"
+use std "assert equal"
 
 export def test_xml_xaccess [] {
     let sample_xml = ('<a><b><c a="b"></c></b><c></c><d><e>z</e><e>x</e></d></a>' | from xml)

--- a/crates/nu-std/tests.nu
+++ b/crates/nu-std/tests.nu
@@ -1,4 +1,4 @@
-use std.nu *
+use std *
 
 # show a test record in a pretty way
 #


### PR DESCRIPTION
Should close #8809.

# Description
this PR uses the automatically loaded library from the tests by replacing `use std.nu ...` with `use std ...`. 

the `README` has been updated by
- removing the very deprencated "concrete examples"
- fixing the `use std` and the "run the tests" sections

the `README` can be previewed [here](https://github.com/amtoine/nushell/blob/refactor/stdlib/use-std-in-tests-and-update-readme/crates/nu-std/README.md) :+1:

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
- :green_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```