### PR TITLE
Fix: clarify error for variables

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1790,11 +1790,7 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
 
 pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     let contents = working_set.get_span_contents(span);
-    let input = match String::from_utf8(contents.to_vec()) {
-        Ok(str) => str,
-        Err(_) => "".to_owned(),
-    };
-
+    let input = String::from_utf8(contents.to_vec()).unwrap_or_default();
     if contents == b"$nothing" {
         return Expression {
             expr: Expr::Nothing,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1835,7 +1835,7 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
             custom_completion: None,
         }
     } else {
-        match did_you_mean(&working_set.get_all(), &input) {
+        match did_you_mean(&working_set.get_all_defined_vals(), &input) {
             Some(str) => working_set.error(ParseError::DidYouMean(str, span)),
             None => working_set.error(ParseError::VariableNotFound(span)),
         };

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1619,6 +1619,26 @@ impl<'a> StateWorkingSet<'a> {
         next_id
     }
 
+    pub fn get_all(&self) -> Vec<String> {
+        if let Some(overlay_frame) = self
+            .permanent_state
+            .active_overlays(vec![].as_mut())
+            .iter()
+            .rev()
+            .next()
+        {
+            return overlay_frame
+                .vars
+                .keys()
+                .map(|x| match String::from_utf8(x.to_vec()) {
+                    Ok(key) => key,
+                    Err(_) => "".to_string(),
+                })
+                .collect::<Vec<String>>();
+        }
+        vec![]
+    }
+
     pub fn get_cwd(&self) -> String {
         let pwd = self
             .permanent_state

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1619,7 +1619,7 @@ impl<'a> StateWorkingSet<'a> {
         next_id
     }
 
-    pub fn get_all(&self) -> Vec<String> {
+    pub fn get_all_defined_vals(&self) -> Vec<String> {
         if let Some(overlay_frame) = self
             .permanent_state
             .active_overlays(vec![].as_mut())

--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -11,6 +11,10 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::extra_tokens), help("Try removing them."))]
     ExtraTokens(#[label = "extra tokens"] Span),
 
+    #[error("Name not found")]
+    #[diagnostic(code(nu::parser::name_not_found))]
+    DidYouMean(String, #[label("did you mean '{0}'?")] Span),
+
     #[error("Extra positional argument.")]
     #[diagnostic(code(nu::parser::extra_positional), help("Usage: {0}"))]
     ExtraPositional(String, #[label = "extra positional argument"] Span),
@@ -503,6 +507,7 @@ impl ParseError {
             ParseError::UnknownOperator(_, _, s) => *s,
             ParseError::InvalidLiteral(_, _, s) => *s,
             ParseError::NotAConstant(s) => *s,
+            ParseError::DidYouMean(_, s) => *s,
         }
     }
 }


### PR DESCRIPTION
# Description
Fixes #8882 
matching $ variables and return it . none result will return ValueNotFound same as before 