### PR TITLE
renames the $in variable to $pipe

### DIFF
--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -43,7 +43,7 @@ impl Completer for VariableCompletion {
         options: &CompletionOptions,
     ) -> Vec<Suggestion> {
         let mut output = vec![];
-        let builtins = ["$nu", "$in", "$env", "$nothing"];
+        let builtins = ["$nu", "$pipe", "$env", "$nothing"];
         let var_str = std::str::from_utf8(&self.var_context.0)
             .unwrap_or("")
             .to_lowercase();

--- a/crates/nu-cmd-lang/src/core_commands/collect.rs
+++ b/crates/nu-cmd-lang/src/core_commands/collect.rs
@@ -69,7 +69,7 @@ impl Command for Collect {
 
         if call.has_flag("keep-env") {
             redirect_env(engine_state, stack, &stack_captures);
-            // for when we support `data | let x = $in;`
+            // for when we support `data | let x = $pipe;`
             // remove the variables added earlier
             for var_id in capture_block.captures.keys() {
                 stack_captures.remove_var(*var_id);

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -292,7 +292,7 @@ impl Command for Do {
             },
             Example {
                 description: "Run the closure, with input",
-                example: r#"77 | do {|x| 100 + $in }"#,
+                example: r#"77 | do {|x| 100 + $pipe }"#,
                 result: None, // TODO: returns 177
             },
         ]

--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -68,8 +68,8 @@ little reason to use this over just writing the values as-is."#
             },
             Example {
                 description:
-                    "Returns the piped-in value, by using the special $in variable to obtain it.",
-                example: "echo $in",
+                    "Returns the piped-in value, by using the special $pipe variable to obtain it.",
+                example: "echo $pipe",
                 result: None,
             },
         ]

--- a/crates/nu-cmd-lang/src/core_commands/match_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/match_.rs
@@ -104,7 +104,7 @@ impl Command for Match {
             },
             Example {
                 description: "Match against pipeline input",
-                example: "{a: {b: 3}} | match $in {{a: { $b }} => ($b + 10) }",
+                example: "{a: {b: 3}} | match $pipe {{a: { $b }} => ($b + 10) }",
                 result: Some(Value::test_int(13)),
             },
         ]

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -112,7 +112,7 @@ fn handle_catch(
             engine_state,
             stack,
             catch_block,
-            // Make the error accessible with $in, too
+            // Make the error accessible with $pipe, too
             err_value.into_pipeline_data(),
             false,
             false,

--- a/crates/nu-command/src/debug/timeit.rs
+++ b/crates/nu-command/src/debug/timeit.rs
@@ -129,7 +129,7 @@ fn test_time_block_2() {
     use nu_test_support::{nu, nu_repl_code, playground::Playground};
     Playground::setup("test_time_block", |dirs, _| {
         let inp = [
-            r#"[2 3 4] | timeit {{result: $in} | to nuon | save foo.txt }"#,
+            r#"[2 3 4] | timeit {{result: $pipe} | to nuon | save foo.txt }"#,
             "open foo.txt",
         ];
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(&inp));

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -315,7 +315,8 @@ impl Command for Ls {
             },
             Example {
                 description: "List given paths and show directories themselves",
-                example: "['/path/to/directory' '/path/to/file'] | each {|| ls -D $in } | flatten",
+                example:
+                    "['/path/to/directory' '/path/to/file'] | each {|| ls -D $pipe } | flatten",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -120,7 +120,7 @@ impl Command for Rm {
         });
         examples.push(Example {
             description: "Delete all 0KB files in the current directory",
-            example: "ls | where size == 0KB and type == file | each { rm $in.name } | null",
+            example: "ls | where size == 0KB and type == file | each { rm $pipe.name } | null",
             result: None,
         });
         examples

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -45,7 +45,7 @@ impl Command for All {
             },
             Example {
                 description: "Check that each item is a string",
-                example: "[foo bar 2 baz] | all {|| ($in | describe) == 'string' }",
+                example: "[foo bar 2 baz] | all {|| ($pipe | describe) == 'string' }",
                 result: Some(Value::test_bool(false)),
             },
             Example {

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -45,7 +45,7 @@ impl Command for Any {
             },
             Example {
                 description: "Check that any item is a string",
-                example: "[1 2 3 4] | any {|| ($in | describe) == 'string' }",
+                example: "[1 2 3 4] | any {|| ($pipe | describe) == 'string' }",
                 result: Some(Value::test_bool(false)),
             },
             Example {

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -228,7 +228,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
             // See https://github.com/nushell/nushell/issues/7034
             // Example {
             //     description: "List all numbers above 3, using an existing closure condition",
-            //     example: "let a = {$in > 3}; [1, 2, 5, 6] | filter $a",
+            //     example: "let a = {$pipe > 3}; [1, 2, 5, 6] | filter $a",
             //     result: Some(Value::List {
             //         vals: vec![
             //             Value::Int {

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -116,7 +116,7 @@ If multiple cell paths are given, this will produce a list of values."#
             },
             Example {
                 description:
-                    "Extract the name of the 3rd record in a list (same as `ls | $in.name`)",
+                    "Extract the name of the 3rd record in a list (same as `ls | $pipe.name`)",
                 example: "ls | get name.2",
                 result: None,
             },

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -47,7 +47,7 @@ impl Command for ParEach {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[1 2 3] | par-each {|| 2 * $in }",
+                example: "[1 2 3] | par-each {|| 2 * $pipe }",
                 description:
                     "Multiplies each number. Note that the list will become arbitrarily disordered.",
                 result: None,

--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -77,7 +77,7 @@ impl Command for Zip {
                 }),
             },
             Example {
-                example: "glob *.ogg | zip ['bang.ogg', 'fanfare.ogg', 'laser.ogg'] | each {|| mv $in.0 $in.1 }",
+                example: "glob *.ogg | zip ['bang.ogg', 'fanfare.ogg', 'laser.ogg'] | each {|| mv $pipe.0 $pipe.1 }",
                 description: "Rename .ogg files to match an existing list of filenames",
                 result: None,
             },

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -60,7 +60,7 @@ impl Command for Tutor {
             },
             Example {
                 description: "Search a tutorial by phrase",
-                example: "tutor -f \"$in\"",
+                example: "tutor -f \"$pipe\"",
                 result: None,
             },
         ]
@@ -351,7 +351,7 @@ $x
 Nushell also comes with built-in variables. The `$nu` variable is a reserved
 variable that contains a lot of information about the currently running
 instance of Nushell. The `$it` variable is the name given to block parameters
-if you don't specify one. And `$in` is the variable that allows you to work
+if you don't specify one. And `$pipe` is the variable that allows you to work
 with all of the data coming in from the pipeline in one place.
 
 "#

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -187,7 +187,7 @@ impl Command for Kill {
         vec![
             Example {
                 description: "Kill the pid using the most memory",
-                example: "ps | sort-by mem | last | kill $in.pid",
+                example: "ps | sort-by mem | last | kill $pipe.pid",
                 result: None,
             },
             Example {

--- a/crates/nu-command/tests/commands/all.rs
+++ b/crates/nu-command/tests/commands/all.rs
@@ -67,7 +67,7 @@ fn works_with_1_param_blocks() {
 
 #[test]
 fn works_with_0_param_blocks() {
-    let actual = nu!("[1 2 3] | all {|| print $in | true }");
+    let actual = nu!("[1 2 3] | all {|| print $pipe | true }");
 
     assert_eq!(actual.out, "123true");
 }
@@ -81,7 +81,7 @@ fn early_exits_with_1_param_blocks() {
 
 #[test]
 fn early_exits_with_0_param_blocks() {
-    let actual = nu!("[1 2 3] | all {|| print $in | false }");
+    let actual = nu!("[1 2 3] | all {|| print $pipe | false }");
 
     assert_eq!(actual.out, "1false");
 }

--- a/crates/nu-command/tests/commands/any.rs
+++ b/crates/nu-command/tests/commands/any.rs
@@ -53,7 +53,7 @@ fn works_with_1_param_blocks() {
 
 #[test]
 fn works_with_0_param_blocks() {
-    let actual = nu!("[1 2 3] | any {|| print $in | false }");
+    let actual = nu!("[1 2 3] | any {|| print $pipe | false }");
 
     assert_eq!(actual.out, "123false");
 }
@@ -67,7 +67,7 @@ fn early_exits_with_1_param_blocks() {
 
 #[test]
 fn early_exits_with_0_param_blocks() {
-    let actual = nu!("[1 2 3] | any {|| print $in | true }");
+    let actual = nu!("[1 2 3] | any {|| print $pipe | true }");
 
     assert_eq!(actual.out, "1true");
 }

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -9,7 +9,7 @@ fn cd_works_with_in_var() {
         let actual = nu!(
             cwd: dirs.root(),
             r#"
-                "cd_test_1" | cd $in; $env.PWD | path split | last
+                "cd_test_1" | cd $pipe; $env.PWD | path split | last
             "#
         );
 

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -523,7 +523,7 @@ fn copy_ignores_ansi_impl(progress: bool) {
 
         let actual = nu!(
             cwd: sandbox.cwd(),
-            "ls | find test | get name | cp {} $in.0 success.txt; ls | find success | get name | ansi strip | get 0",
+            "ls | find test | get name | cp {} $pipe.0 success.txt; ls | find success | get name | ansi strip | get 0",
             progress_flag,
         );
         assert_eq!(actual.out, "success.txt");

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -548,7 +548,7 @@ fn list_ignores_ansi() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                ls | find .txt | each {|| ls $in.name } 
+                ls | find .txt | each {|| ls $pipe.name } 
             "#
         ));
 

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -381,7 +381,7 @@ fn mv_ignores_ansi() {
         let actual = nu!(
              cwd: sandbox.cwd(),
             r#"
-                 ls | find test | mv $in.0.name success.txt; ls | $in.0.name
+                 ls | find test | mv $pipe.0.name success.txt; ls | $pipe.0.name
             "#
         );
 

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -75,7 +75,7 @@ fn http_get_with_accept_errors_and_full_raw_response() {
     let actual = nu!(pipeline(
         format!(
             r#"
-        http get -e -f {url} | $"($in.status) => ($in.body)"
+        http get -e -f {url} | $"($pipe.status) => ($pipe.body)"
         "#,
             url = server.url()
         )
@@ -103,7 +103,7 @@ fn http_get_with_accept_errors_and_full_json_response() {
     let actual = nu!(pipeline(
         format!(
             r#"
-        http get -e -f {url} | $"($in.status) => ($in.body.msg)"
+        http get -e -f {url} | $"($pipe.status) => ($pipe.body.msg)"
         "#,
             url = server.url()
         )

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -374,10 +374,10 @@ fn parse_script_success_with_complex_internal_stream() {
                   #open file.txt | grep-nu search
                 ] {
                   if ($entrada | is-empty) {
-                    if ($in | column? name) {
-                      grep -ihHn $search ($in | get name)
+                    if ($pipe | column? name) {
+                      grep -ihHn $search ($pipe | get name)
                     } else {
-                      ($in | into string) | grep -ihHn $search
+                      ($pipe | into string) | grep -ihHn $search
                     }
                   } else {
                       grep -ihHn $search $entrada
@@ -423,10 +423,10 @@ fn parse_script_failure_with_complex_internal_stream() {
                   #open file.txt | grep-nu search
                 ]
                   if ($entrada | is-empty) {
-                    if ($in | column? name) {
-                      grep -ihHn $search ($in | get name)
+                    if ($pipe | column? name) {
+                      grep -ihHn $search ($pipe | get name)
                     } else {
-                      ($in | into string) | grep -ihHn $search
+                      ($pipe | into string) | grep -ihHn $search
                     }
                   } else {
                       grep -ihHn $search $entrada
@@ -472,10 +472,10 @@ fn parse_script_success_with_complex_external_stream() {
                   #open file.txt | grep-nu search
                 ] {
                   if ($entrada | is-empty) {
-                    if ($in | column? name) {
-                      grep -ihHn $search ($in | get name)
+                    if ($pipe | column? name) {
+                      grep -ihHn $search ($pipe | get name)
                     } else {
-                      ($in | into string) | grep -ihHn $search
+                      ($pipe | into string) | grep -ihHn $search
                     }
                   } else {
                       grep -ihHn $search $entrada
@@ -521,10 +521,10 @@ fn parse_module_success_with_complex_external_stream() {
                   #open file.txt | grep-nu search
                 ] {
                   if ($entrada | is-empty) {
-                    if ($in | column? name) {
-                      grep -ihHn $search ($in | get name)
+                    if ($pipe | column? name) {
+                      grep -ihHn $search ($pipe | get name)
                     } else {
-                      ($in | into string) | grep -ihHn $search
+                      ($pipe | into string) | grep -ihHn $search
                     }
                   } else {
                       grep -ihHn $search $entrada
@@ -570,10 +570,10 @@ fn parse_with_flag_all_success_for_complex_external_stream() {
                   #open file.txt | grep-nu search
                 ] {
                   if ($entrada | is-empty) {
-                    if ($in | column? name) {
-                      grep -ihHn $search ($in | get name)
+                    if ($pipe | column? name) {
+                      grep -ihHn $search ($pipe | get name)
                     } else {
-                      ($in | into string) | grep -ihHn $search
+                      ($pipe | into string) | grep -ihHn $search
                     }
                   } else {
                       grep -ihHn $search $entrada
@@ -619,10 +619,10 @@ fn parse_with_flag_all_failure_for_complex_external_stream() {
                   #open file.txt | grep-nu search
                 ] {
                   if ($entrada | is-empty) {
-                    if ($in | column? name) {
-                      grep -ihHn $search ($in | get name)
+                    if ($pipe | column? name) {
+                      grep -ihHn $search ($pipe | get name)
                     } else {
-                      ($in | into string) | grep -ihHn $search
+                      ($pipe | into string) | grep -ihHn $search
                     }
                   } else {
                       grep -ihHn $search $entrada
@@ -668,10 +668,10 @@ fn parse_with_flag_all_failure_for_complex_list_stream() {
                   #open file.txt | grep-nu search
                 ] {
                   if ($entrada | is-empty) {
-                    if ($in | column? name) {
-                      grep -ihHn $search ($in | get name)
+                    if ($pipe | column? name) {
+                      grep -ihHn $search ($pipe | get name)
                     } else {
-                      ($in | into string) | grep -ihHn $search
+                      ($pipe | into string) | grep -ihHn $search
                     }
                   } else {
                       grep -ihHn $search $entrada

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -281,7 +281,7 @@ fn open_ignore_ansi() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                ls | find nu.zion | get 0 | get name | open $in
+                ls | find nu.zion | get 0 | get name | open $pipe
             "#
         ));
 

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -346,7 +346,7 @@ fn remove_ignores_ansi() {
 
         let actual = nu!(
             cwd: sandbox.cwd(),
-            "ls | find test | get name | rm $in.0; ls | is-empty",
+            "ls | find test | get name | rm $pipe.0; ls | is-empty",
         );
         assert_eq!(actual.out, "true");
     });

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -138,7 +138,7 @@ fn from_int_decimal_trim_trailing_zeros() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        1.00000 | into string | $"($in) flat"
+        1.00000 | into string | $"($pipe) flat"
         "#
     ));
 

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -34,7 +34,7 @@ fn catch_can_access_error() {
 fn catch_can_access_error_as_dollar_in() {
     let output = nu!(
         cwd: ".",
-        "try { foobarbaz } catch { $in | get raw }"
+        "try { foobarbaz } catch { $pipe | get raw }"
     );
 
     assert!(output.err.contains("External command failed"));

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -32,7 +32,7 @@ fn where_inside_block_works() {
 
 #[test]
 fn filters_with_0_arity_block() {
-    let actual = nu!("[1 2 3 4] | where {|| $in < 3 } | to nuon");
+    let actual = nu!("[1 2 3 4] | where {|| $pipe < 3 } | to nuon");
 
     assert_eq!(actual.out, "[1, 2]");
 }

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -8,7 +8,7 @@ fn to_nuon_correct_compaction() {
             open appveyor.yml 
             | to nuon 
             | str length 
-            | $in > 500
+            | $pipe > 500
         "#
     ));
 
@@ -23,7 +23,7 @@ fn to_nuon_list_of_numbers() {
             [1, 2, 3, 4]
             | to nuon
             | from nuon
-            | $in == [1, 2, 3, 4]
+            | $pipe == [1, 2, 3, 4]
         "#
     ));
 
@@ -38,7 +38,7 @@ fn to_nuon_list_of_strings() {
             [abc, xyz, def]
             | to nuon
             | from nuon
-            | $in == [abc, xyz, def]
+            | $pipe == [abc, xyz, def]
         "#
     ));
 
@@ -53,7 +53,7 @@ fn to_nuon_table() {
             [[my, columns]; [abc, xyz], [def, ijk]]
             | to nuon
             | from nuon
-            | $in == [[my, columns]; [abc, xyz], [def, ijk]]
+            | $pipe == [[my, columns]; [abc, xyz], [def, ijk]]
         "#
     ));
 
@@ -110,7 +110,7 @@ fn to_nuon_escaping3() {
             ["hello\\world"]
             | to nuon
             | from nuon
-            | $in == [hello\world]
+            | $pipe == [hello\world]
         "#
     ));
 
@@ -125,7 +125,7 @@ fn to_nuon_escaping4() {
             ["hello\"world"]
             | to nuon
             | from nuon
-            | $in == ["hello\"world"]
+            | $pipe == ["hello\"world"]
         "#
     ));
 
@@ -140,7 +140,7 @@ fn to_nuon_escaping5() {
             {s: "hello\"world"}
             | to nuon
             | from nuon
-            | $in == {s: "hello\"world"}
+            | $pipe == {s: "hello\"world"}
         "#
     ));
 
@@ -169,7 +169,7 @@ fn to_nuon_records() {
             {name: "foo bar", age: 100, height: 10}
             | to nuon
             | from nuon
-            | $in == {name: "foo bar", age: 100, height: 10}
+            | $pipe == {name: "foo bar", age: 100, height: 10}
         "#
     ));
 
@@ -350,7 +350,7 @@ fn read_bool() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         r#"
-            open sample.nuon | get 3 | $in == true
+            open sample.nuon | get 3 | $pipe == true
         "#
     ));
 
@@ -433,7 +433,7 @@ fn to_nuon_quotes_empty_string_in_list() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
             r#"
-    let test = [""]; $test | to nuon | from nuon | $in == [""]
+    let test = [""]; $test | to nuon | from nuon | $pipe == [""]
     "#
     ));
     assert!(actual.err.is_empty());

--- a/crates/nu-command/tests/format_conversions/toml.rs
+++ b/crates/nu-command/tests/format_conversions/toml.rs
@@ -8,7 +8,7 @@ fn record_map_to_toml() {
             {a: 1 b: 2 c: 'qwe'} 
             | to toml
             | from toml
-            | $in == {a: 1 b: 2 c: 'qwe'}
+            | $pipe == {a: 1 b: 2 c: 'qwe'}
         "#
     ));
 
@@ -23,7 +23,7 @@ fn nested_records_to_toml() {
             {a: {a: a b: b} c: 1} 
             | to toml
             | from toml
-            | $in == {a: {a: a b: b} c: 1}
+            | $pipe == {a: {a: a b: b} c: 1}
         "#
     ));
 
@@ -38,7 +38,7 @@ fn records_with_tables_to_toml() {
             {a: [[a b]; [1 2] [3 4]] b: [[c d e]; [1 2 3]]}
             | to toml
             | from toml
-            | $in == {a: [[a b]; [1 2] [3 4]] b: [[c d e]; [1 2 3]]}
+            | $pipe == {a: [[a b]; [1 2] [3 4]] b: [[c d e]; [1 2 3]]}
         "#
     ));
 
@@ -53,7 +53,7 @@ fn nested_tables_to_toml() {
             {c: [[f g]; [[[h k]; [1 2] [3 4]] 1]]}
             | to toml
             | from toml
-            | $in == {c: [[f g]; [[[h k]; [1 2] [3 4]] 1]]}
+            | $pipe == {c: [[f g]; [[[h k]; [1 2] [3 4]] 1]]}
         "#
     ));
 

--- a/crates/nu-protocol/src/ast/pipeline.rs
+++ b/crates/nu-protocol/src/ast/pipeline.rs
@@ -68,7 +68,7 @@ impl PipelineElement {
             },
         }
     }
-    pub fn has_in_variable(&self, working_set: &StateWorkingSet) -> bool {
+    pub fn has_pipe_variable(&self, working_set: &StateWorkingSet) -> bool {
         match self {
             PipelineElement::Expression(_, expression)
             | PipelineElement::Redirection(_, _, expression)
@@ -77,15 +77,15 @@ impl PipelineElement {
             | PipelineElement::SameTargetRedirection {
                 cmd: (_, expression),
                 ..
-            } => expression.has_in_variable(working_set),
+            } => expression.has_pipe_variable(working_set),
             PipelineElement::SeparateRedirection {
                 out: (_, out_expr),
                 err: (_, err_expr),
-            } => out_expr.has_in_variable(working_set) || err_expr.has_in_variable(working_set),
+            } => out_expr.has_pipe_variable(working_set) || err_expr.has_pipe_variable(working_set),
         }
     }
 
-    pub fn replace_in_variable(&mut self, working_set: &mut StateWorkingSet, new_var_id: VarId) {
+    pub fn replace_pipe_variable(&mut self, working_set: &mut StateWorkingSet, new_var_id: VarId) {
         match self {
             PipelineElement::Expression(_, expression)
             | PipelineElement::Redirection(_, _, expression)
@@ -94,16 +94,16 @@ impl PipelineElement {
             | PipelineElement::SameTargetRedirection {
                 cmd: (_, expression),
                 ..
-            } => expression.replace_in_variable(working_set, new_var_id),
+            } => expression.replace_pipe_variable(working_set, new_var_id),
             PipelineElement::SeparateRedirection {
                 out: (_, out_expr),
                 err: (_, err_expr),
             } => {
-                if out_expr.has_in_variable(working_set) {
-                    out_expr.replace_in_variable(working_set, new_var_id)
+                if out_expr.has_pipe_variable(working_set) {
+                    out_expr.replace_pipe_variable(working_set, new_var_id)
                 }
-                if err_expr.has_in_variable(working_set) {
-                    err_expr.replace_in_variable(working_set, new_var_id)
+                if err_expr.has_pipe_variable(working_set) {
+                    err_expr.replace_pipe_variable(working_set, new_var_id)
                 }
             }
         }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -144,7 +144,7 @@ pub struct EngineState {
 const REGEX_CACHE_SIZE: usize = 100; // must be nonzero, otherwise will panic
 
 pub const NU_VARIABLE_ID: usize = 0;
-pub const IN_VARIABLE_ID: usize = 1;
+pub const PIPE_VARIABLE_ID: usize = 1;
 pub const ENV_VARIABLE_ID: usize = 2;
 // NOTE: If you add more to this list, make sure to update the > checks based on the last in the list
 

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -26,7 +26,7 @@ pub use alias::*;
 pub use cli_error::*;
 pub use config::*;
 pub use did_you_mean::did_you_mean;
-pub use engine::{ENV_VARIABLE_ID, IN_VARIABLE_ID, NU_VARIABLE_ID};
+pub use engine::{ENV_VARIABLE_ID, NU_VARIABLE_ID, PIPE_VARIABLE_ID};
 pub use example::*;
 pub use exportable::*;
 pub use id::*;

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3767,7 +3767,7 @@ pub fn format_filesize(
 
 fn get_filesize_format(format_value: &str, filesize_metric: Option<bool>) -> (ByteUnit, &str) {
     macro_rules! either {
-        ($in:ident, $metric:ident, $binary:ident) => {
+        ($pipe:ident, $metric:ident, $binary:ident) => {
             (
                 // filesize_metric always overrides the unit of
                 // filesize_format.
@@ -3775,7 +3775,7 @@ fn get_filesize_format(format_value: &str, filesize_metric: Option<bool>) -> (By
                     Some(true) => byte_unit::ByteUnit::$metric,
                     Some(false) => byte_unit::ByteUnit::$binary,
                     None => {
-                        if $in.ends_with("ib") {
+                        if $pipe.ends_with("ib") {
                             byte_unit::ByteUnit::$binary
                         } else {
                             byte_unit::ByteUnit::$metric

--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -1,5 +1,5 @@
 def error-fmt [] {
-    $"(ansi red)($in)(ansi reset)"
+    $"(ansi red)($pipe)(ansi reset)"
 }
 
 def throw-error [error: string, msg: string, span: record] {
@@ -702,7 +702,7 @@ export def commands [
 }
 
 def pretty-cmd [] {
-    let cmd = $in
+    let cmd = $pipe
     $"(ansi default_dimmed)(ansi default_italic)($cmd)(ansi reset)"
 }
 

--- a/crates/nu-std/std/iter.nu
+++ b/crates/nu-std/std/iter.nu
@@ -92,7 +92,7 @@ export def intersperse [ # -> list<any>
     reduce -f [] {|it, acc|
          $acc ++ [$it, $separator]
     } 
-    | match $in {
+    | match $pipe {
          [] => [],
          $xs => ($xs | take (($xs | length) - 1 ))
     }
@@ -126,15 +126,15 @@ export def scan [ # -> list<any>
         $acc ++ [(do $fn ($acc | last) $it)]
     }
     | if $noinit {
-        $in | skip
+        $pipe | skip
     } else {
-        $in
+        $pipe
     }
 }
 
 # Returns a list of values for which the supplied closure does not
 # return `null` or an error. It is equivalent to 
-#     `$in | each $fn | filter $fn`
+#     `$pipe | each $fn | filter $fn`
 #
 # # Example
 # ```nu

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -82,7 +82,7 @@ export def-env "path add" [
 
 # print a command name as dimmed and italic
 def pretty-command [] {
-    let command = $in
+    let command = $pipe
     return $"(ansi default_dimmed)(ansi default_italic)($command)(ansi reset)"
 }
 
@@ -144,7 +144,7 @@ export def clip [
     --expand (-e): bool  # auto-expand the data given as input
 ] {
     let input = (
-        $in
+        $pipe
         | if $expand { table --expand } else { table }
         | into string
         | if $no_strip {} else { ansi strip }
@@ -195,7 +195,7 @@ export def clip [
 
 # convert an integer amount of nanoseconds to a real duration
 def "from ns" [] {
-    [$in "ns"] | str join | into duration
+    [$pipe "ns"] | str join | into duration
 }
 
 # run a piece of `nushell` code multiple times and measure the time of execution.

--- a/crates/nu-std/std/testing.nu
+++ b/crates/nu-std/std/testing.nu
@@ -73,7 +73,7 @@ def get-annotated [
 # Other annotations are of type string
 # Result gets merged with the template record so that the output shape remains consistent regardless of the table content
 def create-test-record [] {
-    let input = $in
+    let input = $pipe
 
     let template_record = {
         before-each: '',
@@ -95,7 +95,7 @@ def create-test-record [] {
         | update value {|x|
             $x.value.function_name
             | if $x.key in ["test", "test-skip"] {
-                $in
+                $pipe
             } else {
                 get 0
             }
@@ -121,14 +121,14 @@ def throw-error [error: record] {
 
 # show a test record in a pretty way
 #
-# `$in` must be a `record<file: string, module: string, name: string, pass: bool>`.
+# `$pipe` must be a `record<file: string, module: string, name: string, pass: bool>`.
 #
 # the output would be like
 # - "<indentation> x <module> <test>" all in red if failed
 # - "<indentation> s <module> <test>" all in yellow if skipped
 # - "<indentation>   <module> <test>" all in green if passed
 def show-pretty-test [indent: int = 4] {
-    let test = $in
+    let test = $pipe
 
     [
         (" " * $indent)
@@ -211,13 +211,13 @@ def run-tests-for-module [
                 after-each: '',
                 test: $module.before-all
             }
-            | if $in.exit_code == 0 {
-                $in.stdout
+            | if $pipe.exit_code == 0 {
+                $pipe.stdout
             } else {
                 throw-error {
                     msg: "Before-all failed"
                     label: "Failure in test setup"
-                    span: (metadata $in | get span)
+                    span: (metadata $pipe | get span)
                 }
             }
         } else {
@@ -261,7 +261,7 @@ def run-tests-for-module [
 
             $test|insert result {|x|
                 run-test $test
-                | if $in.exit_code == 0 {
+                | if $pipe.exit_code == 0 {
                     'pass'
                 } else {
                     'fail'
@@ -350,7 +350,7 @@ export def run-tests [
         | update test {|x|
             $x.test
             | if ($test|is-empty) {
-                $in
+                $pipe
             } else {
                 where $it == $test
             }

--- a/crates/nu-std/tests/test_dirs.nu
+++ b/crates/nu-std/tests/test_dirs.nu
@@ -20,7 +20,7 @@ def before-each [] {
 
 #[after-each]
 def after-each [] {
-    let base_path = $in.base_path
+    let base_path = $pipe.base_path
     cd $base_path
     cd ..
     rm -r $base_path
@@ -40,8 +40,8 @@ def cur_ring_check [expect_dir:string, expect_position: int scenario:string] {
 #[test]
 def dirs_command [] {
     # careful with order of these statements!
-    # must capture value of $in before executing `use`s
-    let $c = $in
+    # must capture value of $pipe before executing `use`s
+    let $c = $pipe
 
     # must set PWD *before* doing `use` that will run the def-env block in dirs module.
     cd $c.base_path
@@ -90,8 +90,8 @@ def dirs_command [] {
 
 #[test]
 def dirs_next [] {
-    # must capture value of $in before executing `use`s
-    let $c = $in
+    # must capture value of $pipe before executing `use`s
+    let $c = $pipe
     # must set PWD *before* doing `use` that will run the def-env block in dirs module.
     cd $c.base_path
     assert equal $env.PWD $c.base_path "test setup"
@@ -112,8 +112,8 @@ def dirs_next [] {
 
 #[test]
 def dirs_cd [] {
-    # must capture value of $in before executing `use`s
-    let $c = $in
+    # must capture value of $pipe before executing `use`s
+    let $c = $pipe
     # must set PWD *before* doing `use` that will run the def-env block in dirs module.
     cd $c.base_path
 

--- a/crates/nu-std/tests/test_setup_teardown.nu
+++ b/crates/nu-std/tests/test_setup_teardown.nu
@@ -9,23 +9,23 @@ def before-each [] {
 
 #[after-each]
 def after-each [] {
-    log debug $"Teardown is running. Context: ($in)"
+    log debug $"Teardown is running. Context: ($pipe)"
 }
 
 #[test]
 def assert_pass [] {
-    log debug $"Assert is running. Context: ($in)"
+    log debug $"Assert is running. Context: ($pipe)"
 }
 
 #[ignore]
 def assert_skip [] {
-    log debug $"Assert is running. Context: ($in)"
+    log debug $"Assert is running. Context: ($pipe)"
 }
 
 #[ignore]
 def assert_fail_skipped_by_default [] {
     # Change test-skip to test if you want to see what happens if a test fails
-    log debug $"Assert is running. Context: ($in)"
+    log debug $"Assert is running. Context: ($pipe)"
     assert false
 }
 

--- a/crates/nu-std/tests/test_xml.nu
+++ b/crates/nu-std/tests/test_xml.nu
@@ -21,7 +21,7 @@ def before-each [] {
 
 #[test]
 def xml_xaccess [] {
-    let sample_xml = $in.sample_xml
+    let sample_xml = $pipe.sample_xml
 
     assert equal ($sample_xml | xaccess [a]) [$sample_xml]
     assert equal ($sample_xml | xaccess [*]) [$sample_xml]
@@ -32,7 +32,7 @@ def xml_xaccess [] {
 
 #[test]
 def xml_xupdate [] {
-    let sample_xml = $in.sample_xml
+    let sample_xml = $pipe.sample_xml
 
     assert equal ($sample_xml | xupdate [*] {|x| $x | update attributes {i: j}}) ('<a i="j"><b><c a="b"></c></b><c></c><d><e>z</e><e>x</e></d></a>' | from xml)
     assert equal ($sample_xml | xupdate [* d e *] {|x| $x | update content 'nushell'}) ('<a><b><c a="b"></c></b><c></c><d><e>nushell</e><e>nushell</e></d></a>' | from xml)
@@ -41,7 +41,7 @@ def xml_xupdate [] {
 
 #[test]
 def xml_xinsert [] {
-    let sample_xml = $in.sample_xml
+    let sample_xml = $pipe.sample_xml
 
     assert equal ($sample_xml | xinsert [a] {tag: b attributes:{} content: []}) ('<a><b><c a="b"></c></b><c></c><d><e>z</e><e>x</e></d><b></b></a>' | from xml)
     assert equal ($sample_xml | xinsert [a d *] {tag: null attributes: null content: 'n'} | to xml) '<a><b><c a="b"></c></b><c></c><d><e>zn</e><e>xn</e></d></a>'

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -14,7 +14,7 @@ let dark_theme = {
     empty: blue
     # Closures can be used to choose colors for specific values.
     # The value (in this case, a bool) is piped into the closure.
-    bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
+    bool: {|| if $pipe { 'light_cyan' } else { 'light_gray' } }
     int: white
     filesize: {|e|
       if $e == 0b {
@@ -24,20 +24,20 @@ let dark_theme = {
       } else { 'blue' }
     }
     duration: white
-    date: {|| (date now) - $in |
-      if $in < 1hr {
+    date: {|| (date now) - $pipe |
+      if $pipe < 1hr {
         'purple'
-      } else if $in < 6hr {
+      } else if $pipe < 6hr {
         'red'
-      } else if $in < 1day {
+      } else if $pipe < 1day {
         'yellow'
-      } else if $in < 3day {
+      } else if $pipe < 3day {
         'green'
-      } else if $in < 1wk {
+      } else if $pipe < 1wk {
         'light_green'
-      } else if $in < 6wk {
+      } else if $pipe < 6wk {
         'cyan'
-      } else if $in < 52wk {
+      } else if $pipe < 52wk {
         'blue'
       } else { 'dark_gray' }
     }
@@ -99,7 +99,7 @@ let light_theme = {
     empty: blue
     # Closures can be used to choose colors for specific values.
     # The value (in this case, a bool) is piped into the closure.
-    bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
+    bool: {|| if $pipe { 'dark_cyan' } else { 'dark_gray' } }
     int: dark_gray
     filesize: {|e|
       if $e == 0b {
@@ -109,20 +109,20 @@ let light_theme = {
       } else { 'blue_bold' }
     }
     duration: dark_gray
-  date: {|| (date now) - $in |
-    if $in < 1hr {
+  date: {|| (date now) - $pipe |
+    if $pipe < 1hr {
       'purple'
-    } else if $in < 6hr {
+    } else if $pipe < 6hr {
       'red'
-    } else if $in < 1day {
+    } else if $pipe < 1day {
       'yellow'
-    } else if $in < 3day {
+    } else if $pipe < 3day {
       'green'
-    } else if $in < 1wk {
+    } else if $pipe < 1wk {
       'light_green'
-    } else if $in < 6wk {
+    } else if $pipe < 6wk {
       'cyan'
-    } else if $in < 52wk {
+    } else if $pipe < 52wk {
       'blue'
     } else { 'dark_gray' }
   }

--- a/scripts/build-all.nu
+++ b/scripts/build-all.nu
@@ -17,7 +17,7 @@ def build-nushell [] {
 }
 
 def build-plugin [] {
-    let plugin = $in
+    let plugin = $pipe
 
     print $'(char nl)Building ($plugin)'
     print '----------------------------'

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -16,38 +16,44 @@ fn proper_shadow() -> TestResult {
 
 #[test]
 fn in_variable_1() -> TestResult {
-    run_test(r#"[3] | if $in.0 > 4 { "yay!" } else { "boo" }"#, "boo")
+    run_test(r#"[3] | if $pipe.0 > 4 { "yay!" } else { "boo" }"#, "boo")
 }
 
 #[test]
 fn in_variable_2() -> TestResult {
-    run_test(r#"3 | if $in > 2 { "yay!" } else { "boo" }"#, "yay!")
+    run_test(r#"3 | if $pipe > 2 { "yay!" } else { "boo" }"#, "yay!")
 }
 
 #[test]
 fn in_variable_3() -> TestResult {
-    run_test(r#"3 | if $in > 4 { "yay!" } else { $in }"#, "3")
+    run_test(r#"3 | if $pipe > 4 { "yay!" } else { $pipe }"#, "3")
 }
 
 #[test]
 fn in_variable_4() -> TestResult {
-    run_test(r#"3 | do { $in }"#, "3")
+    run_test(r#"3 | do { $pipe }"#, "3")
 }
 
 #[test]
 fn in_variable_5() -> TestResult {
-    run_test(r#"3 | if $in > 2 { $in - 10 } else { $in * 10 }"#, "-7")
+    run_test(
+        r#"3 | if $pipe > 2 { $pipe - 10 } else { $pipe * 10 }"#,
+        "-7",
+    )
 }
 
 #[test]
 fn in_variable_6() -> TestResult {
-    run_test(r#"3 | if $in > 6 { $in - 10 } else { $in * 10 }"#, "30")
+    run_test(
+        r#"3 | if $pipe > 6 { $pipe - 10 } else { $pipe * 10 }"#,
+        "30",
+    )
 }
 
 #[test]
 fn in_and_if_else() -> TestResult {
     run_test(
-        r#"[1, 2, 3] | if false {} else if true { $in | length }"#,
+        r#"[1, 2, 3] | if false {} else if true { $pipe | length }"#,
         "3",
     )
 }
@@ -171,7 +177,7 @@ fn let_sees_input() -> TestResult {
 #[test]
 fn let_sees_in_variable() -> TestResult {
     run_test(
-        r#"def c [] { let x = $in.name; $x | str length }; {name: bob, size: 100 } | c"#,
+        r#"def c [] { let x = $pipe.name; $x | str length }; {name: bob, size: 100 } | c"#,
         "3",
     )
 }
@@ -179,7 +185,7 @@ fn let_sees_in_variable() -> TestResult {
 #[test]
 fn let_sees_in_variable2() -> TestResult {
     run_test(
-        r#"def c [] { let x = ($in | str length); $x }; 'bob' | c"#,
+        r#"def c [] { let x = ($pipe | str length); $x }; 'bob' | c"#,
         "3",
     )
 }
@@ -368,20 +374,20 @@ fn default_value_not_constant2() -> TestResult {
 #[test]
 fn loose_each() -> TestResult {
     run_test(
-        r#"[[1, 2, 3], [4, 5, 6]] | each {|| $in.1 } | math sum"#,
+        r#"[[1, 2, 3], [4, 5, 6]] | each {|| $pipe.1 } | math sum"#,
         "7",
     )
 }
 
 #[test]
 fn in_means_input() -> TestResult {
-    run_test(r#"def shl [] { $in * 2 }; 2 | shl"#, "4")
+    run_test(r#"def shl [] { $pipe * 2 }; 2 | shl"#, "4")
 }
 
 #[test]
 fn in_iteration() -> TestResult {
     run_test(
-        r#"[3, 4, 5] | each {|| echo $"hi ($in)" } | str join"#,
+        r#"[3, 4, 5] | each {|| echo $"hi ($pipe)" } | str join"#,
         "hi 3hi 4hi 5",
     )
 }
@@ -389,7 +395,7 @@ fn in_iteration() -> TestResult {
 #[test]
 fn reusable_in() -> TestResult {
     run_test(
-        r#"[1, 2, 3, 4] | take (($in | length) - 1) | math sum"#,
+        r#"[1, 2, 3, 4] | take (($pipe | length) - 1) | math sum"#,
         "6",
     )
 }
@@ -397,7 +403,7 @@ fn reusable_in() -> TestResult {
 #[test]
 fn better_operator_spans() -> TestResult {
     run_test(
-        r#"metadata ({foo: 10} | (20 - $in.foo)) | get span | $in.start < $in.end"#,
+        r#"metadata ({foo: 10} | (20 - $pipe.foo)) | get span | $pipe.start < $pipe.end"#,
         "true",
     )
 }
@@ -410,7 +416,7 @@ fn range_right_exclusive() -> TestResult {
 /// Issue #7872
 #[test]
 fn assignment_to_in_var_no_panic() -> TestResult {
-    fail_test(r#"$in = 3"#, "needs to be a mutable variable")
+    fail_test(r#"$pipe = 3"#, "needs to be a mutable variable")
 }
 
 #[test]

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -225,7 +225,7 @@ fn equals_separates_long_flag() -> TestResult {
 fn assign_expressions() -> TestResult {
     let env = HashMap::from([("VENV_OLD_PATH", "Foobar"), ("Path", "Quux")]);
     run_test_with_env(
-        r#"$env.Path = (if ($env | columns | "VENV_OLD_PATH" in $in) { $env.VENV_OLD_PATH } else { $env.Path }); echo $env.Path"#,
+        r#"$env.Path = (if ($env | columns | "VENV_OLD_PATH" in $pipe) { $env.VENV_OLD_PATH } else { $env.Path }); echo $env.Path"#,
         "Foobar",
         &env,
     )

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -237,7 +237,7 @@ mod it_evaluation {
                 cwd: dirs.test(), pipeline(
                 r#"
                     open sample.toml
-                    | nu --testbin cococo $in.nu_party_venue
+                    | nu --testbin cococo $pipe.nu_party_venue
                 "#
             ));
 

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1084,7 +1084,7 @@ fn pipeline_params_simple() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1 2 3 | $in.1 * $in.2
+        echo 1 2 3 | $pipe.1 * $pipe.2
         "#)
     );
 
@@ -1096,7 +1096,7 @@ fn pipeline_params_inner() {
     let actual = nu!(
         cwd: ".", pipeline(
         r#"
-        echo 1 2 3 | (echo $in.2 6 7 | $in.0 * $in.1 * $in.2)
+        echo 1 2 3 | (echo $pipe.2 6 7 | $pipe.0 * $pipe.1 * $pipe.2)
         "#)
     );
 

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -95,7 +95,7 @@ export def "test stdlib" [
 
 # print the pipe input inside backticks, dimmed and italic, as a pretty command
 def pretty-print-command [] {
-    $"`(ansi default_dimmed)(ansi default_italic)($in)(ansi reset)`"
+    $"`(ansi default_dimmed)(ansi default_italic)($pipe)(ansi reset)`"
 }
 
 # return a report about the check stage
@@ -289,7 +289,7 @@ def build-nushell [features: string] {
 }
 
 def build-plugin [] {
-    let plugin = $in
+    let plugin = $pipe
 
     print $'(char nl)Building ($plugin)'
     print '----------------------------'
@@ -328,7 +328,7 @@ def "nu-complete list features" [] {
 }
 
 def install-plugin [] {
-    let plugin = $in
+    let plugin = $pipe
 
     print $'(char nl)Installing ($plugin)'
     print '----------------------------'


### PR DESCRIPTION
# Description

Because `$in` is regularly confused to mean "the input given to the command", as per #9551 we want to move to a different name.

In this PR, we move from `$in` to `$pipe` - though there's still some ongoing discussion what would be the best name.

# User-Facing Changes

BREAKING CHANGE BREAKING CHANGE

This renames `$in` to `$pipe`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
