### PR TITLE
Add `zip-into-record` to std iter

### DIFF
--- a/crates/nu-std/std/iter.nu
+++ b/crates/nu-std/std/iter.nu
@@ -197,3 +197,26 @@ export def zip-with [ # -> list<any>
         reduce {|it, acc| do $fn $acc $it }
     }
 }
+
+# Zips two lists and returns a record with the first list as headers
+#
+# # Example
+# ```nu
+# use std ["assert equal" "iter iter zip-into-record"]
+#
+# let res = (
+#     [1 2 3] | iter zip-into-record [2 3 4]
+# )
+#
+# assert equal $res [
+#     [1 2 3];
+#     [2 3 4]
+# ]
+# ```
+export def zip-into-record [ # -> table<any>
+    other: list                     # the values to zip with
+] {
+    into record
+    | append ($other | into record)
+    | headers
+}

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -110,3 +110,17 @@ export def test_iter_flat_map [] {
     let res = ([1 2 3] | iter flat-map {|it| $it + ($it * 10)})
     assert equal $res [11 22 33]
 }
+
+export def test_iter_zip_into_record [] {
+    let headers = [name repo position]
+    let values = [rust github 1]
+
+    let res = (
+        $headers | iter zip-into-record $values
+    )
+
+    assert equal $res [
+        [name    repo    position];
+        [rust    github  1]
+    ]
+}


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Adds a new iter feature `zip-into-record` (#9380)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
User can use `[1 2] | iter zip-into-record [3 4]` to create a table `[[1 2]; [3 4]]`

# Tests + Formatting

I noticed trailing spaces in std library that may wish to be cleaned in the future. 

