### PR TITLE
Changes global allocator to mimalloc, improving performance.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,6 +2146,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libproc"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2386,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.17",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2629,6 +2648,7 @@ dependencies = [
  "ctrlc",
  "log",
  "miette",
+ "mimalloc",
  "nix",
  "nu-ansi-term",
  "nu-cli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ nu-utils = { path = "./crates/nu-utils", version = "0.81.1" }
 nu-ansi-term = "0.47.0"
 reedline = { version = "0.20.0", features = ["bashisms", "sqlite"]}
 
+mimalloc = { version = "0.1.37", default-features = false }
 crossterm = "0.26"
 ctrlc = "3.2"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,8 @@ nu-utils = { path = "./crates/nu-utils", version = "0.81.1" }
 nu-ansi-term = "0.47.0"
 reedline = { version = "0.20.0", features = ["bashisms", "sqlite"]}
 
-mimalloc = { version = "0.1.37", default-features = false }
+mimalloc = { version = "0.1.37", default-features = false, optional = true}
+
 crossterm = "0.26"
 ctrlc = "3.4"
 log = "0.4"
@@ -116,6 +117,8 @@ wasi = ["nu-cmd-lang/wasi"]
 
 # Enable to statically link OpenSSL; otherwise the system version will be used. Not enabled by default because it takes a while to build
 static-link-openssl = ["dep:openssl", "nu-cmd-lang/static-link-openssl"]
+
+mimalloc = ["nu-cmd-lang/mimalloc", "dep:mimalloc"]
 
 # Stable (Default)
 which-support = ["nu-command/which-support", "nu-cmd-lang/which-support"]

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -28,6 +28,7 @@ ahash = "0.8.3"
 shadow-rs = { version = "0.22", default-features = false }
 
 [features]
+mimalloc = []
 which-support = []
 trash-support = []
 sqlite = []

--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -117,6 +117,12 @@ pub fn version(
         vals.push(Value::string(build_rust_channel, call.head));
     }
 
+    cols.push("allocator".to_string());
+    vals.push(Value::String {
+        val: global_allocator().to_string(),
+        span: call.head,
+    });
+
     cols.push("features".to_string());
     vals.push(Value::String {
         val: features_enabled().join(", "),
@@ -142,6 +148,14 @@ pub fn version(
         span: call.head,
     }
     .into_pipeline_data())
+}
+
+fn global_allocator() -> &'static str {
+    if cfg!(feature = "mimalloc") {
+        "mimalloc"
+    } else {
+        "standard"
+    }
 }
 
 fn features_enabled() -> Vec<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,10 +9,9 @@ mod test_bins;
 #[cfg(test)]
 mod tests;
 
-use mimalloc::MiMalloc;
-
+#[cfg(feature = "mimalloc")]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use crate::{
     command::parse_commandline_args,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,11 @@ mod test_bins;
 #[cfg(test)]
 mod tests;
 
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 use crate::{
     command::parse_commandline_args,
     config_files::set_config_path,


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

this PR makes nushell use mimalloc as the default allocator, this has the benefit of reducing startup time on my machine. `17%` on linux and `22%` on windows, when testing using hyperfine.
the overhead to compile seem to be quite small, aswell as the increase of binary size quite small
on linux the binary went from `33.1mb` to `33.2mb`

linux
![image](https://github.com/nushell/nushell/assets/17986183/ba5379b4-2c08-483a-a9ff-a9d8524d2943)

windows 
![image](https://github.com/nushell/nushell/assets/17986183/fda5090f-96a9-48d1-ada4-617694b9d880)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
