### PR TITLE
`rm`: enable trash flag on android and ios platrofm

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -53,12 +53,12 @@ impl Command for Rm {
             )
             .switch(
                 "trash",
-                "move to the platform's trash instead of permanently deleting, it's useless on android and ios",
+                "move to the platform's trash instead of permanently deleting. not used on android and ios",
                 Some('t'),
             )
             .switch(
                 "permanent",
-                "delete permanently, ignoring the 'always_trash' config option, it's always enabled on android and ios",
+                "delete permanently, ignoring the 'always_trash' config option. always enabled on android and ios",
                 Some('p'),
             );
         sig.switch("recursive", "delete subdirectories recursively", Some('r'))

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -50,21 +50,15 @@ impl Command for Rm {
                 "filename",
                 SyntaxShape::Filepath,
                 "the path of the file you want to remove",
-            );
-        #[cfg(all(
-            feature = "trash-support",
-            not(target_os = "android"),
-            not(target_os = "ios")
-        ))]
-        let sig = sig
+            )
             .switch(
                 "trash",
-                "move to the platform's trash instead of permanently deleting",
+                "move to the platform's trash instead of permanently deleting, it's useless on android and ios",
                 Some('t'),
             )
             .switch(
                 "permanent",
-                "delete permanently, ignoring the 'always_trash' config option",
+                "delete permanently, ignoring the 'always_trash' config option, it's always enabled on android and ios",
                 Some('p'),
             );
         sig.switch("recursive", "delete subdirectories recursively", Some('r'))
@@ -169,18 +163,13 @@ fn rm(
 
     let rm_always_trash = config.rm_always_trash;
 
-    #[cfg(any(
-        not(feature = "trash-support"),
-        target_os = "android",
-        target_os = "ios"
-    ))]
+    #[cfg(not(feature = "trash-support"))]
     {
         if rm_always_trash {
             return Err(ShellError::GenericError(
                 "Cannot execute `rm`; the current configuration specifies \
                     `always_trash = true`, but the current nu executable was not \
-                    built with feature `trash_support` or trash is not supported on \
-                    your platform."
+                    built with feature `trash_support`."
                     .into(),
                 "trash required to be true but not supported".into(),
                 Some(span),
@@ -189,8 +178,7 @@ fn rm(
             ));
         } else if trash {
             return Err(ShellError::GenericError(
-                "Cannot execute `rm` with option `--trash`; feature `trash-support` not \
-                    enabled or trash is not supported on your platform"
+                "Cannot execute `rm` with option `--trash`; feature `trash-support` not enabled"
                     .into(),
                 "this option is only available if nu is built with the `trash-support` feature"
                     .into(),


### PR DESCRIPTION
# Description

As title, enable trash flag on all platforms make `rm` more portable across different platforms, but `-t` will do nothing.

Fixes: #8104

# User-Facing Changes
Na

# Tests + Formatting
It's hard to add tests because we don't run tests for android and ios platforms.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
