### PR TITLE
refactor the `lib.rs` of `nu-std` after the new virtual files PR

### DIFF
--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -12,6 +12,10 @@ pub fn load_standard_library(
     engine_state: &mut nu_protocol::engine::EngineState,
 ) -> Result<(), miette::ErrReport> {
     let (block, delta) = {
+        // Using full virtual path to avoid potential conflicts with user having 'std' directory
+        // in their working directory.
+        let std_dir = PathBuf::from(NU_STDLIB_VIRTUAL_DIR).join("std");
+
         let mut std_files = vec![
             ("mod.nu", include_str!("../std/mod.nu")),
             ("dirs.nu", include_str!("../std/dirs.nu")),
@@ -27,7 +31,7 @@ pub fn load_standard_library(
         let mut std_virt_paths = vec![];
 
         for (name, content) in std_files.drain(..) {
-            let name = PathBuf::from(NU_STDLIB_VIRTUAL_DIR).join("std").join(name);
+            let name = std_dir.join(name);
 
             let file_id =
                 working_set.add_file(name.to_string_lossy().to_string(), content.as_bytes());
@@ -38,12 +42,7 @@ pub fn load_standard_library(
             std_virt_paths.push(virtual_file_id);
         }
 
-        // Using full virtual path to avoid potential conflicts with user having 'std' directory
-        // in their working directory.
-        let std_dir = PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-            .join("std")
-            .to_string_lossy()
-            .to_string();
+        let std_dir = std_dir.to_string_lossy().to_string();
         let source = format!(
             r#"
 # Define the `std` module

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -50,7 +50,14 @@ pub fn load_standard_library(
 module {std_dir}
 
 # Prelude
-use std dirs [ enter, shells, g, n, p, dexit ]
+use std dirs [
+    enter
+    shells
+    g
+    n
+    p
+    dexit
+]
 "#
         );
 

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -13,60 +13,22 @@ pub fn load_standard_library(
 ) -> Result<(), miette::ErrReport> {
     let (block, delta) = {
         let mut std_files = vec![
-            (
-                PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-                    .join("std")
-                    .join("mod.nu"),
-                include_str!("../std/mod.nu"),
-            ),
-            (
-                PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-                    .join("std")
-                    .join("dirs.nu"),
-                include_str!("../std/dirs.nu"),
-            ),
-            (
-                PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-                    .join("std")
-                    .join("dt.nu"),
-                include_str!("../std/dt.nu"),
-            ),
-            (
-                PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-                    .join("std")
-                    .join("help.nu"),
-                include_str!("../std/help.nu"),
-            ),
-            (
-                PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-                    .join("std")
-                    .join("iter.nu"),
-                include_str!("../std/iter.nu"),
-            ),
-            (
-                PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-                    .join("std")
-                    .join("log.nu"),
-                include_str!("../std/log.nu"),
-            ),
-            (
-                PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-                    .join("std")
-                    .join("testing.nu"),
-                include_str!("../std/testing.nu"),
-            ),
-            (
-                PathBuf::from(NU_STDLIB_VIRTUAL_DIR)
-                    .join("std")
-                    .join("xml.nu"),
-                include_str!("../std/xml.nu"),
-            ),
+            ("mod.nu", include_str!("../std/mod.nu")),
+            ("dirs.nu", include_str!("../std/dirs.nu")),
+            ("dt.nu", include_str!("../std/dt.nu")),
+            ("help.nu", include_str!("../std/help.nu")),
+            ("iter.nu", include_str!("../std/iter.nu")),
+            ("log.nu", include_str!("../std/log.nu")),
+            ("testing.nu", include_str!("../std/testing.nu")),
+            ("xml.nu", include_str!("../std/xml.nu")),
         ];
 
         let mut working_set = StateWorkingSet::new(engine_state);
         let mut std_virt_paths = vec![];
 
         for (name, content) in std_files.drain(..) {
+            let name = PathBuf::from(NU_STDLIB_VIRTUAL_DIR).join("std").join(name);
+
             let file_id =
                 working_set.add_file(name.to_string_lossy().to_string(), content.as_bytes());
             let virtual_file_id = working_set.add_virtual_path(

--- a/crates/nu-std/std/testing.nu
+++ b/crates/nu-std/std/testing.nu
@@ -5,7 +5,7 @@
 # Assert commands and test runner.
 #
 ##################################################################################
-export use log.nu
+use log.nu
 
 # Universal assert command
 #

--- a/crates/nu-std/tests/test_setup_teardown.nu
+++ b/crates/nu-std/tests/test_setup_teardown.nu
@@ -1,5 +1,4 @@
-use std "log debug"
-use std "log error"
+use std log
 use std "assert"
 use std "assert skip"
 


### PR DESCRIPTION
related to
- #9245 

# Description
this PR is mostly about refactoring the `lib.rs` module of `nu-std`.
i've also remove the `export use` on the `log` module of `std testing`, it used to export all the `log` command outside of the `testing` module, making them available as part of `std` itself.

> **Note**
> this was because of some broken tests, i'm working on it right now... :recycle: 

# User-Facing Changes
before the PR `help modules | where name == std | get 0.commands
` did give
```
╭────┬───────────────────────────╮
│  0 │ log CRITICAL_LEVEL        │
│  1 │ log ERROR_LEVEL           │
│  2 │ log WARNING_LEVEL         │
│  3 │ log INFO_LEVEL            │
│  4 │ log DEBUG_LEVEL           │
│  5 │ log CRITICAL_LEVEL_PREFIX │
│  6 │ log ERROR_LEVEL_PREFIX    │
│  7 │ log WARNING_LEVEL_PREFIX  │
│  8 │ log INFO_LEVEL_PREFIX     │
│  9 │ log DEBUG_LEVEL_PREFIX    │
│ 10 │ log critical              │
│ 11 │ log error                 │
│ 12 │ log warning               │
│ 13 │ log info                  │
│ 14 │ log debug                 │
│ 15 │ log custom                │
│ 16 │ assert                    │
│ 17 │ assert not                │
│ 18 │ assert error              │
│ 19 │ assert skip               │
│ 20 │ assert equal              │
│ 21 │ assert not equal          │
│ 22 │ assert less or equal      │
│ 23 │ assert less               │
│ 24 │ assert greater            │
│ 25 │ assert greater or equal   │
│ 26 │ assert length             │
│ 27 │ assert str contains       │
│ 28 │ run-tests                 │
│ 29 │ path add                  │
│ 30 │ clip                      │
│ 31 │ bench                     │
│ 32 │ banner                    │
╰────┴───────────────────────────╯
```
now we only get
```
╭────┬─────────────────────────╮
│  0 │ assert                  │
│  1 │ assert not              │
│  2 │ assert error            │
│  3 │ assert skip             │
│  4 │ assert equal            │
│  5 │ assert not equal        │
│  6 │ assert less or equal    │
│  7 │ assert less             │
│  8 │ assert greater          │
│  9 │ assert greater or equal │
│ 10 │ assert length           │
│ 11 │ assert str contains     │
│ 12 │ run-tests               │
│ 13 │ path add                │
│ 14 │ clip                    │
│ 15 │ bench                   │
│ 16 │ banner                  │
╰────┴─────────────────────────╯
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```
