### PR TITLE
Allocate less when doing a capture discovery

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -49,6 +49,24 @@ pub fn run_test(input: &str, expected: &str) -> TestResult {
     let name = file.path();
 
     let mut cmd = Command::cargo_bin("nu")?;
+    cmd.arg("--no-std-lib");
+    cmd.arg(name);
+    cmd.env(
+        "PWD",
+        std::env::current_dir().expect("Can't get current dir"),
+    );
+
+    writeln!(file, "{input}")?;
+
+    run_cmd_and_assert(cmd, expected)
+}
+
+#[cfg(test)]
+pub fn run_test_std(input: &str, expected: &str) -> TestResult {
+    let mut file = NamedTempFile::new()?;
+    let name = file.path();
+
+    let mut cmd = Command::cargo_bin("nu")?;
     cmd.arg(name);
     cmd.env(
         "PWD",
@@ -83,6 +101,7 @@ pub fn run_test_contains(input: &str, expected: &str) -> TestResult {
     let name = file.path();
 
     let mut cmd = Command::cargo_bin("nu")?;
+    cmd.arg("--no-std-lib");
     cmd.arg(name);
 
     writeln!(file, "{input}")?;
@@ -108,6 +127,7 @@ pub fn test_ide_contains(input: &str, ide_commands: &[&str], expected: &str) -> 
     let name = file.path();
 
     let mut cmd = Command::cargo_bin("nu")?;
+    cmd.arg("--no-std-lib");
     for ide_command in ide_commands {
         cmd.arg(ide_command);
     }
@@ -136,6 +156,7 @@ pub fn fail_test(input: &str, expected: &str) -> TestResult {
     let name = file.path();
 
     let mut cmd = Command::cargo_bin("nu")?;
+    cmd.arg("--no-std-lib");
     cmd.arg(name);
     cmd.env(
         "PWD",

--- a/src/tests/test_stdlib.rs
+++ b/src/tests/test_stdlib.rs
@@ -1,8 +1,8 @@
-use crate::tests::{fail_test, run_test, TestResult};
+use crate::tests::{fail_test, run_test_std, TestResult};
 
 #[test]
 fn library_loaded() -> TestResult {
-    run_test(
+    run_test_std(
         "help std | lines | first 1 | to text",
         "std.nu, `used` to load all standard library components",
     )
@@ -10,7 +10,7 @@ fn library_loaded() -> TestResult {
 
 #[test]
 fn prelude_loaded() -> TestResult {
-    run_test("std help commands | where name == open | length", "1")
+    run_test_std("std help commands | where name == open | length", "1")
 }
 
 #[test]
@@ -20,5 +20,5 @@ fn not_loaded() -> TestResult {
 
 #[test]
 fn use_command() -> TestResult {
-    run_test("use std assert; assert true; print 'it works'", "it works")
+    run_test_std("use std assert; assert true; print 'it works'", "it works")
 }


### PR DESCRIPTION
# Description

This should be a little more efficient when running the algorithm to find the captured variables.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
