### PR TITLE
Skip tests that do require elevated privileges on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,9 @@ dataframe = ["dep:nu-cmd-dataframe", "nu-cmd-lang/dataframe"]
 # SQLite commands for nushell
 sqlite = ["nu-command/sqlite", "nu-cmd-lang/sqlite"]
 
+# Elevated feature for running tests with administrative privileges on Windows
+elevated = []
+
 [profile.release]
 opt-level = "s"     # Optimize for size
 strip = "debuginfo"

--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -318,6 +318,10 @@ fn canonicalize_tilde_relative_to() {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(
+    all(target_os = "windows", not(feature = "elevated")),
+    ignore = "requires admin privileges on Windows (use 'elevated' feature)"
+)]
 #[test]
 fn canonicalize_symlink() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
@@ -337,6 +341,10 @@ fn canonicalize_symlink() {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(
+    all(target_os = "windows", not(feature = "elevated")),
+    ignore = "requires admin privileges on Windows (use 'elevated' feature)"
+)]
 #[test]
 fn canonicalize_symlink_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
@@ -368,6 +376,10 @@ fn canonicalize_symlink_loop_relative_to_should_fail() {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(
+    all(target_os = "windows", not(feature = "elevated")),
+    ignore = "requires admin privileges on Windows (use 'elevated' feature)"
+)]
 #[test]
 fn canonicalize_nested_symlink_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
@@ -385,6 +397,10 @@ fn canonicalize_nested_symlink_relative_to() {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(
+    all(target_os = "windows", not(feature = "elevated")),
+    ignore = "requires admin privileges on Windows (use 'elevated' feature)"
+)]
 #[test]
 fn canonicalize_nested_symlink_within_symlink_dir_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {


### PR DESCRIPTION

# Description
On Windows, I had trouble running all the tests due to permission issues related to symlinks.
I checked why the tests failed and found that they did because my shell did not have elevated privileges.
Elevating my shell resolves this issue, but I think this shouldn't be the golden standard to elevate the shell in order to test successfully.

The tests that fail are ones creating symlinks. Under Windows, creating symlinks is a permission that [a normal user does not have](https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links#default-values), hence the need to elevate the shell.

To work around this, I added a feature called `elevated` and applied it to all the tests that fail without elevated privileges. I used the following attribute:
```rust
#[cfg_attr(
    all(target_os = "windows", not(feature = "elevated")),
    ignore = "requires admin privileges on Windows (use 'elevated' feature)"
)]
```

This applies the ignore attribute when the target is Windows, and the `elevated` feature is not passed.

I considered some alternatives:

- Dynamically check if the process has elevated privileges and ignore the test. However, this is not easy to implement since this would require a procedural macro to use it in the `cfg_attr` attribute.

- Dynamically check if the process has elevated privileges and print a warning, but running multiple tests may hide the output, making a warning not useful.

I chose the `elevated` feature approach as it is explicit, and it allows developers to run tests with elevated permissions when necessary without complex configurations.

# User-Facing Changes
No changes for users of nushell.

# After Submitting
I think nothing needs to be done.
