### PR TITLE
move over to reedline git version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,9 +4300,8 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d763be5efcabcd27d6e804d126661215aa0a2d898c13c0aa1c953c6652fcec"
+version = "0.19.2"
+source = "git+https://github.com/nushell/reedline.git?branch=main#e0e5957a5dcfc7f839cf6cc079d925098abe7818"
 dependencies = [
  "chrono",
  "crossterm 0.26.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,8 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.80.1" }
 nu-std = { path = "./crates/nu-std", version = "0.80.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.80.1" }
 nu-ansi-term = "0.47.0"
-reedline = { version = "0.19.1", features = ["bashisms", "sqlite"]}
+# reedline = { version = "0.19.2", features = ["bashisms", "sqlite"]}
+reedline = { git = "https://github.com/nushell/reedline.git", features = ["bashisms", "sqlite"], branch = "main"}
 
 crossterm = "0.26"
 ctrlc = "3.2.1"
@@ -156,7 +157,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
+reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Criterion benchmarking setup

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -23,7 +23,8 @@ nu-protocol = { path = "../nu-protocol", version = "0.80.1" }
 nu-utils = { path = "../nu-utils", version = "0.80.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.80.1" }
 nu-ansi-term = "0.47.0"
-reedline = { version = "0.19.1", features = ["bashisms", "sqlite"]}
+# reedline = { version = "0.19.2", features = ["bashisms", "sqlite"]}
+reedline = { git = "https://github.com/nushell/reedline.git", features = ["bashisms", "sqlite"], branch = "main"}
 
 atty = "0.2.14"
 chrono = { default-features = false, features = ["std"], version = "0.4.23" }


### PR DESCRIPTION
# Description
Moves us over to dogfooding the git version of reedline ahead of the next release.

# User-Facing Changes

With luck, you should see fewer bugs :D

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
