### PR TITLE
Let with pipeline

### DIFF
--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -143,7 +143,7 @@ fn external_completer_trailing_space() {
 
 #[test]
 fn external_completer_no_trailing_space() {
-    let block = "let external_completer = {|spans| $spans}";
+    let block = "{|spans| $spans}";
     let input = "gh alias".to_string();
 
     let suggestions = run_external_completion(block, &input);
@@ -154,7 +154,7 @@ fn external_completer_no_trailing_space() {
 
 #[test]
 fn external_completer_pass_flags() {
-    let block = "let external_completer = {|spans| $spans}";
+    let block = "{|spans| $spans}";
     let input = "gh api --".to_string();
 
     let suggestions = run_external_completion(block, &input);

--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -1,4 +1,4 @@
-use nu_engine::eval_expression_with_input;
+use nu_engine::eval_block;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type};
@@ -54,28 +54,23 @@ impl Command for Let {
             .as_var()
             .expect("internal error: missing variable");
 
-        let keyword_expr = call
+        let block_id = call
             .positional_nth(1)
             .expect("checked through parser")
-            .as_keyword()
-            .expect("internal error: missing keyword");
+            .as_block()
+            .expect("internal error: missing right hand side");
 
-        let (rhs, external_failed) = eval_expression_with_input(
+        let block = engine_state.get_block(block_id);
+        let pipeline_data = eval_block(
             engine_state,
             stack,
-            keyword_expr,
+            block,
             input,
             call.redirect_stdout,
             call.redirect_stderr,
         )?;
-        if external_failed {
-            // rhs must be a PipelineData::ExternalStream and it's failed
-            // return the failed stream (with a non-zero exit code) so the engine knows to stop running
-            Ok(rhs)
-        } else {
-            stack.add_var(var_id, rhs.into_value(call.head));
-            Ok(PipelineData::empty())
-        }
+        stack.add_var(var_id, pipeline_data.into_value(call.head));
+        Ok(PipelineData::empty())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -27,7 +27,34 @@ fn let_doesnt_mutate() {
 }
 
 #[test]
+fn let_takes_pipeline() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        let x = "hello world" | str length; print $x
+        "#
+    ));
+
+    assert_eq!(actual.out, "11");
+}
+
+#[test]
+fn let_pipeline_allows_in() {
+    let actual = nu!(
+        cwd: ".", pipeline(
+        r#"
+        def foo [] { let x = $in | str length; print ($x + 10) }; "hello world" | foo
+        "#
+    ));
+
+    assert_eq!(actual.out, "21");
+}
+
+#[ignore]
+#[test]
 fn let_with_external_failed() {
+    // FIXME: this test hasn't run successfully for a long time. We should
+    // bring it back to life at some point.
     let actual = nu!(
         cwd: ".",
         pipeline(r#"let x = nu --testbin outcome_err "aa"; echo fail"#)

--- a/crates/nu-parser/src/lite_parser.rs
+++ b/crates/nu-parser/src/lite_parser.rs
@@ -50,18 +50,14 @@ pub enum LiteElement {
     },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct LitePipeline {
     pub commands: Vec<LiteElement>,
-    pub span: Span,
 }
 
 impl LitePipeline {
-    pub fn new(span: Span) -> Self {
-        Self {
-            commands: vec![],
-            span,
-        }
+    pub fn new() -> Self {
+        Self { commands: vec![] }
     }
 
     pub fn push(&mut self, element: LiteElement) {
@@ -189,9 +185,9 @@ impl LiteBlock {
     }
 }
 
-pub fn lite_parse(tokens: &[Token], span: Span) -> (LiteBlock, Option<ParseError>) {
+pub fn lite_parse(tokens: &[Token]) -> (LiteBlock, Option<ParseError>) {
     let mut block = LiteBlock::new();
-    let mut curr_pipeline = LitePipeline::new(span);
+    let mut curr_pipeline = LitePipeline::new();
     let mut curr_command = LiteCommand::new();
 
     let mut last_token = TokenContents::Eol;

--- a/crates/nu-parser/src/lite_parser.rs
+++ b/crates/nu-parser/src/lite_parser.rs
@@ -53,17 +53,15 @@ pub enum LiteElement {
 #[derive(Debug)]
 pub struct LitePipeline {
     pub commands: Vec<LiteElement>,
-}
-
-impl Default for LitePipeline {
-    fn default() -> Self {
-        Self::new()
-    }
+    pub span: Span,
 }
 
 impl LitePipeline {
-    pub fn new() -> Self {
-        Self { commands: vec![] }
+    pub fn new(span: Span) -> Self {
+        Self {
+            commands: vec![],
+            span,
+        }
     }
 
     pub fn push(&mut self, element: LiteElement) {
@@ -191,9 +189,9 @@ impl LiteBlock {
     }
 }
 
-pub fn lite_parse(tokens: &[Token]) -> (LiteBlock, Option<ParseError>) {
+pub fn lite_parse(tokens: &[Token], span: Span) -> (LiteBlock, Option<ParseError>) {
     let mut block = LiteBlock::new();
-    let mut curr_pipeline = LitePipeline::new();
+    let mut curr_pipeline = LitePipeline::new(span);
     let mut curr_command = LiteCommand::new();
 
     let mut last_token = TokenContents::Eol;

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2810,17 +2810,17 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
             for span in spans.iter().enumerate() {
                 let item = working_set.get_span_contents(*span.1);
                 if item == b"=" && spans.len() > (span.0 + 1) {
-                    let (tokens, parse_errors) = lex(
+                    let (tokens, parse_error) = lex(
                         working_set.get_span_contents(nu_protocol::span(&spans[(span.0 + 1)..])),
                         spans[(span.0 + 1)].start,
                         &[],
                         &[],
                         true,
                     );
-                    // TODO: add parse_errors
 
-                    // let (lite_pipeline, parse_errors) = lite_parse(&tokens);
-                    // let rvalue = parse_pipeline(working_set, &lite_pipeline.block[0], false, 0);
+                    if let Some(parse_error) = parse_error {
+                        working_set.parse_errors.push(parse_error)
+                    }
 
                     let rvalue_span = nu_protocol::span(&spans[(span.0 + 1)..]);
                     let rvalue_block = parse_block(working_set, &tokens, rvalue_span, false, true);
@@ -2835,11 +2835,6 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         ty: output_type,
                         custom_completion: None,
                     };
-
-                    // if idx < (spans.len() - 1) {
-                    //     working_set
-                    //         .error(ParseError::ExtraPositional(call_signature, spans[idx + 1]));
-                    // }
 
                     let mut idx = 0;
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -154,11 +154,6 @@ fn long_flag() -> TestResult {
 }
 
 #[test]
-fn let_not_statement() -> TestResult {
-    fail_test(r#"let x = "hello" | str length"#, "used in pipeline")
-}
-
-#[test]
 fn for_in_missing_var_name() -> TestResult {
     fail_test("for in", "missing")
 }


### PR DESCRIPTION
# Description

This changes the default behaviour of `let` to be able to take a pipeline as its initial value.

For example:

```
> let x = "hello world" | str length
```

This is a change from the existing behaviour, where the right hand side is assumed to be an expression. Pipelines are more general, and can be more powerful.

My google foo is failing me, but this also fixes this issue:

```
let x = foo
```

Currently, this reads `foo` as a bareword that gets converted to a string rather than running the `foo` command. In practice, this is really annoying and is a really hard to spot bug in a script.

# User-Facing Changes

BREAKING CHANGE BREAKING CHANGE

`let` gains the power to be assigned via a pipeline. However, this changes the behaviour of `let x = foo` from assigning the string "foo" to `$x` to being "run the command `foo` and give the result to `$x`"

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
