### PR TITLE
update `ast` to support output to json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,6 +2905,7 @@ dependencies = [
  "rust-embed",
  "same-file",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "serde_yaml",
  "sha2",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -80,6 +80,7 @@ roxmltree = "0.18.0"
 rust-embed = "6.6.0"
 same-file = "1.0.6"
 serde = { version = "1.0.123", features = ["derive"] }
+serde_json = "1.0"
 serde_urlencoded = "0.7.0"
 serde_yaml = "0.9.4"
 sha2 = "0.10.0"

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -1,10 +1,9 @@
+use super::Pipeline;
+use crate::{Signature, Span, VarId};
+use serde::{Deserialize, Serialize};
 use std::ops::{Index, IndexMut};
 
-use crate::{Signature, Span, VarId};
-
-use super::Pipeline;
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Block {
     pub signature: Box<Signature>,
     pub pipelines: Vec<Pipeline>,

--- a/crates/nu-protocol/src/ast/pipeline.rs
+++ b/crates/nu-protocol/src/ast/pipeline.rs
@@ -1,8 +1,8 @@
+use crate::{ast::Expression, engine::StateWorkingSet, Span, VarId};
+use serde::{Deserialize, Serialize};
 use std::ops::{Index, IndexMut};
 
-use crate::{ast::Expression, engine::StateWorkingSet, Span, VarId};
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Redirection {
     Stdout,
     Stderr,
@@ -10,7 +10,7 @@ pub enum Redirection {
 }
 
 // Note: Span in the below is for the span of the connector not the whole element
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PipelineElement {
     Expression(Option<Span>, Expression),
     Redirection(Span, Redirection, Expression),
@@ -106,7 +106,7 @@ impl PipelineElement {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pipeline {
     pub elements: Vec<PipelineElement>,
 }

--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -1,8 +1,9 @@
 use crate::{Span, Type};
 use miette::Diagnostic;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[derive(Clone, Debug, Error, Diagnostic)]
+#[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
 pub enum ParseError {
     /// The parser encountered unexpected tokens, when the code should have
     /// finished. You should remove these or finish adding what you intended


### PR DESCRIPTION
# Description
This PR changes the `ast` command to be able to output `--json` as well as `nuon` (default) with "pretty" and "minified" output. I'm hoping this functionality will be usable in the vscode extension for semantic tokenization and highlighting.

# User-Facing Changes
There's a new `--json`/`-j` option. Prior version output of nuon is maintained as default.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
