### PR TITLE
Drop unused `nu-color-config` in `nu-cmd-lang`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,6 @@ dependencies = [
  "fancy-regex",
  "itertools",
  "nu-ansi-term",
- "nu-color-config",
  "nu-engine",
  "nu-parser",
  "nu-protocol",

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -12,7 +12,6 @@ version = "0.81.1"
 bench = false
 
 [dependencies]
-nu-color-config = { path = "../nu-color-config", version = "0.81.1" }
 nu-engine = { path = "../nu-engine", version = "0.81.1" }
 nu-parser = { path = "../nu-parser", version = "0.81.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.81.1"  }


### PR DESCRIPTION
# Description
Unneeded dependency as `help` moved back to `nu-command`.
Currently probably won't provide a compile time benefit.

