### PR TITLE
FEATURE: add a `main` command to `toolkit.nu`

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -245,3 +245,5 @@ export def setup-git-hooks [] {
         print $"aborting ('toolkit setup-git-hooks' | pretty-print-command)"
     }
 }
+
+export def main [] { help toolkit }


### PR DESCRIPTION
# Description
until now, a call to `toolkit` alone would give
```bash
Error: nu::shell::external_command

  × External command failed
   ╭─[entry #2:1:1]
 1 │ toolkit
   · ───┬───
   ·    ╰── did you mean 'toolkit clippy'?
   ╰────
  help: No such file or directory (os error 2)
```
which i find confusing after a `use toolkit.nu` :thinking: 

this PR adds a `main` command to `toolkit.nu` which runs the `help` command on the module.

# User-Facing Changes
now
```
> use toolkit.nu
> toolkit
Usage:
  > toolkit

Subcommands:
  toolkit check pr - run all the necessary checks and tests to submit a perfect PR
  toolkit clippy - check that you're using the standard code style
  toolkit fmt - check standard code formatting and apply the changes
  toolkit setup-git-hooks - set up git hooks to run:
- `toolkit fmt --check --verbose` on `git commit`
- `toolkit fmt --check --verbose` and `toolkit clippy --verbose` on `git push`
  toolkit test - check that all the tests pass
  toolkit test stdlib - run the tests for the standard library

Flags:
  -h, --help - Display the help message for this command
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```