### PR TITLE
enable history isolation

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -106,6 +106,14 @@ pub fn evaluate_repl(
 
     let config = engine_state.get_config();
 
+    // Setup history_isolation aka "history per session"
+    let history_isolation = config.history_isolation;
+    let history_session_id = if history_isolation {
+        Reedline::create_history_session_id()
+    } else {
+        None
+    };
+
     start_time = std::time::Instant::now();
     let history_path = crate::config_files::get_history_path(
         nushell_path,
@@ -124,7 +132,9 @@ pub fn evaluate_repl(
                 SqliteBackedHistory::with_file(history_path.to_path_buf()).into_diagnostic()?,
             ),
         };
-        line_editor = line_editor.with_history(history);
+        line_editor = line_editor
+            .with_history_session_id(history_session_id)
+            .with_history(history);
     };
     perf(
         "setup history",

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -86,6 +86,7 @@ pub struct Config {
     pub max_history_size: i64,
     pub sync_history_on_enter: bool,
     pub history_file_format: HistoryFileFormat,
+    pub history_isolation: bool,
     pub log_level: String,
     pub keybindings: Vec<ParsedKeybinding>,
     pub menus: Vec<ParsedMenu>,
@@ -129,6 +130,7 @@ impl Default for Config {
             max_history_size: i64::MAX,
             sync_history_on_enter: true,
             history_file_format: HistoryFileFormat::PlainText,
+            history_isolation: false,
             log_level: String::new(),
             keybindings: Vec::new(),
             menus: Vec::new(),
@@ -419,6 +421,9 @@ impl Value {
                                 let value = &vals[index];
                                 let key2 = cols[index].as_str();
                                 match key2 {
+                                    "history_isolation" => {
+                                        try_bool!(cols, vals, index, span, history_isolation)
+                                    }
                                     "sync_on_enter" => {
                                         try_bool!(cols, vals, index, span, sync_history_on_enter)
                                     }

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -266,7 +266,7 @@ let-env config = {
     max_size: 10000 # Session has to be reloaded for this to take effect
     sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
     file_format: "plaintext" # "sqlite" or "plaintext"
-    history_isolation: true # true enables history isolation, false disables it. history_isolation is a unique history per session.
+    history_isolation: true # true enables history isolation, false disables it. true will allow the history to be isolated to the current session. false will allow the history to be shared across all sessions.
   }
   completions: {
     case_sensitive: false # set to true to enable case-sensitive completions

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -266,6 +266,7 @@ let-env config = {
     max_size: 10000 # Session has to be reloaded for this to take effect
     sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
     file_format: "plaintext" # "sqlite" or "plaintext"
+    history_isolation: true # true enables history isolation, false disables it. history_isolation is a unique history per session.
   }
   completions: {
     case_sensitive: false # set to true to enable case-sensitive completions


### PR DESCRIPTION
# Description
This PR impacts the nushell sqlite history only.

This is the first PR that enables history isolation in nushell for the sqlite history. Hopefully, we can continue building on this. 

This PR allows "history isolation" which means that other nushell session's history won't be available in the current session when using the uparrow/downarrow history navigation. This change only impacts the uparrow downarrow history navigation.

What remains to be done is making ctrl+r history menu respect this setting too. Right now, the history menu will still show you all entries from all sessions.

The history command also shows all history items from all sessions. This may remain unchanged since you can just filter by history session right now.

This also fixes a bug where the session id is 0 in the sqlite history since my April 18th reedline PR.

Closes #9064

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
