### PR TITLE
resolve standard library before ide commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,10 @@ fn main() -> Result<()> {
         engine_state.add_env_var("NU_LIB_DIRS".into(), Value::List { vals, span });
     }
 
+    if parsed_nu_cli_args.no_std_lib.is_none() {
+        load_standard_library(&mut engine_state)?;
+    }
+
     // IDE commands
     if let Some(ide_goto_def) = parsed_nu_cli_args.ide_goto_def {
         ide::goto_def(&mut engine_state, &script_name, &ide_goto_def);
@@ -250,10 +254,6 @@ fn main() -> Result<()> {
         column!(),
         use_color,
     );
-
-    if parsed_nu_cli_args.no_std_lib.is_none() {
-        load_standard_library(&mut engine_state)?;
-    }
 
     if let Some(commands) = parsed_nu_cli_args.commands.clone() {
         run_commands(


### PR DESCRIPTION
# Description

This PR moves loading the standard library before the ide commands are executed in hopes that the standard library will no longer give check errors. I'm not sure if this will be a big performance impact or not. We'll have to try it and see.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
