### PR TITLE
fixes `which` showing aliases as built-in nushell commands

### DIFF
--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -44,7 +44,6 @@ impl Command for Which {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        println!("run: call={:?}", call);
         which(engine_state, stack, call)
     }
 
@@ -76,7 +75,6 @@ fn entry(arg: impl Into<String>, path: impl Into<String>, builtin: bool, span: S
 
 fn get_entry_in_commands(engine_state: &EngineState, name: &str, span: Span) -> Option<Value> {
     if let Some(decl_id) = engine_state.find_decl(name.as_bytes(), &[]) {
-        println!("decl_id={}, decl={:?}, signatur={:?}", decl_id, engine_state.get_decl(decl_id).is_alias(), engine_state.get_decl(decl_id).signature());
         let (msg, is_builtin) = if engine_state.get_decl(decl_id).is_custom_command() {
             ("Nushell custom command", false)
         } else if engine_state.get_decl(decl_id).is_alias() {
@@ -84,7 +82,6 @@ fn get_entry_in_commands(engine_state: &EngineState, name: &str, span: Span) -> 
         } else {
             ("Nushell built-in command", true)
         };
-        println!("\tmsg={}, is_builtin{}", msg, is_builtin);
 
         trace!("Found command: {}", name);
 
@@ -108,7 +105,6 @@ fn get_entries_in_nu(
     }
 
     if let Some(ent) = get_entry_in_commands(engine_state, name, span) {
-        println!("\tget_entries_in_nu(engine_state, {}, span): ent={:?}", name, ent);
         all_entries.push(ent);
     }
 
@@ -232,7 +228,6 @@ fn which(
         applications: call.rest(engine_state, stack, 0)?,
         all: call.has_flag("all"),
     };
-    println!("\t{:?}", which_args);
     let ctrlc = engine_state.ctrlc.clone();
 
     if which_args.applications.is_empty() {
@@ -247,10 +242,7 @@ fn which(
     let cwd = env::current_dir_str(engine_state, stack)?;
     let paths = env::path_str(engine_state, stack, call.head)?;
 
-    println!("\tcwd={}\tpaths={}", cwd, paths);
-
     for app in which_args.applications {
-        println!("\tapp={:?}", &app);
         let values = which_single(
             app,
             which_args.all,
@@ -258,7 +250,6 @@ fn which(
             cwd.clone(),
             paths.clone(),
         );
-        println!("\t\tvalues:{:?}", values);
         output.extend(values);
     }
 

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -99,7 +99,6 @@ fn get_entries_in_nu(
 ) -> Vec<Value> {
     let mut all_entries = vec![];
 
-    // TODO: how can all_entries ever be non-empty here?
     if !all_entries.is_empty() && skip_after_first_found {
         return all_entries;
     }

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -25,10 +25,10 @@ fn which_alias_ls() {
 fn which_custom_alias() {
     let actual = nu!(
         cwd: ".", 
-        r#"alias foo = print "foo!"; which foo | get path.0 | str trim"#
+        r#"alias foo = print "foo!"; which foo | to nuon"#
     );
 
-    assert_eq!(actual.out, "Nushell alias");
+    assert_eq!(actual.out, "[[arg, path, built-in]; [foo, \"Nushell alias\", false]]");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -24,11 +24,14 @@ fn which_alias_ls() {
 #[test]
 fn which_custom_alias() {
     let actual = nu!(
-        cwd: ".", 
+        cwd: ".",
         r#"alias foo = print "foo!"; which foo | to nuon"#
     );
 
-    assert_eq!(actual.out, "[[arg, path, built-in]; [foo, \"Nushell alias\", false]]");
+    assert_eq!(
+        actual.out,
+        "[[arg, path, built-in]; [foo, \"Nushell alias\", false]]"
+    );
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -22,6 +22,16 @@ fn which_alias_ls() {
 }
 
 #[test]
+fn which_custom_alias() {
+    let actual = nu!(
+        cwd: ".", 
+        r#"alias foo = print "foo!"; which foo | get path.0 | str trim"#
+    );
+
+    assert_eq!(actual.out, "Nushell alias");
+}
+
+#[test]
 fn which_def_ls() {
     let actual = nu!(
         cwd: ".",

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -894,7 +894,6 @@ pub fn parse_alias(
                 }
             };
 
-            println!("new alias_name: {}", alias_name);
             let decl = Alias {
                 name: alias_name,
                 command,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -894,6 +894,7 @@ pub fn parse_alias(
                 }
             };
 
+            println!("new alias_name: {}", alias_name);
             let decl = Alias {
                 name: alias_name,
                 command,


### PR DESCRIPTION
fixes #8577 

# Description
Currently, using `which` on an alias describes it as a nushell built-in command:
```bash
> alias foo = print "foo!"                                                                                                                                                                                   > which ls foo --all                                                                                                                                                                                        
╭───┬─────┬──────────────────────────┬──────────╮
│ # │ arg │           path           │ built-in │
├───┼─────┼──────────────────────────┼──────────┤
│ 0 │ ls  │ Nushell built-in command │ true     │
│ 1 │ ls  │ /bin/ls                  │ false    │
│ 2 │ foo │ Nushell built-in command │ true     │
╰───┴─────┴──────────────────────────┴──────────╯
```

This PR fixes the behaviour above to the following:
```bash
> alias foo = print "foo!"
> which ls foo --all
╭───┬─────┬──────────────────────────┬──────────╮
│ # │ arg │           path           │ built-in │
├───┼─────┼──────────────────────────┼──────────┤
│ 0 │ ls  │ Nushell built-in command │ true     │
│ 1 │ ls  │ /bin/ls                  │ false    │
│ 2 │ foo │ Nushell alias            │ false    │
╰───┴─────┴──────────────────────────┴──────────╯
```

# User-Facing Changes
Passing in an alias to `which` will no longer return `Nushell built-in command`, `true` for `path` and `built-in` respectively. 

# Tests + Formatting

# After Submitting
