### PR TITLE
Make -I take in a ;-delimited list

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -258,7 +258,7 @@ impl Command for Nu {
             .named(
                 "include-path",
                 SyntaxShape::String,
-                "set the NU_LIB_DIRS for the given script",
+                "set the NU_LIB_DIRS for the given script (semicolon-delimited)",
                 Some('I'),
             )
             .switch("interactive", "start as an interactive shell", Some('i'))

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn main() -> Result<()> {
             .item
             .split(';')
             .map(|x| Value::String {
-                val: x.to_string(),
+                val: x.trim().to_string(),
                 span,
             })
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use log::Level;
 use miette::Result;
 use nu_cli::gather_parent_env_vars;
 use nu_command::{create_default_context, get_init_cwd};
-use nu_protocol::{report_error_new, Span, Value};
+use nu_protocol::{report_error_new, Value};
 use nu_protocol::{util::BufferedReader, PipelineData, RawStream};
 use nu_utils::utils::perf;
 use run::{run_commands, run_file, run_repl};
@@ -138,13 +138,17 @@ fn main() -> Result<()> {
     );
 
     if let Some(include_path) = &parsed_nu_cli_args.include_path {
-        engine_state.add_env_var(
-            "NU_LIB_DIRS".into(),
-            Value::List {
-                vals: vec![Value::test_string(&include_path.item)],
-                span: Span::test_data(),
-            },
-        );
+        let span = include_path.span;
+        let vals: Vec<_> = include_path
+            .item
+            .split(';')
+            .map(|x| Value::String {
+                val: x.to_string(),
+                span,
+            })
+            .collect();
+
+        engine_state.add_env_var("NU_LIB_DIRS".into(), Value::List { vals, span });
     }
 
     // IDE commands


### PR DESCRIPTION
# Description
Changes `-I` to take in a semicolon-delimited list of paths. Eg) `-I "/a/b;/foo/bar"`

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
