### PR TITLE
Remove duplicated dependency on `ansi-str 0.7`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,15 +109,6 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "ansi-str"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b1ed1c166829a0ccb5d79caa0f75cb4abd4adb2ce2c096755b7ad5ffdb0990"
-dependencies = [
- "ansitok",
-]
-
-[[package]]
-name = "ansi-str"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
@@ -2868,7 +2859,7 @@ dependencies = [
 name = "nu-explore"
 version = "0.82.1"
 dependencies = [
- "ansi-str 0.7.2",
+ "ansi-str",
  "crossterm",
  "lscolors",
  "nu-ansi-term 0.47.0",
@@ -3403,7 +3394,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
 dependencies = [
- "ansi-str 0.8.0",
+ "ansi-str",
  "ansitok",
  "bytecount",
  "fnv",
@@ -5068,7 +5059,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce69a5028cd9576063ec1f48edb2c75339fd835e6094ef3e05b3a079bf594a6"
 dependencies = [
- "ansi-str 0.8.0",
+ "ansi-str",
  "ansitok",
  "papergrid",
  "unicode-width",

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -24,5 +24,5 @@ terminal_size = "0.2"
 strip-ansi-escapes = "0.1"
 crossterm = "0.26"
 ratatui = "0.20"
-ansi-str = "0.7"
+ansi-str = "0.8"
 lscolors = { version = "0.14", default-features = false, features = ["nu-ansi-term"] }

--- a/crates/nu-explore/src/views/coloredtextw.rs
+++ b/crates/nu-explore/src/views/coloredtextw.rs
@@ -69,7 +69,7 @@ fn cut_string(text: &str, area: Rect, skip: usize) -> Cow<'_, str> {
     text
 }
 
-fn style_to_tui(style: ansi_str::Style) -> Style {
+fn style_to_tui(style: &ansi_str::Style) -> Style {
     let mut out = Style::default();
     if let Some(clr) = style.background() {
         out.bg = ansi_color_to_tui_color(clr);


### PR DESCRIPTION
# Description
`tabled`/`papergrid` already use `ansi-str 0.8` while `nu-explore`
itself was still depending on `0.7`. Single fix necessary to adapt to
the new API.

cc @zhiburt

# User-Facing Changes
None
