### PR TITLE
Document `fn pipeline()` used with `nu!` tests

### DIFF
--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -27,6 +27,9 @@ impl Outcome {
     }
 }
 
+/// Reformat a multiline pipeline into a single line for use with `nu -c`
+///
+/// Warning: Will not correctly handle statements that are not `;` separated!
 pub fn pipeline(commands: &str) -> String {
     commands
         .trim()


### PR DESCRIPTION
# Description
Its purpose and its limitation around statements are not too obvious but
ubiquituous in our `nu!` tests. Document its behavior as we remove it in
many places for #8670


# User-Facing Changes
None
