### PR TITLE
Change `NU_LIB_DIRS` not to depend on `$nu.config-path`

### DIFF
--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -524,11 +524,12 @@ fn variables_completions() {
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
 
-    assert_eq!(13, suggestions.len());
+    assert_eq!(14, suggestions.len());
 
     let expected: Vec<String> = vec![
         "config-path".into(),
         "current-exe".into(),
+        "default-config-dir".into(),
         "env-path".into(),
         "history-path".into(),
         "home-path".into(),

--- a/crates/nu-engine/src/nu_variable.rs
+++ b/crates/nu-engine/src/nu_variable.rs
@@ -25,7 +25,13 @@ pub struct NuVariable {
 
 impl LazyRecord for NuVariable {
     fn column_names(&self) -> Vec<&'static str> {
-        let mut cols = vec!["config-path", "env-path", "history-path", "loginshell-path"];
+        let mut cols = vec![
+            "default-config-dir",
+            "config-path",
+            "env-path",
+            "history-path",
+            "loginshell-path",
+        ];
 
         #[cfg(feature = "plugin")]
         if self.engine_state.plugin_signatures.is_some() {
@@ -70,6 +76,17 @@ impl LazyRecord for NuVariable {
         }
 
         match column {
+            "default-config-dir" => {
+                if let Some(mut path) = nu_path::config_dir() {
+                    path.push("nushell");
+                    Ok(Value::String {
+                        val: path.to_string_lossy().to_string(),
+                        span: self.span,
+                    })
+                } else {
+                    err("Could not get config directory")
+                }
+            }
             "config-path" => {
                 if let Some(path) = self.engine_state.get_config_path("config-path") {
                     let canon_config_path = canonicalize_path(&self.engine_state, path);

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -72,14 +72,14 @@ let-env ENV_CONVERSIONS = {
 #
 # By default, <nushell-config-dir>/scripts is added
 let-env NU_LIB_DIRS = [
-    ($nu.config-path | path dirname | path join 'scripts')
+    ($nu.default-config-dir | path join 'scripts')
 ]
 
 # Directories to search for plugin binaries when calling register
 #
 # By default, <nushell-config-dir>/plugins is added
 let-env NU_PLUGIN_DIRS = [
-    ($nu.config-path | path dirname | path join 'plugins')
+    ($nu.default-config-dir | path join 'plugins')
 ]
 
 # To add entries to PATH (on Windows you might use Path), you can use the following pattern:


### PR DESCRIPTION
# Description

fixed #8870
In `default_env.nu`, environment variable `NU_LIB_DIRS` is derived from `$nu.config-path` now. If the config file is changed (e.g., by using `--column`), `NU_LIB_DIRS` is also changed.
This PR adds `default-config-dir` to $nu and fix `default_env.nu` to use `default-config-dir` for `NU_LIB_DIRS` definition.

# User-Facing Changes

Users can use `$nu.default-config-dir` to specify the default config directory.

# Tests + Formatting


```bash
$ use toolkit.nu  # or use an `env_change` hook to activate it automatically
$ toolkit check pr

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
```

# After Submitting

nothing