### PR TITLE
FIX: add a space after the default left prompt

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -109,9 +109,10 @@ impl Prompt for NushellPrompt {
             let prompt = default
                 .render_prompt_left()
                 .to_string()
-                .replace('\n', "\r\n");
+                .replace('\n', "\r\n")
+                + " ";
 
-            (prompt + " ").into()
+            prompt.into()
         }
     }
 

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -106,11 +106,12 @@ impl Prompt for NushellPrompt {
             prompt_string.replace('\n', "\r\n").into()
         } else {
             let default = DefaultPrompt::default();
-            default
+            let prompt = default
                 .render_prompt_left()
                 .to_string()
-                .replace('\n', "\r\n")
-                .into()
+                .replace('\n', "\r\n");
+
+            (prompt + " ").into()
         }
     }
 


### PR DESCRIPTION
# Description
when running `nushell` with the `--no-config-file` option, the left prompt does not have a space to separate the directory path from the user input.
in this PR i add a space there to make the prompt easier to read when using `--no-config-file`!

# User-Facing Changes
before: https://asciinema.org/a/581733
after: https://asciinema.org/a/581734

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```