### PR TITLE
Run coverage immediately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,6 @@ jobs:
 
 
   nu-coverage:
-    needs: nu-tests
     env:
       NUSHELL_CARGO_TARGET: ci
 


### PR DESCRIPTION
# Description
Don't wait for the tests to pass to try running the coverage job. In theory that would save some wasted runs but waiting for it can also slow down the review if you want to inspect that a certain branch is covered by tests.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
Coverage runs immediately and can also fail due to failing tests
