### PR TITLE
Reset .github/workflows/release-pkg.nu

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -76,6 +76,16 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
             let-env CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = 'aarch64-linux-gnu-gcc'
             cargo-build-nu $flags
         }
+        'riscv64gc-unknown-linux-gnu' => {
+            sudo apt-get install gcc-riscv64-linux-gnu -y
+            let-env CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER = 'riscv64-linux-gnu-gcc'
+            cargo-build-nu $flags
+        }
+        'armv7-unknown-linux-gnueabihf' => {
+            sudo apt-get install pkg-config gcc-arm-linux-gnueabihf -y
+            let-env CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER = 'arm-linux-gnueabihf-gcc'
+            cargo-build-nu $flags
+        }
         _ => {
             # musl-tools to fix 'Failed to find tool. Is `musl-gcc` installed?'
             # Actually just for x86_64-unknown-linux-musl target


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

We don't need to modify this file to disable the building of `riscv64gc-unknown-linux-gnu` and `armv7-unknown-linux-gnueabihf` binaries, just modify the `.github/workflows/release.yml` file is enough.
Reset this file to make `.github/workflows/nightly-build.yml` work less wrong

