### PR TITLE
revert pr 5812, adding windows terminal fragment

### DIFF
--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -76,14 +76,14 @@
                             KeyPath='yes'/>
                     </Component>
 
-                    <Component Id='icon0' Guid='*' Win64='$(var.Win64)'>
+                    <!-- <Component Id='icon0' Guid='*' Win64='$(var.Win64)'>
                         <File
                             Id='icon0'
                             Name='nu.ico'
                             DiskId='1'
                             Source='assets/nu_logo.ico'
                             KeyPath='yes'/>
-                    </Component>
+                    </Component> -->
 
                     <Directory Id='Bin' Name='bin'>
                         <Component Id='Path' Guid='285921EA-6DC0-4632-B12C-D7D737F30686' Win64='$(var.Win64)' KeyPath='yes'>
@@ -284,7 +284,7 @@
                     </Directory>
                 </Directory>
             </Directory>
-
+<!--
             <Directory Id='CommonAppDataFolder'>
                 <Directory Id='AppDataMicrosoftFolder' Name='Microsoft'>
                     <Directory Id='AppDataWindowsTerminalFolder' Name='Windows Terminal'>
@@ -303,7 +303,7 @@
                     </Directory>
                 </Directory>
             </Directory>
-        </Directory>
+        </Directory> -->
 
         <Feature
             Id='Binaries'
@@ -320,7 +320,7 @@
             -->
             <ComponentRef Id='License'/>
 
-            <ComponentRef Id='icon0'/>
+            <!-- <ComponentRef Id='icon0'/> -->
 
             <ComponentRef Id='binary0'/>
             <!-- <ComponentRef Id='binary1'/> -->
@@ -354,7 +354,7 @@
                 Absent='allow'>
                 <ComponentRef Id='Path'/>
             </Feature>
-
+<!--
             <Feature
                 Id='WindowsTerminalProfile'
                 Title='Windows Terminal Profile'
@@ -362,17 +362,17 @@
                 Level='1'
                 Absent='allow'>
                 <ComponentRef Id='WindowsTerminalProfile'/>
-            </Feature>
+            </Feature> -->
         </Feature>
 
         <SetProperty Id='ARPINSTALLLOCATION' Value='[APPLICATIONFOLDER]' After='CostFinalize'/>
 
-        <Icon Id='ProductICO' SourceFile='assets/nu_logo.ico'/>
+        <!-- <Icon Id='ProductICO' SourceFile='assets/nu_logo.ico'/>
         <Property Id='ARPPRODUCTICON' Value='ProductICO' />
-
+ -->
         <Property Id='ARPHELPLINK' Value='https://www.nushell.sh/book/'/>
 
-        <SetProperty
+        <!-- <SetProperty
             Id="ReplacePathsInWindowsTerminalProfile"
             Sequence="execute"
             Value="&quot;[#exe0]&quot; -c &quot;open '[#WindowsTerminalProfileFile]' | update profiles.commandline '[#exe0]' | update profiles.icon '[#icon0]' | save -f '[#WindowsTerminalProfileFile]'&quot;"
@@ -383,13 +383,13 @@
             DllEntry="CAQuietExec"
             Execute="deferred"
             Return="check"
-            Impersonate="no"/>
-        <InstallExecuteSequence>
-            <Custom Action='ReplacePathsInWindowsTerminalProfile' Before='InstallFinalize'>
+            Impersonate="no"/> -->
                 <!-- Run the custom action if the feature is enabled -->
+        <!-- <InstallExecuteSequence>
+            <Custom Action='ReplacePathsInWindowsTerminalProfile' Before='InstallFinalize'>
                 <![CDATA[&WindowsTerminalProfile=3 OR (!WindowsTerminalProfile=3 AND REINSTALL<>"")]]>
             </Custom>
-        </InstallExecuteSequence>
+        </InstallExecuteSequence> -->
 
         <UI>
             <UIRef Id='WixUI_FeatureTree'/>

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -302,8 +302,8 @@
                         </Directory>
                     </Directory>
                 </Directory>
-            </Directory>
-        </Directory> -->
+            </Directory>-->
+        </Directory>
 
         <Feature
             Id='Binaries'


### PR DESCRIPTION
# Description

This PR reverts PR #5812 because it continually is causing failures in the Winget approval CI. See https://github.com/microsoft/winget-pkgs/pull/106977#issuecomment-1551795077

I'd love to keep this feature but we need to be able to pass winget's validation process without intervention and right now we cannot do that.

Making this a draft to see if anyone responds on how to fix it.

# User-Facing Changes

I tested it and the release ci creates a msi installer and it installs fine with these changes but now there's no more Windows Terminal fragment for nushell.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
