### PR TITLE
allow `ls` to work a little faster via threads

### DIFF
--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -251,7 +251,7 @@ fn test_computable_style_closure_basic() {
                 }
             };"#,
             "[bell book candle] | table | ignore",
-            "ls | get name | to nuon",
+            "ls | get name | sort-by name | to nuon",
         ];
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(&inp));
         assert_eq!(actual_repl.err, "");

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -190,22 +190,18 @@ impl Command for Ls {
                     };
                     {
                         let hidden_dir_clone = Arc::clone(&hidden_dirs);
-                        let hidden_dir_mutex = hidden_dir_clone
+                        let mut hidden_dir_mutex = hidden_dir_clone
                             .lock()
                             .expect("Unable to acquire lock for hidden_dirs");
                         if path_contains_hidden_folder(&path, &hidden_dir_mutex) {
                             return None;
                         }
-                    }
-                    if !all && !hidden_dir_specified && is_hidden_dir(&path) {
-                        if path.is_dir() {
-                            let hidden_dir_clone = Arc::clone(&hidden_dirs);
-                            let mut hidden_dir_mutex = hidden_dir_clone
-                                .lock()
-                                .expect("Unable to acquire lock for hidden_dirs in all block");
-                            hidden_dir_mutex.push(path);
+                        if !all && !hidden_dir_specified && is_hidden_dir(&path) {
+                            if path.is_dir() {
+                                hidden_dir_mutex.push(path);
+                            }
+                            return None;
                         }
-                        return None;
                     }
 
                     let display_name = if short_names {

--- a/crates/nu-command/tests/commands/every.rs
+++ b/crates/nu-command/tests/commands/every.rs
@@ -16,6 +16,7 @@ fn gets_all_rows_by_every_zero() {
             cwd: dirs.test(), pipeline(
             "
                 ls
+                | sort-by name
                 | get name
                 | every 0
                 | to json --raw
@@ -67,6 +68,7 @@ fn gets_all_rows_by_every_one() {
             cwd: dirs.test(), pipeline(
             "
                 ls
+                | sort-by name
                 | get name
                 | every 1
                 | to json --raw
@@ -143,6 +145,7 @@ fn gets_all_rows_except_first_by_every_skip_too_much() {
             cwd: dirs.test(), pipeline(
             "
                 ls
+                | sort-by name
                 | get name
                 | every 999 --skip
                 | to json --raw

--- a/crates/nu-command/tests/commands/every.rs
+++ b/crates/nu-command/tests/commands/every.rs
@@ -193,6 +193,7 @@ fn skips_every_third_row() {
             cwd: dirs.test(), pipeline(
             "
                 ls
+                | sort-by name
                 | get name
                 | every 3 --skip
                 | to json --raw

--- a/crates/nu-command/tests/commands/every.rs
+++ b/crates/nu-command/tests/commands/every.rs
@@ -168,6 +168,7 @@ fn gets_every_third_row() {
             cwd: dirs.test(), pipeline(
             "
                 ls
+                | sort-by name
                 | get name
                 | every 3
                 | to json --raw

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -464,7 +464,7 @@ mod external_command_arguments {
                 let actual = nu!(
                 cwd: dirs.test(), pipeline(
                 r#"
-                    nu --testbin cococo (ls | get name)
+                    nu --testbin cococo (ls | sort-by name | get name)
                 "#
                 ));
 


### PR DESCRIPTION
# Description
This PR allows `ls` to work a little faster by using rayon's threading capabilities.

It's especially noticeable when accessing data from WSL2 to Windows paths.

Before (folder with ~5000 files):
```
timeit ls /mnt/c/Windows/System32
15sec 478ms 404µs 955ns
```

After:
```
timeit ls /mnt/c/Windows/System32
2sec 504ms 446µs 339ns
```

closes #9057 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
