### PR TITLE
disable bracketed paste during evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4320,8 +4320,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18dd49ff50c5be37fc21e1cd0ab42f5533e339906ce0527748b396b5a5a55dc"
+source = "git+https://github.com/nushell/reedline.git?branch=main#de2c627951d0a0e198146e1faa112b74bf92e9c3"
 dependencies = [
  "chrono",
  "crossterm 0.26.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
+reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Criterion benchmarking setup

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -607,6 +607,11 @@ pub fn evaluate_repl(
                         }
                     }
 
+                    // should disable bracketed_paste to avoid strange pasting behavior
+                    // while running commands.
+                    #[cfg(not(target_os = "windows"))]
+                    let _ = line_editor.disable_bracketed_paste();
+
                     eval_source(
                         engine_state,
                         stack,
@@ -615,6 +620,10 @@ pub fn evaluate_repl(
                         PipelineData::empty(),
                         false,
                     );
+                    if engine_state.get_config().bracketed_paste {
+                        #[cfg(not(target_os = "windows"))]
+                        let _ = line_editor.enable_bracketed_paste();
+                    }
                 }
                 let cmd_duration = start_time.elapsed();
 


### PR DESCRIPTION
# Description
Fixes: #9218

When user execute some commands involve user input, currently if we enable `bracketed_paste`, it will results strange behavior (Pasting `0~` and `1~` around texts, e.g: `aaa` -> `0~aaa1~`)  And this is why `gpg` with paste failed.

Sorry that it's hard to make relative testing...

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
