### PR TITLE
Mention `clap_complete_nushell` in the officially supported section

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Please submit an issue or PR to be added to this list.
 -   [Couchbase Shell](https://couchbase.sh)
 -   [virtualenv](https://github.com/pypa/virtualenv)
 -   [atuin](https://github.com/ellie/atuin)
+-   [clap](https://github.com/clap-rs/clap/tree/master/clap_complete_nushell)
 
 ## Contributing
 


### PR DESCRIPTION
@nibon7 's https://github.com/nibon7/clap_complete_nushell has been accepted into the official `clap` organization.

Seems to me worthy to be mentioned in the README

