### PR TITLE
allow `mut` to be used with pipelines

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/mut_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/mut_.rs
@@ -1,4 +1,4 @@
-use nu_engine::eval_expression_with_input;
+use nu_engine::eval_block;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type};
@@ -54,25 +54,22 @@ impl Command for Mut {
             .as_var()
             .expect("internal error: missing variable");
 
-        let keyword_expr = call
+        let block_id = call
             .positional_nth(1)
             .expect("checked through parser")
-            .as_keyword()
-            .expect("internal error: missing keyword");
+            .as_block()
+            .expect("internal error: missing right hand side");
 
-        let rhs = eval_expression_with_input(
+        let pipeline_data = eval_block(
             engine_state,
             stack,
-            keyword_expr,
+            engine_state.get_block(block_id),
             input,
             call.redirect_stdout,
             call.redirect_stderr,
-        )?
-        .0;
+        )?;
 
-        //println!("Adding: {:?} to {}", rhs, var_id);
-
-        stack.add_var(var_id, rhs.into_value(call.head));
+        stack.add_var(var_id, pipeline_data.into_value(call.head));
         Ok(PipelineData::empty())
     }
 

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -177,3 +177,19 @@ fn mut_records_update_properly() {
     let actual = nu!(pipeline("mut a = {}; $a.b.c = 100; $a.b.c"));
     assert_eq!(actual.out, "100");
 }
+
+#[test]
+fn mut_takes_pipeline() {
+    let actual = nu!(r#"mut x = "hello world" | str length; print $x"#);
+
+    assert_eq!(actual.out, "11");
+}
+
+#[test]
+fn mut_pipeline_allows_in() {
+    let actual = nu!(r#"
+        def foo [] { mut x = $in | str length; print ($x + 10) }; "hello world" | foo
+    "#);
+
+    assert_eq!(actual.out, "21");
+}

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2898,13 +2898,13 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
         }]);
     } else {
         working_set.error(ParseError::UnknownState(
-            "internal error: let or const statements not found in core language".into(),
+            "internal error: let statement not found in core language".into(),
             span(spans),
         ))
     }
 
     working_set.error(ParseError::UnknownState(
-        "internal error: let or const statement unparsable".into(),
+        "internal error: let statement unparsable".into(),
         span(spans),
     ));
 


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell/pull/9589

# Description
this PR aims at solving the following error with `mut`:
```nushell
> mut a = ls | get name
Error: nu::parser::unexpected_keyword

  × mut statement used in pipeline.
   ╭─[entry #1:1:1]
 1 │ mut a = ls | get name
   · ─┬─
   ·  ╰── 'mut' in pipeline
   ╰────
  help: Assigning 'ls' to 'a' does not produce a value to be piped. If the pipeline result is meant to be assigned to 'a',
        use 'mut a = (ls | ...)'.
```

## :warning: TODO: modify the parser as in https://github.com/nushell/nushell/pull/9589/files

# User-Facing Changes
users should now be able to use `mut` without `()`.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting