### PR TITLE
rename toolkit's `set-git-hooks` to `setup-git-hooks`

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -231,16 +231,16 @@ export def "check pr" [
 # set up git hooks to run:
 # - `toolkit fmt --check --verbose` on `git commit`
 # - `toolkit fmt --check --verbose` and `toolkit clippy --verbose` on `git push`
-export def set-git-hooks [] {
+export def setup-git-hooks [] {
     if $nu.os-info.name == windows {
         return (print "This git hook isn't available on Windows. Sorry!")
     }
 
     print "This command will change your local git configuration and hence modify your development workflow. Are you sure you want to continue? [y]"
     if (input) == "y" {
-        print $"running ('toolkit set-git-hooks' | pretty-print-command)"
+        print $"running ('toolkit setup-git-hooks' | pretty-print-command)"
         git config --local core.hooksPath .githooks
     } else {
-        print $"aborting ('toolkit set-git-hooks' | pretty-print-command)"
+        print $"aborting ('toolkit setup-git-hooks' | pretty-print-command)"
     }
 }


### PR DESCRIPTION
# Description
this pr renames toolkit's `set-git-hooks` to `setup-git-hooks` to match [CONTRIBUTING.md](https://github.com/nushell/nushell/blob/cbedc8403f6fc58896069d6dae59f2e2a5725036/CONTRIBUTING.md?plain=1#L112)
