### PR TITLE
FEATURE: add `--expand` to `std clip`

### DIFF
--- a/crates/nu-std/lib/mod.nu
+++ b/crates/nu-std/lib/mod.nu
@@ -107,8 +107,14 @@ def check-clipboard [
 export def clip [
     --silent: bool  # do not print the content of the clipboard to the standard output
     --no-notify: bool  # do not throw a notification (only on linux)
+    --expand (-e): bool  # auto-expand the data given as input
 ] {
-    let input = ($in | table | into string | ansi strip)
+    let input = (
+        $in
+        | if $expand { table --expand } else { table }
+        | into string
+        | ansi strip
+    )
 
     match $nu.os-info.name {
         "linux" => {


### PR DESCRIPTION
# Description
i use `std clip` to copy everything from `nushell`.
however i have the auto-expand on tables enabled and when i use `clip` on large tables, it does not copy what i see but the collapsed data => i have to edit the line and add `| table --expand` manually, which is a pain to do regularly :scream: 

in this PR, i just add `--expand` to `std clip` to automatically expand the data before copying it :yum: 

# User-Facing Changes
exploring the `Cargo.toml` of `nushell` with auto-expand, one might see
```
> open Cargo.toml | get package.metadata.binstall.overrides
╭────────────────────────┬───────────────────╮
│                        │ ╭─────────┬─────╮ │
│ x86_64-pc-windows-msvc │ │ pkg-fmt │ zip │ │
│                        │ ╰─────────┴─────╯ │
╰────────────────────────┴───────────────────╯
```
but then
```
open Cargo.toml | get package.metadata.binstall.overrides | clip
```
would only copy
```
╭────────────────────────┬──────────────────╮
│ x86_64-pc-windows-msvc │ {record 1 field} │
╰────────────────────────┴──────────────────╯
```
...

now 
```
open Cargo.toml | get package.metadata.binstall.overrides | clip --expand
```
will copy the expanded record :+1: 

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```