### PR TITLE
use `create_default_context` from `nu-cmd-lang`

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,16 +2,19 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use nu_cli::eval_source;
 use nu_parser::parse;
 use nu_plugin::{EncodingType, PluginResponse};
-use nu_protocol::{PipelineData, Span, Value};
+use nu_protocol::{PipelineData, Span, Value, engine::EngineState};
 use nu_utils::{get_default_config, get_default_env};
 
+fn load_bench_commands() -> EngineState {
+    nu_command::add_shell_command_context(nu_cmd_lang::create_default_context())
+}
 // FIXME: All benchmarks live in this 1 file to speed up build times when benchmarking.
 // When the *_benchmarks functions were in different files, `cargo bench` would build
 // an executable for every single one - incredibly slowly. Would be nice to figure out
 // a way to split things up again.
 
 fn parser_benchmarks(c: &mut Criterion) {
-    let mut engine_state = nu_cmd_lang::create_default_context();
+    let mut engine_state = load_bench_commands();
     // parsing config.nu breaks without PWD set
     engine_state.add_env_var(
         "PWD".into(),
@@ -38,7 +41,7 @@ fn parser_benchmarks(c: &mut Criterion) {
 
     c.bench_function("eval default_env.nu", |b| {
         b.iter(|| {
-            let mut engine_state = nu_cmd_lang::create_default_context();
+            let mut engine_state = load_bench_commands();
             let mut stack = nu_protocol::engine::Stack::new();
             eval_source(
                 &mut engine_state,
@@ -53,7 +56,7 @@ fn parser_benchmarks(c: &mut Criterion) {
 
     c.bench_function("eval default_config.nu", |b| {
         b.iter(|| {
-            let mut engine_state = nu_cmd_lang::create_default_context();
+            let mut engine_state = load_bench_commands();
             // parsing config.nu breaks without PWD set
             engine_state.add_env_var(
                 "PWD".into(),
@@ -75,7 +78,7 @@ fn parser_benchmarks(c: &mut Criterion) {
 fn eval_benchmarks(c: &mut Criterion) {
     c.bench_function("eval default_env.nu", |b| {
         b.iter(|| {
-            let mut engine_state = nu_cmd_lang::create_default_context();
+            let mut engine_state = load_bench_commands();
             let mut stack = nu_protocol::engine::Stack::new();
             eval_source(
                 &mut engine_state,
@@ -90,7 +93,7 @@ fn eval_benchmarks(c: &mut Criterion) {
 
     c.bench_function("eval default_config.nu", |b| {
         b.iter(|| {
-            let mut engine_state = nu_cmd_lang::create_default_context();
+            let mut engine_state = load_bench_commands();
             // parsing config.nu breaks without PWD set
             engine_state.add_env_var(
                 "PWD".into(),

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use nu_cli::eval_source;
 use nu_parser::parse;
 use nu_plugin::{EncodingType, PluginResponse};
-use nu_protocol::{PipelineData, Span, Value, engine::EngineState};
+use nu_protocol::{engine::EngineState, PipelineData, Span, Value};
 use nu_utils::{get_default_config, get_default_env};
 
 fn load_bench_commands() -> EngineState {

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -11,7 +11,7 @@ use nu_utils::{get_default_config, get_default_env};
 // a way to split things up again.
 
 fn parser_benchmarks(c: &mut Criterion) {
-    let mut engine_state = nu_command::create_default_context();
+    let mut engine_state = nu_cmd_lang::create_default_context();
     // parsing config.nu breaks without PWD set
     engine_state.add_env_var(
         "PWD".into(),
@@ -38,7 +38,7 @@ fn parser_benchmarks(c: &mut Criterion) {
 
     c.bench_function("eval default_env.nu", |b| {
         b.iter(|| {
-            let mut engine_state = nu_command::create_default_context();
+            let mut engine_state = nu_cmd_lang::create_default_context();
             let mut stack = nu_protocol::engine::Stack::new();
             eval_source(
                 &mut engine_state,
@@ -53,7 +53,7 @@ fn parser_benchmarks(c: &mut Criterion) {
 
     c.bench_function("eval default_config.nu", |b| {
         b.iter(|| {
-            let mut engine_state = nu_command::create_default_context();
+            let mut engine_state = nu_cmd_lang::create_default_context();
             // parsing config.nu breaks without PWD set
             engine_state.add_env_var(
                 "PWD".into(),
@@ -75,7 +75,7 @@ fn parser_benchmarks(c: &mut Criterion) {
 fn eval_benchmarks(c: &mut Criterion) {
     c.bench_function("eval default_env.nu", |b| {
         b.iter(|| {
-            let mut engine_state = nu_command::create_default_context();
+            let mut engine_state = nu_cmd_lang::create_default_context();
             let mut stack = nu_protocol::engine::Stack::new();
             eval_source(
                 &mut engine_state,
@@ -90,7 +90,7 @@ fn eval_benchmarks(c: &mut Criterion) {
 
     c.bench_function("eval default_config.nu", |b| {
         b.iter(|| {
-            let mut engine_state = nu_command::create_default_context();
+            let mut engine_state = nu_cmd_lang::create_default_context();
             // parsing config.nu breaks without PWD set
             engine_state.add_env_var(
                 "PWD".into(),


### PR DESCRIPTION
a recent addition must have removed the `create_default_context` command from `nu_command`, which breaks the benchmarks :open_mouth: 

## before this PR
```bash
cargo check --all-targets --workspace
```
gives a bunch of
```bash
error[E0425]: cannot find function `create_default_context` in crate `nu_command`
  --> benches/benchmarks.rs:93:48
   |
93 |             let mut engine_state = nu_command::create_default_context();
   |                                                ^^^^^^^^^^^^^^^^^^^^^^ not found in `nu_command`
   |
help: consider importing this function
   |
1  | use nu_cmd_lang::create_default_context;
   |
help: if you import `create_default_context`, refer to it directly
   |
93 -             let mut engine_state = nu_command::create_default_context();
93 +             let mut engine_state = create_default_context();
   |
```
and `cargo bench` does not run...

## with this PR
```bash
cargo check --all-targets --workspace
```
is not happy and the benchmarks run again with `cargo bench`