### PR TITLE
optimize hash md5 for binary input

### DIFF
--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -114,7 +114,7 @@ where
                             }
                             .into_pipeline_data());
                         }
-                        Err(err) => return Err(err)
+                        Err(err) => return Err(err),
                     };
                 }
                 let digest = hasher.finalize();

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -114,7 +114,7 @@ where
                             }
                             .into_pipeline_data());
                         }
-                        Err(err) => return Err(err.to_owned()),
+                        Err(err) => return Err(err)
                     };
                 }
                 let digest = hasher.finalize();

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -101,7 +101,7 @@ where
                         Ok(Value::String { val, .. }) => hasher.update(val.as_bytes()),
                         Ok(Value::Binary { val, .. }) => hasher.update(val),
                         // If any Error value is output, echo it back
-                        Ok(v @ Value::Error { .. }) => return Ok(v.clone().into_pipeline_data()),
+                        Ok(v @ Value::Error { .. }) => return Ok(v.into_pipeline_data()),
                         // Unsupported data
                         Ok(other) => {
                             return Ok(Value::Error {


### PR DESCRIPTION
# Description

Fixes: #8260

# User-Facing Changes

`open bigfile | hash md5` no longer consumes too much memory

# Tests + Formatting

Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```

# After Submitting

If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date.
