### PR TITLE
Fix process_range on 32-bit platforms

### DIFF
--- a/crates/nu-command/src/util.rs
+++ b/crates/nu-command/src/util.rs
@@ -26,7 +26,7 @@ type MakeRangeError = fn(&str, Span) -> ShellError;
 
 pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
     let start = match &range.from {
-        Value::Int { val, .. } => *val as isize,
+        Value::Int { val, .. } => isize::try_from(*val).unwrap_or_default(),
         Value::Nothing { .. } => 0,
         _ => {
             return Err(|msg, span| ShellError::TypeMismatch {
@@ -39,9 +39,9 @@ pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
     let end = match &range.to {
         Value::Int { val, .. } => {
             if matches!(range.inclusion, RangeInclusion::Inclusive) {
-                *val as isize
+                isize::try_from(*val).unwrap_or(isize::max_value())
             } else {
-                *val as isize - 1
+                isize::try_from(*val).unwrap_or(isize::max_value()) - 1
             }
         }
         Value::Nothing { .. } => isize::max_value(),


### PR DESCRIPTION
# Description

This PR fixes `commands::str_::substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given` testcase on 32-bit platform.

```
failures:
---- commands::str_::substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given stdout ----
=== stderr
thread 'commands::str_::substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given' panicked at 'assertion failed: `(left == right)`
  left: `"arepa"`,
 right: `"arepas"`', crates/nu-command/tests/commands/str_/mod.rs:363:9
failures:
    commands::str_::substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given
test result: FAILED. 1072 passed; 1 failed; 23 ignored; 0 measured; 0 filtered out; finished in 2.98s
error: test failed, to rerun pass `-p nu-command --test main`
```

https://gitlab.alpinelinux.org/nibon7/aports/-/jobs/1005935#L3864
https://gitlab.alpinelinux.org/nibon7/aports/-/jobs/1005931#L3867

# User-Facing Changes

N/A

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
