### PR TITLE
Adds multi-file support to IDE support

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1719,7 +1719,8 @@ pub fn parse_use(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeline
                 };
 
                 if let Ok(contents) = std::fs::read(&module_path) {
-                    let file_id = working_set.add_file(module_filename, &contents);
+                    let file_id =
+                        working_set.add_file(module_path.to_string_lossy().to_string(), &contents);
                     let new_span = working_set.get_span_for_file(file_id);
 
                     // Change the currently parsed directory

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5813,7 +5813,12 @@ pub fn parse(
     scoped: bool,
 ) -> Block {
     let name = match fname {
-        Some(fname) => fname.to_string(),
+        Some(fname) => {
+            // use the canonical name for this filename
+            nu_path::expand_to_real_path(fname)
+                .to_string_lossy()
+                .to_string()
+        }
         None => "source".to_string(),
     };
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -37,7 +37,9 @@ pub(crate) fn gather_commandline_args() -> (Vec<String>, String, Vec<String>) {
             #[cfg(feature = "plugin")]
             "--plugin-config" => args.next().map(|a| escape_quote_string(&a)),
             "--log-level" | "--log-target" | "--testbin" | "--threads" | "-t"
-            | "--ide-goto-def" | "--ide-hover" | "--ide-complete" => args.next(),
+            | "--include-path" | "-I" | "--ide-goto-def" | "--ide-hover" | "--ide-complete" => {
+                args.next()
+            }
             _ => None,
         };
 
@@ -109,6 +111,7 @@ pub(crate) fn parse_commandline_args(
             let log_level: Option<Expression> = call.get_flag_expr("log-level");
             let log_target: Option<Expression> = call.get_flag_expr("log-target");
             let execute: Option<Expression> = call.get_flag_expr("execute");
+            let include_path: Option<Expression> = call.get_flag_expr("include-path");
             let table_mode: Option<Value> =
                 call.get_flag(engine_state, &mut stack, "table-mode")?;
 
@@ -142,6 +145,7 @@ pub(crate) fn parse_commandline_args(
             let log_level = extract_contents(log_level)?;
             let log_target = extract_contents(log_target)?;
             let execute = extract_contents(execute)?;
+            let include_path = extract_contents(include_path)?;
 
             let help = call.has_flag("help");
 
@@ -183,6 +187,7 @@ pub(crate) fn parse_commandline_args(
                 log_level,
                 log_target,
                 execute,
+                include_path,
                 ide_goto_def,
                 ide_hover,
                 ide_complete,
@@ -220,6 +225,7 @@ pub(crate) struct NushellCliArgs {
     pub(crate) log_target: Option<Spanned<String>>,
     pub(crate) execute: Option<Spanned<String>>,
     pub(crate) table_mode: Option<Value>,
+    pub(crate) include_path: Option<Spanned<String>>,
     pub(crate) ide_goto_def: Option<Value>,
     pub(crate) ide_hover: Option<Value>,
     pub(crate) ide_complete: Option<Value>,
@@ -248,6 +254,12 @@ impl Command for Nu {
                 SyntaxShape::String,
                 "run the given commands and then enter an interactive shell",
                 Some('e'),
+            )
+            .named(
+                "include-path",
+                SyntaxShape::String,
+                "set the NU_LIB_DIRS for the given script",
+                Some('I'),
             )
             .switch("interactive", "start as an interactive shell", Some('i'))
             .switch("login", "start as a login shell", Some('l'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use log::Level;
 use miette::Result;
 use nu_cli::gather_parent_env_vars;
 use nu_command::{create_default_context, get_init_cwd};
-use nu_protocol::report_error_new;
+use nu_protocol::{report_error_new, Span, Value};
 use nu_protocol::{util::BufferedReader, PipelineData, RawStream};
 use nu_utils::utils::perf;
 use run::{run_commands, run_file, run_repl};
@@ -137,6 +137,16 @@ fn main() -> Result<()> {
         use_color,
     );
 
+    if let Some(include_path) = &parsed_nu_cli_args.include_path {
+        engine_state.add_env_var(
+            "NU_LIB_DIRS".into(),
+            Value::List {
+                vals: vec![Value::test_string(&include_path.item)],
+                span: Span::test_data(),
+            },
+        );
+    }
+
     // IDE commands
     if let Some(ide_goto_def) = parsed_nu_cli_args.ide_goto_def {
         ide::goto_def(&mut engine_state, &script_name, &ide_goto_def);
@@ -147,6 +157,16 @@ fn main() -> Result<()> {
 
         return Ok(());
     } else if let Some(ide_complete) = parsed_nu_cli_args.ide_complete {
+        let cwd = std::env::current_dir().expect("Could not get current working directory.");
+        engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
+        engine_state.add_env_var(
+            "NU_LIB_DIRS".into(),
+            Value::List {
+                vals: vec![Value::test_string("/Users/jt/Source/my_nu")],
+                span: Span::test_data(),
+            },
+        );
+
         ide::complete(Arc::new(engine_state), &script_name, &ide_complete);
 
         return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,13 +159,6 @@ fn main() -> Result<()> {
     } else if let Some(ide_complete) = parsed_nu_cli_args.ide_complete {
         let cwd = std::env::current_dir().expect("Could not get current working directory.");
         engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
-        engine_state.add_env_var(
-            "NU_LIB_DIRS".into(),
-            Value::List {
-                vals: vec![Value::test_string("/Users/jt/Source/my_nu")],
-                span: Span::test_data(),
-            },
-        );
 
         ide::complete(Arc::new(engine_state), &script_name, &ide_complete);
 


### PR DESCRIPTION
# Description

This adds multi-file support to the in-progress IDE support. The main new features are a `-I` flag that allows you to add a new source search path when starting up the nu binary, and fixes for the current IDE support to support spans in other files.

This needs accompanying fixes to the vscode/lsp implementation to pass along the project directory via `-I`.

UPDATE: Marking this draft until we have a means to test this.

# User-Facing Changes

_(List of all changes that impact the user experience here. This helps us keep track of breaking changes.)_

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
