### PR TITLE
fix history clear crash

### DIFF
--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -46,7 +46,7 @@ impl Command for History {
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
 
-        // todo for sqlite history this command should be an alias to `open ~/.config/nushell/history.sqlite3 | get history`
+        // TODO: for sqlite history this command should be an alias to `open ~/.config/nushell/history.sqlite3 | get history`
         if let Some(config_path) = nu_path::config_dir() {
             let clear = call.has_flag("clear");
             let long = call.has_flag("long");

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -52,16 +52,11 @@ impl Command for History {
             let long = call.has_flag("long");
             let ctrlc = engine_state.ctrlc.clone();
 
-            let mut history_path = config_path;
-            history_path.push("nushell");
-            match engine_state.config.history_file_format {
-                HistoryFileFormat::Sqlite => {
-                    history_path.push("history.sqlite3");
-                }
-                HistoryFileFormat::PlainText => {
-                    history_path.push("history.txt");
-                }
-            }
+            let nushell_dir = config_path.join("nushell");
+            let history_path = nushell_dir.join(match engine_state.config.history_file_format {
+                HistoryFileFormat::Sqlite => "history.sqlite3",
+                HistoryFileFormat::PlainText => "history.txt",
+            });
 
             if clear {
                 let _ = std::fs::remove_file(history_path);

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -60,7 +60,10 @@ impl Command for History {
 
             if clear {
                 let _ = std::fs::remove_file(history_path);
-                // TODO: FIXME also clear the auxiliary files when using sqlite
+                if let HistoryFileFormat::Sqlite = engine_state.config.history_file_format {
+                    let _ = std::fs::remove_file(nushell_dir.join("history.sqlite3-shm"));
+                    let _ = std::fs::remove_file(nushell_dir.join("history.sqlite3-wal"));
+                }
                 return Ok(PipelineData::empty());
             }
             let history_reader: Option<Box<dyn ReedlineHistory>> =

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -6,8 +6,8 @@ use nu_protocol::{
         Operator, PathMember, PipelineElement, Redirection,
     },
     engine::{EngineState, ProfilingConfig, Stack},
-    DataSource, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, PipelineMetadata,
-    Range, ShellError, Span, Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
+    DataSource, HistoryFileFormat, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
+    PipelineMetadata, Range, ShellError, Span, Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
 use std::time::Instant;
 use std::{collections::HashMap, path::PathBuf};
@@ -1276,17 +1276,14 @@ pub fn eval_nu_variable(engine_state: &EngineState, span: Span) -> Result<Value,
     }
 
     cols.push("history-path".to_string());
-    if let Some(mut path) = nu_path::config_dir() {
-        path.push("nushell");
-        match engine_state.config.history_file_format {
-            nu_protocol::HistoryFileFormat::Sqlite => {
-                path.push("history.sqlite3");
-            }
-            nu_protocol::HistoryFileFormat::PlainText => {
-                path.push("history.txt");
-            }
-        }
-        let canon_hist_path = canonicalize_path(engine_state, &path);
+    if let Some(path) = nu_path::config_dir() {
+        let history_path =
+            path.join("nushell")
+                .join(match engine_state.config.history_file_format {
+                    HistoryFileFormat::Sqlite => "history.sqlite3",
+                    HistoryFileFormat::PlainText => "history.txt",
+                });
+        let canon_hist_path = canonicalize_path(engine_state, &history_path);
         vals.push(Value::String {
             val: canon_hist_path.to_string_lossy().to_string(),
             span,


### PR DESCRIPTION
should close #7991

# Description
- f879136af, 48300d9d2 and dc63b24bb are simply refactoring, to make things a bit simpler
- 3357f7a21 implements the real fix

# User-Facing Changes
`history --clear` should not crash the shell now with the SQLITE history.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```