### PR TITLE
Replace `users` with `nix` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,7 +1947,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04a4202a60e86f1c9702706bb42270dadd333f2db7810157563c86f17af3c873"
 dependencies = [
- "users 0.10.0",
+ "users",
  "winapi 0.3.9",
 ]
 
@@ -2852,6 +2852,7 @@ dependencies = [
  "mime_guess",
  "mockito",
  "native-tls",
+ "nix",
  "notify",
  "nu-ansi-term",
  "nu-cmd-base",
@@ -2906,7 +2907,6 @@ dependencies = [
  "unicode-segmentation",
  "ureq",
  "url",
- "users 0.11.0",
  "uuid",
  "wax",
  "which",
@@ -5655,16 +5655,6 @@ name = "users"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
-dependencies = [
- "libc",
- "log",
-]
-
-[[package]]
-name = "users"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
 dependencies = [
  "libc",
  "log",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -104,7 +104,7 @@ winreg = "0.50"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 umask = "2.1"
-users = "0.11"
+nix = { version = "0.26", default-features = false, features = ["user"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
 optional = true

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -484,6 +484,7 @@ pub(crate) fn dir_entry_dict(
 
             #[cfg(unix)]
             {
+                use crate::filesystem::util::users;
                 use std::os::unix::fs::MetadataExt;
                 let mode = md.permissions().mode();
                 cols.push("mode".into());
@@ -509,7 +510,7 @@ pub(crate) fn dir_entry_dict(
                 cols.push("user".into());
                 if let Some(user) = users::get_user_by_uid(md.uid()) {
                     vals.push(Value::String {
-                        val: user.name().to_string_lossy().into(),
+                        val: user.name,
                         span,
                     });
                 } else {
@@ -522,7 +523,7 @@ pub(crate) fn dir_entry_dict(
                 cols.push("group".into());
                 if let Some(group) = users::get_group_by_gid(md.gid()) {
                     vals.push(Value::String {
-                        val: group.name().to_string_lossy().into(),
+                        val: group.name,
                         span,
                     });
                 } else {


### PR DESCRIPTION
# Description
The `users` crate hasn't been updated for a long time, this PR tries to replace `users` with `nix`.
See [advisory page](https://rustsec.org/advisories/RUSTSEC-2023-0040.html) for additional details.

@WindSoilder

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
