### PR TITLE
allow custom commands to show up in `$nu.scope.commands` better

### DIFF
--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -281,6 +281,22 @@ impl<'e, 's> ScopeData<'e, 's> {
                 )
             })
             .collect::<Vec<(String, Value)>>();
+
+        // Until we allow custom commands to have input and output types, let's just
+        // make them Type::Any Type::Any so they can show up in our $nu.scope.commands
+        // a little bit better. If sigs is empty, we're pretty sure that we're dealing
+        // with a custom command.
+        if sigs.is_empty() {
+            let any_type = &Type::Any;
+            let v = (
+                any_type.to_shape().to_string(),
+                Value::List {
+                    vals: self.collect_signature_entries(any_type, any_type, signature, span),
+                    span,
+                },
+            );
+            sigs.push(v);
+        }
         sigs.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
         // For most commands, input types are not repeated in
         // `input_output_types`, i.e. each input type has only one associated

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -288,14 +288,13 @@ impl<'e, 's> ScopeData<'e, 's> {
         // with a custom command.
         if sigs.is_empty() {
             let any_type = &Type::Any;
-            let v = (
+            sigs.push((
                 any_type.to_shape().to_string(),
                 Value::List {
                     vals: self.collect_signature_entries(any_type, any_type, signature, span),
                     span,
                 },
-            );
-            sigs.push(v);
+            ));
         }
         sigs.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
         // For most commands, input types are not repeated in


### PR DESCRIPTION
# Description
This PR allows our custom commands to show up in `$nu.scope.commands` better. It still needs work because this PR hard code the input and output types as `Type::Any` but the reason they're being missed in the first place is that they are not assigned an input and output type.

This allows things like this now. Note the `where is_custom == true` 
![image](https://user-images.githubusercontent.com/343840/232523925-97eeef78-9722-4184-b60f-9d06f994c8e3.png)

Another example.
![image](https://user-images.githubusercontent.com/343840/232525706-d4d088d8-6597-43ba-97c8-ab03c2c7408c.png)
![image](https://user-images.githubusercontent.com/343840/232525797-b7e9ded3-b299-489e-af33-7390f4291bfd.png)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
