### PR TITLE
FIX: give same order in `std help ...` as in `help ...`

### DIFF
--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -33,7 +33,7 @@ def command-not-found-error [span: record] {
     throw-error "std::help::command_not_found" "command not found" $span
 }
 
-def get-all-operators [] { return ([
+def get-all-operators [] { return [
     [type, operator, name, description, precedence];
 
     [Assignment, =, Assign, "Assigns a value to a variable.", 10]
@@ -71,7 +71,7 @@ def get-all-operators [] { return ([
     [Boolean, and, And, "Checks if two values are true.", 50]
     [Boolean, or, Or, "Checks if either value is true.", 40]
     [Boolean, xor, Xor, "Checks if one value is true and the other is false.", 45]
-] | sort-by name)}
+]}
 
 def "nu-complete list-aliases" [] {
     $nu.scope.aliases | select name usage | rename value description

--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -241,7 +241,7 @@ export def "help modules" [
     ...module: string@"nu-complete list-modules"  # the name of module to get help on
     --find (-f): string  # string to find in module names
 ] {
-    let modules = ($nu.scope.modules | sort-by name)
+    let modules = $nu.scope.modules
 
     let module = ($module | str join " ")
 


### PR DESCRIPTION
Should close on of the points in
- https://github.com/nushell/nushell/issues/8813

# Description
before this PR, we had a problem
```
cargo run -- -c '{
     modules: ((help modules | get name) == (std help modules | get name))
     aliases: ((help aliases | get name) == (std help aliases | get name))
     externs: ((help externs | get name) == (std help externs | get name))
     operators: ((help operators | get name) == (std help operators | get name))
     commands: ((help commands | get name) == (std help commands | get name))
}'
```
would give
```
╭───────────┬───────╮
│ modules   │ false │
│ aliases   │ true  │
│ externs   │ true  │
│ operators │ false │
│ commands  │ true  │
╰───────────┴───────╯
```

this PR removes the `name` sorting so that the orders are the same between the `std` implementation and the built-in one.

> **Note**
> run the same `cargo run` command as above and see
> ```
> ╭───────────┬──────╮
> │ modules   │ true │
> │ aliases   │ true │
> │ externs   │ true │
> │ operators │ true │
> │ commands  │ true │
> ╰───────────┴──────╯
> ```

# User-Facing Changes
the operators in `std help ...` will be sorted just as the built-in `help ...`.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```