### PR TITLE
Fix internal module reexports

### DIFF
--- a/crates/nu-command/src/strings/format/mod.rs
+++ b/crates/nu-command/src/strings/format/mod.rs
@@ -1,4 +1,4 @@
-pub mod command;
+mod command;
 mod filesize;
 
 pub use self::filesize::FileSize;

--- a/crates/nu-command/src/strings/split/mod.rs
+++ b/crates/nu-command/src/strings/split/mod.rs
@@ -1,9 +1,9 @@
-pub mod chars;
-pub mod column;
-pub mod command;
-pub mod list;
-pub mod row;
-pub mod words;
+mod chars;
+mod column;
+mod command;
+mod list;
+mod row;
+mod words;
 
 pub use chars::SubCommand as SplitChars;
 pub use column::SubCommand as SplitColumn;


### PR DESCRIPTION
# Description
`cargo +stable check` was complaining about ambiguous wildcard
reexports. Fixed by making the reexport of modules not pub as only the
explicitly named symbols are actually needed in the current state.


# User-Facing Changes
None

