### PR TITLE
Add git hooks for formatting and running `clippy`

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,5 @@
 #!/usr/bin/env nu
 
-use ../toolkit.nu [fmt, pretty-print-command]
+use ../toolkit.nu fmt
 
-print $"running ('toolkit fmt' | pretty-print-command)"
-try {
-    fmt --check
-} catch {
-    print $"\nplease run ('toolkit fmt' | pretty-print-command) to fix the formatting before committing!"
-    exit 1
-}
+fmt --check --verbose

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,4 +3,9 @@
 use ../toolkit.nu [fmt, pretty-print-command]
 
 print $"running ('toolkit fmt' | pretty-print-command)"
-fmt
+try {
+    fmt --check
+} catch {
+    print $"\nplease run ('toolkit fmt' | pretty-print-command) to fix the formatting before committing!"
+    exit 1
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env nu
+
+use ../toolkit.nu [fmt, pretty-print-command]
+
+print $"running ('toolkit fmt' | pretty-print-command)"
+fmt

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,18 @@
+#!/usr/bin/env nu
+
+use ../toolkit.nu [fmt, clippy, pretty-print-command]
+
+print $"running ('toolkit fmt' | pretty-print-command)"
+try {
+    fmt --check
+} catch {
+    print $"\nplease run (ansi default_dimmed)(ansi default_italic)toolkit fmt(ansi reset) to fix the formatting"
+    exit 1
+}
+
+print $"running ('toolkit clippy' | pretty-print-command)"
+try {
+    clippy
+} catch {
+    exit 1
+}

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,7 +6,7 @@ print $"running ('toolkit fmt' | pretty-print-command)"
 try {
     fmt --check
 } catch {
-    print $"\nplease run (ansi default_dimmed)(ansi default_italic)toolkit fmt(ansi reset) to fix the formatting"
+    print $"\nplease run ('toolkit fmt' | pretty-print-command) to fix the formatting before pushing!"
     exit 1
 }
 
@@ -14,5 +14,6 @@ print $"running ('toolkit clippy' | pretty-print-command)"
 try {
     clippy
 } catch {
+    print $"\nplease fix the above errors before pushing!"
     exit 1
 }

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,19 +1,6 @@
 #!/usr/bin/env nu
 
-use ../toolkit.nu [fmt, clippy, pretty-print-command]
+use ../toolkit.nu [fmt, clippy]
 
-print $"running ('toolkit fmt' | pretty-print-command)"
-try {
-    fmt --check
-} catch {
-    print $"\nplease run ('toolkit fmt' | pretty-print-command) to fix the formatting before pushing!"
-    exit 1
-}
-
-print $"running ('toolkit clippy' | pretty-print-command)"
-try {
-    clippy
-} catch {
-    print $"\nplease fix the above errors before pushing!"
-    exit 1
-}
+fmt --check --verbose
+clippy --verbose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,21 @@ The most comprehensive test suite we have is the `nu-test-support` crate. For te
   ```shell
   cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect
   ```
+  or via the `toolkit.nu` command:
+  ```shell
+  use toolkit.nu clippy
+  clippy
+  ```
 
 - Run all tests:
 
   ```shell
   cargo test --workspace
+  ```
+  or via the `toolkit.nu` command:
+  ```shell
+  use toolkit.nu test
+  test
   ```
 
 - Run all tests for a specific command
@@ -79,12 +89,30 @@ The most comprehensive test suite we have is the `nu-test-support` crate. For te
   ```shell
   cargo fmt --all -- --check
   ```
+  or via the `toolkit.nu` command:
+  ```shell
+  use toolkit.nu fmt
+  fmt --check
+  ```
 
 - Format the code in the project
 
   ```shell
   cargo fmt --all
   ```
+  or via the `toolkit.nu` command:
+  ```shell
+  use toolkit.nu fmt
+  fmt
+  ```
+
+- Set up `git` hooks to check formatting and run `clippy` before committing and pushing:
+
+  ```shell
+  use toolkit.nu setup-git-hooks
+  setup-git-hooks
+  ```
+  _Unfortunately, this hook isn't available on Windows._
 
 ### Debugging Tips
 

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -216,17 +216,14 @@ export def "check pr" [
 # - `toolkit fmt` on `git commit`
 # - `toolkit fmt --check` and `toolkit clippy` on `git push`
 export def set-git-hooks [] {
-    touch .git/hooks/pre-commit .git/hooks/pre-push
-    ^chmod +x .git/hooks/pre-commit .git/hooks/pre-push
-
-    echo `#!/usr/bin/env nu
+    set-git-hook pre-commit `#!/usr/bin/env nu
 
 use ../../toolkit.nu [fmt, pretty-print-command]
 
 print $"running ('toolkit fmt' | pretty-print-command)"
-fmt` | save -f .git/hooks/pre-commit
+fmt`
 
-    echo `#!/usr/bin/env nu
+    set-git-hook pre-push `#!/usr/bin/env nu
 
 use ../../toolkit.nu [fmt, clippy, pretty-print-command]
 
@@ -243,5 +240,12 @@ try {
     clippy
 } catch {
     exit 1
-}` | save -f .git/hooks/pre-push
+}`
+}
+
+def set-git-hook [
+    filename: string,
+    content: string
+] {
+    echo $content | save $".git/hooks/($filename)" | ^chmod +x $".git/hooks/($filename)"
 }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -212,40 +212,9 @@ export def "check pr" [
     report --no-fail
 }
 
-# creates git hooks to run:
+# set up git hooks to run:
 # - `toolkit fmt` on `git commit`
 # - `toolkit fmt --check` and `toolkit clippy` on `git push`
 export def set-git-hooks [] {
-    set-git-hook pre-commit `#!/usr/bin/env nu
-
-use ../../toolkit.nu [fmt, pretty-print-command]
-
-print $"running ('toolkit fmt' | pretty-print-command)"
-fmt`
-
-    set-git-hook pre-push `#!/usr/bin/env nu
-
-use ../../toolkit.nu [fmt, clippy, pretty-print-command]
-
-print $"running ('toolkit fmt' | pretty-print-command)"
-try {
-    fmt --check
-} catch {
-    print $"\nplease run (ansi default_dimmed)(ansi default_italic)toolkit fmt(ansi reset) to fix the formatting"
-    exit 1
-}
-
-print $"running ('toolkit clippy' | pretty-print-command)"
-try {
-    clippy
-} catch {
-    exit 1
-}`
-}
-
-def set-git-hook [
-    filename: string,
-    content: string
-] {
-    echo $content | save $".git/hooks/($filename)" | ^chmod +x $".git/hooks/($filename)"
+    git config --local core.hooksPath .githooks
 }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -236,5 +236,11 @@ export def set-git-hooks [] {
         return (print "These setup hook isn't available on Windows. Sorry!")
     }
 
-    git config --local core.hooksPath .githooks
+    print "This command will change your local git configuration and hence modify your development workflow. Are you sure you want to continue? [y]"
+    if (input) == "y" {
+        print $"running ('toolkit set-git-hooks' | pretty-print-command)"
+        git config --local core.hooksPath .githooks
+    } else {
+        print $"aborting ('toolkit set-git-hooks' | pretty-print-command)"
+    }
 }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -212,7 +212,7 @@ export def "check pr" [
     report --no-fail
 }
 
-# creates the git hooks to run:
+# creates git hooks to run:
 # - `toolkit fmt` on `git commit`
 # - `toolkit fmt --check` and `toolkit clippy` on `git push`
 export def set-git-hooks [] {

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -233,7 +233,7 @@ export def "check pr" [
 # - `toolkit fmt --check --verbose` and `toolkit clippy --verbose` on `git push`
 export def set-git-hooks [] {
     if $nu.os-info.name == windows {
-        return (print "These setup hook isn't available on Windows. Sorry!")
+        return (print "This git hook isn't available on Windows. Sorry!")
     }
 
     print "This command will change your local git configuration and hence modify your development workflow. Are you sure you want to continue? [y]"

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -232,5 +232,9 @@ export def "check pr" [
 # - `toolkit fmt --check --verbose` on `git commit`
 # - `toolkit fmt --check --verbose` and `toolkit clippy --verbose` on `git push`
 export def set-git-hooks [] {
+    if $nu.os-info.name == windows {
+        return (print "These setup hook isn't available on Windows. Sorry!")
+    }
+
     git config --local core.hooksPath .githooks
 }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -213,7 +213,7 @@ export def "check pr" [
 }
 
 # set up git hooks to run:
-# - `toolkit fmt` on `git commit`
+# - `toolkit fmt --check` on `git commit`
 # - `toolkit fmt --check` and `toolkit clippy` on `git push`
 export def set-git-hooks [] {
     git config --local core.hooksPath .githooks


### PR DESCRIPTION
# Description

As another life improvement (and to avoid those `run cargo fmt` commits 😉), this PR adds a command to the toolkit for formatting and running `clippy` when committing and pushing. 

Thanks to @amtoine for the idea!