### PR TITLE
Fix overlay's help message lead to internal error

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2066,6 +2066,15 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline
 
 pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
+    // check help flag first.
+    if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
+        return Pipeline::from_vec(vec![Expression {
+            expr: Expr::Call(call),
+            span: call_span,
+            ty: Type::Any,
+            custom_completion: None,
+        }]);
+    }
 
     let (overlay_name, _) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
@@ -2110,6 +2119,15 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
 
+    // check help flag first.
+    if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
+        return Pipeline::from_vec(vec![Expression {
+            expr: Expr::Call(call),
+            span: call_span,
+            ty: Type::Any,
+            custom_completion: None,
+        }]);
+    }
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
             Ok(val) => match value_as_string(val, expr.span) {
@@ -2354,6 +2372,15 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 
 pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
+    // check help flag first.
+    if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
+        return Pipeline::from_vec(vec![Expression {
+            expr: Expr::Call(call),
+            span: call_span,
+            ty: Type::Any,
+            custom_completion: None,
+        }]);
+    }
 
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -104,9 +104,10 @@ pub fn parse_keyword(
         let cmd = working_set.get_decl(call.decl_id);
         // check help flag first.
         if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
+            let call_span = call.span();
             return Pipeline::from_vec(vec![Expression {
                 expr: Expr::Call(call),
-                span: call.span(),
+                span: call_span,
                 ty: Type::Any,
                 custom_completion: None,
             }]);

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -102,6 +102,15 @@ pub fn parse_keyword(
     {
         // Apply parse keyword side effects
         let cmd = working_set.get_decl(call.decl_id);
+        // check help flag first.
+        if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
+            return Pipeline::from_vec(vec![Expression {
+                expr: Expr::Call(call),
+                span: call.span(),
+                ty: Type::Any,
+                custom_completion: None,
+            }]);
+        }
 
         match cmd.name() {
             "overlay hide" => parse_overlay_hide(working_set, call),
@@ -2066,15 +2075,6 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline
 
 pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
-    // check help flag first.
-    if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: call_span,
-            ty: Type::Any,
-            custom_completion: None,
-        }]);
-    }
 
     let (overlay_name, _) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
@@ -2119,15 +2119,6 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
 
-    // check help flag first.
-    if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: call_span,
-            ty: Type::Any,
-            custom_completion: None,
-        }]);
-    }
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
             Ok(val) => match value_as_string(val, expr.span) {
@@ -2372,15 +2363,6 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 
 pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
     let call_span = call.span();
-    // check help flag first.
-    if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: call_span,
-            ty: Type::Any,
-            custom_completion: None,
-        }]);
-    }
 
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1312,3 +1312,13 @@ fn alias_overlay_new() {
     assert_eq!(actual.out, "eggs");
     assert_eq!(actual_repl.out, "eggs");
 }
+
+#[test]
+fn overlay_help_no_error() {
+    let actual = nu!(cwd: ".", "overlay hide -h");
+    assert!(actual.err.is_empty());
+    let actual = nu!(cwd: ".", "overlay new -h");
+    assert!(actual.err.is_empty());
+    let actual = nu!(cwd: ".", "overlay use -h");
+    assert!(actual.err.is_empty());
+}


### PR DESCRIPTION
# Description
Fixes: #9005

# User-Facing Changes
NaN

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
