### PR TITLE
add -u flag to cp, mv command

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -1,6 +1,6 @@
 use std::fs::read_link;
 use std::io::{BufReader, BufWriter, ErrorKind, Read, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -184,7 +184,7 @@ impl Command for Cp {
                             canonicalize_with(dst.as_path(), &current_dir_path).unwrap_or(dst);
 
                         // ignore when source file is not newer than target file
-                        if update_mode && is_older(&src, &dst) {
+                        if update_mode && super::util::is_older(&src, &dst) {
                             continue;
                         }
 
@@ -575,34 +575,6 @@ fn copy_symlink(
                 vec![],
             )),
         },
-    }
-}
-
-fn is_older(src: &Path, dst: &Path) -> bool {
-    if !dst.exists() {
-        return true;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        let src_ctime = std::fs::metadata(src)
-            .map(|m| m.ctime())
-            .unwrap_or(i64::MIN);
-        let dst_ctime = std::fs::metadata(dst)
-            .map(|m| m.ctime())
-            .unwrap_or(i64::MAX);
-        src_ctime < dst_ctime
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt;
-        let src_ctime = std::fs::metadata(src)
-            .map(|m| m.last_write_time())
-            .unwrap_or(u64::MIN);
-        let dst_ctime = std::fs::metadata(dst)
-            .map(|m| m.last_write_time())
-            .unwrap_or(u64::MAX);
-        src_ctime < dst_ctime
     }
 }
 

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -132,3 +132,31 @@ fn get_interactive_confirmation(prompt: String) -> Result<bool, Box<dyn Error>> 
         Ok(false)
     }
 }
+
+pub fn is_older(src: &Path, dst: &Path) -> bool {
+    if !dst.exists() {
+        return true;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let src_ctime = std::fs::metadata(src)
+            .map(|m| m.ctime())
+            .unwrap_or(i64::MIN);
+        let dst_ctime = std::fs::metadata(dst)
+            .map(|m| m.ctime())
+            .unwrap_or(i64::MAX);
+        src_ctime <= dst_ctime
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        let src_ctime = std::fs::metadata(src)
+            .map(|m| m.last_write_time())
+            .unwrap_or(u64::MIN);
+        let dst_ctime = std::fs::metadata(dst)
+            .map(|m| m.last_write_time())
+            .unwrap_or(u64::MAX);
+        src_ctime <= dst_ctime
+    }
+}

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -601,5 +601,11 @@ fn copy_file_with_update_flag_impl(progress: bool) {
             progress_flag,
         );
         assert!(actual.out.contains("body"));
+
+        // create a file after assert to make sure that newest_valid.txt is newest
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        sandbox.with_files(vec![FileWithContent("newest_valid.txt", "newest_body")]);
+        let actual = nu!(cwd: sandbox.cwd(), "cp {} -u newest_valid.txt valid.txt; open valid.txt", progress_flag);
+        assert_eq!(actual.out, "newest_body");
     });
 }

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -1,7 +1,7 @@
 use nu_test_support::fs::file_contents;
 use nu_test_support::fs::{
     files_exist_at, AbsoluteFile,
-    Stub::{EmptyFile, FileWithPermission},
+    Stub::{EmptyFile, FileWithContent, FileWithPermission},
 };
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
@@ -577,5 +577,29 @@ fn copy_file_with_read_permission_impl(progress: bool) {
             actual.err.contains("invalid_prem.txt")
                 && actual.err.contains("copying to destination")
         );
+    });
+}
+
+#[test]
+fn copy_file_with_update_flag() {
+    copy_file_with_update_flag_impl(false);
+    copy_file_with_update_flag_impl(true);
+}
+
+fn copy_file_with_update_flag_impl(progress: bool) {
+    Playground::setup("cp_test_19", |_dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("valid.txt"),
+            FileWithContent("newer_valid.txt", "body"),
+        ]);
+
+        let progress_flag = if progress { "-p" } else { "" };
+
+        let actual = nu!(
+            cwd: sandbox.cwd(),
+            "cp {} -u valid.txt newer_valid.txt; open newer_valid.txt",
+            progress_flag,
+        );
+        assert!(actual.out.contains("body"));
     });
 }

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -478,5 +478,13 @@ fn mv_with_update_flag() {
             "mv -uf valid.txt newer_valid.txt; open newer_valid.txt",
         );
         assert_eq!(actual.out, "body");
+
+        // create a file after assert to make sure that newest_valid.txt is newest
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        sandbox.with_files(vec![
+            FileWithContent("newest_valid.txt", "newest_body")
+        ]);
+        let actual = nu!(cwd: sandbox.cwd(), "mv -uf newest_valid.txt valid.txt; open valid.txt");
+        assert_eq!(actual.out, "newest_body");
     });
 }

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -481,9 +481,7 @@ fn mv_with_update_flag() {
 
         // create a file after assert to make sure that newest_valid.txt is newest
         std::thread::sleep(std::time::Duration::from_secs(1));
-        sandbox.with_files(vec![
-            FileWithContent("newest_valid.txt", "newest_body")
-        ]);
+        sandbox.with_files(vec![FileWithContent("newest_valid.txt", "newest_body")]);
         let actual = nu!(cwd: sandbox.cwd(), "mv -uf newest_valid.txt valid.txt; open valid.txt");
         assert_eq!(actual.out, "newest_body");
     });

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -1,4 +1,4 @@
-use nu_test_support::fs::{files_exist_at, Stub::EmptyFile};
+use nu_test_support::fs::{files_exist_at, Stub::EmptyFile, Stub::FileWithContent};
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 
@@ -463,4 +463,20 @@ fn mv_change_case_of_file() {
         assert!(!files_in_test_directory.contains(&original_file_name));
         assert!(files_in_test_directory.contains(&new_file_name));
     })
+}
+
+#[test]
+fn mv_with_update_flag() {
+    Playground::setup("mv_with_update_flag", |_dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("valid.txt"),
+            FileWithContent("newer_valid.txt", "body"),
+        ]);
+
+        let actual = nu!(
+            cwd: sandbox.cwd(),
+            "mv -uf valid.txt newer_valid.txt; open newer_valid.txt",
+        );
+        assert_eq!(actual.out, "body");
+    });
 }


### PR DESCRIPTION
# Description
Closes: #7853

I found that I want this feature too...

So I take over it, sorry for that @VincenzoCarlino 

# User-Facing Changes

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
