### PR TITLE
Upgrade to nu v0.78 for binaries release workflow

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -50,17 +50,17 @@ let flags = $env.TARGET_RUSTFLAGS
 let dist = $'($env.GITHUB_WORKSPACE)/output'
 let version = (open Cargo.toml | get package.version)
 
-$'Debugging info:'
+print $'Debugging info:'
 print { version: $version, bin: $bin, os: $os, target: $target, src: $src, flags: $flags, dist: $dist }; hr-line -b
 
 # $env
 
 let USE_UBUNTU = 'ubuntu-20.04'
 
-$'(char nl)Packaging ($bin) v($version) for ($target) in ($src)...'; hr-line -b
+print $'(char nl)Packaging ($bin) v($version) for ($target) in ($src)...'; hr-line -b
 if not ('Cargo.lock' | path exists) { cargo generate-lockfile }
 
-$'Start building ($bin)...'; hr-line
+print $'Start building ($bin)...'; hr-line
 
 # ----------------------------------------------------------------------------
 # Build for Ubuntu and macOS
@@ -70,23 +70,28 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
         sudo apt update
         sudo apt-get install libxcb-composite0-dev -y
     }
-    if $target == 'aarch64-unknown-linux-gnu' {
-        sudo apt-get install gcc-aarch64-linux-gnu -y
-        let-env CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = 'aarch64-linux-gnu-gcc'
-        cargo-build-nu $flags
-    } else if $target == 'armv7-unknown-linux-gnueabihf' {
-        sudo apt-get install pkg-config gcc-arm-linux-gnueabihf -y
-        let-env CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER = 'arm-linux-gnueabihf-gcc'
-        cargo-build-nu $flags
-    } else if $target == 'riscv64gc-unknown-linux-gnu' {
-        sudo apt-get install gcc-riscv64-linux-gnu -y
-        let-env CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER = 'riscv64-linux-gnu-gcc'
-        cargo-build-nu $flags
-    } else {
-        # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'
-        # Actually just for x86_64-unknown-linux-musl target
-        if $os == $USE_UBUNTU { sudo apt install musl-tools -y }
-        cargo-build-nu $flags
+    match $target {
+        'aarch64-unknown-linux-gnu' => {
+            sudo apt-get install gcc-aarch64-linux-gnu -y
+            let-env CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = 'aarch64-linux-gnu-gcc'
+            cargo-build-nu $flags
+        }
+        'riscv64gc-unknown-linux-gnu' => {
+            sudo apt-get install gcc-riscv64-linux-gnu -y
+            let-env CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER = 'riscv64-linux-gnu-gcc'
+            cargo-build-nu $flags
+        }
+        'armv7-unknown-linux-gnueabihf' => {
+            sudo apt-get install pkg-config gcc-arm-linux-gnueabihf -y
+            let-env CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER = 'arm-linux-gnueabihf-gcc'
+            cargo-build-nu $flags
+        }
+        _ => {
+            # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'
+            # Actually just for x86_64-unknown-linux-musl target
+            if $os == $USE_UBUNTU { sudo apt install musl-tools -y }
+            cargo-build-nu $flags
+        }
     }
 }
 
@@ -107,31 +112,34 @@ if $os in ['windows-latest'] {
 let suffix = if $os == 'windows-latest' { '.exe' }
 # nu, nu_plugin_* were all included
 let executable = $'target/($target)/release/($bin)*($suffix)'
-$'Current executable file: ($executable)'
+print $'Current executable file: ($executable)'
 
 cd $src; mkdir $dist;
 rm -rf $'target/($target)/release/*.d' $'target/($target)/release/nu_pretty_hex*'
-$'(char nl)All executable files:'; hr-line
-ls -f $executable
+print $'(char nl)All executable files:'; hr-line
+# We have to use `print` here to make sure the command output is displayed
+print (ls -f $executable); sleep 1sec
 
-$'(char nl)Copying release files...'; hr-line
+print $'(char nl)Copying release files...'; hr-line
 cp -v README.release.txt $'($dist)/README.txt'
 [LICENSE $executable] | each {|it| cp -rv $it $dist } | flatten
+# Sleep a few seconds to make sure the cp process finished successfully
+sleep 3sec
 
-$'(char nl)Check binary release version detail:'; hr-line
+print $'(char nl)Check binary release version detail:'; hr-line
 let ver = if $os == 'windows-latest' {
     (do -i { ./output/nu.exe -c 'version' }) | str join
 } else {
     (do -i { ./output/nu -c 'version' }) | str join
 }
 if ($ver | str trim | is-empty) {
-    $'(ansi r)Incompatible nu binary...(ansi reset)'
-} else { $ver }
+    print $'(ansi r)Incompatible nu binary...(ansi reset)'
+} else { print $ver }
 
 # ----------------------------------------------------------------------------
 # Create a release archive and send it to output for the following steps
 # ----------------------------------------------------------------------------
-cd $dist; $'(char nl)Creating release archive...'; hr-line
+cd $dist; print $'(char nl)Creating release archive...'; hr-line
 if $os in [$USE_UBUNTU, 'macos-latest'] {
 
     let files = (ls | get name)
@@ -141,7 +149,7 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
     mkdir $dest
     $files | each {|it| mv $it $dest } | ignore
 
-    $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls $dest
+    print $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls $dest
 
     tar -czf $archive $dest
     print $'archive: ---> ($archive)'; ls $archive
@@ -152,7 +160,7 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
 
     let releaseStem = $'($bin)-($version)-($target)'
 
-    $'(char nl)Download less related stuffs...'; hr-line
+    print $'(char nl)Download less related stuffs...'; hr-line
     aria2c https://github.com/jftuga/less-Windows/releases/download/less-v608/less.exe -o less.exe
     aria2c https://raw.githubusercontent.com/jftuga/less-Windows/master/LICENSE -o LICENSE-for-less.txt
 
@@ -160,7 +168,7 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
     if (get-env _EXTRA_) == 'msi' {
 
         let wixRelease = $'($src)/target/wix/($releaseStem).msi'
-        $'(char nl)Start creating Windows msi package...'
+        print $'(char nl)Start creating Windows msi package...'
         cd $src; hr-line
         # Wix need the binaries be stored in target/release/
         cp -r $'($dist)/*' target/release/
@@ -171,7 +179,7 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
 
     } else {
 
-        $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls
+        print $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls
         let archive = $'($dist)/($releaseStem).zip'
         7z a $archive *
         print $'archive: ---> ($archive)';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.72.1
+        version: 0.78.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Description

Upgrade to nu v0.78 for binary packages release workflow

Test Release: https://github.com/hustcer/nu-release/releases/tag/v0.78.2
Release workflow running output: https://github.com/hustcer/nu-release/actions/runs/4656319252/jobs/8239828202

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
