### PR TITLE
fix a typo

### DIFF
--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -387,7 +387,7 @@ fn in_iteration() -> TestResult {
 }
 
 #[test]
-fn reuseable_in() -> TestResult {
+fn reusable_in() -> TestResult {
     run_test(
         r#"[1, 2, 3, 4] | take (($in | length) - 1) | math sum"#,
         "6",


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/commit/bdb09a9a00cf559a036073ef306aefa04787ac1b
- [this job](https://github.com/nushell/nushell/actions/runs/5224369668/jobs/9432486180?pr=9392) from #9392
- [this job](https://github.com/nushell/nushell/actions/runs/5222835000/jobs/9428854834?pr=9391) from #9391

# Description
this PR tries to fix the typo reported in these very recent PRs