### PR TITLE
add a comment note to the PR template about linking issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,11 @@
+<!--
+if this PR closes one or more issues, you can automatically link the PR with
+them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
+- this PR should close #xxxx
+- fixes #xxxx
+
+you can also mention related issues, PRs or discussions!
+-->
 
 # Description
 <!--


### PR DESCRIPTION
i see very often contributors mentionning an issue that their PR is supposed to solve without using the proper [*linking keywords* of *GitHub*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) :thinking: 

in this PR, i've added a little comment to the top of the PR template to hopefully explain how to achieve this automatically without requiring maintainers to link PRs manually :relieved: 