### PR TITLE
Make aliased call not look up predeclarations

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -149,3 +149,9 @@ fn alias_multiword_name() {
     let actual = nu!(r#"alias "foo bar" = echo 'test'; foo bar"#);
     assert_eq!(actual.out, "test");
 }
+
+#[test]
+fn alias_ordering() {
+    let actual = nu!(r#"alias bar = echo; def echo [] { 'dummy echo' }; bar 'foo'"#);
+    assert_eq!(actual.out, "foo");
+}

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -171,9 +171,9 @@ fn use_export_env_combined() {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
+                def foo [] { 'foo' }
                 alias bar = foo
                 export-env { let-env FOO = (bar) }
-                def foo [] { 'foo' }
             "#,
         )]);
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -804,12 +804,16 @@ pub fn parse_alias(
             }
 
             let starting_error_count = working_set.parse_errors.len();
+            working_set.search_predecls = false;
+
             let expr = parse_call(
                 working_set,
                 replacement_spans,
                 replacement_spans[0],
                 false, // TODO: Should this be set properly???
             );
+
+            working_set.search_predecls = true;
 
             if starting_error_count != working_set.parse_errors.len() {
                 if let Some(e) = working_set.parse_errors.get(starting_error_count) {


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Aliased calls are now position-dependent. Previously, you could do 
```
alias foo = bar
def bar [] { 'bar' }
```
The `bar` definition could be defined anywhere in the alias. This is how commands work: The parser first identifies all `def`s in a file as "predeclarations", then you can use them in any order you want. While it's very convenient not having to worry about command ordering, with aliases, however, it makes a "wrapper" pattern impractical. For example:
```
alias old-cd = cd
export def cd [p: path] { 
	old-cd $p
	print 'yay!'
}
```
previously wasn't possible because the `cd` in the first line referred to the `cd` defined on the second line, thanks to the "predeclaration" mechanism. Nowadays, the `cd` in the alias definition ignores predeclarations and the pattern works.

Caveat is that alias now must be defined _after_ the thing it aliases. For example
```
def foo [] { 'foo' }
alias bar = foo
```
the alias must be defined after `def foo`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
