### PR TITLE
add input_output type to `input list` to return string

### DIFF
--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -39,10 +39,13 @@ impl Command for InputList {
 
     fn signature(&self) -> Signature {
         Signature::build("input list")
-            .input_output_types(vec![(
-                Type::List(Box::new(Type::Any)),
-                Type::List(Box::new(Type::Any)),
-            )])
+            .input_output_types(vec![
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Any)),
+                ),
+                (Type::List(Box::new(Type::Any)), Type::String),
+            ])
             .optional("prompt", SyntaxShape::String, "the prompt to display")
             .switch(
                 "multi",

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -44,7 +44,7 @@ impl Command for InputList {
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
-                (Type::List(Box::new(Type::Any)), Type::String),
+                (Type::List(Box::new(Type::String)), Type::String),
             ])
             .optional("prompt", SyntaxShape::String, "the prompt to display")
             .switch(


### PR DESCRIPTION
# Description

This PR fixes a bug that @amtoine found. It adds an input_output type so that `input list`'s signature supports `string` as an output.

## Before
![image](https://github.com/nushell/nushell/assets/343840/7ee2b672-9976-4c69-a9a2-686ddbd3a60d)
```
Signatures:
  list<any> | input list <string?> -> list<any>
```

## After
![image](https://github.com/nushell/nushell/assets/343840/f86747cf-a134-4bb0-b89c-2e28f590f3c3)
```
Signatures:
  list<any> | input list <string?> -> list<any>
  list<string> | input list <string?> -> <string>
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
