### PR TITLE
FIX: filter the `std help ...` by name, usage and search terms

### DIFF
--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -246,7 +246,7 @@ export def "help modules" [
     let module = ($module | str join " ")
 
     if not ($find | is-empty) {
-        let found_modules = ($modules | find $find)
+        let found_modules = ($modules | find $find --columns [name usage search_terms])
 
         if ($found_modules | length) == 1 {
             show-module ($found_modules | get 0)
@@ -356,7 +356,7 @@ export def "help aliases" [
     let alias = ($alias | str join " ")
 
     if not ($find | is-empty) {
-        let found_aliases = ($aliases | find $find)
+        let found_aliases = ($aliases | find $find --columns [name usage search_terms])
 
         if ($found_aliases | length) == 1 {
             show-alias ($found_aliases | get 0)
@@ -402,7 +402,7 @@ export def "help externs" [
     let extern = ($extern | str join " ")
 
     if not ($find | is-empty) {
-        let found_externs = ($externs | find $find)
+        let found_externs = ($externs | find $find --columns [name usage search_terms])
 
         if ($found_externs | length) == 1 {
             show-extern ($found_externs | get 0)
@@ -474,7 +474,7 @@ export def "help operators" [
     let operator = ($operator | str join " ")
 
     if not ($find | is-empty) {
-        let found_operators = ($operators | find $find)
+        let found_operators = ($operators | find $find --columns [name usage search_terms])
 
         if ($found_operators | length) == 1 {
             show-operator ($found_operators | get 0)
@@ -663,7 +663,7 @@ export def "help commands" [
     let command = ($command | str join " ")
 
     if not ($find | is-empty) {
-        let found_commands = ($commands | find $find)
+        let found_commands = ($commands | find $find --columns [name usage search_terms])
 
         if ($found_commands | length) == 1 {
             show-command ($found_commands | get 0)

--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -246,7 +246,7 @@ export def "help modules" [
     let module = ($module | str join " ")
 
     if not ($find | is-empty) {
-        let found_modules = ($modules | find $find --columns [name usage search_terms])
+        let found_modules = ($modules | find $find --columns [name usage])
 
         if ($found_modules | length) == 1 {
             show-module ($found_modules | get 0)
@@ -356,7 +356,7 @@ export def "help aliases" [
     let alias = ($alias | str join " ")
 
     if not ($find | is-empty) {
-        let found_aliases = ($aliases | find $find --columns [name usage search_terms])
+        let found_aliases = ($aliases | find $find --columns [name usage])
 
         if ($found_aliases | length) == 1 {
             show-alias ($found_aliases | get 0)
@@ -402,7 +402,7 @@ export def "help externs" [
     let extern = ($extern | str join " ")
 
     if not ($find | is-empty) {
-        let found_externs = ($externs | find $find --columns [name usage search_terms])
+        let found_externs = ($externs | find $find --columns [name usage])
 
         if ($found_externs | length) == 1 {
             show-extern ($found_externs | get 0)
@@ -474,7 +474,7 @@ export def "help operators" [
     let operator = ($operator | str join " ")
 
     if not ($find | is-empty) {
-        let found_operators = ($operators | find $find --columns [name usage search_terms])
+        let found_operators = ($operators | find $find --columns [type name])
 
         if ($found_operators | length) == 1 {
             show-operator ($found_operators | get 0)


### PR DESCRIPTION
Should close on of the points in
- https://github.com/nushell/nushell/issues/8813

# Description
this PR uses the new `--columns` option for `find` to filter the results of the `std help` commands on the `usage`, `name` and `search_terms` columns.

# User-Facing Changes
the `--find` option of `std help` commands should match more closely the built-in `help` commands output.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```