### PR TITLE
Only add the std lib files once

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -299,7 +299,7 @@ mod command_completions_tests {
 
             let delta = {
                 let mut working_set = StateWorkingSet::new(&engine_state);
-                working_set.add_file("child.nu".into(), input);
+                let _ = working_set.add_file("child.nu".into(), input);
                 working_set.render()
             };
 

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -314,11 +314,9 @@ fn parse_module(
 ) -> Result<PipelineData, ShellError> {
     let filename = filename.unwrap_or_else(|| "empty".to_string());
 
-    let start = working_set.next_span_start();
-    working_set.add_file(filename.clone(), contents);
-    let end = working_set.next_span_start();
+    let file_id = working_set.add_file(filename.clone(), contents);
+    let new_span = working_set.get_span_for_file(file_id);
 
-    let new_span = Span::new(start, end);
     let starting_error_count = working_set.parse_errors.len();
     parse_module_block(working_set, new_span, filename.as_bytes());
 

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -13,7 +13,7 @@ fn quickcheck_parse(data: String) -> bool {
         let context = create_default_context();
         {
             let mut working_set = StateWorkingSet::new(&context);
-            working_set.add_file("quickcheck".into(), data.as_bytes());
+            let _ = working_set.add_file("quickcheck".into(), data.as_bytes());
 
             let _ = nu_parser::parse_block(&mut working_set, &tokens, false, false);
         }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1719,9 +1719,8 @@ pub fn parse_use(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeline
                 };
 
                 if let Ok(contents) = std::fs::read(&module_path) {
-                    let span_start = working_set.next_span_start();
-                    working_set.add_file(module_filename, &contents);
-                    let span_end = working_set.next_span_start();
+                    let file_id = working_set.add_file(module_filename, &contents);
+                    let new_span = working_set.get_span_for_file(file_id);
 
                     // Change the currently parsed directory
                     let prev_currently_parsed_cwd = if let Some(parent) = module_path.parent() {
@@ -1738,11 +1737,8 @@ pub fn parse_use(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeline
                     working_set.parsed_module_files.push(module_path);
 
                     // Parse the module
-                    let (block, module, module_comments) = parse_module_block(
-                        working_set,
-                        Span::new(span_start, span_end),
-                        module_name.as_bytes(),
-                    );
+                    let (block, module, module_comments) =
+                        parse_module_block(working_set, new_span, module_name.as_bytes());
 
                     // Remove the file from the stack of parsed module files
                     working_set.parsed_module_files.pop();
@@ -2245,9 +2241,8 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
                         };
 
                         if let Ok(contents) = std::fs::read(&module_path) {
-                            let span_start = working_set.next_span_start();
-                            working_set.add_file(module_filename, &contents);
-                            let span_end = working_set.next_span_start();
+                            let file_id = working_set.add_file(module_filename, &contents);
+                            let new_span = working_set.get_span_for_file(file_id);
 
                             // Change currently parsed directory
                             let prev_currently_parsed_cwd =
@@ -2261,11 +2256,8 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
                                     working_set.currently_parsed_cwd.clone()
                                 };
 
-                            let (block, module, module_comments) = parse_module_block(
-                                working_set,
-                                Span::new(span_start, span_end),
-                                overlay_name.as_bytes(),
-                            );
+                            let (block, module, module_comments) =
+                                parse_module_block(working_set, new_span, overlay_name.as_bytes());
 
                             // Restore the currently parsed directory back
                             working_set.currently_parsed_cwd = prev_currently_parsed_cwd;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5896,14 +5896,17 @@ pub fn parse(
     contents: &[u8],
     scoped: bool,
 ) -> Block {
-    let span_offset = working_set.next_span_start();
-
     let name = match fname {
         Some(fname) => fname.to_string(),
         None => "source".to_string(),
     };
 
-    working_set.add_file(name, contents);
+    let file_id = working_set.add_file(name, contents);
+    let result = working_set
+        .files()
+        .nth(file_id)
+        .expect("internal error: missing source that has been previously parsed");
+    let span_offset = result.1;
 
     let (output, err) = lex(contents, span_offset, &[], &[], false);
     if let Some(err) = err {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5902,13 +5902,9 @@ pub fn parse(
     };
 
     let file_id = working_set.add_file(name, contents);
-    let result = working_set
-        .files()
-        .nth(file_id)
-        .expect("internal error: missing source that has been previously parsed");
-    let span_offset = result.1;
+    let new_span = working_set.get_span_for_file(file_id);
 
-    let (output, err) = lex(contents, span_offset, &[], &[], false);
+    let (output, err) = lex(contents, new_span.start, &[], &[], false);
     if let Some(err) = err {
         working_set.error(err)
     }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1345,6 +1345,7 @@ impl<'a> StateWorkingSet<'a> {
         "<unknown>".into()
     }
 
+    #[must_use]
     pub fn add_file(&mut self, filename: String, contents: &[u8]) -> usize {
         // First, look for the file to see if we already have it
         for (idx, (fname, file_start, file_end)) in self.files().enumerate() {
@@ -1368,6 +1369,15 @@ impl<'a> StateWorkingSet<'a> {
             .push((filename, next_span_start, next_span_end));
 
         self.num_files() - 1
+    }
+
+    pub fn get_span_for_file(&self, file_id: usize) -> Span {
+        let result = self
+            .files()
+            .nth(file_id)
+            .expect("internal error: could not find source for previously parsed file");
+
+        Span::new(result.1, result.2)
     }
 
     pub fn get_span_contents(&self, span: Span) -> &[u8] {
@@ -2123,7 +2133,7 @@ mod engine_state_tests {
 
         let delta = {
             let mut working_set = StateWorkingSet::new(&engine_state);
-            working_set.add_file("child.nu".into(), &[]);
+            let _ = working_set.add_file("child.nu".into(), &[]);
             working_set.render()
         };
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1346,6 +1346,16 @@ impl<'a> StateWorkingSet<'a> {
     }
 
     pub fn add_file(&mut self, filename: String, contents: &[u8]) -> usize {
+        // First, look for the file to see if we already have it
+        for (idx, (fname, file_start, file_end)) in self.files().enumerate() {
+            if fname == &filename {
+                let prev_contents = self.get_span_contents(Span::new(*file_start, *file_end));
+                if prev_contents == contents {
+                    return idx;
+                }
+            }
+        }
+
         let next_span_start = self.next_span_start();
         let next_span_end = next_span_start + contents.len();
 

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -7,12 +7,14 @@ fn add_file(
     name: &String,
     content: &[u8],
 ) -> (Module, Vec<Span>) {
-    let start = working_set.next_span_start();
-    working_set.add_file(name.clone(), content);
-    let end = working_set.next_span_start();
+    let file = working_set.add_file(name.clone(), content);
+    let result = working_set
+        .files()
+        .nth(file)
+        .expect("internal error: missing source to std lib");
 
     let (_, module, comments) =
-        parse_module_block(working_set, Span::new(start, end), name.as_bytes());
+        parse_module_block(working_set, Span::new(result.1, result.2), name.as_bytes());
 
     if let Some(err) = working_set.parse_errors.first() {
         report_error(working_set, err);

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -7,14 +7,10 @@ fn add_file(
     name: &String,
     content: &[u8],
 ) -> (Module, Vec<Span>) {
-    let file = working_set.add_file(name.clone(), content);
-    let result = working_set
-        .files()
-        .nth(file)
-        .expect("internal error: missing source to std lib");
+    let file_id = working_set.add_file(name.clone(), content);
+    let new_span = working_set.get_span_for_file(file_id);
 
-    let (_, module, comments) =
-        parse_module_block(working_set, Span::new(result.1, result.2), name.as_bytes());
+    let (_, module, comments) = parse_module_block(working_set, new_span, name.as_bytes());
 
     if let Some(err) = working_set.parse_errors.first() {
         report_error(working_set, err);


### PR DESCRIPTION
# Description

We were seeing duplicate entries for the std lib files, and this PR addresses that. Each file should now only be added once.

Note: they are still parsed twice because it's hard to recover the module from the output of `parse` but a bit of clever hacking in a future PR might be able to do that.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
