### PR TITLE
allow paths to have brackets

### DIFF
--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -38,15 +38,28 @@ pub fn glob_from(
         // Path is a glob pattern => do not check for existence
         // Select the longest prefix until the first '*'
         let mut p = PathBuf::new();
-        for c in path.components() {
+        let components = path.components();
+        let mut counter = 0;
+        // Get the path up to the pattern which we'll call the prefix
+        for c in components {
             if let Component::Normal(os) = c {
                 if os.to_string_lossy().contains('*') {
                     break;
                 }
             }
             p.push(c);
+            counter += 1;
         }
-        (Some(p), path)
+
+        // Let's separate the pattern from the path and we'll call this the pattern
+        let mut just_pattern = PathBuf::new();
+        for c in counter..path.components().count() {
+            if let Some(comp) = path.components().nth(c) {
+                just_pattern.push(comp);
+            }
+        }
+
+        (Some(p), just_pattern)
     } else if is_symlink {
         (path.parent().map(|parent| parent.to_path_buf()), path)
     } else {

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -34,7 +34,7 @@ pub fn glob_from(
         Err(_) => false,
     };
 
-    // Check for brakets first
+    // Check for brackets first
     let (prefix, pattern) = if path.to_string_lossy().contains('[') {
         // Path is a glob pattern => do not check for existence
         // Select the longest prefix until the first '*'


### PR DESCRIPTION
# Description

This PR is trying to allow you to have `[blah]` in your path and yet still have `ls` work. This is done by trying to separate the path from the pattern to be searched for. It may still need more work.

I've tested it with:
- mkdir "[test]"
- cd "[test]"
- ls

Related to #9307 
Hopefully fixes #9232 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
