### PR TITLE
Fix a panic bug in platform ansi logic (Closes #9448)

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -697,12 +697,14 @@ Operating system commands:
         if (escape || osc) && (param_is_valid_string) {
             let code_vec: Vec<char> = code_string.chars().collect();
             if code_vec[0] == '\\' {
+                let span = match call.get_flag_expr("escape") {
+                    Some(expr) => expr.span,
+                    None => call.head,
+                };
+
                 return Err(ShellError::TypeMismatch {
                     err_message: "no need for escape characters".into(),
-                    span: call
-                        .get_flag_expr("escape")
-                        .expect("Unexpected missing argument")
-                        .span,
+                    span,
                 });
             }
         }

--- a/crates/nu-command/tests/commands/platform/ansi_.rs
+++ b/crates/nu-command/tests/commands/platform/ansi_.rs
@@ -1,0 +1,13 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn test_ansi_shows_error_on_escape() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            ansi -e \
+        "#
+    ));
+
+    assert!(actual.err.contains("no need for escape characters"))
+}

--- a/crates/nu-command/tests/commands/platform/mod.rs
+++ b/crates/nu-command/tests/commands/platform/mod.rs
@@ -1,2 +1,3 @@
+mod ansi_;
 mod du;
 mod kill;


### PR DESCRIPTION
Fixes #9448 

# Description
Attempts to fix a bug from the linked issue.

# User-Facing Changes
 - The editor doesn't crash on wrong commands
# Tests + Formatting

Tests cover my changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library
