### PR TITLE
Change install context of windows terminal profile to `per-user`

### DIFF
--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -285,18 +285,25 @@
                 </Directory>
             </Directory>
 
-            <Directory Id='CommonAppDataFolder'>
+            <Directory Id='LocalAppDataFolder'>
                 <Directory Id='AppDataMicrosoftFolder' Name='Microsoft'>
                     <Directory Id='AppDataWindowsTerminalFolder' Name='Windows Terminal'>
                         <Directory Id='WindowsTerminalProfileFolder' Name='Fragments'>
                             <Directory Id='WindowsTerminalProfileAppFolder' Name='nu'>
-                                <Component Id='WindowsTerminalProfile' Guid='*' Win64='$(var.Win64)'>
+                                <Component Id='WindowsTerminalProfile' Guid='957239F4-7B87-4399-9F91-7DF2ABE5ED8B' Win64='$(var.Win64)'>
                                     <File
                                         Id='WindowsTerminalProfileFile'
                                         Name='nu.json'
                                         DiskId='1'
                                         Source='wix\windows-terminal-profile.json'
-                                        KeyPath='yes'/>
+                                        System='no'/>
+                                    <RegistryKey Root='HKCU' Key='Software\nu'>
+                                        <RegistryValue Name='WindowsTerminalProfile' Value='1' Type='integer' KeyPath='yes'/>
+                                    </RegistryKey>
+                                    <RemoveFolder Id='RemoveWindowsTerminalProfileFolder1' Directory='WindowsTerminalProfileAppFolder' On='uninstall'/>
+                                    <RemoveFolder Id='RemoveWindowsTerminalProfileFolder2' Directory='WindowsTerminalProfileFolder' On='uninstall'/>
+                                    <RemoveFolder Id='RemoveWindowsTerminalProfileFolder3' Directory='AppDataWindowsTerminalFolder' On='uninstall'/>
+                                    <RemoveFolder Id='RemoveWindowsTerminalProfileFolder4' Directory='AppDataMicrosoftFolder' On='uninstall'/>
                                 </Component>
                             </Directory>
                         </Directory>
@@ -383,7 +390,7 @@
             DllEntry="CAQuietExec"
             Execute="deferred"
             Return="check"
-            Impersonate="no"/>
+            Impersonate="yes"/>
         <InstallExecuteSequence>
             <Custom Action='ReplacePathsInWindowsTerminalProfile' Before='InstallFinalize'>
                 <!-- Run the custom action if the feature is enabled -->

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -382,7 +382,7 @@
         <SetProperty
             Id="ReplacePathsInWindowsTerminalProfile"
             Sequence="execute"
-            Value="&quot;[#exe0]&quot; -c &quot;open '[#WindowsTerminalProfileFile]' | update profiles.commandline '[#exe0]' | update profiles.icon '[#icon0]' | save -f '[#WindowsTerminalProfileFile]'&quot;"
+            Value="&quot;[#exe0]&quot; -c &quot;open `[#WindowsTerminalProfileFile]` | update profiles.commandline `[#exe0]` | update profiles.icon `[#icon0]` | save -f `[#WindowsTerminalProfileFile]`&quot;"
             After='CostFinalize'/>
         <CustomAction
             Id="ReplacePathsInWindowsTerminalProfile"


### PR DESCRIPTION
# Description

Change installation context of the windows terminal profile to `per-user` from `per-system`.

This change is made because installation validation fails in winget ci while executing custom action to replace the installation path of `nu.exe` and `nu.ico` in the windows terminal profile file.

Refer discussions in #5812 and https://github.com/microsoft/winget-pkgs/pull/106977

- Installation path of the windows terminal profile is changed as below:
  - from: `C:\ProgramData\Microsoft\Windows Terminal\Fragments\nu\nu.json`
  - to: `C:\Users\<user>\AppData\Local\Microsoft\Windows Terminal\Fragments\nu\nu.json`
- Custom action to replace the installation path of `nu.exe` and `nu.ico` in the json file will be executed without privilege escalation

This change is expected to eliminate the validation failure in winget ci (need to wait until next release to be sure about it), however, it creates some inconsistency in installation context.

- The windows terminal profile is installed in `per-user` context, other files / PATH env variable are installed in `per-system` context.
- Building the installer shows a warning about this: `warning LGHT1076 : ICE91: The file 'WindowsTerminalProfileFile' will be installed to the per user directory 'WindowsTerminalProfileAppFolder' that doesn't vary based on ALLUSERS value. This file won't be copied to each user's profile even if a per machine installation is desired.`
  which means: WT profile will be installed only for the user that executed the installer and it won't be installed for other users in the system. However, the installer is configured to use `per-system` context, therefore, other files (such as nushell binary `nu.exe`) will be installed for all users.

It might be better if we provide options for installation context (`per-user` or `per-system`) as requested in #5927 in the future, if that doesn't cause problems in winget ci.

# User-Facing Changes

- Installation path of windows terminal profile will be changed as above.
- Windows Terminal profile will be installed only for the user that installed nushell as stated above. The profile should be manually added for other users if needed.

# Tests + Formatting

No test is added since this change is related to installation process in Windows and does not contain source code changes.

Following checks are done manually.

### Environment

- OS: Windows 11 Pro 22H2
- Built the installer by referring `.github/workflows/release-pkg.nu` script

### Checks

- Install: WT profile should be created in `C:\Users\<user>\AppData\Local\Microsoft\Windows Terminal\Fragments\nu\nu.json` and it should contain correct path for `nu.exe` and `nu.ico`.
  - [x] Install (WT profile feature enabled)
  - [x] Install (WT profile enabled) -> Manually remove the WT profile file -> Re-run the installer and Repair

- Uninstall: WT profile should be removed.
  - [x] Install (WT profile enabled) -> Uninstall
  - [x] Install (WT profile enabled) -> Re-run the installer and Modify (WT profile disabled)

# After Submitting

No relevant documentation to update.
