### PR TITLE
check if is homedir first when rm

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -149,7 +149,31 @@ fn rm(
 
     let mut targets: Vec<Spanned<String>> = call.rest(engine_state, stack, 0)?;
 
+    let mut unique_argument_check = None;
+
+    let currentdir_path = current_dir(engine_state, stack)?;
+
+    let home: Option<String> = nu_path::home_dir().map(|path| {
+        {
+            if path.exists() {
+                match nu_path::canonicalize_with(&path, &currentdir_path) {
+                    Ok(canon_path) => canon_path,
+                    Err(_) => path,
+                }
+            } else {
+                path
+            }
+        }
+        .to_string_lossy()
+        .into()
+    });
+
     for (idx, path) in targets.clone().into_iter().enumerate() {
+        if let Some(ref home) = home {
+            if &path.item == home {
+                unique_argument_check = Some(path.span);
+            }
+        }
         let corrected_path = Spanned {
             item: nu_utils::strip_ansi_string_unlikely(path.item),
             span: path.span,
@@ -199,6 +223,17 @@ fn rm(
         ));
     }
 
+    if unique_argument_check.is_some() && !(interactive_once || interactive) {
+        return Err(ShellError::GenericError(
+            "It seems you want to remove your home dir".into(),
+            "please make a check, if you really want to remove it, use -I or -i to confirm it"
+                .into(),
+            unique_argument_check,
+            None,
+            Vec::new(),
+        ));
+    }
+
     let targets_span = Span::new(
         targets
             .iter()
@@ -212,18 +247,12 @@ fn rm(
             .expect("targets were empty"),
     );
 
-    let path = current_dir(engine_state, stack)?;
-
     let (mut target_exists, mut empty_span) = (false, call.head);
     let mut all_targets: HashMap<PathBuf, Span> = HashMap::new();
 
     for target in targets {
-        if path.to_string_lossy() == target.item
-            || path.as_os_str().to_string_lossy().starts_with(&format!(
-                "{}{}",
-                target.item,
-                std::path::MAIN_SEPARATOR
-            ))
+        if currentdir_path.to_string_lossy() == target.item
+            || currentdir_path.starts_with(&format!("{}{}", target.item, std::path::MAIN_SEPARATOR))
         {
             return Err(ShellError::GenericError(
                 "Cannot remove any parent directory".into(),
@@ -234,7 +263,7 @@ fn rm(
             ));
         }
 
-        let path = path.join(&target.item);
+        let path = currentdir_path.join(&target.item);
         match nu_glob::glob_with(
             &path.to_string_lossy(),
             nu_glob::MatchOptions {

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -225,9 +225,8 @@ fn rm(
 
     if unique_argument_check.is_some() && !(interactive_once || interactive) {
         return Err(ShellError::GenericError(
-            "It seems you want to remove your home dir".into(),
-            "please make a check, if you really want to remove it, use -I or -i to confirm it"
-                .into(),
+            "You are trying to remove your home dir".into(),
+            "If you really want to remove your home dir, please use -I or -i".into(),
             unique_argument_check,
             None,
             Vec::new(),

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -136,6 +136,18 @@ fn errors_if_attempting_to_delete_a_directory_with_content_without_recursive_fla
 }
 
 #[test]
+fn errors_if_attempting_to_delete_home() {
+    Playground::setup("rm_test_8", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.root(),
+            "let-env HOME = myhome ; rm -rf ~"
+        );
+
+        assert!(actual.err.contains("use -I or -i to confirm it"));
+    })
+}
+
+#[test]
 fn errors_if_attempting_to_delete_single_dot_as_argument() {
     Playground::setup("rm_test_7", |dirs, _| {
         let actual = nu!(

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -143,7 +143,7 @@ fn errors_if_attempting_to_delete_home() {
             "let-env HOME = myhome ; rm -rf ~"
         );
 
-        assert!(actual.err.contains("use -I or -i to confirm it"));
+        assert!(actual.err.contains("please use -I or -i"));
     })
 }
 


### PR DESCRIPTION
I don't want to rm my home again.. sadly..


# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

check if there is unique argument

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

user will not easily rm their home

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
