### PR TITLE
Add aarch64-pc-windows-msvc building target for nu binaries

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -99,6 +99,7 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
 # Build for Windows without static-link-openssl feature
 # ----------------------------------------------------------------------------
 if $os in ['windows-latest'] {
+    # let-env CARGO_BUILD_TARGET = $target
     if ($flags | str trim | is-empty) {
         cargo build --release --all --target $target
     } else {
@@ -128,7 +129,7 @@ sleep 3sec
 
 print $'(char nl)Check binary release version detail:'; hr-line
 let ver = if $os == 'windows-latest' {
-    (do -i { ./output/nu.exe -c 'version' }) | str join
+    (do -i { .\output\nu.exe -c 'version' }) | str join
 } else {
     (do -i { ./output/nu -c 'version' }) | str join
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3
       with:
-        version: 0.78.0
+        version: 0.79.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         - aarch64-apple-darwin
         - x86_64-apple-darwin
         - x86_64-pc-windows-msvc
+        - aarch64-pc-windows-msvc
         - x86_64-unknown-linux-gnu
         - x86_64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
@@ -41,6 +42,14 @@ jobs:
           os: windows-latest
           target_rustflags: ''
         - target: x86_64-pc-windows-msvc
+          extra: msi
+          os: windows-latest
+          target_rustflags: ''
+        - target: aarch64-pc-windows-msvc
+          extra: 'bin'
+          os: windows-latest
+          target_rustflags: ''
+        - target: aarch64-pc-windows-msvc
           extra: msi
           os: windows-latest
           target_rustflags: ''


### PR DESCRIPTION
# Description

1. Add `aarch64-pc-windows-msvc` building target for nu binaries
2. Bump nushell version for the binary release script

# User-Facing Changes

Add two more packages:

1. aarch64-pc-windows-msvc.zip
2. aarch64-pc-windows-msvc.msi

# Tests + Formatting

Release workflow test: https://github.com/hustcer/nu-release/actions/runs/4943037199
Create release draft test: https://github.com/hustcer/nu-release/releases/tag/v0.79.2
