### PR TITLE
fix the `std` test commands calls in dev documents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ Make sure you've run and fixed any issues with these commands:
 - `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
 - `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
 - `cargo test --workspace` to check that all tests pass
-- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library
+- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library
 
 > **Note**
 > from `nushell` you can also use the `toolkit` as follows

--- a/crates/nu-std/CONTRIBUTING.md
+++ b/crates/nu-std/CONTRIBUTING.md
@@ -204,7 +204,7 @@ More design guidelines:
 ### Useful Commands
 - Run all unit tests for the standard library:
   ```nushell
-  cargo run -- -c 'use std; NU_LOG_LEVEL=ERROR std run-tests'
+  cargo run -- -c 'use std testing; testing run-tests --path crates/nu-std'
   ```
   > **Note**  
   > this uses the debug version of NU interpreter from the same repo, which is
@@ -216,7 +216,7 @@ More design guidelines:
 - Run all tests for a specific test module, e.g,
   `crates/nu-std/tests/test_foo.nu`
   ```nushell
-  cargo run -- -c 'use std; NU_LOG_LEVEL=INFO std run-tests --module test_foo'
+  cargo run -- -c 'use std testing; testing run-tests --path crates/nu-std --module test_foo'
   ```
 - Run a custom command with additional logging (assuming you have instrumented
   the command with `log <level>`, as we recommend.)


### PR DESCRIPTION
related to a comment in https://github.com/nushell/nushell/pull/9500
> `cargo run -- crates/nu-std/tests/run.nu` Not done - doesn't seem to work

this is absolutely true because the command in the PR template was obsolete...
i've also updated the commands in the `CONTRIBUTING` document of the library :+1: 

cc/ @fnordpig 