### PR TITLE
First commit: see spec in PR

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2316,6 +2316,7 @@ pub const FILESIZE_UNIT_GROUPS: &[UnitGroup] = &[
 
 pub const DURATION_UNIT_GROUPS: &[UnitGroup] = &[
     (Unit::Nanosecond, "ns", None),
+    // todo start adding aliases for duration units here
     (Unit::Microsecond, "us", Some((Unit::Nanosecond, 1000))),
     (
         // µ Micro Sign


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
This PR should close #8036, #9028 (in the negative) and #9118.

# Description
# Duration (2) spec
## Goals
1. clean up duration rendering  
   See [below](#clean-up-duration-rendering) for details.  
   Key constraint: don't change the internal representation, e.g, don't add base date field.
2. Something to support the extended duration displayed in Nushell banner.
3. Compute number of duration units between 2 date times, truncating the result to the desired duration unit to maintain accounting accuracy.
## Deliverables
### Clean up `duration` rendering
0. Abide by constraint that Value::Duration remains a number of nanoseconds with no additional fields.
1. `to_string()` only displays weeks .. nanoseconds.  Duration doesn't have base date to compute months or years from.
3. `<string> | into duration -> <duration>`  
parses duration string created by `to_string()`
1. Expanded syntax for duration literals (at parse time)
   1. allow `_` between quantity and unit
   2. accept additional aliases for units, e.g 'w', 'week', also 'weeks', 'wks', not just 'wk'
2. Improved unit output in strings  
   e.g '2weeks 3days' rather than '2wk 3day'  
   Needs singular & plural canonic name for each unit.  
   All output forms will be parsable via `string | into duration`. 
3. stretch goal - make duration string themable, and allow option for `_` between quantity and unit (as well as coloring, etc)
### Doing precise date and duration arithmetic
0. All arithmetic ops currently supported by `Value::Duration`, just verify they rely on integer arithmetic and check for overflow.
2. duration divided by duration -> int   
   Result is largest `int` such that:  
   ```
   int * duration_denom <= duration_num
   ```
   Can be used to answer the question, "how many days (or weeks, or hours...) in this duration?", e.g
   ```
   assert_eq(3weeks / 1day, 21)
   assert_eq(3weeks / 2days, 10)  # integer division truncates
   assert_eq((3weeks + 2days + 42minutes) / 1hour, 552)
   ```

### Date diff, number of days between and limited extended precision duration (month, year)
These are intended to support the "It's been this long since Nushell's first commit:" duration in banner.   
Inspired by current `std dt datetime-diff` and `std dt pretty-print-duration`, but not committed to exact API compatibility.
1. `<end_datetime> | date diff <start_datetime> -> record<year:int month:int day:int ... nanosecond:int>`  
   Returns an extended precision duration as a record.   
   Return value is a record rather than `<duration>` to abide by constraint to not add fields (e.g month) to Value::Duration.   
   Value can exceed the +/- 292 years that the base `duration` type can represent. 
2. `record<year:int month:int day:int ... nanosecond:int> | into duration -> <duration>`  
   Result is a `<duration>`, but operation may fail if input is too big.  
   :note: Despite the above limitation, 
   this is intended to be the way to pretty print the extended duration
   for the Nushell banner.
   ``` 
   > let dt = (date now | date diff 2019-05-10T09:59:12-07:00)
   > let pretty_dur = ($dt | into duration | into string)
   4yrs 1month 29days 12hrs 44mins 26secs 846ms 712µs 800ns   
   ```
   Note the output string gets whatever theming user has configured for duration.  
   The extended precision conversion into duration will not start failing for a couple of centuries yet.
3. `<end_datetime> | date diff --units <duration> <start_datetime> -> int`  
   Returns an integer quantity of duration units in the extended duration between `<start_date>` and `<end_datetime>`.  Answers the question, "how many days (or hours) between these 2 datetimes".  


# User-Facing Changes
TBD
# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
