### PR TITLE
fix: 🐛 handle windows Path casing

### DIFF
--- a/crates/nu-std/lib/mod.nu
+++ b/crates/nu-std/lib/mod.nu
@@ -38,23 +38,17 @@ export def-env "path add" [
     --append (-a)  # append to $env.PATH instead of prepending to.
     ...paths  # the paths to add to $env.PATH.
 ] {
-    let on_windows = ($nu.os-info.family == windows)
-    if  $on_windows {
-        let-env Path = (
-            $env.Path
+    let path_name = if "PATH" in $env { "PATH" } else { "Path" }
+
+    let-env $path_name = (
+            $env
+            | get $path_name
             | if $append { append $paths }
             else { prepend $paths }
-        )
-    } else {
-        let-env PATH = (
-            $env.PATH
-            | if $append { append $paths }
-            else { prepend $paths }
-        )
-    }
+    )
     
     if $ret {
-        if $on_windows { $env.Path } else { $env.PATH }
+        $env | get $path_name
     }
 }
 

--- a/crates/nu-std/lib/mod.nu
+++ b/crates/nu-std/lib/mod.nu
@@ -38,14 +38,23 @@ export def-env "path add" [
     --append (-a)  # append to $env.PATH instead of prepending to.
     ...paths  # the paths to add to $env.PATH.
 ] {
-    let-env PATH = (
-        $env.PATH
-        | if $append { append $paths }
-        else { prepend $paths }
-    )
-
+    let on_windows = ($nu.os-info.family == windows)
+    if  $on_windows {
+        let-env Path = (
+            $env.Path
+            | if $append { append $paths }
+            else { prepend $paths }
+        )
+    } else {
+        let-env PATH = (
+            $env.PATH
+            | if $append { append $paths }
+            else { prepend $paths }
+        )
+    }
+    
     if $ret {
-        $env.PATH
+        if $on_windows { $env.Path } else { $env.PATH }
     }
 }
 

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -8,22 +8,22 @@ export def test_path_add [] {
     with-env [$path_name []] {
         def get_path [] { $env | get $path_name }
     
-        assert equal get_path []
+        assert equal (get_path) []
 
         std path add "/foo/"
-        assert equal get_path ["/foo/"]
+        assert equal (get_path) ["/foo/"]
 
         std path add "/bar/" "/baz/"
-        assert equal get_path ["/bar/", "/baz/", "/foo/"]
+        assert equal (get_path) ["/bar/", "/baz/", "/foo/"]
 
-        let-env PATH = []
+        let-env $path_name = []
 
         std path add "foo"
         std path add "bar" "baz" --append
-        assert equal get_path ["foo", "bar", "baz"]
+        assert equal (get_path) ["foo", "bar", "baz"]
 
         assert equal (std path add "fooooo" --ret) ["fooooo", "foo", "bar", "baz"]
-        assert equal get_path ["fooooo", "foo", "bar", "baz"]
+        assert equal (get_path) ["fooooo", "foo", "bar", "baz"]
     }
 }
 

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -3,23 +3,27 @@ use std
 export def test_path_add [] {
     use std "assert equal"
 
-    with-env [PATH []] {
-        assert equal $env.PATH []
+    let path_name = if "PATH" in $env { "PATH" } else { "Path" }
+
+    with-env [$path_name []] {
+        def get_path [] { $env | get $path_name }
+    
+        assert equal get_path []
 
         std path add "/foo/"
-        assert equal $env.PATH ["/foo/"]
+        assert equal get_path ["/foo/"]
 
         std path add "/bar/" "/baz/"
-        assert equal $env.PATH ["/bar/", "/baz/", "/foo/"]
+        assert equal get_path ["/bar/", "/baz/", "/foo/"]
 
         let-env PATH = []
 
         std path add "foo"
         std path add "bar" "baz" --append
-        assert equal $env.PATH ["foo", "bar", "baz"]
+        assert equal get_path ["foo", "bar", "baz"]
 
         assert equal (std path add "fooooo" --ret) ["fooooo", "foo", "bar", "baz"]
-        assert equal $env.PATH ["fooooo", "foo", "bar", "baz"]
+        assert equal get_path ["fooooo", "foo", "bar", "baz"]
     }
 }
 


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

PATH and Path are different (in nushell at least) based on the OS

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
None the command now works as expected

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
