### PR TITLE
restore cursor shape when exits

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -12,7 +12,7 @@ use nu_color_config::StyleComputer;
 use nu_command::hook::eval_hook;
 use nu_command::util::get_guaranteed_cwd;
 use nu_engine::convert_env_values;
-use nu_parser::{lex, trim_quotes_str};
+use nu_parser::{lex, parse, trim_quotes_str};
 use nu_protocol::{
     config::NuCursorShape,
     engine::{EngineState, Stack, StateWorkingSet},
@@ -585,6 +585,27 @@ pub fn evaluate_repl(
                     );
                 } else if !s.trim().is_empty() {
                     trace!("eval source: {}", s);
+
+                    let mut cmds = s.split_whitespace();
+                    if let Some("exit") = cmds.next() {
+                        let mut working_set = StateWorkingSet::new(engine_state);
+                        let _ = parse(&mut working_set, None, s.as_bytes(), false);
+
+                        if working_set.parse_errors.is_empty() {
+                            match cmds.next() {
+                                Some(s) => {
+                                    if let Ok(n) = s.parse::<i32>() {
+                                        drop(line_editor);
+                                        std::process::exit(n);
+                                    }
+                                }
+                                None => {
+                                    drop(line_editor);
+                                    std::process::exit(0);
+                                }
+                            }
+                        }
+                    }
 
                     eval_source(
                         engine_state,


### PR DESCRIPTION
# Description
This PR restores cursor shape when nushell exists.

Fixes #9243 

Related [nushell/reedline#574](https://github.com/nushell/reedline/pull/574)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* windows

https://github.com/nushell/nushell/assets/15247421/ede8d1c0-ecd1-40b0-87b0-6393c1a7160f


* linux

https://github.com/nushell/nushell/assets/15247421/b428f17e-05cb-45ad-aa5f-3a9753fd9176

* macos

https://github.com/nushell/nushell/assets/15247421/5170dabd-8b9f-4bad-a7a2-bdabfca45cca

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
