### PR TITLE
allow empty string arguments

### DIFF
--- a/crates/nu-parser/src/deparse.rs
+++ b/crates/nu-parser/src/deparse.rs
@@ -26,6 +26,9 @@ pub fn escape_for_script_arg(input: &str) -> String {
                 format!("`{arg_val}`")
             } else if arg_val.contains('"') || arg_val.contains('\\') {
                 escape_quote_string(arg_val)
+            } else if arg_val.is_empty() {
+                // return an empty string
+                "''".to_string()
             } else {
                 arg_val.into()
             };
@@ -37,6 +40,9 @@ pub fn escape_for_script_arg(input: &str) -> String {
         format!("`{input}`")
     } else if input.contains('"') || input.contains('\\') {
         escape_quote_string(input)
+    } else if input.is_empty() {
+        // return an empty string
+        "''".to_string()
     } else {
         input.to_string()
     }


### PR DESCRIPTION
# Description

I'm not sure if this is a good idea or now but I did it to fix #9418. It allows you to pass empty string arguments like this.

file named foo.nu
```
def main [--arg: string = dog] {
  if ($arg | is-empty) {
    echo "empty string"
  } else {
   echo $arg
  }
}
```
`> nu foo.nu --arg ""`
or
`> nu foo.nu --arg=""`
this gives an error
`> nu foo.nu --arg`
this returns the default argument
`> nu foo.nu`

closes #9418 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
