### PR TITLE
feat(rm)!: use arg. spans for I/O errors

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -318,8 +318,8 @@ fn rm(
     }
 
     all_targets
-        .into_keys()
-        .map(move |f| {
+        .into_iter()
+        .map(move |(f, span)| {
             let is_empty = || match f.read_dir() {
                 Ok(mut p) => p.next().is_none(),
                 Err(_) => false,


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Currently, error spans for I/O errors in an `rm` invocation always point to the `rm` argument. This isn't ideal, because the user loses context as to which “target” actually had a problem:

![image](https://user-images.githubusercontent.com/658538/235723366-50db727e-9ba2-4d16-afc6-6a2406c584e0.png)

Shadow the existing `span` variable in outer scope in `rm`'s implementation for the errors that may be detected while handling I/O results. This is desired, because all failures from this point are target-specific, and pointing at the argument that generated the target instead is better. The end user should now see this:

![image](https://user-images.githubusercontent.com/658538/235724345-1d2e98e0-6b20-4bf5-b8a2-8b4368cdfb05.png)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* When `rm` encounters I/O errors, their spans now point to the “target” argument associated with the error, rather than the `rm` token.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

No tests currently cover this. I'm open to adding tests, but adding as follow-up sounds better ATM, since this wasn't covered before.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Nothing needs to be done here, AFAIK. No I/O errors are currently demonstrated in official docs, though maybe they should be?
