### PR TITLE
TRIAGE: add the `needs-triage` to all `ISSUE_TEMPLATE`s

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug Report
 description: Create a report to help us improve
+labels: ["needs-triage"]
 body: 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: "When you want a new feature for something that doesn't already exist"
-labels: "enhancement"
+labels: ["needs-triage", "enhancement"]
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/standard-library-bug-or-feature-report.md
+++ b/.github/ISSUE_TEMPLATE/standard-library-bug-or-feature-report.md
@@ -2,7 +2,7 @@
 name: standard library bug or feature report
 about: Used to submit issues related to the nu standard library
 title: ''
-labels: std-library
+labels: ['needs-triage', 'std-library']
 assignees: ''
 
 ---


### PR DESCRIPTION
as can be seen [here](https://github.com/nushell/nushell/labels?q=needs-), i've created the `needs-triage` and `needs-core-team-attention` labels.

in this PR, i made the `needs-triage` a default label to all the issue templates :yum: 