### PR TITLE
Allow duration defaults

### DIFF
--- a/crates/nu-parser/src/eval.rs
+++ b/crates/nu-parser/src/eval.rs
@@ -114,6 +114,13 @@ pub fn eval_constant(
             span: expr.span,
         }),
         Expr::Nothing => Ok(Value::Nothing { span: expr.span }),
+        Expr::ValueWithUnit(expr, unit) => {
+            if let Ok(Value::Int { val, .. }) = eval_constant(working_set, expr) {
+                Ok(unit.item.to_value(val, unit.span))
+            } else {
+                Err(ParseError::NotAConstant(expr.span))
+            }
+        }
         _ => Err(ParseError::NotAConstant(expr.span)),
     }
 }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -340,8 +340,13 @@ fn default_value12() -> TestResult {
 }
 
 #[test]
-fn default_value_constant() -> TestResult {
+fn default_value_constant1() -> TestResult {
     run_test(r#"def foo [x = "foo"] { $x }; foo"#, "foo")
+}
+
+#[test]
+fn default_value_constant2() -> TestResult {
+    run_test(r#"def foo [secs = 1sec] { $secs }; foo"#, "1sec")
 }
 
 #[test]


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Fixes #9217 (some cases, still can't accept all default expressions)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
- Follow-up of #8940, expanding `eval_constant` so that it can also evaluate values with units.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
- A unit test was added to verify that defaults like `1sec` are accepted.
