### PR TITLE
Revert numberlike parsing restriction

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -197,7 +197,7 @@ impl Command for Char {
             },
             Example {
                 description: "Output Unicode character",
-                example: r#"char -u '1f378'"#,
+                example: r#"char -u 1f378"#,
                 result: Some(Value::test_string("\u{1f378}")),
             },
             Example {
@@ -207,7 +207,7 @@ impl Command for Char {
             },
             Example {
                 description: "Output multi-byte Unicode character",
-                example: r#"char -u '1F468' '200D' '1F466' '200D' '1F466'"#,
+                example: r#"char -u 1F468 200D 1F466 200D 1F466"#,
                 result: Some(Value::test_string(
                     "\u{1F468}\u{200D}\u{1F466}\u{200D}\u{1F466}",
                 )),

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -160,7 +160,7 @@ prints out the list properly."#
             },
             Example {
                 description: "Render a table with 'name' column in it to a grid",
-                example: "[[name patch]; ['0.1.0' false] ['0.1.1' true] ['0.2.0' false]] | grid",
+                example: "[[name patch]; [0.1.0 false] [0.1.1 true] [0.2.0 false]] | grid",
                 result: Some(Value::test_string("0.1.0 │ 0.1.1 │ 0.2.0\n")),
             },
         ]

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -367,7 +367,7 @@ fn does_not_error_when_some_file_is_moving_into_itself() {
 
         let original_dir = dirs.test().join("11");
         let expected = dirs.test().join("12/11");
-        nu!(cwd: dirs.test(), "mv `1*` `12`");
+        nu!(cwd: dirs.test(), "mv 1* 12");
 
         assert!(!original_dir.exists());
         assert!(expected.exists());

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1545,83 +1545,6 @@ pub fn parse_paren_expr(
     }
 }
 
-pub fn parse_numberlike_expr(
-    working_set: &mut StateWorkingSet,
-    span: Span,
-    shape: &SyntaxShape,
-) -> Expression {
-    match shape {
-        SyntaxShape::Binary => parse_binary(working_set, span),
-        SyntaxShape::Number => parse_number(working_set, span),
-        SyntaxShape::Decimal => parse_float(working_set, span),
-        SyntaxShape::Int => parse_int(working_set, span),
-        SyntaxShape::Duration => parse_duration(working_set, span),
-        SyntaxShape::DateTime => parse_datetime(working_set, span),
-        SyntaxShape::Filesize => parse_filesize(working_set, span),
-        SyntaxShape::Range => parse_range(working_set, span),
-        SyntaxShape::CellPath => parse_simple_cell_path(working_set, span),
-        SyntaxShape::String => {
-            working_set.error(ParseError::Mismatch(
-                "string".into(),
-                "number-like value (hint: use quotes or backticks)".into(),
-                span,
-            ));
-            garbage(span)
-        }
-        SyntaxShape::Any => {
-            let bytes = working_set.get_span_contents(span);
-
-            if bytes == b"0b" {
-                // FIXME: having to work around this filesize that also looks like a binary value
-                parse_filesize(working_set, span)
-            } else if bytes.starts_with(b"0x[")
-                || bytes.starts_with(b"0b[")
-                || bytes.starts_with(b"0o[")
-            {
-                parse_binary(working_set, span)
-            } else if bytes.starts_with(b"0x")
-                || bytes.starts_with(b"0b")
-                || bytes.starts_with(b"0o")
-            {
-                parse_int(working_set, span)
-            } else {
-                for shape in &[
-                    SyntaxShape::Range,
-                    SyntaxShape::Int,
-                    SyntaxShape::Binary,
-                    SyntaxShape::Filesize,
-                    SyntaxShape::Duration,
-                    SyntaxShape::DateTime, //FIXME requires 3 failed conversion attempts before failing
-                    SyntaxShape::Number,
-                ] {
-                    let starting_error_count = working_set.parse_errors.len();
-
-                    let result = parse_value(working_set, span, shape);
-
-                    if starting_error_count == working_set.parse_errors.len() {
-                        return result;
-                    } else {
-                        working_set.parse_errors.truncate(starting_error_count);
-                    }
-                }
-
-                working_set.error(ParseError::Expected(
-                    "number-like value (int, float, date, etc)".into(),
-                    span,
-                ));
-                garbage(span)
-            }
-        }
-        _ => {
-            working_set.error(ParseError::Expected(
-                "number-like value (int, float, date, etc)".into(),
-                span,
-            ));
-            garbage(span)
-        }
-    }
-}
-
 pub fn parse_brace_expr(
     working_set: &mut StateWorkingSet,
     span: Span,
@@ -4469,7 +4392,7 @@ pub fn parse_value(
             };
         }
         b"-inf" | b"inf" | b"NaN" => {
-            return parse_numberlike_expr(working_set, span, shape);
+            return parse_float(working_set, span);
         }
         _ => {}
     }
@@ -4492,20 +4415,6 @@ pub fn parse_value(
                 return Expression::garbage(span);
             }
         },
-        x if x.is_ascii_digit() => {
-            // Anything that starts with a number now has to be a number-like value
-            // These include values like ints, floats, dates, durations, etc
-            // To create a string, wrap in quotes, to create a bare word, wrap in backticks
-            return parse_numberlike_expr(working_set, span, shape);
-        }
-        b'-' | b'+' => {
-            if bytes.len() > 1 && bytes[1].is_ascii_digit() {
-                // Anything that starts with a negative number now has to be a number-like value
-                // These include values like ints, floats, dates, durations, etc
-                // To create a string, wrap in quotes, to create a bare word, wrap in backticks
-                return parse_numberlike_expr(working_set, span, shape);
-            }
-        }
         _ => {}
     }
 
@@ -4515,6 +4424,12 @@ pub fn parse_value(
             expression.custom_completion = Some(*custom_completion);
             expression
         }
+        SyntaxShape::Number => parse_number(working_set, span),
+        SyntaxShape::Decimal => parse_float(working_set, span),
+        SyntaxShape::Int => parse_int(working_set, span),
+        SyntaxShape::Duration => parse_duration(working_set, span),
+        SyntaxShape::DateTime => parse_datetime(working_set, span),
+        SyntaxShape::Filesize => parse_filesize(working_set, span),
         SyntaxShape::Range => parse_range(working_set, span),
         SyntaxShape::Filepath => parse_filepath(working_set, span),
         SyntaxShape::Directory => parse_directory(working_set, span),
@@ -4583,10 +4498,16 @@ pub fn parse_value(
                 parse_full_cell_path(working_set, None, span)
             } else {
                 let shapes = [
+                    SyntaxShape::Binary,
+                    SyntaxShape::Filesize,
+                    SyntaxShape::Duration,
                     SyntaxShape::Range,
+                    SyntaxShape::DateTime, //FIXME requires 3 failed conversion attempts before failing
                     SyntaxShape::Record,
                     SyntaxShape::Closure(None),
                     SyntaxShape::Block,
+                    SyntaxShape::Int,
+                    SyntaxShape::Number,
                     SyntaxShape::String,
                 ];
                 for shape in shapes.iter() {

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -227,13 +227,3 @@ fn parse_export_env_missing_block() {
 
     assert!(actual.err.contains("missing block"));
 }
-
-#[test]
-fn numberlike_command_name() {
-    let actual = nu!(cwd: "tests/parsing/samples",
-        r#"
-            def 7zup [] {}
-        "#);
-
-    assert!(actual.err.contains("backticks"));
-}


### PR DESCRIPTION
# Description

This effectively reverts #8635. We shipped this change with 0.78 and received many comments/issues related to this restriction feeling like a step backward.

fixes: #8844 
(and probably other issues)

# User-Facing Changes

Returns numbers and number-like values to being allowed to be bare words. Examples: `3*`, `1fb43`, `4,5`, and related.

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
