### PR TITLE
using ratatui instead of tui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,9 +2957,9 @@ dependencies = [
  "nu-protocol",
  "nu-table",
  "nu-utils",
+ "ratatui",
  "strip-ansi-escapes",
  "terminal_size 0.2.6",
- "tui",
 ]
 
 [[package]]
@@ -4270,6 +4270,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcc0d032bccba900ee32151ec0265667535c230169f5a011154cdcd984e16829"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "crossterm 0.26.1",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "rayon"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5461,19 +5474,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "tui"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
-dependencies = [
- "bitflags",
- "cassowary",
- "crossterm 0.25.0",
- "unicode-segmentation",
- "unicode-width",
-]
 
 [[package]]
 name = "typed-arena"

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -23,6 +23,6 @@ nu-utils = { path = "../nu-utils", version = "0.78.1"  }
 terminal_size = "0.2.1"
 strip-ansi-escapes = "0.1.1"
 crossterm = "0.26"
-tui = "0.19.0"
+ratatui = "0.20.1"
 ansi-str = "0.7.2"
 lscolors = { version = "0.14", default-features = false, features = ["nu-ansi-term"] }

--- a/crates/nu-explore/src/commands/config_show.rs
+++ b/crates/nu-explore/src/commands/config_show.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     Value,
 };
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 use crate::{
     nu_common::{try_build_table, NuSpan},

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     Value,
 };
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 use crate::{
     nu_common::{collect_input, NuSpan},

--- a/crates/nu-explore/src/commands/nu.rs
+++ b/crates/nu-explore/src/commands/nu.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     PipelineData, Value,
 };
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 use crate::{
     nu_common::{collect_pipeline, has_simple_value, run_command_with_value},

--- a/crates/nu-explore/src/pager/command_bar.rs
+++ b/crates/nu-explore/src/pager/command_bar.rs
@@ -1,4 +1,4 @@
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Modifier, Style},

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -24,7 +24,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     Value,
 };
-use tui::{backend::CrosstermBackend, layout::Rect, widgets::Block};
+use ratatui::{backend::CrosstermBackend, layout::Rect, widgets::Block};
 
 use crate::{
     nu_common::{CtrlC, NuColor, NuConfig, NuSpan, NuStyle},
@@ -43,8 +43,8 @@ use super::views::{Layout, View};
 
 use events::UIEvents;
 
-pub type Frame<'a> = tui::Frame<'a, CrosstermBackend<Stdout>>;
-pub type Terminal = tui::Terminal<CrosstermBackend<Stdout>>;
+pub type Frame<'a> = ratatui::Frame<'a, CrosstermBackend<Stdout>>;
+pub type Terminal = ratatui::Terminal<CrosstermBackend<Stdout>>;
 pub type ConfigMap = HashMap<String, Value>;
 
 #[derive(Debug, Clone)]

--- a/crates/nu-explore/src/pager/status_bar.rs
+++ b/crates/nu-explore/src/pager/status_bar.rs
@@ -1,4 +1,4 @@
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Modifier, Style},

--- a/crates/nu-explore/src/views/coloredtextw.rs
+++ b/crates/nu-explore/src/views/coloredtextw.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use ansi_str::{get_blocks, AnsiStr};
-use tui::{
+use ratatui::{
     layout::Rect,
     style::{Color, Modifier, Style},
     widgets::Widget,
@@ -24,7 +24,7 @@ impl<'a> ColoredTextW<'a> {
 }
 
 impl Widget for ColoredTextW<'_> {
-    fn render(self, area: Rect, buf: &mut tui::buffer::Buffer) {
+    fn render(self, area: Rect, buf: &mut ratatui::buffer::Buffer) {
         let text = cut_string(self.text, area, self.col);
 
         let mut offset = 0;

--- a/crates/nu-explore/src/views/configuration.rs
+++ b/crates/nu-explore/src/views/configuration.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
     Value,
 };
 use nu_table::TextStyle;
-use tui::{
+use ratatui::{
     layout::Rect,
     style::Style,
     widgets::{BorderType, Borders, Paragraph},
@@ -197,13 +197,13 @@ impl View for ConfigurationView {
 
         let view_content_area = Rect::new(view_content_x1, 1, view_content_w, view_content_h);
 
-        let option_block = tui::widgets::Block::default()
+        let option_block = ratatui::widgets::Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Plain)
             .border_style(border_color);
         let option_area = Rect::new(option_b_x1, area.y, OPTION_BLOCK_WIDTH, area.height);
 
-        let view_block = tui::widgets::Block::default()
+        let view_block = ratatui::widgets::Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Plain)
             .border_style(border_color);

--- a/crates/nu-explore/src/views/information.rs
+++ b/crates/nu-explore/src/views/information.rs
@@ -1,7 +1,7 @@
 use crossterm::event::KeyEvent;
 use nu_color_config::TextStyle;
 use nu_protocol::engine::{EngineState, Stack};
-use tui::{layout::Rect, widgets::Paragraph};
+use ratatui::{layout::Rect, widgets::Paragraph};
 
 use crate::{
     nu_common::NuText,

--- a/crates/nu-explore/src/views/interactive.rs
+++ b/crates/nu-explore/src/views/interactive.rs
@@ -6,7 +6,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     PipelineData, Value,
 };
-use tui::{
+use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     widgets::{BorderType, Borders, Paragraph},
@@ -67,7 +67,7 @@ impl View for InteractiveView<'_> {
         let border_color = self.border_color;
         let highlighted_color = self.highlighted_color;
 
-        let cmd_block = tui::widgets::Block::default()
+        let cmd_block = ratatui::widgets::Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Plain)
             .border_style(border_color);
@@ -119,7 +119,7 @@ impl View for InteractiveView<'_> {
             }
         }
 
-        let table_block = tui::widgets::Block::default()
+        let table_block = ratatui::widgets::Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Plain)
             .border_style(border_color);

--- a/crates/nu-explore/src/views/mod.rs
+++ b/crates/nu-explore/src/views/mod.rs
@@ -13,7 +13,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     Value,
 };
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 use crate::{nu_common::NuConfig, pager::ConfigMap};
 

--- a/crates/nu-explore/src/views/preview.rs
+++ b/crates/nu-explore/src/views/preview.rs
@@ -6,7 +6,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     Value,
 };
-use tui::layout::Rect;
+use ratatui::layout::Rect;
 
 use crate::{
     nu_common::{NuSpan, NuText},

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
     engine::{EngineState, Stack},
     Value,
 };
-use tui::{layout::Rect, widgets::Block};
+use ratatui::{layout::Rect, widgets::Block};
 
 use crate::{
     nu_common::{collect_input, lscolorize, NuConfig, NuSpan, NuStyle, NuText},

--- a/crates/nu-explore/src/views/record/tablew.rs
+++ b/crates/nu-explore/src/views/record/tablew.rs
@@ -6,7 +6,7 @@ use std::{
 use nu_color_config::{Alignment, StyleComputer, TextStyle};
 use nu_protocol::Value;
 use nu_table::string_width;
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     text::Span,
@@ -91,8 +91,8 @@ impl StatefulWidget for TableW<'_> {
 
     fn render(
         self,
-        area: tui::layout::Rect,
-        buf: &mut tui::buffer::Buffer,
+        area: ratatui::layout::Rect,
+        buf: &mut ratatui::buffer::Buffer,
         state: &mut Self::State,
     ) {
         if area.width < 5 {
@@ -572,7 +572,7 @@ impl Widget for IndexColumn<'_> {
 
             let p = Paragraph::new(text)
                 .style(style)
-                .alignment(tui::layout::Alignment::Right);
+                .alignment(ratatui::layout::Alignment::Right);
             let area = Rect::new(area.x, area.y + row, area.width, 1);
 
             p.render(area, buf);
@@ -690,7 +690,7 @@ fn create_column(data: &[Vec<NuText>], col: usize) -> Vec<NuText> {
 }
 
 fn repeat_vertical(
-    buf: &mut tui::buffer::Buffer,
+    buf: &mut ratatui::buffer::Buffer,
     x_offset: u16,
     y_offset: u16,
     width: u16,
@@ -755,7 +755,7 @@ fn calculate_column_width(column: &[NuText]) -> usize {
 }
 
 fn render_column(
-    buf: &mut tui::buffer::Buffer,
+    buf: &mut ratatui::buffer::Buffer,
     x: u16,
     y: u16,
     available_width: u16,

--- a/crates/nu-explore/src/views/util.rs
+++ b/crates/nu-explore/src/views/util.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use nu_color_config::{Alignment, StyleComputer};
 use nu_protocol::{ShellError, Value};
 use nu_table::{string_width, TextStyle};
-use tui::{
+use ratatui::{
     buffer::Buffer,
     style::{Color, Modifier, Style},
     text::Span,
@@ -33,8 +33,8 @@ pub fn set_span(
     text_width as u16
 }
 
-pub fn nu_style_to_tui(style: NuStyle) -> tui::style::Style {
-    let mut out = tui::style::Style::default();
+pub fn nu_style_to_tui(style: NuStyle) -> ratatui::style::Style {
+    let mut out = ratatui::style::Style::default();
     if let Some(clr) = style.background {
         out.bg = nu_ansi_color_to_tui_color(clr);
     }
@@ -74,7 +74,7 @@ pub fn nu_style_to_tui(style: NuStyle) -> tui::style::Style {
     out
 }
 
-pub fn nu_ansi_color_to_tui_color(clr: NuColor) -> Option<tui::style::Color> {
+pub fn nu_ansi_color_to_tui_color(clr: NuColor) -> Option<ratatui::style::Color> {
     use NuColor::*;
 
     let clr = match clr {
@@ -94,7 +94,7 @@ pub fn nu_ansi_color_to_tui_color(clr: NuColor) -> Option<tui::style::Color> {
         LightCyan => Color::LightCyan,
         White => Color::White,
         Fixed(i) => Color::Indexed(i),
-        Rgb(r, g, b) => tui::style::Color::Rgb(r, g, b),
+        Rgb(r, g, b) => ratatui::style::Color::Rgb(r, g, b),
         LightGray => Color::Gray,
         LightPurple => Color::LightMagenta,
         Purple => Color::Magenta,
@@ -104,8 +104,8 @@ pub fn nu_ansi_color_to_tui_color(clr: NuColor) -> Option<tui::style::Color> {
     Some(clr)
 }
 
-pub fn text_style_to_tui_style(style: TextStyle) -> tui::style::Style {
-    let mut out = tui::style::Style::default();
+pub fn text_style_to_tui_style(style: TextStyle) -> ratatui::style::Style {
+    let mut out = ratatui::style::Style::default();
     if let Some(style) = style.color_style {
         out = nu_style_to_tui(style);
     }


### PR DESCRIPTION
# Description

Refer to https://github.com/fdehau/tui-rs/issues/654, I found that tui maybe un-maintained, instead, I'd suggest to use an actively fork https://github.com/tui-rs-revival/ratatui

cc: @zhiburt 

# User-Facing Changes
NaN

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
