### PR TITLE
Update Contributing.md stating we can not accept PRs that are GPL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,3 +220,7 @@ You can help us to make the review process a smooth experience:
     - Choose what simplifies having confidence in the conflict resolution and the review. **Merge commits in your branch are OK** in the squash model.
   - Feel free to notify your reviewers or affected PR authors if your change might cause larger conflicts with another change.
   - During the rollup of multiple PRs, we may choose to resolve merge conflicts and CI failures ourselves. (Allow maintainers to push to your branch to enable us to do this quickly.)
+
+### License
+
+We use the [MIT License](https://github.com/nushell/nushell/blob/main/LICENSE) in all of our Nushell projects. If you are including or referencing a crate that uses the [GPL License](https://www.gnu.org/licenses/gpl-3.0.en.html#license-text) unfortunately we will not be able to accept your PR.


### PR DESCRIPTION
Recently someone submitted a PR that included a crate that used the GPL license.

To avoid this happening in the future we updated the Contributing.md document stating
this specifically so people will not be confused about our policy.





