### PR TITLE
FEATURE: add a `show_startup_time` field to the config

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -189,7 +189,14 @@ pub fn evaluate_repl(
     }
 
     if engine_state.get_config().show_startup_time && !engine_state.get_config().show_banner {
-        println!("startup time: {}", engine_state.get_startup_time());
+        println!(
+            "startup time: {}",
+            Value::Duration {
+                val: engine_state.get_startup_time(),
+                span: Span::unknown()
+            }
+            .into_string("", engine_state.get_config())
+        );
     }
 
     loop {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -8,6 +8,7 @@ use crate::{
 use crossterm::cursor::SetCursorStyle;
 use log::{trace, warn};
 use miette::{IntoDiagnostic, Result};
+use nu_ansi_term::Color;
 use nu_color_config::StyleComputer;
 use nu_command::hook::eval_hook;
 use nu_command::util::get_guaranteed_cwd;
@@ -188,9 +189,10 @@ pub fn evaluate_repl(
         );
     }
 
+    let dd = Color::Default.dimmed().prefix().to_string();
     if engine_state.get_config().show_startup_time && !engine_state.get_config().show_banner {
         println!(
-            "startup time: {}",
+            "{dd}startup time: {}",
             Value::Duration {
                 val: engine_state.get_startup_time(),
                 span: Span::unknown()

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -188,6 +188,10 @@ pub fn evaluate_repl(
         );
     }
 
+    if engine_state.get_config().show_startup_time && !engine_state.get_config().show_banner {
+        println!("startup time: {}", engine_state.get_startup_time());
+    }
+
     loop {
         let loop_start_time = std::time::Instant::now();
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -189,8 +189,8 @@ pub fn evaluate_repl(
         );
     }
 
-    let dd = Color::Default.dimmed().prefix().to_string();
     if engine_state.get_config().show_startup_time && !engine_state.get_config().show_banner {
+        let dd = Color::Default.dimmed().prefix().to_string();
         println!(
             "{dd}startup time: {}",
             Value::Duration {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -100,6 +100,7 @@ pub struct Config {
     pub enable_external_completion: bool,
     pub trim_strategy: TrimStrategy,
     pub show_banner: bool,
+    pub show_startup_time: bool,
     pub bracketed_paste: bool,
     pub show_clickable_links_in_ls: bool,
     pub render_right_prompt_on_last_line: bool,
@@ -145,6 +146,7 @@ impl Default for Config {
             enable_external_completion: true,
             trim_strategy: TRIM_STRATEGY_DEFAULT,
             show_banner: true,
+            show_startup_time: false,
             bracketed_paste: true,
             show_clickable_links_in_ls: true,
             render_right_prompt_on_last_line: false,
@@ -1210,6 +1212,9 @@ impl Value {
                     }
                     "show_banner" => {
                         try_bool!(cols, vals, index, span, show_banner);
+                    }
+                    "show_startup_time" => {
+                        try_bool!(cols, vals, index, span, show_startup_time);
                     }
                     "render_right_prompt_on_last_line" => {
                         try_bool!(cols, vals, index, span, render_right_prompt_on_last_line);

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -184,6 +184,7 @@ let light_theme = {
 let-env config = {
   # true or false to enable or disable the welcome banner at startup
   show_banner: true
+  show_startup_time: false # true or false to show or not the startup time of Nushell before the first prompt
   ls: {
     use_ls_colors: true # use the LS_COLORS environment variable to colorize output
     clickable_links: true # enable or disable clickable links. Your terminal has to support links.


### PR DESCRIPTION
# Description
a few times we had this question in the core team: if you use `--no-std-lib`, you do not have the banner so how do you get the startup time automatically without running `$nu.startup-time` manually?

one alternative is to use a hook, e.g. in `$env.config.hooks.env_change.PWD = [...]`
```bash
{|before, _| if $before == null and (not ($env.config?.show_banner? | default true)) {
    print $"(ansi {fg: default, attr: "du"})startup time(ansi reset): (ansi {fg: default, attr: "di"})($nu.startup-time)(ansi reset)"
}}
```
but this requires user intervention...

in this PR, i add the `$env.config.show_startup_time` field to do the same as this hook.

- the field has been added to the engine
- a default value of `false` is given
- it has been added to the default config with `false`
- the startup time triggers when `show_startup_time` is `true` AND `show_banner` is `false`, to avoid printing twice the same information

in the end, this PR does not change anything for the user who does not want to see the startup time but allows others to see it without doing anything :+1: 

> **Warning**
> > **Note**
> > addressed in 3716acc377df5db47a121e38feb35ab25247b818 and 023bf2afca6db9fd5512ec641b6655a7437c41b5
>
> something i need to work a bit more on is the output, for now it's not formatted at all...
> ```
> startup time: 112108504
> ~/.local/share/git/store/github.com/amtoine/nushell                          05/26/2023 05:58:59 PM
> ```

# User-Facing Changes
users can now turn on the `startup_time` only with `$env.config.show_startup_time` without the banner and even with `--no-std-lib`

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```