### PR TITLE
use record separator `\x1e` for `include_path`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ fn main() -> Result<()> {
         let span = include_path.span;
         let vals: Vec<_> = include_path
             .item
-            .split(':')
+            .split('\x1e') // \x1e is the record separator character (a character that is unlikely to appear in a path)
             .map(|x| Value::String {
                 val: x.trim().to_string(),
                 span,


### PR DESCRIPTION
# Description

This changes how the include paths are joined together so that it uses a character that will work across platforms. `;` didn't work on Mac/Linux. `:` didn't work in Windows. So, the record separator should work, which is \x1e.

This goes hand-in-hand with https://github.com/nushell/vscode-nushell-lang/pull/113.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
