### PR TITLE
update sqlparser dep to 0.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
  "num 0.4.0",
  "polars",
  "serde",
- "sqlparser 0.33.0",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2894,7 +2894,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "sha2",
- "sqlparser 0.33.0",
+ "sqlparser",
  "sysinfo",
  "tabled",
  "terminal_size 0.2.6",
@@ -3991,7 +3991,7 @@ dependencies = [
  "polars-plan",
  "serde",
  "serde_json",
- "sqlparser 0.34.0",
+ "sqlparser",
 ]
 
 [[package]]
@@ -4991,21 +4991,12 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355dc4d4b6207ca8a3434fc587db0a8016130a574dbcdbfb93d7f7b5bc5b211a"
-dependencies = [
- "log",
- "serde",
-]
-
-[[package]]
-name = "sqlparser"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3706eefb17039056234df6b566b0014f303f867f2656108334a55b8096f59"
 dependencies = [
  "log",
+ "serde",
 ]
 
 [[package]]

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -18,15 +18,12 @@ nu-parser = { path = "../nu-parser", version = "0.82.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.82.1" }
 
 # Potential dependencies for extras
-chrono = { version = "0.4", features = [
-	"std",
-	"unstable-locales",
-], default-features = false }
+chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
 fancy-regex = "0.11"
 indexmap = { version = "1.7", features = ["serde-1"] }
 num = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
-sqlparser = { version = "0.33", features = ["serde"], optional = true }
+sqlparser = { version = "0.34", features = ["serde"], optional = true }
 
 [dependencies.polars]
 features = [

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/sql_expr.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/sql_expr.rs
@@ -139,7 +139,7 @@ fn apply_window_spec(expr: Expr, window_type: &Option<WindowType>) -> Result<Exp
                 // Order by and Row range may not be supported at the moment
             }
             // TODO: make NamedWindow work
-            WindowType::NamedWindow(named) => {
+            WindowType::NamedWindow(_named) => {
                 return Err(PolarsError::ComputeError(
                     format!("Expression: {expr:?} was not supported in polars-sql yet!").into(),
                 ))

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/sql_expr.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/sql_expr.rs
@@ -3,7 +3,7 @@ use polars::prelude::{col, lit, DataType, Expr, LiteralValue, PolarsResult as Re
 
 use sqlparser::ast::{
     BinaryOperator as SQLBinaryOperator, DataType as SQLDataType, Expr as SqlExpr,
-    Function as SQLFunction, Value as SqlValue, WindowSpec,
+    Function as SQLFunction, Value as SqlValue, WindowType,
 };
 
 fn map_sql_polars_datatype(data_type: &SQLDataType) -> Result<DataType> {
@@ -125,18 +125,26 @@ pub fn parse_sql_expr(expr: &SqlExpr) -> Result<Expr> {
     })
 }
 
-fn apply_window_spec(expr: Expr, window_spec: &Option<WindowSpec>) -> Result<Expr> {
-    Ok(match &window_spec {
-        Some(window_spec) => {
-            // Process for simple window specification, partition by first
-            let partition_by = window_spec
-                .partition_by
-                .iter()
-                .map(parse_sql_expr)
-                .collect::<Result<Vec<_>>>()?;
-            expr.over(partition_by)
-            // Order by and Row range may not be supported at the moment
-        }
+fn apply_window_spec(expr: Expr, window_type: &Option<WindowType>) -> Result<Expr> {
+    Ok(match &window_type {
+        Some(wtype) => match wtype {
+            WindowType::WindowSpec(window_spec) => {
+                // Process for simple window specification, partition by first
+                let partition_by = window_spec
+                    .partition_by
+                    .iter()
+                    .map(parse_sql_expr)
+                    .collect::<Result<Vec<_>>>()?;
+                expr.over(partition_by)
+                // Order by and Row range may not be supported at the moment
+            }
+            // TODO: make NamedWindow work
+            WindowType::NamedWindow(named) => {
+                return Err(PolarsError::ComputeError(
+                    format!("Expression: {expr:?} was not supported in polars-sql yet!").into(),
+                ))
+            }
+        },
         None => expr,
     })
 }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.82.1"
 bench = false
 
 [dependencies]
+nu-ansi-term = "0.47.0"
 nu-cmd-base = { path = "../nu-cmd-base", version = "0.82.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
 nu-engine = { path = "../nu-engine", version = "0.82.1" }
@@ -26,15 +27,15 @@ nu-system = { path = "../nu-system", version = "0.82.1" }
 nu-table = { path = "../nu-table", version = "0.82.1" }
 nu-term-grid = { path = "../nu-term-grid", version = "0.82.1" }
 nu-utils = { path = "../nu-utils", version = "0.82.1" }
-nu-ansi-term = "0.47.0"
 
+Inflector = "0.11"
 alphanumeric-sort = "1.5"
 atty = "0.2"
 base64 = "0.21"
 byteorder = "1.4"
 bytesize = "1.2"
 calamine = "0.19"
-chrono = { version = "0.4", features = [ "std", "unstable-locales", ], default-features = false }
+chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
 chrono-humanize = "0.2"
 chrono-tz = "0.8"
 crossterm = "0.26"
@@ -50,7 +51,6 @@ fs_extra = "1.3"
 htmlescape = "0.3"
 indexmap = { version = "1.7", features = ["serde-1"] }
 indicatif = "0.17"
-Inflector = "0.11"
 is-root = "0.1"
 itertools = "0.10"
 log = "0.4"
@@ -59,6 +59,7 @@ md5 = { package = "md-5", version = "0.10" }
 miette = { version = "5.9", features = ["fancy-no-backtrace"] }
 mime = "0.3"
 mime_guess = "2.0"
+native-tls = "0.2"
 notify = "4.0"
 num = { version = "0.4", optional = true }
 num-format = { version = "0.4" }
@@ -83,15 +84,14 @@ serde_json = "1.0"
 serde_urlencoded = "0.7"
 serde_yaml = "0.9"
 sha2 = "0.10"
-sqlparser = { version = "0.33", features = ["serde"], optional = true }
+sqlparser = { version = "0.34", features = ["serde"], optional = true }
 sysinfo = "0.29"
 tabled = { version = "0.12.2", features = ["color"], default-features = false }
 terminal_size = "0.2"
 titlecase = "2.0"
 toml = "0.7"
 unicode-segmentation = "1.10"
-ureq = { version = "2.6", default-features = false, features = [ "json", "charset", "native-tls", "gzip", ] }
-native-tls = "0.2"
+ureq = { version = "2.6", default-features = false, features = ["charset", "gzip", "json", "native-tls"] }
 url = "2.2"
 uuid = { version = "1.3", features = ["v4"] }
 wax = { version = "0.5" }


### PR DESCRIPTION
# Description

This PR updates the sqlparser dep to 0.34.0.

closes #9525

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
