### PR TITLE
REFACTOR: have a single `std` loading call

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ use nu_cli::gather_parent_env_vars;
 use nu_command::{create_default_context, get_init_cwd};
 use nu_protocol::{report_error_new, Value};
 use nu_protocol::{util::BufferedReader, PipelineData, RawStream};
+use nu_std::load_standard_library;
 use nu_utils::utils::perf;
 use run::{run_commands, run_file, run_repl};
 use signals::{ctrlc_protection, sigquit_protection};
@@ -245,6 +246,10 @@ fn main() -> Result<()> {
         column!(),
         use_color,
     );
+
+    if parsed_nu_cli_args.no_std_lib.is_none() {
+        load_standard_library(&mut engine_state)?;
+    }
 
     if let Some(commands) = parsed_nu_cli_args.commands.clone() {
         run_commands(

--- a/src/run.rs
+++ b/src/run.rs
@@ -8,7 +8,6 @@ use crate::{
 use nu_cli::read_plugin_file;
 use nu_cli::{evaluate_commands, evaluate_file, evaluate_repl};
 use nu_protocol::PipelineData;
-use nu_std::load_standard_library;
 use nu_utils::utils::perf;
 
 pub(crate) fn run_commands(
@@ -21,10 +20,6 @@ pub(crate) fn run_commands(
 ) -> Result<(), miette::ErrReport> {
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
-
-    if parsed_nu_cli_args.no_std_lib.is_none() {
-        load_standard_library(engine_state)?;
-    }
 
     #[cfg(feature = "plugin")]
     read_plugin_file(
@@ -112,10 +107,6 @@ pub(crate) fn run_file(
 ) -> Result<(), miette::ErrReport> {
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
-
-    if parsed_nu_cli_args.no_std_lib.is_none() {
-        load_standard_library(engine_state)?;
-    }
 
     #[cfg(feature = "plugin")]
     read_plugin_file(
@@ -213,10 +204,6 @@ pub(crate) fn run_repl(
 ) -> Result<(), miette::ErrReport> {
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
-
-    if parsed_nu_cli_args.no_std_lib.is_none() {
-        load_standard_library(engine_state)?;
-    }
 
     if parsed_nu_cli_args.no_config_file.is_none() {
         setup_config(


### PR DESCRIPTION
# Description
this PR moves the three individual call to `load_standard_library` in the "Nushell branches" of `run.rs` into a single one, before the `if`, in `main.rs`.

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```