### PR TITLE
Use `pretty_assertions` in the root crate

### DIFF
--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
+use pretty_assertions::assert_eq;
 use std::fs;
 use std::path::Path;
-use pretty_assertions::assert_eq;
 
 #[cfg(not(target_os = "windows"))]
 fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -1,6 +1,7 @@
 use nu_test_support::nu;
 use std::fs;
 use std::path::Path;
+use pretty_assertions::assert_eq;
 
 #[cfg(not(target_os = "windows"))]
 fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -1,5 +1,6 @@
 use crate::tests::{fail_test, run_test, run_test_contains, TestResult};
 use nu_test_support::nu;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn no_scope_leak1() -> TestResult {

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -1,4 +1,5 @@
 use nu_test_support::{nu, pipeline};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn const_bool() {

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -1,5 +1,5 @@
 use nu_test_support::{nu, nu_repl_code};
-use pretty_assertions::{assert_eq, assert_ne};
+use pretty_assertions::assert_eq;
 
 fn env_change_hook_code_list(name: &str, code_list: &[&str]) -> String {
     let mut list = String::new();

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -1,4 +1,5 @@
 use nu_test_support::{nu, nu_repl_code};
+use pretty_assertions::{assert_eq, assert_ne};
 
 fn env_change_hook_code_list(name: &str, code_list: &[&str]) -> String {
     let mut list = String::new();

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn module_private_import_decl() {

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, nu_repl_code, pipeline};
+use pretty_assertions::{assert_eq, assert_ne};
 
 #[test]
 fn add_overlay() {

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1,7 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, nu_repl_code, pipeline};
-use pretty_assertions::{assert_eq, assert_ne};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn add_overlay() {

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+use pretty_assertions::assert_eq;
 
 #[test]
 fn source_file_relative_to_file() {

--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
-
 use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::playground::Playground;
-
 use nu_path::canonicalize_with;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn canonicalize_path() {

--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
+use nu_path::canonicalize_with;
 use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::playground::Playground;
-use nu_path::canonicalize_with;
 use pretty_assertions::assert_eq;
+use std::path::Path;
 
 #[test]
 fn canonicalize_path() {

--- a/tests/path/expand_path.rs
+++ b/tests/path/expand_path.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
-
 use nu_test_support::playground::Playground;
-
 use nu_path::expand_path_with;
+use pretty_assertions::assert_eq;
 
 #[cfg(not(windows))]
 #[test]

--- a/tests/path/expand_path.rs
+++ b/tests/path/expand_path.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
-use nu_test_support::playground::Playground;
 use nu_path::expand_path_with;
+use nu_test_support::playground::Playground;
 use pretty_assertions::assert_eq;
+use std::path::PathBuf;
 
 #[cfg(not(windows))]
 #[test]

--- a/tests/plugins/core_inc.rs
+++ b/tests/plugins/core_inc.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::nu_with_plugins;
 use nu_test_support::playground::Playground;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn chooses_highest_increment_if_given_more_than_one() {

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -1,4 +1,5 @@
 use nu_test_support::nu_with_plugins;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn can_get_custom_value_from_plugin_and_instantly_collapse_it() {

--- a/tests/plugins/formats/eml.rs
+++ b/tests/plugins/formats/eml.rs
@@ -1,4 +1,5 @@
 use nu_test_support::nu_with_plugins;
+use pretty_assertions::assert_eq;
 
 const TEST_CWD: &str = "tests/fixtures/formats";
 

--- a/tests/plugins/formats/ics.rs
+++ b/tests/plugins/formats/ics.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::nu_with_plugins;
 use nu_test_support::playground::Playground;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn infers_types() {

--- a/tests/plugins/formats/ini.rs
+++ b/tests/plugins/formats/ini.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::nu_with_plugins;
 use nu_test_support::playground::Playground;
+use pretty_assertions::assert_eq;
 
 const TEST_CWD: &str = "tests/fixtures/formats";
 

--- a/tests/plugins/formats/vcf.rs
+++ b/tests/plugins/formats/vcf.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::nu_with_plugins;
 use nu_test_support::playground::Playground;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn infers_types() {

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -1,4 +1,5 @@
 use nu_test_support::nu;
+use pretty_assertions::assert_eq;
 
 #[ignore = "TODO: This shows old-style aliases. New aliases are under commands"]
 #[test]

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -4,8 +4,8 @@ use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu_repl_code, pipeline};
-
 use serial_test::serial;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn env_shorthand() {

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -4,8 +4,8 @@ use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu_repl_code, pipeline};
-use serial_test::serial;
 use pretty_assertions::assert_eq;
+use serial_test::serial;
 
 #[test]
 fn env_shorthand() {

--- a/tests/shell/environment/nu_env.rs
+++ b/tests/shell/environment/nu_env.rs
@@ -3,6 +3,7 @@ use super::support::Trusted;
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+use pretty_assertions::assert_eq;
 
 use serial_test::serial;
 

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -1,6 +1,7 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, nu_repl_code, pipeline};
+use pretty_assertions::assert_eq;
 
 #[cfg(feature = "which-support")]
 mod environment;

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -1,4 +1,5 @@
 use nu_test_support::nu;
+use pretty_assertions::assert_eq;
 
 #[cfg(feature = "which-support")]
 #[test]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -2,6 +2,7 @@ use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::nu;
 use nu_test_support::pipeline;
 use nu_test_support::playground::Playground;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {

--- a/tests/shell/pipeline/mod.rs
+++ b/tests/shell/pipeline/mod.rs
@@ -1,6 +1,7 @@
 mod commands;
 
 use nu_test_support::nu;
+use pretty_assertions::assert_eq;
 
 #[test]
 fn doesnt_break_on_utf8() {


### PR DESCRIPTION
# Description

This PR is just a minor development improvement. While working on another feature, I noticed that the root crate lists the super useful `pretty_assertions` in the root crate but doesn't use it in most tests. With this change `pretty_assertions::assert_eq!` is used instead of `core::assert_eq!` for better diffs when debugging the tests.

I thought of adding the dependency to other crates but I decided not to since I didn't want a huge disruptive PR :)