### PR TITLE
Change type of flag defaults to Option<Value>

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -117,10 +117,8 @@ pub fn eval_call(
                                 let result = eval_expression(engine_state, caller_stack, arg)?;
 
                                 callee_stack.add_var(var_id, result);
-                            } else if let Some(arg) = &named.default_value {
-                                let result = eval_expression(engine_state, caller_stack, arg)?;
-
-                                callee_stack.add_var(var_id, result);
+                            } else if let Some(value) = &named.default_value {
+                                callee_stack.add_var(var_id, value.to_owned());
                             } else {
                                 callee_stack.add_var(var_id, Value::boolean(true, call.head))
                             }
@@ -131,10 +129,8 @@ pub fn eval_call(
                             let result = eval_expression(engine_state, caller_stack, arg)?;
 
                             callee_stack.add_var(var_id, result);
-                        } else if let Some(arg) = &named.default_value {
-                            let result = eval_expression(engine_state, caller_stack, arg)?;
-
-                            callee_stack.add_var(var_id, result);
+                        } else if let Some(value) = &named.default_value {
+                            callee_stack.add_var(var_id, value.to_owned());
                         } else {
                             callee_stack.add_var(var_id, Value::boolean(true, call.head))
                         }
@@ -145,10 +141,8 @@ pub fn eval_call(
                 if !found {
                     if named.arg.is_none() {
                         callee_stack.add_var(var_id, Value::boolean(false, call.head))
-                    } else if let Some(arg) = &named.default_value {
-                        let result = eval_expression(engine_state, caller_stack, arg)?;
-
-                        callee_stack.add_var(var_id, result);
+                    } else if let Some(value) = named.default_value {
+                        callee_stack.add_var(var_id, value);
                     } else {
                         callee_stack.add_var(var_id, Value::Nothing { span: call.head })
                     }

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -2,7 +2,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::ast::Call;
-use crate::ast::Expression;
 use crate::engine::Command;
 use crate::engine::EngineState;
 use crate::engine::Stack;
@@ -25,7 +24,7 @@ pub struct Flag {
 
     // For custom commands
     pub var_id: Option<VarId>,
-    pub default_value: Option<Expression>,
+    pub default_value: Option<Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -328,9 +328,17 @@ fn default_value_constant() -> TestResult {
 }
 
 #[test]
-fn default_value_not_constant() -> TestResult {
+fn default_value_not_constant1() -> TestResult {
     fail_test(
         r#"def foo [x = ("foo" | str length)] { $x }; foo"#,
+        "expected a constant",
+    )
+}
+
+#[test]
+fn default_value_not_constant2() -> TestResult {
+    fail_test(
+        r#"def foo [--x = ("foo" | str length)] { $x }; foo"#,
         "expected a constant",
     )
 }


### PR DESCRIPTION
# Description
Follow-up of #8940. As @bobhy pointed out, it makes sense for the behaviour of flags to match the one for positional arguments, where default values are of type `Option<Value>` instead of `Option<Expression>`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
The same ones from the original PR:
- Flag default values will now be parsed as constants.
- If the default value is not a constant, a parser error is displayed.

# Tests + Formatting

A [new test](https://github.com/nushell/nushell/blob/e34e2d35f495000897d785bd31d8ace456d0da25/src/tests/test_engine.rs#L338-L344) has been added to verify the new restriction.