### PR TITLE
Remove autoprinting of `for` loop

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -120,7 +120,7 @@ impl Command for For {
                             return Err(err);
                         }
                         Ok(pipeline) => {
-                            let exit_code = pipeline.print(&engine_state, stack, false, false)?;
+                            let exit_code = pipeline.drain_with_exit_code()?;
                             if exit_code != 0 {
                                 return Ok(PipelineData::new_external_stream_with_only_exit_code(
                                     exit_code,


### PR DESCRIPTION
# Description

It's an addition to https://github.com/nushell/nushell/pull/8618
And I think it's good to keep the same behavior when we use for loop for list.

# User-Facing Changes

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
