### PR TITLE
allow `view-source` to read rest arguments

### DIFF
--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -69,7 +69,7 @@ impl Command for ViewSource {
                                     &mut final_contents,
                                     "{}:{} ",
                                     n.name,
-                                    n.shape.to_string()
+                                    n.shape
                                 );
                                 // positional argu,emts
                             }
@@ -78,7 +78,7 @@ impl Command for ViewSource {
                                     &mut final_contents,
                                     "{}?:{} ",
                                     n.name,
-                                    n.shape.to_string()
+                                    n.shape
                                 );
                             }
                             for n in vec_of_flags {
@@ -87,7 +87,7 @@ impl Command for ViewSource {
                                     let _ = write!(&mut final_contents, "(-{})", short);
                                 }
                                 if let Some(arg) = &n.arg {
-                                    let _ = write!(&mut final_contents, ":{}", arg.to_string());
+                                    let _ = write!(&mut final_contents, ":{}", arg);
                                 }
                                 final_contents.push(' ');
                             }
@@ -96,7 +96,7 @@ impl Command for ViewSource {
                                     &mut final_contents,
                                     "...{}:{}",
                                     rest_arg.name,
-                                    rest_arg.shape.to_string()
+                                    rest_arg.shape
                                 );
                             }
                             final_contents.push_str("] ");

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -65,21 +65,11 @@ impl Command for ViewSource {
                             // name of function
                             let mut final_contents = format!("def {val} [ ");
                             for n in vec_of_required {
-                                let _ = write!(
-                                    &mut final_contents,
-                                    "{}:{} ",
-                                    n.name,
-                                    n.shape
-                                );
+                                let _ = write!(&mut final_contents, "{}:{} ", n.name, n.shape);
                                 // positional argu,emts
                             }
                             for n in vec_of_optional {
-                                let _ = write!(
-                                    &mut final_contents,
-                                    "{}?:{} ",
-                                    n.name,
-                                    n.shape
-                                );
+                                let _ = write!(&mut final_contents, "{}?:{} ", n.name, n.shape);
                             }
                             for n in vec_of_flags {
                                 let _ = write!(&mut final_contents, "--{}", n.long);
@@ -95,8 +85,7 @@ impl Command for ViewSource {
                                 let _ = write!(
                                     &mut final_contents,
                                     "...{}:{}",
-                                    rest_arg.name,
-                                    rest_arg.shape
+                                    rest_arg.name, rest_arg.shape
                                 );
                             }
                             final_contents.push_str("] ");

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -5,6 +5,7 @@ use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type,
     Value,
 };
+use std::fmt::Write;
 
 #[derive(Clone)]
 pub struct ViewSource;
@@ -54,46 +55,49 @@ impl Command for ViewSource {
                     let sig = decl.signature();
                     let vec_of_required = &sig.required_positional;
                     let vec_of_optional = &sig.optional_positional;
+                    let rest = &sig.rest_positional;
                     let vec_of_flags = &sig.named;
                     // gets vector of positionals.
                     if let Some(block_id) = decl.get_block_id() {
                         let block = engine_state.get_block(block_id);
                         if let Some(block_span) = block.span {
                             let contents = engine_state.get_span_contents(&block_span);
-                            let mut final_contents = String::from("def ");
-                            final_contents.push_str(&val);
-                            // The name of the function...
-                            final_contents.push_str(" [ ");
+                            // name of function
+                            let mut final_contents = format!("def {val} [ ");
                             for n in vec_of_required {
-                                final_contents.push_str(&n.name);
-                                // name of positional arg
-                                final_contents.push(':');
-                                final_contents.push_str(&n.shape.to_string());
-                                final_contents.push(' ');
+                                let _ = write!(
+                                    &mut final_contents,
+                                    "{}:{} ",
+                                    n.name,
+                                    n.shape.to_string()
+                                );
+                                // positional argu,emts
                             }
                             for n in vec_of_optional {
-                                final_contents.push_str(&n.name);
-                                // name of positional arg
-                                final_contents.push_str("?:");
-                                final_contents.push_str(&n.shape.to_string());
-                                final_contents.push(' ');
+                                let _ = write!(
+                                    &mut final_contents,
+                                    "{}?:{} ",
+                                    n.name,
+                                    n.shape.to_string()
+                                );
                             }
                             for n in vec_of_flags {
-                                final_contents.push_str("--");
-                                final_contents.push_str(&n.long);
-                                final_contents.push(' ');
-                                if n.short.is_some() {
-                                    final_contents.push_str("(-");
-                                    final_contents.push(n.short.expect("this cannot trigger."));
-                                    final_contents.push(')');
+                                let _ = write!(&mut final_contents, "--{}", n.long);
+                                if let Some(short) = n.short {
+                                    let _ = write!(&mut final_contents, "(-{})", short);
                                 }
-                                if n.arg.is_some() {
-                                    final_contents.push_str(": ");
-                                    final_contents.push_str(
-                                        &n.arg.as_ref().expect("this cannot trigger.").to_string(),
-                                    );
+                                if let Some(arg) = &n.arg {
+                                    let _ = write!(&mut final_contents, ":{}", arg.to_string());
                                 }
                                 final_contents.push(' ');
+                            }
+                            if let Some(rest_arg) = rest {
+                                let _ = write!(
+                                    &mut final_contents,
+                                    "...{}:{}",
+                                    rest_arg.name,
+                                    rest_arg.shape.to_string()
+                                );
                             }
                             final_contents.push_str("] ");
                             final_contents.push_str(&String::from_utf8_lossy(contents));
@@ -157,17 +161,22 @@ impl Command for ViewSource {
             Example {
                 description: "View the source of a code block",
                 example: r#"let abc = {|| echo 'hi' }; view source $abc"#,
-                result: Some(Value::test_string("{ echo 'hi' }")),
+                result: Some(Value::test_string("{|| echo 'hi' }")),
             },
             Example {
                 description: "View the source of a custom command",
                 example: r#"def hi [] { echo 'Hi!' }; view source hi"#,
-                result: Some(Value::test_string("{ echo 'Hi!' }")),
+                result: Some(Value::test_string("def hi [ --help(-h) ] { echo 'Hi!' }")),
             },
             Example {
                 description: "View the source of a custom command, which participates in the caller environment",
                 example: r#"def-env foo [] { let-env BAR = 'BAZ' }; view source foo"#,
-                result: Some(Value::test_string("{ let-env BAR = 'BAZ' }")),
+                result: Some(Value::test_string("def foo [ --help(-h) ] { let-env BAR = 'BAZ' }")),
+            },
+            Example {
+                description: "View the source of a custom command with flags and arguments",
+                example: r#"def test [a?:any --b:int ...rest:string] { echo 'test' }; view source test"#,
+                result: Some(Value::test_string("def test [ a?:any --b:int --help(-h) ...rest:string] { echo 'test' }")),
             },
             Example {
                 description: "View the source of a module",

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -65,19 +65,23 @@ impl Command for ViewSource {
                             // name of function
                             let mut final_contents = format!("def {val} [ ");
                             for n in vec_of_required {
-                                let _ = write!(&mut final_contents, "{}:{} ", n.name, n.shape);
+                                let _ = write!(&mut final_contents, "{}: {} ", n.name, n.shape);
                                 // positional argu,emts
                             }
                             for n in vec_of_optional {
-                                let _ = write!(&mut final_contents, "{}?:{} ", n.name, n.shape);
+                                let _ = write!(&mut final_contents, "{}?: {} ", n.name, n.shape);
                             }
                             for n in vec_of_flags {
+                                // skip adding the help flag
+                                if n.long == "help" {
+                                    continue;
+                                }
                                 let _ = write!(&mut final_contents, "--{}", n.long);
                                 if let Some(short) = n.short {
                                     let _ = write!(&mut final_contents, "(-{})", short);
                                 }
                                 if let Some(arg) = &n.arg {
-                                    let _ = write!(&mut final_contents, ":{}", arg);
+                                    let _ = write!(&mut final_contents, ": {}", arg);
                                 }
                                 final_contents.push(' ');
                             }
@@ -155,17 +159,17 @@ impl Command for ViewSource {
             Example {
                 description: "View the source of a custom command",
                 example: r#"def hi [] { echo 'Hi!' }; view source hi"#,
-                result: Some(Value::test_string("def hi [ --help(-h) ] { echo 'Hi!' }")),
+                result: Some(Value::test_string("def hi [] { echo 'Hi!' }")),
             },
             Example {
                 description: "View the source of a custom command, which participates in the caller environment",
                 example: r#"def-env foo [] { let-env BAR = 'BAZ' }; view source foo"#,
-                result: Some(Value::test_string("def foo [ --help(-h) ] { let-env BAR = 'BAZ' }")),
+                result: Some(Value::test_string("def foo [] { let-env BAR = 'BAZ' }")),
             },
             Example {
                 description: "View the source of a custom command with flags and arguments",
                 example: r#"def test [a?:any --b:int ...rest:string] { echo 'test' }; view source test"#,
-                result: Some(Value::test_string("def test [ a?:any --b:int --help(-h) ...rest:string] { echo 'test' }")),
+                result: Some(Value::test_string("def test [ a?: any --b: int ...rest: string] { echo 'test' }")),
             },
             Example {
                 description: "View the source of a module",


### PR DESCRIPTION
# Description
Fixes #8896. Also went back and cleaned up the code slightly.

# User-Facing Changes
`view-source` now is more comprehensive when viewing definitions. 

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
