### PR TITLE
FIX: have consistent errors between `std help` and `std help ...`

### DIFF
--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -748,4 +748,14 @@ You can also learn more at (ansi default_italic)(ansi light_cyan_underline)https
 
     let modules = (try { help modules $item --find $find })
     if not ($modules | is-empty) { return $modules }
+
+    let span = (metadata $item | get span)
+    error make {
+        msg: ("std::help::item_not_found"  | error-fmt)
+        label: {
+            text: "item not found"
+            start: $span.start
+            end: $span.end
+        }
+    }
 }


### PR DESCRIPTION
# Description
an example should show what happens quite clearly :yum: 

> **Note**
> the ugly spanned errors you'll see below are fixed in https://github.com/nushell/nushell/pull/9039 :relieved: 

in all cases we get
```
> std help commands does-not-exist-anywhere
Help pages from external command does-not-exist-anywhere:
No manual entry for does-not-exist-anywhere
Error:
  × std::help::command_not_found
     ╭─[help:662:1]
 662 │
 663 │     let command = ($command | str join " ")
     ·     ─┬─
     ·      ╰── command not found
 664 │
     ╰────
```
but

## :x: before this PR
```
> std help does-not-exist-anywhere
Help pages from external command does-not-exist-anywhere:
No manual entry for does-not-exist-anywhere
```
without any error, which makes it inconsistent with all the other `std help` commands which give errors when not finding an item :thinking: 

## :heavy_check_mark: with this PR
```
> std help does-not-exist-anywhere
Help pages from external command does-not-exist-anywhere:
No manual entry for does-not-exist-anywhere
Error:
  × std::help::item_not_found
     ╭─[help:740:1]
 740 │
 741 │     let item = ($item | str join " ")
     ·     ─┬─
     ·      ╰── item not found
 742 │
     ╰────
```

# User-Facing Changes
more consistent errors when using `std help` and `std help commands`, as shown above.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
```
$nothing
```
