### PR TITLE
if --no-config-file(-n) is passed, do not load config files with -c

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -23,7 +23,7 @@ pub(crate) fn run_commands(
 
     // if the --no-config-file(-n) option is NOT passed, load the plugin file,
     // load the default env file or custom (depending on parsed_nu_cli_args.env_file),
-    // and maybe the default config file (depending on parsed_nu_cli_args.config_file)
+    // and maybe a custom config file (depending on parsed_nu_cli_args.config_file)
     //
     // if the --no-config-file(-n) flag is passed, do not load plugin, env, or config files
     if parsed_nu_cli_args.no_config_file.is_none() {
@@ -46,7 +46,6 @@ pub(crate) fn run_commands(
         let start_time = std::time::Instant::now();
         // only want to load config and env if relative argument is provided.
         if parsed_nu_cli_args.env_file.is_some() {
-            eprintln!("Loading env file: {:?}", &parsed_nu_cli_args.env_file);
             config_files::read_config_file(
                 engine_state,
                 &mut stack,
@@ -54,7 +53,6 @@ pub(crate) fn run_commands(
                 true,
             );
         } else {
-            eprintln!("Loading default env file");
             config_files::read_default_env_file(engine_state, &mut stack)
         }
         perf(
@@ -68,7 +66,6 @@ pub(crate) fn run_commands(
 
         let start_time = std::time::Instant::now();
         if parsed_nu_cli_args.config_file.is_some() {
-            eprintln!("Loading config file: {:?}", &parsed_nu_cli_args.config_file);
             config_files::read_config_file(
                 engine_state,
                 &mut stack,

--- a/src/run.rs
+++ b/src/run.rs
@@ -21,56 +21,70 @@ pub(crate) fn run_commands(
     let mut stack = nu_protocol::engine::Stack::new();
     let start_time = std::time::Instant::now();
 
-    #[cfg(feature = "plugin")]
-    read_plugin_file(
-        engine_state,
-        &mut stack,
-        parsed_nu_cli_args.plugin_file,
-        NUSHELL_FOLDER,
-    );
-    perf(
-        "read plugins",
-        start_time,
-        file!(),
-        line!(),
-        column!(),
-        use_color,
-    );
-
-    let start_time = std::time::Instant::now();
-    // only want to load config and env if relative argument is provided.
-    if parsed_nu_cli_args.env_file.is_some() {
-        config_files::read_config_file(engine_state, &mut stack, parsed_nu_cli_args.env_file, true);
-    } else {
-        config_files::read_default_env_file(engine_state, &mut stack)
-    }
-    perf(
-        "read env.nu",
-        start_time,
-        file!(),
-        line!(),
-        column!(),
-        use_color,
-    );
-
-    let start_time = std::time::Instant::now();
-    if parsed_nu_cli_args.config_file.is_some() {
-        config_files::read_config_file(
+    // if the --no-config-file(-n) option is NOT passed, load the plugin file,
+    // load the default env file or custom (depending on parsed_nu_cli_args.env_file),
+    // and maybe the default config file (depending on parsed_nu_cli_args.config_file)
+    //
+    // if the --no-config-file(-n) flag is passed, do not load plugin, env, or config files
+    if parsed_nu_cli_args.no_config_file.is_none() {
+        #[cfg(feature = "plugin")]
+        read_plugin_file(
             engine_state,
             &mut stack,
-            parsed_nu_cli_args.config_file,
-            false,
+            parsed_nu_cli_args.plugin_file,
+            NUSHELL_FOLDER,
+        );
+        perf(
+            "read plugins",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
+
+        let start_time = std::time::Instant::now();
+        // only want to load config and env if relative argument is provided.
+        if parsed_nu_cli_args.env_file.is_some() {
+            eprintln!("Loading env file: {:?}", &parsed_nu_cli_args.env_file);
+            config_files::read_config_file(
+                engine_state,
+                &mut stack,
+                parsed_nu_cli_args.env_file,
+                true,
+            );
+        } else {
+            eprintln!("Loading default env file");
+            config_files::read_default_env_file(engine_state, &mut stack)
+        }
+        perf(
+            "read env.nu",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
+
+        let start_time = std::time::Instant::now();
+        if parsed_nu_cli_args.config_file.is_some() {
+            eprintln!("Loading config file: {:?}", &parsed_nu_cli_args.config_file);
+            config_files::read_config_file(
+                engine_state,
+                &mut stack,
+                parsed_nu_cli_args.config_file,
+                false,
+            );
+        }
+        perf(
+            "read config.nu",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
         );
     }
-    perf(
-        "read config.nu",
-        start_time,
-        file!(),
-        line!(),
-        column!(),
-        use_color,
-    );
-
     // Before running commands, set up the startup time
     engine_state.set_startup_time(entire_start_time.elapsed().as_nanos() as i64);
     let start_time = std::time::Instant::now();


### PR DESCRIPTION
# Description

I noticed recently these timing discrepancies. I was thinking they would be nearly identical but they were not.
```
> nu --no-std-lib -n -c "$nu.startup-time"
13ms 686µs 209ns
> nu --no-std-lib -n
> $nu.startup-time
2ms 520µs 416ns
```
My research showed that if `-n` was passed with `-c`, then the `-n` was essentially being ignored. This PR corrects that.

Also worthy of understanding, if `nu -c "some command"` is passed, the default env file is always loaded. I believe that's on purpose so that a NU_LIB_DIRS env is available.

## After this PR (on a different system)
```
> nu --no-std-lib -n -c "$nu.startup-time"
6ms 688µs 600ns
> nu -n --no-std-lib
> $nu.startup-time
6ms 661µs 800ns
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
