### PR TITLE
bump rust toolchain to 1.68.2

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -835,16 +835,14 @@ mod windows_helper {
                 &mut find_data,
             ) {
                 Ok(_) => Ok(find_data),
-                Err(e) => {
-                    return Err(ShellError::ReadingFile(
-                        format!(
-                            "Could not read metadata for '{}':\n  '{}'",
-                            filename.to_string_lossy(),
-                            e
-                        ),
-                        span,
-                    ));
-                }
+                Err(e) => Err(ShellError::ReadingFile(
+                    format!(
+                        "Could not read metadata for '{}':\n  '{}'",
+                        filename.to_string_lossy(),
+                        e
+                    ),
+                    span,
+                )),
             }
         }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,5 +16,5 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 3 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.67.1"
+channel = "1.68.2"
 


### PR DESCRIPTION
# Description

In keeping with our tradition of staying 2 versions behind the latest rust compiler version, this PR bump the toolchain to 1.68.2.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
