### PR TITLE
convert a string to a raw binary string of 0s and 1s

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/into.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/into.rs
@@ -1,0 +1,273 @@
+use nu_cmd_base::input_handler::{operate, CmdArgument};
+use nu_engine::CallExt;
+use nu_protocol::{
+    ast::{Call, CellPath},
+    engine::{Command, EngineState, Stack},
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    Type, Value,
+};
+use num_traits::ToPrimitive;
+
+pub struct Arguments {
+    cell_paths: Option<Vec<CellPath>>,
+}
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        self.cell_paths.take()
+    }
+}
+
+#[derive(Clone)]
+pub struct BitsInto;
+
+impl Command for BitsInto {
+    fn name(&self) -> &str {
+        "into bits"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("into bits")
+            .input_output_types(vec![
+                (Type::Binary, Type::String),
+                (Type::Int, Type::String),
+                (Type::Filesize, Type::String),
+                (Type::Duration, Type::String),
+                (Type::String, Type::String),
+                (Type::Bool, Type::String),
+                (Type::Date, Type::String),
+            ])
+            .allow_variants_without_examples(true) // TODO: supply exhaustive examples
+            .rest(
+                "rest",
+                SyntaxShape::CellPath,
+                "for a data structure input, convert data at the given cell paths",
+            )
+            .category(Category::Conversions)
+    }
+
+    fn usage(&self) -> &str {
+        "Convert value to a binary primitive."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "cast"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        into_bits(engine_state, stack, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "convert a binary value into a string, padded to 8 places with 0s",
+                example: "01b | into bits",
+                result: Some(Value::String {
+                    val: "00000001".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "convert an int into a string, padded to 8 places with 0s",
+                example: "1 | into bits",
+                result: Some(Value::String {
+                    val: "00000001".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "convert a filesize value into a string, padded to 8 places with 0s",
+                example: "1b | into bits",
+                result: Some(Value::String {
+                    val: "00000001".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "convert a duration value into a string, padded to 8 places with 0s",
+                example: "1ns | into bits",
+                result: Some(Value::String {
+                    val: "00000001".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "convert a boolean value into a string, padded to 8 places with 0s",
+                example: "true | into bits",
+                result: Some(Value::String {
+                    val: "00000001".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "convert a datetime value into a string, padded to 8 places with 0s",
+                example: "2023-04-17T01:02:03 | into bits",
+                result: Some(Value::String {
+                    val: "01001101 01101111 01101110 00100000 01000001 01110000 01110010 00100000 00110001 00110111 00100000 00110000 00110001 00111010 00110000 00110010 00111010 00110000 00110011 00100000 00110010 00110000 00110010 00110011".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                description: "convert a string into a raw binary string, padded with 0s to 8 places",
+                example: "'nushell.sh' | into bits",
+                result: Some(Value::String {
+                    val: "01101110 01110101 01110011 01101000 01100101 01101100 01101100 00101110 01110011 01101000".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
+        ]
+    }
+}
+
+fn into_bits(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    input: PipelineData,
+) -> Result<PipelineData, ShellError> {
+    let head = call.head;
+    let cell_paths = call.rest(engine_state, stack, 0)?;
+    let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+
+    match input {
+        PipelineData::ExternalStream { stdout: None, .. } => Ok(Value::Binary {
+            val: vec![],
+            span: head,
+        }
+        .into_pipeline_data()),
+        PipelineData::ExternalStream {
+            stdout: Some(stream),
+            ..
+        } => {
+            // TODO: in the future, we may want this to stream out, converting each to bytes
+            let output = stream.into_bytes()?;
+            Ok(Value::Binary {
+                val: output.item,
+                span: head,
+            }
+            .into_pipeline_data())
+        }
+        _ => {
+            let args = Arguments { cell_paths };
+            operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        }
+    }
+}
+
+fn convert_to_smallest_number_type(num: i64, span: Span) -> Value {
+    if let Some(v) = num.to_i8() {
+        let bytes = v.to_ne_bytes();
+        let mut raw_string = "".to_string();
+        for ch in bytes {
+            raw_string.push_str(&format!("{:08b} ", ch));
+        }
+        Value::String {
+            val: raw_string.trim().to_string(),
+            span,
+        }
+    } else if let Some(v) = num.to_i16() {
+        let bytes = v.to_ne_bytes();
+        let mut raw_string = "".to_string();
+        for ch in bytes {
+            raw_string.push_str(&format!("{:08b} ", ch));
+        }
+        Value::String {
+            val: raw_string.trim().to_string(),
+            span,
+        }
+    } else if let Some(v) = num.to_i32() {
+        let bytes = v.to_ne_bytes();
+        let mut raw_string = "".to_string();
+        for ch in bytes {
+            raw_string.push_str(&format!("{:08b} ", ch));
+        }
+        Value::String {
+            val: raw_string.trim().to_string(),
+            span,
+        }
+    } else {
+        let bytes = num.to_ne_bytes();
+        let mut raw_string = "".to_string();
+        for ch in bytes {
+            raw_string.push_str(&format!("{:08b} ", ch));
+        }
+        Value::String {
+            val: raw_string.trim().to_string(),
+            span,
+        }
+    }
+}
+
+pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
+    match input {
+        Value::Binary { val, .. } => {
+            let mut raw_string = "".to_string();
+            for ch in val {
+                raw_string.push_str(&format!("{:08b} ", ch));
+            }
+            Value::String {
+                val: raw_string.trim().to_string(),
+                span,
+            }
+        }
+        Value::Int { val, .. } => convert_to_smallest_number_type(*val, span),
+        Value::Filesize { val, .. } => convert_to_smallest_number_type(*val, span),
+        Value::Duration { val, .. } => convert_to_smallest_number_type(*val, span),
+        Value::String { val, .. } => {
+            let raw_bytes = val.as_bytes();
+            let mut raw_string = "".to_string();
+            for ch in raw_bytes {
+                raw_string.push_str(&format!("{:08b} ", ch));
+            }
+            Value::String {
+                val: raw_string.trim().to_string(),
+                span,
+            }
+        }
+        Value::Bool { val, .. } => {
+            let v = <i64 as From<bool>>::from(*val);
+            convert_to_smallest_number_type(v, span)
+        }
+        Value::Date { val, .. } => {
+            let value = val.format("%c").to_string();
+            let bytes = value.as_bytes();
+            let mut raw_string = "".to_string();
+            for ch in bytes {
+                raw_string.push_str(&format!("{:08b} ", ch));
+            }
+            Value::String {
+                val: raw_string.trim().to_string(),
+                span,
+            }
+        }
+        // Propagate errors by explicitly matching them before the final case.
+        Value::Error { .. } => input.clone(),
+        other => Value::Error {
+            error: Box::new(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "integer, filesize, string, date, duration, binary or bool".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: span,
+                src_span: other.expect_span(),
+            }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(BitsInto {})
+    }
+}

--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -1,12 +1,24 @@
-pub(crate) mod and;
-pub(crate) mod bits_;
-pub(crate) mod not;
-pub(crate) mod or;
-pub(crate) mod rotate_left;
-pub(crate) mod rotate_right;
-pub(crate) mod shift_left;
-pub(crate) mod shift_right;
-pub(crate) mod xor;
+mod and;
+mod bits_;
+mod into;
+mod not;
+mod or;
+mod rotate_left;
+mod rotate_right;
+mod shift_left;
+mod shift_right;
+mod xor;
+
+pub use and::BitsAnd;
+pub use bits_::Bits;
+pub use into::BitsInto;
+pub use not::BitsNot;
+pub use or::BitsOr;
+pub use rotate_left::BitsRol;
+pub use rotate_right::BitsRor;
+pub use shift_left::BitsShl;
+pub use shift_right::BitsShr;
+pub use xor::BitsXor;
 
 use nu_protocol::Spanned;
 

--- a/crates/nu-cmd-extra/src/extra/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/mod.rs
@@ -1,16 +1,6 @@
 mod bits;
 mod bytes;
 
-pub use bits::Bits;
-pub use bits::BitsAnd;
-pub use bits::BitsNot;
-pub use bits::BitsOr;
-pub use bits::BitsRol;
-pub use bits::BitsRor;
-pub use bits::BitsShl;
-pub use bits::BitsShr;
-pub use bits::BitsXor;
-
 pub use bytes::Bytes;
 pub use bytes::BytesAdd;
 pub use bytes::BytesAt;

--- a/crates/nu-cmd-extra/src/extra/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/mod.rs
@@ -14,6 +14,17 @@ pub use bytes::BytesReplace;
 pub use bytes::BytesReverse;
 pub use bytes::BytesStartsWith;
 
+pub use bits::Bits;
+pub use bits::BitsAnd;
+pub use bits::BitsInto;
+pub use bits::BitsNot;
+pub use bits::BitsOr;
+pub use bits::BitsRol;
+pub use bits::BitsRor;
+pub use bits::BitsShl;
+pub use bits::BitsShr;
+pub use bits::BitsXor;
+
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
 pub fn add_extra_command_context(mut engine_state: EngineState) -> EngineState {
@@ -29,16 +40,18 @@ pub fn add_extra_command_context(mut engine_state: EngineState) -> EngineState {
             };
         }
 
+        // Bits
         bind_command! {
-            bits::bits_::Bits,
-            bits::and::BitsAnd,
-            bits::not::BitsNot,
-            bits::or::BitsOr,
-            bits::xor::BitsXor,
-            bits::rotate_left::BitsRol,
-            bits::rotate_right::BitsRor,
-            bits::shift_left::BitsShl,
-            bits::shift_right::BitsShr
+            Bits,
+            BitsAnd,
+            BitsInto,
+            BitsNot,
+            BitsOr,
+            BitsRol,
+            BitsRor,
+            BitsShl,
+            BitsShr,
+            BitsXor
         }
 
         // Bytes

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -114,7 +114,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "convert a string into a raw binary string, padded with 0s to 8 places",
-                example: "'nushell.sh' | into binary --raw",
+                example: "'nushell.sh' | into binary --raw | str trim",
                 result: Some(Value::String {
                     val: "01101110 01110101 01110011 01101000 01100101 01101100 01101100 00101110 01110011 01101000".to_string(),
                     span: Span::test_data(),

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -43,7 +43,7 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "for a data structure input, convert data at the given cell paths",
             )
-            .switch("raw", "Convert to raw", Some('r'))
+            .switch("raw", "convert strings to raw binary", Some('r'))
             .category(Category::Conversions)
     }
 
@@ -145,7 +145,6 @@ fn into_binary(
             stdout: Some(stream),
             ..
         } => {
-            eprintln!("external stream");
             // TODO: in the future, we may want this to stream out, converting each to bytes
             let output = stream.into_bytes()?;
             Ok(Value::Binary {

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -116,7 +116,7 @@ impl Command for SubCommand {
                 description: "convert a string into a raw binary string, padded with 0s to 8 places",
                 example: "'nushell.sh' | into binary --raw",
                 result: Some(Value::String {
-                    val: "01101110 01110101 01110011 01101000 01100101 01101100 01101100 00101110 01110011 01101000 ".to_string(),
+                    val: "01101110 01110101 01110011 01101000 01100101 01101100 01101100 00101110 01110011 01101000".to_string(),
                     span: Span::test_data(),
                 }),
             },
@@ -200,7 +200,7 @@ pub fn action(input: &Value, args: &Arguments, span: Span) -> Value {
                     raw_string.push_str(&format!("{:08b} ", ch));
                 }
                 Value::String {
-                    val: raw_string,
+                    val: raw_string.trim().to_string(),
                     span,
                 }
             } else {

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -9,8 +9,8 @@ use nu_protocol::{
 
 pub struct Arguments {
     cell_paths: Option<Vec<CellPath>>,
-    raw: bool,
 }
+
 impl CmdArgument for Arguments {
     fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
         self.cell_paths.take()
@@ -35,7 +35,6 @@ impl Command for SubCommand {
                 (Type::Bool, Type::Binary),
                 (Type::Filesize, Type::Binary),
                 (Type::Date, Type::Binary),
-                (Type::String, Type::String),
             ])
             .allow_variants_without_examples(true) // TODO: supply exhaustive examples
             .rest(
@@ -43,7 +42,6 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "for a data structure input, convert data at the given cell paths",
             )
-            .switch("raw", "convert strings to raw binary", Some('r'))
             .category(Category::Conversions)
     }
 
@@ -112,14 +110,6 @@ impl Command for SubCommand {
                     span: Span::test_data(),
                 }),
             },
-            Example {
-                description: "convert a string into a raw binary string, padded with 0s to 8 places",
-                example: "'nushell.sh' | into binary --raw",
-                result: Some(Value::String {
-                    val: "01101110 01110101 01110011 01101000 01100101 01101100 01101100 00101110 01110011 01101000".to_string(),
-                    span: Span::test_data(),
-                }),
-            },
         ]
     }
 }
@@ -133,7 +123,6 @@ fn into_binary(
     let head = call.head;
     let cell_paths = call.rest(engine_state, stack, 0)?;
     let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
-    let raw: bool = call.has_flag("raw");
 
     match input {
         PipelineData::ExternalStream { stdout: None, .. } => Ok(Value::Binary {
@@ -154,7 +143,7 @@ fn into_binary(
             .into_pipeline_data())
         }
         _ => {
-            let args = Arguments { raw, cell_paths };
+            let args = Arguments { cell_paths };
             operate(action, args, input, call.head, engine_state.ctrlc.clone())
         }
     }
@@ -176,7 +165,7 @@ fn float_to_endian(n: f64) -> Vec<u8> {
     }
 }
 
-pub fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
     match input {
         Value::Binary { .. } => input.clone(),
         Value::Int { val, .. } => Value::Binary {
@@ -191,24 +180,10 @@ pub fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             val: int_to_endian(*val),
             span,
         },
-        Value::String { val, .. } => {
-            let raw_bytes = val.as_bytes();
-            if args.raw {
-                let mut raw_string = "".to_string();
-                for ch in raw_bytes {
-                    raw_string.push_str(&format!("{:08b} ", ch));
-                }
-                Value::String {
-                    val: raw_string.trim().to_string(),
-                    span,
-                }
-            } else {
-                Value::Binary {
-                    val: raw_bytes.to_vec(),
-                    span,
-                }
-            }
-        }
+        Value::String { val, .. } => Value::Binary {
+            val: val.as_bytes().to_vec(),
+            span,
+        },
         Value::Bool { val, .. } => Value::Binary {
             val: int_to_endian(i64::from(*val)),
             span,

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -114,9 +114,9 @@ impl Command for SubCommand {
             },
             Example {
                 description: "convert a string into a raw binary string, padded with 0s to 8 places",
-                example: "'nushell.sh' | into binary --raw | str trim",
+                example: "'nushell.sh' | into binary --raw",
                 result: Some(Value::String {
-                    val: "01101110 01110101 01110011 01101000 01100101 01101100 01101100 00101110 01110011 01101000".to_string(),
+                    val: "01101110 01110101 01110011 01101000 01100101 01101100 01101100 00101110 01110011 01101000 ".to_string(),
                     span: Span::test_data(),
                 }),
             },


### PR DESCRIPTION
# Description

This PR converts a string into a raw binary represented by a string of 0s and 1s padded to 8 digits with zeros.

This is useful for encoding data.
![image](https://github.com/nushell/nushell/assets/343840/66864c79-3da1-4007-a62b-306ed85f4df4)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
