### PR TITLE
simplify the `nu!` tests for `last` and `first` commands

### DIFF
--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::EmptyFile;
+use nu_test_support::nu;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, pipeline};
 
 #[test]
 fn gets_first_rows_by_amount() {
@@ -12,14 +12,7 @@ fn gets_first_rows_by_amount() {
             EmptyFile("arepas.clu"),
         ]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                ls
-                | first 3
-                | length
-            "#
-        ));
+        let actual = nu!(cwd: dirs.test(), "ls | first 3 | length");
 
         assert_eq!(actual.out, "3");
     })
@@ -36,13 +29,7 @@ fn gets_all_rows_if_amount_higher_than_all_rows() {
         ]);
 
         let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                ls
-                | first 99
-                | length
-            "#
-        ));
+            cwd: dirs.test(), "ls | first 99 | length");
 
         assert_eq!(actual.out, "4");
     })
@@ -53,14 +40,7 @@ fn gets_first_row_when_no_amount_given() {
     Playground::setup("first_test_3", |dirs, sandbox| {
         sandbox.with_files(vec![EmptyFile("caballeros.txt"), EmptyFile("arepas.clu")]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                ls
-                | first
-                | length
-            "#
-        ));
+        let actual = nu!(cwd: dirs.test(), "ls | first | length");
 
         assert_eq!(actual.out, "1");
     })
@@ -68,24 +48,14 @@ fn gets_first_row_when_no_amount_given() {
 
 #[test]
 fn gets_first_row_as_list_when_amount_given() {
-    let actual = nu!(pipeline(
-        r#"
-            [1, 2, 3]
-            | first 1
-            | describe
-        "#
-    ));
+    let actual = nu!("[1, 2, 3] | first 1 | describe");
 
     assert_eq!(actual.out, "list<int> (stream)");
 }
 
 #[test]
 fn gets_first_bytes() {
-    let actual = nu!(pipeline(
-        r#"
-            (0x[aa bb cc] | first 2) == 0x[aa bb]
-        "#
-    ));
+    let actual = nu!("(0x[aa bb cc] | first 2) == 0x[aa bb]");
 
     assert_eq!(actual.out, "true");
 }
@@ -111,24 +81,14 @@ fn works_with_binary_list() {
 
 #[test]
 fn errors_on_negative_rows() {
-    let actual = nu!(pipeline(
-        r#"
-            [1, 2, 3]
-            | first -10
-        "#
-    ));
+    let actual = nu!("[1, 2, 3] | first -10");
 
     assert!(actual.err.contains("use a positive value"));
 }
 
 #[test]
 fn errors_on_empty_list_when_no_rows_given() {
-    let actual = nu!(pipeline(
-        r#"
-            []
-            | first
-        "#
-    ));
+    let actual = nu!("[] | first");
 
     assert!(actual.err.contains("index too large"));
 }

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::EmptyFile;
+use nu_test_support::nu;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, pipeline};
 
 #[test]
 fn gets_the_last_row() {
@@ -22,14 +22,7 @@ fn gets_last_rows_by_amount() {
             EmptyFile("arepas.clu"),
         ]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                ls
-                | last 3
-                | length
-            "#
-        ));
+        let actual = nu!(cwd: dirs.test(), "ls | last 3 | length");
 
         assert_eq!(actual.out, "3");
     })
@@ -40,14 +33,7 @@ fn gets_last_row_when_no_amount_given() {
     Playground::setup("last_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![EmptyFile("caballeros.txt"), EmptyFile("arepas.clu")]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                ls
-                | last
-                | length
-            "#
-        ));
+        let actual = nu!(cwd: dirs.test(), "ls | last | length");
 
         assert_eq!(actual.out, "1");
     })
@@ -55,60 +41,35 @@ fn gets_last_row_when_no_amount_given() {
 
 #[test]
 fn requests_more_rows_than_table_has() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        [date] | last 50 | length
-        "#
-    ));
+    let actual = nu!("[date] | last 50 | length");
 
     assert_eq!(actual.out, "1");
 }
 
 #[test]
 fn gets_last_row_as_list_when_amount_given() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-                [1, 2, 3]
-                | last 1
-                | describe
-            "#
-    ));
+    let actual = nu!("[1, 2, 3] | last 1 | describe");
 
     assert_eq!(actual.out, "list<int> (stream)");
 }
 
 #[test]
 fn gets_last_bytes() {
-    let actual = nu!(pipeline(
-        r#"
-            (0x[aa bb cc] | last 2) == 0x[bb cc]
-        "#
-    ));
+    let actual = nu!("(0x[aa bb cc] | last 2) == 0x[bb cc]");
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn gets_last_byte() {
-    let actual = nu!(pipeline(
-        r#"
-            0x[aa bb cc] | last
-        "#
-    ));
+    let actual = nu!("0x[aa bb cc] | last");
 
     assert_eq!(actual.out, "204");
 }
 
 #[test]
 fn last_errors_on_negative_index() {
-    let actual = nu!(pipeline(
-        "
-            [1, 2, 3]
-            | last -2
-        "
-    ));
+    let actual = nu!("[1, 2, 3] | last -2");
 
     assert!(actual.err.contains("use a positive value"));
 }
@@ -122,12 +83,7 @@ fn fail_on_non_iterator() {
 
 #[test]
 fn errors_on_empty_list_when_no_rows_given() {
-    let actual = nu!(pipeline(
-        r#"
-            []
-            | last
-        "#
-    ));
+    let actual = nu!("[] | last");
 
     assert!(actual.err.contains("index too large"));
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
in most of the tests for `last` and `first`, we do not need to
- give `cwd` to `nu!`
- use pipeline as the tests are all short pipes
- use `r#" ... "#` as the pipes never contain quotes

this PR removes all these points from the tests for the `last` and `first` commands.

# User-Facing Changes
```
$nothing
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
```
$nothing
```
