### PR TITLE
make insert, update, upsert support lazy records

### DIFF
--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -95,3 +95,10 @@ fn insert_uses_enumerate_index() {
 
     assert_eq!(actual.out, "[[index, a, b]; [0, 7, 8], [1, 6, 8]]");
 }
+
+#[test]
+fn insert_support_lazy_record() {
+    let actual =
+        nu!(r#"let x = (lazy make -c ["h"] -g {|a| $a | str upcase}); $x | insert a 10 | get a"#);
+    assert_eq!(actual.out, "10");
+}

--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -105,3 +105,10 @@ fn update_uses_enumerate_index() {
 
     assert_eq!(actual.out, "[[index, a]; [0, 8], [1, 8]]");
 }
+
+#[test]
+fn update_support_lazy_record() {
+    let actual =
+        nu!(r#"let x = (lazy make -c ["h"] -g {|a| $a | str upcase}); $x | update h 10 | get h"#);
+    assert_eq!(actual.out, "10");
+}

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -95,3 +95,14 @@ fn upsert_empty() {
 
     assert!(actual.err.contains("index too large (max: 0)"));
 }
+
+#[test]
+fn upsert_support_lazy_record() {
+    let actual =
+        nu!(r#"let x = (lazy make -c ["h"] -g {|a| $a | str upcase}); $x | upsert h 10 | get h"#);
+    assert_eq!(actual.out, "10");
+
+    let actual =
+        nu!(r#"let x = (lazy make -c ["h"] -g {|a| $a | str upcase}); $x | upsert aa 10 | get aa"#);
+    assert_eq!(actual.out, "10");
+}

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1050,6 +1050,12 @@ impl Value {
                             }
                         }
                     }
+                    Value::LazyRecord { val, .. } => {
+                        // convert to Record first.
+                        let mut record = val.collect()?;
+                        record.upsert_data_at_cell_path(cell_path, new_val)?;
+                        *self = record
+                    }
                     Value::Error { error } => return Err(*error.to_owned()),
                     v => {
                         return Err(ShellError::CantFindColumn {
@@ -1181,6 +1187,12 @@ impl Value {
                             });
                         }
                     }
+                    Value::LazyRecord { val, .. } => {
+                        // convert to Record first.
+                        let mut record = val.collect()?;
+                        record.update_data_at_cell_path(cell_path, new_val)?;
+                        *self = record
+                    }
                     Value::Error { error } => return Err(*error.to_owned()),
                     v => {
                         return Err(ShellError::CantFindColumn {
@@ -1293,6 +1305,13 @@ impl Value {
                             }
                             Ok(())
                         }
+                        Value::LazyRecord { val, .. } => {
+                            // convert to Record first.
+                            let mut record = val.collect()?;
+                            record.remove_data_at_cell_path(cell_path)?;
+                            *self = record;
+                            Ok(())
+                        }
                         v => Err(ShellError::CantFindColumn {
                             col_name: col_name.to_string(),
                             span: *span,
@@ -1389,6 +1408,13 @@ impl Value {
                                     src_span: *v_span,
                                 });
                             }
+                            Ok(())
+                        }
+                        Value::LazyRecord { val, .. } => {
+                            // convert to Record first.
+                            let mut record = val.collect()?;
+                            record.remove_data_at_cell_path(cell_path)?;
+                            *self = record;
                             Ok(())
                         }
                         v => Err(ShellError::CantFindColumn {
@@ -1506,6 +1532,12 @@ impl Value {
 
                         cols.push(col_name.clone());
                         vals.push(new_val);
+                    }
+                    Value::LazyRecord { val, span } => {
+                        // convert to Record first.
+                        let mut record = val.collect()?;
+                        record.insert_data_at_cell_path(cell_path, new_val, *span)?;
+                        *self = record
                     }
                     other => {
                         return Err(ShellError::UnsupportedInput(


### PR DESCRIPTION
# Description
Fixes: #9165
It's because `sys` returns a lazy record, and `insert`, `update`, `upsert` can't operate on lazy record yet.

# User-Facing Changes

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
