### PR TITLE
Set env in exec command

### DIFF
--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -81,6 +81,7 @@ fn exec(
     let cwd = current_dir(engine_state, stack)?;
     let mut command = external_command.spawn_simple_command(&cwd.to_string_lossy())?;
     command.current_dir(cwd);
+    command.envs(&external_command.env_vars);
 
     let err = command.exec(); // this replaces our process, should not return
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -548,7 +548,7 @@ impl ExternalCommand {
         }
     }
 
-    fn create_process(
+    pub fn create_process(
         &self,
         input: &PipelineData,
         use_cmd: bool,


### PR DESCRIPTION
# Description

Previously variables with `let-env` were not available after doing an `exec` command. This PR fixes that

# User-Facing Changes

Can now use environment variables set with nushell after `exec`

# Tests + Formatting

No tests made but formatting has been checked

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
