### PR TITLE
make the behaviours of `last` and `first` more consistent

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -130,11 +130,25 @@ fn first_helper(
                 }
             }
             Value::Binary { val, span } => {
-                let slice: Vec<u8> = val.into_iter().take(rows_desired).collect();
-                Ok(PipelineData::Value(
-                    Value::Binary { val: slice, span },
-                    metadata,
-                ))
+                if return_single_element {
+                    if val.is_empty() {
+                        Err(ShellError::AccessEmptyContent { span: head })
+                    } else {
+                        Ok(PipelineData::Value(
+                            Value::Int {
+                                val: val[0] as i64,
+                                span,
+                            },
+                            metadata,
+                        ))
+                    }
+                } else {
+                    let slice: Vec<u8> = val.into_iter().take(rows_desired).collect();
+                    Ok(PipelineData::Value(
+                        Value::Binary { val: slice, span },
+                        metadata,
+                    ))
+                }
             }
             Value::Range { val, .. } => {
                 if return_single_element {

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -105,6 +105,13 @@ fn first_helper(
     let ctrlc = engine_state.ctrlc.clone();
     let metadata = input.metadata();
 
+    // early exit for `first 0`
+    if rows_desired == 0 {
+        return Ok(Vec::<Value>::new()
+            .into_pipeline_data(ctrlc)
+            .set_metadata(metadata));
+    }
+
     match input {
         PipelineData::Value(val, _) => match val {
             Value::List { vals, .. } => {

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -85,7 +85,7 @@ impl Command for Last {
         let head = call.head;
         let rows: Option<i64> = call.opt(engine_state, stack, 0)?;
 
-        // FIXME: Read the FIXME message in `first.rs`'s `first_helper` implementation.
+        // FIXME: Please read the FIXME message in `first.rs`'s `first_helper` implementation.
         // It has the same issue.
         let return_single_element = rows.is_none();
         let rows_desired: usize = match rows {

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -53,7 +53,7 @@ impl Command for Last {
         vec![
             Example {
                 example: "[1,2,3] | last 2",
-                description: "Get the last 2 items",
+                description: "Return the last 2 items of a list/table",
                 result: Some(Value::List {
                     vals: vec![Value::test_int(2), Value::test_int(3)],
                     span: Span::test_data(),
@@ -61,12 +61,12 @@ impl Command for Last {
             },
             Example {
                 example: "[1,2,3] | last",
-                description: "Get the last item",
+                description: "Return the last item of a list/table",
                 result: Some(Value::test_int(3)),
             },
             Example {
                 example: "0x[01 23 45] | last 2",
-                description: "Get the last 2 bytes",
+                description: "Return the last 2 bytes of a binary value",
                 result: Some(Value::Binary {
                     val: vec![0x23, 0x45],
                     span: Span::test_data(),

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -106,7 +106,7 @@ impl Command for Last {
 
         match input {
             PipelineData::ListStream(_, _) | PipelineData::Value(Value::Range { .. }, _) => {
-                let iterator = input.into_iter_strict(head).unwrap();
+                let iterator = input.into_iter_strict(head)?;
 
                 // only keep last `rows_desired` rows in memory
                 let mut buf = VecDeque::<_>::new();
@@ -132,10 +132,10 @@ impl Command for Last {
             PipelineData::Value(val, _) => match val {
                 Value::List { vals, .. } => {
                     if return_single_element {
-                        if vals.is_empty() {
-                            Err(ShellError::AccessEmptyContent { span: head })
+                        if let Some(v) = vals.last() {
+                            Ok(v.clone().into_pipeline_data())
                         } else {
-                            Ok(vals.last().unwrap().clone().into_pipeline_data())
+                            Err(ShellError::AccessEmptyContent { span: head })
                         }
                     } else {
                         Ok(vals

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -105,8 +105,7 @@ impl Command for Last {
         }
 
         match input {
-            PipelineData::ListStream(_, _)
-            | PipelineData::Value(Value::Range { .. }, _) => {
+            PipelineData::ListStream(_, _) | PipelineData::Value(Value::Range { .. }, _) => {
                 let iterator = input.into_iter_strict(head).unwrap();
 
                 // only keep last `rows_desired` rows in memory
@@ -121,7 +120,6 @@ impl Command for Last {
                 }
 
                 if return_single_element {
-
                     if let Some(last) = buf.pop_back() {
                         Ok(last.into_pipeline_data().set_metadata(metadata))
                     } else {
@@ -130,7 +128,7 @@ impl Command for Last {
                 } else {
                     Ok(buf.into_pipeline_data(ctrlc).set_metadata(metadata))
                 }
-            },
+            }
             PipelineData::Value(val, _) => match val {
                 Value::List { vals, .. } => {
                     if return_single_element {
@@ -150,12 +148,7 @@ impl Command for Last {
                     }
                 }
                 Value::Binary { val, span } => {
-                    let slice: Vec<u8> = val
-                        .into_iter()
-                        .rev()
-                        .take(rows_desired)
-                        .rev()
-                        .collect();
+                    let slice: Vec<u8> = val.into_iter().rev().take(rows_desired).rev().collect();
                     Ok(PipelineData::Value(
                         Value::Binary { val: slice, span },
                         metadata,
@@ -170,12 +163,14 @@ impl Command for Last {
                     src_span: other.expect_span(),
                 }),
             },
-            PipelineData::ExternalStream { span, .. } => Err(ShellError::OnlySupportsThisInputType {
-                exp_input_type: "list, binary or range".into(),
-                wrong_type: "raw data".into(),
-                dst_span: head,
-                src_span: span,
-            }),
+            PipelineData::ExternalStream { span, .. } => {
+                Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "list, binary or range".into(),
+                    wrong_type: "raw data".into(),
+                    dst_span: head,
+                    src_span: span,
+                })
+            }
             PipelineData::Empty => Err(ShellError::OnlySupportsThisInputType {
                 exp_input_type: "list, binary or range".into(),
                 wrong_type: "null".into(),

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -83,9 +83,18 @@ fn gets_first_row_as_list_when_amount_given() {
 fn gets_first_bytes() {
     let actual = nu!(pipeline(
         r#"
-            0x[aa bb]
-            | first 1
-            | into int
+            (0x[aa bb cc] | first 2) == 0x[aa bb]
+        "#
+    ));
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn gets_first_byte() {
+    let actual = nu!(pipeline(
+        r#"
+            0x[aa bb cc] | first
         "#
     ));
 

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -80,6 +80,18 @@ fn gets_first_row_as_list_when_amount_given() {
 }
 
 #[test]
+fn gets_first_bytes() {
+    let actual = nu!(pipeline(
+        r#"
+            0x[aa bb]
+            | first 1
+        "#
+    ));
+
+    assert!(actual.out.contains("aa"));
+}
+
+#[test]
 // covers a situation where `first` used to behave strangely on list<binary> input
 fn works_with_binary_list() {
     let actual = nu!("([0x[01 11]] | first) == 0x[01 11]");
@@ -97,4 +109,16 @@ fn errors_on_negative_rows() {
     ));
 
     assert!(actual.err.contains("use a positive value"));
+}
+
+#[test]
+fn errors_on_empty_list_when_no_rows_given() {
+    let actual = nu!(pipeline(
+        r#"
+            []
+            | first
+        "#
+    ));
+
+    assert!(actual.err.contains("index too large"));
 }

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -85,10 +85,11 @@ fn gets_first_bytes() {
         r#"
             0x[aa bb]
             | first 1
+            | into int
         "#
     ));
 
-    assert!(actual.out.contains("aa"));
+    assert_eq!(actual.out, "170");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -83,13 +83,22 @@ fn gets_last_row_as_list_when_amount_given() {
 fn gets_last_bytes() {
     let actual = nu!(pipeline(
         r#"
-            0x[aa bb]
-            | last 1
-            | into int
+            (0x[aa bb cc] | last 2) == 0x[bb cc]
         "#
     ));
 
-    assert_eq!(actual.out, "187");
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn gets_last_byte() {
+    let actual = nu!(pipeline(
+        r#"
+            0x[aa bb cc] | last
+        "#
+    ));
+
+    assert_eq!(actual.out, "204");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -85,10 +85,11 @@ fn gets_last_bytes() {
         r#"
             0x[aa bb]
             | last 1
+            | into int
         "#
     ));
 
-    assert!(actual.out.contains("bb"));
+    assert_eq!(actual.out, "187");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -80,6 +80,18 @@ fn gets_last_row_as_list_when_amount_given() {
 }
 
 #[test]
+fn gets_last_bytes() {
+    let actual = nu!(pipeline(
+        r#"
+            0x[aa bb]
+            | last 1
+        "#
+    ));
+
+    assert!(actual.out.contains("bb"));
+}
+
+#[test]
 fn last_errors_on_negative_index() {
     let actual = nu!(pipeline(
         "
@@ -96,4 +108,16 @@ fn fail_on_non_iterator() {
     let actual = nu!("1 | last");
 
     assert!(actual.err.contains("only_supports_this_input_type"));
+}
+
+#[test]
+fn errors_on_empty_list_when_no_rows_given() {
+    let actual = nu!(pipeline(
+        r#"
+            []
+            | last
+        "#
+    ));
+
+    assert!(actual.err.contains("index too large"));
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

- fixes #9567 

I have fixed everything mentioned in the issue, and made their help messages more similar.

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

- Previously, `last` on binary data returned an integer. Now it returns a binary
- Now, `[] | last` and `[] | first` are both errors.
- Now, `ls | table | first` and `ls | table | last` are both errors.

