### PR TITLE
refactor: comment out default config

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -177,370 +177,370 @@ let light_theme = {
 }
 
 # External completer example
-# let carapace_completer = {|spans|
-#     carapace $spans.0 nushell $spans | from json
-# }
+let carapace_completer = {|spans|
+    carapace $spans.0 nushell $spans | from json
+}
 
 # The default config record. This is where much of your global configuration is setup.
 $env.config = {
-    # true or false to enable or disable the welcome banner at startup
-    show_banner: true
+#    # true or false to enable or disable the welcome banner at startup
+#    show_banner: true
 
-    ls: {
-        use_ls_colors: true # use the LS_COLORS environment variable to colorize output
-        clickable_links: true # enable or disable clickable links. Your terminal has to support links.
-    }
+#    ls: {
+#        use_ls_colors: true # use the LS_COLORS environment variable to colorize output
+#        clickable_links: true # enable or disable clickable links. Your terminal has to support links.
+#    }
 
-    rm: {
-        always_trash: false # always act as if -t was given. Can be overridden with -p
-    }
+#    rm: {
+#        always_trash: false # always act as if -t was given. Can be overridden with -p
+#    }
 
-    cd: {
-        abbreviations: false # allows `cd s/o/f` to expand to `cd some/other/folder`
-    }
+#    cd: {
+#        abbreviations: false # allows `cd s/o/f` to expand to `cd some/other/folder`
+#    }
 
-    table: {
-        mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
-        index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
-        show_empty: true # show 'empty list' and 'empty record' placeholders for command output
-        trim: {
-            methodology: wrapping # wrapping or truncating
-            wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
-            truncating_suffix: "..." # A suffix used by the 'truncating' methodology
-        }
-    }
+#    table: {
+#        mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
+#        index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
+#        show_empty: true # show 'empty list' and 'empty record' placeholders for command output
+#        trim: {
+#            methodology: wrapping # wrapping or truncating
+#            wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
+#            truncating_suffix: "..." # A suffix used by the 'truncating' methodology
+#        }
+#    }
 
-    # datetime_format determines what a datetime rendered in the shell would look like.
-    # Behavior without this configuration point will be to "humanize" the datetime display,
-    # showing something like "a day ago."
-    datetime_format: {
-        normal: '%a, %d %b %Y %H:%M:%S %z'  # shows up in displays of variables or other datetime's outside of tables
-        # table: '%m/%d/%y %I:%M:%S%p'        # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
-    }
+#    # datetime_format determines what a datetime rendered in the shell would look like.
+#    # Behavior without this configuration point will be to "humanize" the datetime display,
+#    # showing something like "a day ago."
+#    datetime_format: {
+#        normal: '%a, %d %b %Y %H:%M:%S %z'  # shows up in displays of variables or other datetime's outside of tables
+#        table: '%m/%d/%y %I:%M:%S%p'        # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
+#    }
 
-    explore: {
-        help_banner: true
-        exit_esc: true
-        command_bar_text: '#C4C9C6'
-        # command_bar: {fg: '#C4C9C6' bg: '#223311' }
-        status_bar_background: {fg: '#1D1F21' bg: '#C4C9C6' }
-        # status_bar_text: {fg: '#C4C9C6' bg: '#223311' }
-        highlight: {bg: 'yellow' fg: 'black' }
-        status: {
-            # warn: {bg: 'yellow', fg: 'blue'}
-            # error: {bg: 'yellow', fg: 'blue'}
-            # info: {bg: 'yellow', fg: 'blue'}
-        }
-        try: {
-            # border_color: 'red'
-            # highlighted_color: 'blue'
-            # reactive: false
-        }
-        table: {
-            split_line: '#404040'
-            cursor: true
-            line_index: true
-            line_shift: true
-            line_head_top: true
-            line_head_bottom: true
-            show_head: true
-            show_index: true
-            # selected_cell: {fg: 'white', bg: '#777777'}
-            # selected_row: {fg: 'yellow', bg: '#C1C2A3'}
-            # selected_column: blue
-            # padding_column_right: 2
-            # padding_column_left: 2
-            # padding_index_left: 2
-            # padding_index_right: 1
-        }
-        config: {
-            cursor_color: {bg: 'yellow' fg: 'black' }
-            # border_color: white
-            # list_color: green
-        }
-    }
+#    explore: {
+#        help_banner: true
+#        exit_esc: true
+#        command_bar_text: '#C4C9C6'
+#        command_bar: {fg: '#C4C9C6' bg: '#223311' }
+#        status_bar_background: {fg: '#1D1F21' bg: '#C4C9C6' }
+#        status_bar_text: {fg: '#C4C9C6' bg: '#223311' }
+#        highlight: {bg: 'yellow' fg: 'black' }
+#        status: {
+#            warn: {bg: 'yellow', fg: 'blue'}
+#            error: {bg: 'yellow', fg: 'blue'}
+#            info: {bg: 'yellow', fg: 'blue'}
+#        }
+#        try: {
+#            border_color: 'red'
+#            highlighted_color: 'blue'
+#            reactive: false
+#        }
+#        table: {
+#            split_line: '#404040'
+#            cursor: true
+#            line_index: true
+#            line_shift: true
+#            line_head_top: true
+#            line_head_bottom: true
+#            show_head: true
+#            row_index: true
+#            selected_cell: {fg: 'white', bg: '#777777'}
+#            selected_row: {fg: 'yellow', bg: '#C1C2A3'}
+#            selected_column: blue
+#            padding_column_right: 2
+#            padding_column_left: 2
+#            padding_index_left: 2
+#            padding_index_right: 1
+#        }
+#        config: {
+#            cursor_color: {bg: 'yellow' fg: 'black' }
+#            border_color: white
+#            list_color: green
+#        }
+#    }
 
-    history: {
-        max_size: 100_000 # Session has to be reloaded for this to take effect
-        sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
-        file_format: "plaintext" # "sqlite" or "plaintext"
-        isolation: true # true enables history isolation, false disables it. true will allow the history to be isolated to the current session. false will allow the history to be shared across all sessions.
-    }
+#    history: {
+#        max_size: 100_000 # Session has to be reloaded for this to take effect
+#        sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
+#        file_format: "plaintext" # "sqlite" or "plaintext"
+#        isolation: true # true enables history isolation, false disables it. true will allow the history to be isolated to the current session. false will allow the history to be shared across all sessions.
+#    }
 
-    completions: {
-        case_sensitive: false # set to true to enable case-sensitive completions
-        quick: true  # set this to false to prevent auto-selecting completions when only one remains
-        partial: true  # set this to false to prevent partial filling of the prompt
-        algorithm: "prefix"  # prefix or fuzzy
-        external: {
-            enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up may be very slow
-            max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
-            completer: null # check 'carapace_completer' above as an example
-        }
-    }
+#    completions: {
+#        case_sensitive: false # set to true to enable case-sensitive completions
+#        quick: true  # set this to false to prevent auto-selecting completions when only one remains
+#        partial: true  # set this to false to prevent partial filling of the prompt
+#        algorithm: "prefix"  # prefix or fuzzy
+#        external: {
+#            enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up may be very slow
+#            max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
+#            completer: null # check 'carapace_completer' above as an example
+#        }
+#    }
 
-    filesize: {
-        metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
-        format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
-    }
+#    filesize: {
+#        metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
+#        format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
+#    }
 
-    cursor_shape: {
-        emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)
-        vi_insert: block # block, underscore, line , blink_block, blink_underscore, blink_line (block is the default)
-        vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
-    }
+#    cursor_shape: {
+#        emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)
+#        vi_insert: block # block, underscore, line , blink_block, blink_underscore, blink_line (block is the default)
+#        vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
+#    }
 
-    color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
-    use_grid_icons: true
-    footer_mode: "25" # always, never, number_of_rows, auto
-    float_precision: 2 # the precision for displaying floats in tables
-    # buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
-    use_ansi_coloring: true
-    bracketed_paste: true # enable bracketed paste, currently useless on windows
-    edit_mode: emacs # emacs, vi
-    shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.
-    render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
+#    color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
+#    use_grid_icons: true
+#    footer_mode: "25" # always, never, number_of_rows, auto
+#    float_precision: 2 # the precision for displaying floats in tables
+#    buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
+#    use_ansi_coloring: true
+#    bracketed_paste: true # enable bracketed paste, currently useless on windows
+#    edit_mode: emacs # emacs, vi
+#    shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.
+#    render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
 
     hooks: {
-        pre_prompt: [{||
-            null  # replace with source code to run before the prompt is shown
-        }]
-        pre_execution: [{||
-            null  # replace with source code to run before the repl input is run
-        }]
-        env_change: {
-            PWD: [{|before, after|
-                null  # replace with source code to run if the PWD environment is different since the last repl input
-            }]
-        }
-        display_output: {||
-            if (term size).columns >= 100 { table -e } else { table }
-        }
-        command_not_found: {||
-            null  # replace with source code to return an error message when a command is not found
-        }
+#        pre_prompt: [{||
+#            null  # replace with source code to run before the prompt is shown
+#        }]
+#        pre_execution: [{||
+#            null  # replace with source code to run before the repl input is run
+#        }]
+#        env_change: {
+#            PWD: [{|before, after|
+#                null  # replace with source code to run if the PWD environment is different since the last repl input
+#            }]
+#        }
+#        display_output: {||
+#            if (term size).columns >= 100 { table -e } else { table }
+#        }
+#        command_not_found: {||
+#            null  # replace with source code to return an error message when a command is not found
+#        }
     }
 
     menus: [
-        # Configuration for default nushell menus
-        # Note the lack of source parameter
-        {
-            name: completion_menu
-            only_buffer_difference: false
-            marker: "| "
-            type: {
-                layout: columnar
-                columns: 4
-                col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-                col_padding: 2
-            }
-            style: {
-                text: green
-                selected_text: green_reverse
-                description_text: yellow
-            }
-        }
-        {
-            name: history_menu
-            only_buffer_difference: true
-            marker: "? "
-            type: {
-                layout: list
-                page_size: 10
-            }
-            style: {
-                text: green
-                selected_text: green_reverse
-                description_text: yellow
-            }
-        }
-        {
-            name: help_menu
-            only_buffer_difference: true
-            marker: "? "
-            type: {
-                layout: description
-                columns: 4
-                col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-                col_padding: 2
-                selection_rows: 4
-                description_rows: 10
-            }
-            style: {
-                text: green
-                selected_text: green_reverse
-                description_text: yellow
-            }
-        }
-        # Example of extra menus created using a nushell source
-        # Use the source field to create a list of records that populates
-        # the menu
-        {
-            name: commands_menu
-            only_buffer_difference: false
-            marker: "# "
-            type: {
-                layout: columnar
-                columns: 4
-                col_width: 20
-                col_padding: 2
-            }
-            style: {
-                text: green
-                selected_text: green_reverse
-                description_text: yellow
-            }
-            source: { |buffer, position|
-                scope commands
-                | where name =~ $buffer
-                | each { |it| {value: $it.name description: $it.usage} }
-            }
-        }
-        {
-            name: vars_menu
-            only_buffer_difference: true
-            marker: "# "
-            type: {
-                layout: list
-                page_size: 10
-            }
-            style: {
-                text: green
-                selected_text: green_reverse
-                description_text: yellow
-            }
-            source: { |buffer, position|
-                scope variables
-                | where name =~ $buffer
-                | sort-by name
-                | each { |it| {value: $it.name description: $it.type} }
-            }
-        }
-        {
-            name: commands_with_description
-            only_buffer_difference: true
-            marker: "# "
-            type: {
-                layout: description
-                columns: 4
-                col_width: 20
-                col_padding: 2
-                selection_rows: 4
-                description_rows: 10
-            }
-            style: {
-                text: green
-                selected_text: green_reverse
-                description_text: yellow
-            }
-            source: { |buffer, position|
-                scope commands
-                | where name =~ $buffer
-                | each { |it| {value: $it.name description: $it.usage} }
-            }
-        }
+#        # Configuration for default nushell menus
+#        # Note the lack of source parameter
+#        {
+#            name: completion_menu
+#            only_buffer_difference: false
+#            marker: "| "
+#            type: {
+#                layout: columnar
+#                columns: 4
+#                col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
+#                col_padding: 2
+#            }
+#            style: {
+#                text: green
+#                selected_text: green_reverse
+#                description_text: yellow
+#            }
+#        }
+#        {
+#            name: history_menu
+#            only_buffer_difference: true
+#            marker: "? "
+#            type: {
+#                layout: list
+#                page_size: 10
+#            }
+#            style: {
+#                text: green
+#                selected_text: green_reverse
+#                description_text: yellow
+#            }
+#        }
+#        {
+#            name: help_menu
+#            only_buffer_difference: true
+#            marker: "? "
+#            type: {
+#                layout: description
+#                columns: 4
+#                col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
+#                col_padding: 2
+#                selection_rows: 4
+#                description_rows: 10
+#            }
+#            style: {
+#                text: green
+#                selected_text: green_reverse
+#                description_text: yellow
+#            }
+#        }
+#        # Example of extra menus created using a nushell source
+#        # Use the source field to create a list of records that populates
+#        # the menu
+#        {
+#            name: commands_menu
+#            only_buffer_difference: false
+#            marker: "# "
+#            type: {
+#                layout: columnar
+#                columns: 4
+#                col_width: 20
+#                col_padding: 2
+#            }
+#            style: {
+#                text: green
+#                selected_text: green_reverse
+#                description_text: yellow
+#            }
+#            source: { |buffer, position|
+#                scope commands
+#                | where name =~ $buffer
+#                | each { |it| {value: $it.name description: $it.usage} }
+#            }
+#        }
+#        {
+#            name: vars_menu
+#            only_buffer_difference: true
+#            marker: "# "
+#            type: {
+#                layout: list
+#                page_size: 10
+#            }
+#            style: {
+#                text: green
+#                selected_text: green_reverse
+#                description_text: yellow
+#            }
+#            source: { |buffer, position|
+#                scope variables
+#                | where name =~ $buffer
+#                | sort-by name
+#                | each { |it| {value: $it.name description: $it.type} }
+#            }
+#        }
+#        {
+#            name: commands_with_description
+#            only_buffer_difference: true
+#            marker: "# "
+#            type: {
+#                layout: description
+#                columns: 4
+#                col_width: 20
+#                col_padding: 2
+#                selection_rows: 4
+#                description_rows: 10
+#            }
+#            style: {
+#                text: green
+#                selected_text: green_reverse
+#                description_text: yellow
+#            }
+#            source: { |buffer, position|
+#                scope commands
+#                | where name =~ $buffer
+#                | each { |it| {value: $it.name description: $it.usage} }
+#            }
+#        }
     ]
 
     keybindings: [
-        {
-            name: completion_menu
-            modifier: none
-            keycode: tab
-            mode: [emacs vi_normal vi_insert]
-            event: {
-                until: [
-                    { send: menu name: completion_menu }
-                    { send: menunext }
-                ]
-            }
-        }
-        {
-            name: completion_previous
-            modifier: shift
-            keycode: backtab
-            mode: [emacs, vi_normal, vi_insert] # Note: You can add the same keybinding to all modes by using a list
-            event: { send: menuprevious }
-        }
-        {
-            name: history_menu
-            modifier: control
-            keycode: char_r
-            mode: emacs
-            event: { send: menu name: history_menu }
-        }
-        {
-            name: next_page
-            modifier: control
-            keycode: char_x
-            mode: emacs
-            event: { send: menupagenext }
-        }
-        {
-            name: undo_or_previous_page
-            modifier: control
-            keycode: char_z
-            mode: emacs
-            event: {
-                until: [
-                    { send: menupageprevious }
-                    { edit: undo }
-                ]
-            }
-        }
-        {
-            name: yank
-            modifier: control
-            keycode: char_y
-            mode: emacs
-            event: {
-                until: [
-                    {edit: pastecutbufferafter}
-                ]
-            }
-        }
-        {
-            name: unix-line-discard
-            modifier: control
-            keycode: char_u
-            mode: [emacs, vi_normal, vi_insert]
-            event: {
-                until: [
-                    {edit: cutfromlinestart}
-                ]
-            }
-        }
-        {
-            name: kill-line
-            modifier: control
-            keycode: char_k
-            mode: [emacs, vi_normal, vi_insert]
-            event: {
-                until: [
-                    {edit: cuttolineend}
-                ]
-            }
-        }
-        # Keybindings used to trigger the user defined menus
-        {
-            name: commands_menu
-            modifier: control
-            keycode: char_t
-            mode: [emacs, vi_normal, vi_insert]
-            event: { send: menu name: commands_menu }
-        }
-        {
-            name: vars_menu
-            modifier: alt
-            keycode: char_o
-            mode: [emacs, vi_normal, vi_insert]
-            event: { send: menu name: vars_menu }
-        }
-        {
-            name: commands_with_description
-            modifier: control
-            keycode: char_s
-            mode: [emacs, vi_normal, vi_insert]
-            event: { send: menu name: commands_with_description }
-        }
+#        {
+#            name: completion_menu
+#            modifier: none
+#            keycode: tab
+#            mode: [emacs vi_normal vi_insert]
+#            event: {
+#                until: [
+#                    { send: menu name: completion_menu }
+#                    { send: menunext }
+#                ]
+#            }
+#        }
+#        {
+#            name: completion_previous
+#            modifier: shift
+#            keycode: backtab
+#            mode: [emacs, vi_normal, vi_insert] # Note: You can add the same keybinding to all modes by using a list
+#            event: { send: menuprevious }
+#        }
+#        {
+#            name: history_menu
+#            modifier: control
+#            keycode: char_r
+#            mode: emacs
+#            event: { send: menu name: history_menu }
+#        }
+#        {
+#            name: next_page
+#            modifier: control
+#            keycode: char_x
+#            mode: emacs
+#            event: { send: menupagenext }
+#        }
+#        {
+#            name: undo_or_previous_page
+#            modifier: control
+#            keycode: char_z
+#            mode: emacs
+#            event: {
+#                until: [
+#                    { send: menupageprevious }
+#                    { edit: undo }
+#                ]
+#            }
+#        }
+#        {
+#            name: yank
+#            modifier: control
+#            keycode: char_y
+#            mode: emacs
+#            event: {
+#                until: [
+#                    {edit: pastecutbufferafter}
+#                ]
+#            }
+#        }
+#        {
+#            name: unix-line-discard
+#            modifier: control
+#            keycode: char_u
+#            mode: [emacs, vi_normal, vi_insert]
+#            event: {
+#                until: [
+#                    {edit: cutfromlinestart}
+#                ]
+#            }
+#        }
+#        {
+#            name: kill-line
+#            modifier: control
+#            keycode: char_k
+#            mode: [emacs, vi_normal, vi_insert]
+#            event: {
+#                until: [
+#                    {edit: cuttolineend}
+#                ]
+#            }
+#        }
+#        # Keybindings used to trigger the user defined menus
+#        {
+#            name: commands_menu
+#            modifier: control
+#            keycode: char_t
+#            mode: [emacs, vi_normal, vi_insert]
+#            event: { send: menu name: commands_menu }
+#        }
+#        {
+#            name: vars_menu
+#            modifier: alt
+#            keycode: char_o
+#            mode: [emacs, vi_normal, vi_insert]
+#            event: { send: menu name: vars_menu }
+#        }
+#        {
+#            name: commands_with_description
+#            modifier: control
+#            keycode: char_s
+#            mode: [emacs, vi_normal, vi_insert]
+#            event: { send: menu name: commands_with_description }
+#        }
     ]
 }

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -17,29 +17,29 @@ let dark_theme = {
     bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
     int: white
     filesize: {|e|
-      if $e == 0b {
-        'white'
-      } else if $e < 1mb {
-        'cyan'
-      } else { 'blue' }
+        if $e == 0b {
+            'white'
+        } else if $e < 1mb {
+            'cyan'
+        } else { 'blue' }
     }
     duration: white
     date: {|| (date now) - $in |
-      if $in < 1hr {
-        'purple'
-      } else if $in < 6hr {
-        'red'
-      } else if $in < 1day {
-        'yellow'
-      } else if $in < 3day {
-        'green'
-      } else if $in < 1wk {
-        'light_green'
-      } else if $in < 6wk {
-        'cyan'
-      } else if $in < 52wk {
-        'blue'
-      } else { 'dark_gray' }
+        if $in < 1hr {
+            'purple'
+        } else if $in < 6hr {
+            'red'
+        } else if $in < 1day {
+            'yellow'
+        } else if $in < 3day {
+            'green'
+        } else if $in < 1wk {
+            'light_green'
+        } else if $in < 6wk {
+            'cyan'
+        } else if $in < 52wk {
+            'blue'
+        } else { 'dark_gray' }
     }
     range: white
     float: white
@@ -102,30 +102,30 @@ let light_theme = {
     bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
     int: dark_gray
     filesize: {|e|
-      if $e == 0b {
-        'dark_gray'
-      } else if $e < 1mb {
-        'cyan_bold'
-      } else { 'blue_bold' }
+        if $e == 0b {
+            'dark_gray'
+        } else if $e < 1mb {
+            'cyan_bold'
+        } else { 'blue_bold' }
     }
     duration: dark_gray
-  date: {|| (date now) - $in |
-    if $in < 1hr {
-      'purple'
-    } else if $in < 6hr {
-      'red'
-    } else if $in < 1day {
-      'yellow'
-    } else if $in < 3day {
-      'green'
-    } else if $in < 1wk {
-      'light_green'
-    } else if $in < 6wk {
-      'cyan'
-    } else if $in < 52wk {
-      'blue'
-    } else { 'dark_gray' }
-  }
+    date: {|| (date now) - $in |
+        if $in < 1hr {
+            'purple'
+        } else if $in < 6hr {
+            'red'
+        } else if $in < 1day {
+            'yellow'
+        } else if $in < 3day {
+            'green'
+        } else if $in < 1wk {
+            'light_green'
+        } else if $in < 6wk {
+            'cyan'
+        } else if $in < 52wk {
+            'blue'
+        } else { 'dark_gray' }
+    }
     range: dark_gray
     float: dark_gray
     string: dark_gray
@@ -181,373 +181,366 @@ let light_theme = {
 #     carapace $spans.0 nushell $spans | from json
 # }
 
-
 # The default config record. This is where much of your global configuration is setup.
 $env.config = {
-  # true or false to enable or disable the welcome banner at startup
-  show_banner: true
-  ls: {
-    use_ls_colors: true # use the LS_COLORS environment variable to colorize output
-    clickable_links: true # enable or disable clickable links. Your terminal has to support links.
-  }
-  rm: {
-    always_trash: false # always act as if -t was given. Can be overridden with -p
-  }
-  cd: {
-    abbreviations: false # allows `cd s/o/f` to expand to `cd some/other/folder`
-  }
-  table: {
-    mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
-    index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
-    show_empty: true # show 'empty list' and 'empty record' placeholders for command output
-    trim: {
-      methodology: wrapping # wrapping or truncating
-      wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
-      truncating_suffix: "..." # A suffix used by the 'truncating' methodology
-    }
-  }
+    # true or false to enable or disable the welcome banner at startup
+    show_banner: true
 
-  # datetime_format determines what a datetime rendered in the shell would look like.
-  # Behavior without this configuration point will be to "humanize" the datetime display,
-  # showing something like "a day ago."
-
-  datetime_format: {
-    normal: '%a, %d %b %Y %H:%M:%S %z'  # shows up in displays of variables or other datetime's outside of tables
-    # table: '%m/%d/%y %I:%M:%S%p'        # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
-  }
-
-  explore: {
-    help_banner: true
-    exit_esc: true
-
-    command_bar_text: '#C4C9C6'
-    # command_bar: {fg: '#C4C9C6' bg: '#223311' }
-
-    status_bar_background: {fg: '#1D1F21' bg: '#C4C9C6' }
-    # status_bar_text: {fg: '#C4C9C6' bg: '#223311' }
-
-    highlight: {bg: 'yellow' fg: 'black' }
-
-    status: {
-      # warn: {bg: 'yellow', fg: 'blue'}
-      # error: {bg: 'yellow', fg: 'blue'}
-      # info: {bg: 'yellow', fg: 'blue'}
+    ls: {
+        use_ls_colors: true # use the LS_COLORS environment variable to colorize output
+        clickable_links: true # enable or disable clickable links. Your terminal has to support links.
     }
 
-    try: {
-      # border_color: 'red'
-      # highlighted_color: 'blue'
+    rm: {
+        always_trash: false # always act as if -t was given. Can be overridden with -p
+    }
 
-      # reactive: false
+    cd: {
+        abbreviations: false # allows `cd s/o/f` to expand to `cd some/other/folder`
     }
 
     table: {
-      split_line: '#404040'
-
-      cursor: true
-
-      line_index: true
-      line_shift: true
-      line_head_top: true
-      line_head_bottom: true
-
-      show_head: true
-      show_index: true
-
-      # selected_cell: {fg: 'white', bg: '#777777'}
-      # selected_row: {fg: 'yellow', bg: '#C1C2A3'}
-      # selected_column: blue
-
-      # padding_column_right: 2
-      # padding_column_left: 2
-
-      # padding_index_left: 2
-      # padding_index_right: 1
+        mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
+        index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
+        show_empty: true # show 'empty list' and 'empty record' placeholders for command output
+        trim: {
+            methodology: wrapping # wrapping or truncating
+            wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
+            truncating_suffix: "..." # A suffix used by the 'truncating' methodology
+        }
     }
 
-    config: {
-      cursor_color: {bg: 'yellow' fg: 'black' }
+    # datetime_format determines what a datetime rendered in the shell would look like.
+    # Behavior without this configuration point will be to "humanize" the datetime display,
+    # showing something like "a day ago."
+    datetime_format: {
+        normal: '%a, %d %b %Y %H:%M:%S %z'  # shows up in displays of variables or other datetime's outside of tables
+        # table: '%m/%d/%y %I:%M:%S%p'        # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
+    }
 
-      # border_color: white
-      # list_color: green
+    explore: {
+        help_banner: true
+        exit_esc: true
+        command_bar_text: '#C4C9C6'
+        # command_bar: {fg: '#C4C9C6' bg: '#223311' }
+        status_bar_background: {fg: '#1D1F21' bg: '#C4C9C6' }
+        # status_bar_text: {fg: '#C4C9C6' bg: '#223311' }
+        highlight: {bg: 'yellow' fg: 'black' }
+        status: {
+            # warn: {bg: 'yellow', fg: 'blue'}
+            # error: {bg: 'yellow', fg: 'blue'}
+            # info: {bg: 'yellow', fg: 'blue'}
+        }
+        try: {
+            # border_color: 'red'
+            # highlighted_color: 'blue'
+            # reactive: false
+        }
+        table: {
+            split_line: '#404040'
+            cursor: true
+            line_index: true
+            line_shift: true
+            line_head_top: true
+            line_head_bottom: true
+            show_head: true
+            show_index: true
+            # selected_cell: {fg: 'white', bg: '#777777'}
+            # selected_row: {fg: 'yellow', bg: '#C1C2A3'}
+            # selected_column: blue
+            # padding_column_right: 2
+            # padding_column_left: 2
+            # padding_index_left: 2
+            # padding_index_right: 1
+        }
+        config: {
+            cursor_color: {bg: 'yellow' fg: 'black' }
+            # border_color: white
+            # list_color: green
+        }
     }
-  }
 
-  history: {
-    max_size: 100_000 # Session has to be reloaded for this to take effect
-    sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
-    file_format: "plaintext" # "sqlite" or "plaintext"
-    isolation: true # true enables history isolation, false disables it. true will allow the history to be isolated to the current session. false will allow the history to be shared across all sessions.
-  }
-  completions: {
-    case_sensitive: false # set to true to enable case-sensitive completions
-    quick: true  # set this to false to prevent auto-selecting completions when only one remains
-    partial: true  # set this to false to prevent partial filling of the prompt
-    algorithm: "prefix"  # prefix or fuzzy
-    external: {
-      enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up may be very slow
-      max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
-      completer: null # check 'carapace_completer' above as an example
+    history: {
+        max_size: 100_000 # Session has to be reloaded for this to take effect
+        sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
+        file_format: "plaintext" # "sqlite" or "plaintext"
+        isolation: true # true enables history isolation, false disables it. true will allow the history to be isolated to the current session. false will allow the history to be shared across all sessions.
     }
-  }
-  filesize: {
-    metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
-    format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
-  }
-  cursor_shape: {
-    emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)
-    vi_insert: block # block, underscore, line , blink_block, blink_underscore, blink_line (block is the default)
-    vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
-  }
-  color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
-  use_grid_icons: true
-  footer_mode: "25" # always, never, number_of_rows, auto
-  float_precision: 2 # the precision for displaying floats in tables
-  # buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
-  use_ansi_coloring: true
-  bracketed_paste: true # enable bracketed paste, currently useless on windows
-  edit_mode: emacs # emacs, vi
-  shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.
-  render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
 
-  hooks: {
-    pre_prompt: [{||
-      null  # replace with source code to run before the prompt is shown
-    }]
-    pre_execution: [{||
-      null  # replace with source code to run before the repl input is run
-    }]
-    env_change: {
-      PWD: [{|before, after|
-        null  # replace with source code to run if the PWD environment is different since the last repl input
-      }]
+    completions: {
+        case_sensitive: false # set to true to enable case-sensitive completions
+        quick: true  # set this to false to prevent auto-selecting completions when only one remains
+        partial: true  # set this to false to prevent partial filling of the prompt
+        algorithm: "prefix"  # prefix or fuzzy
+        external: {
+            enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up may be very slow
+            max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
+            completer: null # check 'carapace_completer' above as an example
+        }
     }
-    display_output: {||
-      if (term size).columns >= 100 { table -e } else { table }
+
+    filesize: {
+        metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
+        format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
     }
-    command_not_found: {||
-      null  # replace with source code to return an error message when a command is not found
+
+    cursor_shape: {
+        emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)
+        vi_insert: block # block, underscore, line , blink_block, blink_underscore, blink_line (block is the default)
+        vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
     }
-  }
-  menus: [
-      # Configuration for default nushell menus
-      # Note the lack of source parameter
-      {
-        name: completion_menu
-        only_buffer_difference: false
-        marker: "| "
-        type: {
-            layout: columnar
-            columns: 4
-            col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-            col_padding: 2
+
+    color_config: $dark_theme   # if you want a light theme, replace `$dark_theme` to `$light_theme`
+    use_grid_icons: true
+    footer_mode: "25" # always, never, number_of_rows, auto
+    float_precision: 2 # the precision for displaying floats in tables
+    # buffer_editor: "emacs" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
+    use_ansi_coloring: true
+    bracketed_paste: true # enable bracketed paste, currently useless on windows
+    edit_mode: emacs # emacs, vi
+    shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.
+    render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
+
+    hooks: {
+        pre_prompt: [{||
+            null  # replace with source code to run before the prompt is shown
+        }]
+        pre_execution: [{||
+            null  # replace with source code to run before the repl input is run
+        }]
+        env_change: {
+            PWD: [{|before, after|
+                null  # replace with source code to run if the PWD environment is different since the last repl input
+            }]
         }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
+        display_output: {||
+            if (term size).columns >= 100 { table -e } else { table }
         }
-      }
-      {
-        name: history_menu
-        only_buffer_difference: true
-        marker: "? "
-        type: {
-            layout: list
-            page_size: 10
+        command_not_found: {||
+            null  # replace with source code to return an error message when a command is not found
         }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-      }
-      {
-        name: help_menu
-        only_buffer_difference: true
-        marker: "? "
-        type: {
-            layout: description
-            columns: 4
-            col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-            col_padding: 2
-            selection_rows: 4
-            description_rows: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-      }
-      # Example of extra menus created using a nushell source
-      # Use the source field to create a list of records that populates
-      # the menu
-      {
-        name: commands_menu
-        only_buffer_difference: false
-        marker: "# "
-        type: {
-            layout: columnar
-            columns: 4
-            col_width: 20
-            col_padding: 2
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-        source: { |buffer, position|
-            scope commands
-            | where name =~ $buffer
-            | each { |it| {value: $it.name description: $it.usage} }
-        }
-      }
-      {
-        name: vars_menu
-        only_buffer_difference: true
-        marker: "# "
-        type: {
-            layout: list
-            page_size: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-        source: { |buffer, position|
-            scope variables
-            | where name =~ $buffer
-            | sort-by name
-            | each { |it| {value: $it.name description: $it.type} }
-        }
-      }
-      {
-        name: commands_with_description
-        only_buffer_difference: true
-        marker: "# "
-        type: {
-            layout: description
-            columns: 4
-            col_width: 20
-            col_padding: 2
-            selection_rows: 4
-            description_rows: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
-        source: { |buffer, position|
-            scope commands
-            | where name =~ $buffer
-            | each { |it| {value: $it.name description: $it.usage} }
-        }
-      }
-  ]
-  keybindings: [
-    {
-      name: completion_menu
-      modifier: none
-      keycode: tab
-      mode: [emacs vi_normal vi_insert]
-      event: {
-        until: [
-          { send: menu name: completion_menu }
-          { send: menunext }
-        ]
-      }
     }
-    {
-      name: completion_previous
-      modifier: shift
-      keycode: backtab
-      mode: [emacs, vi_normal, vi_insert] # Note: You can add the same keybinding to all modes by using a list
-      event: { send: menuprevious }
-    }
-    {
-      name: history_menu
-      modifier: control
-      keycode: char_r
-      mode: emacs
-      event: { send: menu name: history_menu }
-    }
-    {
-      name: next_page
-      modifier: control
-      keycode: char_x
-      mode: emacs
-      event: { send: menupagenext }
-    }
-    {
-      name: undo_or_previous_page
-      modifier: control
-      keycode: char_z
-      mode: emacs
-      event: {
-        until: [
-          { send: menupageprevious }
-          { edit: undo }
-        ]
-       }
-    }
-    {
-      name: yank
-      modifier: control
-      keycode: char_y
-      mode: emacs
-      event: {
-        until: [
-          {edit: pastecutbufferafter}
-        ]
-      }
-    }
-    {
-      name: unix-line-discard
-      modifier: control
-      keycode: char_u
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {edit: cutfromlinestart}
-        ]
-      }
-    }
-    {
-      name: kill-line
-      modifier: control
-      keycode: char_k
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {edit: cuttolineend}
-        ]
-      }
-    }
-    # Keybindings used to trigger the user defined menus
-    {
-      name: commands_menu
-      modifier: control
-      keycode: char_t
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: menu name: commands_menu }
-    }
-    {
-      name: vars_menu
-      modifier: alt
-      keycode: char_o
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: menu name: vars_menu }
-    }
-    {
-      name: commands_with_description
-      modifier: control
-      keycode: char_s
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: menu name: commands_with_description }
-    }
-  ]
+
+    menus: [
+        # Configuration for default nushell menus
+        # Note the lack of source parameter
+        {
+            name: completion_menu
+            only_buffer_difference: false
+            marker: "| "
+            type: {
+                layout: columnar
+                columns: 4
+                col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
+                col_padding: 2
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+        }
+        {
+            name: history_menu
+            only_buffer_difference: true
+            marker: "? "
+            type: {
+                layout: list
+                page_size: 10
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+        }
+        {
+            name: help_menu
+            only_buffer_difference: true
+            marker: "? "
+            type: {
+                layout: description
+                columns: 4
+                col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
+                col_padding: 2
+                selection_rows: 4
+                description_rows: 10
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+        }
+        # Example of extra menus created using a nushell source
+        # Use the source field to create a list of records that populates
+        # the menu
+        {
+            name: commands_menu
+            only_buffer_difference: false
+            marker: "# "
+            type: {
+                layout: columnar
+                columns: 4
+                col_width: 20
+                col_padding: 2
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+            source: { |buffer, position|
+                scope commands
+                | where name =~ $buffer
+                | each { |it| {value: $it.name description: $it.usage} }
+            }
+        }
+        {
+            name: vars_menu
+            only_buffer_difference: true
+            marker: "# "
+            type: {
+                layout: list
+                page_size: 10
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+            source: { |buffer, position|
+                scope variables
+                | where name =~ $buffer
+                | sort-by name
+                | each { |it| {value: $it.name description: $it.type} }
+            }
+        }
+        {
+            name: commands_with_description
+            only_buffer_difference: true
+            marker: "# "
+            type: {
+                layout: description
+                columns: 4
+                col_width: 20
+                col_padding: 2
+                selection_rows: 4
+                description_rows: 10
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+            source: { |buffer, position|
+                scope commands
+                | where name =~ $buffer
+                | each { |it| {value: $it.name description: $it.usage} }
+            }
+        }
+    ]
+
+    keybindings: [
+        {
+            name: completion_menu
+            modifier: none
+            keycode: tab
+            mode: [emacs vi_normal vi_insert]
+            event: {
+                until: [
+                    { send: menu name: completion_menu }
+                    { send: menunext }
+                ]
+            }
+        }
+        {
+            name: completion_previous
+            modifier: shift
+            keycode: backtab
+            mode: [emacs, vi_normal, vi_insert] # Note: You can add the same keybinding to all modes by using a list
+            event: { send: menuprevious }
+        }
+        {
+            name: history_menu
+            modifier: control
+            keycode: char_r
+            mode: emacs
+            event: { send: menu name: history_menu }
+        }
+        {
+            name: next_page
+            modifier: control
+            keycode: char_x
+            mode: emacs
+            event: { send: menupagenext }
+        }
+        {
+            name: undo_or_previous_page
+            modifier: control
+            keycode: char_z
+            mode: emacs
+            event: {
+                until: [
+                    { send: menupageprevious }
+                    { edit: undo }
+                ]
+            }
+        }
+        {
+            name: yank
+            modifier: control
+            keycode: char_y
+            mode: emacs
+            event: {
+                until: [
+                    {edit: pastecutbufferafter}
+                ]
+            }
+        }
+        {
+            name: unix-line-discard
+            modifier: control
+            keycode: char_u
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {edit: cutfromlinestart}
+                ]
+            }
+        }
+        {
+            name: kill-line
+            modifier: control
+            keycode: char_k
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {edit: cuttolineend}
+                ]
+            }
+        }
+        # Keybindings used to trigger the user defined menus
+        {
+            name: commands_menu
+            modifier: control
+            keycode: char_t
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: menu name: commands_menu }
+        }
+        {
+            name: vars_menu
+            modifier: alt
+            keycode: char_o
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: menu name: vars_menu }
+        }
+        {
+            name: commands_with_description
+            modifier: control
+            keycode: char_s
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: menu name: commands_with_description }
+        }
+    ]
 }

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -2,85 +2,87 @@
 #
 # version = 0.82.1
 
-def create_left_prompt [] {
-    mut home = ""
-    try {
-        if $nu.os-info.name == "windows" {
-            $home = $env.USERPROFILE
-        } else {
-            $home = $env.HOME
+export-env {
+    def create_left_prompt [] {
+        mut home = ""
+        try {
+            if $nu.os-info.name == "windows" {
+                $home = $env.USERPROFILE
+            } else {
+                $home = $env.HOME
+            }
         }
+
+        let dir = ([
+            ($env.PWD | str substring 0..($home | str length) | str replace --string $home "~"),
+            ($env.PWD | str substring ($home | str length)..)
+        ] | str join)
+
+        let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
+        let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
+        let path_segment = $"($path_color)($dir)"
+
+        $path_segment | str replace --all --string (char path_sep) $"($separator_color)/($path_color)"
     }
 
-    let dir = ([
-        ($env.PWD | str substring 0..($home | str length) | str replace --string $home "~"),
-        ($env.PWD | str substring ($home | str length)..)
-    ] | str join)
+    def create_right_prompt [] {
+        # create a right prompt in magenta with green separators and am/pm underlined
+        let time_segment = ([
+            (ansi reset)
+            (ansi magenta)
+            (date now | date format '%Y/%m/%d %r')
+        ] | str join | str replace --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
+            str replace --all "([AP]M)" $"(ansi magenta_underline)${1}")
 
-    let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
-    let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
-    let path_segment = $"($path_color)($dir)"
+        let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
+            (ansi rb)
+            ($env.LAST_EXIT_CODE)
+        ] | str join)
+        } else { "" }
 
-    $path_segment | str replace --all --string (char path_sep) $"($separator_color)/($path_color)"
+        ([$last_exit_code, (char space), $time_segment] | str join)
+    }
+
+    # Use nushell functions to define your right and left prompt
+    # $env.PROMPT_COMMAND = {|| create_left_prompt }
+    # $env.PROMPT_COMMAND_RIGHT = {|| create_right_prompt }
 }
-
-def create_right_prompt [] {
-    # create a right prompt in magenta with green separators and am/pm underlined
-    let time_segment = ([
-        (ansi reset)
-        (ansi magenta)
-        (date now | date format '%Y/%m/%d %r')
-    ] | str join | str replace --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
-        str replace --all "([AP]M)" $"(ansi magenta_underline)${1}")
-
-    let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
-        (ansi rb)
-        ($env.LAST_EXIT_CODE)
-    ] | str join)
-    } else { "" }
-
-    ([$last_exit_code, (char space), $time_segment] | str join)
-}
-
-# Use nushell functions to define your right and left prompt
-$env.PROMPT_COMMAND = {|| create_left_prompt }
-$env.PROMPT_COMMAND_RIGHT = {|| create_right_prompt }
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt
-$env.PROMPT_INDICATOR = {|| "> " }
-$env.PROMPT_INDICATOR_VI_INSERT = {|| ": " }
-$env.PROMPT_INDICATOR_VI_NORMAL = {|| "> " }
-$env.PROMPT_MULTILINE_INDICATOR = {|| "::: " }
+# $env.PROMPT_INDICATOR = {|| "> " }
+# $env.PROMPT_INDICATOR_VI_INSERT = {|| ": " }
+# $env.PROMPT_INDICATOR_VI_NORMAL = {|| "> " }
+# $env.PROMPT_MULTILINE_INDICATOR = {|| "::: " }
 
 # Specifies how environment variables are:
 # - converted from a string to a value on Nushell startup (from_string)
 # - converted from a value back to a string when running external commands (to_string)
 # Note: The conversions happen *after* config.nu is loaded
-$env.ENV_CONVERSIONS = {
-  "PATH": {
-    from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
-    to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
-  }
-  "Path": {
-    from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
-    to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
-  }
-}
+# $env.ENV_CONVERSIONS = {
+#     "PATH": {
+#         from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
+#         to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
+#     }
+#     "Path": {
+#         from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
+#         to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
+#     }
+# }
 
 # Directories to search for scripts when calling source or use
 #
 # By default, <nushell-config-dir>/scripts is added
-$env.NU_LIB_DIRS = [
-    ($nu.default-config-dir | path join 'scripts')
-]
+# $env.NU_LIB_DIRS = [
+#     ($nu.default-config-dir | path join 'scripts')
+# ]
 
 # Directories to search for plugin binaries when calling register
 #
 # By default, <nushell-config-dir>/plugins is added
-$env.NU_PLUGIN_DIRS = [
-    ($nu.default-config-dir | path join 'plugins')
-]
+# $env.NU_PLUGIN_DIRS = [
+#     ($nu.default-config-dir | path join 'plugins')
+# ]
 
 # To add entries to PATH (on Windows you might use Path), you can use the following pattern:
 # $env.PATH = ($env.PATH | split row (char esep) | prepend '/some/path')

--- a/crates/nu-utils/src/sample_config/sample_login.nu
+++ b/crates/nu-utils/src/sample_config/sample_login.nu
@@ -1,9 +1,12 @@
 # Example Nushell Loginshell Config File
+#
+# version = 0.82.1
+#
 # - has to be as login.nu in the default config directory
 # - will be sourced after config.nu and env.nu in case of nushell started as login shell
 
 # just as an example for overwriting of an environment variable of env.nu
-$env.PROMPT_INDICATOR = {|| "(LS)> " }
+# $env.PROMPT_INDICATOR = {|| "(LS)> " }
 
 # Similar to env-path and config-path there is a variable containing the path to login.nu
-echo $nu.loginshell-path
+# echo $nu.loginshell-path


### PR DESCRIPTION
should close https://github.com/nushell/nushell/issues/9630
inspiration:
- the Kitty default config file

# Description
there appears to be some confusion about `| table` at the end of the pipe.
the `display_output` hook in the default config and the fact that the book mentions `... | table` can be confusing because the output of `table` cannot be piped further :thinking: 

the idea with this PR is to
- make the default config files basically do nothing
- still show all what's possible in the files for visibility

users can see what they can do in the config but they have to uncomment explicitely the features they want, e.g. the `display_output` will still be there but commented so that it does not mess with the output by default.

### changelog
- make the format consistent in `default_config.nu`
- comment the lines in the three config files
- move the `create_left_prompt` and `create_right_prompt` to an `export-env` block in `env.nu` so that they are not in the scope of the REPL
- leave some things uncommented
    - the themes
    - the `$env.config` record
    - the `$env.config.hook` record
    - the `$env.config.menus` array
    - the `$env.config.keybindings` array

> **Note**
> the idea behind the four `$env.config` being left uncommented is that, as they are quite big, users might forget to uncomment the closing symbols, breaking the config file.
> it also has the benefit of giving some highlight in the file.

# User-Facing Changes
now the default config does not do anything.
the files contain the same information but it's the user's responsibility to uncomment what they want in their config.

# Tests + Formatting

# After Submitting