### PR TITLE
limit the ide-check error amount

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -115,8 +115,6 @@ pub(crate) fn parse_commandline_args(
                 call.get_flag(engine_state, &mut stack, "ide-complete")?;
             let ide_check: Option<Value> = call.get_flag(engine_state, &mut stack, "ide-check")?;
 
-            eprintln!("ide_check: {:?}", &ide_check);
-
             fn extract_contents(
                 expression: Option<Expression>,
             ) -> Result<Option<Spanned<String>>, ShellError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,8 +167,8 @@ fn main() -> Result<()> {
         ide::complete(Arc::new(engine_state), &script_name, &ide_complete);
 
         return Ok(());
-    } else if parsed_nu_cli_args.ide_check.is_some() {
-        ide::check(&mut engine_state, &script_name);
+    } else if let Some(max_errors) = parsed_nu_cli_args.ide_check {
+        ide::check(&mut engine_state, &script_name, &max_errors);
 
         return Ok(());
     }

--- a/src/tests/test_ide.rs
+++ b/src/tests/test_ide.rs
@@ -4,7 +4,7 @@ use crate::tests::{test_ide_contains, TestResult};
 fn parser_recovers() -> TestResult {
     test_ide_contains(
         "3 + \"bob\"\nlet x = \"fred\"\n",
-        &["--ide-check"],
+        &["--ide-check 5"],
         "\"typename\":\"string\"",
     )
 }


### PR DESCRIPTION
# Description

This PR limits the amount of errors returned with the --ide-check flag.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
