### PR TITLE
FEATURE: do not use theme-independant colors in the default configs

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -26,21 +26,21 @@ let dark_theme = {
     duration: white
     date: {|| (date now) - $in |
       if $in < 1hr {
-        'red3b'
+        'purple'
       } else if $in < 6hr {
-        'orange3'
+        'red'
       } else if $in < 1day {
-        'yellow3b'
+        'yellow'
       } else if $in < 3day {
-        'chartreuse2b'
+        'green'
       } else if $in < 1wk {
-        'green3b'
+        'light_green'
       } else if $in < 6wk {
-        'darkturquoise'
+        'cyan'
       } else if $in < 52wk {
-        'deepskyblue3b'
+        'blue'
       } else { 'dark_gray' }
-    }    
+    }
     range: white
     float: white
     string: white
@@ -66,7 +66,7 @@ let dark_theme = {
     shape_flag: blue_bold
     shape_float: purple_bold
     # shapes are used to change the cli syntax highlighting
-    shape_garbage: { fg: "#FFFFFF" bg: "#FF0000" attr: b}
+    shape_garbage: { fg: white bg: red attr: b}
     shape_globpattern: cyan_bold
     shape_int: purple_bold
     shape_internalcall: cyan_bold
@@ -109,19 +109,19 @@ let light_theme = {
     duration: dark_gray
   date: {|| (date now) - $in |
     if $in < 1hr {
-      'red3b'
+      'purple'
     } else if $in < 6hr {
-      'orange3'
+      'red'
     } else if $in < 1day {
-      'yellow3b'
+      'yellow'
     } else if $in < 3day {
-      'chartreuse2b'
+      'green'
     } else if $in < 1wk {
-      'green3b'
+      'light_green'
     } else if $in < 6wk {
-      'darkturquoise'
+      'cyan'
     } else if $in < 52wk {
-      'deepskyblue3b'
+      'blue'
     } else { 'dark_gray' }
   }
     range: dark_gray
@@ -149,7 +149,7 @@ let light_theme = {
     shape_flag: blue_bold
     shape_float: purple_bold
     # shapes are used to change the cli syntax highlighting
-    shape_garbage: { fg: "#FFFFFF" bg: "#FF0000" attr: b}
+    shape_garbage: { fg: white bg: red attr: b}
     shape_globpattern: cyan_bold
     shape_int: purple_bold
     shape_internalcall: cyan_bold


### PR DESCRIPTION
# Description
i was playing with my theme a bit and i was thinking about the following
- the default themes should not use precise colors
- the default themes should let the terminal set the exact colors

for instance, the `filesize` field of the `$env.config.color_config` looks good but not with terminal themes like dracula or tokyonight :open_mouth: 

in this PR, i just use "built-in" colors, like `red` or `yellow_bold` or `{fg: green attr: n}` to let the terminal theme set the colors :yum: 

# User-Facing Changes
i tried to stay as close as the previous default themes, so there should be the least amount of differences :relieved: 

# Tests + Formatting
```
$nothing
```

# After Submitting
```
$nothing
```