### PR TITLE
Add "regex" search term to commands with regex functionality

### DIFF
--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -20,7 +20,7 @@ impl Command for Parse {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["pattern", "match"]
+        vec!["pattern", "match", "regex"]
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -45,7 +45,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["separate", "divide"]
+        vec!["separate", "divide", "regex"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -38,7 +38,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["separate", "divide"]
+        vec!["separate", "divide", "regex"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -38,7 +38,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["separate", "divide"]
+        vec!["separate", "divide", "regex"]
     }
 
     fn run(

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -61,7 +61,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["search", "shift", "switch"]
+        vec!["search", "shift", "switch", "regex"]
     }
 
     fn run(


### PR DESCRIPTION
Just makes it easier to find these commands when using the `help` system - the `find` command already has the "regex" search term.