### PR TITLE
Remove ZB and ZiB from file size type

### DIFF
--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -457,10 +457,6 @@ fn convert_to_value(
                     val: size * 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
                     span,
                 }),
-                Unit::Zettabyte => Ok(Value::Filesize {
-                    val: size * 1000 * 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
-                    span,
-                }),
 
                 Unit::Kibibyte => Ok(Value::Filesize {
                     val: size * 1024,
@@ -484,10 +480,6 @@ fn convert_to_value(
                 }),
                 Unit::Exbibyte => Ok(Value::Filesize {
                     val: size * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
-                    span,
-                }),
-                Unit::Zebibyte => Ok(Value::Filesize {
-                    val: size * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
                     span,
                 }),
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2313,14 +2313,12 @@ pub const FILESIZE_UNIT_GROUPS: &[UnitGroup] = &[
     (Unit::Terabyte, "TB", Some((Unit::Gigabyte, 1000))),
     (Unit::Petabyte, "PB", Some((Unit::Terabyte, 1000))),
     (Unit::Exabyte, "EB", Some((Unit::Petabyte, 1000))),
-    (Unit::Zettabyte, "ZB", Some((Unit::Exabyte, 1000))),
     (Unit::Kibibyte, "KIB", Some((Unit::Byte, 1024))),
     (Unit::Mebibyte, "MIB", Some((Unit::Kibibyte, 1024))),
     (Unit::Gibibyte, "GIB", Some((Unit::Mebibyte, 1024))),
     (Unit::Tebibyte, "TIB", Some((Unit::Gibibyte, 1024))),
     (Unit::Pebibyte, "PIB", Some((Unit::Tebibyte, 1024))),
     (Unit::Exbibyte, "EIB", Some((Unit::Pebibyte, 1024))),
-    (Unit::Zebibyte, "ZIB", Some((Unit::Exbibyte, 1024))),
     (Unit::Byte, "B", None),
 ];
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3754,7 +3754,6 @@ fn get_filesize_format(format_value: &str, filesize_metric: Option<bool>) -> (By
         "tb" | "tib" => either!(format_value, TB, TiB),
         "pb" | "pib" => either!(format_value, TB, TiB),
         "eb" | "eib" => either!(format_value, EB, EiB),
-        "zb" | "zib" => either!(format_value, ZB, ZiB),
         _ => (byte_unit::ByteUnit::B, "auto"),
     }
 }

--- a/crates/nu-protocol/src/value/unit.rs
+++ b/crates/nu-protocol/src/value/unit.rs
@@ -11,7 +11,6 @@ pub enum Unit {
     Terabyte,
     Petabyte,
     Exabyte,
-    Zettabyte,
 
     // Filesize units: ISO/IEC 80000
     Kibibyte,
@@ -20,7 +19,6 @@ pub enum Unit {
     Tebibyte,
     Pebibyte,
     Exbibyte,
-    Zebibyte,
 
     // Duration units
     Nanosecond,
@@ -61,10 +59,6 @@ impl Unit {
                 val: size * 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
                 span,
             },
-            Unit::Zettabyte => Value::Filesize {
-                val: size * 1000 * 1000 * 1000 * 1000 * 1000 * 1000 * 1000,
-                span,
-            },
 
             Unit::Kibibyte => Value::Filesize {
                 val: size * 1024,
@@ -88,10 +82,6 @@ impl Unit {
             },
             Unit::Exbibyte => Value::Filesize {
                 val: size * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
-                span,
-            },
-            Unit::Zebibyte => Value::Filesize {
-                val: size * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
                 span,
             },
 

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -283,7 +283,7 @@ let-env config = {
   }
   filesize: {
     metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
-    format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, zb, zib, auto
+    format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
   }
   cursor_shape: {
     emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR removes ZB and ZiB from file size type, as they 
were showing incorrect values due to an integer overflow.

Fixes: #9337
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->