### PR TITLE
add pwd to ide-complete to match other ide functions

### DIFF
--- a/src/ide.rs
+++ b/src/ide.rs
@@ -578,6 +578,9 @@ pub fn hover(engine_state: &mut EngineState, file_path: &String, location: &Valu
 }
 
 pub fn complete(engine_reference: Arc<EngineState>, file_path: &String, location: &Value) {
+    let cwd = std::env::current_dir().expect("Could not get current working directory.");
+    engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
+
     let stack = Stack::new();
     let mut completer = NuCompleter::new(engine_reference, stack);
 


### PR DESCRIPTION
# Description
This PR just adds the preamble of getting the PWD before executing the complete function for the --ide-complete command line parameter. We've had troubles with other ide commands, so I thought it was a good idea to go ahead and add it here too.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
