### PR TITLE
Reuse parsed modules

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1838,13 +1838,25 @@ pub fn parse_module_file_or_dir(
                     path_span,
                     name_override.or(Some(module_name)),
                 ) {
-                    let module = working_set.get_module_mut(module_id);
+                    let mut module = working_set.get_module(module_id).clone();
 
                     for (submodule_name, submodule_id) in submodules {
                         module.add_submodule(submodule_name, submodule_id);
                     }
 
-                    Some(module_id)
+                    let module_name = String::from_utf8_lossy(&module.name).to_string();
+
+                    let module_comments =
+                        if let Some(comments) = working_set.get_module_comments(module_id) {
+                            comments.to_vec()
+                        } else {
+                            vec![]
+                        };
+
+                    let new_module_id =
+                        working_set.add_module(&module_name, module, module_comments);
+
+                    Some(new_module_id)
                 } else {
                     None
                 }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1727,6 +1727,10 @@ fn parse_module_file(
     let file_id = working_set.add_file(path.to_string_lossy().to_string(), &contents);
     let new_span = working_set.get_span_for_file(file_id);
 
+    if let Some(module_id) = working_set.find_module_by_span(new_span) {
+        return Some(module_id);
+    }
+
     // Change the currently parsed directory
     let prev_currently_parsed_cwd = if let Some(parent) = path.parent() {
         let prev = working_set.currently_parsed_cwd.clone();

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1997,6 +1997,22 @@ impl<'a> StateWorkingSet<'a> {
 
         None
     }
+
+    pub fn find_module_by_span(&self, span: Span) -> Option<ModuleId> {
+        for (id, module) in self.delta.modules.iter().enumerate() {
+            if Some(span) == module.span {
+                return Some(self.permanent_state.num_modules() + id);
+            }
+        }
+
+        for (module_id, module) in self.permanent_state.modules.iter().enumerate() {
+            if Some(span) == module.span {
+                return Some(module_id);
+            }
+        }
+
+        None
+    }
 }
 
 impl Default for EngineState {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1322,6 +1322,13 @@ impl<'a> StateWorkingSet<'a> {
         module_id
     }
 
+    pub fn get_module_comments(&self, module_id: ModuleId) -> Option<&[Span]> {
+        self.delta
+            .usage
+            .get_module_comments(module_id)
+            .or_else(|| self.permanent_state.get_module_comments(module_id))
+    }
+
     pub fn next_span_start(&self) -> usize {
         let permanent_span_start = self.permanent_state.next_span_start();
 
@@ -1775,18 +1782,6 @@ impl<'a> StateWorkingSet<'a> {
             self.delta
                 .modules
                 .get(module_id - num_permanent_modules)
-                .expect("internal error: missing module")
-        }
-    }
-
-    pub fn get_module_mut(&mut self, module_id: ModuleId) -> &mut Module {
-        let num_permanent_modules = self.permanent_state.num_modules();
-        if module_id < num_permanent_modules {
-            panic!("Attempt to mutate a module that is in the permanent (immutable) state")
-        } else {
-            self.delta
-                .modules
-                .get_mut(module_id - num_permanent_modules)
                 .expect("internal error: missing module")
         }
     }

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, pipeline};
+use nu_test_support::{nu, nu_repl_code, pipeline};
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -639,6 +639,14 @@ fn module_dir() {
     let inp = &[import, "spam baz"];
     let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
     assert_eq!(actual.out, "spambaz");
+}
+
+#[test]
+fn module_dir_import_twice_no_panic() {
+    let import = "use samples/spam";
+    let inp = &[import, import, "spam"];
+    let actual_repl = nu!(cwd: "tests/modules", nu_repl_code(inp));
+    assert_eq!(actual_repl.out, "spam");
 }
 
 #[test]


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Similar to https://github.com/nushell/nushell/pull/8949, Nushell reuses parsed module if the same file is being parsed again.

## Benchmarks 

(results rounded to milliseconds, the mean values from `bench` vary within +-1 ms)

### Baseline

Overhead of calling `nu` on empty file:
```
> touch empty.nu
> bench { nu empty.nu } | get mean
~40ms
> bench { /home/kubouch/.cargo/target/release/nu empty.nu } | get mean
~40ms
```

### Benchmark 1

Repeated calls to `use`

```
# test.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
use crates/nu-std/lib/mod.nu
```

Old vs. new running times:
```
> use std bench
> bench { nu test.nu } | get main  
~128ms (+88 ms from baseline)
> bench { /home/kubouch/.cargo/target/release/nu test.nu } | get mean
~47ms (+7 ms from baseline)
```

## Benchmark 2

Real project which reuses a `utils` module in several files (https://github.com/kubouch/nuun, commit 5bf92d799d1561ddebd329c3e8106d575f4c8fa0)

```
# test_nuun.nu
use /home/kubouch/git/nuun/nuun/
```
```
> use std bench
> bench { nu test_nuun.nu } | get main  
~48 ms (+8 ms from baseline)
> bench { /home/kubouch/.cargo/target/release/nu test_nuun.nu } | get mean
~46 ms (+6 ms from baseline)
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Speedup if parsing the same file more than once as a module.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
