### PR TITLE
stdlib: fix the `clip` command with integer values

### DIFF
--- a/crates/nu-std/lib/mod.nu
+++ b/crates/nu-std/lib/mod.nu
@@ -107,10 +107,7 @@ export def clip [
     --silent: bool  # do not print the content of the clipboard to the standard output
     --no-notify: bool  # do not throw a notification (only on linux)
 ] {
-    let input = $in
-    let input = if ($input | describe) == "string" {
-        $input | ansi strip
-    } else { $input }
+    let input = ($in | table | into string | ansi strip)
 
     match $nu.os-info.name {
         "linux" => {

--- a/crates/nu-std/lib/mod.nu
+++ b/crates/nu-std/lib/mod.nu
@@ -140,12 +140,7 @@ export def clip [
 
     if not $silent {
         print $input
-
-        print --no-newline $"(ansi white_italic)(ansi white_dimmed)saved to clipboard"
-        if ($input | describe) == "string" {
-            print " (stripped)"
-        }
-        print --no-newline $"(ansi reset)"
+        print $"(ansi white_italic)(ansi white_dimmed)saved to clipboard(ansi reset)"
     }
 
     if (not $no_notify) and ($nu.os-info.name == linux) {


### PR DESCRIPTION
# Description
this PR fixes the `std clip` command which would not copy integer data :open_mouth: 
and, as all the input data is now treated as raw `string` with the `table | into string` conversion, i've removed the "stripped" print when done clipping the data :+1: 

:x: from the `main` on which this PR is based (cbedc8403)
> **Note**
> from inside`cargo run` and with a `use std clip`
- :heavy_check_mark: `'foo' | clip`
- :heavy_check_mark: `ls | get 0 | clip`
- :x: `123 | clip`
 
# User-Facing Changes
:heavy_check_mark: from the tip of the PR branch
> **Note**
> from inside`cargo run` and with a `use std clip`
- :heavy_check_mark: `'foo' | clip`
- :heavy_check_mark: `ls | get 0 | clip`
- :heavy_check_mark: `123 | clip`

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```
