### PR TITLE
Exclude deprecated commands from completions

### DIFF
--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -89,7 +89,7 @@ impl CommandCompletion {
         let filter_predicate = |command: &[u8]| match_algorithm.matches_u8(command, partial);
 
         let mut results = working_set
-            .find_commands_by_predicate(filter_predicate)
+            .find_commands_by_predicate(filter_predicate, true)
             .into_iter()
             .map(move |x| Suggestion {
                 value: String::from_utf8_lossy(&x.0).to_string(),


### PR DESCRIPTION
# Description
We previously simply searched all commands in the working set. As our deprecated/removed subcommands are documented by stub commands that don't do anything apart from providing a message, they were still included. 
With this change we check the `Signature.category` to not be `Category::Deprecated`.

## Note on performance
Making this change will exercise `Command.signature()` much more frequently! As the rust-implemented commands include their builders here this probably will cause a number of extra allocations. There is actually no valid reason why the commands should construct a new `Signature` for each call to `Command.signature()`.  
This will introduce some overhead to generate the completions for commands.
# User-Facing Changes
Example: `str <TAB>`

![grafik](https://github.com/nushell/nushell/assets/15833959/4d5ec5fe-aa93-45af-aa60-3854a20fcb04)

