### PR TITLE
Pin reedline to `0.19.1` for 0.80 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4366,8 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.19.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#65c4e7a419122a526b66adb9695d9d924bf921f6"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d763be5efcabcd27d6e804d126661215aa0a2d898c13c0aa1c953c6652fcec"
 dependencies = [
  "chrono",
  "crossterm 0.26.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ nu-std = { path = "./crates/nu-std", version = "0.79.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.79.1" }
 
 nu-ansi-term = "0.47.0"
-reedline = { version = "0.19.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.19.1", features = ["bashisms", "sqlite"]}
 
 rayon = "1.7.0"
 is_executable = "1.0.1"
@@ -160,7 +160,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
+# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Criterion benchmarking setup

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -24,7 +24,7 @@ nu-utils = { path = "../nu-utils", version = "0.79.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.79.1" }
 
 nu-ansi-term = "0.47.0"
-reedline = { version = "0.19.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.19.1", features = ["bashisms", "sqlite"]}
 
 atty = "0.2.14"
 chrono = { default-features = false, features = ["std"], version = "0.4.23" }


### PR DESCRIPTION
# Description
This just includes the bracketed paste bugfix in nushell/reedline#577


# User-Facing Changes
None

# Tests + Formatting

# After Submitting
