### PR TITLE
stdlib: make helper modules available in std

### DIFF
--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -67,6 +67,7 @@ pub fn load_standard_library(
         let content = include_str!("../lib/mod.nu");
 
         // these modules are loaded in the order they appear in this list
+        #[rustfmt::skip]
         let submodules = vec![
             // helper modules that could be used in other parts of the library
             ("log", include_str!("../lib/log.nu")),

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -66,10 +66,13 @@ pub fn load_standard_library(
         let name = "std".to_string();
         let content = include_str!("../lib/mod.nu");
 
+        // these modules are loaded in the order they appear in this list
         let submodules = vec![
+            // helper modules that could be used in other parts of the library
             ("log", include_str!("../lib/log.nu")),
             ("assert", include_str!("../lib/assert.nu")),
 
+            // the rest of the library
             ("dirs", include_str!("../lib/dirs.nu")),
             ("help", include_str!("../lib/help.nu")),
             ("xml", include_str!("../lib/xml.nu")),

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -67,10 +67,11 @@ pub fn load_standard_library(
         let content = include_str!("../lib/mod.nu");
 
         let submodules = vec![
+            ("log", include_str!("../lib/log.nu")),
             ("assert", include_str!("../lib/assert.nu")),
+
             ("dirs", include_str!("../lib/dirs.nu")),
             ("help", include_str!("../lib/help.nu")),
-            ("log", include_str!("../lib/log.nu")),
             ("xml", include_str!("../lib/xml.nu")),
         ];
 


### PR DESCRIPTION
> **Note**
> waiting for the following to land
> - https://github.com/nushell/nushell/pull/8824 to avoid conflicts, i'll add this to `CONTRIBUTING.md` once it's ready :+1: 

should close #8839 

# Description
this PR moves the `log` submodule of `std` to the top of the call stack, making it available in the rest of the library as `log`.
i've added some comments around the `submodules` list in `load_standard_library` to make it clear how it should work.
 
# User-Facing Changes
`log` and `assert` are now available in the rest of `std`.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```