### PR TITLE
allow hyphens in variable names

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -52,7 +52,6 @@ fn is_identifier_byte(b: u8) -> bool {
         && b != b'('
         && b != b'{'
         && b != b'+'
-        && b != b'-'
         && b != b'*'
         && b != b'^'
         && b != b'/'
@@ -135,7 +134,9 @@ fn is_identifier(bytes: &[u8]) -> bool {
 }
 
 pub fn is_variable(bytes: &[u8]) -> bool {
-    if bytes.len() > 1 && bytes[0] == b'$' {
+    if bytes.starts_with(b"-") {
+        false
+    } else if bytes.len() > 1 && bytes[0] == b'$' {
         is_identifier(&bytes[1..])
     } else {
         is_identifier(bytes)
@@ -3415,13 +3416,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     contents.split(|x| x == &b'(').map(|x| x.to_vec()).collect();
 
                                 let long = String::from_utf8_lossy(&flags[0][2..]).to_string();
-                                let mut variable_name = flags[0][2..].to_vec();
-                                // Replace the '-' in a variable name with '_'
-                                (0..variable_name.len()).for_each(|idx| {
-                                    if variable_name[idx] == b'-' {
-                                        variable_name[idx] = b'_';
-                                    }
-                                });
+                                let variable_name = flags[0][2..].to_vec();
 
                                 if !is_variable(&variable_name) {
                                     working_set.error(ParseError::Expected(
@@ -3470,13 +3465,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         String::from_utf8_lossy(short_flag).to_string();
                                     let chars: Vec<char> = short_flag.chars().collect();
                                     let long = String::from_utf8_lossy(&flags[0][2..]).to_string();
-                                    let mut variable_name = flags[0][2..].to_vec();
-
-                                    (0..variable_name.len()).for_each(|idx| {
-                                        if variable_name[idx] == b'-' {
-                                            variable_name[idx] = b'_';
-                                        }
-                                    });
+                                    let variable_name = flags[0][2..].to_vec();
 
                                     if !is_variable(&variable_name) {
                                         working_set.error(ParseError::Expected(

--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -104,7 +104,7 @@ def print-help-header [
 ] {
     let header = $"(ansi green)($text)(ansi reset):"
 
-    if $no_newline {
+    if $no-newline {
         print -n $header
     } else {
         print $header

--- a/crates/nu-std/lib/iter.nu
+++ b/crates/nu-std/lib/iter.nu
@@ -31,9 +31,9 @@ export def "iter find" [ # -> any | null
     fn: closure          # the closure used to perform the search 
 ] {
     try {
-       filter $fn | get 0?
+        filter $fn | get 0?
     } catch {
-       null
+        null
     }
 }
 
@@ -51,11 +51,11 @@ export def "iter intersperse" [ # -> list<any>
     separator: any,             # the separator to be used
 ] {
     reduce -f [] {|it, acc|
-          $acc ++ [$it, $separator]
+        $acc ++ [$it, $separator]
     } 
     | match $in {
-         [] => [],
-         $xs => ($xs | take (($xs | length) - 1 ))
+        [] => [],
+        $xs => ($xs | take (($xs | length) - 1 ))
     }
 }
 
@@ -72,7 +72,7 @@ export def "iter intersperse" [ # -> list<any>
 #
 # assert equal $scanned [0, 1, 3, 6]
 #
-# # use the --noinit(-n) flag to remove the initial value from
+# # use the --no-init(-n) flag to remove the initial value from
 # # the final result
 # let scanned = ([1 2 3] | iter scan 0 {|x, y| $x + $y} -n)
 #
@@ -81,16 +81,16 @@ export def "iter intersperse" [ # -> list<any>
 export def "iter scan" [ # -> list<any>
     init: any            # initial value to seed the initial state
     fn: closure          # the closure to perform the scan
-    --noinit(-n)         # remove the initial value from the result
+    --no-init(-n)        # remove the initial value from the result
 ] {                      
-   reduce -f [$init] {|it, acc|
-      $acc ++ [(do $fn ($acc | last) $it)]
-   }
-   | if $noinit {
-     $in | skip
-   } else {
-      $in
-   }
+    reduce -f [$init] {|it, acc|
+        $acc ++ [(do $fn ($acc | last) $it)]
+    }
+    | if $no-init {
+        $in | skip
+    } else {
+        $in
+    }
 }
 
 # Returns a list of values for which the supplied closure does not

--- a/crates/nu-std/lib/testing.nu
+++ b/crates/nu-std/lib/testing.nu
@@ -46,7 +46,7 @@ export def assert [
     let span = (metadata $condition).span
     error make {
         msg: ($message | default "Assertion failed."),
-        label: ($error_label | default {
+        label: ($error-label | default {
             text: "It is not true.",
             start: (metadata $condition).span.start,
             end: (metadata $condition).span.end

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -68,7 +68,7 @@ fn do_rest_args() -> TestResult {
 #[test]
 fn custom_switch1() -> TestResult {
     run_test(
-        r#"def florb [ --dry-run: bool ] { if ($dry_run) { "foo" } else { "bar" } }; florb --dry-run"#,
+        r#"def florb [ --dry-run: bool ] { if ($dry-run) { "foo" } else { "bar" } }; florb --dry-run"#,
         "foo",
     )
 }
@@ -76,7 +76,7 @@ fn custom_switch1() -> TestResult {
 #[test]
 fn custom_switch2() -> TestResult {
     run_test(
-        r#"def florb [ --dry-run: bool ] { if ($dry_run) { "foo" } else { "bar" } }; florb"#,
+        r#"def florb [ --dry-run: bool ] { if ($dry-run) { "foo" } else { "bar" } }; florb"#,
         "bar",
     )
 }
@@ -84,7 +84,7 @@ fn custom_switch2() -> TestResult {
 #[test]
 fn custom_switch3() -> TestResult {
     run_test(
-        r#"def florb [ --dry-run ] { if ($dry_run) { "foo" } else { "bar" } }; florb --dry-run"#,
+        r#"def florb [ --dry-run ] { if ($dry-run) { "foo" } else { "bar" } }; florb --dry-run"#,
         "foo",
     )
 }
@@ -92,7 +92,7 @@ fn custom_switch3() -> TestResult {
 #[test]
 fn custom_switch4() -> TestResult {
     run_test(
-        r#"def florb [ --dry-run ] { if ($dry_run) { "foo" } else { "bar" } }; florb"#,
+        r#"def florb [ --dry-run ] { if ($dry-run) { "foo" } else { "bar" } }; florb"#,
         "bar",
     )
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -141,11 +141,6 @@ fn bad_var_name() -> TestResult {
 }
 
 #[test]
-fn bad_var_name2() -> TestResult {
-    fail_test(r#"let $foo-bar = 4"#, "valid variable")
-}
-
-#[test]
 fn long_flag() -> TestResult {
     run_test(
         r#"([a, b, c] | enumerate | each --keep-empty { |e| if $e.index != 1 { 100 }}).1 | to nuon"#,
@@ -156,6 +151,34 @@ fn long_flag() -> TestResult {
 #[test]
 fn let_not_statement() -> TestResult {
     fail_test(r#"let x = "hello" | str length"#, "used in pipeline")
+}
+
+#[test]
+fn variable_name_with_hyphen_1() -> TestResult {
+    run_test("let my-var = 42; $my-var", "42")
+}
+
+#[test]
+fn variable_name_with_hyphen_2() -> TestResult {
+    fail_test("let -my-var = 42; $my-var", "expected valid variable name")
+}
+
+#[test]
+fn variable_name_with_hyphen_3() -> TestResult {
+    run_test("def my-cmd [my-param] { $my-param }; my-cmd 42", "42")
+}
+
+#[test]
+fn variable_name_with_hyphen_4() -> TestResult {
+    run_test(
+        "def my-cmd [--my-param: int] { $my-param }; my-cmd --my-param 42",
+        "42",
+    )
+}
+
+#[test]
+fn variable_name_with_hyphen_5() -> TestResult {
+    run_test("def my-cmd [my-param?: int] { $my-param }; my-cmd 42", "42")
 }
 
 #[test]


### PR DESCRIPTION
# Description

this pr allows hyphens in variables names

```nu
let my-var = 42   # okay

def my-cmd [
   my-param,      # okay
   --my-flag,     # okay
] {
   if $my-flag {} # `my-flag` can now be used using hyphens, this was not possible
}

let -my-var = 42  # however, a variable cannot start with a hyphen
```

> the reason why a variable cannot start with a hyphen is because parameters and other variables are checked using the same code, so a name starting with a hyphen would be seen as a flag