### PR TITLE
support blink cursor, and fix underscore's cursorshape

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -710,8 +710,11 @@ pub fn evaluate_repl(
 fn map_nucursorshape_to_cursorshape(shape: NuCursorShape) -> SetCursorStyle {
     match shape {
         NuCursorShape::Block => SetCursorStyle::SteadyBlock,
-        NuCursorShape::UnderScore => SetCursorStyle::DefaultUserShape,
-        NuCursorShape::Line => SetCursorStyle::BlinkingBar,
+        NuCursorShape::UnderScore => SetCursorStyle::SteadyUnderScore,
+        NuCursorShape::Line => SetCursorStyle::SteadyBar,
+        NuCursorShape::BlinkBlock => SetCursorStyle::BlinkingBlock,
+        NuCursorShape::BlinkUnderScore => SetCursorStyle::BlinkingUnderScore,
+        NuCursorShape::BlinkLine => SetCursorStyle::BlinkingBar,
     }
 }
 

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -60,6 +60,9 @@ pub enum NuCursorShape {
     UnderScore,
     Line,
     Block,
+    BlinkUnderScore,
+    BlinkLine,
+    BlinkBlock,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -654,6 +657,9 @@ impl Value {
                                         NuCursorShape::Line => "line",
                                         NuCursorShape::Block => "block",
                                         NuCursorShape::UnderScore => "underscore",
+                                        NuCursorShape::BlinkLine => "blink_line",
+                                        NuCursorShape::BlinkBlock => "blink_block",
+                                        NuCursorShape::BlinkUnderScore => "blink_underscore",
                                     },
                                     *$span,
                                 )
@@ -680,9 +686,21 @@ impl Value {
                                                     config.cursor_shape_vi_insert =
                                                         NuCursorShape::UnderScore;
                                                 }
+                                                "blink_line" => {
+                                                    config.cursor_shape_vi_insert =
+                                                        NuCursorShape::BlinkLine;
+                                                }
+                                                "blink_block" => {
+                                                    config.cursor_shape_vi_insert =
+                                                        NuCursorShape::BlinkBlock;
+                                                }
+                                                "blink_underscore" => {
+                                                    config.cursor_shape_vi_insert =
+                                                        NuCursorShape::BlinkUnderScore;
+                                                }
                                                 _ => {
                                                     invalid!(Some(*span),
-                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', or 'underscore'"
+                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
                                                     );
                                                     // Reconstruct
                                                     vals[index] = reconstruct_cursor_shape!(
@@ -716,9 +734,21 @@ impl Value {
                                                     config.cursor_shape_vi_normal =
                                                         NuCursorShape::UnderScore;
                                                 }
+                                                "blink_line" => {
+                                                    config.cursor_shape_vi_normal =
+                                                        NuCursorShape::BlinkLine;
+                                                }
+                                                "blink_block" => {
+                                                    config.cursor_shape_vi_normal =
+                                                        NuCursorShape::BlinkBlock;
+                                                }
+                                                "blink_underscore" => {
+                                                    config.cursor_shape_vi_normal =
+                                                        NuCursorShape::BlinkUnderScore;
+                                                }
                                                 _ => {
                                                     invalid!(Some(*span),
-                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', or 'underscore'"
+                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
                                                     );
                                                     // Reconstruct
                                                     vals[index] = reconstruct_cursor_shape!(
@@ -751,9 +781,21 @@ impl Value {
                                                     config.cursor_shape_emacs =
                                                         NuCursorShape::UnderScore;
                                                 }
+                                                "blink_line" => {
+                                                    config.cursor_shape_emacs =
+                                                        NuCursorShape::BlinkLine;
+                                                }
+                                                "blink_block" => {
+                                                    config.cursor_shape_emacs =
+                                                        NuCursorShape::BlinkBlock;
+                                                }
+                                                "blink_underscore" => {
+                                                    config.cursor_shape_emacs =
+                                                        NuCursorShape::BlinkUnderScore;
+                                                }
                                                 _ => {
                                                     invalid!(Some(*span),
-                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', or 'underscore'"
+                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
                                                     );
                                                     // Reconstruct
                                                     vals[index] = reconstruct_cursor_shape!(

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -283,9 +283,9 @@ let-env config = {
     format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
   }
   cursor_shape: {
-    emacs: line # block, underscore, line (line is the default)
-    vi_insert: block # block, underscore, line (block is the default)
-    vi_normal: underscore # block, underscore, line  (underscore is the default)
+    emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)
+    vi_insert: block # block, underscore, line , blink_block, blink_underscore, blink_line (block is the default)
+    vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
   }
   color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
   use_grid_icons: true


### PR DESCRIPTION
# Description
Close: #8988

Thanks to new crossterm version, nushell can support blink cursor shape.  It can be config with the following value:
1. blink_block
2. blink_line
3. blink_underscore

And original block, line, underscore will be steady.  It also fixes wrong shape of `underscore`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
