### PR TITLE
Revert install context of windows terminal profile to per-system

### DIFF
--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -285,25 +285,18 @@
                 </Directory>
             </Directory>
 
-            <Directory Id='LocalAppDataFolder'>
+            <Directory Id='CommonAppDataFolder'>
                 <Directory Id='AppDataMicrosoftFolder' Name='Microsoft'>
                     <Directory Id='AppDataWindowsTerminalFolder' Name='Windows Terminal'>
                         <Directory Id='WindowsTerminalProfileFolder' Name='Fragments'>
                             <Directory Id='WindowsTerminalProfileAppFolder' Name='nu'>
-                                <Component Id='WindowsTerminalProfile' Guid='957239F4-7B87-4399-9F91-7DF2ABE5ED8B' Win64='$(var.Win64)'>
+                                <Component Id='WindowsTerminalProfile' Guid='*' Win64='$(var.Win64)'>
                                     <File
                                         Id='WindowsTerminalProfileFile'
                                         Name='nu.json'
                                         DiskId='1'
                                         Source='wix\windows-terminal-profile.json'
-                                        System='no'/>
-                                    <RegistryKey Root='HKCU' Key='Software\nu'>
-                                        <RegistryValue Name='WindowsTerminalProfile' Value='1' Type='integer' KeyPath='yes'/>
-                                    </RegistryKey>
-                                    <RemoveFolder Id='RemoveWindowsTerminalProfileFolder1' Directory='WindowsTerminalProfileAppFolder' On='uninstall'/>
-                                    <RemoveFolder Id='RemoveWindowsTerminalProfileFolder2' Directory='WindowsTerminalProfileFolder' On='uninstall'/>
-                                    <RemoveFolder Id='RemoveWindowsTerminalProfileFolder3' Directory='AppDataWindowsTerminalFolder' On='uninstall'/>
-                                    <RemoveFolder Id='RemoveWindowsTerminalProfileFolder4' Directory='AppDataMicrosoftFolder' On='uninstall'/>
+                                        KeyPath='yes'/>
                                 </Component>
                             </Directory>
                         </Directory>
@@ -390,7 +383,7 @@
             DllEntry="CAQuietExec"
             Execute="deferred"
             Return="check"
-            Impersonate="yes"/>
+            Impersonate="no"/>
         <InstallExecuteSequence>
             <Custom Action='ReplacePathsInWindowsTerminalProfile' Before='InstallFinalize'>
                 <!-- Run the custom action if the feature is enabled -->


### PR DESCRIPTION
# Description

Revert installation context of windows terminal profile to per-system, since installation context of other features are per-system, and having different installation context creates unnecessary inconsistency.

Installation context change of windows terminal profile to per-user (#9322) was made to resolve the recent installer verification failure on winget submission PRs, but the cause of this problem seems to be in another place (#9513).

For more details, refer discussions in #5812 and #9322.

# User-Facing Changes

Windows terminal profile for nushell will be installed in system context.
Installation path will be changed as below:
- before: `C:\Users\<user>\AppData\Local\Microsoft\Windows Terminal\Fragments\nu\nu.json`
- to: `C:\ProgramData\Microsoft\Windows Terminal\Fragments\nu\nu.json`

# Tests + Formatting

Confirmed successful installation of nushell and windows terminal profile file in windows using below installer that created by release ci workflow. It also contains changes made in #9513.

Release ci workflow: https://github.com/wolimst/nushell/actions/runs/5357440849
Installer: https://github.com/wolimst/nushell/releases/tag/0.81.0-test
