### PR TITLE
feat(xdg_state)!: support xdg_state dir on unix

### DIFF
--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -47,12 +47,16 @@ impl Command for History {
         let head = call.head;
 
         // todo for sqlite history this command should be an alias to `open ~/.config/nushell/history.sqlite3 | get history`
-        if let Some(config_path) = nu_path::config_dir() {
+        #[cfg(not(unix))]
+        let history_dir_result = nu_path::config_dir();
+        #[cfg(unix)]
+        let history_dir_result = nu_path::state_dir();
+        if let Some(history_dir) = history_dir_result {
             let clear = call.has_flag("clear");
             let long = call.has_flag("long");
             let ctrlc = engine_state.ctrlc.clone();
 
-            let mut history_path = config_path;
+            let mut history_path = history_dir;
             history_path.push("nushell");
             match engine_state.config.history_file_format {
                 HistoryFileFormat::Sqlite => {

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -115,7 +115,11 @@ pub fn eval_config_contents(
 }
 
 pub(crate) fn get_history_path(storage_path: &str, mode: HistoryFileFormat) -> Option<PathBuf> {
-    nu_path::config_dir().map(|mut history_path| {
+    #[cfg(unix)]
+    let history_path = nu_path::state_dir();
+    #[cfg(not(unix))]
+    let history_path = nu_path::config_dir();
+    history_path.map(|mut history_path| {
         history_path.push(storage_path);
         history_path.push(match mode {
             HistoryFileFormat::PlainText => HISTORY_FILE_TXT,

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -10,6 +10,25 @@ pub fn config_dir() -> Option<PathBuf> {
     dirs_next::config_dir()
 }
 
+#[cfg(unix)]
+pub fn state_dir() -> Option<PathBuf> {
+    let Some(home_dir) = dirs_next::home_dir() else {
+        return None;
+    };
+    Some(
+        std::env::var_os("XDG_STATE_HOME")
+            .and_then(|path| {
+                let path = PathBuf::from(path);
+                if path.is_absolute() {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| home_dir.join(".local/state")),
+    )
+}
+
 #[cfg(windows)]
 pub fn canonicalize(path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
     path.canonicalize()?.to_winuser_path()

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -5,6 +5,8 @@ mod tilde;
 mod util;
 
 pub use expansions::{canonicalize_with, expand_path_with, expand_to_real_path};
+#[cfg(unix)]
+pub use helpers::state_dir;
 pub use helpers::{config_dir, home_dir};
 pub use tilde::expand_tilde;
 pub use util::trim_trailing_slash;


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

support xdg_state dir, put history file in here

reference to the pr 

https://github.com/xdg-rs/dirs/pull/43

elvish and nvim has already put history file in it

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
