### PR TITLE
test-runner: add configurable threading

### DIFF
--- a/crates/nu-std/std/testing.nu
+++ b/crates/nu-std/std/testing.nu
@@ -1,5 +1,8 @@
 use log.nu
 
+def "nu-complete threads" [] {
+    seq 1 (sys|get cpu|length)
+}
 
 # Here we store the map of annotations internal names and the annotation actually used during test creation
 # The reason we do that is to allow annotations to be easily renamed without modifying rest of the code
@@ -255,7 +258,7 @@ def run-tests-for-module [
                 ''
             }
         }
-        | par-each {|test|
+        | par-each  --threads $env.threads {|test|
             log info $"Running ($test.test) in module ($module.name)"
             log debug $"Global context is ($global_context)"
 
@@ -298,13 +301,27 @@ def run-tests-for-module [
 # * after-each  - function to run after every test case. Receives the context record just like the test cases
 # * after-all   - function to run after all test cases have been executed. Receives the global context record
 export def run-tests [
-    --path: path,             # Path to look for tests. Default: current directory.
-    --module: string,         # Test module to run. Default: all test modules found.
-    --test: string,           # Pattern to use to include tests. Default: all tests found in the files.
-    --exclude: string,        # Pattern to use to exclude tests. Default: no tests are excluded
-    --exclude-module: string, # Pattern to use to exclude test modules. Default: No modules are excluded
-    --list,                   # list the selected tests without running them.
+    --path: path,                         # Path to look for tests. Default: current directory.
+    --module: string,                     # Test module to run. Default: all test modules found.
+    --test: string,                       # Pattern to use to include tests. Default: all tests found in the files.
+    --exclude: string,                    # Pattern to use to exclude tests. Default: no tests are excluded
+    --exclude-module: string,             # Pattern to use to exclude test modules. Default: No modules are excluded
+    --list,                               # list the selected tests without running them.
+    --threads: int@"nu-complete threads", # Amount of threads to use for parallel execution. Default: All threads are utilized
 ] {
+
+    let available_threads = (sys | get cpu | length)
+
+    # Can't use pattern matching here due to https://github.com/nushell/nushell/issues/9198
+    $env.threads = (if $threads == null {
+        $available_threads
+    } else if $threads < 1 {
+        1
+    } else if $threads <= $available_threads {
+        $threads
+    } else {
+        $available_threads
+    })
 
     let module_search_pattern = ('**' | path join ({
         stem: ($module | default "*")
@@ -336,7 +353,7 @@ export def run-tests [
 
     let modules = (
         ls ($path | path join $module_search_pattern)
-        | par-each {|row| {file: $row.name name: ($row.name | path parse | get stem)}}
+        | par-each --threads $env.threads {|row| {file: $row.name name: ($row.name | path parse | get stem)}}
         | insert commands {|module|
             get-annotated $module.file
         }
@@ -366,7 +383,7 @@ export def run-tests [
 
     let results = (
         $modules
-        | par-each {|module|
+        | par-each  --threads $env.threads {|module|
             run-tests-for-module $module
         }
         | flatten
@@ -375,7 +392,7 @@ export def run-tests [
         let text = ([
             $"(ansi purple)some tests did not pass (char lparen)see complete errors below(char rparen):(ansi reset)"
             ""
-            ($results | par-each {|test| ($test | show-pretty-test 4)} | str join "\n")
+            ($results | par-each   --threads $env.threads {|test| ($test | show-pretty-test 4)} | str join "\n")
             ""
         ] | str join "\n")
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Max amount of threads used by the test runner can now be configured via the `--threads` flag

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
