### PR TITLE
fix clippy warning on clippy 0.1.69

### DIFF
--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -99,7 +99,6 @@ impl Command for Items {
             PipelineData::Value(Value::Record { cols, vals, .. }, ..) => Ok(cols
                 .into_iter()
                 .zip(vals.into_iter())
-                .into_iter()
                 .map_while(run_for_each_item)
                 .into_pipeline_data(ctrlc)),
             // Errors

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1155,11 +1155,7 @@ impl<'a> StateWorkingSet<'a> {
     }
 
     pub fn unique_overlay_names(&self) -> HashSet<&Vec<u8>> {
-        let mut names: HashSet<&Vec<u8>> = self
-            .permanent_state
-            .active_overlay_names(&[])
-            .into_iter()
-            .collect();
+        let mut names: HashSet<&Vec<u8>> = self.permanent_state.active_overlay_names(&[]).collect();
 
         for scope_frame in self.delta.scope.iter().rev() {
             for overlay_id in scope_frame.active_overlays.iter().rev() {


### PR DESCRIPTION
# Description
As title, when I run clippy locally, I get something like following warning:
<img width="1383" alt="Screenshot 2023-05-15 at 22 34 57" src="https://github.com/nushell/nushell/assets/22256154/4d4254bc-9e42-437e-9169-d15e9a97aa57">

This pr is going to fix it

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
