### PR TITLE
fix conflict between filesize and hexadecimal numbers

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2217,7 +2217,7 @@ pub fn parse_filesize(working_set: &mut StateWorkingSet, span: Span) -> Expressi
 
     let bytes = working_set.get_span_contents(span);
 
-    // the hex digit `b` might be mistaked for the unit `b`, so check that first
+    // the hex digit `b` might be mistaken for the unit `b`, so check that first
     if bytes.starts_with(b"0x") {
         working_set.error(ParseError::Expected("filesize with valid units", span));
         return garbage(span);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2217,6 +2217,12 @@ pub fn parse_filesize(working_set: &mut StateWorkingSet, span: Span) -> Expressi
 
     let bytes = working_set.get_span_contents(span);
 
+    // the hex digit `b` might be mistaked for the unit `b`, so check that first
+    if bytes.starts_with(b"0x") {
+        working_set.error(ParseError::Expected("filesize with valid units", span));
+        return garbage(span)
+    }
+
     match parse_unit_value(bytes, span, FILESIZE_UNIT_GROUPS, Type::Filesize, |x| {
         x.to_uppercase()
     }) {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2220,7 +2220,7 @@ pub fn parse_filesize(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     // the hex digit `b` might be mistaked for the unit `b`, so check that first
     if bytes.starts_with(b"0x") {
         working_set.error(ParseError::Expected("filesize with valid units", span));
-        return garbage(span)
+        return garbage(span);
     }
 
     match parse_unit_value(bytes, span, FILESIZE_UNIT_GROUPS, Type::Filesize, |x| {

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -561,3 +561,8 @@ fn filesize_with_underscores_2() -> TestResult {
 fn filesize_with_underscores_3() -> TestResult {
     fail_test("42m_b", "executable was not found")
 }
+
+#[test]
+fn filesize_is_not_hex() -> TestResult {
+    run_test("0x42b", 1067)
+}

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -564,5 +564,5 @@ fn filesize_with_underscores_3() -> TestResult {
 
 #[test]
 fn filesize_is_not_hex() -> TestResult {
-    run_test("0x42b", 1067)
+    run_test("0x42b", "1067")
 }


### PR DESCRIPTION
closes #9278 

# Description

removes ambiguity between the `b` the filesize `bytes` unit and `b` the hex digit