### PR TITLE
use an easier-to-read date format in prompt

### DIFF
--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -29,7 +29,7 @@ def create_right_prompt [] {
     let time_segment = ([
         (ansi reset)
         (ansi magenta)
-        (date now | date format '%m/%d/%Y %r')
+        (date now | date format '%Y/%m/%d %r')
     ] | str join | str replace --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
         str replace --all "([AP]M)" $"(ansi magenta_underline)${1}")
 


### PR DESCRIPTION
# Description

Switches the right prompt to use an easier-to-read date format (YYYY-MM-DD)

It's currently using (MM-DD-YYYY) which is only used in a few countries but it is unfortunately ambiguous with countries that use (DD-MM-YYYY) format (most countries). While YYYY-MM-DD is used in fewer countries than DD-MM-YYYY it's at least unambiguous to MM-DD-YYYY countries.

More info: https://en.wikipedia.org/wiki/Date_format_by_country

Alternatively, we could spell out the month name (even abbreviated) to make it clear as well.

# User-Facing Changes

Just changes the date in the default right prompt

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
