### PR TITLE
Remove `is-root` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,16 +1910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-root"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a4202a60e86f1c9702706bb42270dadd333f2db7810157563c86f17af3c873"
-dependencies = [
- "users",
- "winapi",
-]
-
-[[package]]
 name = "is-terminal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,7 +2767,6 @@ dependencies = [
  "htmlescape",
  "indexmap",
  "indicatif",
- "is-root",
  "itertools",
  "libc",
  "log",
@@ -5584,16 +5573,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
-]
-
-[[package]]
-name = "users"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
-dependencies = [
- "libc",
- "log",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -51,7 +51,6 @@ fs_extra = "1.3"
 htmlescape = "0.3"
 indexmap = { version = "1.7", features = ["serde-1"] }
 indicatif = "0.17"
-is-root = "0.1"
 itertools = "0.10"
 log = "0.4"
 lscolors = { version = "0.14", default-features = false, features = ["nu-ansi-term"] }
@@ -111,7 +110,13 @@ optional = true
 version = "3.0"
 
 [target.'cfg(windows)'.dependencies.windows]
-features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_SystemServices"]
+features = [
+	"Win32_Foundation",
+	"Win32_Storage_FileSystem",
+	"Win32_System_SystemServices",
+	"Win32_Security",
+	"Win32_System_Threading"
+]
 version = "0.48"
 
 [features]


### PR DESCRIPTION
# Description
This PR tries to remove `is-root` crate.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
