### PR TITLE
Enable history entry exclusion with leading space

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -141,6 +141,7 @@ pub fn evaluate_repl(
         };
         line_editor = line_editor
             .with_history_session_id(history_session_id)
+            .with_history_exclusion_prefix(Some(" ".into()))
             .with_history(history);
     };
     perf(


### PR DESCRIPTION
# Description
Makes use of the feature introduced by nushell/reedline#566

If we consider this to be problematic we can decide to add a config
point for this behavior, but at first I was a bit hesistant expanding
the config in this area.


# User-Facing Changes
Follows precedent found in bash/zsh/fish to exclude lines starting with
a space from the history.
Like in fish you can still recall the last entry once but it will not be
stored and will be forgotten after the next submitted entry.


# Tests + Formatting
(-)

