### PR TITLE
bump nushell from release version to development version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.60"
-version = "0.80.0"
+version = "0.80.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -47,22 +47,22 @@ crossterm = "0.26"
 ctrlc = "3.2.1"
 log = "0.4"
 miette = { version = "5.7.0", features = ["fancy-no-backtrace"] }
-nu-cli = { path = "./crates/nu-cli", version = "0.80.0" }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.80.0" }
-nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.80.0" }
-nu-command = { path = "./crates/nu-command", version = "0.80.0" }
-nu-engine = { path = "./crates/nu-engine", version = "0.80.0" }
-nu-json = { path = "./crates/nu-json", version = "0.80.0" }
-nu-parser = { path = "./crates/nu-parser", version = "0.80.0" }
-nu-path = { path = "./crates/nu-path", version = "0.80.0" }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.80.0" }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.80.0" }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.80.0" }
-nu-system = { path = "./crates/nu-system", version = "0.80.0" }
-nu-table = { path = "./crates/nu-table", version = "0.80.0" }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.80.0" }
-nu-std = { path = "./crates/nu-std", version = "0.80.0" }
-nu-utils = { path = "./crates/nu-utils", version = "0.80.0" }
+nu-cli = { path = "./crates/nu-cli", version = "0.80.1" }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.80.1" }
+nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.80.1" }
+nu-command = { path = "./crates/nu-command", version = "0.80.1" }
+nu-engine = { path = "./crates/nu-engine", version = "0.80.1" }
+nu-json = { path = "./crates/nu-json", version = "0.80.1" }
+nu-parser = { path = "./crates/nu-parser", version = "0.80.1" }
+nu-path = { path = "./crates/nu-path", version = "0.80.1" }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.80.1" }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.80.1" }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.80.1" }
+nu-system = { path = "./crates/nu-system", version = "0.80.1" }
+nu-table = { path = "./crates/nu-table", version = "0.80.1" }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.80.1" }
+nu-std = { path = "./crates/nu-std", version = "0.80.1" }
+nu-utils = { path = "./crates/nu-utils", version = "0.80.1" }
 
 nu-ansi-term = "0.47.0"
 reedline = { version = "0.19.1", features = ["bashisms", "sqlite"]}
@@ -92,7 +92,7 @@ nix = { version = "0.26", default-features = false, features = [
 atty = "0.2"
 
 [dev-dependencies]
-nu-test-support = { path = "./crates/nu-test-support", version = "0.80.0" }
+nu-test-support = { path = "./crates/nu-test-support", version = "0.80.1" }
 tempfile = "3.5.0"
 assert_cmd = "2.0.2"
 criterion = "0.4"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -5,23 +5,23 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.80.0" }
+nu-test-support = { path = "../nu-test-support", version = "0.80.1" }
 rstest = { version = "0.17.0", default-features = false }
 
 [dependencies]
-nu-command = { path = "../nu-command", version = "0.80.0" }
-nu-engine = { path = "../nu-engine", version = "0.80.0" }
-nu-path = { path = "../nu-path", version = "0.80.0" }
-nu-parser = { path = "../nu-parser", version = "0.80.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.80.0" }
-nu-utils = { path = "../nu-utils", version = "0.80.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.80.0" }
+nu-command = { path = "../nu-command", version = "0.80.1" }
+nu-engine = { path = "../nu-engine", version = "0.80.1" }
+nu-path = { path = "../nu-path", version = "0.80.1" }
+nu-parser = { path = "../nu-parser", version = "0.80.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1" }
+nu-utils = { path = "../nu-utils", version = "0.80.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.80.1" }
 
 nu-ansi-term = "0.47.0"
 reedline = { version = "0.19.1", features = ["bashisms", "sqlite"]}

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -6,17 +6,17 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-lang"
 edition = "2021"
 license = "MIT"
 name = "nu-cmd-lang"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-color-config = { path = "../nu-color-config", version = "0.80.0" }
-nu-engine = { path = "../nu-engine", version = "0.80.0" }
-nu-parser = { path = "../nu-parser", version = "0.80.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.80.0"  }
-nu-utils = { path = "../nu-utils", version = "0.80.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.80.1" }
+nu-engine = { path = "../nu-engine", version = "0.80.1" }
+nu-parser = { path = "../nu-parser", version = "0.80.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1"  }
+nu-utils = { path = "../nu-utils", version = "0.80.1" }
 
 nu-ansi-term = "0.47.0"
 
@@ -29,4 +29,4 @@ shadow-rs = { version = "0.21.0", default-features = false }
 shadow-rs = { version = "0.21.0", default-features = false }
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.80.0"  }
+nu-test-support = { path="../nu-test-support", version = "0.80.1"  }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-confi
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
@@ -13,11 +13,11 @@ bench = false
 [dependencies]
 serde = { version="1.0.123", features=["derive"] }
 
-nu-protocol = { path = "../nu-protocol", version = "0.80.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1"  }
 nu-ansi-term = "0.47.0"
-nu-utils = { path = "../nu-utils", version = "0.80.0" }
-nu-engine = { path = "../nu-engine", version = "0.80.0" }
-nu-json = { path="../nu-json", version = "0.80.0"  }
+nu-utils = { path = "../nu-utils", version = "0.80.1" }
+nu-engine = { path = "../nu-engine", version = "0.80.1" }
+nu-json = { path="../nu-json", version = "0.80.1"  }
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.80.0"  }
+nu-test-support = { path="../nu-test-support", version = "0.80.1"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-command"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
-version = "0.80.0"
+version = "0.80.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,20 +13,20 @@ version = "0.80.0"
 bench = false
 
 [dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.80.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.80.0" }
-nu-engine = { path = "../nu-engine", version = "0.80.0" }
-nu-explore = { path = "../nu-explore", version = "0.80.0" }
-nu-glob = { path = "../nu-glob", version = "0.80.0" }
-nu-json = { path = "../nu-json", version = "0.80.0" }
-nu-parser = { path = "../nu-parser", version = "0.80.0" }
-nu-path = { path = "../nu-path", version = "0.80.0" }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.80.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.80.0" }
-nu-system = { path = "../nu-system", version = "0.80.0" }
-nu-table = { path = "../nu-table", version = "0.80.0" }
-nu-term-grid = { path = "../nu-term-grid", version = "0.80.0" }
-nu-utils = { path = "../nu-utils", version = "0.80.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.80.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.80.1" }
+nu-engine = { path = "../nu-engine", version = "0.80.1" }
+nu-explore = { path = "../nu-explore", version = "0.80.1" }
+nu-glob = { path = "../nu-glob", version = "0.80.1" }
+nu-json = { path = "../nu-json", version = "0.80.1" }
+nu-parser = { path = "../nu-parser", version = "0.80.1" }
+nu-path = { path = "../nu-path", version = "0.80.1" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.80.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1" }
+nu-system = { path = "../nu-system", version = "0.80.1" }
+nu-table = { path = "../nu-table", version = "0.80.1" }
+nu-term-grid = { path = "../nu-term-grid", version = "0.80.1" }
+nu-utils = { path = "../nu-utils", version = "0.80.1" }
 num-format = { version = "0.4.3" }
 nu-ansi-term = "0.47.0"
 
@@ -167,7 +167,7 @@ trash-support = ["trash"]
 which-support = ["which"]
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.80.0" }
+nu-test-support = { path = "../nu-test-support", version = "0.80.1" }
 mockito = "1.0.0"
 
 dirs-next = "2.0.0"

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.80.0"  }
-nu-path = { path = "../nu-path", version = "0.80.0"  }
-nu-glob = { path = "../nu-glob", version = "0.80.0" }
-nu-utils = { path = "../nu-utils", version = "0.80.0"  }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.80.1"  }
+nu-path = { path = "../nu-path", version = "0.80.1"  }
+nu-glob = { path = "../nu-glob", version = "0.80.1" }
+nu-utils = { path = "../nu-utils", version = "0.80.1"  }
 
 chrono = { version="0.4.23", features = ["std"], default-features = false }
 serde = {version = "1.0.143", default-features = false }

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -5,20 +5,20 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-explore"
 edition = "2021"
 license = "MIT"
 name = "nu-explore"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
 
 [dependencies]
 nu-ansi-term = "0.47.0"
-nu-protocol = { path = "../nu-protocol", version = "0.80.0" }
-nu-parser = { path = "../nu-parser", version = "0.80.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.80.0" }
-nu-engine = { path = "../nu-engine", version = "0.80.0" }
-nu-table = { path = "../nu-table", version = "0.80.0" }
-nu-json = { path = "../nu-json", version = "0.80.0"  }
-nu-utils = { path = "../nu-utils", version = "0.80.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1" }
+nu-parser = { path = "../nu-parser", version = "0.80.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.80.1" }
+nu-engine = { path = "../nu-engine", version = "0.80.1" }
+nu-table = { path = "../nu-table", version = "0.80.1" }
+nu-json = { path = "../nu-json", version = "0.80.1"  }
+nu-utils = { path = "../nu-utils", version = "0.80.1"  }
 
 terminal_size = "0.2.1"
 strip-ansi-escapes = "0.1.1"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.80.0"
+version = "0.80.1"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.80.0"
+version = "0.80.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,5 +22,5 @@ num-traits = "0.2.14"
 serde = "1.0"
 
 [dev-dependencies]
-# nu-path = { path="../nu-path", version = "0.80.0" }
+# nu-path = { path="../nu-path", version = "0.80.1" }
 # serde_json = "1.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
@@ -17,10 +17,10 @@ itertools = "0.10"
 miette = {version = "5.7.0", features = ["fancy-no-backtrace"]}
 thiserror = "1.0.31"
 serde_json = "1.0"
-nu-path = {path = "../nu-path", version = "0.80.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.80.0" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.80.0"  }
-nu-engine = { path = "../nu-engine", version = "0.80.0" }
+nu-path = {path = "../nu-path", version = "0.80.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1" }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.80.1"  }
+nu-engine = { path = "../nu-engine", version = "0.80.1" }
 log = "0.4"
 
 [dev-dependencies]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -5,15 +5,15 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
 
 [dependencies]
 bincode = "1.3.3"
-nu-protocol = { path = "../nu-protocol", version = "0.80.0"  }
-nu-engine = { path = "../nu-engine", version = "0.80.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1"  }
+nu-engine = { path = "../nu-engine", version = "0.80.1"  }
 serde = { version = "1.0.143" }
 serde_json = { version = "1.0"}
 rmp = "0.8.11"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.80.0"
+version = "0.80.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +13,7 @@ version = "0.80.0"
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.80.0" }
+nu-utils = { path = "../nu-utils", version = "0.80.1" }
 
 byte-unit = "4.0.9"
 chrono = { version = "0.4.23", features = [
@@ -39,4 +39,4 @@ plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = "1.0"
-nu-test-support = { path = "../nu-test-support", version = "0.80.0" }
+nu-test-support = { path = "../nu-test-support", version = "0.80.1" }

--- a/crates/nu-std/Cargo.toml
+++ b/crates/nu-std/Cargo.toml
@@ -5,9 +5,9 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-std"
 edition = "2021"
 license = "MIT"
 name = "nu-std"
-version = "0.80.0"
+version = "0.80.1"
 
 [dependencies]
 miette = { version = "5.6.0", features = ["fancy-no-backtrace"] }
-nu-parser = { version = "0.80.0", path = "../nu-parser" }
-nu-protocol = { version = "0.80.0", path = "../nu-protocol" }
+nu-parser = { version = "0.80.1", path = "../nu-parser" }
+nu-protocol = { version = "0.80.1", path = "../nu-protocol" }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.80.0"
+version = "0.80.1"
 edition = "2021"
 license = "MIT"
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -5,20 +5,20 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.80.0" }
-nu-utils = { path = "../nu-utils", version = "0.80.0" }
-nu-engine = { path = "../nu-engine", version = "0.80.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.80.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1" }
+nu-utils = { path = "../nu-utils", version = "0.80.1" }
+nu-engine = { path = "../nu-engine", version = "0.80.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.80.1" }
 
 nu-ansi-term = "0.47.0"
 
 tabled = { version = "0.12.0", features = ["color"], default-features = false }
 
 [dev-dependencies]
-# nu-test-support = { path="../nu-test-support", version = "0.80.0"  }
+# nu-test-support = { path="../nu-test-support", version = "0.80.1"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 bench = false
@@ -13,4 +13,4 @@ bench = false
 [dependencies]
 unicode-width = "0.1.9"
 
-nu-utils = { path = "../nu-utils", version = "0.80.0"  }
+nu-utils = { path = "../nu-utils", version = "0.80.1"  }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-suppor
 edition = "2021"
 license = "MIT"
 name = "nu-test-support"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 doctest = false
 bench = false
 
 [dependencies]
-nu-path = { path="../nu-path", version = "0.80.0"  }
-nu-glob = { path = "../nu-glob", version = "0.80.0" }
-nu-utils = { path="../nu-utils", version = "0.80.0"  }
+nu-path = { path="../nu-path", version = "0.80.1"  }
+nu-glob = { path = "../nu-glob", version = "0.80.1" }
+nu-utils = { path="../nu-utils", version = "0.80.1"  }
 num-format = "0.4.3"
 which = "4.3.0"
 

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-utils"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
-version = "0.80.0"
+version = "0.80.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -1,6 +1,6 @@
 # Nushell Config File
 #
-# version = 0.80.0
+# version = 0.80.1
 
 # For more information on defining custom themes, see
 # https://www.nushell.sh/book/coloring_and_theming.html

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -1,6 +1,6 @@
 # Nushell Environment Config File
 #
-# version = 0.80.0
+# version = 0.80.1
 
 def create_left_prompt [] {
     mut home = ""

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -10,7 +10,7 @@ name = "nu_plugin_custom_values"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.80.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.80.0", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.80.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1", features = ["plugin"] }
 serde = { version = "1.0", default-features = false }
 typetag = "0.2.5"

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_exam
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.80.0"
+version = "0.80.1"
 
 [[bin]]
 name = "nu_plugin_example"
@@ -15,5 +15,5 @@ bench = false
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.80.0" }
-nu-protocol = { path="../nu-protocol", version = "0.80.0", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.80.1" }
+nu-protocol = { path="../nu-protocol", version = "0.80.1", features = ["plugin"]}

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -5,13 +5,13 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_form
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_formats"
-version = "0.80.0"
+version = "0.80.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.80.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.80.0", features = ["plugin"] }
-nu-engine = { path = "../nu-engine", version = "0.80.0" }
+nu-plugin = { path = "../nu-plugin", version = "0.80.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.80.1", features = ["plugin"] }
+nu-engine = { path = "../nu-engine", version = "0.80.1" }
 indexmap = { version = "1.7", features = ["serde-1"] }
 
 eml-parser = "0.1.0"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gsta
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 doctest = false
@@ -16,8 +16,8 @@ name = "nu_plugin_gstat"
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.80.0" }
-nu-protocol = { path="../nu-protocol", version = "0.80.0" }
-nu-engine = { path="../nu-engine", version = "0.80.0" }
+nu-plugin = { path="../nu-plugin", version = "0.80.1" }
+nu-protocol = { path="../nu-protocol", version = "0.80.1" }
+nu-engine = { path="../nu-engine", version = "0.80.1" }
 
 git2 = "0.17.0"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_inc"
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.80.0" }
-nu-protocol = { path="../nu-protocol", version = "0.80.0", features = ["plugin"]}
+nu-plugin = { path="../nu-plugin", version = "0.80.1" }
+nu-protocol = { path="../nu-protocol", version = "0.80.1", features = ["plugin"]}
 
 semver = "1.0.16"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_quer
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.80.0"
+version = "0.80.1"
 
 [lib]
 doctest = false
@@ -17,9 +17,9 @@ bench = false
 
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.80.0" }
-nu-protocol = { path="../nu-protocol", version = "0.80.0" }
-nu-engine = { path="../nu-engine", version = "0.80.0" }
+nu-plugin = { path="../nu-plugin", version = "0.80.1" }
+nu-protocol = { path="../nu-protocol", version = "0.80.1" }
+nu-engine = { path="../nu-engine", version = "0.80.1" }
 gjson = "0.8.0"
 scraper = { default-features = false, version = "0.15.0" }
 sxd-document = "0.3.2"


### PR DESCRIPTION
# Description

Bump nushell to 0.80.1 development version

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
