### PR TITLE
revert: move to ahash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,7 +2716,6 @@ dependencies = [
 name = "nu-cli"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "atty",
  "chrono",
  "crossterm 0.26.1",
@@ -2747,7 +2746,6 @@ dependencies = [
 name = "nu-cmd-dataframe"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "chrono",
  "fancy-regex",
  "indexmap",
@@ -2766,7 +2764,6 @@ dependencies = [
 name = "nu-cmd-extra"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "nu-cmd-lang",
  "nu-engine",
  "nu-parser",
@@ -2779,7 +2776,6 @@ dependencies = [
 name = "nu-cmd-lang"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "fancy-regex",
  "itertools",
  "nu-ansi-term",
@@ -2794,7 +2790,6 @@ dependencies = [
 name = "nu-color-config"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "nu-ansi-term",
  "nu-engine",
  "nu-json",
@@ -2809,7 +2804,6 @@ name = "nu-command"
 version = "0.81.1"
 dependencies = [
  "Inflector",
- "ahash 0.8.3",
  "alphanumeric-sort",
  "atty",
  "base64 0.21.2",
@@ -2909,7 +2903,6 @@ dependencies = [
 name = "nu-engine"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "nu-glob",
  "nu-path",
  "nu-protocol",
@@ -2921,7 +2914,6 @@ dependencies = [
 name = "nu-explore"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "ansi-str 0.7.2",
  "crossterm 0.26.1",
  "lscolors",
@@ -2958,7 +2950,6 @@ dependencies = [
 name = "nu-parser"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "bytesize",
  "chrono",
  "itertools",
@@ -2984,7 +2975,6 @@ dependencies = [
 name = "nu-plugin"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "bincode",
  "nu-engine",
  "nu-protocol",
@@ -3006,7 +2996,6 @@ dependencies = [
 name = "nu-protocol"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "byte-unit",
  "chrono",
  "chrono-humanize",
@@ -3039,7 +3028,6 @@ dependencies = [
 name = "nu-system"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "atty",
  "chrono",
  "libc",
@@ -3057,7 +3045,6 @@ dependencies = [
 name = "nu-table"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "nu-ansi-term",
  "nu-color-config",
  "nu-engine",
@@ -3152,7 +3139,6 @@ dependencies = [
 name = "nu_plugin_query"
 version = "0.81.1"
 dependencies = [
- "ahash 0.8.3",
  "gjson",
  "nu-engine",
  "nu-plugin",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -38,7 +38,6 @@ once_cell = "1.17"
 percent-encoding = "2"
 sysinfo = "0.29"
 unicode-segmentation = "1.10"
-ahash = "0.8.3"
 
 [features]
 plugin = []

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -1,5 +1,4 @@
 use crate::completions::{Completer, CompletionOptions, MatchAlgorithm, SortBy};
-use ahash::{HashMap, HashMapExt};
 use nu_engine::eval_call;
 use nu_protocol::{
     ast::{Argument, Call, Expr, Expression},
@@ -7,6 +6,7 @@ use nu_protocol::{
     PipelineData, Span, Type, Value,
 };
 use reedline::Suggestion;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::completer::map_value_completions;

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -27,7 +27,6 @@ indexmap = { version = "1.7", features = ["serde-1"] }
 num = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "0.33", features = ["serde"], optional = true }
-ahash = "0.8.3"
 
 [dependencies.polars]
 features = [

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/sql_context.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/sql_context.rs
@@ -1,5 +1,4 @@
 use crate::dataframe::eager::sql_expr::parse_sql_expr;
-use ahash::{HashMap, HashMapExt};
 use polars::error::{ErrString, PolarsError};
 use polars::prelude::{col, DataFrame, DataType, IntoLazy, LazyFrame};
 use sqlparser::ast::{
@@ -7,6 +6,7 @@ use sqlparser::ast::{
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::Parser;
+use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct SQLContext {

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -19,7 +19,6 @@ nu-protocol = { path = "../nu-protocol", version = "0.81.1" }
 
 # Potential dependencies for extras
 num-traits = "0.2"
-ahash = "0.8.3"
 
 [features]
 extra = ["default"]

--- a/crates/nu-cmd-extra/src/example_test.rs
+++ b/crates/nu-cmd-extra/src/example_test.rs
@@ -15,11 +15,11 @@ mod test_examples {
         check_example_input_and_output_types_match_command_signature,
     };
 
-    use ahash::{HashSet, HashSetExt};
     use nu_protocol::{
         engine::{Command, EngineState, StateWorkingSet},
         Type,
     };
+    use std::collections::HashMap;
 
     pub fn test_examples(cmd: impl Command + 'static) {
         let examples = cmd.examples();

--- a/crates/nu-cmd-extra/src/example_test.rs
+++ b/crates/nu-cmd-extra/src/example_test.rs
@@ -19,7 +19,7 @@ mod test_examples {
         engine::{Command, EngineState, StateWorkingSet},
         Type,
     };
-    use std::collections::HashMap;
+    use std::collections::HashSet;
 
     pub fn test_examples(cmd: impl Command + 'static) {
         let examples = cmd.examples();

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -21,7 +21,6 @@ nu-ansi-term = "0.47.0"
 fancy-regex = "0.11"
 itertools = "0.10"
 shadow-rs = { version = "0.22", default-features = false }
-ahash = "0.8.3"
 
 [build-dependencies]
 shadow-rs = { version = "0.22", default-features = false }

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -1,10 +1,10 @@
-use ahash::{HashSet, HashSetExt};
 use itertools::Itertools;
 use nu_protocol::{
     ast::Block,
     engine::{EngineState, Stack, StateDelta, StateWorkingSet},
     Example, PipelineData, Signature, Span, Type, Value,
 };
+use std::collections::HashSet;
 
 pub fn check_example_input_and_output_types_match_command_signature(
     example: &Example,

--- a/crates/nu-cmd-lang/src/example_test.rs
+++ b/crates/nu-cmd-lang/src/example_test.rs
@@ -16,11 +16,11 @@ mod test_examples {
     use crate::{
         Break, Collect, Def, Describe, Echo, ExportCommand, ExportDef, If, Let, Module, Mut, Use,
     };
-    use ahash::{HashSet, HashSetExt};
     use nu_protocol::{
         engine::{Command, EngineState, StateWorkingSet},
         Type, Value,
     };
+    use std::collections::HashSet;
 
     pub fn test_examples(cmd: impl Command + 'static) {
         let examples = cmd.examples();

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -18,7 +18,6 @@ nu-engine = { path = "../nu-engine", version = "0.81.1" }
 nu-json = { path="../nu-json", version = "0.81.1"  }
 
 serde = { version="1.0", features=["derive"] }
-ahash = "0.8.3"
 
 [dev-dependencies]
 nu-test-support = { path="../nu-test-support", version = "0.81.1"  }

--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -2,9 +2,9 @@ use crate::{
     nu_style::{color_from_hex, lookup_style},
     parse_nustyle, NuStyle,
 };
-use ahash::{HashMap, HashMapExt};
 use nu_ansi_term::Style;
 use nu_protocol::Value;
+use std::collections::HashMap;
 
 pub fn lookup_ansi_color_style(s: &str) -> Style {
     if s.starts_with('#') {

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -1,12 +1,12 @@
 use crate::text_style::Alignment;
 use crate::{color_record_to_nustyle, lookup_ansi_color_style, TextStyle};
-use ahash::HashMap;
 use nu_ansi_term::{Color, Style};
 use nu_engine::{env::get_config, eval_block};
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
     CliError, IntoPipelineData, Value,
 };
+use std::collections::HashMap;
 
 use std::fmt::{Debug, Formatter, Result};
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -28,7 +28,6 @@ nu-utils = { path = "../nu-utils", version = "0.81.1" }
 nu-ansi-term = "0.47.0"
 
 alphanumeric-sort = "1.5"
-ahash = "0.8.3"
 atty = "0.2"
 base64 = "0.21"
 byteorder = "1.4"

--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -159,8 +159,8 @@ impl PartialEq for HashableValue {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
     use nu_protocol::ast::{CellPath, PathMember};
+    use std::collections::{HashMap, HashSet};
 
     #[test]
     fn from_value() {

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -1,5 +1,4 @@
 use super::hashable_value::HashableValue;
-use ahash::{HashMap, HashMapExt};
 use itertools::Itertools;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -8,6 +7,7 @@ use nu_protocol::{
     Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape,
     Type, Value,
 };
+use std::collections::HashMap;
 use std::iter;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/deprecated/deprecated_commands.rs
+++ b/crates/nu-command/src/deprecated/deprecated_commands.rs
@@ -1,4 +1,4 @@
-use ahash::HashMap;
+use std::collections::HashMap;
 
 /// Return map of <deprecated_command_name, new_command_name>
 /// This covers simple deprecated commands nicely, but it's not great for deprecating

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -1,4 +1,4 @@
-use ahash::HashMap;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use nu_protocol::{

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -1,4 +1,4 @@
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::{

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -24,7 +24,7 @@ mod test_examples {
         engine::{Command, EngineState, StateWorkingSet},
         Type,
     };
-    use std::collections::HashMap;
+    use std::collections::HashSet;
 
     pub fn test_examples(cmd: impl Command + 'static) {
         let examples = cmd.examples();

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -14,7 +14,6 @@ mod test_examples {
         SplitRow, Str, StrJoin, StrLength, StrReplace, Update, Url, Values, Wrap,
     };
     use crate::{Each, To};
-    use ahash::{HashSet, HashSetExt};
     use nu_cmd_lang::example_support::{
         check_all_signature_input_output_types_entries_have_examples,
         check_example_evaluates_to_expected_output,
@@ -25,6 +24,7 @@ mod test_examples {
         engine::{Command, EngineState, StateWorkingSet},
         Type,
     };
+    use std::collections::HashMap;
 
     pub fn test_examples(cmd: impl Command + 'static) {
         let examples = cmd.examples();

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -1,4 +1,4 @@
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 #[cfg(all(
     feature = "trash-support",
     not(target_os = "android"),

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -1,4 +1,3 @@
-use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -6,6 +5,7 @@ use nu_protocol::{
     Config, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use std::cmp::max;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone)]
 pub struct Join;

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -1,4 +1,3 @@
-use ahash::{HashSet, HashSetExt};
 use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath, PathMember};
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -6,6 +5,7 @@ use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
     PipelineIterator, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
+use std::collections::HashSet;
 
 #[derive(Clone)]
 pub struct Select;

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -1,5 +1,4 @@
 use crate::formats::value_to_string;
-use ahash::{HashMap, HashMapExt};
 use itertools::Itertools;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -8,6 +7,7 @@ use nu_protocol::{
     Span, Type, Value,
 };
 use std::collections::hash_map::IntoIter;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct Uniq;

--- a/crates/nu-command/src/filters/update_cells.rs
+++ b/crates/nu-command/src/filters/update_cells.rs
@@ -1,4 +1,3 @@
-use ahash::HashSet;
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::{Block, Call};
 use nu_protocol::engine::{Closure, Command, EngineState, Stack};
@@ -6,6 +5,7 @@ use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
     PipelineIterator, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
+use std::collections::HashSet;
 use std::iter::FromIterator;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/formats/to/html.rs
+++ b/crates/nu-command/src/formats/to/html.rs
@@ -1,5 +1,4 @@
 use crate::formats::to::delimited::merge_descriptors;
-use ahash::{HashMap, HashMapExt};
 use fancy_regex::Regex;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
@@ -10,6 +9,7 @@ use nu_protocol::{
 };
 use rust_embed::RustEmbed;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Write;
 

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -1,9 +1,9 @@
 use crate::math::utils::run_with_function;
-use ahash::{HashMap, HashMapExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
 use std::cmp::Ordering;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct SubCommand;

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -9,7 +9,7 @@ use nu_protocol::{
 };
 use ureq::{Error, ErrorKind, Request, Response};
 
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 use std::io::BufReader;
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -1,4 +1,4 @@
-use ahash::HashMap;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use nu_engine::CallExt;

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -1,4 +1,3 @@
-use ahash::{HashMap, HashMapExt};
 use nu_ansi_term::*;
 use nu_engine::CallExt;
 use nu_protocol::engine::{EngineState, Stack};
@@ -7,6 +6,7 @@ use nu_protocol::{
     PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use once_cell::sync::Lazy;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct AnsiCommand;

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -1,5 +1,4 @@
 use crate::hook::eval_hook;
-use ahash::HashMap;
 use nu_engine::env_to_strings;
 use nu_engine::CallExt;
 use nu_protocol::{
@@ -12,6 +11,7 @@ use nu_protocol::{
 use nu_system::ForegroundProcess;
 use os_pipe::PipeReader;
 use pathdiff::diff_paths;
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command as CommandSys, Stdio};

--- a/crates/nu-command/src/viewers/icons.rs
+++ b/crates/nu-command/src/viewers/icons.rs
@@ -1,6 +1,6 @@
-use ahash::HashMap;
 use nu_protocol::{ShellError, Span};
 use once_cell::sync::Lazy;
+use std::collections::HashMap;
 use std::path::Path;
 
 // Attribution: Thanks exa. Most of this file is taken from around here

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -17,7 +17,6 @@ nu-glob = { path = "../nu-glob", version = "0.81.1" }
 nu-utils = { path = "../nu-utils", version = "0.81.1"  }
 
 sysinfo ="0.29"
-ahash = "0.8.3"
 
 [features]
 plugin = []

--- a/crates/nu-engine/src/column.rs
+++ b/crates/nu-engine/src/column.rs
@@ -1,5 +1,5 @@
-use ahash::HashSet;
 use nu_protocol::Value;
+use std::collections::HashSet;
 
 pub fn get_columns(input: &[Value]) -> Vec<String> {
     let mut columns = vec![];

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -1,4 +1,4 @@
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use nu_protocol::ast::{Call, Expr, PathMember};

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,5 +1,4 @@
 use crate::{current_dir_str, get_full_help, nu_variable::NuVariable};
-use ahash::{HashMap, HashMapExt};
 use nu_path::expand_path_with;
 use nu_protocol::{
     ast::{
@@ -10,6 +9,7 @@ use nu_protocol::{
     DataSource, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, PipelineMetadata,
     Range, ShellError, Span, Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
+use std::collections::HashMap;
 use std::time::Instant;
 
 pub fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -1,10 +1,10 @@
-use ahash::{HashMap, HashMapExt};
 use nu_protocol::{
     engine::{Command, EngineState, Stack, Visibility},
     ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use std::borrow::Borrow;
 use std::cmp::Ordering;
+use std::collections::HashMap;
 
 pub fn create_scope(
     engine_state: &EngineState,

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -25,5 +25,4 @@ strip-ansi-escapes = "0.1"
 crossterm = "0.26"
 ratatui = "0.20"
 ansi-str = "0.7"
-ahash = "0.8.3"
 lscolors = { version = "0.14", default-features = false, features = ["nu-ansi-term"] }

--- a/crates/nu-explore/src/commands/config_show.rs
+++ b/crates/nu-explore/src/commands/config_show.rs
@@ -1,9 +1,9 @@
-use ahash::HashMap;
 use nu_protocol::{
     engine::{EngineState, Stack},
     Value,
 };
 use ratatui::layout::Rect;
+use std::collections::HashMap;
 use std::io::Result;
 
 use crate::{

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -1,4 +1,4 @@
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 use std::io::{self, Result};
 
 use crossterm::event::KeyEvent;

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -3,7 +3,6 @@ use crate::{
     util::{create_lscolors, create_map, map_into_value},
     PagerConfig, StyleConfig,
 };
-use ahash::HashMap;
 use nu_ansi_term::{Color, Style};
 use nu_color_config::{get_color_map, StyleComputer};
 use nu_engine::CallExt;
@@ -12,6 +11,7 @@ use nu_protocol::{
     engine::{Command, EngineState, Stack},
     Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
+use std::collections::HashMap;
 
 /// A `less` like program to render a [Value] as a table.
 #[derive(Clone)]

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -1,4 +1,4 @@
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 
 use nu_engine::get_columns;
 use nu_protocol::{ast::PathMember, ListStream, PipelineData, PipelineMetadata, RawStream, Value};

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -9,7 +9,7 @@ use std::{
     sync::atomic::Ordering,
 };
 
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 
 use crossterm::{
     event::{KeyCode, KeyEvent, KeyModifiers},

--- a/crates/nu-explore/src/registry/mod.rs
+++ b/crates/nu-explore/src/registry/mod.rs
@@ -4,8 +4,8 @@ use crate::{
     commands::{SimpleCommand, ViewCommand},
     views::View,
 };
-use ahash::HashMap;
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 pub use command::Command;
 

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -2,7 +2,7 @@ mod tablew;
 
 use std::borrow::Cow;
 
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 
 use crossterm::event::{KeyCode, KeyEvent};
 use nu_color_config::{get_color_map, StyleComputer};

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -21,7 +21,6 @@ chrono = { default-features = false, features = ['std'], version = "0.4" }
 itertools = "0.10"
 log = "0.4"
 serde_json = "1.0"
-ahash = "0.8.3"
 
 [dev-dependencies]
 rstest = { version = "0.17", default-features = false }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1,5 +1,4 @@
 use crate::parser_path::ParserPath;
-use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use itertools::Itertools;
 use log::trace;
 use nu_path::canonicalize_with;
@@ -12,6 +11,7 @@ use nu_protocol::{
     span, Alias, BlockId, Exportable, Module, ModuleId, ParseError, PositionalArg,
     ResolvedImportPattern, Span, Spanned, SyntaxShape, Type, VarId,
 };
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -27,9 +27,9 @@ use crate::parse_keywords::{
     parse_use, parse_where, parse_where_expr, LIB_DIRS_VAR,
 };
 
-use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use itertools::Itertools;
 use log::trace;
+use std::collections::{HashMap, HashSet};
 use std::{num::ParseIntError, str};
 
 #[cfg(feature = "plugin")]

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -18,4 +18,3 @@ bincode = "1.3"
 rmp-serde = "1.1"
 serde = { version = "1.0" }
 serde_json = { version = "1.0"}
-ahash = "0.8.3"

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -1,7 +1,7 @@
 mod declaration;
-use ahash::HashMap;
 pub use declaration::PluginDeclaration;
 use nu_engine::documentation::get_flags_section;
+use std::collections::HashMap;
 
 use crate::protocol::{CallInput, LabeledError, PluginCall, PluginData, PluginResponse};
 use crate::EncodingType;

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -29,7 +29,6 @@ strum = "0.24"
 strum_macros = "0.24"
 thiserror = "1.0"
 typetag = "0.2"
-ahash = "0.8.3"
 
 [features]
 plugin = ["serde_json"]

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -1,4 +1,4 @@
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/nu-protocol/src/ast/import_pattern.rs
+++ b/crates/nu-protocol/src/ast/import_pattern.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{span, ModuleId, Span};
-use ahash::{HashSet, HashSetExt};
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ImportPatternMember {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -1,6 +1,6 @@
 use crate::{ShellError, Span, Value};
-use ahash::{HashMap, HashMapExt};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 const TRIM_STRATEGY_DEFAULT: TrimStrategy = TrimStrategy::Wrap {
     try_to_keep_words: true,

--- a/crates/nu-protocol/src/engine/capture_block.rs
+++ b/crates/nu-protocol/src/engine/capture_block.rs
@@ -1,4 +1,4 @@
-use ahash::HashMap;
+use std::collections::HashMap;
 
 use crate::{BlockId, Value, VarId};
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -7,9 +7,9 @@ use crate::{
     Signature, Span, Type, VarId, Variable, VirtualPathId,
 };
 use crate::{ParseError, Value};
-use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use core::panic;
 use std::borrow::Borrow;
+use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::path::PathBuf;

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -1,6 +1,6 @@
 use crate::{DeclId, ModuleId, OverlayId, Type, Value, VarId};
-use ahash::{HashMap, HashMapExt};
 use std::borrow::Borrow;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 pub static DEFAULT_OVERLAY_NAME: &str = "zero";

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -1,4 +1,4 @@
-use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
+use std::collections::{HashMap, HashSet};
 
 use crate::engine::EngineState;
 use crate::engine::DEFAULT_OVERLAY_NAME;

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -1,4 +1,4 @@
-use ahash::{HashMap, HashMapExt};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -11,7 +11,6 @@ use crate::ast::{Math, Operator};
 use crate::engine::EngineState;
 use crate::ShellError;
 use crate::{did_you_mean, BlockId, Config, Span, Spanned, Type, VarId};
-use ahash::HashMap;
 use byte_unit::ByteUnit;
 use chrono::{DateTime, Duration, FixedOffset};
 use chrono_humanize::HumanTime;
@@ -24,6 +23,7 @@ use nu_utils::get_system_locale;
 use num_format::ToFormattedString;
 pub use range::*;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::{
     borrow::Cow,
     fmt::{Display, Formatter, Result as FmtResult},

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -31,5 +31,4 @@ mach2 = "0.4"
 chrono = "0.4"
 ntapi = "0.4"
 once_cell = "1.17"
-ahash="0.8.3"
 winapi = { version = "0.3", features = ["tlhelp32", "fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi", "std", "securitybaseapi"] }

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -1,7 +1,6 @@
 // Attribution: a lot of this came from procs https://github.com/dalance/procs
 // and sysinfo https://github.com/GuillaumeGomez/sysinfo
 
-use ahash::{HashMap, HashMapExt};
 use chrono::offset::TimeZone;
 use chrono::{Local, NaiveDate};
 use libc::c_void;
@@ -14,6 +13,7 @@ use ntapi::ntrtl::{RtlGetVersion, PRTL_USER_PROCESS_PARAMETERS, RTL_USER_PROCESS
 use ntapi::ntwow64::{PEB32, PRTL_USER_PROCESS_PARAMETERS32, RTL_USER_PROCESS_PARAMETERS32};
 use once_cell::sync::Lazy;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::ffi::OsString;
 use std::mem::{size_of, zeroed, MaybeUninit};
 use std::os::windows::ffi::OsStringExt;

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -17,7 +17,6 @@ nu-engine = { path = "../nu-engine", version = "0.81.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.81.1" }
 nu-ansi-term = "0.47.0"
 tabled = { version = "0.12.2", features = ["color"], default-features = false }
-ahash = "0.8.3"
 
 [dev-dependencies]
 # nu-test-support = { path="../nu-test-support", version = "0.81.1"  }

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -1,9 +1,9 @@
 use crate::table_theme::TableTheme;
-use ahash::HashMap;
 use nu_ansi_term::Style;
 use nu_color_config::TextStyle;
 use nu_protocol::TrimStrategy;
 use std::cmp::min;
+use std::collections::HashMap;
 use tabled::{
     builder::Builder,
     grid::{

--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -1,7 +1,7 @@
-use ahash::{HashMap, HashMapExt};
 use nu_color_config::{Alignment, StyleComputer, TextStyle};
 use nu_engine::column::get_columns;
 use nu_protocol::{ast::PathMember, Config, Span, TableIndexMode, Value};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::{cmp::max, sync::atomic::AtomicBool};
 

--- a/crates/nu-table/src/types/mod.rs
+++ b/crates/nu-table/src/types/mod.rs
@@ -2,10 +2,10 @@ mod collapse;
 mod expanded;
 mod general;
 
-use ahash::HashMap;
 use nu_color_config::{Alignment, StyleComputer, TextStyle};
 use nu_protocol::TrimStrategy;
 use nu_protocol::{Config, FooterMode, ShellError, Span, Value};
+use std::collections::HashMap;
 
 use crate::{string_wrap, NuTable, TableConfig, TableTheme};
 

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -25,4 +25,3 @@ gjson = "0.8"
 scraper = { default-features = false, version = "0.16" }
 sxd-document = "0.3"
 sxd-xpath = "0.4"
-ahash = "0.8.3"

--- a/crates/nu_plugin_query/src/web_tables.rs
+++ b/crates/nu_plugin_query/src/web_tables.rs
@@ -1,6 +1,6 @@
 use crate::query_web::css;
-use ahash::{HashMap, HashMapExt};
 use scraper::{element_ref::ElementRef, Html, Selector as ScraperSelector};
+use std::collections::HashMap;
 
 pub type Headers = HashMap<String, usize>;
 


### PR DESCRIPTION
This PR reverts https://github.com/nushell/nushell/pull/9391

We try not to revert PRs like this, though after discussion with the Nushell team, we decided to revert this one.

The main reason is that Nushell, as a codebase, isn't ready for these kinds of optimisations. It's in the part of the development cycle where our main focus should be on improving the algorithms inside of Nushell itself. Once we have matured our algorithms, then we can look for opportunities to switch out technologies we're using for alternate forms.

Much of Nushell still has lots of opportunities for tuning the codebase, paying down technical debt, and making the codebase generally cleaner and more robust. This should be the focus. Performance improvements should flow out of that work.

Said another, optimisation that isn't part of tuning the codebase is premature at this stage. We need to focus on doing the hard work of making the engine, parser, etc better.

# User-Facing Changes

Reverts the HashMap -> ahash change.

cc @FilipAndersson245 