### PR TITLE
Fix warning on declared config variable that originates from commands

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -4,7 +4,7 @@ use nu_cli::read_plugin_file;
 use nu_cli::{eval_config_contents, eval_source};
 use nu_path::canonicalize_with;
 use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
-use nu_protocol::report_error;
+use nu_protocol::{report_error, Span};
 use nu_protocol::{ParseError, PipelineData, Spanned};
 use nu_utils::{get_default_config, get_default_env};
 use std::fs::File;
@@ -207,8 +207,13 @@ pub(crate) fn setup_config(
     // Give a warning if we see `$config` for a few releases
     {
         let working_set = StateWorkingSet::new(engine_state);
-        if working_set.find_variable(b"$config").is_some() {
-            println!("warning: use `let-env config = ...` instead of `let config = ...`");
+        if let Some(var) = working_set
+            .find_variable(b"$config")
+            .and_then(|id| stack.get_var(id, Span::new(0, 0)).ok())
+        {
+            if var.as_record().is_ok() {
+                println!("warning: use `let-env config = ...` instead of `let config = ...`");
+            }
         }
     }
 }

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -209,7 +209,7 @@ pub(crate) fn setup_config(
         let working_set = StateWorkingSet::new(engine_state);
         if let Some(var) = working_set
             .find_variable(b"$config")
-            .and_then(|id| stack.get_var(id, Span::new(0, 0)).ok())
+            .and_then(|id| stack.get_var(id, Span::unknown()).ok())
         {
             if var.as_record().is_ok() {
                 println!("warning: use `let-env config = ...` instead of `let config = ...`");


### PR DESCRIPTION
# Description

This PR fixes an issue described in  #8890 where config variables declared in command parameters cause the warning `use `let-env config = ...` instead of `let config = ...` to be printed.

# User-Facing Changes
The user is only warned when they define a config variable with a warning with the type `record`.

# Tests + Formatting

I think this can only be tested manually by first trying to reproduce #8890.
To test if the warning is still printed when it's supposed to be one can add `let config = $env.config` to the end of the `config.nu` file.  
