### PR TITLE
make *dots* tests easier to read

### DIFF
--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -295,7 +295,7 @@ mod tests {
 
         #[test]
         fn string_with_three_ndots_and_garbage() {
-            check_ndots_expansion(r"file .../ garbage.*[", "file .../ garbage.*[");
+            check_ndots_expansion(r"not_a_cmd.../ garbage.*[", "not_a_cmd.../ garbage.*[");
         }
     }
 
@@ -324,12 +324,18 @@ mod tests {
         fn string_with_three_ndots_and_garbage() {
             // filenames can contain spaces, in these cases the ... .... etc.
             // that are part of a filepath should not be expanded
-            check_ndots_expansion("not_a_cmd .../ garbage.*[", "not_a_cmd .../ garbage.*[");
-            check_ndots_expansion("/not_a_cmd .../ garbage.*[", "/not_a_cmd .../ garbage.*[");
-            check_ndots_expansion("./not_a_cmd .../ garbage.*[", "./not_a_cmd .../ garbage.*[");
-            check_ndots_expansion("../../nac .../ garbage.*[", ".../nac .../ garbage.*[");
-            check_ndots_expansion("../../nac .../ garbage.*[...", ".../nac .../ garbage.*[...");
-            check_ndots_expansion("../../ garbage.*[", ".../ garbage.*[");
+            check_ndots_expansion("not_a_cmd.../ garbage.*[", "not_a_cmd.../ garbage.*[");
+            check_ndots_expansion("/not_a_cmd.../ garbage.*[", "/not_a_cmd.../ garbage.*[");
+            check_ndots_expansion("./not_a_cmd.../ garbage.*[", "./not_a_cmd.../ garbage.*[");
+            check_ndots_expansion(
+                "../../not a cmd.../ garbage.*[",
+                ".../not a cmd.../ garbage.*[",
+            );
+            check_ndots_expansion(
+                "../../not a cmd.../ garbage.*[...",
+                ".../not a cmd.../ garbage.*[...",
+            );
+            check_ndots_expansion("../../ not a cmd garbage.*[", ".../ not a cmd garbage.*[");
         }
     }
 }


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/8544

cc/ @jntrnr @ahkrr 

# Description
some of the tests in the `dots.rs` file are a bit hard to read because some of the paths look like command calls :thinking: 

in an attempt to making them easier to read, in the tests of `dots.rs`, this PR
- replaces `file .../` with `not_a_cmd.../` because it's not a call to the `file` command
- removes the space in `not_a_cmd .../` to see it's not a command call
- adds a bit more `not a cmd` to the last tests, to be consistent with the other tests

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`