### PR TITLE
Removes some permutations of benchmarks for plugin encoding/decoding.

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -127,17 +127,7 @@ fn encoding_test_data(row_cnt: usize, col_cnt: usize) -> Value {
 
 fn encoding_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Encoding");
-    let test_cnt_pairs = [
-        (100, 5),
-        (100, 10),
-        (100, 15),
-        (1000, 5),
-        (1000, 10),
-        (1000, 15),
-        (10000, 5),
-        (10000, 10),
-        (10000, 15),
-    ];
+    let test_cnt_pairs = [(100, 5), (100, 15), (10000, 5), (10000, 15)];
     for (row_cnt, col_cnt) in test_cnt_pairs.into_iter() {
         for fmt in ["json", "msgpack"] {
             group.bench_function(&format!("{fmt} encode {row_cnt} * {col_cnt}"), |b| {
@@ -154,17 +144,7 @@ fn encoding_benchmarks(c: &mut Criterion) {
 
 fn decoding_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Decoding");
-    let test_cnt_pairs = [
-        (100, 5),
-        (100, 10),
-        (100, 15),
-        (1000, 5),
-        (1000, 10),
-        (1000, 15),
-        (10000, 5),
-        (10000, 10),
-        (10000, 15),
-    ];
+    let test_cnt_pairs = [(100, 5), (100, 15), (10000, 5), (10000, 15)];
     for (row_cnt, col_cnt) in test_cnt_pairs.into_iter() {
         for fmt in ["json", "msgpack"] {
             group.bench_function(&format!("{fmt} decode for {row_cnt} * {col_cnt}"), |b| {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Removes some of the permutations for the encoding/decoding benchmarks, as they add a lot of noise when doing the benchmark suite. this change removes 20 benchmark runs, but preserve the outline ones (smaller, larger), for a total of 16 benchmarks remaining, I think we could maybe reduce this future?

@WindSoilder do you have any input here?

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
