### PR TITLE
disallow blocks as first-class values

### DIFF
--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -43,3 +43,19 @@ fn date_plus_duration() -> TestResult {
     let expected = "2023-04-20";
     run_test(input, expected)
 }
+
+#[test]
+fn block_not_first_class_def() -> TestResult {
+    fail_test(
+        "def foo [x: block] { do $x }",
+        "Blocks are not support as first-class values",
+    )
+}
+
+#[test]
+fn block_not_first_class_let() -> TestResult {
+    fail_test(
+        "let x: block = { 3 }",
+        "Blocks are not support as first-class values",
+    )
+}


### PR DESCRIPTION
# Description

This PR disallows blocks as first-class values by removing the ability to create them using the `block` syntax shape or type. Now, the parser will only ever be able to create closures as first-class values.

This means that `{ 3 }` will always be treated as a closure, unless used in the specifically supported use case of the literal being given as an arg to `for`, `if` and other built-in block users.

Note: first-class value here means "value that can be passed into commands and held in variables"

# User-Facing Changes

This may break some user scripts as `: block` is no longer allows as a type annotation. Note: these cases were not actually supported before, as, for example, passing a block that accessed a variable would have errored when the block was later evaluated.

Closures do not have the restriction mentioned above and are the much safer value to pass as first-class, so now they are the only block-like value to be allowed to be passed.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
