### PR TITLE
upserting data of a cellpath that doesn't exist into a record creates the cellpath

### DIFF
--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -174,12 +174,6 @@ fn mut_path_operator_assign() {
 
 #[test]
 fn mut_records_update_properly() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        mut a = {}; $a.b.c = 100; $a.b.c
-        "#
-    ));
-
+    let actual = nu!(pipeline("mut a = {}; $a.b.c = 100; $a.b.c"));
     assert_eq!(actual.out, "100");
 }

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -171,3 +171,15 @@ fn mut_path_operator_assign() {
 
     assert_eq!(actual.out, "5");
 }
+
+#[test]
+fn mut_records_update_properly() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        mut a = {}; $a.b.c = 100; $a.b.c
+        "#
+    ));
+
+    assert_eq!(actual.out, "100");
+}

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1036,8 +1036,8 @@ impl Value {
                             }
                         }
                         if !found {
+                            cols.push(col_name.clone());
                             if cell_path.len() == 1 {
-                                cols.push(col_name.clone());
                                 vals.push(new_val);
                             } else {
                                 let mut new_col = Value::Record {


### PR DESCRIPTION
# Description
Fixes #9254.

# User-Facing Changes
upserting data of a cellpath that doesn't exist into a record now creates the cellpath.

# Tests + Formatting

```
~/CodingProjects/nushell> mut a = {}                                                                       
~/CodingProjects/nushell> $a.b.c = 99                                                                            
~/CodingProjects/nushell> $a                                                                                    
╭───┬────────────╮
│   │ ╭───┬────╮ │
│ b │ │ c │ 99 │ │
│   │ ╰───┴────╯ │
╰───┴────────────╯
```

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
