### PR TITLE
Correct error description for unknown external commands

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -312,7 +312,12 @@ impl ExternalCommand {
                                             format!("command '{cmd_name}' was not found but it exists in module '{module_name}'; try importing it with `use`")
                                         }
                                     } else {
-                                        format!("did you mean '{s}'?")
+                                        // If command and suggestion are the same, display not found
+                                        if cmd_name == &s {
+                                            format!("'{cmd_name}' was not found")
+                                        } else {
+                                            format!("did you mean '{s}'?")
+                                        }
                                     }
                                 }
                             }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -129,6 +129,18 @@ fn command_not_found_error_suggests_typo_fix() {
 }
 
 #[test]
+fn command_not_found_error_shows_not_found() {
+    let actual = nu!(
+        cwd: ".",
+        r#"
+            export extern "foo" [];
+            foo
+        "#
+    );
+    assert!(actual.err.contains("'foo' was not found"));
+}
+
+#[test]
 fn command_substitution_wont_output_extra_newline() {
     let actual = nu!(
         cwd: ".",


### PR DESCRIPTION
# Description
Fixes issue https://github.com/nushell/nushell/issues/8643 

# User-Facing Changes

Before
<img width="442" alt="image" src="https://user-images.githubusercontent.com/5063945/231624884-49a1ce4e-598d-4d19-882d-c22d168e6a5a.png">

After
<img width="449" alt="image" src="https://user-images.githubusercontent.com/5063945/231625076-5f1becd7-7477-4d2f-b765-3956210da7f2.png">

