### PR TITLE
Fix clippy warnings (upcoming)

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/between_values.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/between_values.rs
@@ -25,9 +25,9 @@ pub(super) fn between_dataframes(
         },
         _ => Err(ShellError::OperatorMismatch {
             op_span: operator.span,
-            lhs_ty: left.get_type(),
+            lhs_ty: left.get_type().to_string(),
             lhs_span: left.span()?,
-            rhs_ty: right.get_type(),
+            rhs_ty: right.get_type().to_string(),
             rhs_span: right.span()?,
         }),
     }
@@ -167,9 +167,9 @@ pub(super) fn compute_between_series(
         },
         _ => Err(ShellError::OperatorMismatch {
             op_span: operator.span,
-            lhs_ty: left.get_type(),
+            lhs_ty: left.get_type().to_string(),
             lhs_span: left.span()?,
-            rhs_ty: right.get_type(),
+            rhs_ty: right.get_type().to_string(),
             rhs_span: right.span()?,
         }),
     }
@@ -210,9 +210,9 @@ pub(super) fn compute_series_single_value(
     if !lhs.is_series() {
         return Err(ShellError::OperatorMismatch {
             op_span: operator.span,
-            lhs_ty: left.get_type(),
+            lhs_ty: left.get_type().to_string(),
             lhs_span: left.span()?,
-            rhs_ty: right.get_type(),
+            rhs_ty: right.get_type().to_string(),
             rhs_span: right.span()?,
         });
     }
@@ -231,9 +231,9 @@ pub(super) fn compute_series_single_value(
             Value::String { val, .. } => add_string_to_series(&lhs, val, lhs_span),
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -246,9 +246,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -261,9 +261,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -284,9 +284,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -304,9 +304,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -325,9 +325,9 @@ pub(super) fn compute_series_single_value(
             ),
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -341,9 +341,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -357,9 +357,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -373,9 +373,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -389,9 +389,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -400,9 +400,9 @@ pub(super) fn compute_series_single_value(
             Value::String { val, .. } => contains_series_pat(&lhs, val, lhs_span),
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -413,9 +413,9 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
@@ -426,17 +426,17 @@ pub(super) fn compute_series_single_value(
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
-                lhs_ty: left.get_type(),
+                lhs_ty: left.get_type().to_string(),
                 lhs_span: left.span()?,
-                rhs_ty: right.get_type(),
+                rhs_ty: right.get_type().to_string(),
                 rhs_span: right.span()?,
             }),
         },
         _ => Err(ShellError::OperatorMismatch {
             op_span: operator.span,
-            lhs_ty: left.get_type(),
+            lhs_ty: left.get_type().to_string(),
             lhs_span: left.span()?,
-            rhs_ty: right.get_type(),
+            rhs_ty: right.get_type().to_string(),
             rhs_span: right.span()?,
         }),
     }

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/custom_value.rs
@@ -126,9 +126,9 @@ fn with_operator(
             .into_value(lhs_span)),
         _ => Err(ShellError::OperatorMismatch {
             op_span,
-            lhs_ty: Type::Custom(left.typetag_name().into()),
+            lhs_ty: Type::Custom(left.typetag_name().into()).to_string(),
             lhs_span,
-            rhs_ty: Type::Custom(right.typetag_name().into()),
+            rhs_ty: Type::Custom(right.typetag_name().into()).to_string(),
             rhs_span,
         }),
     }

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -394,9 +394,7 @@ fn convert_str_from_unit_to_unit(
         ("yr", "yr") => Ok(val as f64),
         ("yr", "dec") => Ok(val as f64 / 10.0),
 
-        _ => Err(ShellError::CantConvertWithValue {
-            to_type: "string duration".to_string(),
-            from_type: "string duration".to_string(),
+        _ => Err(ShellError::CantConvertToDuration {
             details: to_unit.to_string(),
             dst_span: span,
             src_span: value_span,
@@ -433,9 +431,7 @@ fn string_to_duration(s: &str, span: Span, value_span: Span) -> Result<i64, Shel
         }
     }
 
-    Err(ShellError::CantConvertWithValue {
-        to_type: "duration".to_string(),
-        from_type: "string".to_string(),
+    Err(ShellError::CantConvertToDuration {
         details: s.to_string(),
         dst_span: span,
         src_span: value_span,
@@ -476,9 +472,7 @@ fn string_to_unit_duration(
         }
     }
 
-    Err(ShellError::CantConvertWithValue {
-        to_type: "duration".to_string(),
-        from_type: "string".to_string(),
+    Err(ShellError::CantConvertToDuration {
         details: s.to_string(),
         dst_span: span,
         src_span: value_span,

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -85,9 +85,9 @@ pub fn median(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellE
             if elem[0].partial_cmp(&elem[1]).is_none() {
                 return Err(ShellError::OperatorMismatch {
                     op_span: *head,
-                    lhs_ty: elem[0].get_type(),
+                    lhs_ty: elem[0].get_type().to_string(),
                     lhs_span: elem[0].span()?,
-                    rhs_ty: elem[1].get_type(),
+                    rhs_ty: elem[1].get_type().to_string(),
                     rhs_span: elem[1].span()?,
                 });
             }

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -104,9 +104,9 @@ pub fn mode(values: &[Value], _span: Span, head: &Span) -> Result<Value, ShellEr
             if elem[0].partial_cmp(&elem[1]).is_none() {
                 return Err(ShellError::OperatorMismatch {
                     op_span: *head,
-                    lhs_ty: elem[0].get_type(),
+                    lhs_ty: elem[0].get_type().to_string(),
                     lhs_span: elem[0].span()?,
-                    rhs_ty: elem[1].get_type(),
+                    rhs_ty: elem[1].get_type().to_string(),
                     rhs_span: elem[1].span()?,
                 });
             }

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -41,9 +41,9 @@ pub fn max(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
         } else {
             return Err(ShellError::OperatorMismatch {
                 op_span: head,
-                lhs_ty: biggest.get_type(),
+                lhs_ty: biggest.get_type().to_string(),
                 lhs_span: biggest.span()?,
-                rhs_ty: value.get_type(),
+                rhs_ty: value.get_type().to_string(),
                 rhs_span: value.span()?,
             });
         }
@@ -72,9 +72,9 @@ pub fn min(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
         } else {
             return Err(ShellError::OperatorMismatch {
                 op_span: head,
-                lhs_ty: smallest.get_type(),
+                lhs_ty: smallest.get_type().to_string(),
                 lhs_span: smallest.span()?,
-                rhs_ty: value.get_type(),
+                rhs_ty: value.get_type().to_string(),
                 rhs_span: value.span()?,
             });
         }

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -138,7 +138,7 @@ pub fn request_add_authorization_header(
 #[allow(clippy::large_enum_variant)]
 pub enum ShellErrorOrRequestError {
     ShellError(ShellError),
-    RequestError(String, Error),
+    RequestError(String, Box<Error>),
 }
 
 impl From<ShellError> for ShellErrorOrRequestError {
@@ -256,7 +256,7 @@ fn send_cancellable_request(
         match rx.recv_timeout(Duration::from_millis(100)) {
             Ok(result) => {
                 return result.map_err(|e| {
-                    ShellErrorOrRequestError::RequestError(request_url.to_string(), e)
+                    ShellErrorOrRequestError::RequestError(request_url.to_string(), Box::new(e))
                 });
             }
             Err(RecvTimeoutError::Timeout) => continue,
@@ -516,7 +516,7 @@ pub fn request_handle_response(
             ShellErrorOrRequestError::ShellError(e) => Err(e),
             ShellErrorOrRequestError::RequestError(_, e) => {
                 if flags.allow_errors {
-                    if let Error::Status(_, resp) = e {
+                    if let Error::Status(_, resp) = *e {
                         Ok(request_handle_response_content(
                             engine_state,
                             stack,
@@ -526,10 +526,10 @@ pub fn request_handle_response(
                             resp,
                         )?)
                     } else {
-                        Err(handle_response_error(span, requested_url, e))
+                        Err(handle_response_error(span, requested_url, *e))
                     }
                 } else {
-                    Err(handle_response_error(span, requested_url, e))
+                    Err(handle_response_error(span, requested_url, *e))
                 }
             }
         },
@@ -574,7 +574,7 @@ pub fn request_handle_response_headers(
         Err(e) => match e {
             ShellErrorOrRequestError::ShellError(e) => Err(e),
             ShellErrorOrRequestError::RequestError(requested_url, e) => {
-                Err(handle_response_error(span, &requested_url, e))
+                Err(handle_response_error(span, &requested_url, *e))
             }
         },
     }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -2243,7 +2243,7 @@ mod engine_state_tests {
         let variables = working_set
             .list_variables()
             .into_iter()
-            .map(|v| from_utf8(v))
+            .map(from_utf8)
             .collect::<Result<Vec<&str>, Utf8Error>>()?;
         assert_eq!(variables, vec![varname_with_sigil]);
         Ok(())

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -2,7 +2,7 @@ use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{ast::Operator, Span, Type, Value};
+use crate::{ast::Operator, Span, Value};
 
 /// The fundamental error type for the evaluation engine. These cases represent different kinds of errors
 /// the evaluator might face, along with helpful spans to label. An error renderer will take this error value
@@ -19,10 +19,10 @@ pub enum ShellError {
     OperatorMismatch {
         #[label = "type mismatch for operator"]
         op_span: Span,
-        lhs_ty: Type,
+        lhs_ty: String,
         #[label("{lhs_ty}")]
         lhs_span: Span,
-        rhs_ty: Type,
+        rhs_ty: String,
         #[label("{rhs_ty}")]
         rhs_span: Span,
     },
@@ -391,20 +391,13 @@ pub enum ShellError {
         help: Option<String>,
     },
 
-    /// Failed to convert a value of one type into a different type. Includes hint for what the first value is.
-    ///
-    /// ## Resolution
-    ///
-    /// Not all values can be coerced this way. Check the supported type(s) and try again.
-    #[error("Can't convert {from_type} `{details}` to {to_type}.")]
+    #[error("Can't convert string `{details}` to duration.")]
     #[diagnostic(code(nu::shell::cant_convert_with_value))]
-    CantConvertWithValue {
-        to_type: String,
-        from_type: String,
+    CantConvertToDuration {
         details: String,
-        #[label("can't be converted to {to_type}")]
+        #[label("can't be converted to duration")]
         dst_span: Span,
-        #[label("this {from_type} value...")]
+        #[label("this string value...")]
         src_span: Span,
         #[help]
         help: Option<String>,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2174,9 +2174,9 @@ impl Value {
 
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -2211,9 +2211,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -2292,9 +2292,9 @@ impl Value {
 
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -2402,9 +2402,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -2539,9 +2539,9 @@ impl Value {
 
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -2675,9 +2675,9 @@ impl Value {
 
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -2698,9 +2698,9 @@ impl Value {
         {
             return Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             });
         }
@@ -2713,9 +2713,9 @@ impl Value {
         } else {
             Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             })
         }
@@ -2741,9 +2741,9 @@ impl Value {
         {
             return Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             });
         }
@@ -2755,9 +2755,9 @@ impl Value {
             })
             .ok_or(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             })
     }
@@ -2782,9 +2782,9 @@ impl Value {
         {
             return Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             });
         }
@@ -2796,9 +2796,9 @@ impl Value {
             })
             .ok_or(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             })
     }
@@ -2823,9 +2823,9 @@ impl Value {
         {
             return Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             });
         }
@@ -2837,9 +2837,9 @@ impl Value {
             }),
             None => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -2862,9 +2862,9 @@ impl Value {
                 }
                 _ => Err(ShellError::OperatorMismatch {
                     op_span: op,
-                    lhs_ty: self.get_type(),
+                    lhs_ty: self.get_type().to_string(),
                     lhs_span: self.span()?,
-                    rhs_ty: rhs.get_type(),
+                    rhs_ty: rhs.get_type().to_string(),
                     rhs_span: rhs.span()?,
                 }),
             }
@@ -2888,9 +2888,9 @@ impl Value {
                 }
                 _ => Err(ShellError::OperatorMismatch {
                     op_span: op,
-                    lhs_ty: self.get_type(),
+                    lhs_ty: self.get_type().to_string(),
                     lhs_span: self.span()?,
-                    rhs_ty: rhs.get_type(),
+                    rhs_ty: rhs.get_type().to_string(),
                     rhs_span: rhs.span()?,
                 }),
             }
@@ -2946,9 +2946,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3003,9 +3003,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3079,9 +3079,9 @@ impl Value {
             ),
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3098,9 +3098,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3117,9 +3117,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3136,9 +3136,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3155,9 +3155,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3174,9 +3174,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3193,9 +3193,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3212,9 +3212,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3268,9 +3268,9 @@ impl Value {
 
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3287,9 +3287,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3306,9 +3306,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3325,9 +3325,9 @@ impl Value {
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }
@@ -3360,9 +3360,9 @@ impl Value {
 
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
-                lhs_ty: self.get_type(),
+                lhs_ty: self.get_type().to_string(),
                 lhs_span: self.span()?,
-                rhs_ty: rhs.get_type(),
+                rhs_ty: rhs.get_type().to_string(),
                 rhs_span: rhs.span()?,
             }),
         }

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -77,7 +77,7 @@ fn scope_command_defaults(#[case] var: &str, #[case] exp_result: &str) -> TestRe
             let rslt = ($nu.scope.commands | where name == 't1' | get signatures.0.any | where parameter_name == '{var}' | get parameter_default.0);
             $"<($rslt)> ($rslt | describe)""#
         ),
-        &format!("{exp_result}"),
+        exp_result,
     )
 }
 


### PR DESCRIPTION
# Description

Fixes the clippy warnings we're about to get hit with next time we upgrade Rust.

The big one was shrinking ShellError and related under 128 bytes.

# User-Facing Changes

Shouldn't notice much difference. In theory, we could see a tiny perf improvement, but I didn't notice one.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
