### PR TITLE
CI: disable `nu-coverage`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
 
 
   nu-coverage:
+    if: false
     env:
       NUSHELL_CARGO_TARGET: ci
 


### PR DESCRIPTION
appears the `nu-coverage` job of the CI has decided to go wild, marking a lot of runs with :x:, both in PRs and on the `main` branch :scream: 

this PR tries to mitigate the damage by disabling the pipeline.

> **Note**
> see [*Using conditions to control job execution*](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution)