### PR TITLE
Update `proc-macro2` lock, fix nightly build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,9 +4089,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
# Description
Building failed with recent nightly versions due to an outdated
`proc-macro2` version in the lockfile.

See:
https://github.com/rust-lang/rust/issues/113152
https://github.com/dtolnay/proc-macro2/pull/391

# User-Facing Changes
`cargo +nightly build` will succeed again
