### PR TITLE
add a "capture" example to `str replace`, before the fancy ones

### DIFF
--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -134,6 +134,11 @@ impl Command for SubCommand {
                 result: Some(Value::test_string("azc azc azc")),
             },
             Example {
+                description: "Use captures to manipulate the input text",
+                example: r#""abc-def" | str replace "(.+)-(.+)" "${2}_${1}""#,
+                result: Some(Value::test_string("def_abc")),
+            },
+            Example {
                 description: "Find and replace with fancy-regex",
                 example: r#"'a successful b' | str replace '\b([sS])uc(?:cs|s?)e(ed(?:ed|ing|s?)|ss(?:es|ful(?:ly)?|i(?:ons?|ve(?:ly)?)|ors?)?)\b' '${1}ucce$2'"#,
                 result: Some(Value::test_string("a successful b")),


### PR DESCRIPTION
closes https://github.com/nushell/nushell/issues/9437
cc/ @Sygmei :wink: 

# Description
the syntax of *captures* used in `str replace` can be confusing for people not used to the `regex` syntax.
there is already a capture example in `help str replace`
```bash
  Find and replace with fancy-regex
  > 'a successful b' | str replace '\b([sS])uc(?:cs|s?)e(ed(?:ed|ing|s?)|ss(?:es|ful(?:ly)?|i(?:ons?|ve(?:ly)?)|ors?)?)\b' '${1}ucce$2'
  a successful b
```
but it's really not trivial to understand the *capture* syntax...

this PR adds a simpler example only focused on *captures* :partying_face: 
```bash
  Use captures to manipulate the input text
  > "abc-def" | str replace "(.+)-(.+)" "${2}_${1}"
  def_abc
```

# User-Facing Changes
an example in `help str replace` to understand the syntax of *captures*.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```