### PR TITLE
toolkit: use `--features` instead of `--dataframe` and refactor a bit

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -19,7 +19,9 @@ export def fmt [
         try {
             cargo fmt --all -- --check
         } catch {
-            error make -u { msg: $"\nplease run ('toolkit fmt' | pretty-print-command) to fix formatting!" }
+            error make --unspanned {
+                msg: $"\nplease run ('toolkit fmt' | pretty-print-command) to fix formatting!"
+            }
         }
     } else {
         cargo fmt --all
@@ -37,10 +39,19 @@ export def clippy [
         print $"running ('toolkit clippy' | pretty-print-command)"
     }
 
-    try {
-        cargo clippy --workspace --features ($features | str join ",") -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err
-    } catch {
-        error make -u { msg: $"\nplease fix the above ('clippy' | pretty-print-command) errors before continuing!" }
+    try {(
+        cargo clippy
+            --workspace
+            --features ($features | str join ",")
+        --
+            -D warnings
+            -D clippy::unwrap_used
+            -A clippy::needless_collect
+            -A clippy::result_large_err
+    )} catch {
+        error make --unspanned {
+            msg: $"\nplease fix the above ('clippy' | pretty-print-command) errors before continuing!"
+        }
     }
 }
 

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -58,7 +58,7 @@ export def clippy [
 # check that all the tests pass
 export def test [
     --fast: bool  # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
-    --features: list<string> # the list of features to run *Clippy* on
+    --features: list<string> # the list of features to run the tests on
 ] {
     if $fast {
         cargo nextest run --all --features ($features | str join ",")
@@ -211,7 +211,7 @@ def report [
 # now the whole `toolkit check pr` passes! :tada:
 export def "check pr" [
     --fast: bool  # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
-    --features: list<string> # the list of features to run *Clippy* on
+    --features: list<string> # the list of features to check the current PR on
 ] {
     let-env NU_TEST_LOCALE_OVERRIDE = 'en_US.utf8';
     try {


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/9357

# Description
with the new `extra` feature introduce in the `toolkit.nu` module in https://github.com/nushell/nushell/pull/9357, the `--dataframe` option does not make sense anymore...

this PR changes that and replaces it with `--features: list<string>`.
this has the benefit of simplifying the commands because we can just pass `--features  ($features | str join ",")` to the `cargo` commands regardless of whether the `$features` list is empty of not :ok_hand: 

i've also refactored a bit the module:
- break the long `error make -u` lines
- break the long `cargo clippy` command

# User-Facing Changes
devs can now choose which feature to test with the `toolkit` commands.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```
