### PR TITLE
`rename`: add -b flag to support closure input

### DIFF
--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -106,15 +106,6 @@ impl Command for Rename {
                     span: Span::test_data(),
                 }),
             },
-            Example {
-                description: "Rename fields based on fields' value",
-                example: "{a: abc, b: dec} | rename -b {|it| $it.value | str replace 'c' 'z'}",
-                result: Some(Value::Record {
-                    cols: vec!["abz".to_string(), "dez".to_string()],
-                    vals: vec![Value::test_string("abc"), Value::test_string("dec")],
-                    span: Span::test_data(),
-                }),
-            },
         ]
     }
 }
@@ -183,19 +174,7 @@ fn rename(
 
                             if let Some(var) = block.signature.get_positional(0) {
                                 if let Some(var_id) = &var.var_id {
-                                    // make argument to be something like this:
-                                    // {"index": col_name, "value": val}
-                                    stack.add_var(
-                                        *var_id,
-                                        Value::record(
-                                            vec!["index".to_string(), "value".to_string()],
-                                            vec![
-                                                Value::string(cols[idx].clone(), span),
-                                                vals[idx].clone(),
-                                            ],
-                                            span,
-                                        ),
-                                    )
+                                    stack.add_var(*var_id, Value::string(cols[idx].clone(), span))
                                 }
                             }
                             let eval_result = eval_block_with_early_return(

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -169,19 +169,19 @@ fn rename(
                     if let Some((engine_state, block, mut stack, env_vars, env_hidden)) =
                         block_info.clone()
                     {
-                        for idx in 0..cols.len() {
+                        for c in &mut cols {
                             stack.with_env(&env_vars, &env_hidden);
 
                             if let Some(var) = block.signature.get_positional(0) {
                                 if let Some(var_id) = &var.var_id {
-                                    stack.add_var(*var_id, Value::string(cols[idx].clone(), span))
+                                    stack.add_var(*var_id, Value::string(c.clone(), span))
                                 }
                             }
                             let eval_result = eval_block_with_early_return(
                                 &engine_state,
                                 &mut stack,
                                 &block,
-                                Value::string(cols[idx].clone(), span).into_pipeline_data(),
+                                Value::string(c.clone(), span).into_pipeline_data(),
                                 redirect_stdout,
                                 redirect_stderr,
                             );
@@ -189,7 +189,7 @@ fn rename(
                                 Err(e) => return Value::Error { error: Box::new(e) },
                                 Ok(res) => match res.collect_string_strict(span) {
                                     Err(e) => return Value::Error { error: Box::new(e) },
-                                    Ok(c) => cols[idx] = c.0,
+                                    Ok(new_c) => *c = new_c.0,
                                 },
                             }
                         }

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -1,8 +1,9 @@
-use nu_engine::CallExt;
+use nu_engine::{eval_block_with_early_return, CallExt};
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    Type, Value,
 };
 
 #[derive(Clone)]
@@ -24,6 +25,12 @@ impl Command for Rename {
                 SyntaxShape::List(Box::new(SyntaxShape::String)),
                 "column name to be changed",
                 Some('c'),
+            )
+            .named(
+                "block",
+                SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                "A closure to apply changes on each column",
+                Some('b'),
             )
             .rest("rest", SyntaxShape::String, "the new names for the columns")
             .category(Category::Filters)
@@ -90,6 +97,24 @@ impl Command for Rename {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Rename fields based on a given closure",
+                example: "{abc: 1, bbc: 2} | rename -b {str replace -a 'b' 'z'}",
+                result: Some(Value::Record {
+                    cols: vec!["azc".to_string(), "zzc".to_string()],
+                    vals: vec![Value::test_int(1), Value::test_int(2)],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "Rename fields based on fields' value",
+                example: "{a: abc, b: dec} | rename -b {|it| $it.value | str replace 'c' 'z'}",
+                result: Some(Value::Record {
+                    cols: vec!["abz".to_string(), "dez".to_string()],
+                    vals: vec![Value::test_string("abc"), Value::test_string("dec")],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }
@@ -124,6 +149,20 @@ fn rename(
         }
     }
 
+    let redirect_stdout = call.redirect_stdout;
+    let redirect_stderr = call.redirect_stderr;
+    let block_info =
+        if let Some(capture_block) = call.get_flag::<Closure>(engine_state, stack, "block")? {
+            let engine_state = engine_state.clone();
+            let block = engine_state.get_block(capture_block.block_id).clone();
+            let stack = stack.captures_to_stack(&capture_block.captures);
+            let orig_env_vars = stack.env_vars.clone();
+            let orig_env_hidden = stack.env_hidden.clone();
+            Some((engine_state, block, stack, orig_env_vars, orig_env_hidden))
+        } else {
+            None
+        };
+
     let columns: Vec<String> = call.rest(engine_state, stack, 0)?;
     let metadata = input.metadata();
 
@@ -136,38 +175,79 @@ fn rename(
                     vals,
                     span,
                 } => {
-                    match &specified_column {
-                        Some(c) => {
-                            // check if the specified column to be renamed exists
-                            if !cols.contains(&c[0]) {
-                                return Value::Error {
-                                    error: Box::new(ShellError::UnsupportedInput(
-                                        format!(
-                                            "The column '{}' does not exist in the input",
-                                            &c[0]
+                    if let Some((engine_state, block, mut stack, env_vars, env_hidden)) =
+                        block_info.clone()
+                    {
+                        for idx in 0..cols.len() {
+                            stack.with_env(&env_vars, &env_hidden);
+
+                            if let Some(var) = block.signature.get_positional(0) {
+                                if let Some(var_id) = &var.var_id {
+                                    // make argument to be something like this:
+                                    // {"index": col_name, "value": val}
+                                    stack.add_var(
+                                        *var_id,
+                                        Value::record(
+                                            vec!["index".to_string(), "value".to_string()],
+                                            vec![
+                                                Value::string(cols[idx].clone(), span),
+                                                vals[idx].clone(),
+                                            ],
+                                            span,
                                         ),
-                                        "value originated from here".into(),
-                                        // Arrow 1 points at the specified column name,
-                                        specified_col_span.unwrap_or(head_span),
-                                        // Arrow 2 points at the input value.
-                                        span,
-                                    )),
-                                };
-                            }
-                            for (idx, val) in cols.iter_mut().enumerate() {
-                                if *val == c[0] {
-                                    cols[idx] = c[1].to_string();
-                                    break;
+                                    )
                                 }
+                            }
+                            let eval_result = eval_block_with_early_return(
+                                &engine_state,
+                                &mut stack,
+                                &block,
+                                Value::string(cols[idx].clone(), span).into_pipeline_data(),
+                                redirect_stdout,
+                                redirect_stderr,
+                            );
+                            match eval_result {
+                                Err(e) => return Value::Error { error: Box::new(e) },
+                                Ok(res) => match res.collect_string_strict(span) {
+                                    Err(e) => return Value::Error { error: Box::new(e) },
+                                    Ok(c) => cols[idx] = c.0,
+                                },
                             }
                         }
-                        None => {
-                            for (idx, val) in columns.iter().enumerate() {
-                                if idx >= cols.len() {
-                                    // skip extra new columns names if we already reached the final column
-                                    break;
+                    } else {
+                        match &specified_column {
+                            Some(c) => {
+                                // check if the specified column to be renamed exists
+                                if !cols.contains(&c[0]) {
+                                    return Value::Error {
+                                        error: Box::new(ShellError::UnsupportedInput(
+                                            format!(
+                                                "The column '{}' does not exist in the input",
+                                                &c[0]
+                                            ),
+                                            "value originated from here".into(),
+                                            // Arrow 1 points at the specified column name,
+                                            specified_col_span.unwrap_or(head_span),
+                                            // Arrow 2 points at the input value.
+                                            span,
+                                        )),
+                                    };
                                 }
-                                cols[idx] = val.clone();
+                                for (idx, val) in cols.iter_mut().enumerate() {
+                                    if *val == c[0] {
+                                        cols[idx] = c[1].to_string();
+                                        break;
+                                    }
+                                }
+                            }
+                            None => {
+                                for (idx, val) in columns.iter().enumerate() {
+                                    if idx >= cols.len() {
+                                        // skip extra new columns names if we already reached the final column
+                                        break;
+                                    }
+                                    cols[idx] = val.clone();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
# Description
Closes: #8108 

Adding a new `-b` flag to `rename` command.  I have thought about making it as a positional argument, but I don't think it's ok because we alredy have `...rest` parameters

Here are how they works:
```
#  Rename fields based on a given closure
> {a: 1, b: 2} | rename -b {str upcase}
  ╭───┬───╮
  │ A │ 1 │
  │ B │ 2 │
  ╰───┴───╯

#  Rename fields based on fields' value
> {a: abc, b: def} | rename -b {|it| $it.value | str upcase}
  ╭─────┬─────╮
  │ ABC │ abc │
  │ DEF │ def │
  ╰─────┴─────╯
```
# User-Facing Changes


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
