### PR TITLE
fix the span of the global `std help` item

### DIFF
--- a/crates/nu-std/lib/help.nu
+++ b/crates/nu-std/lib/help.nu
@@ -719,15 +719,15 @@ You can also learn more at (ansi default_italic)(ansi light_cyan_underline)https
         return
     }
 
-    let item = ($item | str join " ")
+    let target_item = ($item | str join " ")
 
-    let commands = (try { help commands $item --find $find })
+    let commands = (try { help commands $target_item --find $find })
     if not ($commands | is-empty) { return $commands }
 
-    let aliases = (try { help aliases $item --find $find })
+    let aliases = (try { help aliases $target_item --find $find })
     if not ($aliases | is-empty) { return $aliases }
 
-    let modules = (try { help modules $item --find $find })
+    let modules = (try { help modules $target_item --find $find })
     if not ($modules | is-empty) { return $modules }
 
     let span = (metadata $item | get span)


### PR DESCRIPTION
related to 
- #9101
- #9039

# Description
i actually forgot to fix in #9039 the new "*item*" introduced by #9101... :eyes: 
there it is :innocent: 

# User-facing changes
going from
```
> std help git-commiteuwqi
Help pages from external command git-commiteuwqi:
No manual entry for git-commiteuwqi
Error:
  × std::help::item_not_found
     ╭─[help:721:1]
 721 │
 722 │     let item = ($item | str join " ")
     ·     ─┬─
     ·      ╰── item not found
 723 │
     ╰────
```
to
```
> std help git-commiteuwqi
Help pages from external command git-commiteuwqi:
No manual entry for git-commiteuwqi
Error:
  × std::help::item_not_found
   ╭─[entry #2:1:1]
 1 │ std help git-commiteuwqi
   ·          ───────┬───────
   ·                 ╰── item not found
   ╰────
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```