### PR TITLE
Pin `reedline` to `0.19.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4322,8 +4322,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.18.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#86beb8793e9fa910eada7929f50ea78207590a69"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8684e0f5d6fb8529156a19c637645dd7fd5018efbdeaa306f53f54e3b404de"
 dependencies = [
  "chrono",
  "crossterm 0.26.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ nu-std = { path = "./crates/nu-std", version = "0.78.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.78.1" }
 
 nu-ansi-term = "0.47.0"
-reedline = { version = "0.18.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.19.0", features = ["bashisms", "sqlite"]}
 
 rayon = "1.7.0"
 is_executable = "1.0.1"
@@ -160,7 +160,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
+# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Criterion benchmarking setup

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -24,7 +24,7 @@ nu-utils = { path = "../nu-utils", version = "0.78.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.78.1" }
 
 nu-ansi-term = "0.47.0"
-reedline = { version = "0.18.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.19.0", features = ["bashisms", "sqlite"]}
 
 atty = "0.2.14"
 chrono = { default-features = false, features = ["std"], version = "0.4.23" }


### PR DESCRIPTION
# Description
See release notes:

https://github.com/nushell/reedline/releases/tag/v0.19.0
