### PR TITLE
Add useful example to `http options` documentation

### DIFF
--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -72,7 +72,7 @@ impl Command for SubCommand {
     }
 
     fn extra_usage(&self) -> &str {
-        "Performs HTTP OPTIONS operation."
+        "Performs an HTTP OPTIONS request. Most commonly used for making CORS preflight requests."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -97,18 +97,8 @@ impl Command for SubCommand {
                 result: None,
             },
             Example {
-                description: "Get options from example.com, with username and password",
-                example: "http options -u myuser -p mypass https://www.example.com",
-                result: None,
-            },
-            Example {
-                description: "Get options from example.com, with custom header",
-                example: "http options -H [my-header-key my-header-value] https://www.example.com",
-                result: None,
-            },
-            Example {
-                description: "Get options from example.com, with custom headers",
-                example: "http options -H [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                description: "Simulate a browser cross-origin preflight request from www.example.com to media.example.com",
+                example: "http options https://media.example.com/api/ -H [Origin https://www.example.com Access-Control-Request-Headers \"Content-Type, X-Custom-Header\" Access-Control-Request-Method GET]",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -97,6 +97,21 @@ impl Command for SubCommand {
                 result: None,
             },
             Example {
+                description: "Get options from example.com, with username and password",
+                example: "http options -u myuser -p mypass https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get options from example.com, with custom header",
+                example: "http options -H [my-header-key my-header-value] https://www.example.com",
+                result: None,
+            },
+            Example {
+                description: "Get options from example.com, with custom headers",
+                example: "http options -H [my-header-key-A my-header-value-A my-header-key-B my-header-value-B] https://www.example.com",
+                result: None,
+            },
+            Example {
                 description: "Simulate a browser cross-origin preflight request from www.example.com to media.example.com",
                 example: "http options https://media.example.com/api/ -H [Origin https://www.example.com Access-Control-Request-Headers \"Content-Type, X-Custom-Header\" Access-Control-Request-Method GET]",
                 result: None,


### PR DESCRIPTION
This PR adds a more real-world example of how the new http options is used, as well as some additional information in the description.