### PR TITLE
Fix `headers` command handling of missing values

### DIFF
--- a/crates/nu-command/tests/commands/headers.rs
+++ b/crates/nu-command/tests/commands/headers.rs
@@ -31,6 +31,19 @@ fn headers_adds_missing_column_name() {
 }
 
 #[test]
+fn headers_handles_missing_values() {
+    let actual = nu!(
+    cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            [{x: x, y: y}, {x: x, y: y}, {x: x, z: z}]
+            | headers
+            | to json --raw"#
+    ));
+
+    assert_eq!(actual.out, r#"[{"x": "x","y": "y"},{"x": "x"}]"#)
+}
+
+#[test]
 fn headers_invalid_column_type_empty_record() {
     let actual = nu!(
     cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/commands/headers.rs
+++ b/crates/nu-command/tests/commands/headers.rs
@@ -32,15 +32,15 @@ fn headers_adds_missing_column_name() {
 
 #[test]
 fn headers_handles_missing_values() {
-    let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
-            [{x: x, y: y}, {x: x, y: y}, {x: x, z: z}]
+            [{x: a, y: b}, {x: 1, y: 2}, {x: 1, z: 3}]
             | headers
-            | to json --raw"#
+            | to nuon --raw
+        "#
     ));
 
-    assert_eq!(actual.out, r#"[{"x": "x","y": "y"},{"x": "x"}]"#)
+    assert_eq!(actual.out, "[{a: 1, b: 2}, {a: 1}]")
 }
 
 #[test]


### PR DESCRIPTION
# Description
This fixes the `headers` command handling of missing values (issue #9602). Previously, each row in the table would have its columns set to be exactly equal to the first row even if it had less columns than the first row. This would cause to values magically change their column or cause panics in other commands if rows ended up having more columns than values.

# Tests
Added a missing values  test for the `headers` command
