### PR TITLE
REFACTOR: fix typos and simplify external `std help`

### DIFF
--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -674,9 +674,7 @@ export def "help commands" [
     } else if not ($command | is-empty) {
         let found_command = ($commands | where name == $command)
 
-        if not ($found_commands | is-empty) {
-            show-command ($found_commands | get 0)
-        } else {
+        if ($found_command | is-empty) {
             try {
                 print $"(ansi default_italic)Help pages from external command ($command | pretty-cmd):(ansi reset)"
                 ^($env.NU_HELPER? | default "man") $command
@@ -685,6 +683,7 @@ export def "help commands" [
             }
         }
 
+        show-command ($found_command | get 0)
     } else {
         $commands | select name category usage signatures search_terms
     }

--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -658,7 +658,7 @@ export def "help commands" [
     ...command: string@"nu-complete list-commands"  # the name of command to get help on
     --find (-f): string  # string to find in command names and usage
 ] {
-    let commands = ($nu.scope.commands | where not is_extern | reject is_extern | sort-by name )
+    let commands = ($nu.scope.commands | where not is_extern | reject is_extern | sort-by name)
 
     let command = ($command | str join " ")
 
@@ -672,14 +672,14 @@ export def "help commands" [
             $found_commands | select name category usage signatures search_terms
         }
     } else if not ($command | is-empty) {
-        let found_commands = ($commands | where name == $command)
+        let found_command = ($commands | where name == $command)
 
         if not ($found_commands | is-empty) {
             show-command ($found_commands | get 0)
         } else {
             try {
                 print $"(ansi default_italic)Help pages from external command ($command | pretty-cmd):(ansi reset)"
-                 ^($env.NU_HELPER? | default "man") $command
+                ^($env.NU_HELPER? | default "man") $command
             } catch {
                 command-not-found-error (metadata $command | get span)
             }


### PR DESCRIPTION
followup to #9025
cc/ @YummyOreo 

# Description
this PR simply fixes some typos and simplifies the logic of the external help page opening :yum: 

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```