### PR TITLE
Reuse the cached parse results of parsed files

### DIFF
--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -1,5 +1,5 @@
 use nu_command::create_default_context;
-use nu_protocol::{engine::StateWorkingSet, Category};
+use nu_protocol::{engine::StateWorkingSet, Category, Span};
 use quickcheck_macros::quickcheck;
 
 mod commands;
@@ -15,7 +15,8 @@ fn quickcheck_parse(data: String) -> bool {
             let mut working_set = StateWorkingSet::new(&context);
             let _ = working_set.add_file("quickcheck".into(), data.as_bytes());
 
-            let _ = nu_parser::parse_block(&mut working_set, &tokens, false, false);
+            let _ =
+                nu_parser::parse_block(&mut working_set, &tokens, Span::new(0, 0), false, false);
         }
     }
     true

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2671,7 +2671,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeli
                         // working set, if it was a successful parse.
                         let block = parse(
                             working_set,
-                            path.file_name().and_then(|x| x.to_str()),
+                            Some(&path.to_string_lossy()),
                             &contents,
                             scoped,
                         );

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1941,6 +1941,22 @@ impl<'a> StateWorkingSet<'a> {
             .collect();
         build_usage(&comment_lines)
     }
+
+    pub fn find_block_by_span(&self, span: Span) -> Option<Block> {
+        for block in &self.delta.blocks {
+            if Some(span) == block.span {
+                return Some(block.clone());
+            }
+        }
+
+        for block in &self.permanent_state.blocks {
+            if Some(span) == block.span {
+                return Some(block.clone());
+            }
+        }
+
+        None
+    }
 }
 
 impl Default for EngineState {


### PR DESCRIPTION
# Description

This does a lookup in the cache of parsed files to see if a span can be found for a file that was previously loaded with the same contents, then uses that span to find the parsed block for that file. The end result should, in theory, be identical but doesn't require any reparsing or creating new blocks/new definitions that aren't needed.

This drops the sg.nu benchmark from:
```
╭───┬───────────────────╮
│ 0 │ 280ms 606µs 208ns │
│ 1 │ 282ms 654µs 416ns │
│ 2 │ 252ms 640µs 541ns │
│ 3 │  250ms 940µs 41ns │
│ 4 │ 241ms 216µs 375ns │
│ 5 │ 257ms 310µs 583ns │
│ 6 │ 196ms 739µs 416ns │
╰───┴───────────────────╯
```

to:
```
╭───┬───────────────────╮
│ 0 │ 118ms 698µs 125ns │
│ 1 │       121ms 327µs │
│ 2 │ 121ms 873µs 500ns │
│ 3 │  124ms 94µs 708ns │
│ 4 │ 113ms 733µs 291ns │
│ 5 │ 108ms 663µs 125ns │
│ 6 │  63ms 482µs 625ns │
╰───┴───────────────────╯
```

I was hoping to also see some startup time improvements, but I didn't notice much there.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
