### PR TITLE
swap the date and the log level in the `std log` format

### DIFF
--- a/crates/nu-std/lib/log.nu
+++ b/crates/nu-std/lib/log.nu
@@ -140,7 +140,7 @@ def log-formatted [
     prefix: string,
     message: string
 ] {
-    print --stderr $"($color)($prefix)|(now)|(ansi u)($message)(ansi reset)"
+    print --stderr $"($color)(now)|($prefix)|(ansi u)($message)(ansi reset)"
 }
 
 # Log a critical message


### PR DESCRIPTION
related to https://github.com/nushell/nushell/issues/8588#issuecomment-1538624565

# Description
this PR switches the date and log level in `std log` :+1: 

# User-Facing Changes
the date and log level are now swapped in the `std log` format.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```