### PR TITLE
Remove any durations over weeks

### DIFF
--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -229,11 +229,6 @@ fn convert_str_from_unit_to_unit(
         ("ns", "hr") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0),
         ("ns", "day") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0),
         ("ns", "wk") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 7.0),
-        ("ns", "month") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 30.0),
-        ("ns", "yr") => Ok(val as f64 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
-        ("ns", "dec") => {
-            Ok(val as f64 / 10.0 / 1000.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0)
-        }
 
         ("us", "ns") => Ok(val as f64 * 1000.0),
         ("us", "us") => Ok(val as f64),
@@ -245,9 +240,6 @@ fn convert_str_from_unit_to_unit(
         ("us", "hr") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0),
         ("us", "day") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0),
         ("us", "wk") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 7.0),
-        ("us", "month") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 30.0),
-        ("us", "yr") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
-        ("us", "dec") => Ok(val as f64 / 10.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
 
         // Micro sign
         ("µs", "ns") => Ok(val as f64 * 1000.0),
@@ -260,9 +252,6 @@ fn convert_str_from_unit_to_unit(
         ("µs", "hr") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0),
         ("µs", "day") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0),
         ("µs", "wk") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 7.0),
-        ("µs", "month") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 30.0),
-        ("µs", "yr") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
-        ("µs", "dec") => Ok(val as f64 / 10.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
 
         // Greek small letter
         ("μs", "ns") => Ok(val as f64 * 1000.0),
@@ -275,9 +264,6 @@ fn convert_str_from_unit_to_unit(
         ("μs", "hr") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0),
         ("μs", "day") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0),
         ("μs", "wk") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 7.0),
-        ("μs", "month") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 30.0),
-        ("μs", "yr") => Ok(val as f64 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
-        ("μs", "dec") => Ok(val as f64 / 10.0 / 1000.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
 
         ("ms", "ns") => Ok(val as f64 * 1000.0 * 1000.0),
         ("ms", "us") => Ok(val as f64 * 1000.0),
@@ -289,9 +275,6 @@ fn convert_str_from_unit_to_unit(
         ("ms", "hr") => Ok(val as f64 / 1000.0 / 60.0 / 60.0),
         ("ms", "day") => Ok(val as f64 / 1000.0 / 60.0 / 60.0 / 24.0),
         ("ms", "wk") => Ok(val as f64 / 1000.0 / 60.0 / 60.0 / 24.0 / 7.0),
-        ("ms", "month") => Ok(val as f64 / 1000.0 / 60.0 / 60.0 / 24.0 / 30.0),
-        ("ms", "yr") => Ok(val as f64 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
-        ("ms", "dec") => Ok(val as f64 / 10.0 / 1000.0 / 60.0 / 60.0 / 24.0 / 365.0),
 
         ("sec", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0),
         ("sec", "us") => Ok(val as f64 * 1000.0 * 1000.0),
@@ -303,9 +286,6 @@ fn convert_str_from_unit_to_unit(
         ("sec", "hr") => Ok(val as f64 / 60.0 / 60.0),
         ("sec", "day") => Ok(val as f64 / 60.0 / 60.0 / 24.0),
         ("sec", "wk") => Ok(val as f64 / 60.0 / 60.0 / 24.0 / 7.0),
-        ("sec", "month") => Ok(val as f64 / 60.0 / 60.0 / 24.0 / 30.0),
-        ("sec", "yr") => Ok(val as f64 / 60.0 / 60.0 / 24.0 / 365.0),
-        ("sec", "dec") => Ok(val as f64 / 10.0 / 60.0 / 60.0 / 24.0 / 365.0),
 
         ("min", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0),
         ("min", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0),
@@ -317,9 +297,6 @@ fn convert_str_from_unit_to_unit(
         ("min", "hr") => Ok(val as f64 / 60.0),
         ("min", "day") => Ok(val as f64 / 60.0 / 24.0),
         ("min", "wk") => Ok(val as f64 / 60.0 / 24.0 / 7.0),
-        ("min", "month") => Ok(val as f64 / 60.0 / 24.0 / 30.0),
-        ("min", "yr") => Ok(val as f64 / 60.0 / 24.0 / 365.0),
-        ("min", "dec") => Ok(val as f64 / 10.0 / 60.0 / 24.0 / 365.0),
 
         ("hr", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0),
         ("hr", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0),
@@ -331,9 +308,6 @@ fn convert_str_from_unit_to_unit(
         ("hr", "hr") => Ok(val as f64),
         ("hr", "day") => Ok(val as f64 / 24.0),
         ("hr", "wk") => Ok(val as f64 / 24.0 / 7.0),
-        ("hr", "month") => Ok(val as f64 / 24.0 / 30.0),
-        ("hr", "yr") => Ok(val as f64 / 24.0 / 365.0),
-        ("hr", "dec") => Ok(val as f64 / 10.0 / 24.0 / 365.0),
 
         ("day", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0),
         ("day", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0),
@@ -345,9 +319,6 @@ fn convert_str_from_unit_to_unit(
         ("day", "hr") => Ok(val as f64 * 24.0),
         ("day", "day") => Ok(val as f64),
         ("day", "wk") => Ok(val as f64 / 7.0),
-        ("day", "month") => Ok(val as f64 / 30.0),
-        ("day", "yr") => Ok(val as f64 / 365.0),
-        ("day", "dec") => Ok(val as f64 / 10.0 / 365.0),
 
         ("wk", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 7.0),
         ("wk", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 7.0),
@@ -359,37 +330,6 @@ fn convert_str_from_unit_to_unit(
         ("wk", "hr") => Ok(val as f64 * 24.0 * 7.0),
         ("wk", "day") => Ok(val as f64 * 7.0),
         ("wk", "wk") => Ok(val as f64),
-        ("wk", "month") => Ok(val as f64 / 4.0),
-        ("wk", "yr") => Ok(val as f64 / 52.0),
-        ("wk", "dec") => Ok(val as f64 / 10.0 / 52.0),
-
-        ("month", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 30.0),
-        ("month", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 30.0),
-        ("month", "µs") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 30.0), // Micro sign
-        ("month", "μs") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 30.0), // Greek small letter
-        ("month", "ms") => Ok(val as f64 * 1000.0 * 60.0 * 60.0 * 24.0 * 30.0),
-        ("month", "sec") => Ok(val as f64 * 60.0 * 60.0 * 24.0 * 30.0),
-        ("month", "min") => Ok(val as f64 * 60.0 * 24.0 * 30.0),
-        ("month", "hr") => Ok(val as f64 * 24.0 * 30.0),
-        ("month", "day") => Ok(val as f64 * 30.0),
-        ("month", "wk") => Ok(val as f64 * 4.0),
-        ("month", "month") => Ok(val as f64),
-        ("month", "yr") => Ok(val as f64 / 12.0),
-        ("month", "dec") => Ok(val as f64 / 10.0 / 12.0),
-
-        ("yr", "ns") => Ok(val as f64 * 1000.0 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 365.0),
-        ("yr", "us") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 365.0),
-        ("yr", "µs") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 365.0), // Micro sign
-        ("yr", "μs") => Ok(val as f64 * 1000.0 * 1000.0 * 60.0 * 60.0 * 24.0 * 365.0), // Greek small letter
-        ("yr", "ms") => Ok(val as f64 * 1000.0 * 60.0 * 60.0 * 24.0 * 365.0),
-        ("yr", "sec") => Ok(val as f64 * 60.0 * 60.0 * 24.0 * 365.0),
-        ("yr", "min") => Ok(val as f64 * 60.0 * 24.0 * 365.0),
-        ("yr", "hr") => Ok(val as f64 * 24.0 * 365.0),
-        ("yr", "day") => Ok(val as f64 * 365.0),
-        ("yr", "wk") => Ok(val as f64 * 52.0),
-        ("yr", "month") => Ok(val as f64 * 12.0),
-        ("yr", "yr") => Ok(val as f64),
-        ("yr", "dec") => Ok(val as f64 / 10.0),
 
         _ => Err(ShellError::CantConvertWithValue {
             to_type: "string duration".to_string(),
@@ -397,10 +337,7 @@ fn convert_str_from_unit_to_unit(
             details: to_unit.to_string(),
             dst_span: span,
             src_span: value_span,
-            help: Some(
-                "supported units are ns, us/µs, ms, sec, min, hr, day, wk, month, yr, and dec"
-                    .to_string(),
-            ),
+            help: Some("supported units are ns, us/µs, ms, sec, min, hr, day, and wk".to_string()),
         }),
     }
 }
@@ -430,10 +367,7 @@ fn string_to_duration(s: &str, span: Span, value_span: Span) -> Result<i64, Shel
         details: s.to_string(),
         dst_span: span,
         src_span: value_span,
-        help: Some(
-            "supported units are ns, us/µs, ms, sec, min, hr, day, wk, month, yr, and dec"
-                .to_string(),
-        ),
+        help: Some("supported units are ns, us/µs, ms, sec, min, hr, day, and wk".to_string()),
     })
 }
 
@@ -467,10 +401,7 @@ fn string_to_unit_duration(
         details: s.to_string(),
         dst_span: span,
         src_span: value_span,
-        help: Some(
-            "supported units are ns, us/µs, ms, sec, min, hr, day, wk, month, yr, and dec"
-                .to_string(),
-        ),
+        help: Some("supported units are ns, us/µs, ms, sec, min, hr, day, and wk".to_string()),
     })
 }
 

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -86,18 +86,10 @@ impl Command for SubCommand {
                 description: "convert duration to record",
                 example: "-500day | into record",
                 result: Some(Value::Record {
-                    cols: vec![
-                        "year".into(),
-                        "month".into(),
-                        "week".into(),
-                        "day".into(),
-                        "sign".into(),
-                    ],
+                    cols: vec!["week".into(), "day".into(), "sign".into()],
                     vals: vec![
-                        Value::Int { val: 1, span },
-                        Value::Int { val: 4, span },
-                        Value::Int { val: 2, span },
-                        Value::Int { val: 1, span },
+                        Value::Int { val: 71, span },
+                        Value::Int { val: 3, span },
                         Value::String {
                             val: "-".into(),
                             span,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3420,8 +3420,6 @@ pub enum TimePeriod {
     Hours(i64),
     Days(i64),
     Weeks(i64),
-    Months(i64),
-    Years(i64),
 }
 
 impl TimePeriod {
@@ -3435,8 +3433,6 @@ impl TimePeriod {
             Self::Hours(n) => format!("{n} hr").into(),
             Self::Days(n) => format!("{n} day").into(),
             Self::Weeks(n) => format!("{n} wk").into(),
-            Self::Months(n) => format!("{n} month").into(),
-            Self::Years(n) => format!("{n} yr").into(),
         }
     }
 }
@@ -3465,8 +3461,6 @@ pub fn format_duration(duration: i64) -> String {
 pub fn format_duration_as_timeperiod(duration: i64) -> (i32, Vec<TimePeriod>) {
     // Attribution: most of this is taken from chrono-humanize-rs. Thanks!
     // https://gitlab.com/imp/chrono-humanize-rs/-/blob/master/src/humantime.rs
-    const DAYS_IN_YEAR: i64 = 365;
-    const DAYS_IN_MONTH: i64 = 30;
 
     let (sign, duration) = if duration >= 0 {
         (1, duration)
@@ -3475,20 +3469,6 @@ pub fn format_duration_as_timeperiod(duration: i64) -> (i32, Vec<TimePeriod>) {
     };
 
     let dur = Duration::nanoseconds(duration);
-
-    /// Split this a duration into number of whole years and the remainder
-    fn split_years(duration: Duration) -> (Option<i64>, Duration) {
-        let years = duration.num_days() / DAYS_IN_YEAR;
-        let remainder = duration - Duration::days(years * DAYS_IN_YEAR);
-        normalize_split(years, remainder)
-    }
-
-    /// Split this a duration into number of whole months and the remainder
-    fn split_months(duration: Duration) -> (Option<i64>, Duration) {
-        let months = duration.num_days() / DAYS_IN_MONTH;
-        let remainder = duration - Duration::days(months * DAYS_IN_MONTH);
-        normalize_split(months, remainder)
-    }
 
     /// Split this a duration into number of whole weeks and the remainder
     fn split_weeks(duration: Duration) -> (Option<i64>, Duration) {
@@ -3555,17 +3535,8 @@ pub fn format_duration_as_timeperiod(duration: i64) -> (i32, Vec<TimePeriod>) {
     }
 
     let mut periods = vec![];
-    let (years, remainder) = split_years(dur);
-    if let Some(years) = years {
-        periods.push(TimePeriod::Years(years));
-    }
 
-    let (months, remainder) = split_months(remainder);
-    if let Some(months) = months {
-        periods.push(TimePeriod::Months(months));
-    }
-
-    let (weeks, remainder) = split_weeks(remainder);
+    let (weeks, remainder) = split_weeks(dur);
     if let Some(weeks) = weeks {
         periods.push(TimePeriod::Weeks(weeks));
     }


### PR DESCRIPTION
# Description

A while back, we [removed durations over a week](https://github.com/nushell/nushell/pull/6613) because they became inaccurate to calculate. For example, what is the length of a month? (28 days? 30 days? 31 days?) or a year? (365 days? 366 days?)

This leads to issues like #9118 where we don't display a sensible duration.

This PR removes any notion of durations above weeks. This is certainly less visually pleasing, but should be more accurate.

Before:
```
It's been this long since Nushell's first commit:
3yr 12month 1day 23hr 4min 10sec 929ms 851µs
```

Now:
```
It's been this long since Nushell's first commit:
208wk 23hr 24min 26sec 705ms 244µs
```

Fixes #9118 

# User-Facing Changes

Durations will now only show up to weeks and not months or years.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
