### PR TITLE
some minor color fixups

### DIFF
--- a/crates/nu-color-config/src/nu_style.rs
+++ b/crates/nu-color-config/src/nu_style.rs
@@ -31,6 +31,12 @@ fn style_get_attr(s: Style) -> Option<String> {
     if s.is_dimmed {
         attrs.push('d');
     };
+    if s.is_hidden {
+        attrs.push('h');
+    };
+    if s.is_italic {
+        attrs.push('i');
+    };
     if s.is_reverse {
         attrs.push('r');
     };
@@ -546,28 +552,7 @@ pub fn lookup_style(s: &str) -> Style {
 }
 
 pub fn lookup_color(s: &str) -> Option<Color> {
-    let color = match s {
-        "g" | "green" => Color::Green,
-        "lg" | "light_green" => Color::LightGreen,
-        "r" | "red" => Color::Red,
-        "lr" | "light_red" => Color::LightRed,
-        "u" | "blue" => Color::Blue,
-        "lu" | "light_blue" => Color::LightBlue,
-        "b" | "black" => Color::Black,
-        "ligr" | "light_gray" => Color::LightGray,
-        "y" | "yellow" => Color::Yellow,
-        "ly" | "light_yellow" => Color::LightYellow,
-        "p" | "purple" => Color::Purple,
-        "lp" | "light_purple" => Color::LightPurple,
-        "c" | "cyan" => Color::Cyan,
-        "lc" | "light_cyan" => Color::LightCyan,
-        "w" | "white" => Color::White,
-        "dgr" | "dark_gray" => Color::DarkGray,
-        "def" | "default" => Color::Default,
-        _ => return None,
-    };
-
-    Some(color)
+    lookup_style(s).foreground
 }
 
 fn fill_modifiers(attrs: &str, style: &mut Style) {

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -141,7 +141,7 @@ impl<'a> StyleComputer<'a> {
         let config = engine_state.get_config();
 
         // Create the hashmap
-        #[rustfmt_skip]
+        #[rustfmt::skip]
         let mut map: StyleMapping = HashMap::from([
             ("separator".to_string(), ComputableStyle::Static(Color::White.normal())),
             ("leading_trailing_space_bg".to_string(), ComputableStyle::Static(Style::default().on(Color::Rgb(128, 128, 128)))),

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -140,37 +140,29 @@ impl<'a> StyleComputer<'a> {
     pub fn from_config(engine_state: &'a EngineState, stack: &'a Stack) -> StyleComputer<'a> {
         let config = engine_state.get_config();
 
-        macro_rules! initial {
-            ($a:expr, $b:expr) => {
-                ($a.to_string(), ComputableStyle::Static($b))
-            };
-        }
-
         // Create the hashmap
+        #[rustfmt_skip]
         let mut map: StyleMapping = HashMap::from([
-            initial!("separator", Color::White.normal()),
-            initial!(
-                "leading_trailing_space_bg",
-                Style::default().on(Color::Rgb(128, 128, 128))
-            ),
-            initial!("header", Color::White.normal()),
-            initial!("empty", Color::White.normal()),
-            initial!("bool", Color::White.normal()),
-            initial!("int", Color::White.normal()),
-            initial!("filesize", Color::White.normal()),
-            initial!("duration", Color::White.normal()),
-            initial!("date", Color::White.normal()),
-            initial!("range", Color::White.normal()),
-            initial!("float", Color::White.normal()),
-            initial!("string", Color::White.normal()),
-            initial!("nothing", Color::White.normal()),
-            initial!("binary", Color::White.normal()),
-            initial!("cellpath", Color::White.normal()),
-            initial!("row_index", Color::Green.bold()),
-            initial!("record", Color::White.normal()),
-            initial!("list", Color::White.normal()),
-            initial!("block", Color::White.normal()),
-            initial!("hints", Color::DarkGray.normal()),
+            ("separator".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("leading_trailing_space_bg".to_string(), ComputableStyle::Static(Style::default().on(Color::Rgb(128, 128, 128)))),
+            ("header".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("empty".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("bool".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("int".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("filesize".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("duration".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("date".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("range".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("float".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("string".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("nothing".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("binary".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("cellpath".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("row_index".to_string(), ComputableStyle::Static(Color::Green.bold())),
+            ("record".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("list".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("block".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("hints".to_string(), ComputableStyle::Static(Color::DarkGray.normal())),
         ]);
 
         for (key, value) in &config.color_config {


### PR DESCRIPTION
# Description

This PR cleans a couple things up. Nothing major, just a few things that caught my eye looking for something else.
1. less macros
2. hidden and italic styles weren't fully available
3. lookup_color function didn't lookup all the colors available

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
