### PR TITLE
FEATURE: move common functionality to subroutine in `build-all-windows.cmd`

### DIFF
--- a/build-all-windows.cmd
+++ b/build-all-windows.cmd
@@ -1,36 +1,30 @@
 @echo off
-@echo -------------------------------------------------------------------
-@echo Building nushell (nu.exe) with dataframes and all the plugins
-@echo -------------------------------------------------------------------
-@echo.
+echo -------------------------------------------------------------------
+echo Building nushell (nu.exe) with dataframes and all the plugins
+echo -------------------------------------------------------------------
+echo.
 
 echo Building nushell.exe
 cargo build --features=dataframe
-@echo.
+echo.
 
-@cd crates\nu_plugin_example
-echo Building nu_plugin_example.exe
-cargo build
-@echo.
+call :build crates\nu_plugin_example nu_plugin_example.exe
+call :build ..\..\crates\nu_plugin_gstat nu_plugin_gstat.exe
+call :build ..\..\crates\nu_plugin_inc nu_plugin_inc.exe
+call :build ..\..\crates\nu_plugin_query nu_plugin_query.exe
+call :build ..\..\crates\nu_plugin_custom_values nu_plugin_custom_values.exe
 
-@cd ..\..\crates\nu_plugin_gstat
-echo Building nu_plugin_gstat.exe
-cargo build
-@echo.
+cd ..\..
+exit /b 0
 
-@cd ..\..\crates\nu_plugin_inc
-echo Building nu_plugin_inc.exe
-cargo build
-@echo.
+:build
+    setlocal
+    set "location=%~1"
+    set "target=%~2"
 
-@cd ..\..\crates\nu_plugin_query
-echo Building nu_plugin_query.exe
-cargo build
-@echo.
-
-@cd ..\..\crates\nu_plugin_custom_values
-echo Building nu_plugin_custom_values.exe
-cargo build
-@echo.
-
-@cd ..\..
+    cd "%location%"
+    echo Building %target%
+    cargo build
+    echo.
+    endlocal
+exit /b 0


### PR DESCRIPTION
# Description
- remove redundant `@` after `echo off`
- use `call :build` to simplify code

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
