### PR TITLE
REFACTOR: simplify the declaration of extra commands

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -6,9 +6,9 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct BitsAnd;
 
-impl Command for SubCommand {
+impl Command for BitsAnd {
     fn name(&self) -> &str {
         "bits and"
     }
@@ -99,6 +99,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(SubCommand {})
+        test_examples(BitsAnd {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -1,12 +1,12 @@
-mod and;
-mod bits_;
-mod not;
-mod or;
-mod rotate_left;
-mod rotate_right;
-mod shift_left;
-mod shift_right;
-mod xor;
+pub(crate) mod and;
+pub(crate) mod bits_;
+pub(crate) mod not;
+pub(crate) mod or;
+pub(crate) mod rotate_left;
+pub(crate) mod rotate_right;
+pub(crate) mod shift_left;
+pub(crate) mod shift_right;
+pub(crate) mod xor;
 
 use nu_protocol::engine::StateWorkingSet;
 use nu_protocol::Spanned;

--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -8,42 +8,7 @@ pub(crate) mod shift_left;
 pub(crate) mod shift_right;
 pub(crate) mod xor;
 
-use nu_protocol::engine::StateWorkingSet;
 use nu_protocol::Spanned;
-
-pub use and::SubCommand as BitsAnd;
-pub use bits_::Bits;
-pub use not::SubCommand as BitsNot;
-pub use or::SubCommand as BitsOr;
-pub use rotate_left::SubCommand as BitsRotateLeft;
-pub use rotate_right::SubCommand as BitsRotateRight;
-pub use shift_left::SubCommand as BitsShiftLeft;
-pub use shift_right::SubCommand as BitsShiftRight;
-pub use xor::SubCommand as BitsXor;
-
-pub fn add_bits_decls(working_set: &mut StateWorkingSet) {
-    macro_rules! bind_command {
-            ( $command:expr ) => {
-                working_set.add_decl(Box::new($command));
-            };
-            ( $( $command:expr ),* ) => {
-                $( working_set.add_decl(Box::new($command)); )*
-            };
-        }
-
-    // Dataframe commands
-    bind_command!(
-        Bits,
-        BitsAnd,
-        BitsNot,
-        BitsOr,
-        BitsXor,
-        BitsRotateLeft,
-        BitsRotateRight,
-        BitsShiftLeft,
-        BitsShiftRight
-    );
-}
 
 #[derive(Clone, Copy)]
 enum NumberBytes {

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -7,9 +7,9 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct BitsNot;
 
-impl Command for SubCommand {
+impl Command for BitsNot {
     fn name(&self) -> &str {
         "bits not"
     }
@@ -169,6 +169,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(SubCommand {})
+        test_examples(BitsNot {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/or.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/or.rs
@@ -6,9 +6,9 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct BitsOr;
 
-impl Command for SubCommand {
+impl Command for BitsOr {
     fn name(&self) -> &str {
         "bits or"
     }
@@ -99,6 +99,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(SubCommand {})
+        test_examples(BitsOr {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -9,9 +9,9 @@ use num_traits::int::PrimInt;
 use std::fmt::Display;
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct BitsRol;
 
-impl Command for SubCommand {
+impl Command for BitsRol {
     fn name(&self) -> &str {
         "bits rol"
     }
@@ -155,6 +155,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(SubCommand {})
+        test_examples(BitsRol {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -9,9 +9,9 @@ use num_traits::int::PrimInt;
 use std::fmt::Display;
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct BitsRor;
 
-impl Command for SubCommand {
+impl Command for BitsRor {
     fn name(&self) -> &str {
         "bits ror"
     }
@@ -159,6 +159,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(SubCommand {})
+        test_examples(BitsRor {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -9,9 +9,9 @@ use num_traits::CheckedShl;
 use std::fmt::Display;
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct BitsShl;
 
-impl Command for SubCommand {
+impl Command for BitsShl {
     fn name(&self) -> &str {
         "bits shl"
     }
@@ -178,6 +178,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(SubCommand {})
+        test_examples(BitsShl {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -9,9 +9,9 @@ use num_traits::CheckedShr;
 use std::fmt::Display;
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct BitsShr;
 
-impl Command for SubCommand {
+impl Command for BitsShr {
     fn name(&self) -> &str {
         "bits shr"
     }
@@ -168,6 +168,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(SubCommand {})
+        test_examples(BitsShr {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/xor.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/xor.rs
@@ -6,9 +6,9 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct SubCommand;
+pub struct BitsXor;
 
-impl Command for SubCommand {
+impl Command for BitsXor {
     fn name(&self) -> &str {
         "bits xor"
     }
@@ -98,6 +98,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(SubCommand {})
+        test_examples(BitsXor {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/mod.rs
@@ -1,9 +1,26 @@
 mod bits;
 
-pub use bits::add_bits_decls;
-
 use nu_protocol::engine::StateWorkingSet;
 
 pub fn add_extra_decls(working_set: &mut StateWorkingSet) {
-    add_bits_decls(working_set);
+    macro_rules! bind_command {
+            ( $command:expr ) => {
+                working_set.add_decl(Box::new($command));
+            };
+            ( $( $command:expr ),* ) => {
+                $( working_set.add_decl(Box::new($command)); )*
+            };
+        }
+
+    bind_command!(
+        bits::bits_::Bits,
+        bits::and::BitsAnd,
+        bits::not::BitsNot,
+        bits::or::BitsOr,
+        bits::xor::BitsXor,
+        bits::rotate_left::BitsRol,
+        bits::rotate_right::BitsRor,
+        bits::shift_left::BitsShl,
+        bits::shift_right::BitsShr
+    );
 }


### PR DESCRIPTION
cc/ @stormasm 

# Description
i was about to start the cratification of the 0% commands and thought i could refactor and simplify a bit the declaration of the `bits` commands, having hopefully a simpler structure to work with the other commands :relieved: 

this PR:
- gives real names to all the `bits` commands, instead of `SubCommand`
- make them publicly available inside the `nu-cmd-extra` crate to declare them through `add_extra_decls`
- move the declaration code to the top-level `mod.nu` of `nu-cmd-extra` so that all commands can be declared there as in `default_context` in `nu-command`

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```
