### PR TITLE
Apply nightly clippy fixes

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -183,7 +183,7 @@ pub fn value_to_string(
         Value::Float { val, .. } => {
             // This serialises these as 'nan', 'inf' and '-inf', respectively.
             if &val.round() == val
-                && val != &f64::NAN
+                && !val.is_nan()
                 && val != &f64::INFINITY
                 && val != &f64::NEG_INFINITY
             {

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -182,11 +182,7 @@ pub fn value_to_string(
         Value::Filesize { val, .. } => Ok(format!("{}b", *val)),
         Value::Float { val, .. } => {
             // This serialises these as 'nan', 'inf' and '-inf', respectively.
-            if &val.round() == val
-                && !val.is_nan()
-                && val != &f64::INFINITY
-                && val != &f64::NEG_INFINITY
-            {
+            if &val.round() == val && val.is_finite() {
                 Ok(format!("{}.0", *val))
             } else {
                 Ok(format!("{}", *val))

--- a/crates/nu-command/src/strings/str_/case/mod.rs
+++ b/crates/nu-command/src/strings/str_/case/mod.rs
@@ -1,13 +1,13 @@
-pub mod camel_case;
-pub mod capitalize;
-pub mod downcase;
-pub mod kebab_case;
-pub mod pascal_case;
-pub mod screaming_snake_case;
-pub mod snake_case;
-pub mod str_;
-pub mod title_case;
-pub mod upcase;
+mod camel_case;
+mod capitalize;
+mod downcase;
+mod kebab_case;
+mod pascal_case;
+mod screaming_snake_case;
+mod snake_case;
+mod str_;
+mod title_case;
+mod upcase;
 
 pub use camel_case::SubCommand as StrCamelCase;
 pub use capitalize::SubCommand as StrCapitalize;

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -389,7 +389,7 @@ fn rm_prints_filenames_on_error() {
 
         set_dir_read_only(test_dir, true);
         let _cleanup = Cleanup {
-            dir_to_clean: &test_dir,
+            dir_to_clean: test_dir,
         };
 
         // This rm is expected to fail, and stderr output indicating so is also expected.

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -695,6 +695,12 @@ struct HjsonFormatter<'a> {
     braces_same_line: bool,
 }
 
+impl<'a> Default for HjsonFormatter<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> HjsonFormatter<'a> {
     /// Construct a formatter that defaults to using two spaces for indentation.
     pub fn new() -> Self {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
This PR fixes the following nightly clippy warnings.

```
warning: you should consider adding a `Default` implementation for `HjsonFormatter<'a>`
   --> crates/nu-json/src/ser.rs:700:5
    |
700 | /     pub fn new() -> Self {
701 | |         HjsonFormatter::with_indent(b"  ")
702 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
    = note: `#[warn(clippy::new_without_default)]` on by default
help: try adding this
    |
698 + impl<'a> Default for HjsonFormatter<'a> {
699 +     fn default() -> Self {
700 +         Self::new()
701 +     }
702 + }
    |

warning: `nu-json` (lib) generated 1 warning
warning: private item shadows public glob re-export
  --> crates/nu-command/src/strings/mod.rs:8:1
   |
8  | mod str_;
   | ^^^^^^^^^
   |
note: the name `str_` in the type namespace is supposed to be publicly re-exported here
  --> crates/nu-command/src/strings/mod.rs:17:9
   |
17 | pub use str_::*;
   |         ^^^^^^^
note: but the private item here shadows it
  --> crates/nu-command/src/strings/mod.rs:8:1
   |
8  | mod str_;
   | ^^^^^^^^^
   = note: `#[warn(hidden_glob_reexports)]` on by default

warning: incorrect NaN comparison, NaN cannot be directly compared to itself
   --> crates/nu-command/src/formats/to/nuon.rs:186:20
    |
186 |                 && val != &f64::NAN
    |                    ^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(invalid_nan_comparisons)]` on by default
help: use `f32::is_nan()` or `f64::is_nan()` instead
    |
186 -                 && val != &f64::NAN
186 +                 && !val.is_nan()
    |

warning: `nu-command` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p nu-command` to apply 1 suggestion)
   Compiling nu v0.81.1 (/data/source/nushell)
warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> crates/nu-command/tests/commands/rm.rs:392:27
    |
392 |             dir_to_clean: &test_dir,
    |                           ^^^^^^^^^ help: change this to: `test_dir`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: `nu-command` (test "main") generated 1 warning (run `cargo clippy --fix --test "main"` to apply 1 suggestion)
warning: `nu-command` (lib test) generated 2 warnings (2 duplicates)
warning: `nu-json` (lib test) generated 1 warning (1 duplicate)
    Finished dev [unoptimized + debuginfo] target(s) in 3.89s

```

# User-Facing Changes
N/A

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
