### PR TITLE
Pull in the latest features from reedline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.19.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#65c4e7a419122a526b66adb9695d9d924bf921f6"
+source = "git+https://github.com/nushell/reedline.git?branch=main#7f54706cab9c64139e382936303a484c9c2726d3"
 dependencies = [
  "chrono",
  "crossterm 0.26.1",

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -140,6 +140,7 @@ pub fn evaluate_repl(
             ),
         };
         line_editor = line_editor
+            .with_history_exclusion_prefix(Some(" ".into()))
             .with_history_session_id(history_session_id)
             .with_history(history);
     };


### PR DESCRIPTION
# Description

We missed to upgrade to the latest features of reedline and only upgraded publicly to the changes that fix the bracketed paste on the reedline side.

This includes a semantic change in the core of reedline on how bindings are processed and also a bigger change to the history to support ignoring of entries for the history.
If you just release the current reedline `main` we would not enable history exclusion. This requires the second commit of this PR.

## Commits

We may want to only merge the first (Doing a branched of release of just what we already pinned in `Cargo.lock` seems like extraordinary effort)

- Update to most recent reedline state
- Enable history exclusion with preceding SPACE


# User-Facing Changes

If we land the first commit will change the behavior of keybindings that were previously ignored as they tried to capture a potentially printable character that was directly inserted into the buffer. Now more bindings are possible:
- Binding a printable character in the inserting modes (`vi_insert` and `emacs`).
- Use of `Ctrl-Alt` combinations that were previously ignored to make sure `AltGr` characters (found on many European keyboards) can properly be inserted.

If we land the second commit before the release will ignore all manually entered lines starting with the space from addition to the history. You can still recall the last entry by pressing up arrow once even if it started with a space but it will not be stored in the history file.

# Tests + Formatting

The newest reedline behavior wasn't really tested by a wider base of users in the full nushell context.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
