### PR TITLE
Fix negative precision round with ints (issue #9049)

### DIFF
--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -80,7 +80,17 @@ impl Command for SubCommand {
 }
 
 fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
-    match value {
+    let mut result_value = value.clone();
+
+    // We treat int values as float values in order to avoid code repetition in the match closure
+    if let Value::Int { val, span } = result_value {
+        result_value = Value::Float {
+            val: val as f64,
+            span,
+        };
+    }
+
+    match result_value {
         Value::Float { val, span } => match precision {
             Some(precision_number) => Value::Float {
                 val: ((val * ((10_f64).powf(precision_number as f64))).round()
@@ -92,7 +102,6 @@ fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
                 span,
             },
         },
-        Value::Int { .. } => value,
         Value::Error { .. } => value,
         other => Value::Error {
             error: Box::new(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -75,6 +75,18 @@ impl Command for SubCommand {
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Apply negative precision to a list of numbers",
+                example: "[123, 123.3, -123.4] | math round -p -1",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_int(120),
+                        Value::test_int(120),
+                        Value::test_int(-120),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }
@@ -102,6 +114,7 @@ fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
                 span,
             },
         },
+        Value::Error { .. } => value,
         other => Value::Error {
             error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -80,17 +80,17 @@ impl Command for SubCommand {
 }
 
 fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
-    let mut result_value = value.clone();
-
     // We treat int values as float values in order to avoid code repetition in the match closure
-    if let Value::Int { val, span } = result_value {
-        result_value = Value::Float {
+    let value = if let Value::Int { val, span } = value {
+        Value::Float {
             val: val as f64,
             span,
-        };
-    }
+        }
+    } else {
+        value
+    };
 
-    match result_value {
+    match value {
         Value::Float { val, span } => match precision {
             Some(precision_number) => Value::Float {
                 val: ((val * ((10_f64).powf(precision_number as f64))).round()
@@ -102,7 +102,6 @@ fn operate(value: Value, head: Span, precision: Option<i64>) -> Value {
                 span,
             },
         },
-        Value::Error { .. } => value,
         other => Value::Error {
             error: Box::new(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "numeric".into(),

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -4,7 +4,7 @@ use nu_test_support::nu;
 fn can_round_very_large_numbers() {
     let actual = nu!(
         cwd: ".",
-        "echo 18.1372544780074142289927665486772012345 | math round"
+        "18.1372544780074142289927665486772012345 | math round"
     );
 
     assert_eq!(actual.out, "18")
@@ -14,7 +14,7 @@ fn can_round_very_large_numbers() {
 fn can_round_very_large_numbers_with_precision() {
     let actual = nu!(
         cwd: ".",
-        "echo 18.13725447800741422899276654867720121457878988 | math round -p 10"
+        "18.13725447800741422899276654867720121457878988 | math round -p 10"
     );
 
     assert_eq!(actual.out, "18.137254478")
@@ -24,7 +24,7 @@ fn can_round_very_large_numbers_with_precision() {
 fn can_round_integer_with_negative_precision() {
     let actual = nu!(
         cwd: ".",
-        "echo 123 | math round -p -1"
+        "123 | math round -p -1"
     );
 
     assert_eq!(actual.out, "120")
@@ -34,7 +34,7 @@ fn can_round_integer_with_negative_precision() {
 fn can_round_float_with_negative_precision() {
     let actual = nu!(
         cwd: ".",
-        "echo 123.3 | math round -p -1"
+        "123.3 | math round -p -1"
     );
 
     assert_eq!(actual.out, "120")

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -2,50 +2,35 @@ use nu_test_support::nu;
 
 #[test]
 fn can_round_very_large_numbers() {
-    let actual = nu!(
-        cwd: ".",
-        "18.1372544780074142289927665486772012345 | math round"
-    );
+    let actual = nu!("18.1372544780074142289927665486772012345 | math round");
 
     assert_eq!(actual.out, "18")
 }
 
 #[test]
 fn can_round_very_large_numbers_with_precision() {
-    let actual = nu!(
-        cwd: ".",
-        "18.13725447800741422899276654867720121457878988 | math round -p 10"
-    );
+    let actual = nu!("18.13725447800741422899276654867720121457878988 | math round -p 10");
 
     assert_eq!(actual.out, "18.137254478")
 }
 
 #[test]
 fn can_round_integer_with_negative_precision() {
-    let actual = nu!(
-        cwd: ".",
-        "123 | math round -p -1"
-    );
+    let actual = nu!("123 | math round -p -1");
 
     assert_eq!(actual.out, "120")
 }
 
 #[test]
 fn can_round_float_with_negative_precision() {
-    let actual = nu!(
-        cwd: ".",
-        "123.3 | math round -p -1"
-    );
+    let actual = nu!("123.3 | math round -p -1");
 
     assert_eq!(actual.out, "120")
 }
 
 #[test]
 fn fails_with_wrong_input_type() {
-    let actual = nu!(
-        cwd: ".",
-        "\"not_a_number\" | math round"
-    );
+    let actual = nu!("\"not_a_number\" | math round");
 
     assert!(actual.err.contains("Input type not supported"))
 }

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -39,3 +39,13 @@ fn can_round_float_with_negative_precision() {
 
     assert_eq!(actual.out, "120")
 }
+
+#[test]
+fn fails_with_wrong_input_type() {
+    let actual = nu!(
+        cwd: ".",
+        "\"not_a_number\" | math round"
+    );
+
+    assert!(actual.err.contains("Input type not supported"))
+}

--- a/crates/nu-command/tests/commands/math/round.rs
+++ b/crates/nu-command/tests/commands/math/round.rs
@@ -19,3 +19,23 @@ fn can_round_very_large_numbers_with_precision() {
 
     assert_eq!(actual.out, "18.137254478")
 }
+
+#[test]
+fn can_round_integer_with_negative_precision() {
+    let actual = nu!(
+        cwd: ".",
+        "echo 123 | math round -p -1"
+    );
+
+    assert_eq!(actual.out, "120")
+}
+
+#[test]
+fn can_round_float_with_negative_precision() {
+    let actual = nu!(
+        cwd: ".",
+        "echo 123.3 | math round -p -1"
+    );
+
+    assert_eq!(actual.out, "120")
+}


### PR DESCRIPTION
# Description
Before this PR, `math round` ignores the input if it's an `int`. This results in the following behaviour:
```
> 123 | math round --precision -1
123
```
When the correct result is 120.

Now `int values` are converted to `float values` before actually rounding up the number in order to take advantage of the float implementation.

Fixes #9049. 

# User-Facing Changes

# Tests + Formatting

# After Submitting
