### PR TITLE
Upgrade `open` crate to fix WSL bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,6 +1978,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "is-root"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2006,16 @@ dependencies = [
  "io-lifetimes",
  "rustix 0.37.11",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -3357,10 +3376,11 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "open"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075c5203b3a2b698bc72c6c10b1f6263182135751d5013ea66e8a4b3d0562a43"
+checksum = "873240a4a404d44c8cd1bf394359245d466a5695771fea15a79cafbc5e5cf4d7"
 dependencies = [
+ "is-wsl",
  "pathdiff",
 ]
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -67,7 +67,7 @@ notify = "4.0.17"
 num = { version = "0.4.0", optional = true }
 num-traits = "0.2.14"
 once_cell = "1.17"
-open = "4.0.0"
+open = "4.0.2"
 pathdiff = "0.2.1"
 powierza-coefficient = "1.0.2"
 quick-xml = "0.28"


### PR DESCRIPTION
This PR upgrades the [`open`](https://github.com/Byron/open-rs) crate (used in the `start` command) from 4.0.1 to 4.0.2. This fixes a bug where `open` doesn't always work properly on WSL: https://github.com/Byron/open-rs/pull/71