### PR TITLE
Added `log custom` command & exported log levels

### DIFF
--- a/crates/nu-std/lib/log.nu
+++ b/crates/nu-std/lib/log.nu
@@ -1,14 +1,15 @@
-def CRITICAL_LEVEL [] { 50 }
-def ERROR_LEVEL    [] { 40 }
-def WARNING_LEVEL  [] { 30 }
-def INFO_LEVEL     [] { 20 }
-def DEBUG_LEVEL    [] { 10 }
+export def "log CRITICAL_LEVEL" [] { 50 }
+export def "log ERROR_LEVEL"    [] { 40 }
+export def "log WARNING_LEVEL"  [] { 30 }
+export def "log INFO_LEVEL"     [] { 20 }
+export def "log DEBUG_LEVEL"    [] { 10 }
 
 def parse-string-level [level: string] {
     (
         if $level == "CRITICAL" { (CRITICAL_LEVEL)}
         else if $level == "CRIT" { (CRITICAL_LEVEL)}
         else if $level == "ERROR" { (ERROR_LEVEL) }
+        else if $level == "ERR" { (ERROR_LEVEL) }
         else if $level == "WARNING" { (WARNING_LEVEL) }
         else if $level == "WARN" { (WARNING_LEVEL) }
         else if $level == "INFO" { (INFO_LEVEL) }
@@ -60,4 +61,20 @@ export def "log debug" [message: string] {
     if (current-log-level) > (DEBUG_LEVEL) { return }
 
     print --stderr $"(ansi default_dimmed)DBG|(now)|($message)(ansi reset)"
+}
+
+# Log with custom message format and verbosity level
+# # Usage:
+# ```
+# use std
+# std log custom "my message" $"(ansi yellow)MY MESSAGE: %MSG%(ansi reset)" (std log WARNING_LEVEL)
+# ```
+export def "log custom" [
+    message: string, # Message inserted into the log template
+    format: string, # A string to be printed into stderr. Add %MSG% in place where the $message argument should be placed
+    log_level: int # Log's verbosity level
+    ] {
+    if (current-log-level) > ($log_level) { return }
+
+    print --stderr ($format | str replace "%MSG%" $message)
 }

--- a/crates/nu-std/tests/test_logger.nu
+++ b/crates/nu-std/tests/test_logger.nu
@@ -36,3 +36,26 @@ export def test_debug [] {
     assert no message INFO debug 
     assert message DEBUG debug DBG
 }
+
+
+def "run custom" [system_level, format, message_level] {
+    do {
+        ^$nu.current-exe -c $'use std; NU_LOG_LEVEL=($system_level) std log custom "test message" $format $message_level' 
+    } | complete | get -i stderr
+}
+
+def "assert custom message" [system_level, format, message_level] {
+    let output = (run custom $system_level $format $message_level)
+    assert equal $output ($format | str replace "%MSG%" "test message")
+}
+
+def "assert no custom message" [system_level, format, message_level] {
+    let output = (run custom $system_level $format $message_level)
+    assert equal $output ""
+}
+
+export def test_custom [] {
+    assert no custom message ERROR "%MSG%" debug
+    assert custom message debug "%MSG" info
+    assert custom message warn $"(ansi red)my_msg: %MSG%(ansi reset)" critical
+}


### PR DESCRIPTION
# Description
- Log levels are now exported members of `std log`, e.g. `std log CRITICAL_LEVEL`
- Added `std log custom` command that allows to declare custom message format (actual message replaces `%MSG%` in the template) with user-defined log level.


# User-Facing Changes
New possibilities included in description

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
