### PR TITLE
fix reedline breaking changes due to PR562

### DIFF
--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -91,7 +91,7 @@ impl Command for History {
                 match engine_state.config.history_file_format {
                     HistoryFileFormat::PlainText => Ok(history_reader
                         .and_then(|h| {
-                            h.search(SearchQuery::everything(SearchDirection::Forward))
+                            h.search(SearchQuery::everything(SearchDirection::Forward, None))
                                 .ok()
                         })
                         .map(move |entries| {
@@ -114,7 +114,7 @@ impl Command for History {
                         .into_pipeline_data(ctrlc)),
                     HistoryFileFormat::Sqlite => Ok(history_reader
                         .and_then(|h| {
-                            h.search(SearchQuery::everything(SearchDirection::Forward))
+                            h.search(SearchQuery::everything(SearchDirection::Forward, None))
                                 .ok()
                         })
                         .map(move |entries| {


### PR DESCRIPTION
# Description
This PR fixes the breaking changes to the reedline API due to https://github.com/nushell/reedline/pull/562. It does not implement any new features but just gets nushell back to compiling again.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
