### PR TITLE
Remove npm install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ To quickly install Nu:
 brew install nushell
 # Windows
 winget install nushell
-# Cross Platform installation if you have node and npm installed, Note that nu plugins were not included
-npm install -g nushell
 ```
 
 To use `Nu` in GitHub Action, check [setup-nu](https://github.com/marketplace/actions/setup-nu) for more detail.


### PR DESCRIPTION
# Description

Remove npm install instruction

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
