### PR TITLE
Add `overlay delete` command, so we have a way to make it not recordable

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/overlay/delete.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/delete.rs
@@ -1,0 +1,92 @@
+use super::OverlayHide;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type};
+
+#[derive(Clone)]
+pub struct OverlayDelete;
+
+impl Command for OverlayDelete {
+    fn name(&self) -> &str {
+        "overlay delete"
+    }
+
+    fn usage(&self) -> &str {
+        "delete an active overlay."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("overlay delete")
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .optional("name", SyntaxShape::String, "Overlay to delete")
+            .switch(
+                "keep-custom",
+                "Keep all newly added commands and aliases in the next activated overlay",
+                Some('k'),
+            )
+            .named(
+                "keep-env",
+                SyntaxShape::List(Box::new(SyntaxShape::String)),
+                "List of environment variables to keep in the next activated overlay",
+                Some('e'),
+            )
+            .category(Category::Core)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        // only different to `overlay hide` in parse stage.
+        let hide_cmd = OverlayHide;
+        hide_cmd.run(engine_state, stack, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Keep a custom command after hiding the overlay",
+                example: r#"module spam { export def foo [] { "foo" } }
+    overlay use spam
+    def bar [] { "bar" }
+    overlay delete spam --keep-custom
+    bar
+    "#,
+                result: None,
+            },
+            Example {
+                description: "Delete an overlay created from a file",
+                example: r#"'export alias f = "foo"' | save spam.nu
+    overlay use spam.nu
+    overlay delete spam"#,
+                result: None,
+            },
+            Example {
+                description: "Delete the last activated overlay",
+                example: r#"module spam { export-env { let-env FOO = "foo" } }
+    overlay use spam
+    overlay delete"#,
+                result: None,
+            },
+            Example {
+                description: "Keep the current working directory when deleting an overlay",
+                example: r#"overlay new spam
+    cd some-dir
+    overlay delete --keep-env [ PWD ] spam"#,
+                result: None,
+            },
+        ]
+    }
+}

--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -126,7 +126,7 @@ impl Command for OverlayHide {
                 result: None,
             },
             Example {
-                description: "Keep the current working directory when removing an overlay",
+                description: "Keep the current working directory when hiding an overlay",
                 example: r#"overlay new spam
     cd some-dir
     overlay hide --keep-env [ PWD ] spam"#,

--- a/crates/nu-cmd-lang/src/core_commands/overlay/mod.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/mod.rs
@@ -1,10 +1,12 @@
 mod command;
+mod delete;
 mod hide;
 mod list;
 mod new;
 mod use_;
 
 pub use command::Overlay;
+pub use delete::OverlayDelete;
 pub use hide::OverlayHide;
 pub use list::OverlayList;
 pub use new::OverlayNew;

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -51,6 +51,7 @@ pub fn create_default_context() -> EngineState {
             OverlayList,
             OverlayNew,
             OverlayHide,
+            OverlayDelete,
             Let,
             Loop,
             Match,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -116,6 +116,7 @@ pub fn parse_keyword(
 
         match cmd.name() {
             "overlay hide" => parse_overlay_hide(working_set, call),
+            "overlay delete" => parse_overlay_delete(working_set, call),
             "overlay new" => parse_overlay_new(working_set, call),
             "overlay use" => parse_overlay_use(working_set, call),
             _ => Pipeline::from_vec(vec![call_expr]),
@@ -2682,6 +2683,14 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 }
 
 pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
+    del_overlay(working_set, call, true)
+}
+
+pub fn parse_overlay_delete(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
+    del_overlay(working_set, call, false)
+}
+
+fn del_overlay(working_set: &mut StateWorkingSet, call: Box<Call>, permanently: bool) -> Pipeline {
     let call_span = call.span();
 
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
@@ -2736,11 +2745,14 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
         return pipeline;
     }
 
-    working_set.remove_overlay(overlay_name.as_bytes(), keep_custom);
+    if permanently {
+        working_set.remove_overlay(overlay_name.as_bytes(), keep_custom);
+    } else {
+        working_set.delete_overlay(overlay_name.as_bytes(), keep_custom);
+    }
 
     pipeline
 }
-
 pub fn parse_let_or_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
     let name = working_set.get_span_contents(spans[0]);
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -249,6 +249,24 @@ impl EngineState {
             .overlays
             .retain(|overlay_info| !first.deleted_overlays.contains(&overlay_info.0));
 
+        // overlays are saved as a vector, the overlay id is vector' index
+        // so after delete overlays, active overlays need to be changed accordingly.
+        // or else active_overlay ids will be incorrect.
+        for overlay_id in &mut self.scope.active_overlays {
+            for del_id in deleted_ids.iter() {
+                if *overlay_id > *del_id {
+                    *overlay_id -= 1;
+                }
+            }
+        }
+        for overlay_id in &mut activated_ids {
+            for del_id in deleted_ids.iter() {
+                if *overlay_id > *del_id {
+                    *overlay_id -= 1;
+                }
+            }
+        }
+
         let mut removed_ids = vec![];
 
         for name in &first.removed_overlays {

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -112,6 +112,11 @@ impl ScopeFrame {
                 removed_overlays.push(name.clone());
             }
         }
+        for name in &self.deleted_overlays {
+            if !removed_overlays.contains(name) {
+                removed_overlays.push(name.clone());
+            }
+        }
 
         self.active_overlays
             .iter()

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -61,6 +61,9 @@ pub struct ScopeFrame {
     /// Removed overlays from previous scope frames / permanent state
     pub removed_overlays: Vec<Vec<u8>>,
 
+    /// Deleted overlays from previous scope frames / permanent state
+    pub deleted_overlays: Vec<Vec<u8>>,
+
     /// temporary storage for predeclarations
     pub predecls: HashMap<Vec<u8>, DeclId>,
 }
@@ -71,6 +74,7 @@ impl ScopeFrame {
             overlays: vec![],
             active_overlays: vec![],
             removed_overlays: vec![],
+            deleted_overlays: vec![],
             predecls: HashMap::new(),
         }
     }
@@ -80,6 +84,7 @@ impl ScopeFrame {
             overlays: vec![(name, OverlayFrame::from_origin(origin, prefixed))],
             active_overlays: vec![0],
             removed_overlays: vec![],
+            deleted_overlays: vec![],
             predecls: HashMap::new(),
         }
     }


### PR DESCRIPTION
# Description

Introduce `overlay delete` command, overlay deleted by this way is not recordable.
```
❯ overlay use tests/overlays/samples/spam.nu;
❯ let-env a = "b"
❯ overlay delete spam
❯ overlay use tests/overlays/samples/spam.nu;

# overlay is deleted rather than hidden,so we can't access $env.a after re-use.
❯ $env.a
Error: nu::shell::column_not_found

  × Cannot find column
   ╭─[entry #5:1:1]
 1 │ $env.a
   · ──┬─ ┬
   ·   │  ╰── cannot find column 'a'
   ·   ╰── value originates here
   ╰────
```

I've considered to rename from `removed_overlay` to `hidden_overlay` in code base, but the change set will be too large, I think it's ok to keep it small for easily review

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
