### PR TITLE
throw an error instead of a panic if no input is provided to `inspect`

### DIFF
--- a/crates/nu-command/src/debug/inspect.rs
+++ b/crates/nu-command/src/debug/inspect.rs
@@ -34,6 +34,11 @@ impl Command for Inspect {
     ) -> Result<PipelineData, ShellError> {
         let input_metadata = input.metadata();
         let input_val = input.into_value(call.head);
+        if input_val.is_nothing() {
+            return Err(ShellError::PipelineEmpty {
+                dst_span: input_val.expect_span(),
+            })
+        }
         let original_input = input_val.clone();
         let description = match input_val {
             Value::CustomValue { ref val, .. } => val.value_string(),

--- a/crates/nu-command/src/debug/inspect.rs
+++ b/crates/nu-command/src/debug/inspect.rs
@@ -37,7 +37,7 @@ impl Command for Inspect {
         if input_val.is_nothing() {
             return Err(ShellError::PipelineEmpty {
                 dst_span: input_val.expect_span(),
-            })
+            });
         }
         let original_input = input_val.clone();
         let description = match input_val {

--- a/crates/nu-command/src/debug/inspect.rs
+++ b/crates/nu-command/src/debug/inspect.rs
@@ -36,7 +36,7 @@ impl Command for Inspect {
         let input_val = input.into_value(call.head);
         if input_val.is_nothing() {
             return Err(ShellError::PipelineEmpty {
-                dst_span: input_val.expect_span(),
+                dst_span: call.head,
             });
         }
         let original_input = input_val.clone();

--- a/crates/nu-command/tests/commands/inspect.rs
+++ b/crates/nu-command/tests/commands/inspect.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn inspect_with_empty_pipeline() {
+    let actual = nu!("inspect");
+    assert!(actual.err.contains("no input value was piped in"));
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -37,6 +37,7 @@ mod headers;
 mod help;
 mod histogram;
 mod insert;
+mod inspect;
 mod into_filesize;
 mod into_int;
 mod join;


### PR DESCRIPTION
# Description

This is a small PR to fix Nu crashing when calling `inspect` with no data piped in(#9255).


# User-Facing Changes

none.
