### PR TITLE
Removes unnecessary cwd and pipeline from various tests  

### DIFF
--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -270,7 +270,7 @@ fn test_computable_style_closure_errors() {
         };"#,
         "[bell] | table",
     ];
-    let actual_repl = nu!(cwd: ".", nu_repl_code(&inp));
+    let actual_repl = nu!(nu_repl_code(&inp));
     // Check that the error was printed
     assert!(actual_repl.err.contains("type mismatch for operator"));
     // Check that the value was printed

--- a/crates/nu-command/src/strings/split/words.rs
+++ b/crates/nu-command/src/strings/split/words.rs
@@ -363,17 +363,17 @@ fn split_words_helper(
 #[cfg(test)]
 mod test {
     use super::*;
-    use nu_test_support::{nu, pipeline};
+    use nu_test_support::nu;
 
     #[test]
     fn test_incompat_flags() {
-        let out = nu!(cwd: ".", pipeline("'a' | split words -bg -l 2"));
+        let out = nu!("'a' | split words -bg -l 2");
         assert!(out.err.contains("incompatible_parameters"));
     }
 
     #[test]
     fn test_incompat_flags_2() {
-        let out = nu!(cwd: ".", pipeline("'a' | split words -g"));
+        let out = nu!("'a' | split words -g");
         assert!(out.err.contains("incompatible_parameters"));
     }
 

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -71,9 +71,8 @@ fn cant_alias_keyword() {
 
 #[test]
 fn alias_wont_recurse() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(pipeline(
+        "
             module myspamsymbol {
                 export def myfoosymbol [prefix: string, msg: string] {
                     $prefix + $msg
@@ -82,7 +81,7 @@ fn alias_wont_recurse() {
             use myspamsymbol myfoosymbol;
             alias myfoosymbol = myfoosymbol 'hello';
             myfoosymbol ' world'
-        "#
+        "
     ));
 
     assert_eq!(actual.out, "hello world");

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -4,8 +4,8 @@ use nu_test_support::{nu, pipeline};
 fn checks_all_rows_are_true() {
     let actual = nu!(pipeline(
         r#"
-                echo  [ "Andrés", "Andrés", "Andrés" ]
-                | all {|it| $it == "Andrés" }
+            echo  [ "Andrés", "Andrés", "Andrés" ]
+            | all {|it| $it == "Andrés" }
         "#
     ));
 
@@ -14,14 +14,14 @@ fn checks_all_rows_are_true() {
 
 #[test]
 fn checks_all_rows_are_false_with_param() {
-    let actual = nu!(r#" [1, 2, 3, 4] | all { |a| $a >= 5 } "#);
+    let actual = nu!(" [1, 2, 3, 4] | all { |a| $a >= 5 } ");
 
     assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn checks_all_rows_are_true_with_param() {
-    let actual = nu!(r#" [1, 2, 3, 4] | all { |a| $a < 5 } "#);
+    let actual = nu!(" [1, 2, 3, 4] | all { |a| $a < 5 } ");
 
     assert_eq!(actual.out, "true");
 }
@@ -29,16 +29,16 @@ fn checks_all_rows_are_true_with_param() {
 #[test]
 fn checks_all_columns_of_a_table_is_true() {
     let actual = nu!(pipeline(
-        r#"
-                echo [
-                        [  first_name, last_name,   rusty_at, likes  ];
-                        [      Andrés,  Robalino, '10/11/2013',   1    ]
-                        [    JT,    Turner, '10/12/2013',   1    ]
-                        [      Darren, Schroeder, '10/11/2013',   1    ]
-                        [      Yehuda,      Katz, '10/11/2013',   1    ]
-                ]
-                | all {|x| $x.likes > 0 }
-        "#
+        "
+            echo [
+                    [  first_name, last_name,   rusty_at, likes  ];
+                    [      Andrés,  Robalino, '10/11/2013',   1    ]
+                    [    JT,    Turner, '10/12/2013',   1    ]
+                    [      Darren, Schroeder, '10/11/2013',   1    ]
+                    [      Yehuda,      Katz, '10/11/2013',   1    ]
+            ]
+            | all {|x| $x.likes > 0 }
+        "
     ));
 
     assert_eq!(actual.out, "true");
@@ -60,35 +60,35 @@ fn checks_if_all_returns_error_with_invalid_command() {
 
 #[test]
 fn works_with_1_param_blocks() {
-    let actual = nu!(r#"[1 2 3] | all {|e| print $e | true }"#);
+    let actual = nu!("[1 2 3] | all {|e| print $e | true }");
 
     assert_eq!(actual.out, "123true");
 }
 
 #[test]
 fn works_with_0_param_blocks() {
-    let actual = nu!(r#"[1 2 3] | all {|| print $in | true }"#);
+    let actual = nu!("[1 2 3] | all {|| print $in | true }");
 
     assert_eq!(actual.out, "123true");
 }
 
 #[test]
 fn early_exits_with_1_param_blocks() {
-    let actual = nu!(r#"[1 2 3] | all {|e| print $e | false }"#);
+    let actual = nu!("[1 2 3] | all {|e| print $e | false }");
 
     assert_eq!(actual.out, "1false");
 }
 
 #[test]
 fn early_exits_with_0_param_blocks() {
-    let actual = nu!(r#"[1 2 3] | all {|| print $in | false }"#);
+    let actual = nu!("[1 2 3] | all {|| print $in | false }");
 
     assert_eq!(actual.out, "1false");
 }
 
 #[test]
 fn all_uses_enumerate_index() {
-    let actual = nu!(r#"[7 8 9] | enumerate | all {|el| print $el.index | true }"#);
+    let actual = nu!("[7 8 9] | enumerate | all {|el| print $el.index | true }");
 
     assert_eq!(actual.out, "012true");
 }

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -4,8 +4,8 @@ use nu_test_support::{nu, pipeline};
 fn checks_any_row_is_true() {
     let actual = nu!(pipeline(
         r#"
-                echo  [ "Ecuador", "USA", "New Zealand" ]
-                | any {|it| $it == "New Zealand" }
+            echo  [ "Ecuador", "USA", "New Zealand" ]
+            | any {|it| $it == "New Zealand" }
         "#
     ));
 
@@ -15,16 +15,16 @@ fn checks_any_row_is_true() {
 #[test]
 fn checks_any_column_of_a_table_is_true() {
     let actual = nu!(pipeline(
-        r#"
-                echo [
-                        [  first_name, last_name,   rusty_at, likes  ];
-                        [      Andrés,  Robalino, '10/11/2013',   1    ]
-                        [    JT,    Turner, '10/12/2013',   1    ]
-                        [      Darren, Schroeder, '10/11/2013',   1    ]
-                        [      Yehuda,      Katz, '10/11/2013',   1    ]
-                ]
-                | any {|x| $x.rusty_at == '10/12/2013' }
-        "#
+        "
+            echo [
+                    [  first_name, last_name,   rusty_at, likes  ];
+                    [      Andrés,  Robalino, '10/11/2013',   1    ]
+                    [    JT,    Turner, '10/12/2013',   1    ]
+                    [      Darren, Schroeder, '10/11/2013',   1    ]
+                    [      Yehuda,      Katz, '10/11/2013',   1    ]
+            ]
+            | any {|x| $x.rusty_at == '10/12/2013' }
+        "
     ));
 
     assert_eq!(actual.out, "true");
@@ -46,35 +46,35 @@ fn checks_if_any_returns_error_with_invalid_command() {
 
 #[test]
 fn works_with_1_param_blocks() {
-    let actual = nu!(r#"[1 2 3] | any {|e| print $e | false }"#);
+    let actual = nu!("[1 2 3] | any {|e| print $e | false }");
 
     assert_eq!(actual.out, "123false");
 }
 
 #[test]
 fn works_with_0_param_blocks() {
-    let actual = nu!(r#"[1 2 3] | any {|| print $in | false }"#);
+    let actual = nu!("[1 2 3] | any {|| print $in | false }");
 
     assert_eq!(actual.out, "123false");
 }
 
 #[test]
 fn early_exits_with_1_param_blocks() {
-    let actual = nu!(r#"[1 2 3] | any {|e| print $e | true }"#);
+    let actual = nu!("[1 2 3] | any {|e| print $e | true }");
 
     assert_eq!(actual.out, "1true");
 }
 
 #[test]
 fn early_exits_with_0_param_blocks() {
-    let actual = nu!(r#"[1 2 3] | any {|| print $in | true }"#);
+    let actual = nu!("[1 2 3] | any {|| print $in | true }");
 
     assert_eq!(actual.out, "1true");
 }
 
 #[test]
 fn any_uses_enumerate_index() {
-    let actual = nu!(r#"[7 8 9] | enumerate | any {|el| print $el.index | false }"#);
+    let actual = nu!("[7 8 9] | enumerate | any {|el| print $el.index | false }");
 
     assert_eq!(actual.out, "012false");
 }

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -2,50 +2,35 @@ use nu_test_support::nu;
 
 #[test]
 fn each_works_separately() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats",
-        "echo [1 2 3] | each { |it| echo $it 10 | math sum } | to json -r"
-    );
+    let actual = nu!("echo [1 2 3] | each { |it| echo $it 10 | math sum } | to json -r");
 
     assert_eq!(actual.out, "[11,12,13]");
 }
 
 #[test]
 fn each_group_works() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats",
-        "echo [1 2 3 4 5 6] | group 3 | to json --raw"
-    );
+    let actual = nu!("echo [1 2 3 4 5 6] | group 3 | to json --raw");
 
     assert_eq!(actual.out, "[[1,2,3],[4,5,6]]");
 }
 
 #[test]
 fn each_window() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats",
-        "echo [1 2 3 4] | window 3 | to json --raw"
-    );
+    let actual = nu!("echo [1 2 3 4] | window 3 | to json --raw");
 
     assert_eq!(actual.out, "[[1,2,3],[2,3,4]]");
 }
 
 #[test]
 fn each_window_stride() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats",
-        "echo [1 2 3 4 5 6] | window 3 -s 2 | to json --raw"
-    );
+    let actual = nu!("echo [1 2 3 4 5 6] | window 3 -s 2 | to json --raw");
 
     assert_eq!(actual.out, "[[1,2,3],[3,4,5]]");
 }
 
 #[test]
 fn each_no_args_in_block() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats",
-        "echo [[foo bar]; [a b] [c d] [e f]] | each {|i| $i | to json -r } | get 1"
-    );
+    let actual = nu!("echo [[foo bar]; [a b] [c d] [e f]] | each {|i| $i | to json -r } | get 1");
 
     assert_eq!(actual.out, r#"{"foo": "c","bar": "d"}"#);
 }
@@ -53,7 +38,6 @@ fn each_no_args_in_block() {
 #[test]
 fn each_implicit_it_in_block() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         "echo [[foo bar]; [a b] [c d] [e f]] | each { |it| nu --testbin cococo $it.foo } | str join"
     );
 

--- a/crates/nu-command/tests/commands/export_def.rs
+++ b/crates/nu-command/tests/commands/export_def.rs
@@ -1,13 +1,8 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn export_subcommands_help() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        export def -h
-        "#
-    ));
+    let actual = nu!("export def -h");
 
     assert!(actual
         .out

--- a/crates/nu-command/tests/commands/fill.rs
+++ b/crates/nu-command/tests/commands/fill.rs
@@ -2,29 +2,19 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn string_fill_plain() {
-    let actual = nu!(
-        cwd: ".",
-        pipeline(
-            r#"
-            "abc" | fill --alignment center --character "+" --width 5
-            "#
-        )
-    );
+    let actual = nu!(r#""abc" | fill --alignment center --character "+" --width 5"#);
 
     assert_eq!(actual.out, "+abc+");
 }
 
 #[test]
 fn string_fill_fancy() {
-    let actual = nu!(
-        cwd: ".",
-        pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
             $"(ansi red)a(ansi green)\u{65}\u{308}(ansi cyan)c(ansi reset)" 
             | fill --alignment center --character "+" --width 5
             "#
-        )
-    );
+    ));
 
     assert_eq!(
         actual.out,

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -68,13 +68,12 @@ fn gets_first_row_when_no_amount_given() {
 
 #[test]
 fn gets_first_row_as_list_when_amount_given() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
-                [1, 2, 3]
-                | first 1
-                | describe
-            "#
+            [1, 2, 3]
+            | first 1
+            | describe
+        "#
     ));
 
     assert_eq!(actual.out, "list<int> (stream)");
@@ -83,24 +82,18 @@ fn gets_first_row_as_list_when_amount_given() {
 #[test]
 // covers a situation where `first` used to behave strangely on list<binary> input
 fn works_with_binary_list() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        ([0x[01 11]] | first) == 0x[01 11]
-            "#
-    ));
+    let actual = nu!("([0x[01 11]] | first) == 0x[01 11]");
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn errors_on_negative_rows() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
-                [1, 2, 3]
-                | first -10
-            "#
+            [1, 2, 3]
+            | first -10
+        "#
     ));
 
     assert!(actual.err.contains("use a positive value"));

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -176,7 +176,7 @@ fn errors_fetching_by_index_out_of_bounds() {
 
 #[test]
 fn errors_fetching_by_accessing_empty_list() {
-    let actual = nu!(cwd: ".", pipeline(r#"[] | get 3"#));
+    let actual = nu!("[] | get 3");
     assert!(actual.err.contains("Row number too large (empty content)"),);
 }
 

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -19,13 +19,13 @@ fn help_commands_length() {
 
 #[test]
 fn help_shows_signature() {
-    let actual = nu!(cwd: ".", pipeline("help str distance"));
+    let actual = nu!("help str distance");
     assert!(actual
         .out
         .contains("<string> | str distance <string> -> <int>"));
 
     // don't show signature for parser keyword
-    let actual = nu!(cwd: ".", pipeline("help alias"));
+    let actual = nu!("help alias");
     assert!(!actual.out.contains("Signatures"));
 }
 
@@ -36,7 +36,7 @@ fn help_aliases() {
         "alias SPAM = print 'spam'",
         "help aliases | where name == SPAM | length",
     ];
-    let actual = nu!(cwd: ".", nu_repl_code(code));
+    let actual = nu!(nu_repl_code(code));
 
     assert_eq!(actual.out, "1");
 }
@@ -289,21 +289,21 @@ fn help_usage_extra_usage_command() {
             "#,
         )]);
 
-        let actual = nu!(cwd: dirs.test(), pipeline("use spam.nu *; help modules spam"));
+        let actual = nu!(cwd: dirs.test(), "use spam.nu *; help modules spam");
         assert!(actual.out.contains("module_line1"));
         assert!(actual.out.contains("module_line2"));
 
         let actual = nu!(cwd: dirs.test(),
-            pipeline("use spam.nu *; help modules | where name == spam | get 0.usage"));
+            "use spam.nu *; help modules | where name == spam | get 0.usage");
         assert!(actual.out.contains("module_line1"));
         assert!(!actual.out.contains("module_line2"));
 
-        let actual = nu!(cwd: dirs.test(), pipeline("use spam.nu *; help commands foo"));
+        let actual = nu!(cwd: dirs.test(), "use spam.nu *; help commands foo");
         assert!(actual.out.contains("def_line1"));
         assert!(actual.out.contains("def_line2"));
 
         let actual = nu!(cwd: dirs.test(),
-            pipeline("use spam.nu *; help commands | where name == foo | get 0.usage"));
+            "use spam.nu *; help commands | where name == foo | get 0.usage");
         assert!(actual.out.contains("def_line1"));
         assert!(!actual.out.contains("def_line2"));
     })
@@ -356,7 +356,7 @@ fn help_modules_main_1() {
         "help spam",
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.out.contains("  spam"));
 }

--- a/crates/nu-command/tests/commands/join.rs
+++ b/crates/nu-command/tests/commands/join.rs
@@ -84,7 +84,7 @@ fn do_cases_where_result_is_same_between_join_types(join_type: &str) {
         (("[{a: 1}]", "[{a: 1 b: 1}]", "a"), "[[a, b]; [1, 1]]"),
     ] {
         let expr = format!("{} | join {} {} {} | to nuon", left, right, join_type, on);
-        let actual = nu!(cwd: ".", expr).out;
+        let actual = nu!(expr).out;
         assert_eq!(actual, expected);
 
         // Test again with streaming input (using `each` to convert the input into a ListStream)
@@ -93,7 +93,7 @@ fn do_cases_where_result_is_same_between_join_types(join_type: &str) {
             "{} | {} join {} {} {} | to nuon",
             left, to_list_stream, right, join_type, on
         );
-        let actual = nu!(cwd: ".", expr).out;
+        let actual = nu!(expr).out;
         assert_eq!(actual, expected);
     }
 }
@@ -199,7 +199,7 @@ fn do_cases_where_result_differs_between_join_types(join_type: &str) {
         for (join_type_, expected) in join_types {
             if join_type_ == join_type {
                 let expr = format!("{} | join {} {} {} | to nuon", left, right, join_type, on);
-                let actual = nu!(cwd: ".", expr).out;
+                let actual = nu!(expr).out;
                 assert_eq!(actual, expected);
 
                 // Test again with streaming input (using `each` to convert the input into a ListStream)
@@ -208,7 +208,7 @@ fn do_cases_where_result_differs_between_join_types(join_type: &str) {
                     "{} | {} join {} {} {} | to nuon",
                     left, to_list_stream, right, join_type, on
                 );
-                let actual = nu!(cwd: ".", expr).out;
+                let actual = nu!(expr).out;
                 assert_eq!(actual, expected);
             }
         }
@@ -339,7 +339,7 @@ fn do_cases_where_result_differs_between_join_types_with_different_join_keys(joi
         for (join_type_, expected) in join_types {
             if join_type_ == join_type {
                 let expr = format!("{} | join {} {} {} {} | to nuon", left, right, join_type, left_on, right_on);
-                let actual = nu!(cwd: ".", expr).out;
+                let actual = nu!(expr).out;
                 assert_eq!(actual, expected);
 
                 // Test again with streaming input (using `each` to convert the input into a ListStream)
@@ -348,7 +348,7 @@ fn do_cases_where_result_differs_between_join_types_with_different_join_keys(joi
                     "{} | {} join {} {} {} {} | to nuon",
                     left, to_list_stream, right, join_type, left_on, right_on
                 );
-                let actual = nu!(cwd: ".", expr).out;
+                let actual = nu!(expr).out;
                 assert_eq!(actual, expected);
             }
         }
@@ -366,7 +366,7 @@ fn test_alternative_table_syntax() {
         (("[[a]; [1]]", "[[a]; [1]]", "a"), "[[a]; [1]]"),
     ] {
         let expr = format!("{} | join {} {} {} | to nuon", left, right, join_type, on);
-        let actual = nu!(cwd: ".", &expr).out;
+        let actual = nu!(&expr).out;
         assert_eq!(actual, expected, "Expression was {}", &expr);
     }
 }

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -81,12 +81,11 @@ fn gets_last_row_as_list_when_amount_given() {
 
 #[test]
 fn last_errors_on_negative_index() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-                [1, 2, 3]
-                | last -2
-            "#
+    let actual = nu!(pipeline(
+        "
+            [1, 2, 3]
+            | last -2
+        "
     ));
 
     assert!(actual.err.contains("use a positive value"));
@@ -94,7 +93,7 @@ fn last_errors_on_negative_index() {
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | last"));
+    let actual = nu!("1 | last");
 
     assert!(actual.err.contains("only_supports_this_input_type"));
 }


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Cleans up various tests that unnecessarily use the `cwd` argument of `nu!`, and the `pipeline` function for single line commands. Also replaces some unnecessary raw strings with normal strings. Part of #8670.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
None

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
All checks pass

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->