### PR TITLE
fix right prompt in the default_env.nu

### DIFF
--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -25,14 +25,13 @@ def create_left_prompt [] {
 }
 
 def create_right_prompt [] {
-    let time_segment_color = (ansi magenta)
-
+    # create a right prompt in magenta with green separators and am/pm underlined
     let time_segment = ([
         (ansi reset)
-        $time_segment_color
+        (ansi magenta)
         (date now | date format '%m/%d/%Y %r')
-    ] | str join | str replace --all "([/:])" $"(ansi light_magenta_bold)${1}($time_segment_color)" |
-        str replace --all "([AP]M)" $"(ansi light_magenta_underline)${1}")
+    ] | str join | str replace --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
+        str replace --all "([AP]M)" $"(ansi magenta_underline)${1}")
 
     let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
         (ansi rb)


### PR DESCRIPTION
# Description

## Before
![image](https://github.com/nushell/nushell/assets/343840/4618c7b9-693c-4658-80e7-991464b8032f)

## After
![image](https://github.com/nushell/nushell/assets/343840/81305e69-fe47-46d9-b573-d9d1992f5088)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
