### PR TITLE
Fix: switch var span instead expr's span

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -543,7 +543,8 @@ pub fn eval_expression(
             let block = engine_state.get_block(*block_id);
 
             for var_id in &block.captures {
-                captures.insert(*var_id, stack.get_var(*var_id, expr.span)?);
+                let var_span = engine_state.get_var(*var_id).declaration_span;
+                captures.insert(*var_id, stack.get_var(*var_id, var_span)?);
             }
             Ok(Value::Closure {
                 val: *block_id,


### PR DESCRIPTION
Fixes : #9067 
change span on checking variable existence .

Can add tests if can check when span error showing to have evaluated tests

Before : 
```nu
77 | do {|x| 100 + $in + $x }            
Error: nu::shell::variable_not_found (link)

  × Variable not found
   ╭─[entry #4:1:1]
 1 │ 77 | do {|x| 100 + $in + $x }
   ·              ───────┬──────
   ·                     ╰── variable not found
   ╰────

```

After this commit : 
```nu
77 | do {|x| 100 + $in + $x }            
Error: nu::shell::variable_not_found

  × Variable not found
   ╭─[entry #2:1:1]
 1 │ 77 | do {|x| 100 + $in + $x }
   ·           ┬
   ·           ╰── variable not found
   ╰────

```