### PR TITLE
Fix `explore` crashes on {}

### DIFF
--- a/crates/nu-explore/src/nu_common/mod.rs
+++ b/crates/nu-explore/src/nu_common/mod.rs
@@ -22,9 +22,9 @@ pub use table::try_build_table;
 pub use value::{collect_input, collect_pipeline, create_map, map_into_value, nu_str};
 
 pub fn has_simple_value(data: &[Vec<Value>]) -> Option<&Value> {
-    if data.len() == 1 
-        && data[0].len() == 1 
-        && !matches!(&data[0][0], Value::List { .. } | Value::Record { .. }) 
+    if data.len() == 1
+        && data[0].len() == 1
+        && !matches!(&data[0][0], Value::List { .. } | Value::Record { .. })
     {
         Some(&data[0][0])
     } else {

--- a/crates/nu-explore/src/nu_common/mod.rs
+++ b/crates/nu-explore/src/nu_common/mod.rs
@@ -22,9 +22,10 @@ pub use table::try_build_table;
 pub use value::{collect_input, collect_pipeline, create_map, map_into_value, nu_str};
 
 pub fn has_simple_value(data: &[Vec<Value>]) -> Option<&Value> {
-    let has_single_value = data.len() == 1 && data[0].len() == 1;
-    let is_complex_type = matches!(&data[0][0], Value::List { .. } | Value::Record { .. });
-    if has_single_value && !is_complex_type {
+    if data.len() == 1 
+        && data[0].len() == 1 
+        && !matches!(&data[0][0], Value::List { .. } | Value::Record { .. }) 
+    {
         Some(&data[0][0])
     } else {
         None


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes: #8479 

Co-authored-by: Jan9103 <55753387+Jan9103@users.noreply.github.com>

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
