### PR TITLE
remove the "MODULE NOT FOUND" print from the parser

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1779,7 +1779,6 @@ pub fn parse_use(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeline
                     );
                 }
             } else {
-                println!("MODULE NOT FOUND");
                 working_set.error(ParseError::ModuleNotFound(import_pattern.head.span));
                 return (
                     Pipeline::from_vec(vec![Expression {


### PR DESCRIPTION
related to #8765.
should close #8812.

# Description
this PR simply removes the `prinln("MODULE NOT FOUND")` from the parser.

# User-Facing Changes
no more `MODULE NOT FOUND` while typing a `use` command

# Tests + Formatting
the `MODULE NOT FOUND` string only appears once so i did not run the tests here.
- :black_circle: `toolkit fmt`
- :black_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```