### PR TITLE
add a negation glob option to the glob command

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -6,7 +9,7 @@ use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
     Spanned, SyntaxShape, Type, Value,
 };
-use wax::{Glob as WaxGlob, WalkBehavior};
+use wax::{Glob as WaxGlob, WalkBehavior, WalkEntry};
 
 #[derive(Clone)]
 pub struct Glob;
@@ -166,53 +169,80 @@ impl Command for Glob {
             }
         };
 
-        let (not_pat, not_span) = if let Some(not_pat) = not_pattern {
+        let (not_pat, not_span) = if let Some(not_pat) = not_pattern.clone() {
             (not_pat.item, not_pat.span)
         } else {
             (String::new(), Span::test_data())
         };
 
-        let glob_results = glob
-            .walk_with_behavior(
-                path,
-                WalkBehavior {
-                    depth: folder_depth,
-                    ..Default::default()
-                },
-            )
-            .not([not_pat.as_str()])
-            .map_err(|err| {
-                ShellError::GenericError(
-                    "error with glob's not pattern".to_string(),
-                    format!("{err}"),
-                    Some(not_span),
-                    None,
-                    Vec::new(),
+        Ok(if not_pattern.is_some() {
+            let glob_results = glob
+                .walk_with_behavior(
+                    path,
+                    WalkBehavior {
+                        depth: folder_depth,
+                        ..Default::default()
+                    },
                 )
-            })?
-            .flatten();
-
-        let mut result: Vec<Value> = Vec::new();
-        for entry in glob_results {
-            if nu_utils::ctrl_c::was_pressed(&ctrlc) {
-                result.clear();
-                break;
-            }
-            let file_type = entry.file_type();
-
-            if !(no_dirs && file_type.is_dir()
-                || no_files && file_type.is_file()
-                || no_symlinks && file_type.is_symlink())
-            {
-                result.push(Value::String {
-                    val: entry.into_path().to_string_lossy().to_string(),
-                    span,
-                });
-            }
-        }
-
-        Ok(result
-            .into_iter()
-            .into_pipeline_data(engine_state.ctrlc.clone()))
+                .not([not_pat.as_str()])
+                .map_err(|err| {
+                    ShellError::GenericError(
+                        "error with glob's not pattern".to_string(),
+                        format!("{err}"),
+                        Some(not_span),
+                        None,
+                        Vec::new(),
+                    )
+                })?
+                .flatten();
+            let result = glob_to_value(ctrlc, glob_results, no_dirs, no_files, no_symlinks, span)?;
+            result
+                .into_iter()
+                .into_pipeline_data(engine_state.ctrlc.clone())
+        } else {
+            let glob_results = glob
+                .walk_with_behavior(
+                    path,
+                    WalkBehavior {
+                        depth: folder_depth,
+                        ..Default::default()
+                    },
+                )
+                .flatten();
+            let result = glob_to_value(ctrlc, glob_results, no_dirs, no_files, no_symlinks, span)?;
+            result
+                .into_iter()
+                .into_pipeline_data(engine_state.ctrlc.clone())
+        })
     }
+}
+
+fn glob_to_value<'a>(
+    ctrlc: Option<Arc<AtomicBool>>,
+    glob_results: impl Iterator<Item = WalkEntry<'a>>,
+    no_dirs: bool,
+    no_files: bool,
+    no_symlinks: bool,
+    span: Span,
+) -> Result<Vec<Value>, ShellError> {
+    let mut result: Vec<Value> = Vec::new();
+    for entry in glob_results {
+        if nu_utils::ctrl_c::was_pressed(&ctrlc) {
+            result.clear();
+            return Err(ShellError::InterruptedByUser { span: None });
+        }
+        let file_type = entry.file_type();
+
+        if !(no_dirs && file_type.is_dir()
+            || no_files && file_type.is_file()
+            || no_symlinks && file_type.is_symlink())
+        {
+            result.push(Value::String {
+                val: entry.into_path().to_string_lossy().to_string(),
+                span,
+            });
+        }
+    }
+
+    Ok(result)
 }

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -44,7 +44,7 @@ impl Command for Glob {
             .named(
                 "not",
                 SyntaxShape::String,
-                "Pattern NOT to match",
+                "Pattern to exclude from the results",
                 Some('n'),
             )
             .category(Category::FileSystem)
@@ -108,7 +108,7 @@ impl Command for Glob {
                 result: None,
             },
             Example {
-                description: "Search for files name tsconfig.json that are not in node_modules directories",
+                description: "Search for files named tsconfig.json that are not in node_modules directories",
                 example: r#"glob **/tsconfig.json --not **/node_modules/**"#,
                 result: None,
             },


### PR DESCRIPTION
# Description
This PR adds the ability to add a negation glob.

Normal Example:
```
> glob **/tsconfig.json
╭───┬────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ 0 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\client\node_modules\big-integer\tsconfig.json │
│ 1 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\client\tsconfig.json                          │
│ 2 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\node_modules\fastq\test\tsconfig.json         │
│ 3 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\node_modules\jszip\tsconfig.json              │
│ 4 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\server\tsconfig.json                          │
│ 5 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\tsconfig.json                                 │
╰───┴────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
Negation Example:
```
> glob **/tsconfig.json --not **/node_modules/**
╭───┬───────────────────────────────────────────────────────────────────────────────╮
│ 0 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\client\tsconfig.json │
│ 1 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\server\tsconfig.json │
│ 2 │ C:\Users\username\source\repos\forks\vscode-nushell-lang\tsconfig.json        │
╰───┴───────────────────────────────────────────────────────────────────────────────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
