### PR TITLE
add dataframe support to toolkit

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -31,13 +31,18 @@ export def fmt [
 # > it is important to make `clippy` happy :relieved:
 export def clippy [
     --verbose: bool # print extra information about the command's progress
+    --dataframe: bool # use the dataframe feature
 ] {
     if $verbose {
         print $"running ('toolkit clippy' | pretty-print-command)"
     }
 
     try {
-        cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err
+        if $dataframe {
+            cargo clippy --workspace --features=dataframe -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err
+        } else {
+            cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err
+        }
     } catch {
         error make -u { msg: $"\nplease fix the above ('clippy' | pretty-print-command) errors before continuing!" }
     }
@@ -46,9 +51,14 @@ export def clippy [
 # check that all the tests pass
 export def test [
     --fast: bool  # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
+    --dataframe: bool # use the dataframe feature
 ] {
-    if ($fast) {
-        cargo nextest --workspace
+    if ($fast and $dataframe) {
+        cargo nextest run --all --features=dataframe
+    } else if ($fast) {
+        cargo nextest run --all
+    } else if ($dataframe) {
+        cargo test --workspace --features=dataframe
     } else {
         cargo test --workspace
     }
@@ -198,6 +208,7 @@ def report [
 # now the whole `toolkit check pr` passes! :tada:
 export def "check pr" [
     --fast: bool  # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
+    --dataframe: bool # use the dataframe feature
 ] {
     let-env NU_TEST_LOCALE_OVERRIDE = 'en_US.utf8';
     try {
@@ -207,14 +218,24 @@ export def "check pr" [
     }
 
     try {
-        clippy --verbose
+        if $dataframe { 
+            clippy --dataframe --verbose 
+        } else { 
+            clippy --verbose 
+        }
     } catch {
         return (report --fail-clippy)
     }
 
     print $"running ('toolkit test' | pretty-print-command)"
     try {
-        if $fast { test --fast } else { test }
+        if $fast and $dataframe { 
+            test --fast --dataframe 
+        } else if $fast { 
+            test --fast 
+        } else { 
+            test 
+        }
     } catch {
         return (report --fail-test)
     }


### PR DESCRIPTION
# Description
This PR allows you to pass `--dataframe` into `toolkit check pr --fast --dataframe` in order to check and build with the dataframe feature.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
