### PR TITLE
Add $env.CURRENT_FILE variable

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -93,6 +93,10 @@ pub fn evaluate_file(
         "FILE_PWD".to_string(),
         Value::string(parent.to_string_lossy(), Span::unknown()),
     );
+    stack.add_env_var(
+        "CURRENT_FILE".to_string(),
+        Value::string(file_path.to_string_lossy(), Span::unknown()),
+    );
 
     let mut working_set = StateWorkingSet::new(engine_state);
     trace!("parsing file: {}", file_path_str);

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -134,6 +134,11 @@ impl Command for OverlayUse {
                     callee_stack.add_env_var("FILE_PWD".to_string(), file_pwd);
                 }
 
+                if let Some(file_path) = &maybe_path {
+                    let file_path = Value::string(file_path.to_string_lossy(), call.head);
+                    callee_stack.add_env_var("CURRENT_FILE".to_string(), file_path);
+                }
+
                 let _ = eval_block(
                     engine_state,
                     &mut callee_stack,

--- a/crates/nu-command/src/env/let_env.rs
+++ b/crates/nu-command/src/env/let_env.rs
@@ -51,7 +51,7 @@ impl Command for LetEnv {
                 .0
                 .into_value(call.head);
 
-        if env_var.item == "FILE_PWD" || env_var.item == "PWD" {
+        if env_var.item == "FILE_PWD" || env_var.item == "CURRENT_FILE" || env_var.item == "PWD" {
             return Err(ShellError::AutomaticEnvVarSetManually {
                 envvar_name: env_var.item,
                 span: env_var.span,

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -42,28 +42,22 @@ impl Command for LoadEnv {
         match arg {
             Some((cols, vals)) => {
                 for (env_var, rhs) in cols.into_iter().zip(vals) {
-                    if env_var == "FILE_PWD" {
+                    let env_var_ = env_var.as_str();
+                    if ["FILE_PWD", "CURRENT_FILE", "PWD"].contains(&env_var_) {
                         return Err(ShellError::AutomaticEnvVarSetManually {
                             envvar_name: env_var,
                             span: call.head,
                         });
                     }
-
-                    if env_var == "PWD" {
-                        return Err(ShellError::AutomaticEnvVarSetManually {
-                            envvar_name: env_var,
-                            span: call.head,
-                        });
-                    } else {
-                        stack.add_env_var(env_var, rhs);
-                    }
+                    stack.add_env_var(env_var, rhs);
                 }
                 Ok(PipelineData::empty())
             }
             None => match input {
                 PipelineData::Value(Value::Record { cols, vals, .. }, ..) => {
                     for (env_var, rhs) in cols.into_iter().zip(vals) {
-                        if env_var == "FILE_PWD" {
+                        let env_var_ = env_var.as_str();
+                        if ["FILE_PWD", "CURRENT_FILE"].contains(&env_var_) {
                             return Err(ShellError::AutomaticEnvVarSetManually {
                                 envvar_name: env_var,
                                 span: call.head,

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -126,6 +126,17 @@ fn has_file_pwd() {
     })
 }
 
+#[test]
+fn has_file_loc() {
+    Playground::setup("has_file_pwd", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent("spam.nu", "$env.CURRENT_FILE")]);
+
+        let actual = nu!(cwd: dirs.test(), "nu spam.nu");
+
+        assert!(actual.out.ends_with("spam.nu"));
+    })
+}
+
 // FIXME: autoenv not currently implemented
 #[ignore]
 #[test]


### PR DESCRIPTION
# Description

Adds the `$env.FILE_LOC` variable when running scripts. This points to the file location of the currently running script (or sourced, used script). This is useful for scripts that don't know their own filename. So the difference with FILE_PWD is that FILE_LOC points to the file itself so it allows recursive scripting. Like in this example (uses current-exe from #8789):

```nushell
exec $nu.current-exe $env.FILE_LOC recurse
```

I named the variable FILE_LOC because it's short. I can of course rename it to something else like CURRENT_FILE, or NU_CURRENT_FILE, or FILE_BEING_EXECUTED, or SCRIPT_LOCATION, or whatever

Fixes #8752

# User-Facing Changes

Adds the `$env.FILE_LOC` variable when running scripts.

# Tests + Formatting

Test is added and `cargo fmt` has been run

# After Submitting

This is something that could be put in an advanced scripting section of the book.