### PR TITLE
Change type of parameter default values to `Option<Value>`

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -72,9 +72,8 @@ pub fn eval_call(
             if let Some(arg) = call.positional_nth(param_idx) {
                 let result = eval_expression(engine_state, caller_stack, arg)?;
                 callee_stack.add_var(var_id, result);
-            } else if let Some(arg) = &param.default_value {
-                let result = eval_expression(engine_state, caller_stack, arg)?;
-                callee_stack.add_var(var_id, result);
+            } else if let Some(value) = &param.default_value {
+                callee_stack.add_var(var_id, value.to_owned());
             } else {
                 callee_stack.add_var(var_id, Value::nothing(call.head));
             }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3647,7 +3647,8 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                             }
                                         }
                                         *shape = expression.ty.to_shape();
-                                        *default_value = Some(expression);
+                                        *default_value =
+                                            eval_constant(working_set, &expression).ok();
                                         *required = false;
                                     }
                                     Arg::RestPositional(..) => {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3646,9 +3646,19 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                                 }
                                             }
                                         }
+
+                                        *default_value = if let Ok(constant) =
+                                            eval_constant(working_set, &expression)
+                                        {
+                                            Some(constant)
+                                        } else {
+                                            working_set.error(ParseError::NonConstantDefaultValue(
+                                                expression.span,
+                                            ));
+                                            None
+                                        };
+
                                         *shape = expression.ty.to_shape();
-                                        *default_value =
-                                            eval_constant(working_set, &expression).ok();
                                         *required = false;
                                     }
                                     Arg::RestPositional(..) => {

--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -349,6 +349,10 @@ pub enum ParseError {
         #[label = "parameter {0} needs to be '{1}' instead of '{2}'"] Span,
     ),
 
+    #[error("Default values should be constant expressions.")]
+    #[diagnostic(code(nu::parser::non_constant_default_value))]
+    NonConstantDefaultValue(#[label = "expected a constant value"] Span),
+
     #[error("Extra columns.")]
     #[diagnostic(code(nu::parser::extra_columns))]
     ExtraColumns(
@@ -485,6 +489,7 @@ impl ParseError {
             ParseError::IncompleteParser(s) => *s,
             ParseError::RestNeedsName(s) => *s,
             ParseError::ParameterMismatchType(_, _, _, s) => *s,
+            ParseError::NonConstantDefaultValue(s) => *s,
             ParseError::ExtraColumns(_, s) => *s,
             ParseError::MissingColumns(_, s) => *s,
             ParseError::AssignmentMismatch(_, _, s) => *s,

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -11,6 +11,7 @@ use crate::PipelineData;
 use crate::ShellError;
 use crate::SyntaxShape;
 use crate::Type;
+use crate::Value;
 use crate::VarId;
 use std::fmt::Write;
 
@@ -35,7 +36,7 @@ pub struct PositionalArg {
 
     // For custom commands
     pub var_id: Option<VarId>,
-    pub default_value: Option<Expression>,
+    pub default_value: Option<Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -323,11 +323,6 @@ fn default_value12() -> TestResult {
 }
 
 #[test]
-fn default_value_expression() -> TestResult {
-    run_test(r#"def foo [x = ("foo" | str length)] { $x }; foo"#, "3")
-}
-
-#[test]
 fn loose_each() -> TestResult {
     run_test(
         r#"[[1, 2, 3], [4, 5, 6]] | each {|| $in.1 } | math sum"#,

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -323,6 +323,14 @@ fn default_value12() -> TestResult {
 }
 
 #[test]
+fn default_value_not_constant() -> TestResult {
+    fail_test(
+        r#"def foo [x = ("foo" | str length)] { $x }; foo"#,
+        "expected a constant",
+    )
+}
+
+#[test]
 fn loose_each() -> TestResult {
     run_test(
         r#"[[1, 2, 3], [4, 5, 6]] | each {|| $in.1 } | math sum"#,

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -323,6 +323,11 @@ fn default_value12() -> TestResult {
 }
 
 #[test]
+fn default_value_constant() -> TestResult {
+    run_test(r#"def foo [x = "foo"] { $x }; foo"#, "foo")
+}
+
+#[test]
 fn default_value_not_constant() -> TestResult {
     fail_test(
         r#"def foo [x = ("foo" | str length)] { $x }; foo"#,


### PR DESCRIPTION
# Description

Fixes #8939.

# User-Facing Changes

- Parameter default values will now be parsed as constants.
- If the default value is not a constant, a parser error is displayed.

# Tests + Formatting

The [only affected test](https://github.com/nushell/nushell/blob/d42c2b2dbc941d63c5a05404a0c22c4a7cd9f965/src/tests/test_engine.rs#L325-L328) has been updated to reflect the new behavior.
