### PR TITLE
#9469 Refactor Plugin Interface

### DIFF
--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 [dependencies]
 nu-engine = { path = "../nu-engine", version = "0.81.1" }
 nu-path = {path = "../nu-path", version = "0.81.1" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.81.1"  }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.81.1", features = ['nu-internal'] }
 nu-protocol = { path = "../nu-protocol", version = "0.81.1" }
 
 bytesize = "1.2"

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3158,7 +3158,7 @@ pub fn parse_where(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
 
 #[cfg(feature = "plugin")]
 pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
-    use nu_plugin::{get_signature, PluginDeclaration};
+    use nu_plugin::nu_internal::{get_signature, PluginDeclaration};
     use nu_protocol::{engine::Stack, PluginSignature};
 
     let cwd = working_set.get_cwd();

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -10,6 +10,9 @@ version = "0.81.1"
 [lib]
 bench = false
 
+[features]
+nu-internal = []
+
 [dependencies]
 nu-engine = { path = "../nu-engine", version = "0.81.1"  }
 nu-protocol = { path = "../nu-protocol", version = "0.81.1"  }

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -52,7 +52,7 @@ pub use protocol::{EvaluatedCall, LabeledError};
 pub use serializers::EncodingType;
 
 /// Contains functionality internal to Nushell
-/// 
+///
 /// This module contains items that are used by other components of Nushell
 /// to interface with Nushell plugins. They generally will not be of use to
 /// plugin authors. Plugin authors should not typically include the `nu-internal`

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -47,7 +47,8 @@ mod plugin;
 mod protocol;
 mod serializers;
 
-pub use plugin::{get_signature, serve_plugin, Plugin, PluginDeclaration};
+pub use plugin::{serve_plugin, Plugin};
+#[cfg(feature = "nu-internal")]
+pub use plugin::{get_signature, PluginDeclaration};
 pub use protocol::{EvaluatedCall, LabeledError, PluginResponse};
 pub use serializers::EncodingType;
-// pub use serializers::{json::JsonSerializer, msgpack::MsgPackSerializer};

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -51,6 +51,12 @@ pub use plugin::{serve_plugin, Plugin};
 pub use protocol::{EvaluatedCall, LabeledError};
 pub use serializers::EncodingType;
 
+/// Contains functionality internal to Nushell
+/// 
+/// This module contains items that are used by other components of Nushell
+/// to interface with Nushell plugins. They generally will not be of use to
+/// plugin authors. Plugin authors should not typically include the `nu-internal`
+/// feature.
 #[cfg(feature = "nu-internal")]
 pub mod nu_internal {
     pub use crate::plugin::{get_signature, PluginDeclaration};

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -48,7 +48,11 @@ mod protocol;
 mod serializers;
 
 pub use plugin::{serve_plugin, Plugin};
-#[cfg(feature = "nu-internal")]
-pub use plugin::{get_signature, PluginDeclaration};
-pub use protocol::{EvaluatedCall, LabeledError, PluginResponse};
+pub use protocol::{EvaluatedCall, LabeledError};
 pub use serializers::EncodingType;
+
+#[cfg(feature = "nu-internal")]
+pub mod nu_internal {
+    pub use crate::plugin::{get_signature, PluginDeclaration};
+    pub use crate::protocol::PluginResponse;
+}

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -16,7 +16,7 @@
 //! invoked by Nushell.
 //!
 //! ```
-//! use nu_plugin::{EvaluatedCall, LabeledError, MsgPackSerializer, Plugin, serve_plugin};
+//! use nu_plugin::{EvaluatedCall, EncodingType, LabeledError, Plugin, serve_plugin};
 //! use nu_protocol::{PluginSignature, Value};
 //!
 //! struct MyPlugin;
@@ -36,7 +36,7 @@
 //! }
 //!
 //! fn main() {
-//!    serve_plugin(&mut MyPlugin{}, MsgPackSerializer)
+//!    serve_plugin(&mut MyPlugin{}, EncodingType::MsgPack)
 //! }
 //! ```
 //!
@@ -49,4 +49,5 @@ mod serializers;
 
 pub use plugin::{get_signature, serve_plugin, Plugin, PluginDeclaration};
 pub use protocol::{EvaluatedCall, LabeledError, PluginResponse};
-pub use serializers::{json::JsonSerializer, msgpack::MsgPackSerializer, EncodingType};
+pub use serializers::EncodingType;
+// pub use serializers::{json::JsonSerializer, msgpack::MsgPackSerializer};

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -11,6 +11,7 @@ use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{ast::Call, PluginSignature, Signature};
 use nu_protocol::{Example, PipelineData, ShellError, Value};
 
+/// Description of a plugin used internally by Nushell
 #[derive(Clone)]
 pub struct PluginDeclaration {
     name: String,

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -1,5 +1,5 @@
-use crate::{EvaluatedCall, EncodingType};
 use crate::serializers::{json::JsonSerializer, msgpack::MsgPackSerializer};
+use crate::{EncodingType, EvaluatedCall};
 
 use super::{call_plugin, create_command, get_plugin_encoding};
 use crate::protocol::{
@@ -132,10 +132,10 @@ impl Command for PluginDeclaration {
         };
 
         let response = match encoding {
-            EncodingType::Json =>
-                call_plugin::<JsonSerializer>(&mut child, plugin_call, call.head),
-            EncodingType::MsgPack =>
-                call_plugin::<MsgPackSerializer>(&mut child, plugin_call, call.head),
+            EncodingType::Json => call_plugin::<JsonSerializer>(&mut child, plugin_call, call.head),
+            EncodingType::MsgPack => {
+                call_plugin::<MsgPackSerializer>(&mut child, plugin_call, call.head)
+            }
         };
 
         let response = response.map_err(|err| {

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -11,7 +11,6 @@ use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{ast::Call, PluginSignature, Signature};
 use nu_protocol::{Example, PipelineData, ShellError, Value};
 
-#[doc(hidden)] // Note: not for plugin authors / only used in nu-parser
 #[derive(Clone)]
 pub struct PluginDeclaration {
     name: String,

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -137,7 +137,7 @@ impl Command for PluginDeclaration {
             EncodingType::MsgPack =>
                 call_plugin::<MsgPackSerializer>(&mut child, plugin_call, call.head),
         };
-        
+
         let response = response.map_err(|err| {
             let decl = engine_state.get_decl(call.decl_id);
             ShellError::GenericError(

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -129,7 +129,6 @@ pub(crate) fn call_plugin<Encoder: PluginEncoder>(
     }
 }
 
-#[doc(hidden)] // Note: not for plugin authors / only used in nu-parser
 #[cfg(feature = "nu-internal")]
 pub fn get_signature(
     path: &Path,

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -19,10 +19,7 @@ use nu_protocol::{CustomValue, PluginSignature, ShellError, Span, Value};
 use super::EvaluatedCall;
 
 #[cfg(feature = "nu-internal")]
-use std::{
-    collections::HashMap,
-    io::ErrorKind,
-};
+use std::{collections::HashMap, io::ErrorKind};
 
 pub(crate) const OUTPUT_BUFFER_SIZE: usize = 8192;
 

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -129,6 +129,12 @@ pub(crate) fn call_plugin<Encoder: PluginEncoder>(
     }
 }
 
+/// Generates a signature of the plugin for the shell
+/// 
+/// This function handles serialization and IO to pass details on a plugin's
+/// signature to Nushell. It will invoke the plugin executable at the specified
+/// path and send it commands to report it's [`PluginSignature`] on stdout, which
+/// this function will then deserialize for use by Nushell.
 #[cfg(feature = "nu-internal")]
 pub fn get_signature(
     path: &Path,

--- a/crates/nu-plugin/src/protocol/evaluated_call.rs
+++ b/crates/nu-plugin/src/protocol/evaluated_call.rs
@@ -1,10 +1,12 @@
-use nu_engine::eval_expression;
-use nu_protocol::{
-    ast::Call,
-    engine::{EngineState, Stack},
-    FromValue, ShellError, Span, Spanned, Value,
-};
+use nu_protocol::{FromValue, ShellError, Span, Spanned, Value};
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "nu-internal")]
+use {
+    nu_engine::eval_expression,
+    nu_protocol::ast::Call,
+    nu_protocol::engine::{EngineState, Stack},
+};
 
 /// A representation of the plugin's invocation command including command line args
 ///
@@ -28,6 +30,7 @@ pub struct EvaluatedCall {
 }
 
 impl EvaluatedCall {
+    #[cfg(feature = "nu-internal")]
     pub(crate) fn try_from_call(
         call: &Call,
         engine_state: &EngineState,

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -107,13 +107,19 @@ impl From<ShellError> for LabeledError {
     }
 }
 
-// Information received from the plugin
-// Needs to be public to communicate with nu-parser but not typically
-// used by Plugin authors
+/// Possible responses from a plugin to Nushell
+/// 
+/// This enum is used internally by [`serve_plugin`](crate::serve_plugin)
+/// to serialize [Plugin](crate::Plugin) output and by Nushell to deserialize
+/// the response.
 #[derive(Serialize, Deserialize)]
 pub enum PluginResponse {
+    /// An error response
     Error(LabeledError),
+    /// Signatures for the commands created by the plugin
     Signature(Vec<PluginSignature>),
+    /// A standard response to a plugin invocation
     Value(Box<Value>),
+    /// A plugin response utilizing plugin custom values
     PluginData(String, PluginData),
 }

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -110,7 +110,6 @@ impl From<ShellError> for LabeledError {
 // Information received from the plugin
 // Needs to be public to communicate with nu-parser but not typically
 // used by Plugin authors
-#[doc(hidden)]
 #[derive(Serialize, Deserialize)]
 pub enum PluginResponse {
     Error(LabeledError),

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -108,7 +108,7 @@ impl From<ShellError> for LabeledError {
 }
 
 /// Possible responses from a plugin to Nushell
-/// 
+///
 /// This enum is used internally by [`serve_plugin`](crate::serve_plugin)
 /// to serialize [Plugin](crate::Plugin) output and by Nushell to deserialize
 /// the response.

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -3,9 +3,12 @@ use std::path::PathBuf;
 use nu_protocol::{CustomValue, ShellError, Value};
 use serde::Serialize;
 
-use crate::{plugin::{call_plugin, create_command, get_plugin_encoding}, serializers::EncodingType};
-use crate::serializers::{json::JsonSerializer, msgpack::MsgPackSerializer};
 use super::{PluginCall, PluginData, PluginResponse};
+use crate::serializers::{json::JsonSerializer, msgpack::MsgPackSerializer};
+use crate::{
+    plugin::{call_plugin, create_command, get_plugin_encoding},
+    serializers::EncodingType,
+};
 
 /// An opaque container for a custom value that is handled fully by a plugin
 ///
@@ -80,10 +83,10 @@ impl CustomValue for PluginCustomValue {
         };
 
         let response = match encoding {
-            EncodingType::Json =>
-                call_plugin::<JsonSerializer>(&mut child, plugin_call, span),
-            EncodingType::MsgPack =>
-                call_plugin::<MsgPackSerializer>(&mut child, plugin_call, span),
+            EncodingType::Json => call_plugin::<JsonSerializer>(&mut child, plugin_call, span),
+            EncodingType::MsgPack => {
+                call_plugin::<MsgPackSerializer>(&mut child, plugin_call, span)
+            }
         };
 
         let response = response.map_err(|err| {

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -4,16 +4,15 @@ use crate::{plugin::PluginEncoder, protocol::PluginResponse};
 
 /// A `PluginEncoder` that enables the plugin to communicate with Nushel with JSON
 /// serialized data.
-#[derive(Clone, Debug)]
-pub struct JsonSerializer;
+// #[derive(Clone, Debug)]
+pub(crate) struct JsonSerializer;
 
 impl PluginEncoder for JsonSerializer {
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "json"
     }
 
     fn encode_call(
-        &self,
         plugin_call: &crate::protocol::PluginCall,
         writer: &mut impl std::io::Write,
     ) -> Result<(), nu_protocol::ShellError> {
@@ -22,7 +21,6 @@ impl PluginEncoder for JsonSerializer {
     }
 
     fn decode_call(
-        &self,
         reader: &mut impl std::io::BufRead,
     ) -> Result<crate::protocol::PluginCall, nu_protocol::ShellError> {
         serde_json::from_reader(reader)
@@ -30,7 +28,6 @@ impl PluginEncoder for JsonSerializer {
     }
 
     fn encode_response(
-        &self,
         plugin_response: &PluginResponse,
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError> {
@@ -39,7 +36,6 @@ impl PluginEncoder for JsonSerializer {
     }
 
     fn decode_response(
-        &self,
         reader: &mut impl std::io::BufRead,
     ) -> Result<PluginResponse, ShellError> {
         serde_json::from_reader(reader)
@@ -58,14 +54,13 @@ mod tests {
     #[test]
     fn callinfo_round_trip_signature() {
         let plugin_call = PluginCall::Signature;
-        let encoder = JsonSerializer {};
 
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&plugin_call, &mut buffer)
+        JsonSerializer
+            ::encode_call(&plugin_call, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
+        let returned = JsonSerializer
+            ::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -114,13 +109,12 @@ mod tests {
             input: CallInput::Value(input.clone()),
         });
 
-        let encoder = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&plugin_call, &mut buffer)
+        JsonSerializer
+            ::encode_call(&plugin_call, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
+        let returned = JsonSerializer
+            ::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -164,13 +158,12 @@ mod tests {
             span,
         });
 
-        let encoder = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&collapse_custom_value, &mut buffer)
+        JsonSerializer
+            ::encode_call(&collapse_custom_value, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
+        let returned = JsonSerializer
+            ::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -199,13 +192,12 @@ mod tests {
 
         let response = PluginResponse::Signature(vec![signature.clone()]);
 
-        let encoder = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        JsonSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -260,13 +252,12 @@ mod tests {
 
         let response = PluginResponse::Value(Box::new(value.clone()));
 
-        let encoder = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        JsonSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -294,13 +285,13 @@ mod tests {
             },
         );
 
-        let encoder = JsonSerializer {};
+        let JsonSerializer = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        JsonSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -324,13 +315,12 @@ mod tests {
         };
         let response = PluginResponse::Error(error.clone());
 
-        let encoder = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        JsonSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -350,13 +340,13 @@ mod tests {
         };
         let response = PluginResponse::Error(error.clone());
 
-        let encoder = JsonSerializer {};
+        let JsonSerializer = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        JsonSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -4,7 +4,6 @@ use crate::{plugin::PluginEncoder, protocol::PluginResponse};
 
 /// A `PluginEncoder` that enables the plugin to communicate with Nushel with JSON
 /// serialized data.
-// #[derive(Clone, Debug)]
 pub(crate) struct JsonSerializer;
 
 impl PluginEncoder for JsonSerializer {
@@ -273,7 +272,6 @@ mod tests {
             },
         );
 
-        let JsonSerializer = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
         JsonSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
@@ -324,7 +322,6 @@ mod tests {
         };
         let response = PluginResponse::Error(error.clone());
 
-        let JsonSerializer = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
         JsonSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -35,9 +35,7 @@ impl PluginEncoder for JsonSerializer {
             .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
     }
 
-    fn decode_response(
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginResponse, ShellError> {
+    fn decode_response(reader: &mut impl std::io::BufRead) -> Result<PluginResponse, ShellError> {
         serde_json::from_reader(reader)
             .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
     }
@@ -56,11 +54,9 @@ mod tests {
         let plugin_call = PluginCall::Signature;
 
         let mut buffer: Vec<u8> = Vec::new();
-        JsonSerializer
-            ::encode_call(&plugin_call, &mut buffer)
+        JsonSerializer::encode_call(&plugin_call, &mut buffer)
             .expect("unable to serialize message");
-        let returned = JsonSerializer
-            ::decode_call(&mut buffer.as_slice())
+        let returned = JsonSerializer::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -110,11 +106,9 @@ mod tests {
         });
 
         let mut buffer: Vec<u8> = Vec::new();
-        JsonSerializer
-            ::encode_call(&plugin_call, &mut buffer)
+        JsonSerializer::encode_call(&plugin_call, &mut buffer)
             .expect("unable to serialize message");
-        let returned = JsonSerializer
-            ::decode_call(&mut buffer.as_slice())
+        let returned = JsonSerializer::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -159,11 +153,9 @@ mod tests {
         });
 
         let mut buffer: Vec<u8> = Vec::new();
-        JsonSerializer
-            ::encode_call(&collapse_custom_value, &mut buffer)
+        JsonSerializer::encode_call(&collapse_custom_value, &mut buffer)
             .expect("unable to serialize message");
-        let returned = JsonSerializer
-            ::decode_call(&mut buffer.as_slice())
+        let returned = JsonSerializer::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -193,11 +185,9 @@ mod tests {
         let response = PluginResponse::Signature(vec![signature.clone()]);
 
         let mut buffer: Vec<u8> = Vec::new();
-        JsonSerializer
-            ::encode_response(&response, &mut buffer)
+        JsonSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = JsonSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -253,11 +243,9 @@ mod tests {
         let response = PluginResponse::Value(Box::new(value.clone()));
 
         let mut buffer: Vec<u8> = Vec::new();
-        JsonSerializer
-            ::encode_response(&response, &mut buffer)
+        JsonSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = JsonSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -287,11 +275,9 @@ mod tests {
 
         let JsonSerializer = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        JsonSerializer
-            ::encode_response(&response, &mut buffer)
+        JsonSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = JsonSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -316,11 +302,9 @@ mod tests {
         let response = PluginResponse::Error(error.clone());
 
         let mut buffer: Vec<u8> = Vec::new();
-        JsonSerializer
-            ::encode_response(&response, &mut buffer)
+        JsonSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = JsonSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -342,11 +326,9 @@ mod tests {
 
         let JsonSerializer = JsonSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        JsonSerializer
-            ::encode_response(&response, &mut buffer)
+        JsonSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = JsonSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = JsonSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {

--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -3,7 +3,7 @@ use {
     nu_protocol::ShellError,
     crate::{
         plugin::PluginEncoder,
-        PluginResponse
+        protocol::PluginResponse,
     },
 };
 

--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -47,7 +47,7 @@ impl EncodingType {
     ) -> Result<PluginResponse, ShellError> {
         match self {
             EncodingType::Json => JsonSerializer::decode_response(reader),
-            EncodingType::MsgPack => JsonSerializer::decode_response(reader),
+            EncodingType::MsgPack => MsgPackSerializer::decode_response(reader),
         }
     }
 }

--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -1,22 +1,19 @@
-#[cfg(feature="nu-internal")]
+#[cfg(feature = "nu-internal")]
 use {
+    crate::{plugin::PluginEncoder, protocol::PluginResponse},
     nu_protocol::ShellError,
-    crate::{
-        plugin::PluginEncoder,
-        protocol::PluginResponse,
-    },
 };
 
 pub(crate) mod json;
 pub(crate) mod msgpack;
 
-#[cfg(feature="nu-internal")]
+#[cfg(feature = "nu-internal")]
 use self::{json::JsonSerializer, msgpack::MsgPackSerializer};
 
 /// Indicates what encoding type should be used when serving the [Plugin](crate::Plugin)
-/// 
+///
 /// An `EncodingType` is passed to [`serve_plugin`](crate::serve_plugin) to indicate
-/// how data should be serialized when passed between the Plugin executable and 
+/// how data should be serialized when passed between the Plugin executable and
 /// Nushell.
 #[derive(Clone, Debug)]
 pub enum EncodingType {
@@ -39,7 +36,7 @@ impl EncodingType {
 #[cfg(feature = "nu-internal")]
 impl EncodingType {
     /// Internal method used by Nushell
-    /// 
+    ///
     /// Hidden behind the `nu-internal` feature.
     pub fn encode_call(
         &self,
@@ -53,7 +50,7 @@ impl EncodingType {
     }
 
     /// Internal method used by Nushell
-    /// 
+    ///
     /// Hidden behind the `nu-internal` feature.
     pub fn decode_response(
         &self,

--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -1,74 +1,83 @@
-use crate::{
-    plugin::PluginEncoder,
-    protocol::{PluginCall, PluginResponse},
-};
-use nu_protocol::ShellError;
-
 pub mod json;
 pub mod msgpack;
 
-#[doc(hidden)]
 #[derive(Clone, Debug)]
 pub enum EncodingType {
-    Json(json::JsonSerializer),
-    MsgPack(msgpack::MsgPackSerializer),
+    Json,
+    MsgPack,
 }
 
 impl EncodingType {
     pub fn try_from_bytes(bytes: &[u8]) -> Option<Self> {
         match bytes {
-            b"json" => Some(Self::Json(json::JsonSerializer {})),
-            b"msgpack" => Some(Self::MsgPack(msgpack::MsgPackSerializer {})),
+            b"json" => Some(Self::Json),
+            b"msgpack" => Some(Self::MsgPack),
             _ => None,
         }
     }
-
-    pub fn encode_call(
-        &self,
-        plugin_call: &PluginCall,
-        writer: &mut impl std::io::Write,
-    ) -> Result<(), ShellError> {
-        match self {
-            EncodingType::Json(encoder) => encoder.encode_call(plugin_call, writer),
-            EncodingType::MsgPack(encoder) => encoder.encode_call(plugin_call, writer),
-        }
-    }
-
-    pub fn decode_call(
-        &self,
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginCall, ShellError> {
-        match self {
-            EncodingType::Json(encoder) => encoder.decode_call(reader),
-            EncodingType::MsgPack(encoder) => encoder.decode_call(reader),
-        }
-    }
-
-    pub fn encode_response(
-        &self,
-        plugin_response: &PluginResponse,
-        writer: &mut impl std::io::Write,
-    ) -> Result<(), ShellError> {
-        match self {
-            EncodingType::Json(encoder) => encoder.encode_response(plugin_response, writer),
-            EncodingType::MsgPack(encoder) => encoder.encode_response(plugin_response, writer),
-        }
-    }
-
-    pub fn decode_response(
-        &self,
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginResponse, ShellError> {
-        match self {
-            EncodingType::Json(encoder) => encoder.decode_response(reader),
-            EncodingType::MsgPack(encoder) => encoder.decode_response(reader),
-        }
-    }
-
-    pub fn to_str(&self) -> &'static str {
-        match self {
-            Self::Json(_) => "json",
-            Self::MsgPack(_) => "msgpack",
-        }
-    }
 }
+
+// #[derive(Clone, Debug)]
+// pub enum EncodingType {
+//     Json(json::JsonSerializer),
+//     MsgPack(msgpack::MsgPackSerializer),
+// }
+
+// impl EncodingType {
+//     pub fn try_from_bytes(bytes: &[u8]) -> Option<Self> {
+//         match bytes {
+//             b"json" => Some(Self::Json(json::JsonSerializer {})),
+//             b"msgpack" => Some(Self::MsgPack(msgpack::MsgPackSerializer {})),
+//             _ => None,
+//         }
+//     }
+
+//     pub fn encode_call(
+//         &self,
+//         plugin_call: &PluginCall,
+//         writer: &mut impl std::io::Write,
+//     ) -> Result<(), ShellError> {
+//         match self {
+//             EncodingType::Json(encoder) => encoder.encode_call(plugin_call, writer),
+//             EncodingType::MsgPack(encoder) => encoder.encode_call(plugin_call, writer),
+//         }
+//     }
+
+//     pub fn decode_call(
+//         &self,
+//         reader: &mut impl std::io::BufRead,
+//     ) -> Result<PluginCall, ShellError> {
+//         match self {
+//             EncodingType::Json(encoder) => encoder.decode_call(reader),
+//             EncodingType::MsgPack(encoder) => encoder.decode_call(reader),
+//         }
+//     }
+
+//     pub fn encode_response(
+//         &self,
+//         plugin_response: &PluginResponse,
+//         writer: &mut impl std::io::Write,
+//     ) -> Result<(), ShellError> {
+//         match self {
+//             EncodingType::Json(encoder) => encoder.encode_response(plugin_response, writer),
+//             EncodingType::MsgPack(encoder) => encoder.encode_response(plugin_response, writer),
+//         }
+//     }
+
+//     pub fn decode_response(
+//         &self,
+//         reader: &mut impl std::io::BufRead,
+//     ) -> Result<PluginResponse, ShellError> {
+//         match self {
+//             EncodingType::Json(encoder) => encoder.decode_response(reader),
+//             EncodingType::MsgPack(encoder) => encoder.decode_response(reader),
+//         }
+//     }
+
+//     pub fn to_str(&self) -> &'static str {
+//         match self {
+//             Self::Json(_) => "json",
+//             Self::MsgPack(_) => "msgpack",
+//         }
+//     }
+// }

--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "nu-internal")]
 use {
-    crate::{plugin::PluginEncoder, protocol::PluginResponse},
+    crate::{plugin::PluginEncoder, protocol::PluginCall, protocol::PluginResponse},
     nu_protocol::ShellError,
+    std::io::{BufRead, Write},
 };
 
 pub(crate) mod json;
@@ -40,8 +41,8 @@ impl EncodingType {
     /// Hidden behind the `nu-internal` feature.
     pub fn encode_call(
         &self,
-        plugin_call: &crate::protocol::PluginCall,
-        writer: &mut impl std::io::Write,
+        plugin_call: &PluginCall,
+        writer: &mut impl Write,
     ) -> Result<(), nu_protocol::ShellError> {
         match self {
             EncodingType::Json => JsonSerializer::encode_call(plugin_call, writer),
@@ -52,10 +53,7 @@ impl EncodingType {
     /// Internal method used by Nushell
     ///
     /// Hidden behind the `nu-internal` feature.
-    pub fn decode_response(
-        &self,
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginResponse, ShellError> {
+    pub fn decode_response(&self, reader: &mut impl BufRead) -> Result<PluginResponse, ShellError> {
         match self {
             EncodingType::Json => JsonSerializer::decode_response(reader),
             EncodingType::MsgPack => MsgPackSerializer::decode_response(reader),

--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -9,12 +9,20 @@ use {
 
 pub(crate) mod json;
 pub(crate) mod msgpack;
+
 #[cfg(feature="nu-internal")]
 use self::{json::JsonSerializer, msgpack::MsgPackSerializer};
 
+/// Indicates what encoding type should be used when serving the [Plugin](crate::Plugin)
+/// 
+/// An `EncodingType` is passed to [`serve_plugin`](crate::serve_plugin) to indicate
+/// how data should be serialized when passed between the Plugin executable and 
+/// Nushell.
 #[derive(Clone, Debug)]
 pub enum EncodingType {
+    /// Use the [JSON](https://www.json.org/) text serialization format
     Json,
+    /// Use the [MsgPack](https://msgpack.org/index.html) binary serialization format
     MsgPack,
 }
 
@@ -30,6 +38,9 @@ impl EncodingType {
 
 #[cfg(feature = "nu-internal")]
 impl EncodingType {
+    /// Internal method used by Nushell
+    /// 
+    /// Hidden behind the `nu-internal` feature.
     pub fn encode_call(
         &self,
         plugin_call: &crate::protocol::PluginCall,
@@ -41,6 +52,9 @@ impl EncodingType {
         }
     }
 
+    /// Internal method used by Nushell
+    /// 
+    /// Hidden behind the `nu-internal` feature.
     pub fn decode_response(
         &self,
         reader: &mut impl std::io::BufRead,

--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -34,9 +34,7 @@ impl PluginEncoder for MsgPackSerializer {
             .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
     }
 
-    fn decode_response(
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginResponse, ShellError> {
+    fn decode_response(reader: &mut impl std::io::BufRead) -> Result<PluginResponse, ShellError> {
         rmp_serde::from_read(reader)
             .map_err(|err| ShellError::PluginFailedToDecode(err.to_string()))
     }
@@ -55,11 +53,9 @@ mod tests {
         let plugin_call = PluginCall::Signature;
 
         let mut buffer: Vec<u8> = Vec::new();
-        MsgPackSerializer
-            ::encode_call(&plugin_call, &mut buffer)
+        MsgPackSerializer::encode_call(&plugin_call, &mut buffer)
             .expect("unable to serialize message");
-        let returned = MsgPackSerializer
-            ::decode_call(&mut buffer.as_slice())
+        let returned = MsgPackSerializer::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -109,11 +105,9 @@ mod tests {
         });
 
         let mut buffer: Vec<u8> = Vec::new();
-        MsgPackSerializer
-            ::encode_call(&plugin_call, &mut buffer)
+        MsgPackSerializer::encode_call(&plugin_call, &mut buffer)
             .expect("unable to serialize message");
-        let returned = MsgPackSerializer
-            ::decode_call(&mut buffer.as_slice())
+        let returned = MsgPackSerializer::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -158,11 +152,9 @@ mod tests {
         });
 
         let mut buffer: Vec<u8> = Vec::new();
-        MsgPackSerializer
-            ::encode_call(&collapse_custom_value, &mut buffer)
+        MsgPackSerializer::encode_call(&collapse_custom_value, &mut buffer)
             .expect("unable to serialize message");
-        let returned = MsgPackSerializer
-            ::decode_call(&mut buffer.as_slice())
+        let returned = MsgPackSerializer::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -192,11 +184,9 @@ mod tests {
         let response = PluginResponse::Signature(vec![signature.clone()]);
 
         let mut buffer: Vec<u8> = Vec::new();
-        MsgPackSerializer
-            ::encode_response(&response, &mut buffer)
+        MsgPackSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = MsgPackSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -252,11 +242,9 @@ mod tests {
         let response = PluginResponse::Value(Box::new(value.clone()));
 
         let mut buffer: Vec<u8> = Vec::new();
-        MsgPackSerializer
-            ::encode_response(&response, &mut buffer)
+        MsgPackSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = MsgPackSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -285,11 +273,9 @@ mod tests {
         );
 
         let mut buffer: Vec<u8> = Vec::new();
-        MsgPackSerializer
-            ::encode_response(&response, &mut buffer)
+        MsgPackSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = MsgPackSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -314,11 +300,9 @@ mod tests {
         let response = PluginResponse::Error(error.clone());
 
         let mut buffer: Vec<u8> = Vec::new();
-        MsgPackSerializer
-            ::encode_response(&response, &mut buffer)
+        MsgPackSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = MsgPackSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -339,11 +323,9 @@ mod tests {
         let response = PluginResponse::Error(error.clone());
 
         let mut buffer: Vec<u8> = Vec::new();
-        MsgPackSerializer
-            ::encode_response(&response, &mut buffer)
+        MsgPackSerializer::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = MsgPackSerializer
-            ::decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {

--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -4,7 +4,7 @@ use nu_protocol::ShellError;
 /// A `PluginEncoder` that enables the plugin to communicate with Nushel with MsgPack
 /// serialized data.
 // #[derive(Clone, Debug)]
-pub struct MsgPackSerializer;
+pub(crate) struct MsgPackSerializer;
 
 impl PluginEncoder for MsgPackSerializer {
     fn name() -> &'static str {

--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -3,16 +3,15 @@ use nu_protocol::ShellError;
 
 /// A `PluginEncoder` that enables the plugin to communicate with Nushel with MsgPack
 /// serialized data.
-#[derive(Clone, Debug)]
+// #[derive(Clone, Debug)]
 pub struct MsgPackSerializer;
 
 impl PluginEncoder for MsgPackSerializer {
-    fn name(&self) -> &str {
+    fn name() -> &'static str {
         "msgpack"
     }
 
     fn encode_call(
-        &self,
         plugin_call: &crate::protocol::PluginCall,
         writer: &mut impl std::io::Write,
     ) -> Result<(), nu_protocol::ShellError> {
@@ -21,7 +20,6 @@ impl PluginEncoder for MsgPackSerializer {
     }
 
     fn decode_call(
-        &self,
         reader: &mut impl std::io::BufRead,
     ) -> Result<crate::protocol::PluginCall, nu_protocol::ShellError> {
         rmp_serde::from_read(reader)
@@ -29,7 +27,6 @@ impl PluginEncoder for MsgPackSerializer {
     }
 
     fn encode_response(
-        &self,
         plugin_response: &PluginResponse,
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError> {
@@ -38,7 +35,6 @@ impl PluginEncoder for MsgPackSerializer {
     }
 
     fn decode_response(
-        &self,
         reader: &mut impl std::io::BufRead,
     ) -> Result<PluginResponse, ShellError> {
         rmp_serde::from_read(reader)
@@ -57,14 +53,13 @@ mod tests {
     #[test]
     fn callinfo_round_trip_signature() {
         let plugin_call = PluginCall::Signature;
-        let encoder = MsgPackSerializer {};
 
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&plugin_call, &mut buffer)
+        MsgPackSerializer
+            ::encode_call(&plugin_call, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
+        let returned = MsgPackSerializer
+            ::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -113,13 +108,12 @@ mod tests {
             input: CallInput::Value(input.clone()),
         });
 
-        let encoder = MsgPackSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&plugin_call, &mut buffer)
+        MsgPackSerializer
+            ::encode_call(&plugin_call, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
+        let returned = MsgPackSerializer
+            ::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -163,13 +157,12 @@ mod tests {
             span,
         });
 
-        let encoder = MsgPackSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&collapse_custom_value, &mut buffer)
+        MsgPackSerializer
+            ::encode_call(&collapse_custom_value, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
+        let returned = MsgPackSerializer
+            ::decode_call(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -198,13 +191,12 @@ mod tests {
 
         let response = PluginResponse::Signature(vec![signature.clone()]);
 
-        let encoder = MsgPackSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        MsgPackSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -259,13 +251,12 @@ mod tests {
 
         let response = PluginResponse::Value(Box::new(value.clone()));
 
-        let encoder = MsgPackSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        MsgPackSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -293,13 +284,12 @@ mod tests {
             },
         );
 
-        let encoder = MsgPackSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        MsgPackSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -323,13 +313,12 @@ mod tests {
         };
         let response = PluginResponse::Error(error.clone());
 
-        let encoder = MsgPackSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        MsgPackSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {
@@ -349,13 +338,12 @@ mod tests {
         };
         let response = PluginResponse::Error(error.clone());
 
-        let encoder = MsgPackSerializer {};
         let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
+        MsgPackSerializer
+            ::encode_response(&response, &mut buffer)
             .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
+        let returned = MsgPackSerializer
+            ::decode_response(&mut buffer.as_slice())
             .expect("unable to deserialize message");
 
         match returned {

--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -3,7 +3,6 @@ use nu_protocol::ShellError;
 
 /// A `PluginEncoder` that enables the plugin to communicate with Nushel with MsgPack
 /// serialized data.
-// #[derive(Clone, Debug)]
 pub(crate) struct MsgPackSerializer;
 
 impl PluginEncoder for MsgPackSerializer {

--- a/crates/nu_plugin_custom_values/src/main.rs
+++ b/crates/nu_plugin_custom_values/src/main.rs
@@ -2,7 +2,7 @@ mod cool_custom_value;
 mod second_custom_value;
 
 use cool_custom_value::CoolCustomValue;
-use nu_plugin::{serve_plugin, MsgPackSerializer, Plugin};
+use nu_plugin::{serve_plugin, EncodingType, Plugin};
 use nu_plugin::{EvaluatedCall, LabeledError};
 use nu_protocol::{Category, PluginSignature, ShellError, Value};
 use second_custom_value::SecondCustomValue;
@@ -74,5 +74,5 @@ impl CustomValuePlugin {
 }
 
 fn main() {
-    serve_plugin(&mut CustomValuePlugin, MsgPackSerializer {})
+    serve_plugin(&mut CustomValuePlugin, EncodingType::MsgPack)
 }

--- a/crates/nu_plugin_example/src/main.rs
+++ b/crates/nu_plugin_example/src/main.rs
@@ -1,4 +1,4 @@
-use nu_plugin::{serve_plugin, MsgPackSerializer};
+use nu_plugin::{serve_plugin, EncodingType};
 use nu_plugin_example::Example;
 
 fn main() {
@@ -6,7 +6,7 @@ fn main() {
     // used to encode and decode the messages. The available options are
     // MsgPackSerializer and JsonSerializer. Both are defined in the serializer
     // folder in nu-plugin.
-    serve_plugin(&mut Example {}, MsgPackSerializer {})
+    serve_plugin(&mut Example {}, EncodingType::MsgPack)
 
     // Note
     // When creating plugins in other languages one needs to consider how a plugin

--- a/crates/nu_plugin_formats/src/main.rs
+++ b/crates/nu_plugin_formats/src/main.rs
@@ -1,6 +1,6 @@
-use nu_plugin::{serve_plugin, MsgPackSerializer};
+use nu_plugin::{serve_plugin, EncodingType};
 use nu_plugin_formats::FromCmds;
 
 fn main() {
-    serve_plugin(&mut FromCmds, MsgPackSerializer {})
+    serve_plugin(&mut FromCmds, EncodingType::MsgPack)
 }

--- a/crates/nu_plugin_gstat/src/main.rs
+++ b/crates/nu_plugin_gstat/src/main.rs
@@ -1,6 +1,6 @@
-use nu_plugin::{serve_plugin, MsgPackSerializer};
+use nu_plugin::{serve_plugin, EncodingType};
 use nu_plugin_gstat::GStat;
 
 fn main() {
-    serve_plugin(&mut GStat::new(), MsgPackSerializer {})
+    serve_plugin(&mut GStat::new(), EncodingType::MsgPack)
 }

--- a/crates/nu_plugin_inc/src/main.rs
+++ b/crates/nu_plugin_inc/src/main.rs
@@ -1,6 +1,6 @@
-use nu_plugin::{serve_plugin, JsonSerializer};
+use nu_plugin::{serve_plugin, EncodingType};
 use nu_plugin_inc::Inc;
 
 fn main() {
-    serve_plugin(&mut Inc::new(), JsonSerializer {})
+    serve_plugin(&mut Inc::new(), EncodingType::Json)
 }

--- a/crates/nu_plugin_query/src/main.rs
+++ b/crates/nu_plugin_query/src/main.rs
@@ -1,6 +1,6 @@
-use nu_plugin::{serve_plugin, JsonSerializer};
+use nu_plugin::{serve_plugin, EncodingType};
 use nu_plugin_query::Query;
 
 fn main() {
-    serve_plugin(&mut Query {}, JsonSerializer {})
+    serve_plugin(&mut Query {}, EncodingType::Json)
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

Fixes [Hide implementation details from nu-plugin public interface](https://github.com/nushell/nushell/issues/9469)

# Description
This change makes some changes to the plugin API with the intent of better encapsulating implementation details as well as better partitioning those parts of the `nu-plugin` crate to separate public items used by plugin authors from public items used by other Nushell crates.

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
This is a breaking change for existing Plugins. All plugin samples in this repo have been updated.

Instead of serving a plugin like this:
```rust
fn main() {
   serve_plugin(&mut MyPlugin{}, MsgPackSerializer)
}
```

a plugin author must now:
```rust
fn main() {
   serve_plugin(&mut MyPlugin{}, EncodingType::MsgPack)
}
```

Some items that were never meant for plugin authors are now behind a crate feature in `nu-plugin`. This feature is activated in `crates/nu-parser/Cargo.toml`. They have also been moved to a sub-module which allows us to add documentation while avoiding confusion over whether certain items should be used outside of Nushell internals.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
This change will require an update to the hidden plugin tutorial.
