### PR TITLE
Add d flag to touch

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -46,6 +46,7 @@ crossterm = "0.24.0"
 csv = "1.2.0"
 dialoguer = { default-features = false, version = "0.10.3" }
 digest = { default-features = false, version = "0.10.0" }
+dateparser = "0.2.0"
 dtparse = "1.2.0"
 encoding_rs = "0.8.30"
 fancy-regex = "0.11.0"

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -290,26 +290,24 @@ fn parse_given_string_to_date(
             if let Some(date) = date {
                 Ok(Some(date))
             } else {
-                return Err(ShellError::NushellFailed {
+                Err(ShellError::NushellFailed {
                     msg: "Cannot create a local now time".to_string(),
-                });
+                })
             }
         }
-        false if date_string.item == "." => {
-            return Err(ShellError::DatetimeParseError(
-                "Cannot parse the '.' date. Did you simply mean '' ?".to_string(),
-                date_string.span,
-            ));
-        }
+        false if date_string.item == "." => Err(ShellError::DatetimeParseError(
+            "Cannot parse the '.' date. Did you simply mean '' ?".to_string(),
+            date_string.span,
+        )),
         false => {
             let parsed_date = date_string.item.parse::<DateTimeUtc>().ok();
             if let Some(date) = parsed_date {
                 Ok(Some(DateTime::from(date.0)))
             } else {
-                return Err(ShellError::DatetimeParseError(
+                Err(ShellError::DatetimeParseError(
                     "Cannot parse the provided date.".to_string(),
                     date_string.span,
-                ));
+                ))
             }
         }
     }
@@ -358,19 +356,9 @@ fn parse_relative_time(s: &str) -> Option<Duration> {
         _ => None,
     };
 
-    let relative_time = if past_time {
-        match result {
-            Some(duration) => {
-                if duration.num_milliseconds() < 0 {
-                    Some(duration)
-                } else {
-                    Some(Duration::milliseconds(-duration.num_milliseconds()))
-                }
-            }
-            None => None,
-        }
+    if past_time {
+        result.filter(|&duration| duration.num_milliseconds() < 0)
     } else {
         result
-    };
-    relative_time
+    }
 }


### PR DESCRIPTION
# Description

This PR adds back the `-d` flag in the `touch` command. It was removed in #6629 and recently users had issues with the outdated documentation #8723. 

# User-Facing Changes

Adds some extra options to the user, but it does not create significant user-facing changes. 

# Tests + Formatting

I plan to add some tests but first I'd like to have some other folks take a look at the code to make sure we're on the right track. 

# Known issues 
1. This PR adds another crate, `dateparser` - while adding yet another crate is not ideal, I was not able to use `dtparser::parse` and convert properly between timezones and offsets. I had weird bugs and the code was not very pretty. Dateparser allows us to have a bit more flexibility in the formatting of the date input. 

2. Parsing relative time inputs is tricky. For example, if the date is Feb 29, 2020, which is a leap year, and then we issue the command `touch -m -d "2 years ago"`, which date should it be changed to:
- Feb 28, 2018
- Mar 1, 2018

@jntrnr @fdncred @sholderbach  - would love your input here. Also, JT, there was some mentioning that this did not work well in Oceania. I'd love to add some tests for that, so can you suggest how to go that route? 