### PR TITLE
Skip `strum` in regular `nu-protocol` build

### DIFF
--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -25,8 +25,6 @@ miette = { version = "5.9", features = ["fancy-no-backtrace"] }
 num-format = "0.4"
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", optional = true }
-strum = "0.24"
-strum_macros = "0.24"
 thiserror = "1.0"
 typetag = "0.2"
 ahash = "0.8.3"
@@ -36,4 +34,6 @@ plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = "1.0"
+strum = "0.24"
+strum_macros = "0.24"
 nu-test-support = { path = "../nu-test-support", version = "0.81.1" }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -1,11 +1,13 @@
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
 use strum_macros::EnumIter;
 
 use std::fmt::Display;
 
 use crate::SyntaxShape;
 
-#[derive(Clone, Debug, Default, EnumIter, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[cfg_attr(test, derive(EnumIter))]
 pub enum Type {
     Any,
     Binary,


### PR DESCRIPTION
# Description
`derive(EnumIter)` is only required to run completeness tests.
Thus make the derive conditional on test and move `strum` and
`strum_macros` to the dev dependencies.

## Is it worth it?

Removing this derive does not change the binary size (checked via `cargo bloat --crates` from `cargo-bloat`).
Compile time change is below a second so hard to judge based on a single run of `cargo clean --profile dev; cargo build --timings`
Unsure if this negatively impacts how incremental compilation can recompile when you switch between `cargo build`/`run` and `cargo test` in your local workflow.

To get rid of `strum`/`strum_macros` as a proc macro crate we would need to also remove it from `reedline`. 
Further more a crate in the `polars` dependency tree uses `strum` (curently not as relevant for the 1.0 build).
