### PR TITLE
add `iter` module to standard library

### DIFF
--- a/crates/nu-std/lib/iter.nu
+++ b/crates/nu-std/lib/iter.nu
@@ -27,7 +27,7 @@
 # assert equal $found "abc"
 # assert equal $not_found null
 # ```
-export def "iter find" [        # -> any | null  
+export def "iter find" [ # -> any | null  
     predicate: closure   # the closure used to perform the search 
 ] {
     let list = (self collect)
@@ -49,7 +49,7 @@ export def "iter find" [        # -> any | null
 # assert equal $res [1 0 2 0 3 0 4]
 # ```
 export def "iter intersperse" [ # -> list<any>
-    separator: any,      # the separator to be used
+    separator: any,             # the separator to be used
 ] {
     let list = (self collect)
 
@@ -88,11 +88,11 @@ export def "iter intersperse" [ # -> list<any>
 #
 # assert equal $scanned [1, 3, 6]
 # ```
-export def "iter scan" [
+export def "iter scan" [ # -> list<any>
     init: any            # initial value to seed the initial state
     f: closure           # the closure to perform the scan
-    --noinit(-n)        # remove the initial value from the result
-] {                      # -> list<any>
+    --noinit(-n)         # remove the initial value from the result
+] {                      
    let res = (reduce -f [$init] {|it, acc|
       $acc ++ [(do $f ($acc | last) $it)]
    })

--- a/crates/nu-std/lib/iter.nu
+++ b/crates/nu-std/lib/iter.nu
@@ -1,0 +1,105 @@
+# | Filter Extensions
+# 
+# This module implements extensions to the `filters` commands
+#
+# They are prefixed with `iter` so as to avoid conflicts with 
+# the inbuilt filters
+
+# Returns the first element of the list that matches the
+# closure predicate, `null` otherwise
+#
+# # Invariant
+# > The closure has to be a predicate (returning a bool value)
+# > else `null` is returned
+# > The closure also has to be valid for the types it receives
+# > These will be flagged as errors later as closure annotations
+# > are implemented
+#
+# # Example
+# ```
+# use std ["assert equal" "iter find"]
+#
+# let haystack = ["shell", "abc", "around", "nushell", "std"] 
+#
+# let found = ($haystack | iter find {|it| $it starts-with "a" })
+# let not_found = ($haystack | iter find {|it| $it mod 2 == 0})
+# 
+# assert equal $found "abc"
+# assert equal $not_found null
+# ```
+export def "iter find" [        # -> any | null  
+    predicate: closure   # the closure used to perform the search 
+] {
+    let list = (self collect)
+    try {
+       $list | filter $predicate | get 0?
+    } catch {
+       null
+    }
+}
+
+# Returns a new list with the separator between adjacent
+# items of the original list
+#
+# # Example
+# ```
+# use std ["assert equal" "iter intersperse"]
+#
+# let res = ([1 2 3 4] | iter intersperse 0)
+# assert equal $res [1 0 2 0 3 0 4]
+# ```
+export def "iter intersperse" [ # -> list<any>
+    separator: any,      # the separator to be used
+] {
+    let list = (self collect)
+
+    let len = ($list | length);
+    if ($list | is-empty) {
+        return $list
+    }
+
+    $list 
+    | enumerate
+    | reduce -f [] {|it, acc|
+        if ($it.index == $len - 1) {
+           $acc ++ [$it.item]
+        } else {
+            $acc ++ [$it.item, $separator]
+        }
+    }
+}
+
+
+# Returns the elements after head of a list.
+#
+# The list must be non-empty otherwise [] is returned
+#
+# # Example
+# ```
+# use std ["assert equal" "iter tail"]
+#
+# let tail = ([1 2 3] | iter tail)
+# let empty = ([] | iter tail)
+#
+# assert equal $tail [2 3]
+# assert equal $tail []
+# ```
+export def "iter tail" [] {    # -> list<any>
+    let list = (self collect)
+    if ($list | is-empty) {
+       return []
+    }
+
+    match $list {
+        [$head, ..$tail] => $tail,
+        _ => $list
+    }
+}
+
+# Accepts inputs from a pipeline and builds a list for the `iter *`
+# commands to work with
+def "self collect" [] {
+    reduce -f [] {|it, acc|
+        $acc ++ $it
+    }
+}

--- a/crates/nu-std/lib/iter.nu
+++ b/crates/nu-std/lib/iter.nu
@@ -69,7 +69,7 @@ export def "iter intersperse" [ # -> list<any>
     }
 }
 
-# Returns the a list of intermediate steps performed by `reduce`
+# Returns a list of intermediate steps performed by `reduce`
 # (`fold`). It takes two arguments, an initial value to seed the
 # initial state and a closure that takes two arguments, the first
 # being the internal state and the second the list element in the

--- a/crates/nu-std/lib/iter.nu
+++ b/crates/nu-std/lib/iter.nu
@@ -78,13 +78,13 @@ export def "iter intersperse" [ # -> list<any>
 # # Example
 # ```
 # use std ["assert equal" "iter scan"]
-# let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y})
+# let scanned = ([1 2 3] | iter scan 0 {|x, y| $x + $y})
 #
 # assert equal $scanned [0, 1, 3, 6]
 #
 # # use the --noinit(-n) flag to remove the initial value from
 # # the final result
-# let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y} -n)
+# let scanned = ([1 2 3] | iter scan 0 {|x, y| $x + $y} -n)
 #
 # assert equal $scanned [1, 3, 6]
 # ```

--- a/crates/nu-std/lib/iter.nu
+++ b/crates/nu-std/lib/iter.nu
@@ -69,9 +69,44 @@ export def "iter intersperse" [ # -> list<any>
     }
 }
 
+# Returns the a list of intermediate steps performed by `reduce`
+# (`fold`). It takes two arguments, an initial value to seed the
+# initial state and a closure that takes two arguments, the first
+# being the internal state and the second the list element in the
+# current iteration.
+#
+# # Example
+# ```
+# use std ["assert equal" "iter scan"]
+# let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y})
+#
+# assert equal $scanned [0, 1, 3, 6]
+#
+# # use the --no-init(-n) flag to remove the initial value from
+# # the final result
+# let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y} -n)
+#
+# assert equal $scanned [1, 3, 6]
+# ```
+export def "iter scan" [
+    init: any            # initial value to seed the initial state
+    f: closure           # the closure to perform the scan
+    --noinit(-n)        # remove the initial value from the result
+] {                      # -> list<any>
+   let res = (reduce -f [$init] {|it, acc|
+      $acc ++ [(do $f ($acc | last) $it)]
+   })
+
+   if $noinit {
+     $res | skip
+   } else {
+      $res
+   }
+}
+
 # Accepts inputs from a pipeline and builds a list for the `iter *`
 # commands to work with
-def "self collect" [] {
+def "self collect" [] {  # -> list<any>
     reduce -f [] {|it, acc|
         $acc ++ $it
     }

--- a/crates/nu-std/lib/iter.nu
+++ b/crates/nu-std/lib/iter.nu
@@ -69,33 +69,6 @@ export def "iter intersperse" [ # -> list<any>
     }
 }
 
-
-# Returns the elements after head of a list.
-#
-# The list must be non-empty otherwise [] is returned
-#
-# # Example
-# ```
-# use std ["assert equal" "iter tail"]
-#
-# let tail = ([1 2 3] | iter tail)
-# let empty = ([] | iter tail)
-#
-# assert equal $tail [2 3]
-# assert equal $tail []
-# ```
-export def "iter tail" [] {    # -> list<any>
-    let list = (self collect)
-    if ($list | is-empty) {
-       return []
-    }
-
-    match $list {
-        [$head, ..$tail] => $tail,
-        _ => $list
-    }
-}
-
 # Accepts inputs from a pipeline and builds a list for the `iter *`
 # commands to work with
 def "self collect" [] {

--- a/crates/nu-std/lib/iter.nu
+++ b/crates/nu-std/lib/iter.nu
@@ -82,7 +82,7 @@ export def "iter intersperse" [ # -> list<any>
 #
 # assert equal $scanned [0, 1, 3, 6]
 #
-# # use the --no-init(-n) flag to remove the initial value from
+# # use the --noinit(-n) flag to remove the initial value from
 # # the final result
 # let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y} -n)
 #

--- a/crates/nu-std/lib/mod.nu
+++ b/crates/nu-std/lib/mod.nu
@@ -5,6 +5,7 @@ export-env {
     use dirs *
 }
 export use help *
+export use iter *
 export use log *
 export use testing *
 export use xml *

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -74,6 +74,7 @@ pub fn load_standard_library(
 
             // the rest of the library
             ("dirs", include_str!("../lib/dirs.nu")),
+            ("iter", include_str!("../lib/iter.nu")),
             ("help", include_str!("../lib/help.nu")),
             ("testing", include_str!("../lib/testing.nu")),
             ("xml", include_str!("../lib/xml.nu")),

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -43,11 +43,3 @@ def test_iter_intersperse [] {
     let res = (4 | iter intersperse 1)
     assert equal $res [4]
 }
-
-def test_iter_tail [] {
-    let res = ([1 2 3 4] | iter tail)
-    assert equal $res [2 3 4]
-
-    let res = ([] | iter tail)
-    assert equal $res []
-}

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -42,3 +42,14 @@ def test_iter_intersperse [] {
     let res = (4 | iter intersperse 1)
     assert equal $res [4]
 }
+
+def test_iter_scan [] {
+    let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y} -n)
+    assert equal $scanned [1, 3, 6]
+
+    let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y})
+    assert equal $scanned [0, 1, 3, 6]
+
+    let scanned = ([a b c d] | scan "" {|x, y| [$x, $y] | str join} -n)
+    assert equal $scanned ["a" "ab" "abc" "abcd"]
+}

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -1,11 +1,6 @@
 use std *
 
-export def test_iter_cmd [] {
-    test_iter_intersperse
-    test_iter_find
-}
-
-def test_iter_find [] {
+export def test_iter_find [] {
     let hastack1 = [1 2 3 4 5 6 7]
     let hastack2 = [nushell rust shell iter std]
     let hastack3 = [nu 69 2023-04-20 "std"]
@@ -23,7 +18,7 @@ def test_iter_find [] {
     assert equal $res null
 }
 
-def test_iter_intersperse [] {
+export def test_iter_intersperse [] {
     let res = ([1 2 3 4] | iter intersperse 0)
     assert equal $res [1 0 2 0 3 0 4]
 
@@ -43,13 +38,13 @@ def test_iter_intersperse [] {
     assert equal $res [4]
 }
 
-def test_iter_scan [] {
-    let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y} -n)
+export def test_iter_scan [] {
+    let scanned = ([1 2 3] | iter scan 0 {|x, y| $x + $y} -n)
     assert equal $scanned [1, 3, 6]
 
-    let scanned = ([1 2 3] | scan 0 {|x, y| $x + $y})
+    let scanned = ([1 2 3] | iter scan 0 {|x, y| $x + $y})
     assert equal $scanned [0, 1, 3, 6]
 
-    let scanned = ([a b c d] | scan "" {|x, y| [$x, $y] | str join} -n)
+    let scanned = ([a b c d] | iter scan "" {|x, y| [$x, $y] | str join} -n)
     assert equal $scanned ["a" "ab" "abc" "abcd"]
 }

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -1,0 +1,53 @@
+use std *
+
+export def test_iter_cmd [] {
+    test_iter_intersperse
+    test_iter_find
+    test_iter_tail
+}
+
+def test_iter_find [] {
+    let hastack1 = [1 2 3 4 5 6 7]
+    let hastack2 = [nushell rust shell iter std]
+    let hastack3 = [nu 69 2023-04-20 "std"]
+
+    let res = ($hastack1 | iter find {|it| $it mod 2 == 0})
+    assert equal $res 2
+
+    let res = ($hastack2 | iter find {|it| $it starts-with 's'})
+    assert equal $res 'shell'
+
+    let res = ($hastack2 | iter find {|it| ($it | length) == 50})
+    assert equal $res null
+
+    let res = ($hastack3 | iter find {|it| (it | describe) == filesize})
+    assert equal $res null
+}
+
+def test_iter_intersperse [] {
+    let res = ([1 2 3 4] | iter intersperse 0)
+    assert equal $res [1 0 2 0 3 0 4]
+
+    let res = ([] | iter intersperse x)
+    assert equal $res []
+
+    let res = ([1] | iter intersperse 5)
+    assert equal $res [1]
+
+    let res = ([a b c d e] | iter intersperse 5)
+    assert equal $res [a 5 b 5 c 5 d 5 e]
+
+    let res = (1..4 | iter intersperse 0)
+    assert equal $res [1 0 2 0 3 0 4]
+
+    let res = (4 | iter intersperse 1)
+    assert equal $res [4]
+}
+
+def test_iter_tail [] {
+    let res = ([1 2 3 4] | iter tail)
+    assert equal $res [2 3 4]
+
+    let res = ([] | iter tail)
+    assert equal $res []
+}

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -3,7 +3,6 @@ use std *
 export def test_iter_cmd [] {
     test_iter_intersperse
     test_iter_find
-    test_iter_tail
 }
 
 def test_iter_find [] {


### PR DESCRIPTION
# Description
 
this pr introduces an `iter` module
to the standard library.

the module is aimed at extending the filter commands. 