### PR TITLE
Modify the bits command in nu-cmd-extra to improve visibility

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -2,16 +2,20 @@ mod and;
 mod bits_;
 mod not;
 mod or;
-pub(crate) mod rotate_left;
-pub(crate) mod rotate_right;
-pub(crate) mod shift_left;
-pub(crate) mod shift_right;
+mod rotate_left;
+mod rotate_right;
+mod shift_left;
+mod shift_right;
 mod xor;
 
 pub use and::BitsAnd;
 pub use bits_::Bits;
 pub use not::BitsNot;
 pub use or::BitsOr;
+pub use rotate_left::BitsRol;
+pub use rotate_right::BitsRor;
+pub use shift_left::BitsShl;
+pub use shift_right::BitsShr;
 pub use xor::BitsXor;
 
 use nu_protocol::Spanned;

--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -1,12 +1,18 @@
-pub(crate) mod and;
-pub(crate) mod bits_;
-pub(crate) mod not;
-pub(crate) mod or;
+mod and;
+mod bits_;
+mod not;
+mod or;
 pub(crate) mod rotate_left;
 pub(crate) mod rotate_right;
 pub(crate) mod shift_left;
 pub(crate) mod shift_right;
-pub(crate) mod xor;
+mod xor;
+
+pub use and::BitsAnd;
+pub use bits_::Bits;
+pub use not::BitsNot;
+pub use or::BitsOr;
+pub use xor::BitsXor;
 
 use nu_protocol::Spanned;
 

--- a/crates/nu-cmd-extra/src/extra/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/mod.rs
@@ -1,6 +1,12 @@
 mod bits;
 mod bytes;
 
+pub use bits::Bits;
+pub use bits::BitsAnd;
+pub use bits::BitsNot;
+pub use bits::BitsOr;
+pub use bits::BitsXor;
+
 pub use bytes::Bytes;
 pub use bytes::BytesAdd;
 pub use bytes::BytesAt;
@@ -30,11 +36,11 @@ pub fn add_extra_command_context(mut engine_state: EngineState) -> EngineState {
         }
 
         bind_command! {
-            bits::bits_::Bits,
-            bits::and::BitsAnd,
-            bits::not::BitsNot,
-            bits::or::BitsOr,
-            bits::xor::BitsXor,
+            Bits,
+            BitsAnd,
+            BitsNot,
+            BitsOr,
+            BitsXor,
             bits::rotate_left::BitsRol,
             bits::rotate_right::BitsRor,
             bits::shift_left::BitsShl,

--- a/crates/nu-cmd-extra/src/extra/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/mod.rs
@@ -5,6 +5,10 @@ pub use bits::Bits;
 pub use bits::BitsAnd;
 pub use bits::BitsNot;
 pub use bits::BitsOr;
+pub use bits::BitsRol;
+pub use bits::BitsRor;
+pub use bits::BitsShl;
+pub use bits::BitsShr;
 pub use bits::BitsXor;
 
 pub use bytes::Bytes;
@@ -41,10 +45,10 @@ pub fn add_extra_command_context(mut engine_state: EngineState) -> EngineState {
             BitsNot,
             BitsOr,
             BitsXor,
-            bits::rotate_left::BitsRol,
-            bits::rotate_right::BitsRor,
-            bits::shift_left::BitsShl,
-            bits::shift_right::BitsShr
+            BitsRol,
+            BitsRor,
+            BitsShl,
+            BitsShr
         }
 
         // Bytes


### PR DESCRIPTION

In the spirit of #9509 we are changing the visibility of the bits commands
to align with the way they are correctly done in the bytes commands...

Thanks to @sholderbach for pointing out this nice improvement
to me in my PR earlier in the day...

```rust
mod and;
mod bits_;
mod not;
mod or;
mod rotate_left;
mod rotate_right;
mod shift_left;
mod shift_right;
mod xor;
```