### PR TITLE
Tweak run-external signature so command must be a string

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -42,7 +42,7 @@ impl Command for External {
             .switch("redirect-stdout", "redirect stdout to the pipeline", None)
             .switch("redirect-stderr", "redirect stderr to the pipeline", None)
             .switch("trim-end-newline", "trimming end newlines", None)
-            .required("command", SyntaxShape::Any, "external command to run")
+            .required("command", SyntaxShape::String, "external command to run")
             .rest("args", SyntaxShape::Any, "arguments for external command")
             .category(Category::System)
     }


### PR DESCRIPTION
Tiny fix: clarify in `run-external`'s signature that the external command must be a string.

### Before
```
Signatures:
  <any> | run-external <any> -> <any>

Parameters:
  command <any>: external command to run
  ...args <any>: arguments for external command
```

### After
```
Signatures:
  <any> | run-external <string> -> <any>

Parameters:
  command <string>: external command to run
  ...args <any>: arguments for external command
```


### Notes

I was hoping to change more `any`s to more specific types, but alas I think we can only change `command` right now. The input can be any type and it gets rendered to a string before being passed to the external. The args can be any value type and they get converted to strings. The output can be either binary or a string.