### PR TITLE
fix: fix cursor position when cursor is at the end of the commandline

### DIFF
--- a/crates/nu-cli/src/commands/commandline.rs
+++ b/crates/nu-cli/src/commands/commandline.rs
@@ -118,8 +118,9 @@ impl Command for Commandline {
                     .expect("repl cursor pos mutex");
                 let char_pos = buffer
                     .grapheme_indices(true)
+                    .chain(std::iter::once((*cursor_pos, "")))
                     .position(|(i, _c)| i == *cursor_pos)
-                    .unwrap_or(buffer.len());
+                    .expect("Cursor position isn't on a grapheme boundary");
                 Ok(Value::String {
                     val: char_pos.to_string(),
                     span: call.head,

--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -62,7 +62,27 @@ fn commandline_test_cursor() -> TestResult {
 }
 
 #[test]
-fn commandline_test_cursor_show_pos() -> TestResult {
+fn commandline_test_cursor_show_pos_begin() -> TestResult {
+    run_test(
+        "commandline --replace '0👩‍❤️‍👩'\n\
+        commandline --cursor '0'\n\
+        commandline --cursor",
+        "0",
+    )
+}
+
+#[test]
+fn commandline_test_cursor_show_pos_end() -> TestResult {
+    run_test(
+        "commandline --replace '0👩‍❤️‍👩'\n\
+        commandline --cursor '2'\n\
+        commandline --cursor",
+        "2",
+    )
+}
+
+#[test]
+fn commandline_test_cursor_show_pos_mid() -> TestResult {
     run_test(
         "commandline --replace '0👩‍❤️‍👩2'\n\
         commandline --cursor '1'\n\

--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -47,14 +47,14 @@ fn commandline_test_replace() -> TestResult {
 fn commandline_test_cursor() -> TestResult {
     run_test(
         "commandline --replace '0👩‍❤️‍👩2'\n\
-        commandline --cursor '1' \n\
+        commandline --cursor '1'\n\
         commandline --insert 'x'\n\
         commandline",
         "0x👩‍❤️‍👩2",
     )?;
     run_test(
         "commandline --replace '0👩‍❤️‍👩2'\n\
-        commandline --cursor '2' \n\
+        commandline --cursor '2'\n\
         commandline --insert 'x'\n\
         commandline",
         "0👩‍❤️‍👩x2",
@@ -65,13 +65,13 @@ fn commandline_test_cursor() -> TestResult {
 fn commandline_test_cursor_show_pos() -> TestResult {
     run_test(
         "commandline --replace '0👩‍❤️‍👩2'\n\
-        commandline --cursor '1' \n\
+        commandline --cursor '1'\n\
         commandline --cursor",
         "1",
     )?;
     run_test(
         "commandline --replace '0👩‍❤️‍👩2'\n\
-        commandline --cursor '2' \n\
+        commandline --cursor '2'\n\
         commandline --cursor",
         "2",
     )
@@ -81,7 +81,7 @@ fn commandline_test_cursor_show_pos() -> TestResult {
 fn commandline_test_cursor_too_small() -> TestResult {
     run_test(
         "commandline --replace '123456'\n\
-        commandline --cursor '-1' \n\
+        commandline --cursor '-1'\n\
         commandline --insert '0'\n\
         commandline",
         "0123456",
@@ -92,7 +92,7 @@ fn commandline_test_cursor_too_small() -> TestResult {
 fn commandline_test_cursor_too_large() -> TestResult {
     run_test(
         "commandline --replace '123456'\n\
-        commandline --cursor '10' \n\
+        commandline --cursor '10'\n\
         commandline --insert '0'\n\
         commandline",
         "1234560",


### PR DESCRIPTION
# Description
Fix getting the cursor position, when it's at the end of the commandline.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting

# After Submitting
