### PR TITLE
Slim down tests

### DIFF
--- a/crates/nu-command/tests/commands/histogram.rs
+++ b/crates/nu-command/tests/commands/histogram.rs
@@ -94,37 +94,17 @@ fn summarizes_by_values() {
 
 #[test]
 fn help() {
-    Playground::setup("histogram_test_3", |dirs, _sandbox| {
-        let help_command = nu!(
-        cwd: dirs.test(), pipeline(
-        r#"
-                help histogram
-            "#
-        ));
+    let help_command = nu!("help histogram");
+    let help_short = nu!("histogram -h");
+    let help_long = nu!("histogram --help");
 
-        let help_short = nu!(
-        cwd: dirs.test(), pipeline(
-        r#"
-                histogram -h
-            "#
-        ));
-
-        let help_long = nu!(
-        cwd: dirs.test(), pipeline(
-        r#"
-                histogram --help
-            "#
-        ));
-
-        assert_eq!(help_short.out, help_command.out);
-        assert_eq!(help_long.out, help_command.out);
-    })
+    assert_eq!(help_short.out, help_command.out);
+    assert_eq!(help_long.out, help_command.out);
 }
 
 #[test]
 fn count() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo [[bit];  [1] [0] [0] [0] [0] [0] [0] [1] [1]]
             | histogram bit --percentage-type relative

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -2,7 +2,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn regular_columns() {
-    let actual = nu!(cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo [
                 [first_name, last_name, rusty_at, type];
@@ -22,15 +22,14 @@ fn regular_columns() {
 
 #[test]
 fn skip_cell_rejection() {
-    let actual = nu!(cwd: ".", pipeline(
-        r#"[ {a: 1, b: 2,c:txt}, { a:val } ] | reject a | get c?.0"#));
+    let actual = nu!("[ {a: 1, b: 2,c:txt}, { a:val } ] | reject a | get c?.0");
 
     assert_eq!(actual.out, "txt");
 }
 
 #[test]
 fn complex_nested_columns() {
-    let actual = nu!(cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             {
                 "nu": {
@@ -63,7 +62,7 @@ fn complex_nested_columns() {
 
 #[test]
 fn ignores_duplicate_columns_rejected() {
-    let actual = nu!(cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo [
                 ["first name", "last name"];
@@ -82,60 +81,36 @@ fn ignores_duplicate_columns_rejected() {
 
 #[test]
 fn reject_record_from_raw_eval() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
-            {"a": 3} | reject a | describe
-            "#
-        )
-    );
+    let actual = nu!(r#"{"a": 3} | reject a | describe"#);
 
     assert!(actual.out.contains("record"));
 }
 
 #[test]
 fn reject_table_from_raw_eval() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
-            [{"a": 3}] | reject a
-            "#
-        )
-    );
+    let actual = nu!(r#"[{"a": 3}] | reject a"#);
 
     assert!(actual.out.contains("record 0 fields"));
 }
 
 #[test]
 fn reject_nested_field() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
-            {a:{b:3,c:5}} | reject a.b | debug
-            "#
-        )
-    );
+    let actual = nu!("{a:{b:3,c:5}} | reject a.b | debug");
 
     assert_eq!(actual.out, "{a: {c: 5}}");
 }
 
 #[test]
 fn reject_two_identical_elements() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"[[a, a]; [1, 2]] | reject a"#
-        )
-    );
+    let actual = nu!("[[a, a]; [1, 2]] | reject a");
+
     assert!(actual.out.contains("record 0 fields"));
 }
 
 #[test]
 fn reject_large_vec_with_two_identical_elements() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"[[a, b, c, d, e, a]; [1323, 23, 45, 100, 2, 2423]] | reject a"#
-        )
-    );
+    let actual = nu!("[[a, b, c, d, e, a]; [1323, 23, 45, 100, 2, 2423]] | reject a");
+
     assert!(!actual.out.contains("1323"));
     assert!(!actual.out.contains("2423"));
     assert!(actual.out.contains('b'));

--- a/crates/nu-command/tests/commands/semicolon.rs
+++ b/crates/nu-command/tests/commands/semicolon.rs
@@ -1,5 +1,5 @@
+use nu_test_support::nu;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, pipeline};
 
 #[test]
 fn semicolon_allows_lhs_to_complete() {
@@ -18,12 +18,7 @@ fn semicolon_allows_lhs_to_complete() {
 
 #[test]
 fn semicolon_lhs_error_stops_processing() {
-    let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
-    r#"
-        where 1 1; echo done
-    "#
-    ));
+    let actual = nu!("where 1 1; echo done");
 
     assert!(!actual.out.contains("done"));
 }

--- a/crates/nu-command/tests/commands/seq.rs
+++ b/crates/nu-command/tests/commands/seq.rs
@@ -1,25 +1,15 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn float_in_seq_leads_to_lists_of_floats() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        seq 1.0 0.5 6 | describe
-        "#
-    ));
+    let actual = nu!("seq 1.0 0.5 6 | describe");
 
     assert_eq!(actual.out, "list<float> (stream)");
 }
 
 #[test]
 fn ints_in_seq_leads_to_lists_of_ints() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        seq 1 2 6 | describe
-        "#
-    ));
+    let actual = nu!("seq 1 2 6 | describe");
 
     assert_eq!(actual.out, "list<int> (stream)");
 }

--- a/crates/nu-command/tests/commands/seq_char.rs
+++ b/crates/nu-command/tests/commands/seq_char.rs
@@ -1,25 +1,15 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn fails_when_first_arg_is_multiple_chars() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        seq char aa z
-        "#
-    ));
+    let actual = nu!("seq char aa z");
 
     assert!(actual.err.contains("should be 1 character long"));
 }
 
 #[test]
 fn fails_when_second_arg_is_multiple_chars() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        seq char a zz
-        "#
-    ));
+    let actual = nu!("seq char a zz");
 
     assert!(actual.err.contains("should be 1 character long"));
 }

--- a/crates/nu-command/tests/commands/sort.rs
+++ b/crates/nu-command/tests/commands/sort.rs
@@ -35,12 +35,7 @@ fn sort_primitive_values() {
 
 #[test]
 fn sort_different_types() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [a, 1, b, 2, c, 3, [4, 5, 6], d, 4, [1, 2, 3]] | sort | to json --raw
-        "#
-    ));
+    let actual = nu!("[a, 1, b, 2, c, 3, [4, 5, 6], d, 4, [1, 2, 3]] | sort | to json --raw");
 
     let json_output = r#"[1,2,3,4,"a","b","c","d",[1,2,3],[4,5,6]]"#;
     assert_eq!(actual.out, json_output);
@@ -48,20 +43,14 @@ fn sort_different_types() {
 
 #[test]
 fn sort_natural() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"['1' '2' '3' '4' '5' '10' '100'] | sort -n | to nuon"#
-    ));
+    let actual = nu!("['1' '2' '3' '4' '5' '10' '100'] | sort -n | to nuon");
 
     assert_eq!(actual.out, r#"["1", "2", "3", "4", "5", "10", "100"]"#);
 }
 
 #[test]
 fn sort_record_natural() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"{10:0,99:0,1:0,9:0,100:0} | sort -n | to nuon"#
-    ));
+    let actual = nu!("{10:0,99:0,1:0,9:0,100:0} | sort -n | to nuon");
 
     assert_eq!(
         actual.out,
@@ -71,50 +60,35 @@ fn sort_record_natural() {
 
 #[test]
 fn sort_record_insensitive() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"{abe:1,zed:2,ABE:3} | sort -i | to nuon"#
-    ));
+    let actual = nu!("{abe:1,zed:2,ABE:3} | sort -i | to nuon");
 
     assert_eq!(actual.out, r#"{abe: 1, ABE: 3, zed: 2}"#);
 }
 
 #[test]
 fn sort_record_insensitive_reverse() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"{abe:1,zed:2,ABE:3} | sort -ir | to nuon"#
-    ));
+    let actual = nu!("{abe:1,zed:2,ABE:3} | sort -ir | to nuon");
 
     assert_eq!(actual.out, r#"{zed: 2, ABE: 3, abe: 1}"#);
 }
 
 #[test]
 fn sort_record_values_natural() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"{1:"1",2:"2",4:"100",3:"10"} | sort -vn | to nuon"#
-    ));
+    let actual = nu!(r#"{1:"1",2:"2",4:"100",3:"10"} | sort -vn | to nuon"#);
 
     assert_eq!(actual.out, r#"{"1": "1", "2": "2", "3": "10", "4": "100"}"#);
 }
 
 #[test]
 fn sort_record_values_insensitive() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"{1:abe,2:zed,3:ABE} | sort -vi | to nuon"#
-    ));
+    let actual = nu!("{1:abe,2:zed,3:ABE} | sort -vi | to nuon");
 
     assert_eq!(actual.out, r#"{"1": abe, "3": ABE, "2": zed}"#);
 }
 
 #[test]
 fn sort_record_values_insensitive_reverse() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"{1:abe,2:zed,3:ABE} | sort -vir | to nuon"#
-    ));
+    let actual = nu!("{1:abe,2:zed,3:ABE} | sort -vir | to nuon");
 
     assert_eq!(actual.out, r#"{"2": zed, "3": ABE, "1": abe}"#);
 }

--- a/crates/nu-command/tests/commands/sort_by.rs
+++ b/crates/nu-command/tests/commands/sort_by.rs
@@ -117,19 +117,14 @@ fn ls_sort_by_type_name_insensitive() {
 
 #[test]
 fn no_column_specified_fails() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [2 0 1] | sort-by
-        "#
-    ));
+    let actual = nu!("[2 0 1] | sort-by");
 
     assert!(actual.err.contains("missing parameter"));
 }
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | sort-by"));
+    let actual = nu!("1 | sort-by");
 
     assert!(actual.err.contains("only_supports_this_input_type"));
 }

--- a/crates/nu-command/tests/commands/transpose.rs
+++ b/crates/nu-command/tests/commands/transpose.rs
@@ -1,37 +1,22 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn row() {
-    let actual = nu!(
-    cwd: ".", pipeline(
-    r#"
-        [[key value]; [foo 1] [foo 2]] | transpose -r | debug
-            "#
-    ));
+    let actual = nu!("[[key value]; [foo 1] [foo 2]] | transpose -r | debug");
 
     assert!(actual.out.contains("foo: 1"));
 }
 
 #[test]
 fn row_but_last() {
-    let actual = nu!(
-    cwd: ".", pipeline(
-    r#"
-        [[key value]; [foo 1] [foo 2]] | transpose -r -l | debug
-            "#
-    ));
+    let actual = nu!("[[key value]; [foo 1] [foo 2]] | transpose -r -l | debug");
 
     assert!(actual.out.contains("foo: 2"));
 }
 
 #[test]
 fn row_but_all() {
-    let actual = nu!(
-    cwd: ".", pipeline(
-    r#"
-        [[key value]; [foo 1] [foo 2]] | transpose -r -a | debug
-            "#
-    ));
+    let actual = nu!("[[key value]; [foo 1] [foo 2]] | transpose -r -a | debug");
 
     assert!(actual.out.contains("foo: [1, 2]"));
 }

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -180,14 +180,14 @@ fn uniq_unique() {
 
 #[test]
 fn uniq_simple_vals_ints() {
-    let actual = nu!("[1 2 3 4 1 5]| uniq");
+    let actual = nu!("[1 2 3 4 1 5] | uniq");
     let expected = nu!("[1 2 3 4 5]");
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn uniq_simple_vals_strs() {
-    let actual = nu!("[A B C A]| uniq");
+    let actual = nu!("[A B C A] | uniq");
     let expected = nu!("[A B C]");
     assert_eq!(actual.out, expected.out);
 }

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -23,7 +23,6 @@ fn removes_duplicate_rows() {
                 open los_tres_caballeros.csv
                 | uniq
                 | length
-
             "#
         ));
 
@@ -53,7 +52,6 @@ fn uniq_values() {
                 | select type
                 | uniq
                 | length
-
             "#
         ));
 
@@ -125,7 +123,6 @@ fn nested_json_structures() {
                 open nested_json_structures.json
                 | uniq
                 | length
-
             "#
         ));
         assert_eq!(actual.out, "3");
@@ -134,13 +131,11 @@ fn nested_json_structures() {
 
 #[test]
 fn uniq_when_keys_out_of_order() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [{"a": "a", "b": [1,2,3]}, {"b": [1,2,3], "a": "a"}]
             | uniq
             | length
-
         "#
     ));
 
@@ -149,8 +144,7 @@ fn uniq_when_keys_out_of_order() {
 
 #[test]
 fn uniq_counting() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             ["A", "B", "A"]
             | wrap item
@@ -163,10 +157,9 @@ fn uniq_counting() {
     ));
     assert_eq!(actual.out, "2");
 
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
-            echo ["A", "B", "A"]
+            ["A", "B", "A"]
             | wrap item
             | uniq --count
             | flatten
@@ -180,89 +173,41 @@ fn uniq_counting() {
 
 #[test]
 fn uniq_unique() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            echo [1 2 3 4 1 5]
-            | uniq --unique
-        "#
-    ));
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        echo [2 3 4 5]
-        "#
-    ));
-    print!("{}", actual.out);
-    print!("{}", expected.out);
+    let actual = nu!("[1 2 3 4 1 5] | uniq --unique");
+    let expected = nu!("[2 3 4 5]");
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn uniq_simple_vals_ints() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            echo [1 2 3 4 1 5]
-            | uniq
-        "#
-    ));
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        echo [1 2 3 4 5]
-        "#
-    ));
-    print!("{}", actual.out);
-    print!("{}", expected.out);
+    let actual = nu!("[1 2 3 4 1 5]| uniq");
+    let expected = nu!("[1 2 3 4 5]");
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn uniq_simple_vals_strs() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            echo [A B C A]
-            | uniq
-        "#
-    ));
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        echo [A B C]
-        "#
-    ));
-    print!("{}", actual.out);
-    print!("{}", expected.out);
+    let actual = nu!("[A B C A]| uniq");
+    let expected = nu!("[A B C]");
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn table() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[fruit day]; [apple monday] [apple friday] [Apple friday] [apple monday] [pear monday] [orange tuesday]]
             | uniq
         "#
     ));
 
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        echo [[fruit day]; [apple monday] [apple friday] [Apple friday] [pear monday] [orange tuesday]]
-        "#
-    ));
-    print!("{}", actual.out);
-    print!("{}", expected.out);
+    let expected = nu!("[[fruit day]; [apple monday] [apple friday] [Apple friday] [pear monday] [orange tuesday]]");
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn table_with_ignore_case() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[origin, people];
                 [World, (
@@ -284,8 +229,7 @@ fn table_with_ignore_case() {
         "#
     ));
 
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let expected = nu!(pipeline(
         r#"
         echo [[origin, people];
                 [World, (
@@ -302,8 +246,5 @@ fn table_with_ignore_case() {
         "#
     ));
 
-    print!("{}", actual.out);
-    print!("{}", expected.out);
-    assert_eq!(actual.out, expected.out);
     assert_eq!(actual.out, expected.out);
 }

--- a/crates/nu-command/tests/commands/uniq_by.rs
+++ b/crates/nu-command/tests/commands/uniq_by.rs
@@ -22,7 +22,6 @@ fn removes_duplicate_rows() {
                 open los_tres_caballeros.csv
                 | uniq-by last_name
                 | length
-
             "#
         ));
 
@@ -32,30 +31,15 @@ fn removes_duplicate_rows() {
 
 #[test]
 fn uniq_when_keys_out_of_order() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [{"a": "a", "b": [1,2,3]}, {"b": [1,2,3,4], "a": "a"}]
-            | uniq-by a
-        "#
-    ));
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        echo [{"a": "a", "b": [1,2,3]}]
-        "#
-    ));
+    let actual = nu!(r#"[{"a": "a", "b": [1,2,3]}, {"b": [1,2,3,4], "a": "a"}] | uniq-by a"#);
+    let expected = nu!(r#"[{"a": "a", "b": [1,2,3]}]"#);
 
-    print!("{}", actual.out);
-    print!("{}", expected.out);
-    assert_eq!(actual.out, expected.out);
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn uniq_counting() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             ["A", "B", "A"]
             | wrap item
@@ -68,10 +52,9 @@ fn uniq_counting() {
     ));
     assert_eq!(actual.out, "2");
 
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
-            echo ["A", "B", "A"]
+            ["A", "B", "A"]
             | wrap item
             | uniq-by item --count
             | flatten
@@ -85,8 +68,7 @@ fn uniq_counting() {
 
 #[test]
 fn uniq_unique() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo [1 2 3 4 1 5]
             | wrap item
@@ -94,29 +76,20 @@ fn uniq_unique() {
             | get item
         "#
     ));
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        echo [2 3 4 5]
-        "#
-    ));
-    print!("{}", actual.out);
-    print!("{}", expected.out);
+    let expected = nu!("[2 3 4 5]");
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn table() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[fruit day]; [apple monday] [apple friday] [Apple friday] [apple monday] [pear monday] [orange tuesday]]
             | uniq-by fruit
         "#
     ));
 
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let expected = nu!(pipeline(
         r#"
         echo [[fruit day]; [apple monday] [Apple friday] [pear monday] [orange tuesday]]
         "#
@@ -135,29 +108,24 @@ fn uniq_by_empty() {
 
 #[test]
 fn uniq_by_multiple_columns() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[fruit day]; [apple monday] [apple friday] [Apple friday] [apple monday] [pear monday] [orange tuesday]]
             | uniq-by fruit day
         "#
     ));
 
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let expected = nu!(pipeline(
         r#"
         echo [[fruit day]; [apple monday] [apple friday] [Apple friday] [pear monday] [orange tuesday]]
         "#
     ));
-    print!("{}", actual.out);
-    print!("{}", expected.out);
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn table_with_ignore_case() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[origin, people];
                 [World, (
@@ -179,8 +147,7 @@ fn table_with_ignore_case() {
         "#
     ));
 
-    let expected = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+    let expected = nu!(pipeline(
         r#"
         echo [[origin, people];
                 [World, (
@@ -197,33 +164,19 @@ fn table_with_ignore_case() {
         "#
     ));
 
-    print!("{}", actual.out);
-    print!("{}", expected.out);
-    assert_eq!(actual.out, expected.out);
     assert_eq!(actual.out, expected.out);
 }
 
 #[test]
 fn missing_parameter() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [11 22 33] | uniq-by
-        "#
-    ));
+    let actual = nu!("[11 22 33] | uniq-by");
 
     assert!(actual.err.contains("missing parameter"));
 }
 
 #[test]
 fn wrong_column() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            [[fruit day]; [apple monday] [apple friday]]
-            | uniq-by column1
-        "#
-    ));
+    let actual = nu!("[[fruit day]; [apple monday] [apple friday]] | uniq-by column1");
 
     assert!(actual.err.contains("cannot find column 'column1'"));
 }

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -16,9 +16,7 @@ fn sets_the_column() {
 
 #[test]
 fn doesnt_convert_record_to_table() {
-    let actual = nu!(
-        cwd: ".", r#"{a:1} | update a 2 | to nuon"#
-    );
+    let actual = nu!("{a:1} | update a 2 | to nuon");
 
     assert_eq!(actual.out, "{a: 2}");
 }
@@ -83,44 +81,27 @@ fn upsert_column_missing() {
 
 #[test]
 fn update_list() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            [1, 2, 3] | update 1 abc | to json -r
-        "#
-    ));
-
+    let actual = nu!("[1, 2, 3] | update 1 abc | to json -r");
     assert_eq!(actual.out, r#"[1,"abc",3]"#);
 }
 
 #[test]
 fn update_past_end_list() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-            [1, 2, 3] | update 5 abc | to json -r
-        "#
-    ));
-
+    let actual = nu!("[1, 2, 3] | update 5 abc | to json -r");
     assert!(actual.err.contains("too large"));
 }
 
 #[test]
 fn update_nonexistent_column() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"{a:1} | update b 2"#
-    ));
-
+    let actual = nu!("{a:1} | update b 2");
     assert!(actual.err.contains("cannot find column 'b'"));
 }
 
 #[test]
 fn update_uses_enumerate_index() {
     let actual = nu!(
-        cwd: ".", pipeline(
         r#"[[a]; [7] [6]] | enumerate | update item.a {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"#
-    ));
+    );
 
     assert_eq!(actual.out, "[[index, a]; [0, 8], [1, 8]]");
 }

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -16,10 +16,7 @@ fn sets_the_column() {
 
 #[test]
 fn doesnt_convert_record_to_table() {
-    let actual = nu!(
-        cwd: ".", r#"{a:1} | upsert a 2 | to nuon"#
-    );
-
+    let actual = nu!("{a:1} | upsert a 2 | to nuon");
     assert_eq!(actual.out, "{a: 2}");
 }
 
@@ -80,30 +77,21 @@ fn upsert_uses_enumerate_index_inserting() {
 
 #[test]
 fn upsert_uses_enumerate_index_updating() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[[a]; [7] [6]] | enumerate | upsert a {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"#
-    ));
+    let actual = nu!("[[a]; [7] [6]] | enumerate | upsert a {|el| $el.index + 1 + $el.item.a } | flatten | to nuon");
 
     assert_eq!(actual.out, "[[index, a]; [0, 8], [1, 8]]");
 }
 
 #[test]
 fn index_does_not_exist() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1,2,3] | upsert 4 4"#
-    ));
+    let actual = nu!("[1,2,3] | upsert 4 4");
 
     assert!(actual.err.contains("index too large (max: 3)"));
 }
 
 #[test]
 fn upsert_empty() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[] | upsert 1 1"#
-    ));
+    let actual = nu!("[] | upsert 1 1");
 
     assert!(actual.err.contains("index too large (max: 0)"));
 }

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -14,7 +14,6 @@ fn filters_by_unit_size_comparison() {
 #[test]
 fn filters_with_nothing_comparison() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         r#"'[{"foo": 3}, {"foo": null}, {"foo": 4}]' | from json | get foo | compact | where $it > 1 | math sum"#
     );
 
@@ -33,20 +32,14 @@ fn where_inside_block_works() {
 
 #[test]
 fn filters_with_0_arity_block() {
-    let actual = nu!(
-        cwd: ".",
-        "[1 2 3 4] | where {|| $in < 3 } | to nuon"
-    );
+    let actual = nu!("[1 2 3 4] | where {|| $in < 3 } | to nuon");
 
     assert_eq!(actual.out, "[1, 2]");
 }
 
 #[test]
 fn filters_with_1_arity_block() {
-    let actual = nu!(
-        cwd: ".",
-        "[1 2 3 6 7 8] | where {|e| $e < 5 } | to nuon"
-    );
+    let actual = nu!("[1 2 3 6 7 8] | where {|e| $e < 5 } | to nuon");
 
     assert_eq!(actual.out, "[1, 2, 3]");
 }
@@ -64,7 +57,6 @@ fn unique_env_each_iteration() {
 #[test]
 fn where_in_table() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         r#"'[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name in ["foo"] | get size | math sum"#
     );
 
@@ -74,7 +66,6 @@ fn where_in_table() {
 #[test]
 fn where_not_in_table() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         r#"'[{"name": "foo", "size": 3}, {"name": "foo", "size": 2}, {"name": "bar", "size": 4}]' | from json | where name not-in ["foo"] | get size | math sum"#
     );
 
@@ -83,10 +74,7 @@ fn where_not_in_table() {
 
 #[test]
 fn where_uses_enumerate_index() {
-    let actual = nu!(
-        cwd: ".",
-        r#"[7 8 9 10] | enumerate | where {|el| $el.index < 2 } | to nuon"#
-    );
+    let actual = nu!("[7 8 9 10] | enumerate | where {|el| $el.index < 2 } | to nuon");
 
     assert_eq!(actual.out, "[[index, item]; [0, 7], [1, 8]]");
 }


### PR DESCRIPTION
This PR just tidies up some tests by removing unused code:

1. If the filesystem is not touched, don't use the filesystem playground/sandbox
2. If the filesystem is not touched, don't specify the `cwd`
3. If the command is short, don't bother wrapping it in `pipeline()`
4. If the command doesn't have quotes, don't bother with a `r#"..."#` raw string

Part of #8670. 