### PR TITLE
improve subtyping

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -9,7 +9,7 @@ pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
     let is_compatible = |expected: &[(String, Type)], found: &[(String, Type)]| {
         if expected.is_empty() {
             true
-        } else if expected.len() != found.len() {
+        } else if expected.len() > found.len() {
             false
         } else {
             expected.iter().all(|(col_x, ty_x)| {

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -7,16 +7,18 @@ use nu_protocol::{
 pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
     // Structural subtyping
     let is_compatible = |expected: &[(String, Type)], found: &[(String, Type)]| {
-        // the expected type is `any`
         if expected.is_empty() {
             true
         } else if expected.len() != found.len() {
             false
         } else {
-            expected
-                .iter()
-                .zip(found.iter())
-                .all(|(lhs, rhs)| lhs.0 == rhs.0 && type_compatible(&lhs.1, &rhs.1))
+            expected.iter().all(|(col_x, ty_x)| {
+                if let Some((_, ty_y)) = found.iter().find(|(col_y, _)| col_x == col_y) {
+                    type_compatible(ty_x, ty_y)
+                } else {
+                    false
+                }
+            })
         }
     };
 

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -41,7 +41,7 @@ impl Type {
         let is_subtype_collection = |this: &[(String, Type)], that: &[(String, Type)]| {
             if this.is_empty() || that.is_empty() {
                 true
-            } else if this.len() != that.len() {
+            } else if this.len() > that.len() {
                 false
             } else {
                 this.iter().all(|(col_x, ty_x)| {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -44,9 +44,13 @@ impl Type {
             } else if this.len() != that.len() {
                 false
             } else {
-                this.iter()
-                    .zip(that.iter())
-                    .all(|(lhs, rhs)| lhs.0 == rhs.0 && lhs.1.is_subtype(&rhs.1))
+                this.iter().all(|(col_x, ty_x)| {
+                    if let Some((_, ty_y)) = that.iter().find(|(col_y, _)| col_x == col_y) {
+                        ty_x.is_subtype(ty_y)
+                    } else {
+                        false
+                    }
+                })
             }
         };
 

--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -65,6 +65,24 @@ fn record_subtyping() -> TestResult {
     run_test(
         "def test [rec: record<name: string, age: int>] { $rec | describe };
         test { age: 4, name: 'John' }",
-        "record<name: string, age: int>",
+        "record<age: int, name: string>",
+    )
+}
+
+#[test]
+fn record_subtyping_2() -> TestResult {
+    run_test(
+        "def test [rec: record<name: string, age: int>] { $rec | describe };
+        test { age: 4, name: 'John', height: '5-9' }",
+        "record<age: int, name: string, height: string>",
+    )
+}
+
+#[test]
+fn record_subtyping_3() -> TestResult {
+    fail_test(
+        "def test [rec: record<name: string, age: int>] { $rec | describe };
+        test { name: 'Nu' }",
+        "expected"
     )
 }

--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -63,7 +63,7 @@ fn block_not_first_class_let() -> TestResult {
 #[test]
 fn record_subtyping() -> TestResult {
     run_test(
-        "def test [r: record<name: string, age: int>] { $rec | describe };
+        "def test [rec: record<name: string, age: int>] { $rec | describe };
         test { age: 4, name: 'John' }",
         "record<name: string, age: int>",
     )

--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -83,6 +83,6 @@ fn record_subtyping_3() -> TestResult {
     fail_test(
         "def test [rec: record<name: string, age: int>] { $rec | describe };
         test { name: 'Nu' }",
-        "expected"
+        "expected",
     )
 }

--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -59,3 +59,12 @@ fn block_not_first_class_let() -> TestResult {
         "Blocks are not support as first-class values",
     )
 }
+
+#[test]
+fn record_subtyping() -> TestResult {
+    run_test(
+        "def test [r: rec<name: string, age: int>] { $rec | describe };
+        test { age: 4, name: 'John' }",
+        "record<name: string, age: int>",
+    )
+}

--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -63,7 +63,7 @@ fn block_not_first_class_let() -> TestResult {
 #[test]
 fn record_subtyping() -> TestResult {
     run_test(
-        "def test [r: rec<name: string, age: int>] { $rec | describe };
+        "def test [r: record<name: string, age: int>] { $rec | describe };
         test { age: 4, name: 'John' }",
         "record<name: string, age: int>",
     )


### PR DESCRIPTION
# Description

the current subtyping rule needs you to define the record entries in the same order as declared in the annotation. this pr improves that

now
```nushell
{ name: 'Him', age: 12 } 

# ,

{ age: 100, name: 'It' }

# and

{ name: 'Red', age: 69, height: "5-8" }

# will all match

record<name: string, age: int>

# previously only the first one would match
```

however, something like

```nushell
{ name: 'Her' } # will not


# and

{ name: 'Car', wheels: 5 }
```

EDIT: applied JT's suggestion