### PR TITLE
Remove "Progress" section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ A new type of shell.
   - [Opening files](#opening-files)
   - [Plugins](#plugins)
 - [Goals](#goals)
-- [Progress](#progress)
 - [Officially Supported By](#officially-supported-by)
 - [Contributing](#contributing)
 - [License](#license)
@@ -209,27 +208,6 @@ Nu adheres closely to a set of goals that make up its design philosophy. As feat
 -   Nu views data as either structured or unstructured. It is a structured shell like PowerShell.
 
 -   Finally, Nu views data functionally. Rather than using mutation, pipelines act as a means to load, change, and save data without mutable state.
-
-## Progress
-
-Nu is under heavy development and will naturally change as it matures. The chart below isn't meant to be exhaustive, but it helps give an idea for some of the areas of development and their relative maturity:
-
-| Features      | Not started | Prototype | MVP | Preview | Mature | Notes                                                                |
-| ------------- | :---------: | :-------: | :-: | :-----: | :----: | -------------------------------------------------------------------- |
-| Aliases       |             |           |     |    X    |        | Aliases allow for shortening large commands, while passing flags     |
-| Notebook      |             |     X     |     |         |        | Initial jupyter support, but it loses state and lacks features       |
-| File ops      |             |           |     |    X    |        | cp, mv, rm, mkdir have some support, but lacking others              |
-| Environment   |             |           |     |    X    |        | Temporary environment and scoped environment variables               |
-| Shells        |             |           |     |    X    |        | Basic value and file shells, but no opt-in/opt-out for commands      |
-| Protocol      |             |           |     |    X    |        | Streaming protocol is serviceable                                    |
-| Plugins       |             |           |  X  |         |        | Plugins work on one row at a time, lack batching and expression eval |
-| Errors        |             |           |     |    X    |        | Error reporting works, but could use usability polish                |
-| Documentation |             |           |  X  |         |        | Book updated to latest release, including usage examples             |
-| Paging        |             |           |     |    X    |        | Textview has paging, but we'd like paging for tables                 |
-| Functions     |             |           |     |    X    |        | Functions and aliases are supported                                  |
-| Variables     |             |           |     |    X    |        | Nu supports variables and environment variables                      |
-| Completions   |             |           |     |    X    |        | Completions for filepaths                                            |
-| Type-checking |             |           |     |    x    |        | Commands check basic types, and input/output types                   |
 
 ## Officially Supported By
 


### PR DESCRIPTION
I would personally propose to remove the progress board table from our README.

At the stage where we are at right now with most items in a pre-stable stage I don't think it is a good use of README real estate anymore. It hasn't been updated in over 7 months for a single item and older than a year for most boxes.

For upcoming users the list doesn't present detailed enough explanations of potential pitfalls and may be more confusing by mentioning features that are not really present (e.g. paging). Generally I have the impression that the community generally helps raise awareness about the limitations of the pre-1.0 state together with our release notes that try to highlight the pace of breaking or evolving changes.

Potential users are probably best served by additional links to learn more about our features and generally improved documentation and community tutorials

For contributors that want to look for areas to help out, this view is both not granular enough for real guidance and is maybe even actively harmful in highlighting areas we don't prioritize for 1.0 stability (e.g. notebook integration)

Contributors are probably better served by our planned write-ups around the 1.0 roadmap and updating GitHub Kanban/project boards.