### PR TITLE
[nu-explore] fix Cargo description

### DIFF
--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["The Nushell Project Developers"]
-description = "Nushell table printing"
+description = "Nushell table pager"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-explore"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION

# Description
The old description ("Nushell table printing") is identical to that of `nu-table`. Per `explore --help` it is probably more accurate to say "Nushell table pager".

# User-Facing Changes
N/A

# Tests + Formatting
```
❯ cargo metadata --no-deps | from json | get packages | get 14 | get description
warning: please specify `--format-version` flag explicitly to avoid compatibility problems
Nushell table pager
```

# After Submitting
N/A - change will go out when `0.82.0` is released