### PR TITLE
chore: ✨ enable setup-git-hooks on windows

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -233,8 +233,6 @@ export def "check pr" [
 # - `toolkit fmt --check --verbose` on `git commit`
 # - `toolkit fmt --check --verbose` and `toolkit clippy --verbose` on `git push`
 export def setup-git-hooks [] {
-
-
     print "This command will change your local git configuration and hence modify your development workflow. Are you sure you want to continue? [y]"
     if (input) == "y" {
         print $"running ('toolkit setup-git-hooks' | pretty-print-command)"

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -233,9 +233,7 @@ export def "check pr" [
 # - `toolkit fmt --check --verbose` on `git commit`
 # - `toolkit fmt --check --verbose` and `toolkit clippy --verbose` on `git push`
 export def setup-git-hooks [] {
-    if $nu.os-info.name == windows {
-        return (print "This git hook isn't available on Windows. Sorry!")
-    }
+
 
     print "This command will change your local git configuration and hence modify your development workflow. Are you sure you want to continue? [y]"
     if (input) == "y" {


### PR DESCRIPTION
# Description
Enable setup-git-hooks on windows. It works just fine without doing anything special. More testing from other windows users is welcomed as there might be a reason it was done that way before.

# User-Facing Changes
`toolkit setup-git-hooks` now work on windows
