### PR TITLE
Move from `winres` to better-maintained `winresource` fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
  "simplelog",
  "tempfile",
  "time 0.3.20",
- "winres",
+ "winresource",
 ]
 
 [[package]]
@@ -2914,7 +2914,7 @@ dependencies = [
  "terminal_size 0.2.6",
  "thiserror",
  "titlecase",
- "toml 0.7.3",
+ "toml",
  "trash",
  "umask",
  "unicode-segmentation",
@@ -5387,15 +5387,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
@@ -6100,12 +6091,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "winres"
-version = "0.1.12"
+name = "winresource"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+checksum = "5cd38cf1ae6704c0bd03ee663068b8303b9c4bb069f83143c21ef25b19d1bc30"
 dependencies = [
- "toml 0.5.11",
+ "toml",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ signal-hook = { version = "0.3.14", default-features = false }
 
 
 [target.'cfg(windows)'.build-dependencies]
-winres = "0.1"
+winresource = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = { version = "0.26", default-features = false, features = [

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 #[cfg(windows)]
 fn main() {
-    let mut res = winres::WindowsResource::new();
+    let mut res = winresource::WindowsResource::new();
     res.set("ProductName", "Nushell");
     res.set("FileDescription", "Nushell");
     res.set("LegalCopyright", "Copyright (C) 2022");


### PR DESCRIPTION
This MR closes #8986; big thanks to @WindSoilder for investigating this and making the MR very easy.

I did manual testing to confirm that the icon etc. are still being set correctly after this change. Also skimmed the `winresource` code, no issues jumped out at me.