### PR TITLE
pass `std bench` into `table -e` in the example

### DIFF
--- a/crates/nu-std/lib/mod.nu
+++ b/crates/nu-std/lib/mod.nu
@@ -176,7 +176,7 @@ def "from ns" [] {
 #
 # # Examples
 #     measure the performance of simple addition
-#     > std bench { 1 + 2 } -n 10
+#     > std bench { 1 + 2 } -n 10 | table -e
 #     ╭───────┬────────────────────╮
 #     │ mean  │ 4µs 956ns          │
 #     │ std   │ 4µs 831ns          │


### PR DESCRIPTION
cc/ @fdncred 

# Description
in the examples of `std bench` there is an expanded table without explicitely expanding it...
this PR adds a `table -e` to the `std bench` call in the example.

# User-Facing Changes
the help page of `std bench` now does make sense :relieved: 

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```