### PR TITLE
Added `assert not` command (assertion that the value/expression is `false`)

### DIFF
--- a/crates/nu-std/lib/testing.nu
+++ b/crates/nu-std/lib/testing.nu
@@ -54,6 +54,55 @@ export def assert [
     }
 }
 
+
+# Negative assertion
+#
+# If the condition is not false, it generates an error.
+#
+# # Examples
+#
+# >_ assert (42 == 3)
+# >_ assert (3 == 3)
+# Error:
+#   × Assertion failed: 
+#     ╭─[myscript.nu:11:1]
+#  11 │ assert (42 == 3)
+#  12 │ assert (3 == 3)
+#     ·         ───┬────
+#     ·            ╰── It is not false.
+#  13 │
+#     ╰────
+#
+# 
+# The --error-label flag can be used if you want to create a custom assert command:
+# ```
+# def "assert not even" [number: int] {
+#     assert not ($number mod 2 == 0) --error-label {
+#         start: (metadata $number).span.start,
+#         end: (metadata $number).span.end,
+#         text: $"($number) is an even number",
+#     }
+# }
+# ```
+#
+export def "assert not" [
+    condition: bool, # Condition, which should be false 
+    message?: string, # Optional error message
+    --error-label: record # Label for `error make` if you want to create a custom assert
+] {
+    if $condition {
+        let span = (metadata $condition).span
+        error make {
+            msg: ($message | default "Assertion failed."),
+            label: ($error_label | default {
+                text: "It is not false.",
+                start: (metadata $condition).span.start,
+                end: (metadata $condition).span.end
+            })
+        }
+    }
+}
+
 # Assert that executing the code generates an error
 #
 # For more documentation see the assert command

--- a/crates/nu-std/lib/testing.nu
+++ b/crates/nu-std/lib/testing.nu
@@ -48,8 +48,8 @@ export def assert [
         msg: ($message | default "Assertion failed."),
         label: ($error_label | default {
             text: "It is not true.",
-            start: (metadata $condition).span.start,
-            end: (metadata $condition).span.end
+            start: $span.start,
+            end: $span.end
         })
     }
 }
@@ -96,8 +96,8 @@ export def "assert not" [
             msg: ($message | default "Assertion failed."),
             label: ($error_label | default {
                 text: "It is not false.",
-                start: (metadata $condition).span.start,
-                end: (metadata $condition).span.end
+                start: $span.start,
+                end: $span.end
             })
         }
     }

--- a/crates/nu-std/tests/test_asserts.nu
+++ b/crates/nu-std/tests/test_asserts.nu
@@ -7,6 +7,13 @@ export def test_assert [] {
     assert error { assert (1 + 2 == 4) }
 }
 
+export def test_assert_not [] {
+    assert not false
+    assert not (1 + 2 == 4)
+    assert error { assert not true }
+    assert error { assert not (1 + 2 == 3) }
+}
+
 export def test_assert_equal [] {
     assert equal (1 + 2) 3
     assert equal (0.1 + 0.2 | into string | into decimal) 0.3 # 0.30000000000000004 == 0.3

--- a/crates/nu-std/tests/test_logger.nu
+++ b/crates/nu-std/tests/test_logger.nu
@@ -114,8 +114,8 @@ def "assert custom message contains" [
     tested_str
 ] {
     let output = (run custom $system_level $format $message_level)
-    assert ($output | str contains  $tested_str)
-    assert ($output | str contains "test message")
+    assert str contains $output $tested_str
+    assert str contains $output "test message"
 }
 
 def "assert custom message not contains" [
@@ -125,8 +125,8 @@ def "assert custom message not contains" [
     tested_str
 ] {
     let output = (run custom $system_level $format $message_level)
-    assert (not ($output | str contains  $tested_str))
-    assert ($output | str contains "test message")
+    assert not ($output | str contains  $tested_str)
+    assert str contains $output "test message"
 }
 
 def "assert no custom message" [


### PR DESCRIPTION
# Description
A new command to simplify assertions for `false`.

The name is just a draft, though I could not come up with a better name. I have rejected `assert false`, because I would have to rename `assert` to `assert true` which would break the compatibility and worsen the shell experience of the good old `assert`.

Another idea I have rejected was something like `assert_false` to keep it consistent with the naming convention of our stdlib.

I am open to suggestions :)

# User-Facing Changes
Just a new command

# Tests + Formatting
- [x] Done

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
