### PR TITLE
Bump `indexmap` to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -2677,7 +2678,7 @@ dependencies = [
 name = "nu-cmd-base"
 version = "0.82.1"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "nu-engine",
  "nu-path",
  "nu-protocol",
@@ -2689,7 +2690,7 @@ version = "0.82.1"
 dependencies = [
  "chrono",
  "fancy-regex",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "nu-cmd-lang",
  "nu-engine",
  "nu-parser",
@@ -2779,7 +2780,7 @@ dependencies = [
  "filetime",
  "fs_extra",
  "htmlescape",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "indicatif",
  "is-root",
  "itertools",
@@ -2954,7 +2955,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "fancy-regex",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "lru",
  "miette",
  "nu-test-support",
@@ -3065,7 +3066,7 @@ version = "0.82.1"
 dependencies = [
  "eml-parser",
  "ical",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "nu-plugin",
  "nu-protocol",
  "rust-ini",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,7 +1833,6 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
- "serde",
 ]
 
 [[package]]

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -13,4 +13,4 @@ version = "0.82.1"
 nu-engine = { path = "../nu-engine", version = "0.82.1" }
 nu-path = { path = "../nu-path", version = "0.82.1" }
 nu-protocol = { version = "0.82.1", path = "../nu-protocol" }
-indexmap = { version = "2.0", features = ["serde"] }
+indexmap = { version = "2.0" }

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -13,4 +13,4 @@ version = "0.82.1"
 nu-engine = { path = "../nu-engine", version = "0.82.1" }
 nu-path = { path = "../nu-path", version = "0.82.1" }
 nu-protocol = { version = "0.82.1", path = "../nu-protocol" }
-indexmap = { version = "1.7", features = ["serde-1"] }
+indexmap = { version = "2.0", features = ["serde"] }

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -20,7 +20,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.82.1" }
 # Potential dependencies for extras
 chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
 fancy-regex = "0.11"
-indexmap = { version = "1.7", features = ["serde-1"] }
+indexmap = { version = "2.0", features = ["serde"] }
 num = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "0.34", features = ["serde"], optional = true }

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -20,7 +20,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.82.1" }
 # Potential dependencies for extras
 chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
 fancy-regex = "0.11"
-indexmap = { version = "2.0", features = ["serde"] }
+indexmap = { version = "2.0" }
 num = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "0.34", features = ["serde"], optional = true }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -49,7 +49,7 @@ filesize = "0.2"
 filetime = "0.2"
 fs_extra = "1.3"
 htmlescape = "0.3"
-indexmap = { version = "2.0", features = ["serde"] }
+indexmap = "2.0"
 indicatif = "0.17"
 is-root = "0.1"
 itertools = "0.10"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -49,7 +49,7 @@ filesize = "0.2"
 filetime = "0.2"
 fs_extra = "1.3"
 htmlescape = "0.3"
-indexmap = { version = "1.7", features = ["serde-1"] }
+indexmap = { version = "2.0", features = ["serde"] }
 indicatif = "0.17"
 is-root = "0.1"
 itertools = "0.10"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -19,7 +19,7 @@ byte-unit = "4.0"
 chrono = { version = "0.4", features = [ "serde", "std", "unstable-locales" ], default-features = false }
 chrono-humanize = "0.2"
 fancy-regex = "0.11"
-indexmap = { version = "1.7" }
+indexmap = { version = "2.0" }
 lru = "0.10"
 miette = { version = "5.9", features = ["fancy-no-backtrace"] }
 num-format = "0.4"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -19,7 +19,7 @@ byte-unit = "4.0"
 chrono = { version = "0.4", features = [ "serde", "std", "unstable-locales" ], default-features = false }
 chrono-humanize = "0.2"
 fancy-regex = "0.11"
-indexmap = { version = "2.0" }
+indexmap = "2.0"
 lru = "0.10"
 miette = { version = "5.9", features = ["fancy-no-backtrace"] }
 num-format = "0.4"

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.82.1"
 nu-plugin = { path = "../nu-plugin", version = "0.82.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.82.1", features = ["plugin"] }
 
-indexmap = { version = "2.0", features = ["serde"] }
+indexmap = "2.0"
 eml-parser = "0.1"
 ical = "0.8"
 rust-ini = "0.19.0"

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.82.1"
 nu-plugin = { path = "../nu-plugin", version = "0.82.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.82.1", features = ["plugin"] }
 
-indexmap = { version = "1.7", features = ["serde-1"] }
+indexmap = { version = "2.0", features = ["serde"] }
 eml-parser = "0.1"
 ical = "0.8"
 rust-ini = "0.19.0"


### PR DESCRIPTION
# Description
Apart from `polars` (only used with `--features dataframe`) and the dev-dependencies our deps use `indexmap 2.0`.
Thus the default or `extra` `cargo build` will reduce deps.
This also will help deduplicating `hashbrown` and `ahash`.

For #8060

- Bump `indexmap` to 2.0
- Remove unneeded `serde` feature from `indexmap`

# User-Facing Changes
None
