### PR TITLE
fix typo in deprecated message: `$nu` should be `$env`

### DIFF
--- a/crates/nu-command/src/deprecated/let_env.rs
+++ b/crates/nu-command/src/deprecated/let_env.rs
@@ -36,7 +36,7 @@ impl Command for LetEnvDeprecated {
     ) -> Result<PipelineData, ShellError> {
         Err(nu_protocol::ShellError::DeprecatedCommand(
             self.name().to_string(),
-            "$nu.<environment variable> = ...".to_owned(),
+            "$env.<environment variable> = ...".to_owned(),
             call.head,
         ))
     }


### PR DESCRIPTION
# Description

This PR fixes a small typeo where it has `$nu` and it should be `$env`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
