### PR TITLE
Prevent `rustflags` build config from being ignored in ci workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        with:
+          rustflags: ""
 
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -89,6 +91,8 @@ jobs:
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        with:
+          rustflags: ""
 
       - name: Tests
         run: cargo test --workspace --profile ci --exclude nu_plugin_* ${{ matrix.flags }}
@@ -113,6 +117,8 @@ jobs:
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        with:
+          rustflags: ""
 
       - name: Install Nushell
         # prior to [*standard library: bring the tests into the main CI*](#8525)
@@ -172,6 +178,8 @@ jobs:
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        with:
+          rustflags: ""
 
       - name: Clippy
         run: cargo clippy --package nu_plugin_* ${{ matrix.flags }} -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err
@@ -201,6 +209,9 @@ jobs:
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+        with:
+          rustflags: ""
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -136,6 +136,8 @@ jobs:
 
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+      with:
+        rustflags: ''
 
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,8 @@ jobs:
 
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
+      with:
+        rustflags: ''
 
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3


### PR DESCRIPTION
# Description

Prevent `rustflags` build configuration from being ignored in github actions ci workflows.

[actions-rust-lang/setup-rust-toolchain](https://github.com/actions-rust-lang/setup-rust-toolchain/) used in ci workflows sets `RUSTFLAGS="-D warnings"` env variable by default. It has priority over some other sources of `rustflags` as described in [the cargo reference](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags).

Nushell is using `target.x86_64-pc-windows-msvc.rustflags` to statically link MSVC runtime in windows platform, but this config is being ignored in ci workflows.

By unsetting `RUSTFLAGS` env variable, `rustflags` build configurations will be properly used in ci workflows.

I assume that this was the cause of the installer verification failures on the recent winget submission PRs. For more details, refer discussions in https://github.com/microsoft/winget-pkgs/pull/106977 and https://github.com/nushell/nushell/pull/9322#issuecomment-1602932971.

# User-Facing Changes

Pre-built releases for windows that are created by the release ci workflow will now contain statically linked MSVC runtime.

# Tests + Formatting

Confirmed successful installation in a windows sandbox instance, which was failing before. It also contains changes made in #9514.

Release ci workflow: https://github.com/wolimst/nushell/actions/runs/5357440849
Installer: https://github.com/wolimst/nushell/releases/tag/0.81.0-test

# After Submitting

Need to check the installer verification result in a winget submission PR for the next release, if this PR gets merged.