### PR TITLE
Remove unnecessary `cwd`, `pipeline()`, `r#` from various tests

### DIFF
--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -1,65 +1,65 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 use pretty_assertions::assert_eq;
 
 #[test]
 fn const_bool() {
-    let inp = &[r#"const x = false"#, r#"$x"#];
+    let inp = &["const x = false", "$x"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn const_int() {
-    let inp = &[r#"const x = 10"#, r#"$x"#];
+    let inp = &["const x = 10", "$x"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "10");
 }
 
 #[test]
 fn const_float() {
-    let inp = &[r#"const x = 1.234"#, r#"$x"#];
+    let inp = &["const x = 1.234", "$x"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "1.234");
 }
 
 #[test]
 fn const_binary() {
-    let inp = &[r#"const x = 0x[12]"#, r#"$x"#];
+    let inp = &["const x = 0x[12]", "$x"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.out.contains("12"));
 }
 
 #[test]
 fn const_datetime() {
-    let inp = &[r#"const x = 2021-02-27T13:55:40+00:00"#, r#"$x"#];
+    let inp = &["const x = 2021-02-27T13:55:40+00:00", "$x"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.out.contains("Sat, 27 Feb 2021 13:55:40"));
 }
 
 #[test]
 fn const_list() {
-    let inp = &[r#"const x = [ a b c ]"#, r#"$x | describe"#];
+    let inp = &["const x = [ a b c ]", "$x | describe"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "list<string>");
 }
 
 #[test]
 fn const_record() {
-    let inp = &[r#"const x = { a: 10, b: 20, c: 30 }"#, r#"$x | describe"#];
+    let inp = &["const x = { a: 10, b: 20, c: 30 }", "$x | describe"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "record<a: int, b: int, c: int>");
 }
@@ -67,38 +67,38 @@ fn const_record() {
 #[test]
 fn const_table() {
     let inp = &[
-        r#"const x = [[a b c]; [10 20 30] [100 200 300]]"#,
-        r#"$x | describe"#,
+        "const x = [[a b c]; [10 20 30] [100 200 300]]",
+        "$x | describe",
     ];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "table<a: int, b: int, c: int>");
 }
 
 #[test]
 fn const_string() {
-    let inp = &[r#"const x = "abc""#, r#"$x"#];
+    let inp = &[r#"const x = "abc""#, "$x"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "abc");
 }
 
 #[test]
 fn const_nothing() {
-    let inp = &[r#"const x = $nothing"#, r#"$x | describe"#];
+    let inp = &["const x = $nothing", "$x | describe"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "nothing");
 }
 
 #[test]
 fn const_unsupported() {
-    let inp = &[r#"const x = ('abc' | str length)"#];
+    let inp = &["const x = ('abc' | str length)"];
 
-    let actual = nu!(cwd: "tests/const_", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.err.contains("not_a_constant"));
 }

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -2,9 +2,7 @@ use nu_test_support::nu;
 
 #[test]
 fn source_file_relative_to_file() {
-    let actual = nu!(cwd: "tests/eval", r#"
-        {x: 1, x: 2}
-        "#);
+    let actual = nu!("{x: 1, x: 2}");
 
     assert!(actual.err.contains("redefined"));
 }

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -11,7 +11,7 @@ fn env_change_hook_code_list(name: &str, code_list: &[&str]) -> String {
     }
 
     format!(
-        r#"$env.config = {{
+        "$env.config = {{
             hooks: {{
                 env_change: {{
                     {name} : [
@@ -19,25 +19,25 @@ fn env_change_hook_code_list(name: &str, code_list: &[&str]) -> String {
                     ]
                 }}
             }}
-        }}"#
+        }}"
     )
 }
 
 fn env_change_hook(name: &str, code: &str) -> String {
     format!(
-        r#"$env.config = {{
+        "$env.config = {{
             hooks: {{
                 env_change: {{
                     {name} : {code}
                 }}
             }}
-        }}"#
+        }}"
     )
 }
 
 fn env_change_hook_code(name: &str, code: &str) -> String {
     format!(
-        r#"$env.config = {{
+        "$env.config = {{
             hooks: {{
                 env_change: {{
                     {name} : {{
@@ -45,13 +45,13 @@ fn env_change_hook_code(name: &str, code: &str) -> String {
                     }}
                 }}
             }}
-        }}"#
+        }}"
     )
 }
 
 fn env_change_hook_code_condition(name: &str, condition: &str, code: &str) -> String {
     format!(
-        r#"$env.config = {{
+        "$env.config = {{
             hooks: {{
                 env_change: {{
                     {name} : {{
@@ -60,51 +60,51 @@ fn env_change_hook_code_condition(name: &str, condition: &str, code: &str) -> St
                     }}
                 }}
             }}
-        }}"#
+        }}"
     )
 }
 
 fn pre_prompt_hook(code: &str) -> String {
     format!(
-        r#"$env.config = {{
+        "$env.config = {{
             hooks: {{
                 pre_prompt: {code}
             }}
-        }}"#
+        }}"
     )
 }
 
 fn pre_prompt_hook_code(code: &str) -> String {
     format!(
-        r#"$env.config = {{
+        "$env.config = {{
             hooks: {{
                 pre_prompt: {{
                     code: {code}
                 }}
             }}
-        }}"#
+        }}"
     )
 }
 
 fn pre_execution_hook(code: &str) -> String {
     format!(
-        r#"$env.config = {{
+        "$env.config = {{
             hooks: {{
                 pre_execution: {code}
             }}
-        }}"#
+        }}"
     )
 }
 
 fn pre_execution_hook_code(code: &str) -> String {
     format!(
-        r#"$env.config = {{
+        "$env.config = {{
             hooks: {{
                 pre_execution: {{
                     code: {code}
                 }}
             }}
-        }}"#
+        }}"
     )
 }
 
@@ -326,7 +326,7 @@ fn pre_execution_block_preserve_env_var() {
 #[test]
 fn pre_execution_commandline() {
     let inp = &[
-        &pre_execution_hook_code(r#"{|| $env.repl_commandline = (commandline) }"#),
+        &pre_execution_hook_code("{|| $env.repl_commandline = (commandline) }"),
         "$env.repl_commandline",
     ];
 
@@ -377,8 +377,8 @@ fn env_change_block_condition_pwd() {
     let inp = &[
         &env_change_hook_code_condition(
             "PWD",
-            r#"{|before, after| ($after | path basename) == samples }"#,
-            r#"'source-env .nu-env'"#,
+            "{|before, after| ($after | path basename) == samples }",
+            "'source-env .nu-env'",
         ),
         "cd samples",
         "$env.SPAM",
@@ -393,14 +393,14 @@ fn env_change_block_condition_pwd() {
 #[test]
 fn env_change_block_condition_correct_args() {
     let inp = &[
-        r#"$env.FOO = 1"#,
+        "$env.FOO = 1",
         &env_change_hook_code_condition(
             "FOO",
-            r#"{|before, after| $before == 1 and $after == 2}"#,
-            r#"{|before, after| $env.SPAM = ($before == 1 and $after == 2) }"#,
+            "{|before, after| $before == 1 and $after == 2}",
+            "{|before, after| $env.SPAM = ($before == 1 and $after == 2) }",
         ),
         "",
-        r#"$env.FOO = 2"#,
+        "$env.FOO = 2",
         "$env.SPAM",
     ];
 
@@ -413,7 +413,7 @@ fn env_change_block_condition_correct_args() {
 #[test]
 fn env_change_dont_panic_with_many_args() {
     let inp = &[
-        &env_change_hook_code("FOO", r#"{ |a, b, c| $env.SPAM = 'spam' }"#),
+        &env_change_hook_code("FOO", "{ |a, b, c| $env.SPAM = 'spam' }"),
         "$env.FOO = 1",
         "",
     ];
@@ -427,13 +427,13 @@ fn env_change_dont_panic_with_many_args() {
 #[test]
 fn err_hook_wrong_env_type_1() {
     let inp = &[
-        r#"$env.config = {
+        "$env.config = {
             hooks: {
                 env_change: {
                     FOO : 1
                 }
             }
-        }"#,
+        }",
         "$env.FOO = 1",
         "",
     ];
@@ -465,7 +465,7 @@ fn err_hook_wrong_env_type_2() {
 #[test]
 fn err_hook_wrong_env_type_3() {
     let inp = &[
-        r#"$env.config = {
+        "$env.config = {
             hooks: {
                 env_change: {
                     FOO : {
@@ -473,7 +473,7 @@ fn err_hook_wrong_env_type_3() {
                     }
                 }
             }
-        }"#,
+        }",
         "$env.FOO = 1",
         "",
     ];

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -116,7 +116,7 @@ fn env_change_define_command() {
         "foo",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "got foo!");
@@ -130,7 +130,7 @@ fn env_change_define_variable() {
         "$x",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -144,7 +144,7 @@ fn env_change_define_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -158,7 +158,7 @@ fn env_change_define_alias() {
         "spam",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -172,7 +172,7 @@ fn env_change_simple_block_preserve_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -192,7 +192,7 @@ fn env_change_simple_block_list_shadow_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -206,7 +206,7 @@ fn env_change_block_preserve_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -219,7 +219,7 @@ fn pre_prompt_define_command() {
         "foo",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "got foo!");
@@ -229,7 +229,7 @@ fn pre_prompt_define_command() {
 fn pre_prompt_simple_block_preserve_env_var() {
     let inp = &[&pre_prompt_hook(r#"{|| $env.SPAM = "spam" }"#), "$env.SPAM"];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -247,7 +247,7 @@ fn pre_prompt_simple_block_list_shadow_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -260,7 +260,7 @@ fn pre_prompt_block_preserve_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -273,7 +273,7 @@ fn pre_execution_define_command() {
         "foo",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "got foo!");
@@ -286,7 +286,7 @@ fn pre_execution_simple_block_preserve_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -304,7 +304,7 @@ fn pre_execution_simple_block_list_shadow_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -317,7 +317,7 @@ fn pre_execution_block_preserve_env_var() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "spam");
@@ -330,7 +330,7 @@ fn pre_execution_commandline() {
         "$env.repl_commandline",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "$env.repl_commandline");
@@ -350,7 +350,7 @@ fn env_change_shadow_command() {
         "foo",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "got foo!");
@@ -364,7 +364,7 @@ fn env_change_block_dont_preserve_command() {
         "foo",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     #[cfg(windows)]
     assert_ne!(actual_repl.out, "foo");
@@ -404,7 +404,7 @@ fn env_change_block_condition_correct_args() {
         "$env.SPAM",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual_repl.err, "");
     assert_eq!(actual_repl.out, "true");
@@ -418,7 +418,7 @@ fn env_change_dont_panic_with_many_args() {
         "",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual_repl.err.contains("incompatible_parameters"));
     assert_eq!(actual_repl.out, "");
@@ -438,7 +438,7 @@ fn err_hook_wrong_env_type_1() {
         "",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
     dbg!(&actual_repl.err);
 
     assert!(actual_repl.err.contains("unsupported_config_value"));
@@ -456,7 +456,7 @@ fn err_hook_wrong_env_type_2() {
         "",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual_repl.err.contains("type_mismatch"));
     assert_eq!(actual_repl.out, "");
@@ -478,7 +478,7 @@ fn err_hook_wrong_env_type_3() {
         "",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
@@ -501,7 +501,7 @@ fn err_hook_non_boolean_condition_output() {
         "",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
@@ -524,7 +524,7 @@ fn err_hook_non_condition_not_a_block() {
         "",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
@@ -546,7 +546,7 @@ fn err_hook_parse_error() {
         "",
     ];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
@@ -556,7 +556,7 @@ fn err_hook_parse_error() {
 fn err_hook_dont_allow_string() {
     let inp = &[&pre_prompt_hook(r#"'def foo [] { "got foo!" }'"#), "foo"];
 
-    let actual_repl = nu!(cwd: "tests/hooks", nu_repl_code(inp));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual_repl.out.is_empty());
     assert!(actual_repl.err.contains("unsupported_config_value"));

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -9,11 +9,11 @@ fn module_private_import_decl() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     use spam.nu foo-helper
 
                     export def foo [] { foo-helper }
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
@@ -23,7 +23,7 @@ fn module_private_import_decl() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, "foo"];
+        let inp = &["use main.nu foo", "foo"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -37,11 +37,11 @@ fn module_private_import_alias() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     use spam.nu foo-helper
 
                     export def foo [] { foo-helper }
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
@@ -50,7 +50,7 @@ fn module_private_import_alias() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, "foo"];
+        let inp = &["use main.nu foo", "foo"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -64,9 +64,9 @@ fn module_private_import_decl_not_public() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     use spam.nu foo-helper
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
@@ -76,7 +76,7 @@ fn module_private_import_decl_not_public() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, "foo-helper"];
+        let inp = &["use main.nu foo", "foo-helper"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -90,9 +90,9 @@ fn module_public_import_decl() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     export use spam.nu foo
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
@@ -102,7 +102,7 @@ fn module_public_import_decl() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, "foo"];
+        let inp = &["use main.nu foo", "foo"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -116,9 +116,9 @@ fn module_public_import_alias() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     export use spam.nu foo
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
@@ -127,7 +127,7 @@ fn module_public_import_alias() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, "foo"];
+        let inp = &["use main.nu foo", "foo"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -141,21 +141,21 @@ fn module_nested_imports() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     export use spam.nu [ foo bar ]
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
-                r#"
+                "
                     export use spam2.nu [ foo bar ]
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam2.nu",
-                r#"
+                "
                     export use spam3.nu [ foo bar ]
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam3.nu",
@@ -165,8 +165,8 @@ fn module_nested_imports() {
                 "#,
             )]);
 
-        let inp1 = &[r#"use main.nu foo"#, "foo"];
-        let inp2 = &[r#"use main.nu bar"#, "bar"];
+        let inp1 = &["use main.nu foo", "foo"];
+        let inp2 = &["use main.nu bar", "bar"];
 
         let actual = nu!(cwd: dirs.test(), &inp1.join("; "));
         assert_eq!(actual.out, "foo");
@@ -185,21 +185,21 @@ fn module_nested_imports_in_dirs() {
             .mkdir("spam/spam3")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     export use spam/spam.nu [ foo bar ]
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam/spam.nu",
-                r#"
+                "
                     export use spam2/spam2.nu [ foo bar ]
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam/spam2/spam2.nu",
-                r#"
+                "
                     export use ../spam3/spam3.nu [ foo bar ]
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam/spam3/spam3.nu",
@@ -209,8 +209,8 @@ fn module_nested_imports_in_dirs() {
                 "#,
             )]);
 
-        let inp1 = &[r#"use main.nu foo"#, "foo"];
-        let inp2 = &[r#"use main.nu bar"#, "bar"];
+        let inp1 = &["use main.nu foo", "foo"];
+        let inp2 = &["use main.nu bar", "bar"];
 
         let actual = nu!(cwd: dirs.test(), &inp1.join("; "));
         assert_eq!(actual.out, "foo");
@@ -226,9 +226,9 @@ fn module_public_import_decl_prefixed() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     export use spam.nu
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
@@ -238,7 +238,7 @@ fn module_public_import_decl_prefixed() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu"#, "main spam foo"];
+        let inp = &["use main.nu", "main spam foo"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -261,16 +261,16 @@ fn module_nested_imports_in_dirs_prefixed() {
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam/spam.nu",
-                r#"
+                "
                     export use spam2/spam2.nu
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam/spam2/spam2.nu",
-                r#"
+                "
                     export use ../spam3/spam3.nu
                     export use ../spam3/spam3.nu foo
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam/spam3/spam3.nu",
@@ -280,7 +280,7 @@ fn module_nested_imports_in_dirs_prefixed() {
                 "#,
             )]);
 
-        let inp1 = &[r#"use main.nu"#, "main spam2 foo"];
+        let inp1 = &["use main.nu", "main spam2 foo"];
         let inp2 = &[r#"use main.nu "spam2 spam3 bar""#, "spam2 spam3 bar"];
 
         let actual = nu!(cwd: dirs.test(), &inp1.join("; "));
@@ -297,11 +297,11 @@ fn module_import_env_1() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     export-env { source-env spam.nu }
 
                     export def foo [] { $env.FOO_HELPER }
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
@@ -310,7 +310,7 @@ fn module_import_env_1() {
                 "#,
             )]);
 
-        let inp = &[r#"source-env main.nu"#, r#"use main.nu foo"#, "foo"];
+        let inp = &["source-env main.nu", "use main.nu foo", "foo"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -324,9 +324,9 @@ fn module_import_env_2() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     export-env { source-env spam.nu }
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
@@ -335,7 +335,7 @@ fn module_import_env_2() {
                 "#,
             )]);
 
-        let inp = &[r#"source-env main.nu"#, r#"$env.FOO"#];
+        let inp = &["source-env main.nu", "$env.FOO"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -348,12 +348,12 @@ fn module_cyclical_imports_0() {
     Playground::setup("module_cyclical_imports_0", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "spam.nu",
-            r#"
+            "
                     use eggs.nu
-                "#,
+                ",
         )]);
 
-        let inp = &[r#"module eggs { use spam.nu }"#];
+        let inp = &["module eggs { use spam.nu }"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -366,12 +366,12 @@ fn module_cyclical_imports_1() {
     Playground::setup("module_cyclical_imports_1", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "spam.nu",
-            r#"
+            "
                     use spam.nu
-                "#,
+                ",
         )]);
 
-        let inp = &[r#"use spam.nu"#];
+        let inp = &["use spam.nu"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -385,18 +385,18 @@ fn module_cyclical_imports_2() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
-                r#"
+                "
                     use eggs.nu
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "eggs.nu",
-                r#"
+                "
                     use spam.nu
-                "#,
+                ",
             )]);
 
-        let inp = &[r#"use spam.nu"#];
+        let inp = &["use spam.nu"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -410,24 +410,24 @@ fn module_cyclical_imports_3() {
         sandbox
             .with_files(vec![FileWithContentToBeTrimmed(
                 "spam.nu",
-                r#"
+                "
                     use eggs.nu
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "eggs.nu",
-                r#"
+                "
                     use bacon.nu
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "bacon.nu",
-                r#"
+                "
                     use spam.nu
-                "#,
+                ",
             )]);
 
-        let inp = &[r#"use spam.nu"#];
+        let inp = &["use spam.nu"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -445,7 +445,7 @@ fn module_import_const_file() {
             "#,
         )]);
 
-        let inp = &[r#"const file = 'spam.nu'"#, r#"use $file foo"#, "foo"];
+        let inp = &["const file = 'spam.nu'", "use $file foo", "foo"];
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
@@ -465,8 +465,8 @@ fn module_import_const_module_name() {
 
         let inp = &[
             r#"module spam { export def foo [] { "foo" } }"#,
-            r#"const mod = 'spam'"#,
-            r#"use $mod foo"#,
+            "const mod = 'spam'",
+            "use $mod foo",
             "foo",
         ];
 
@@ -523,7 +523,7 @@ fn module_invalid_alias_name() {
 
 #[test]
 fn module_main_alias_not_allowed() {
-    let inp = &[r#"module spam { export alias main = echo 'spam' }"#];
+    let inp = &["module spam { export alias main = echo 'spam' }"];
 
     let actual = nu!(&inp.join("; "));
 
@@ -532,7 +532,7 @@ fn module_main_alias_not_allowed() {
 
 #[test]
 fn module_valid_known_external_name() {
-    let inp = &[r#"module spam { extern spam [] }"#];
+    let inp = &["module spam { extern spam [] }"];
 
     let actual = nu!(&inp.join("; "));
 
@@ -541,7 +541,7 @@ fn module_valid_known_external_name() {
 
 #[test]
 fn module_invalid_known_external_name() {
-    let inp = &[r#"module spam { export extern spam [] }"#];
+    let inp = &["module spam { export extern spam [] }"];
 
     let actual = nu!(&inp.join("; "));
 
@@ -551,10 +551,10 @@ fn module_invalid_known_external_name() {
 #[test]
 fn main_inside_module_is_main() {
     let inp = &[
-        r#"module spam {
+        "module spam {
             export def main [] { 'foo' };
             export def foo [] { main }
-        }"#,
+        }",
         "use spam foo",
         "foo",
     ];
@@ -566,7 +566,7 @@ fn main_inside_module_is_main() {
 
 #[test]
 fn module_as_file() {
-    let inp = &[r#"module samples/spam.nu"#, "use spam foo", "foo"];
+    let inp = &["module samples/spam.nu", "use spam foo", "foo"];
 
     let actual = nu!(cwd: "tests/modules", &inp.join("; "));
 
@@ -575,7 +575,7 @@ fn module_as_file() {
 
 #[test]
 fn export_module_as_file() {
-    let inp = &[r#"export module samples/spam.nu"#, "use spam foo", "foo"];
+    let inp = &["export module samples/spam.nu", "use spam foo", "foo"];
 
     let actual = nu!(cwd: "tests/modules", &inp.join("; "));
 
@@ -584,7 +584,7 @@ fn export_module_as_file() {
 
 #[test]
 fn deep_import_patterns() {
-    let module_decl = r#"
+    let module_decl = "
         module spam {
             export module eggs {
                 export module beans {
@@ -593,7 +593,7 @@ fn deep_import_patterns() {
                 };
             };
         }
-    "#;
+    ";
 
     let inp = &[module_decl, "use spam", "spam eggs beans foo"];
     let actual = nu!(&inp.join("; "));
@@ -687,14 +687,14 @@ fn module_dir_missing_mod_nu() {
 #[test]
 fn allowed_local_module() {
     let inp = &["module spam { module spam {} }"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
+    let actual = nu!(&inp.join("; "));
     assert!(actual.err.is_empty());
 }
 
 #[test]
 fn not_allowed_submodule() {
     let inp = &["module spam { export module spam {} }"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
+    let actual = nu!(&inp.join("; "));
     assert!(actual.err.contains("named_as_module"));
 }
 
@@ -705,48 +705,48 @@ fn module_self_name() {
         "use spam",
         "spam",
     ];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
+    let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "spam");
 }
 
 #[test]
 fn module_self_name_main_not_allowed() {
     let inp = &[
-        r#"module spam {
+        "module spam {
             export def main [] { 'main spam' };
 
             export module mod {
                 export def main [] { 'mod spam' }
             }
-        }"#,
+        }",
         "use spam",
         "spam",
     ];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
+    let actual = nu!(&inp.join("; "));
     assert!(actual.err.contains("module_double_main"));
 
     let inp = &[
-        r#"module spam {
+        "module spam {
             export module mod {
                 export def main [] { 'mod spam' }
             };
 
             export def main [] { 'main spam' }
-        }"#,
+        }",
         "use spam",
         "spam",
     ];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
+    let actual = nu!(&inp.join("; "));
     assert!(actual.err.contains("module_double_main"));
 }
 
 #[test]
 fn module_main_not_found() {
     let inp = &["module spam {}", "use spam main"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
+    let actual = nu!(&inp.join("; "));
     assert!(actual.err.contains("export_not_found"));
 
     let inp = &["module spam {}", "use spam [ main ]"];
-    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
+    let actual = nu!(&inp.join("; "));
     assert!(actual.err.contains("export_not_found"));
 }

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, nu_repl_code, pipeline};
+use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
 
 #[test]
@@ -23,9 +23,9 @@ fn module_private_import_decl() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, r#"foo"#];
+        let inp = &[r#"use main.nu foo"#, "foo"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -50,9 +50,9 @@ fn module_private_import_alias() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, r#"foo"#];
+        let inp = &[r#"use main.nu foo"#, "foo"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -76,9 +76,9 @@ fn module_private_import_decl_not_public() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, r#"foo-helper"#];
+        let inp = &[r#"use main.nu foo"#, "foo-helper"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert!(!actual.err.is_empty());
     })
@@ -102,9 +102,9 @@ fn module_public_import_decl() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, r#"foo"#];
+        let inp = &[r#"use main.nu foo"#, "foo"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -127,9 +127,9 @@ fn module_public_import_alias() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu foo"#, r#"foo"#];
+        let inp = &[r#"use main.nu foo"#, "foo"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -165,13 +165,13 @@ fn module_nested_imports() {
                 "#,
             )]);
 
-        let inp1 = &[r#"use main.nu foo"#, r#"foo"#];
-        let inp2 = &[r#"use main.nu bar"#, r#"bar"#];
+        let inp1 = &[r#"use main.nu foo"#, "foo"];
+        let inp2 = &[r#"use main.nu bar"#, "bar"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp1.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp1.join("; "));
         assert_eq!(actual.out, "foo");
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp2.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp2.join("; "));
         assert_eq!(actual.out, "bar");
     })
 }
@@ -209,13 +209,13 @@ fn module_nested_imports_in_dirs() {
                 "#,
             )]);
 
-        let inp1 = &[r#"use main.nu foo"#, r#"foo"#];
-        let inp2 = &[r#"use main.nu bar"#, r#"bar"#];
+        let inp1 = &[r#"use main.nu foo"#, "foo"];
+        let inp2 = &[r#"use main.nu bar"#, "bar"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp1.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp1.join("; "));
         assert_eq!(actual.out, "foo");
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp2.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp2.join("; "));
         assert_eq!(actual.out, "bar");
     })
 }
@@ -238,9 +238,9 @@ fn module_public_import_decl_prefixed() {
                 "#,
             )]);
 
-        let inp = &[r#"use main.nu"#, r#"main spam foo"#];
+        let inp = &[r#"use main.nu"#, "main spam foo"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -280,13 +280,13 @@ fn module_nested_imports_in_dirs_prefixed() {
                 "#,
             )]);
 
-        let inp1 = &[r#"use main.nu"#, r#"main spam2 foo"#];
-        let inp2 = &[r#"use main.nu "spam2 spam3 bar""#, r#"spam2 spam3 bar"#];
+        let inp1 = &[r#"use main.nu"#, "main spam2 foo"];
+        let inp2 = &[r#"use main.nu "spam2 spam3 bar""#, "spam2 spam3 bar"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp1.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp1.join("; "));
         assert_eq!(actual.out, "foo");
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp2.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp2.join("; "));
         assert_eq!(actual.out, "bar");
     })
 }
@@ -310,9 +310,9 @@ fn module_import_env_1() {
                 "#,
             )]);
 
-        let inp = &[r#"source-env main.nu"#, r#"use main.nu foo"#, r#"foo"#];
+        let inp = &[r#"source-env main.nu"#, r#"use main.nu foo"#, "foo"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -337,7 +337,7 @@ fn module_import_env_2() {
 
         let inp = &[r#"source-env main.nu"#, r#"$env.FOO"#];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -355,7 +355,7 @@ fn module_cyclical_imports_0() {
 
         let inp = &[r#"module eggs { use spam.nu }"#];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert!(actual.err.contains("module not found"));
     })
@@ -373,7 +373,7 @@ fn module_cyclical_imports_1() {
 
         let inp = &[r#"use spam.nu"#];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert!(actual.err.contains("cyclical"));
     })
@@ -398,7 +398,7 @@ fn module_cyclical_imports_2() {
 
         let inp = &[r#"use spam.nu"#];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert!(actual.err.contains("cyclical"));
     })
@@ -429,7 +429,7 @@ fn module_cyclical_imports_3() {
 
         let inp = &[r#"use spam.nu"#];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert!(actual.err.contains("cyclical"));
     })
@@ -445,9 +445,9 @@ fn module_import_const_file() {
             "#,
         )]);
 
-        let inp = &[r#"const file = 'spam.nu'"#, r#"use $file foo"#, r#"foo"#];
+        let inp = &[r#"const file = 'spam.nu'"#, r#"use $file foo"#, "foo"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -467,10 +467,10 @@ fn module_import_const_module_name() {
             r#"module spam { export def foo [] { "foo" } }"#,
             r#"const mod = 'spam'"#,
             r#"use $mod foo"#,
-            r#"foo"#,
+            "foo",
         ];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -480,7 +480,7 @@ fn module_import_const_module_name() {
 fn module_valid_def_name() {
     let inp = &[r#"module spam { def spam [] { "spam" } }"#];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "");
 }
@@ -489,7 +489,7 @@ fn module_valid_def_name() {
 fn module_invalid_def_name() {
     let inp = &[r#"module spam { export def spam [] { "spam" } }"#];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.err.contains("named_as_module"));
 }
@@ -498,7 +498,7 @@ fn module_invalid_def_name() {
 fn module_valid_alias_name_1() {
     let inp = &[r#"module spam { alias spam = echo "spam" }"#];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "");
 }
@@ -507,7 +507,7 @@ fn module_valid_alias_name_1() {
 fn module_valid_alias_name_2() {
     let inp = &[r#"module spam { alias main = echo "spam" }"#];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "");
 }
@@ -516,7 +516,7 @@ fn module_valid_alias_name_2() {
 fn module_invalid_alias_name() {
     let inp = &[r#"module spam { export alias spam = echo "spam" }"#];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.err.contains("named_as_module"));
 }
@@ -525,7 +525,7 @@ fn module_invalid_alias_name() {
 fn module_main_alias_not_allowed() {
     let inp = &[r#"module spam { export alias main = echo 'spam' }"#];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.err.contains("export_main_alias_not_allowed"));
 }
@@ -534,7 +534,7 @@ fn module_main_alias_not_allowed() {
 fn module_valid_known_external_name() {
     let inp = &[r#"module spam { extern spam [] }"#];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "");
 }
@@ -543,7 +543,7 @@ fn module_valid_known_external_name() {
 fn module_invalid_known_external_name() {
     let inp = &[r#"module spam { export extern spam [] }"#];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.err.contains("named_as_module"));
 }
@@ -559,7 +559,7 @@ fn main_inside_module_is_main() {
         "foo",
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "foo");
 }
@@ -568,7 +568,7 @@ fn main_inside_module_is_main() {
 fn module_as_file() {
     let inp = &[r#"module samples/spam.nu"#, "use spam foo", "foo"];
 
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
 
     assert_eq!(actual.out, "foo");
 }
@@ -577,7 +577,7 @@ fn module_as_file() {
 fn export_module_as_file() {
     let inp = &[r#"export module samples/spam.nu"#, "use spam foo", "foo"];
 
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
 
     assert_eq!(actual.out, "foo");
 }
@@ -596,19 +596,19 @@ fn deep_import_patterns() {
     "#;
 
     let inp = &[module_decl, "use spam", "spam eggs beans foo"];
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "foo");
 
     let inp = &[module_decl, "use spam eggs", "eggs beans foo"];
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "foo");
 
     let inp = &[module_decl, "use spam eggs beans", "beans foo"];
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "foo");
 
     let inp = &[module_decl, "use spam eggs beans foo", "foo"];
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "foo");
 }
 
@@ -617,27 +617,27 @@ fn module_dir() {
     let import = "use samples/spam";
 
     let inp = &[import, "spam"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "spam");
 
     let inp = &[import, "spam foo"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "foo");
 
     let inp = &[import, "spam bar"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "bar");
 
     let inp = &[import, "spam foo baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "foobaz");
 
     let inp = &[import, "spam bar baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "barbaz");
 
     let inp = &[import, "spam baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "spambaz");
 }
 
@@ -646,19 +646,19 @@ fn module_dir_deep() {
     let import = "use samples/spam";
 
     let inp = &[import, "spam bacon"];
-    let actual_repl = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual_repl.out, "bacon");
 
     let inp = &[import, "spam bacon foo"];
-    let actual_repl = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual_repl.out, "bacon foo");
 
     let inp = &[import, "spam bacon beans"];
-    let actual_repl = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual_repl.out, "beans");
 
     let inp = &[import, "spam bacon beans foo"];
-    let actual_repl = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual_repl = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual_repl.out, "beans foo");
 }
 
@@ -673,28 +673,28 @@ fn module_dir_import_twice_no_panic() {
 #[test]
 fn not_allowed_submodule_file() {
     let inp = &["use samples/not_allowed"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert!(actual.err.contains("invalid_module_file_name"));
 }
 
 #[test]
 fn module_dir_missing_mod_nu() {
     let inp = &["use samples/missing_mod_nu"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert!(actual.err.contains("module_missing_mod_nu_file"));
 }
 
 #[test]
 fn allowed_local_module() {
     let inp = &["module spam { module spam {} }"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert!(actual.err.is_empty());
 }
 
 #[test]
 fn not_allowed_submodule() {
     let inp = &["module spam { export module spam {} }"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert!(actual.err.contains("named_as_module"));
 }
 
@@ -705,7 +705,7 @@ fn module_self_name() {
         "use spam",
         "spam",
     ];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "spam");
 }
 
@@ -722,7 +722,7 @@ fn module_self_name_main_not_allowed() {
         "use spam",
         "spam",
     ];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert!(actual.err.contains("module_double_main"));
 
     let inp = &[
@@ -736,17 +736,17 @@ fn module_self_name_main_not_allowed() {
         "use spam",
         "spam",
     ];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert!(actual.err.contains("module_double_main"));
 }
 
 #[test]
 fn module_main_not_found() {
     let inp = &["module spam {}", "use spam main"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert!(actual.err.contains("export_not_found"));
 
     let inp = &["module spam {}", "use spam [ main ]"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert!(actual.err.contains("export_not_found"));
 }

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1,18 +1,18 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, nu_repl_code, pipeline};
+use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
 
 #[test]
 fn add_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"foo"#,
+        "overlay use spam",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -22,12 +22,12 @@ fn add_overlay() {
 fn add_overlay_as_new_name() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam as spam_new"#,
-        r#"foo"#,
+        "overlay use spam as spam_new",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -37,13 +37,13 @@ fn add_overlay_as_new_name() {
 fn add_overlay_twice() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"overlay use spam"#,
-        r#"foo"#,
+        "overlay use spam",
+        "overlay use spam",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -53,12 +53,12 @@ fn add_overlay_twice() {
 fn add_prefixed_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use --prefix spam"#,
-        r#"spam foo"#,
+        "overlay use --prefix spam",
+        "spam foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -68,13 +68,13 @@ fn add_prefixed_overlay() {
 fn add_prefixed_overlay_twice() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use --prefix spam"#,
-        r#"overlay use --prefix spam"#,
-        r#"spam foo"#,
+        "overlay use --prefix spam",
+        "overlay use --prefix spam",
+        "spam foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -84,12 +84,12 @@ fn add_prefixed_overlay_twice() {
 fn add_prefixed_overlay_mismatch_1() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use --prefix spam"#,
-        r#"overlay use spam"#,
+        "overlay use --prefix spam",
+        "overlay use spam",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("exists with a prefix"));
     // Why doesn't the REPL test work with the previous expected output
@@ -100,12 +100,12 @@ fn add_prefixed_overlay_mismatch_1() {
 fn add_prefixed_overlay_mismatch_2() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"overlay use --prefix spam"#,
+        "overlay use spam",
+        "overlay use --prefix spam",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("exists without a prefix"));
     // Why doesn't the REPL test work with the previous expected output
@@ -116,14 +116,14 @@ fn add_prefixed_overlay_mismatch_2() {
 fn prefixed_overlay_keeps_custom_decl() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use --prefix spam"#,
+        "overlay use --prefix spam",
         r#"def bar [] { "bar" }"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"bar"#,
+        "overlay hide --keep-custom spam",
+        "bar",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "bar");
     assert_eq!(actual_repl.out, "bar");
@@ -133,12 +133,12 @@ fn prefixed_overlay_keeps_custom_decl() {
 fn add_overlay_env() {
     let inp = &[
         r#"module spam { export-env { $env.FOO = "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"$env.FOO"#,
+        "overlay use spam",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -148,12 +148,12 @@ fn add_overlay_env() {
 fn add_prefixed_overlay_env_no_prefix() {
     let inp = &[
         r#"module spam { export-env { $env.FOO = "foo" } }"#,
-        r#"overlay use --prefix spam"#,
-        r#"$env.FOO"#,
+        "overlay use --prefix spam",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -161,9 +161,9 @@ fn add_prefixed_overlay_env_no_prefix() {
 
 #[test]
 fn add_overlay_from_file_decl() {
-    let inp = &[r#"overlay use samples/spam.nu"#, r#"foo"#];
+    let inp = &["overlay use samples/spam.nu", "foo"];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
@@ -172,13 +172,9 @@ fn add_overlay_from_file_decl() {
 
 #[test]
 fn add_overlay_from_const_file_decl() {
-    let inp = &[
-        r#"const file = 'samples/spam.nu'"#,
-        r#"overlay use $file"#,
-        r#"foo"#,
-    ];
+    let inp = &["const file = 'samples/spam.nu'", "overlay use $file", "foo"];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
 
     assert_eq!(actual.out, "foo");
 }
@@ -187,12 +183,12 @@ fn add_overlay_from_const_file_decl() {
 fn add_overlay_from_const_module_name_decl() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"const mod = 'spam'"#,
-        r#"overlay use $mod"#,
-        r#"foo"#,
+        "const mod = 'spam'",
+        "overlay use $mod",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "foo");
 }
@@ -200,12 +196,12 @@ fn add_overlay_from_const_module_name_decl() {
 #[test]
 fn new_overlay_from_const_name() {
     let inp = &[
-        r#"const mod = 'spam'"#,
-        r#"overlay new $mod"#,
-        r#"overlay list | last"#,
+        "const mod = 'spam'",
+        "overlay new $mod",
+        "overlay list | last",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -213,13 +209,13 @@ fn new_overlay_from_const_name() {
 #[test]
 fn hide_overlay_from_const_name() {
     let inp = &[
-        r#"const mod = 'spam'"#,
-        r#"overlay new $mod"#,
-        r#"overlay hide $mod"#,
-        r#"overlay list | str join ' '"#,
+        "const mod = 'spam'",
+        "overlay new $mod",
+        "overlay hide $mod",
+        "overlay list | str join ' '",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(!actual.out.contains("spam"));
 }
@@ -227,7 +223,7 @@ fn hide_overlay_from_const_name() {
 // This one tests that the `nu_repl()` loop works correctly
 #[test]
 fn add_overlay_from_file_decl_cd() {
-    let inp = &[r#"cd samples"#, r#"overlay use spam.nu"#, r#"foo"#];
+    let inp = &["cd samples", "overlay use spam.nu", "foo"];
 
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
@@ -236,9 +232,9 @@ fn add_overlay_from_file_decl_cd() {
 
 #[test]
 fn add_overlay_from_file_alias() {
-    let inp = &[r#"overlay use samples/spam.nu"#, r#"bar"#];
+    let inp = &["overlay use samples/spam.nu", "bar"];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert_eq!(actual.out, "bar");
@@ -247,9 +243,9 @@ fn add_overlay_from_file_alias() {
 
 #[test]
 fn add_overlay_from_file_env() {
-    let inp = &[r#"overlay use samples/spam.nu"#, r#"$env.BAZ"#];
+    let inp = &["overlay use samples/spam.nu", "$env.BAZ"];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert_eq!(actual.out, "baz");
@@ -260,12 +256,12 @@ fn add_overlay_from_file_env() {
 fn add_overlay_scoped() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"do { overlay use spam }"#,
-        r#"foo"#,
+        "do { overlay use spam }",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -278,14 +274,14 @@ fn add_overlay_scoped() {
 fn update_overlay_from_module() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
+        "overlay use spam",
         r#"module spam { export def foo [] { "bar" } }"#,
-        r#"overlay use spam"#,
-        r#"foo"#,
+        "overlay use spam",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "bar");
     assert_eq!(actual_repl.out, "bar");
@@ -295,14 +291,14 @@ fn update_overlay_from_module() {
 fn update_overlay_from_module_env() {
     let inp = &[
         r#"module spam { export-env { $env.FOO = "foo" } }"#,
-        r#"overlay use spam"#,
+        "overlay use spam",
         r#"module spam { export-env { $env.FOO = "bar" } }"#,
-        r#"overlay use spam"#,
-        r#"$env.FOO"#,
+        "overlay use spam",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "bar");
     assert_eq!(actual_repl.out, "bar");
@@ -312,15 +308,15 @@ fn update_overlay_from_module_env() {
 fn overlay_use_do_not_eval_twice() {
     let inp = &[
         r#"module spam { export-env { $env.FOO = "foo" } }"#,
-        r#"overlay use spam"#,
+        "overlay use spam",
         r#"$env.FOO = "bar""#,
-        r#"overlay hide spam"#,
-        r#"overlay use spam"#,
-        r#"$env.FOO"#,
+        "overlay hide spam",
+        "overlay use spam",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "bar");
     assert_eq!(actual_repl.out, "bar");
@@ -330,13 +326,13 @@ fn overlay_use_do_not_eval_twice() {
 fn hide_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"overlay hide spam"#,
-        r#"foo"#,
+        "overlay use spam",
+        "overlay hide spam",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -349,13 +345,13 @@ fn hide_overlay() {
 fn hide_last_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"overlay hide"#,
-        r#"foo"#,
+        "overlay use spam",
+        "overlay hide",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -368,13 +364,13 @@ fn hide_last_overlay() {
 fn hide_overlay_scoped() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"do { overlay hide spam }"#,
-        r#"foo"#,
+        "overlay use spam",
+        "do { overlay hide spam }",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -384,13 +380,13 @@ fn hide_overlay_scoped() {
 fn hide_overlay_env() {
     let inp = &[
         r#"module spam { export-env { $env.FOO = "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"overlay hide spam"#,
-        r#"$env.FOO"#,
+        "overlay use spam",
+        "overlay hide spam",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("not_found"));
     assert!(actual_repl.err.contains("not_found"));
@@ -400,13 +396,13 @@ fn hide_overlay_env() {
 fn hide_overlay_scoped_env() {
     let inp = &[
         r#"module spam { export-env { $env.FOO = "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"do { overlay hide spam }"#,
-        r#"$env.FOO"#,
+        "overlay use spam",
+        "do { overlay hide spam }",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -414,10 +410,10 @@ fn hide_overlay_scoped_env() {
 
 #[test]
 fn list_default_overlay() {
-    let inp = &[r#"overlay list | last"#];
+    let inp = &["overlay list | last"];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "zero");
     assert_eq!(actual_repl.out, "zero");
@@ -427,12 +423,12 @@ fn list_default_overlay() {
 fn list_last_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"overlay list | last"#,
+        "overlay use spam",
+        "overlay list | last",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "spam");
     assert_eq!(actual_repl.out, "spam");
@@ -442,12 +438,12 @@ fn list_last_overlay() {
 fn list_overlay_scoped() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"do { overlay list | last }"#,
+        "overlay use spam",
+        "do { overlay list | last }",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "spam");
     assert_eq!(actual_repl.out, "spam");
@@ -456,14 +452,14 @@ fn list_overlay_scoped() {
 #[test]
 fn hide_overlay_discard_decl() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
+        "overlay use samples/spam.nu",
         r#"def bagr [] { "bagr" }"#,
-        r#"overlay hide spam"#,
-        r#"bagr"#,
+        "overlay hide spam",
+        "bagr",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -475,14 +471,14 @@ fn hide_overlay_discard_decl() {
 #[test]
 fn hide_overlay_discard_alias() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
+        "overlay use samples/spam.nu",
         r#"alias bagr = echo "bagr""#,
-        r#"overlay hide spam"#,
-        r#"bagr"#,
+        "overlay hide spam",
+        "bagr",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -494,14 +490,14 @@ fn hide_overlay_discard_alias() {
 #[test]
 fn hide_overlay_discard_env() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"$env.BAGR = 'bagr'"#,
-        r#"overlay hide spam"#,
-        r#"$env.BAGR"#,
+        "overlay use samples/spam.nu",
+        "$env.BAGR = 'bagr'",
+        "overlay hide spam",
+        "$env.BAGR",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("not_found"));
     assert!(actual_repl.err.contains("not_found"));
@@ -510,13 +506,13 @@ fn hide_overlay_discard_env() {
 #[test]
 fn hide_overlay_keep_decl() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
+        "overlay use samples/spam.nu",
         r#"def bagr [] { "bagr" }"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"bagr"#,
+        "overlay hide --keep-custom spam",
+        "bagr",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert!(actual.out.contains("bagr"));
@@ -526,13 +522,13 @@ fn hide_overlay_keep_decl() {
 #[test]
 fn hide_overlay_keep_alias() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"alias bagr = echo 'bagr'"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"bagr"#,
+        "overlay use samples/spam.nu",
+        "alias bagr = echo 'bagr'",
+        "overlay hide --keep-custom spam",
+        "bagr",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert!(actual.out.contains("bagr"));
@@ -542,14 +538,14 @@ fn hide_overlay_keep_alias() {
 #[test]
 fn hide_overlay_dont_keep_env() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"$env.BAGR = 'bagr'"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"$env.BAGR"#,
+        "overlay use samples/spam.nu",
+        "$env.BAGR = 'bagr'",
+        "overlay hide --keep-custom spam",
+        "$env.BAGR",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("not_found"));
     assert!(actual_repl.err.contains("not_found"));
@@ -558,14 +554,14 @@ fn hide_overlay_dont_keep_env() {
 #[test]
 fn hide_overlay_dont_keep_overwritten_decl() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"def foo [] { 'bar' }"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"foo"#,
+        "overlay use samples/spam.nu",
+        "def foo [] { 'bar' }",
+        "overlay hide --keep-custom spam",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -577,14 +573,14 @@ fn hide_overlay_dont_keep_overwritten_decl() {
 #[test]
 fn hide_overlay_dont_keep_overwritten_alias() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"alias bar = echo `baz`"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"bar"#,
+        "overlay use samples/spam.nu",
+        "alias bar = echo `baz`",
+        "overlay hide --keep-custom spam",
+        "bar",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -596,14 +592,14 @@ fn hide_overlay_dont_keep_overwritten_alias() {
 #[test]
 fn hide_overlay_dont_keep_overwritten_env() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"$env.BAZ = 'bagr'"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"$env.BAZ"#,
+        "overlay use samples/spam.nu",
+        "$env.BAZ = 'bagr'",
+        "overlay hide --keep-custom spam",
+        "$env.BAZ",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("not_found"));
     assert!(actual_repl.err.contains("not_found"));
@@ -612,15 +608,15 @@ fn hide_overlay_dont_keep_overwritten_env() {
 #[test]
 fn hide_overlay_keep_decl_in_latest_overlay() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"def bagr [] { 'bagr' }"#,
-        r#"module eggs { }"#,
-        r#"overlay use eggs"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"bagr"#,
+        "overlay use samples/spam.nu",
+        "def bagr [] { 'bagr' }",
+        "module eggs { }",
+        "overlay use eggs",
+        "overlay hide --keep-custom spam",
+        "bagr",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert!(actual.out.contains("bagr"));
@@ -630,15 +626,15 @@ fn hide_overlay_keep_decl_in_latest_overlay() {
 #[test]
 fn hide_overlay_keep_alias_in_latest_overlay() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"alias bagr = echo 'bagr'"#,
-        r#"module eggs { }"#,
-        r#"overlay use eggs"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"bagr"#,
+        "overlay use samples/spam.nu",
+        "alias bagr = echo 'bagr'",
+        "module eggs { }",
+        "overlay use eggs",
+        "overlay hide --keep-custom spam",
+        "bagr",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert!(actual.out.contains("bagr"));
@@ -648,16 +644,16 @@ fn hide_overlay_keep_alias_in_latest_overlay() {
 #[test]
 fn hide_overlay_dont_keep_env_in_latest_overlay() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
-        r#"$env.BAGR = 'bagr'"#,
-        r#"module eggs { }"#,
-        r#"overlay use eggs"#,
-        r#"overlay hide --keep-custom spam"#,
-        r#"$env.BAGR"#,
+        "overlay use samples/spam.nu",
+        "$env.BAGR = 'bagr'",
+        "module eggs { }",
+        "overlay use eggs",
+        "overlay hide --keep-custom spam",
+        "$env.BAGR",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("not_found"));
     assert!(actual_repl.err.contains("not_found"));
@@ -666,14 +662,14 @@ fn hide_overlay_dont_keep_env_in_latest_overlay() {
 #[test]
 fn preserve_overrides() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
+        "overlay use samples/spam.nu",
         r#"def foo [] { "new-foo" }"#,
-        r#"overlay hide spam"#,
-        r#"overlay use spam"#,
-        r#"foo"#,
+        "overlay hide spam",
+        "overlay use spam",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert_eq!(actual.out, "new-foo");
@@ -683,14 +679,14 @@ fn preserve_overrides() {
 #[test]
 fn reset_overrides() {
     let inp = &[
-        r#"overlay use samples/spam.nu"#,
+        "overlay use samples/spam.nu",
         r#"def foo [] { "new-foo" }"#,
-        r#"overlay hide spam"#,
-        r#"overlay use samples/spam.nu"#,
-        r#"foo"#,
+        "overlay hide spam",
+        "overlay use samples/spam.nu",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
@@ -699,10 +695,10 @@ fn reset_overrides() {
 
 #[test]
 fn overlay_new() {
-    let inp = &[r#"overlay new spam"#, r#"overlay list | last"#];
+    let inp = &["overlay new spam", "overlay list | last"];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "spam");
     assert_eq!(actual_repl.out, "spam");
@@ -711,13 +707,13 @@ fn overlay_new() {
 #[test]
 fn overlay_keep_pwd() {
     let inp = &[
-        r#"overlay new spam"#,
-        r#"cd samples"#,
-        r#"overlay hide --keep-env [ PWD ] spam"#,
-        r#"$env.PWD | path basename"#,
+        "overlay new spam",
+        "cd samples",
+        "overlay hide --keep-env [ PWD ] spam",
+        "$env.PWD | path basename",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert_eq!(actual.out, "samples");
@@ -726,9 +722,9 @@ fn overlay_keep_pwd() {
 
 #[test]
 fn overlay_wrong_rename_type() {
-    let inp = &[r#"module spam {}"#, r#"overlay use spam as { echo foo }"#];
+    let inp = &["module spam {}", "overlay use spam as { echo foo }"];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.err.contains("parse_mismatch"));
 }
@@ -737,12 +733,12 @@ fn overlay_wrong_rename_type() {
 fn overlay_add_renamed() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam as eggs --prefix"#,
-        r#"eggs foo"#,
+        "overlay use spam as eggs --prefix",
+        "eggs foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -752,14 +748,14 @@ fn overlay_add_renamed() {
 fn overlay_add_renamed_const() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"const name = 'spam'"#,
-        r#"const new_name = 'eggs'"#,
-        r#"overlay use $name as $new_name --prefix"#,
-        r#"eggs foo"#,
+        "const name = 'spam'",
+        "const new_name = 'eggs'",
+        "overlay use $name as $new_name --prefix",
+        "eggs foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -767,12 +763,9 @@ fn overlay_add_renamed_const() {
 
 #[test]
 fn overlay_add_renamed_from_file() {
-    let inp = &[
-        r#"overlay use samples/spam.nu as eggs --prefix"#,
-        r#"eggs foo"#,
-    ];
+    let inp = &["overlay use samples/spam.nu as eggs --prefix", "eggs foo"];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/overlays", &inp.join("; "));
     let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
@@ -783,13 +776,13 @@ fn overlay_add_renamed_from_file() {
 fn overlay_cant_rename_existing_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam"#,
-        r#"overlay hide spam"#,
-        r#"overlay use spam as eggs"#,
+        "overlay use spam",
+        "overlay hide spam",
+        "overlay use spam as eggs",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("cant_add_overlay_help"));
     assert!(actual_repl.err.contains("cant_add_overlay_help"));
@@ -799,13 +792,13 @@ fn overlay_cant_rename_existing_overlay() {
 fn overlay_can_add_renamed_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam as eggs --prefix"#,
-        r#"overlay use spam --prefix"#,
-        r#"(spam foo) + (eggs foo)"#,
+        "overlay use spam as eggs --prefix",
+        "overlay use spam --prefix",
+        "(spam foo) + (eggs foo)",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foofoo");
     assert_eq!(actual_repl.out, "foofoo");
@@ -815,13 +808,13 @@ fn overlay_can_add_renamed_overlay() {
 fn overlay_hide_renamed_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam as eggs"#,
-        r#"overlay hide eggs"#,
-        r#"foo"#,
+        "overlay use spam as eggs",
+        "overlay hide eggs",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("external_command"));
     assert!(actual_repl.err.contains("external_command"));
@@ -831,14 +824,14 @@ fn overlay_hide_renamed_overlay() {
 fn overlay_hide_and_add_renamed_overlay() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use spam as eggs"#,
-        r#"overlay hide eggs"#,
-        r#"overlay use eggs"#,
-        r#"foo"#,
+        "overlay use spam as eggs",
+        "overlay hide eggs",
+        "overlay use eggs",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -847,13 +840,13 @@ fn overlay_hide_and_add_renamed_overlay() {
 #[test]
 fn overlay_use_export_env() {
     let inp = &[
-        r#"module spam { export-env { $env.FOO = 'foo' } }"#,
-        r#"overlay use spam"#,
-        r#"$env.FOO"#,
+        "module spam { export-env { $env.FOO = 'foo' } }",
+        "overlay use spam",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -862,14 +855,14 @@ fn overlay_use_export_env() {
 #[test]
 fn overlay_use_export_env_hide() {
     let inp = &[
-        r#"$env.FOO = 'foo'"#,
-        r#"module spam { export-env { hide-env FOO } }"#,
-        r#"overlay use spam"#,
-        r#"$env.FOO"#,
+        "$env.FOO = 'foo'",
+        "module spam { export-env { hide-env FOO } }",
+        "overlay use spam",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("not_found"));
     assert!(actual_repl.err.contains("not_found"));
@@ -882,17 +875,17 @@ fn overlay_use_do_cd() {
             .mkdir("test1/test2")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
-                r#"
+                "
                     export-env { cd test1/test2 }
-                "#,
+                ",
             )]);
 
         let inp = &[
-            r#"overlay use test1/test2/spam.nu"#,
-            r#"$env.PWD | path basename"#,
+            "overlay use test1/test2/spam.nu",
+            "$env.PWD | path basename",
         ];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "test2");
     })
@@ -905,17 +898,17 @@ fn overlay_use_do_cd_file_relative() {
             .mkdir("test1/test2")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
-                r#"
+                "
                     export-env { cd ($env.FILE_PWD | path join '..') }
-                "#,
+                ",
             )]);
 
         let inp = &[
-            r#"overlay use test1/test2/spam.nu"#,
-            r#"$env.PWD | path basename"#,
+            "overlay use test1/test2/spam.nu",
+            "$env.PWD | path basename",
         ];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "test1");
     })
@@ -928,21 +921,18 @@ fn overlay_use_dont_cd_overlay() {
             .mkdir("test1/test2")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
-                r#"
+                "
                     export-env {
                         overlay new spam
                         cd test1/test2
                         overlay hide spam
                     }
-                "#,
+                ",
             )]);
 
-        let inp = &[
-            r#"source-env test1/test2/spam.nu"#,
-            r#"$env.PWD | path basename"#,
-        ];
+        let inp = &["source-env test1/test2/spam.nu", "$env.PWD | path basename"];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "overlay_use_dont_cd_overlay");
     })
@@ -951,14 +941,14 @@ fn overlay_use_dont_cd_overlay() {
 #[test]
 fn overlay_use_find_scoped_module() {
     Playground::setup("overlay_use_find_module_scoped", |dirs, _| {
-        let inp = r#"
+        let inp = "
                 do {
                     module spam { }
 
                     overlay use spam
                     overlay list | last
                 }
-            "#;
+            ";
 
         let actual = nu!(cwd: dirs.test(), inp);
 
@@ -969,17 +959,17 @@ fn overlay_use_find_scoped_module() {
 #[test]
 fn overlay_preserve_hidden_env_1() {
     let inp = &[
-        r#"overlay new spam"#,
-        r#"$env.FOO = 'foo'"#,
-        r#"overlay new eggs"#,
-        r#"$env.FOO = 'bar'"#,
-        r#"hide-env FOO"#,
-        r#"overlay use eggs"#,
-        r#"$env.FOO"#,
+        "overlay new spam",
+        "$env.FOO = 'foo'",
+        "overlay new eggs",
+        "$env.FOO = 'bar'",
+        "hide-env FOO",
+        "overlay use eggs",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -988,20 +978,20 @@ fn overlay_preserve_hidden_env_1() {
 #[test]
 fn overlay_preserve_hidden_env_2() {
     let inp = &[
-        r#"overlay new spam"#,
-        r#"$env.FOO = 'foo'"#,
-        r#"overlay hide spam"#,
-        r#"overlay new eggs"#,
-        r#"$env.FOO = 'bar'"#,
-        r#"hide-env FOO"#,
-        r#"overlay hide eggs"#,
-        r#"overlay use spam"#,
-        r#"overlay use eggs"#,
-        r#"$env.FOO"#,
+        "overlay new spam",
+        "$env.FOO = 'foo'",
+        "overlay hide spam",
+        "overlay new eggs",
+        "$env.FOO = 'bar'",
+        "hide-env FOO",
+        "overlay hide eggs",
+        "overlay use spam",
+        "overlay use eggs",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -1010,18 +1000,18 @@ fn overlay_preserve_hidden_env_2() {
 #[test]
 fn overlay_reset_hidden_env() {
     let inp = &[
-        r#"overlay new spam"#,
-        r#"$env.FOO = 'foo'"#,
-        r#"overlay new eggs"#,
-        r#"$env.FOO = 'bar'"#,
-        r#"hide-env FOO"#,
-        r#"module eggs { export-env { $env.FOO = 'bar' } }"#,
-        r#"overlay use eggs"#,
-        r#"$env.FOO"#,
+        "overlay new spam",
+        "$env.FOO = 'foo'",
+        "overlay new eggs",
+        "$env.FOO = 'bar'",
+        "hide-env FOO",
+        "module eggs { export-env { $env.FOO = 'bar' } }",
+        "overlay use eggs",
+        "$env.FOO",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "bar");
     assert_eq!(actual_repl.out, "bar");
@@ -1031,17 +1021,17 @@ fn overlay_reset_hidden_env() {
 #[test]
 fn overlay_preserve_hidden_decl() {
     let inp = &[
-        r#"overlay new spam"#,
-        r#"def foo [] { 'foo' }"#,
-        r#"overlay new eggs"#,
-        r#"def foo [] { 'bar' }"#,
-        r#"hide foo"#,
-        r#"overlay use eggs"#,
-        r#"foo"#,
+        "overlay new spam",
+        "def foo [] { 'foo' }",
+        "overlay new eggs",
+        "def foo [] { 'bar' }",
+        "hide foo",
+        "overlay use eggs",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -1051,17 +1041,17 @@ fn overlay_preserve_hidden_decl() {
 #[test]
 fn overlay_preserve_hidden_alias() {
     let inp = &[
-        r#"overlay new spam"#,
-        r#"alias foo = echo 'foo'"#,
-        r#"overlay new eggs"#,
-        r#"alias foo = echo 'bar'"#,
-        r#"hide foo"#,
-        r#"overlay use eggs"#,
-        r#"foo"#,
+        "overlay new spam",
+        "alias foo = echo 'foo'",
+        "overlay new eggs",
+        "alias foo = echo 'bar'",
+        "hide foo",
+        "overlay use eggs",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -1071,11 +1061,11 @@ fn overlay_preserve_hidden_alias() {
 fn overlay_trim_single_quote() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use 'spam'"#,
-        r#"overlay list | last "#,
+        "overlay use 'spam'",
+        "overlay list | last ",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -1084,12 +1074,12 @@ fn overlay_trim_single_quote() {
 fn overlay_trim_single_quote_hide() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
-        r#"overlay use 'spam'"#,
-        r#"overlay hide spam "#,
-        r#"foo"#,
+        "overlay use 'spam'",
+        "overlay hide spam ",
+        "foo",
     ];
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -1103,10 +1093,10 @@ fn overlay_trim_double_quote() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
         r#"overlay use "spam" "#,
-        r#"overlay list | last "#,
+        "overlay list | last ",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -1116,11 +1106,11 @@ fn overlay_trim_double_quote_hide() {
     let inp = &[
         r#"module spam { export def foo [] { "foo" } }"#,
         r#"overlay use "spam" "#,
-        r#"overlay hide spam "#,
-        r#"foo"#,
+        "overlay hide spam ",
+        "foo",
     ];
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(!actual.err.is_empty());
     #[cfg(windows)]
@@ -1132,22 +1122,22 @@ fn overlay_trim_double_quote_hide() {
 #[test]
 fn overlay_use_and_restore_older_env_vars() {
     let inp = &[
-        r#"module spam {
+        "module spam {
             export-env {
                 let old_baz = $env.BAZ;
                 $env.BAZ = $old_baz + 'baz'
             }
-        }"#,
-        r#"$env.BAZ = 'baz'"#,
-        r#"overlay use spam"#,
-        r#"overlay hide spam"#,
-        r#"$env.BAZ = 'new-baz'"#,
-        r#"overlay use --reload spam"#,
-        r#"$env.BAZ"#,
+        }",
+        "$env.BAZ = 'baz'",
+        "overlay use spam",
+        "overlay hide spam",
+        "$env.BAZ = 'new-baz'",
+        "overlay use --reload spam",
+        "$env.BAZ",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "new-bazbaz");
     assert_eq!(actual_repl.out, "new-bazbaz");
@@ -1156,23 +1146,23 @@ fn overlay_use_and_restore_older_env_vars() {
 #[test]
 fn overlay_use_and_reload() {
     let inp = &[
-        r#"module spam {
+        "module spam {
             export def foo [] { 'foo' };
             export alias fooalias = echo 'foo';
             export-env {
                 $env.FOO = 'foo'
             }
-        }"#,
-        r#"overlay use spam"#,
-        r#"def foo [] { 'newfoo' }"#,
-        r#"alias fooalias = echo 'newfoo'"#,
-        r#"$env.FOO = 'newfoo'"#,
-        r#"overlay use --reload spam"#,
-        r#"$'(foo)(fooalias)($env.FOO)'"#,
+        }",
+        "overlay use spam",
+        "def foo [] { 'newfoo' }",
+        "alias fooalias = echo 'newfoo'",
+        "$env.FOO = 'newfoo'",
+        "overlay use --reload spam",
+        "$'(foo)(fooalias)($env.FOO)'",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foofoofoo");
     assert_eq!(actual_repl.out, "foofoofoo");
@@ -1181,16 +1171,16 @@ fn overlay_use_and_reload() {
 #[test]
 fn overlay_use_and_reolad_keep_custom() {
     let inp = &[
-        r#"overlay new spam"#,
-        r#"def foo [] { 'newfoo' }"#,
-        r#"alias fooalias = echo 'newfoo'"#,
-        r#"$env.FOO = 'newfoo'"#,
-        r#"overlay use --reload spam"#,
-        r#"$'(foo)(fooalias)($env.FOO)'"#,
+        "overlay new spam",
+        "def foo [] { 'newfoo' }",
+        "alias fooalias = echo 'newfoo'",
+        "$env.FOO = 'newfoo'",
+        "overlay use --reload spam",
+        "$'(foo)(fooalias)($env.FOO)'",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "newfoonewfoonewfoo");
     assert_eq!(actual_repl.out, "newfoonewfoonewfoo");
@@ -1200,11 +1190,11 @@ fn overlay_use_and_reolad_keep_custom() {
 fn overlay_use_main() {
     let inp = &[
         r#"module spam { export def main [] { "spam" } }"#,
-        r#"overlay use spam"#,
-        r#"spam"#,
+        "overlay use spam",
+        "spam",
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -1213,11 +1203,11 @@ fn overlay_use_main() {
 fn overlay_use_main_prefix() {
     let inp = &[
         r#"module spam { export def main [] { "spam" } }"#,
-        r#"overlay use spam --prefix"#,
-        r#"spam"#,
+        "overlay use spam --prefix",
+        "spam",
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -1226,12 +1216,12 @@ fn overlay_use_main_prefix() {
 fn overlay_use_main_def_env() {
     let inp = &[
         r#"module spam { export def-env main [] { $env.SPAM = "spam" } }"#,
-        r#"overlay use spam"#,
-        r#"spam"#,
-        r#"$env.SPAM"#,
+        "overlay use spam",
+        "spam",
+        "$env.SPAM",
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -1240,12 +1230,12 @@ fn overlay_use_main_def_env() {
 fn overlay_use_main_def_known_external() {
     // note: requires installed cargo
     let inp = &[
-        r#"module cargo { export extern main [] }"#,
-        r#"overlay use cargo"#,
-        r#"cargo --version"#,
+        "module cargo { export extern main [] }",
+        "overlay use cargo",
+        "cargo --version",
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.out.contains("cargo"));
 }
@@ -1254,11 +1244,11 @@ fn overlay_use_main_def_known_external() {
 fn overlay_use_main_not_exported() {
     let inp = &[
         r#"module spam { def main [] { "spam" } }"#,
-        r#"overlay use spam"#,
-        r#"spam"#,
+        "overlay use spam",
+        "spam",
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.err.contains("external_command"));
 }
@@ -1266,16 +1256,16 @@ fn overlay_use_main_not_exported() {
 #[test]
 fn alias_overlay_hide() {
     let inp = &[
-        r#"overlay new spam"#,
-        r#"def foo [] { 'foo' }"#,
-        r#"overlay new eggs"#,
-        r#"alias oh = overlay hide"#,
-        r#"oh spam"#,
-        r#"foo"#,
+        "overlay new spam",
+        "def foo [] { 'foo' }",
+        "overlay new eggs",
+        "alias oh = overlay hide",
+        "oh spam",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("external_command"));
     assert!(actual_repl.err.contains("external_command"));
@@ -1284,14 +1274,14 @@ fn alias_overlay_hide() {
 #[test]
 fn alias_overlay_use() {
     let inp = &[
-        r#"module spam { export def foo [] { 'foo' } }"#,
-        r#"alias ou = overlay use"#,
-        r#"ou spam"#,
-        r#"foo"#,
+        "module spam { export def foo [] { 'foo' } }",
+        "alias ou = overlay use",
+        "ou spam",
+        "foo",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "foo");
     assert_eq!(actual_repl.out, "foo");
@@ -1300,14 +1290,14 @@ fn alias_overlay_use() {
 #[test]
 fn alias_overlay_new() {
     let inp = &[
-        r#"alias on = overlay new"#,
-        r#"on spam"#,
-        r#"on eggs"#,
-        r#"overlay list | last"#,
+        "alias on = overlay new",
+        "on spam",
+        "on eggs",
+        "overlay list | last",
     ];
 
-    let actual = nu!(cwd: "tests/overlays", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/overlays", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert_eq!(actual.out, "eggs");
     assert_eq!(actual_repl.out, "eggs");
@@ -1318,27 +1308,27 @@ fn overlay_use_module_dir() {
     let import = "overlay use samples/spam";
 
     let inp = &[import, "spam"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "spam");
 
     let inp = &[import, "foo"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "foo");
 
     let inp = &[import, "bar"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "bar");
 
     let inp = &[import, "foo baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "foobaz");
 
     let inp = &[import, "bar baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "barbaz");
 
     let inp = &[import, "baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "spambaz");
 }
 
@@ -1347,36 +1337,36 @@ fn overlay_use_module_dir_prefix() {
     let import = "overlay use samples/spam --prefix";
 
     let inp = &[import, "spam"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "spam");
 
     let inp = &[import, "spam foo"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "foo");
 
     let inp = &[import, "spam bar"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "bar");
 
     let inp = &[import, "spam foo baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "foobaz");
 
     let inp = &[import, "spam bar baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "barbaz");
 
     let inp = &[import, "spam baz"];
-    let actual = nu!(cwd: "tests/modules", pipeline(&inp.join("; ")));
+    let actual = nu!(cwd: "tests/modules", &inp.join("; "));
     assert_eq!(actual.out, "spambaz");
 }
 
 #[test]
 fn overlay_help_no_error() {
-    let actual = nu!(cwd: ".", "overlay hide -h");
+    let actual = nu!("overlay hide -h");
     assert!(actual.err.is_empty());
-    let actual = nu!(cwd: ".", "overlay new -h");
+    let actual = nu!("overlay new -h");
     assert!(actual.err.is_empty());
-    let actual = nu!(cwd: ".", "overlay use -h");
+    let actual = nu!("overlay use -h");
     assert!(actual.err.is_empty());
 }

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -210,8 +210,7 @@ fn parse_file_relative_to_parsed_file_dont_use_cwd_2() {
 
 #[test]
 fn parse_export_env_in_module() {
-    let actual = nu!(
-        r#"
+    let actual = nu!(r#"
             module spam { export-env { } }
         "#);
 
@@ -220,8 +219,7 @@ fn parse_export_env_in_module() {
 
 #[test]
 fn parse_export_env_missing_block() {
-    let actual = nu!(
-        r#"
+    let actual = nu!(r#"
             module spam { export-env }
         "#);
 
@@ -230,8 +228,7 @@ fn parse_export_env_missing_block() {
 
 #[test]
 fn call_command_with_non_ascii_argument() {
-    let actual = nu!(
-        r#"
+    let actual = nu!(r#"
             def nu-arg [--umlaut(-ö): int] {}
             nu-arg -ö 42
         "#);
@@ -241,8 +238,7 @@ fn call_command_with_non_ascii_argument() {
 
 #[test]
 fn parse_long_duration() {
-    let actual = nu!(
-        r#"
+    let actual = nu!(r#"
             "78.797877879789789sec" | into duration
         "#);
 

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -210,7 +210,7 @@ fn parse_file_relative_to_parsed_file_dont_use_cwd_2() {
 
 #[test]
 fn parse_export_env_in_module() {
-    let actual = nu!(cwd: "tests/parsing/samples",
+    let actual = nu!(
         r#"
             module spam { export-env { } }
         "#);
@@ -220,7 +220,7 @@ fn parse_export_env_in_module() {
 
 #[test]
 fn parse_export_env_missing_block() {
-    let actual = nu!(cwd: "tests/parsing/samples",
+    let actual = nu!(
         r#"
             module spam { export-env }
         "#);
@@ -230,7 +230,7 @@ fn parse_export_env_missing_block() {
 
 #[test]
 fn call_command_with_non_ascii_argument() {
-    let actual = nu!(cwd: "tests/parsing/samples",
+    let actual = nu!(
         r#"
             def nu-arg [--umlaut(-ö): int] {}
             nu-arg -ö 42
@@ -241,7 +241,7 @@ fn call_command_with_non_ascii_argument() {
 
 #[test]
 fn parse_long_duration() {
-    let actual = nu!(cwd: "tests/parsing/samples",
+    let actual = nu!(
         r#"
             "78.797877879789789sec" | into duration
         "#);

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -5,9 +5,9 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn source_file_relative_to_file() {
-    let actual = nu!(cwd: "tests/parsing/samples", r#"
+    let actual = nu!(cwd: "tests/parsing/samples", "
         nu source_file_relative.nu
-        "#);
+        ");
 
     assert_eq!(actual.out, "5");
 }
@@ -15,55 +15,55 @@ fn source_file_relative_to_file() {
 #[test]
 fn source_const_file() {
     let actual = nu!(cwd: "tests/parsing/samples",
-    r#"
+    "
         const file = 'single_line.nu'
         source $file
-    "#);
+    ");
 
     assert_eq!(actual.out, "5");
 }
 
 #[test]
 fn run_nu_script_single_line() {
-    let actual = nu!(cwd: "tests/parsing/samples", r#"
+    let actual = nu!(cwd: "tests/parsing/samples", "
         nu single_line.nu
-        "#);
+        ");
 
     assert_eq!(actual.out, "5");
 }
 
 #[test]
 fn run_nu_script_multiline_start_pipe() {
-    let actual = nu!(cwd: "tests/parsing/samples", r#"
+    let actual = nu!(cwd: "tests/parsing/samples", "
         nu multiline_start_pipe.nu
-        "#);
+        ");
 
     assert_eq!(actual.out, "4");
 }
 
 #[test]
 fn run_nu_script_multiline_start_pipe_win() {
-    let actual = nu!(cwd: "tests/parsing/samples", r#"
+    let actual = nu!(cwd: "tests/parsing/samples", "
         nu multiline_start_pipe_win.nu
-        "#);
+        ");
 
     assert_eq!(actual.out, "3");
 }
 
 #[test]
 fn run_nu_script_multiline_end_pipe() {
-    let actual = nu!(cwd: "tests/parsing/samples", r#"
+    let actual = nu!(cwd: "tests/parsing/samples", "
         nu multiline_end_pipe.nu
-        "#);
+        ");
 
     assert_eq!(actual.out, "2");
 }
 
 #[test]
 fn run_nu_script_multiline_end_pipe_win() {
-    let actual = nu!(cwd: "tests/parsing/samples", r#"
+    let actual = nu!(cwd: "tests/parsing/samples", "
         nu multiline_end_pipe_win.nu
-        "#);
+        ");
 
     assert_eq!(actual.out, "3");
 }
@@ -76,11 +76,11 @@ fn parse_file_relative_to_parsed_file_simple() {
             .mkdir("lol/lol")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "lol/lol/lol.nu",
-                r#"
+                "
                     use ../lol_shell.nu
 
                     $env.LOL = (lol_shell ls)
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "lol/lol_shell.nu",
@@ -91,10 +91,10 @@ fn parse_file_relative_to_parsed_file_simple() {
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            "
                 source-env lol/lol/lol.nu;
                 $env.LOL
-            "#
+            "
         ));
 
         assert_eq!(actual.out, "lol");
@@ -110,13 +110,13 @@ fn parse_file_relative_to_parsed_file() {
             .mkdir("lol/lol")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "lol/lol/lol.nu",
-                r#"
+                "
                     source-env ../../foo.nu
                     use ../lol_shell.nu
                     overlay use ../../lol/lol_shell.nu
 
                     $env.LOL = $'($env.FOO) (lol_shell ls) (ls)'
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "lol/lol_shell.nu",
@@ -126,17 +126,17 @@ fn parse_file_relative_to_parsed_file() {
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "foo.nu",
-                r#"
+                "
                     $env.FOO = 'foo'
-                "#,
+                ",
             )]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            "
                 source-env lol/lol/lol.nu;
                 $env.LOL
-            "#
+            "
         ));
 
         assert_eq!(actual.out, "foo lol lol");
@@ -150,29 +150,29 @@ fn parse_file_relative_to_parsed_file_dont_use_cwd_1() {
             .mkdir("lol")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "lol/lol.nu",
-                r#"
+                "
                     source-env foo.nu
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "lol/foo.nu",
-                r#"
+                "
                     $env.FOO = 'good'
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "foo.nu",
-                r#"
+                "
                     $env.FOO = 'bad'
-                "#,
+                ",
             )]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            "
                 source-env lol/lol.nu;
                 $env.FOO
-            "#
+            "
         ));
 
         assert_eq!(actual.out, "good");
@@ -186,22 +186,22 @@ fn parse_file_relative_to_parsed_file_dont_use_cwd_2() {
             .mkdir("lol")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "lol/lol.nu",
-                r#"
+                "
                     source-env foo.nu
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "foo.nu",
-                r#"
+                "
                     $env.FOO = 'bad'
-                "#,
+                ",
             )]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            "
                 source-env lol/lol.nu
-            "#
+            "
         ));
 
         assert!(actual.err.contains("File not found"));
@@ -210,28 +210,28 @@ fn parse_file_relative_to_parsed_file_dont_use_cwd_2() {
 
 #[test]
 fn parse_export_env_in_module() {
-    let actual = nu!(r#"
+    let actual = nu!("
             module spam { export-env { } }
-        "#);
+        ");
 
     assert!(actual.err.is_empty());
 }
 
 #[test]
 fn parse_export_env_missing_block() {
-    let actual = nu!(r#"
+    let actual = nu!("
             module spam { export-env }
-        "#);
+        ");
 
     assert!(actual.err.contains("missing block"));
 }
 
 #[test]
 fn call_command_with_non_ascii_argument() {
-    let actual = nu!(r#"
+    let actual = nu!("
             def nu-arg [--umlaut(-ö): int] {}
             nu-arg -ö 42
-        "#);
+        ");
 
     assert_eq!(actual.err.len(), 0);
 }

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -4,12 +4,9 @@ use pretty_assertions::assert_eq;
 #[ignore = "TODO: This shows old-style aliases. New aliases are under commands"]
 #[test]
 fn scope_shows_alias() {
-    let actual = nu!(
-        cwd: ".",
-        r#"alias xaz = echo alias1
+    let actual = nu!(r#"alias xaz = echo alias1
         scope aliases | find xaz | length
-        "#
-    );
+        "#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 1);
@@ -17,12 +14,9 @@ fn scope_shows_alias() {
 
 #[test]
 fn scope_shows_command() {
-    let actual = nu!(
-        cwd: ".",
-        r#"def xaz [] { echo xaz }
+    let actual = nu!(r#"def xaz [] { echo xaz }
         scope commands | find xaz | length
-        "#
-    );
+        "#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 1);
@@ -30,15 +24,12 @@ fn scope_shows_command() {
 
 #[test]
 fn scope_doesnt_show_scoped_hidden_alias() {
-    let actual = nu!(
-        cwd: ".",
-        r#"alias xaz = echo alias1
+    let actual = nu!(r#"alias xaz = echo alias1
         do {
             hide xaz
             scope aliases | find xaz | length
         }
-        "#
-    );
+        "#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -46,13 +37,10 @@ fn scope_doesnt_show_scoped_hidden_alias() {
 
 #[test]
 fn scope_doesnt_show_hidden_alias() {
-    let actual = nu!(
-        cwd: ".",
-        r#"alias xaz = echo alias1
+    let actual = nu!(r#"alias xaz = echo alias1
         hide xaz
         scope aliases | find xaz | length
-        "#
-    );
+        "#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -60,15 +48,12 @@ fn scope_doesnt_show_hidden_alias() {
 
 #[test]
 fn scope_doesnt_show_scoped_hidden_command() {
-    let actual = nu!(
-        cwd: ".",
-        r#"def xaz [] { echo xaz }
+    let actual = nu!(r#"def xaz [] { echo xaz }
         do {
             hide xaz
             scope commands | find xaz | length
         }
-        "#
-    );
+        "#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -76,13 +61,10 @@ fn scope_doesnt_show_scoped_hidden_command() {
 
 #[test]
 fn scope_doesnt_show_hidden_command() {
-    let actual = nu!(
-        cwd: ".",
-        r#"def xaz [] { echo xaz }
+    let actual = nu!(r#"def xaz [] { echo xaz }
         hide xaz
         scope commands | find xaz | length
-        "#
-    );
+        "#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -92,15 +74,12 @@ fn scope_doesnt_show_hidden_command() {
 #[ignore]
 #[test]
 fn correctly_report_of_shadowed_alias() {
-    let actual = nu!(
-        cwd: ".",
-        r#"alias xaz = echo alias1
+    let actual = nu!(r#"alias xaz = echo alias1
         def helper [] {
             alias xaz = echo alias2
             scope aliases
         }
-        helper | where alias == xaz | get expansion.0"#
-    );
+        helper | where alias == xaz | get expansion.0"#);
 
     assert_eq!(actual.out, "echo alias2");
 }

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -4,9 +4,9 @@ use pretty_assertions::assert_eq;
 #[ignore = "TODO: This shows old-style aliases. New aliases are under commands"]
 #[test]
 fn scope_shows_alias() {
-    let actual = nu!(r#"alias xaz = echo alias1
+    let actual = nu!("alias xaz = echo alias1
         scope aliases | find xaz | length
-        "#);
+        ");
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 1);
@@ -14,9 +14,9 @@ fn scope_shows_alias() {
 
 #[test]
 fn scope_shows_command() {
-    let actual = nu!(r#"def xaz [] { echo xaz }
+    let actual = nu!("def xaz [] { echo xaz }
         scope commands | find xaz | length
-        "#);
+        ");
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 1);
@@ -24,12 +24,12 @@ fn scope_shows_command() {
 
 #[test]
 fn scope_doesnt_show_scoped_hidden_alias() {
-    let actual = nu!(r#"alias xaz = echo alias1
+    let actual = nu!("alias xaz = echo alias1
         do {
             hide xaz
             scope aliases | find xaz | length
         }
-        "#);
+        ");
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -37,10 +37,10 @@ fn scope_doesnt_show_scoped_hidden_alias() {
 
 #[test]
 fn scope_doesnt_show_hidden_alias() {
-    let actual = nu!(r#"alias xaz = echo alias1
+    let actual = nu!("alias xaz = echo alias1
         hide xaz
         scope aliases | find xaz | length
-        "#);
+        ");
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -48,12 +48,12 @@ fn scope_doesnt_show_hidden_alias() {
 
 #[test]
 fn scope_doesnt_show_scoped_hidden_command() {
-    let actual = nu!(r#"def xaz [] { echo xaz }
+    let actual = nu!("def xaz [] { echo xaz }
         do {
             hide xaz
             scope commands | find xaz | length
         }
-        "#);
+        ");
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -61,10 +61,10 @@ fn scope_doesnt_show_scoped_hidden_command() {
 
 #[test]
 fn scope_doesnt_show_hidden_command() {
-    let actual = nu!(r#"def xaz [] { echo xaz }
+    let actual = nu!("def xaz [] { echo xaz }
         hide xaz
         scope commands | find xaz | length
-        "#);
+        ");
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -74,12 +74,12 @@ fn scope_doesnt_show_hidden_command() {
 #[ignore]
 #[test]
 fn correctly_report_of_shadowed_alias() {
-    let actual = nu!(r#"alias xaz = echo alias1
+    let actual = nu!("alias xaz = echo alias1
         def helper [] {
             alias xaz = echo alias2
             scope aliases
         }
-        helper | where alias == xaz | get expansion.0"#);
+        helper | where alias == xaz | get expansion.0");
 
     assert_eq!(actual.out, "echo alias2");
 }

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -2,8 +2,8 @@ use super::support::Trusted;
 
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::nu;
-use nu_test_support::playground::Playground;
 use nu_test_support::nu_repl_code;
+use nu_test_support::playground::Playground;
 use pretty_assertions::assert_eq;
 use serial_test::serial;
 

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -1,25 +1,24 @@
 use super::support::Trusted;
 
 use nu_test_support::fs::Stub::FileWithContent;
-use nu_test_support::nu;
-use nu_test_support::nu_repl_code;
 use nu_test_support::playground::Playground;
+use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
 use serial_test::serial;
 
 #[test]
 fn env_shorthand() {
-    let actual = nu!(r#"
+    let actual = nu!("
         FOO=bar echo $env.FOO
-        "#);
+        ");
     assert_eq!(actual.out, "bar");
 }
 
 #[test]
 fn env_shorthand_with_equals() {
-    let actual = nu!(r#"
+    let actual = nu!("
         RUST_LOG=my_module=info $env.RUST_LOG
-    "#);
+    ");
     assert_eq!(actual.out, "my_module=info");
 }
 
@@ -34,25 +33,25 @@ fn env_shorthand_with_interpolation() {
 
 #[test]
 fn env_shorthand_with_comma_equals() {
-    let actual = nu!(r#"
+    let actual = nu!("
         RUST_LOG=info,my_module=info $env.RUST_LOG
-    "#);
+    ");
     assert_eq!(actual.out, "info,my_module=info");
 }
 
 #[test]
 fn env_shorthand_with_comma_colons_equals() {
-    let actual = nu!(r#"
+    let actual = nu!("
         RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace $env.RUST_LOG
-    "#);
+    ");
     assert_eq!(actual.out, "info,my_module=info,lib_crate::lib_mod=trace");
 }
 
 #[test]
 fn env_shorthand_multi_second_with_comma_colons_equals() {
-    let actual = nu!(r#"
+    let actual = nu!("
         FOO=bar RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace $env.FOO + $env.RUST_LOG
-    "#);
+    ");
     assert_eq!(
         actual.out,
         "barinfo,my_module=info,lib_crate::lib_mod=trace"
@@ -61,9 +60,9 @@ fn env_shorthand_multi_second_with_comma_colons_equals() {
 
 #[test]
 fn env_shorthand_multi_first_with_comma_colons_equals() {
-    let actual = nu!(r#"
+    let actual = nu!("
         RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace FOO=bar $env.FOO + $env.RUST_LOG
-    "#);
+    ");
     assert_eq!(
         actual.out,
         "barinfo,my_module=info,lib_crate::lib_mod=trace"
@@ -72,9 +71,9 @@ fn env_shorthand_multi_first_with_comma_colons_equals() {
 
 #[test]
 fn env_shorthand_multi() {
-    let actual = nu!(r#"
+    let actual = nu!("
         FOO=bar BAR=baz $env.FOO + $env.BAR
-    "#);
+    ");
     assert_eq!(actual.out, "barbaz");
 }
 
@@ -88,30 +87,30 @@ fn env_assignment() {
 
 #[test]
 fn mutate_env_file_pwd_env_var_fails() {
-    let actual = nu!(r#"$env.FILE_PWD = 'foo'"#);
+    let actual = nu!("$env.FILE_PWD = 'foo'");
 
     assert!(actual.err.contains("automatic_env_var_set_manually"));
 }
 
 #[test]
 fn load_env_file_pwd_env_var_fails() {
-    let actual = nu!(r#"load-env { FILE_PWD : 'foo' }"#);
+    let actual = nu!("load-env { FILE_PWD : 'foo' }");
 
     assert!(actual.err.contains("automatic_env_var_set_manually"));
 }
 
 #[test]
 fn load_env_pwd_env_var_fails() {
-    let actual = nu!(r#"load-env { PWD : 'foo' }"#);
+    let actual = nu!("load-env { PWD : 'foo' }");
 
     assert!(actual.err.contains("automatic_env_var_set_manually"));
 }
 
 #[test]
 fn passes_with_env_env_var_to_external_process() {
-    let actual = nu!(r#"
+    let actual = nu!("
         with-env [FOO foo] {nu --testbin echo_env FOO}
-        "#);
+        ");
     assert_eq!(actual.out, "foo");
 }
 
@@ -151,9 +150,9 @@ fn passes_env_from_local_cfg_to_external_process() {
         )]);
 
         let actual = Trusted::in_path(&dirs, || {
-            nu!(cwd: dirs.test(), r#"
+            nu!(cwd: dirs.test(), "
                 nu --testbin echo_env FOO
-            "#)
+            ")
         });
 
         assert_eq!(actual.out, "foo");
@@ -178,8 +177,8 @@ fn hides_env_in_block() {
 
 #[test]
 fn env_var_not_var() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo $CARGO
-        "#);
+        ");
     assert!(actual.err.contains("use $env.CARGO instead of $CARGO"));
 }

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -3,13 +3,13 @@ use super::support::Trusted;
 use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu_repl_code, pipeline};
+use nu_test_support::nu_repl_code;
 use pretty_assertions::assert_eq;
 use serial_test::serial;
 
 #[test]
 fn env_shorthand() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         FOO=bar echo $env.FOO
         "#);
     assert_eq!(actual.out, "bar");
@@ -17,7 +17,7 @@ fn env_shorthand() {
 
 #[test]
 fn env_shorthand_with_equals() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         RUST_LOG=my_module=info $env.RUST_LOG
     "#);
     assert_eq!(actual.out, "my_module=info");
@@ -25,7 +25,7 @@ fn env_shorthand_with_equals() {
 
 #[test]
 fn env_shorthand_with_interpolation() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         let num = 123
         FOO=$"($num) bar" echo $env.FOO
         "#);
@@ -34,7 +34,7 @@ fn env_shorthand_with_interpolation() {
 
 #[test]
 fn env_shorthand_with_comma_equals() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         RUST_LOG=info,my_module=info $env.RUST_LOG
     "#);
     assert_eq!(actual.out, "info,my_module=info");
@@ -42,7 +42,7 @@ fn env_shorthand_with_comma_equals() {
 
 #[test]
 fn env_shorthand_with_comma_colons_equals() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace $env.RUST_LOG
     "#);
     assert_eq!(actual.out, "info,my_module=info,lib_crate::lib_mod=trace");
@@ -50,7 +50,7 @@ fn env_shorthand_with_comma_colons_equals() {
 
 #[test]
 fn env_shorthand_multi_second_with_comma_colons_equals() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         FOO=bar RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace $env.FOO + $env.RUST_LOG
     "#);
     assert_eq!(
@@ -61,7 +61,7 @@ fn env_shorthand_multi_second_with_comma_colons_equals() {
 
 #[test]
 fn env_shorthand_multi_first_with_comma_colons_equals() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         RUST_LOG=info,my_module=info,lib_crate::lib_mod=trace FOO=bar $env.FOO + $env.RUST_LOG
     "#);
     assert_eq!(
@@ -72,7 +72,7 @@ fn env_shorthand_multi_first_with_comma_colons_equals() {
 
 #[test]
 fn env_shorthand_multi() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         FOO=bar BAR=baz $env.FOO + $env.BAR
     "#);
     assert_eq!(actual.out, "barbaz");
@@ -80,7 +80,7 @@ fn env_shorthand_multi() {
 
 #[test]
 fn env_assignment() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         $env.FOOBAR = "barbaz"; $env.FOOBAR
     "#);
     assert_eq!(actual.out, "barbaz");
@@ -88,28 +88,28 @@ fn env_assignment() {
 
 #[test]
 fn mutate_env_file_pwd_env_var_fails() {
-    let actual = nu!(cwd: ".", r#"$env.FILE_PWD = 'foo'"#);
+    let actual = nu!(r#"$env.FILE_PWD = 'foo'"#);
 
     assert!(actual.err.contains("automatic_env_var_set_manually"));
 }
 
 #[test]
 fn load_env_file_pwd_env_var_fails() {
-    let actual = nu!(cwd: ".", r#"load-env { FILE_PWD : 'foo' }"#);
+    let actual = nu!(r#"load-env { FILE_PWD : 'foo' }"#);
 
     assert!(actual.err.contains("automatic_env_var_set_manually"));
 }
 
 #[test]
 fn load_env_pwd_env_var_fails() {
-    let actual = nu!(cwd: ".", r#"load-env { PWD : 'foo' }"#);
+    let actual = nu!(r#"load-env { PWD : 'foo' }"#);
 
     assert!(actual.err.contains("automatic_env_var_set_manually"));
 }
 
 #[test]
 fn passes_with_env_env_var_to_external_process() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         with-env [FOO foo] {nu --testbin echo_env FOO}
         "#);
     assert_eq!(actual.out, "foo");
@@ -169,8 +169,8 @@ fn hides_env_in_block() {
         "do $b",
     ];
 
-    let actual = nu!(cwd: "tests/shell/environment", pipeline(&inp.join("; ")));
-    let actual_repl = nu!(cwd: "tests/shell/environment", nu_repl_code(inp));
+    let actual = nu!(&inp.join("; "));
+    let actual_repl = nu!(nu_repl_code(inp));
 
     assert!(actual.err.contains("column_not_found"));
     assert!(actual_repl.err.contains("column_not_found"));
@@ -178,7 +178,7 @@ fn hides_env_in_block() {
 
 #[test]
 fn env_var_not_var() {
-    let actual = nu!(cwd: ".", r#"
+    let actual = nu!(r#"
         echo $CARGO
         "#);
     assert!(actual.err.contains("use $env.CARGO instead of $CARGO"));

--- a/tests/shell/environment/nu_env.rs
+++ b/tests/shell/environment/nu_env.rs
@@ -61,42 +61,42 @@ fn picks_up_and_lets_go_env_keys_when_entering_trusted_directory_with_implied_cd
         ]);
         let actual = nu!(
             cwd: dirs.test(),
-            r#"
+            "
             do {autoenv trust -q foo ; = null }
             foo
-            echo $env.testkey"#
+            echo $env.testkey"
         );
         assert_eq!(actual.out, "testvalue");
         //Assert testkey is gone when leaving foo
         let actual = nu!(
             cwd: dirs.test(),
-            r#"
+            "
             do {autoenv trust -q foo; = null } ;
             foo
             ..
             echo $env.testkey
-            "#
+            "
         );
         assert!(actual.err.contains("Unknown"));
         //Assert testkey is present also when jumping over foo
         let actual = nu!(
             cwd: dirs.test(),
-            r#"
+            "
             do {autoenv trust -q foo; = null } ;
             do {autoenv trust -q foo/bar; = null } ;
             foo/bar
             echo $env.testkey
             echo $env.bar
-            "#
+            "
         );
         assert_eq!(actual.out, "testvaluetrue");
         //Assert bar removed after leaving bar
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo;
+            "autoenv trust -q foo;
                foo/bar
                ../..
-               echo $env.bar"#
+               echo $env.bar"
         );
         assert!(actual.err.contains("Unknown"));
     });
@@ -145,10 +145,10 @@ fn picks_up_env_keys_when_entering_trusted_directory_indirectly() {
         let expected = "0.30.0";
 
         let actual = Trusted::in_path(&dirs, || {
-            nu!(cwd: dirs.test().join("crates"), r#"
+            nu!(cwd: dirs.test().join("crates"), "
                 cd ../../autoenv_test_3
                 echo $env.nu-ver
-            "#)
+            ")
         });
 
         assert_eq!(actual.out, expected);
@@ -324,11 +324,11 @@ fn given_a_hierarchy_of_trusted_directories_when_entering_in_any_nested_ones_sho
         ]);
 
         let actual = Trusted::in_path(&dirs, || {
-            nu!(cwd: dirs.test().parent().unwrap(), r#"
+            nu!(cwd: dirs.test().parent().unwrap(), "
                 do { autoenv trust -q autoenv_test_9/nu_plugin_rb ; = null } # Silence autoenv trust -q message from output
                 cd autoenv_test_9/nu_plugin_rb
                 echo $env.organization
-            "#)
+            ")
         });
 
         assert_eq!(actual.out, "nushell");
@@ -355,11 +355,11 @@ fn given_a_hierarchy_of_trusted_directories_nested_ones_should_overwrite_variabl
         ]);
 
         let actual = Trusted::in_path(&dirs, || {
-            nu!(cwd: dirs.test().parent().unwrap(), r#"
+            nu!(cwd: dirs.test().parent().unwrap(), "
                 do { autoenv trust -q autoenv_test_10/nu_plugin_rb ; = null } # Silence autoenv trust -q message from output
                 cd autoenv_test_10/nu_plugin_rb
                 echo $env.organization
-            "#)
+            ")
         });
 
         assert_eq!(actual.out, "Andrab");
@@ -385,16 +385,16 @@ fn local_config_should_not_be_added_when_running_scripts() {
             ),
             FileWithContent(
                 "script.nu",
-                r#"cd foo
-                echo $env.organization"#,
+                "cd foo
+                echo $env.organization",
             ),
         ]);
 
         let actual = Trusted::in_path(&dirs, || {
-            nu!(cwd: dirs.test(), r#"
+            nu!(cwd: dirs.test(), "
                 do { autoenv trust -q foo } # Silence autoenv trust message from output
                 nu script.nu
-            "#)
+            ")
         });
 
         assert_eq!(actual.out, "nu");
@@ -419,14 +419,14 @@ fn given_a_hierarchy_of_trusted_directories_going_back_restores_overwritten_vari
         ]);
 
         let actual = Trusted::in_path(&dirs, || {
-            nu!(cwd: dirs.test().parent().unwrap(), r#"
+            nu!(cwd: dirs.test().parent().unwrap(), "
                 do { autoenv trust -q autoenv_test_11/nu_plugin_rb } # Silence autoenv trust message from output
                 cd autoenv_test_11
                 cd nu_plugin_rb
                 do { rm ../.nu-env | ignore } # By deleting the root nu-env we have guarantees that the variable gets restored (not by autoenv when re-entering)
                 cd ..
                 echo $env.organization
-            "#)
+            ")
         });
 
         assert_eq!(actual.out, "nushell");
@@ -450,38 +450,38 @@ fn local_config_env_var_present_and_removed_correctly() {
         //Assert testkey is not present before entering directory
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo;
-               echo $env.testkey"#
+            "autoenv trust -q foo;
+               echo $env.testkey"
         );
         assert!(actual.err.contains("Unknown"));
         //Assert testkey is present in foo
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo; cd foo
-               echo $env.testkey"#
+            "autoenv trust -q foo; cd foo
+               echo $env.testkey"
         );
         assert_eq!(actual.out, "testvalue");
         //Assert testkey is present also in subdirectories
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo; cd foo
+            "autoenv trust -q foo; cd foo
                cd bar
-               echo $env.testkey"#
+               echo $env.testkey"
         );
         assert_eq!(actual.out, "testvalue");
         //Assert testkey is present also when jumping over foo
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo; cd foo/bar
-               echo $env.testkey"#
+            "autoenv trust -q foo; cd foo/bar
+               echo $env.testkey"
         );
         assert_eq!(actual.out, "testvalue");
         //Assert testkey removed after leaving foo
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo; cd foo
+            "autoenv trust -q foo; cd foo
                cd ..
-               echo $env.testkey"#
+               echo $env.testkey"
         );
         assert!(actual.err.contains("Unknown"));
     });
@@ -512,42 +512,42 @@ fn local_config_env_var_gets_overwritten() {
         //Assert overwrite_me is not present before entering directory
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo;
-               echo $env.overwrite_me"#
+            "autoenv trust -q foo;
+               echo $env.overwrite_me"
         );
         assert!(actual.err.contains("Unknown"));
         //Assert overwrite_me is foo in foo
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo; cd foo
-               echo $env.overwrite_me"#
+            "autoenv trust -q foo; cd foo
+               echo $env.overwrite_me"
         );
         assert_eq!(actual.out, "foo");
         //Assert overwrite_me is bar in bar
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo
+            "autoenv trust -q foo
                autoenv trust -q foo/bar
                cd foo
                cd bar
-               echo $env.overwrite_me"#
+               echo $env.overwrite_me"
         );
         assert_eq!(actual.out, "bar");
         //Assert overwrite_me is present also when jumping over foo
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo; autoenv trust -q foo/bar; cd foo/bar
+            "autoenv trust -q foo; autoenv trust -q foo/bar; cd foo/bar
                echo $env.overwrite_me
-            "#
+            "
         );
         assert_eq!(actual.out, "bar");
         //Assert overwrite_me removed after leaving bar
         let actual = nu!(
             cwd: dirs.test(),
-            r#"autoenv trust -q foo; autoenv trust -q foo/bar; cd foo
+            "autoenv trust -q foo; autoenv trust -q foo/bar; cd foo
                cd bar
                cd ..
-               echo $env.overwrite_me"#
+               echo $env.overwrite_me"
         );
         assert_eq!(actual.out, "foo");
     });

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -12,8 +12,7 @@ mod pipeline;
 #[ignore]
 #[test]
 fn plugins_are_declared_with_wix() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             open Cargo.toml
             | get bin.name
@@ -73,9 +72,9 @@ fn nu_lib_dirs_repl() {
             )]);
 
         let inp_lines = &[
-            r#"$env.NU_LIB_DIRS = [ ('scripts' | path expand) ]"#,
-            r#"source-env foo.nu"#,
-            r#"$env.FOO"#,
+            "$env.NU_LIB_DIRS = [ ('scripts' | path expand) ]",
+            "source-env foo.nu",
+            "$env.FOO",
         ];
 
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(inp_lines));
@@ -98,15 +97,15 @@ fn nu_lib_dirs_script() {
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     source-env foo.nu
-                "#,
+                ",
             )]);
 
         let inp_lines = &[
-            r#"$env.NU_LIB_DIRS = [ ('scripts' | path expand) ]"#,
-            r#"source-env main.nu"#,
-            r#"$env.FOO"#,
+            "$env.NU_LIB_DIRS = [ ('scripts' | path expand) ]",
+            "source-env main.nu",
+            "$env.FOO",
         ];
 
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(inp_lines));
@@ -129,9 +128,9 @@ fn nu_lib_dirs_relative_repl() {
             )]);
 
         let inp_lines = &[
-            r#"$env.NU_LIB_DIRS = [ 'scripts' ]"#,
-            r#"source-env foo.nu"#,
-            r#"$env.FOO"#,
+            "$env.NU_LIB_DIRS = [ 'scripts' ]",
+            "source-env foo.nu",
+            "$env.FOO",
         ];
 
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(inp_lines));
@@ -155,11 +154,11 @@ fn const_nu_lib_dirs_relative() {
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "main.nu",
-                r#"
+                "
                     const NU_LIB_DIRS = [ 'scripts' ]
                     source-env foo.nu
                     $env.FOO
-                "#,
+                ",
             )]);
 
         let outcome = nu!(cwd: dirs.test(), "source main.nu");
@@ -176,9 +175,9 @@ fn nu_lib_dirs_relative_script() {
             .mkdir("scripts")
             .with_files(vec![FileWithContentToBeTrimmed(
                 "scripts/main.nu",
-                r#"
+                "
                     source-env ../foo.nu
-                "#,
+                ",
             )])
             .with_files(vec![FileWithContentToBeTrimmed(
                 "foo.nu",
@@ -188,9 +187,9 @@ fn nu_lib_dirs_relative_script() {
             )]);
 
         let inp_lines = &[
-            r#"$env.NU_LIB_DIRS = [ 'scripts' ]"#,
-            r#"source-env scripts/main.nu"#,
-            r#"$env.FOO"#,
+            "$env.NU_LIB_DIRS = [ 'scripts' ]",
+            "source-env scripts/main.nu",
+            "$env.FOO",
         ];
 
         let actual_repl = nu!(cwd: dirs.test(), nu_repl_code(inp_lines));
@@ -204,11 +203,11 @@ fn nu_lib_dirs_relative_script() {
 fn run_script_that_looks_like_module() {
     Playground::setup("run_script_that_looks_like_module", |dirs, _| {
         let inp_lines = &[
-            r#"module spam { export def eggs [] { 'eggs' } }"#,
+            "module spam { export def eggs [] { 'eggs' } }",
             "export use spam eggs",
-            r#"export def foo [] { eggs }"#,
-            r#"export alias bar = foo"#,
-            r#"export def-env baz [] { bar }"#,
+            "export def foo [] { eggs }",
+            "export alias bar = foo",
+            "export def-env baz [] { bar }",
             "baz",
         ];
 
@@ -221,7 +220,7 @@ fn run_script_that_looks_like_module() {
 #[test]
 fn run_export_extern() {
     Playground::setup("run_script_that_looks_like_module", |dirs, _| {
-        let inp_lines = &[r#"export extern foo []"#, "help foo"];
+        let inp_lines = &["export extern foo []", "help foo"];
 
         let actual = nu!(cwd: dirs.test(), inp_lines.join("; "));
 

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -205,11 +205,11 @@ fn run_script_that_looks_like_module() {
     Playground::setup("run_script_that_looks_like_module", |dirs, _| {
         let inp_lines = &[
             r#"module spam { export def eggs [] { 'eggs' } }"#,
-            r#"export use spam eggs"#,
+            "export use spam eggs",
             r#"export def foo [] { eggs }"#,
             r#"export alias bar = foo"#,
             r#"export def-env baz [] { bar }"#,
-            r#"baz"#,
+            "baz",
         ];
 
         let actual = nu!(cwd: dirs.test(), inp_lines.join("; "));
@@ -221,7 +221,7 @@ fn run_script_that_looks_like_module() {
 #[test]
 fn run_export_extern() {
     Playground::setup("run_script_that_looks_like_module", |dirs, _| {
-        let inp_lines = &[r#"export extern foo []"#, r#"help foo"#];
+        let inp_lines = &[r#"export extern foo []"#, "help foo"];
 
         let actual = nu!(cwd: dirs.test(), inp_lines.join("; "));
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -28,10 +28,10 @@ fn automatically_change_directory() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            r#"
+            "
                 autodir
                 echo (pwd)
-            "#
+            "
         );
 
         assert!(actual.out.ends_with("autodir"));
@@ -49,10 +49,10 @@ fn automatically_change_directory_with_trailing_slash_and_same_name_as_command()
 
         let actual = nu!(
             cwd: dirs.test(),
-            r#"
+            "
                 cd/
                 pwd
-            "#
+            "
         );
 
         assert!(actual.out.ends_with("cd"));
@@ -61,14 +61,14 @@ fn automatically_change_directory_with_trailing_slash_and_same_name_as_command()
 
 #[test]
 fn correctly_escape_external_arguments() {
-    let actual = nu!(r#"^nu --testbin cococo '$0'"#);
+    let actual = nu!("^nu --testbin cococo '$0'");
 
     assert_eq!(actual.out, "$0");
 }
 
 #[test]
 fn escape_also_escapes_equals() {
-    let actual = nu!(r#"^MYFOONAME=MYBARVALUE"#);
+    let actual = nu!("^MYFOONAME=MYBARVALUE");
 
     assert!(actual.err.contains("executable was not found"));
 }
@@ -85,21 +85,21 @@ fn execute_binary_in_string() {
 
 #[test]
 fn single_quote_dollar_external() {
-    let actual = nu!(r#"let author = 'JT'; ^echo $'foo=($author)'"#);
+    let actual = nu!("let author = 'JT'; ^echo $'foo=($author)'");
 
     assert_eq!(actual.out, "foo=JT");
 }
 
 #[test]
 fn redirects_custom_command_external() {
-    let actual = nu!(r#"def foo [] { nu --testbin cococo foo bar }; foo | str length"#);
+    let actual = nu!("def foo [] { nu --testbin cococo foo bar }; foo | str length");
 
     assert_eq!(actual.out, "8");
 }
 
 #[test]
 fn passes_binary_data_between_externals() {
-    let actual = nu!(cwd: "tests/fixtures/formats", r#"nu --testbin meowb sample.db | nu --testbin relay | hash sha256"#);
+    let actual = nu!(cwd: "tests/fixtures/formats", "nu --testbin meowb sample.db | nu --testbin relay | hash sha256");
 
     assert_eq!(
         actual.out,
@@ -157,13 +157,13 @@ mod it_evaluation {
 
             let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            "
                 ls
                 | sort-by name
                 | get name
                 | each { |it| nu --testbin cococo $it }
                 | get 1
-                "#
+                "
             ));
 
             assert_eq!(actual.out, "jt_likes_cake.txt");
@@ -175,20 +175,20 @@ mod it_evaluation {
         Playground::setup("it_argument_test_2", |dirs, sandbox| {
             sandbox.with_files(vec![FileWithContentToBeTrimmed(
                 "nu_candies.txt",
-                r#"
+                "
                     AndrásWithKitKatzz
                     AndrásWithKitKatz
-                "#,
+                ",
             )]);
 
             let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            "
                 open nu_candies.txt
                 | lines
                 | each { |it| nu --testbin chop $it}
                 | get 1
-                "#
+                "
             ));
 
             assert_eq!(actual.out, "AndrásWithKitKat");
@@ -197,9 +197,9 @@ mod it_evaluation {
 
     #[test]
     fn can_properly_buffer_lines_externally() {
-        let actual = nu!(r#"
+        let actual = nu!("
                 nu --testbin repeater c 8197 | lines | length
-            "#);
+            ");
 
         assert_eq!(actual.out, "1");
     }
@@ -215,10 +215,10 @@ mod it_evaluation {
 
             let actual = nu!(
                 cwd: dirs.test(), pipeline(
-                r#"
+                "
                     open sample.toml
                     | nu --testbin cococo $in.nu_party_venue
-                "#
+                "
             ));
 
             assert_eq!(actual.out, "zion");
@@ -244,13 +244,13 @@ mod stdin_evaluation {
     #[test]
     fn does_not_block_indefinitely() {
         let stdout = nu!(pipeline(
-            r#"
+            "
                 ( nu --testbin iecho yes
                 | nu --testbin chop
                 | nu --testbin chop
                 | lines
                 | first )
-            "#
+            "
         ))
         .out;
 
@@ -264,9 +264,9 @@ mod external_words {
     use nu_test_support::{pipeline, playground::Playground};
     #[test]
     fn relaxed_external_words() {
-        let actual = nu!(r#"
+        let actual = nu!("
         nu --testbin cococo joturner@foo.bar.baz
-        "#);
+        ");
 
         assert_eq!(actual.out, "joturner@foo.bar.baz");
     }
@@ -306,9 +306,9 @@ mod external_words {
 
             let actual = nu!(
                 cwd: dirs.test(), pipeline(
-                &format!(r#"
+                &format!("
                     nu --testbin meow {nu_path_argument} | from toml | get nu_party_venue
-                "#)
+                ")
             ));
 
             assert_eq!(actual.out, "zion");
@@ -353,9 +353,9 @@ mod nu_commands {
 
     #[test]
     fn command_list_arg_test() {
-        let actual = nu!(r#"
+        let actual = nu!("
         nu ['-c' 'version']
-        "#);
+        ");
 
         assert!(actual.out.contains("version"));
         assert!(actual.out.contains("rust_version"));
@@ -364,9 +364,9 @@ mod nu_commands {
 
     #[test]
     fn command_cell_path_arg_test() {
-        let actual = nu!(r#"
+        let actual = nu!("
         nu ([ '-c' 'version' ])
-        "#);
+        ");
 
         assert!(actual.out.contains("version"));
         assert!(actual.out.contains("rust_version"));
@@ -379,18 +379,18 @@ mod nu_script {
 
     #[test]
     fn run_nu_script() {
-        let actual = nu!(cwd: "tests/fixtures/formats", r#"
+        let actual = nu!(cwd: "tests/fixtures/formats", "
         nu script.nu
-        "#);
+        ");
 
         assert_eq!(actual.out, "done");
     }
 
     #[test]
     fn run_nu_script_multiline() {
-        let actual = nu!(cwd: "tests/fixtures/formats", r#"
+        let actual = nu!(cwd: "tests/fixtures/formats", "
         nu script_multiline.nu
-        "#);
+        ");
 
         assert_eq!(actual.out, "23");
     }
@@ -401,9 +401,9 @@ mod tilde_expansion {
 
     #[test]
     fn as_home_directory_when_passed_as_argument_and_begins_with_tilde() {
-        let actual = nu!(r#"
+        let actual = nu!("
             nu --testbin cococo  ~
-        "#);
+        ");
 
         assert!(!actual.out.contains('~'));
     }
@@ -435,9 +435,9 @@ mod external_command_arguments {
 
                 let actual = nu!(
                 cwd: dirs.test(), pipeline(
-                r#"
+                "
                     nu --testbin cococo (ls | get name)
-                "#
+                "
                 ));
 
                 assert_eq!(
@@ -461,9 +461,9 @@ mod external_command_arguments {
 
                 let actual = nu!(
                 cwd: dirs.test(), pipeline(
-                r#"
+                "
                     nu --testbin cococo (ls | sort-by name | get name).1
-                "#
+                "
                 ));
 
                 assert_eq!(actual.out, "ferris_not_here.txt");

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -4,10 +4,7 @@ use pretty_assertions::assert_eq;
 #[cfg(feature = "which-support")]
 #[test]
 fn shows_error_for_command_not_found() {
-    let actual = nu!(
-        cwd: ".",
-        "ferris_is_not_here.exe"
-    );
+    let actual = nu!("ferris_is_not_here.exe");
 
     assert!(!actual.err.is_empty());
 }
@@ -15,10 +12,7 @@ fn shows_error_for_command_not_found() {
 #[cfg(feature = "which-support")]
 #[test]
 fn shows_error_for_command_not_found_in_pipeline() {
-    let actual = nu!(
-        cwd: ".",
-        "ferris_is_not_here.exe | echo done"
-    );
+    let actual = nu!("ferris_is_not_here.exe | echo done");
 
     assert!(!actual.err.is_empty());
 }
@@ -67,23 +61,21 @@ fn automatically_change_directory_with_trailing_slash_and_same_name_as_command()
 
 #[test]
 fn correctly_escape_external_arguments() {
-    let actual = nu!(cwd: ".", r#"^nu --testbin cococo '$0'"#);
+    let actual = nu!(r#"^nu --testbin cococo '$0'"#);
 
     assert_eq!(actual.out, "$0");
 }
 
 #[test]
 fn escape_also_escapes_equals() {
-    let actual = nu!(cwd: ".", r#"^MYFOONAME=MYBARVALUE"#);
+    let actual = nu!(r#"^MYFOONAME=MYBARVALUE"#);
 
     assert!(actual.err.contains("executable was not found"));
 }
 
 #[test]
 fn execute_binary_in_string() {
-    let actual = nu!(
-    cwd: ".",
-    r#"
+    let actual = nu!(r#"
         let cmd = "nu"
         ^$"($cmd)" --testbin cococo "$0"
     "#);
@@ -93,14 +85,14 @@ fn execute_binary_in_string() {
 
 #[test]
 fn single_quote_dollar_external() {
-    let actual = nu!(cwd: ".", r#"let author = 'JT'; ^echo $'foo=($author)'"#);
+    let actual = nu!(r#"let author = 'JT'; ^echo $'foo=($author)'"#);
 
     assert_eq!(actual.out, "foo=JT");
 }
 
 #[test]
 fn redirects_custom_command_external() {
-    let actual = nu!(cwd: ".", r#"def foo [] { nu --testbin cococo foo bar }; foo | str length"#);
+    let actual = nu!(r#"def foo [] { nu --testbin cococo foo bar }; foo | str length"#);
 
     assert_eq!(actual.out, "8");
 }
@@ -118,44 +110,35 @@ fn passes_binary_data_between_externals() {
 #[test]
 fn command_not_found_error_suggests_search_term() {
     // 'distinct' is not a command, but it is a search term for 'uniq'
-    let actual = nu!(cwd: ".", "ls | distinct");
+    let actual = nu!("ls | distinct");
     assert!(actual.err.contains("uniq"));
 }
 
 #[test]
 fn command_not_found_error_suggests_typo_fix() {
-    let actual = nu!(cwd: ".", "benchmark { echo 'foo'}");
+    let actual = nu!("benchmark { echo 'foo'}");
     assert!(actual.err.contains("timeit"));
 }
 
 #[test]
 fn command_not_found_error_shows_not_found() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             export extern "foo" [];
             foo
-        "#
-    );
+        "#);
     assert!(actual.err.contains("'foo' was not found"));
 }
 
 #[test]
 fn command_substitution_wont_output_extra_newline() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         with-env [FOO "bar"] { echo $"prefix (nu --testbin echo_env FOO) suffix" }
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "prefix bar suffix");
 
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         with-env [FOO "bar"] { (nu --testbin echo_env FOO) }
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "bar");
 }
 
@@ -214,12 +197,9 @@ mod it_evaluation {
 
     #[test]
     fn can_properly_buffer_lines_externally() {
-        let actual = nu!(
-            cwd: ".",
-            r#"
+        let actual = nu!(r#"
                 nu --testbin repeater c 8197 | lines | length
-            "#
-        );
+            "#);
 
         assert_eq!(actual.out, "1");
     }
@@ -252,9 +232,8 @@ mod stdin_evaluation {
 
     #[test]
     fn does_not_panic_with_no_newline_in_stream() {
-        let actual = nu!(
-            cwd: ".",
-            pipeline(r#"
+        let actual = nu!(pipeline(
+            r#"
                 nu --testbin nonu "wheres the nuline?" | length
             "#
         ));
@@ -264,9 +243,8 @@ mod stdin_evaluation {
 
     #[test]
     fn does_not_block_indefinitely() {
-        let stdout = nu!(
-            cwd: ".",
-            pipeline(r#"
+        let stdout = nu!(pipeline(
+            r#"
                 ( nu --testbin iecho yes
                 | nu --testbin chop
                 | nu --testbin chop
@@ -286,7 +264,7 @@ mod external_words {
     use nu_test_support::{pipeline, playground::Playground};
     #[test]
     fn relaxed_external_words() {
-        let actual = nu!(cwd: ".", r#"
+        let actual = nu!(r#"
         nu --testbin cococo joturner@foo.bar.baz
         "#);
 
@@ -297,7 +275,7 @@ mod external_words {
     #[ignore]
     #[test]
     fn no_escaping_for_single_quoted_strings() {
-        let actual = nu!(cwd: ".", r#"
+        let actual = nu!(r#"
         nu --testbin cococo 'test "things"'
         "#);
 
@@ -345,7 +323,7 @@ mod nu_commands {
 
     #[test]
     fn echo_internally_externally() {
-        let actual = nu!(cwd: ".", r#"
+        let actual = nu!(r#"
         nu -c "echo 'foo'"
         "#);
 
@@ -366,7 +344,7 @@ mod nu_commands {
 
     #[test]
     fn better_arg_quoting() {
-        let actual = nu!(cwd: ".", r#"
+        let actual = nu!(r#"
         nu -c "\# '"
         "#);
 
@@ -375,7 +353,7 @@ mod nu_commands {
 
     #[test]
     fn command_list_arg_test() {
-        let actual = nu!(cwd: ".", r#"
+        let actual = nu!(r#"
         nu ['-c' 'version']
         "#);
 
@@ -386,7 +364,7 @@ mod nu_commands {
 
     #[test]
     fn command_cell_path_arg_test() {
-        let actual = nu!(cwd: ".", r#"
+        let actual = nu!(r#"
         nu ([ '-c' 'version' ])
         "#);
 
@@ -423,24 +401,18 @@ mod tilde_expansion {
 
     #[test]
     fn as_home_directory_when_passed_as_argument_and_begins_with_tilde() {
-        let actual = nu!(
-            cwd: ".",
-            r#"
+        let actual = nu!(r#"
             nu --testbin cococo  ~
-        "#
-        );
+        "#);
 
         assert!(!actual.out.contains('~'));
     }
 
     #[test]
     fn does_not_expand_when_passed_as_argument_and_does_not_start_with_tilde() {
-        let actual = nu!(
-            cwd: ".",
-            r#"
+        let actual = nu!(r#"
                 nu --testbin cococo  "1~1"
-                "#
-        );
+                "#);
 
         assert_eq!(actual.out, "1~1");
     }
@@ -524,10 +496,7 @@ mod external_command_arguments {
     #[cfg(not(windows))]
     #[test]
     fn semicolons_are_sanitized_before_passing_to_subshell() {
-        let actual = nu!(
-            cwd: ".",
-            "^echo \"a;b\""
-        );
+        let actual = nu!("^echo \"a;b\"");
 
         assert_eq!(actual.out, "a;b");
     }
@@ -535,10 +504,7 @@ mod external_command_arguments {
     #[cfg(not(windows))]
     #[test]
     fn ampersands_are_sanitized_before_passing_to_subshell() {
-        let actual = nu!(
-            cwd: ".",
-            "^echo \"a&b\""
-        );
+        let actual = nu!("^echo \"a&b\"");
 
         assert_eq!(actual.out, "a&b");
     }
@@ -546,10 +512,7 @@ mod external_command_arguments {
     #[cfg(not(windows))]
     #[test]
     fn subcommands_are_sanitized_before_passing_to_subshell() {
-        let actual = nu!(
-            cwd: ".",
-            "nu --testbin cococo \"$(ls)\""
-        );
+        let actual = nu!("nu --testbin cococo \"$(ls)\"");
 
         assert_eq!(actual.out, "$(ls)");
     }
@@ -557,10 +520,7 @@ mod external_command_arguments {
     #[cfg(not(windows))]
     #[test]
     fn shell_arguments_are_sanitized_even_if_coming_from_other_commands() {
-        let actual = nu!(
-            cwd: ".",
-            "nu --testbin cococo (echo \"a;&$(hello)\")"
-        );
+        let actual = nu!("nu --testbin cococo (echo \"a;&$(hello)\")");
 
         assert_eq!(actual.out, "a;&$(hello)");
     }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -62,36 +62,27 @@ fn treats_dot_dot_as_path_not_range() {
 
 #[test]
 fn subexpression_properly_redirects() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             echo (nu --testbin cococo "hello") | str join
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "hello");
 }
 
 #[test]
 fn argument_subexpression() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             echo "foo" | each { |it| echo (echo $it) }
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "foo");
 }
 
 #[test]
 fn for_loop() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             for i in 1..3 { print $i }
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "123");
 }
@@ -126,36 +117,27 @@ fn subexpression_handles_dot() {
 
 #[test]
 fn string_interpolation_with_it() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
                     echo "foo" | each { |it| echo $"($it)" }
-            "#
-    );
+            "#);
 
     assert_eq!(actual.out, "foo");
 }
 
 #[test]
 fn string_interpolation_with_it_column_path() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
                     echo [[name]; [sammie]] | each { |it| echo $"($it.name)" } | get 0
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "sammie");
 }
 
 #[test]
 fn string_interpolation_shorthand_overlap() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
                     $"3 + 4 = (3 + 4)"
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "3 + 4 = 7");
 }
@@ -164,12 +146,9 @@ fn string_interpolation_shorthand_overlap() {
 #[ignore]
 #[test]
 fn string_interpolation_and_paren() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
                     $"a paren is ('(')"
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "a paren is (");
 }
@@ -177,144 +156,109 @@ fn string_interpolation_and_paren() {
 #[test]
 fn string_interpolation_with_unicode() {
     //カ = U+30AB : KATAKANA LETTER KA
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             $"カ"
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "カ");
 }
 
 #[test]
 fn run_custom_command() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             def add-me [x y] { $x + $y}; add-me 10 5
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "15");
 }
 
 #[test]
 fn run_custom_command_with_flag() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         def foo [--bar:number] { if ($bar | is-empty) { echo "empty" } else { echo $bar } }; foo --bar 10
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "10");
 }
 
 #[test]
 fn run_custom_command_with_flag_missing() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         def foo [--bar:number] { if ($bar | is-empty) { echo "empty" } else { echo $bar } }; foo
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "empty");
 }
 
 #[test]
 fn run_custom_subcommand() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         def "str double" [x] { echo $x $x | str join }; str double bob
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "bobbob");
 }
 
 #[test]
 fn run_inner_custom_command() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
           def outer [x] { def inner [y] { echo $y }; inner $x }; outer 10
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "10");
 }
 
 #[test]
 fn run_broken_inner_custom_command() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         def outer [x] { def inner [y] { echo $y }; inner $x }; inner 10
-        "#
-    );
+        "#);
 
     assert!(!actual.err.is_empty());
 }
 
 #[test]
 fn run_custom_command_with_rest() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             def rest-me [...rest: string] { echo $rest.1 $rest.0}; rest-me "hello" "world" | to json --raw
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, r#"["world","hello"]"#);
 }
 
 #[test]
 fn run_custom_command_with_rest_and_arg() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             def rest-me-with-arg [name: string, ...rest: string] { echo $rest.1 $rest.0 $name}; rest-me-with-arg "hello" "world" "yay" | to json --raw
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, r#"["yay","world","hello"]"#);
 }
 
 #[test]
 fn run_custom_command_with_rest_and_flag() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             def rest-me-with-flag [--name: string, ...rest: string] { echo $rest.1 $rest.0 $name}; rest-me-with-flag "hello" "world" --name "yay" | to json --raw
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, r#"["world","hello","yay"]"#);
 }
 
 #[test]
 fn run_custom_command_with_empty_rest() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             def rest-me-with-empty-rest [...rest: string] { $rest }; rest-me-with-empty-rest | is-empty
-        "#
-    );
+        "#);
 
-    assert_eq!(actual.out, r#"true"#);
-    assert_eq!(actual.err, r#""#);
+    assert_eq!(actual.out, "true");
+    assert_eq!(actual.err, "");
 }
 
 //FIXME: jt: blocked on https://github.com/nushell/engine-q/issues/912
 #[ignore]
 #[test]
 fn run_custom_command_with_rest_other_name() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             def say-hello [
                 greeting:string,
                 ...names:string # All of the names
@@ -322,75 +266,59 @@ fn run_custom_command_with_rest_other_name() {
                     echo $"($greeting), ($names | sort-by | str join)"
                 }
             say-hello Salutations E D C A B
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, r#"Salutations, ABCDE"#);
-    assert_eq!(actual.err, r#""#);
+    assert_eq!(actual.err, "");
 }
 
 #[test]
 fn alias_a_load_env() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             def activate-helper [] { {BOB: SAM} }; alias activate = load-env (activate-helper); activate; $env.BOB
-        "#
-    );
+        "#);
 
-    assert_eq!(actual.out, r#"SAM"#);
+    assert_eq!(actual.out, "SAM");
 }
 
 #[test]
 fn let_variable() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             let x = 5
             let y = 12
             $x + $y
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "17");
 }
 
 #[test]
 fn let_doesnt_leak() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         do { let x = 5 }; echo $x
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("variable not found"));
 }
 
 #[test]
 fn mutate_env_variable() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             $env.TESTENVVAR = "hello world"
             echo $env.TESTENVVAR
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "hello world");
 }
 
 #[test]
 fn mutate_env_hides_variable() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             $env.TESTENVVAR = "hello world"
             print $env.TESTENVVAR
             hide-env TESTENVVAR
             print $env.TESTENVVAR
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "hello world");
     assert!(actual.err.contains("not_found"));
@@ -398,9 +326,7 @@ fn mutate_env_hides_variable() {
 
 #[test]
 fn mutate_env_hides_variable_in_parent_scope() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             $env.TESTENVVAR = "hello world"
             print $env.TESTENVVAR
             do {
@@ -408,8 +334,7 @@ fn mutate_env_hides_variable_in_parent_scope() {
                 print $env.TESTENVVAR
             }
             print $env.TESTENVVAR
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "hello world");
     assert!(actual.err.contains("not_found"));
@@ -417,35 +342,27 @@ fn mutate_env_hides_variable_in_parent_scope() {
 
 #[test]
 fn unlet_env_variable() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             $env.TEST_VAR = "hello world"
             hide-env TEST_VAR
             echo $env.TEST_VAR
-        "#
-    );
+        "#);
     assert!(actual.err.contains("not_found"));
 }
 
 #[test]
 #[ignore]
 fn unlet_nonexistent_variable() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             hide-env NONEXISTENT_VARIABLE
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("did not find"));
 }
 
 #[test]
 fn unlet_variable_in_parent_scope() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             $env.DEBUG = "1"
             print $env.DEBUG
             do {
@@ -455,81 +372,62 @@ fn unlet_variable_in_parent_scope() {
                 print $env.DEBUG
             }
             print $env.DEBUG
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "1211");
 }
 
 #[test]
 fn mutate_env_doesnt_leak() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         do { $env.xyz = "my message" }; echo $env.xyz
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("not_found"));
 }
 
 #[test]
 fn proper_shadow_mutate_env_aliases() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         $env.DEBUG = "true"; print $env.DEBUG | table; do { $env.DEBUG = "false"; print $env.DEBUG } | table; print $env.DEBUG
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "truefalsetrue");
 }
 
 #[test]
 fn load_env_variable() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             echo {TESTENVVAR: "hello world"} | load-env
             echo $env.TESTENVVAR
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "hello world");
 }
 
 #[test]
 fn load_env_variable_arg() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             load-env {TESTENVVAR: "hello world"}
             echo $env.TESTENVVAR
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "hello world");
 }
 
 #[test]
 fn load_env_doesnt_leak() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         do { echo { name: xyz, value: "my message" } | load-env }; echo $env.xyz
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("not_found"));
 }
 
 #[test]
 fn proper_shadow_load_env_aliases() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         $env.DEBUG = "true"; print $env.DEBUG | table; do { echo {DEBUG: "false"} | load-env; print $env.DEBUG } | table; print $env.DEBUG
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "truefalsetrue");
 }
 
@@ -537,15 +435,12 @@ fn proper_shadow_load_env_aliases() {
 #[ignore]
 #[test]
 fn load_env_can_hide_var_envs() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         $env.DEBUG = "1"
         echo $env.DEBUG
         load-env [[name, value]; [DEBUG null]]
         echo $env.DEBUG
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "1");
     assert!(actual.err.contains("error"));
     assert!(actual.err.contains("Unknown column"));
@@ -555,9 +450,7 @@ fn load_env_can_hide_var_envs() {
 #[ignore]
 #[test]
 fn load_env_can_hide_var_envs_in_parent_scope() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         $env.DEBUG = "1"
         echo $env.DEBUG
         do {
@@ -565,8 +458,7 @@ fn load_env_can_hide_var_envs_in_parent_scope() {
             echo $env.DEBUG
         }
         echo $env.DEBUG
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "11");
     assert!(actual.err.contains("error"));
     assert!(actual.err.contains("Unknown column"));
@@ -574,32 +466,23 @@ fn load_env_can_hide_var_envs_in_parent_scope() {
 
 #[test]
 fn proper_shadow_let_aliases() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         let DEBUG = false; print $DEBUG | table; do { let DEBUG = true; print $DEBUG } | table; print $DEBUG
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "falsetruefalse");
 }
 
 #[test]
 fn block_params_override() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         [1, 2, 3] | each { |a| echo $it }
-        "#
-    );
+        "#);
     assert!(actual.err.contains("variable not found"));
 }
 
 #[test]
 fn alias_reuse() {
-    let actual = nu!(
-        cwd: ".",
-        r#"alias foo = echo bob; foo; foo"#
-    );
+    let actual = nu!(r#"alias foo = echo bob; foo; foo"#);
 
     assert!(actual.out.contains("bob"));
     assert!(actual.err.is_empty());
@@ -607,352 +490,262 @@ fn alias_reuse() {
 
 #[test]
 fn block_params_override_correct() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         [1, 2, 3] | each { |a| echo $a } | to json --raw
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "[1,2,3]");
 }
 
 #[test]
 fn hex_number() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!("
         0x10
-        "#
-    );
+        ");
     assert_eq!(actual.out, "16");
 }
 
 #[test]
 fn binary_number() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!("
         0b10
-        "#
-    );
+        ");
     assert_eq!(actual.out, "2");
 }
 
 #[test]
 fn octal_number() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!("
         0o10
-        "#
-    );
+        ");
     assert_eq!(actual.out, "8");
 }
 
 #[test]
 fn run_dynamic_closures() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         let closure = {|| echo "holaaaa" }; do $closure
-        "#
-    );
+        "#);
     assert_eq!(actual.out, "holaaaa");
 }
 
 #[cfg(feature = "which-support")]
 #[test]
 fn argument_subexpression_reports_errors() {
-    let actual = nu!(
-        cwd: ".",
-        "echo (ferris_is_not_here.exe)"
-    );
+    let actual = nu!("echo (ferris_is_not_here.exe)");
 
     assert!(!actual.err.is_empty());
 }
 
 #[test]
 fn can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external() {
-    let actual = nu!(
-        cwd: ".",
-        r#""nushelll" | nu --testbin chop"#
-    );
+    let actual = nu!(r#""nushelll" | nu --testbin chop"#);
 
     assert_eq!(actual.out, "nushell");
 }
 
 #[test]
 fn bad_operator() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             2 $ 2
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("operator"));
 }
 
 #[test]
 fn index_out_of_bounds() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             let foo = [1, 2, 3]; echo $foo.5
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("too large"));
 }
 
 #[test]
 fn negative_decimal_start() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             -1.3 + 4
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "2.7");
 }
 
 #[test]
 fn string_inside_of() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             "bob" in "bobby"
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn string_not_inside_of() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             "bob" not-in "bobby"
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn index_row() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         let foo = [[name]; [joe] [bob]]; echo $foo.1 | to json --raw
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, r#"{"name": "bob"}"#);
 }
 
 #[test]
 fn index_cell() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         let foo = [[name]; [joe] [bob]]; echo $foo.name.1
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "bob");
 }
 
 #[test]
 fn index_cell_alt() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         let foo = [[name]; [joe] [bob]]; echo $foo.1.name
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "bob");
 }
 
 #[test]
 fn not_echoing_ranges_without_numbers() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             echo ..
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "..");
 }
 
 #[test]
 fn not_echoing_exclusive_ranges_without_numbers() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             echo ..<
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "..<");
 }
 
 #[test]
 fn echoing_ranges() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             echo 1..3 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn echoing_exclusive_ranges() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             echo 1..<4 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn table_literals1() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             echo [[name age]; [foo 13]] | get age.0
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "13");
 }
 
 #[test]
 fn table_literals2() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo [[name age] ; [bob 13] [sally 20]] | get age | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "33");
 }
 
 #[test]
 fn list_with_commas() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo [1, 2, 3] | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn range_with_left_var() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         ({ size: 3}.size)..10 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "52");
 }
 
 #[test]
 fn range_with_right_var() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         4..({ size: 30}.size) | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "459");
 }
 
 #[test]
 fn range_with_open_left() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo ..30 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "465");
 }
 
 #[test]
 fn exclusive_range_with_open_left() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo ..<31 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "465");
 }
 
 #[test]
 fn range_with_open_right() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo 5.. | first 10 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "95");
 }
 
 #[test]
 fn exclusive_range_with_open_right() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo 5..< | first 10 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "95");
 }
 
 #[test]
 fn range_with_mixed_types() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo 1..10.5 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "55");
 }
 
 #[test]
 fn filesize_math() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         100 * 10kib
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "1000.0 KiB");
     // why 1000.0 KB instead of 1.0 MB?
@@ -961,119 +754,93 @@ fn filesize_math() {
 
 #[test]
 fn filesize_math2() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         100 / 10kb
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("doesn't support"));
 }
 
 #[test]
 fn filesize_math3() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         100kib / 10
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "10.0 KiB");
 }
 #[test]
 fn filesize_math4() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         100kib * 5
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "500.0 KiB");
 }
 
 #[test]
 fn filesize_math5() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         1000 * 1kib
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "1000.0 KiB");
 }
 
 #[test]
 fn filesize_math6() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         1000 * 1mib
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "1000.0 MiB");
 }
 
 #[test]
 fn filesize_math7() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         1000 * 1gib
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "1000.0 GiB");
 }
 
 #[test]
 fn exclusive_range_with_mixed_types() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo 1..<10.5 | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "55");
 }
 
 #[test]
 fn table_with_commas() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         echo [[name, age, height]; [JT, 42, 185] [Unknown, 99, 99]] | get age | math sum
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "141");
 }
 
 #[test]
 fn duration_overflow() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         ls | get modified | each { |it| $it + 10000000000000000day }
-        "#)
-    );
+        "#
+    ));
 
     assert!(actual.err.contains("duration too large"));
 }
 
 #[test]
 fn date_and_duration_overflow() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         ls | get modified | each { |it| $it + 1000000000day }
-        "#)
-    );
+        "#
+    ));
 
     // assert_eq!(actual.err, "overflow");
     assert!(actual.err.contains("duration too large"));
@@ -1081,32 +848,29 @@ fn date_and_duration_overflow() {
 
 #[test]
 fn pipeline_params_simple() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo 1 2 3 | $in.1 * $in.2
-        "#)
-    );
+        "#
+    ));
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn pipeline_params_inner() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo 1 2 3 | (echo $in.2 6 7 | $in.0 * $in.1 * $in.2)
-        "#)
-    );
+        "#
+    ));
 
     assert_eq!(actual.out, "126");
 }
 
 #[test]
 fn better_table_lex() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         let table = [
             [name, size];
@@ -1115,65 +879,60 @@ fn better_table_lex() {
             [large, 12]
         ];
         $table.1.size
-        "#)
-    );
+        "#
+    ));
 
     assert_eq!(actual.out, "10");
 }
 
 #[test]
 fn better_subexpr_lex() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         (echo boo
         sam | str length | math sum)
-        "#)
-    );
+        "#
+    ));
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn subsubcommand() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         def "aws s3 rb" [url] { $url + " loaded" }; aws s3 rb localhost
-        "#)
-    );
+        "#
+    ));
 
     assert_eq!(actual.out, "localhost loaded");
 }
 
 #[test]
 fn manysubcommand() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         def "aws s3 rb ax vf qqqq rrrr" [url] { $url + " loaded" }; aws s3 rb ax vf qqqq rrrr localhost
-        "#)
-    );
+        "#
+    ));
 
     assert_eq!(actual.out, "localhost loaded");
 }
 
 #[test]
 fn nothing_string_1() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         null == "foo"
-        "#)
-    );
+        "#
+    ));
 
     assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn hide_alias_shadowing() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         def test-shadowing [] {
             alias greet = echo hello;
@@ -1182,8 +941,8 @@ fn hide_alias_shadowing() {
             do $xyz
         };
         test-shadowing
-        "#)
-    );
+        "#
+    ));
     assert_eq!(actual.out, "hello");
 }
 
@@ -1191,8 +950,7 @@ fn hide_alias_shadowing() {
 #[ignore]
 #[test]
 fn hide_alias_does_not_escape_scope() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         def test-alias [] {
             alias greet = echo hello;
@@ -1200,14 +958,14 @@ fn hide_alias_does_not_escape_scope() {
             greet
         };
         test-alias
-        "#)
-    );
+        "#
+    ));
     assert_eq!(actual.out, "hello");
 }
 
 #[test]
 fn hide_alias_hides_alias() {
-    let actual = nu!(cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         def test-alias [] {
             alias ll = ls -l;
@@ -1215,8 +973,8 @@ fn hide_alias_hides_alias() {
             ll
         };
         test-alias
-        "#)
-    );
+        "#
+    ));
 
     assert!(actual.err.contains("did you mean 'all'?"));
 }
@@ -1237,32 +995,32 @@ mod parse {
 
     #[test]
     fn errors_if_flag_passed_is_not_exact() {
-        let actual = nu!(cwd: ".", "debug -ra");
+        let actual = nu!("debug -ra");
 
         assert!(actual.err.contains("unknown flag"),);
 
-        let actual = nu!(cwd: ".", "debug --rawx");
+        let actual = nu!("debug --rawx");
 
         assert!(actual.err.contains("unknown flag"),);
     }
 
     #[test]
     fn errors_if_flag_is_not_supported() {
-        let actual = nu!(cwd: ".", "debug --ferris");
+        let actual = nu!("debug --ferris");
 
         assert!(actual.err.contains("unknown flag"),);
     }
 
     #[test]
     fn errors_if_passed_an_unexpected_argument() {
-        let actual = nu!(cwd: ".", "debug ferris");
+        let actual = nu!("debug ferris");
 
         assert!(actual.err.contains("extra positional argument"),);
     }
 
     #[test]
     fn ensure_backticks_are_bareword_command() {
-        let actual = nu!(cwd: ".", "`8abc123`");
+        let actual = nu!("`8abc123`");
 
         assert!(actual.err.contains("was not found"),);
     }
@@ -1274,24 +1032,18 @@ mod tilde_expansion {
     #[test]
     #[should_panic]
     fn as_home_directory_when_passed_as_argument_and_begins_with_tilde() {
-        let actual = nu!(
-            cwd: ".",
-            r#"
+        let actual = nu!(r#"
             echo ~
-        "#
-        );
+        "#);
 
         assert!(!actual.out.contains('~'),);
     }
 
     #[test]
     fn does_not_expand_when_passed_as_argument_and_does_not_start_with_tilde() {
-        let actual = nu!(
-            cwd: ".",
-            r#"
+        let actual = nu!(r#"
                     echo "1~1"
-                "#
-        );
+                "#);
 
         assert_eq!(actual.out, "1~1");
     }
@@ -1302,20 +1054,14 @@ mod variable_scoping {
 
     macro_rules! test_variable_scope {
         ($func:literal == $res:literal $(,)*) => {
-            let actual = nu!(
-                cwd: ".",
-                $func
-            );
+            let actual = nu!($func);
 
             assert_eq!(actual.out, $res);
         };
     }
     macro_rules! test_variable_scope_list {
         ($func:literal == $res:expr $(,)*) => {
-            let actual = nu!(
-                cwd: ".",
-                $func
-            );
+            let actual = nu!($func);
 
             let result: Vec<&str> = actual.out.matches("ZZZ").collect();
             assert_eq!(result, $res);

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::{nu, pipeline};
 use nu_test_support::playground::Playground;
+use nu_test_support::{nu, pipeline};
 use pretty_assertions::assert_eq;
 
 #[test]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -8,23 +8,23 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
     Playground::setup("internal_to_external_pipe_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "nu_times.csv",
-            r#"
+            "
                 name,rusty_luck,origin
                 Jason,1,Canada
                 JT,1,New Zealand
                 Andrés,1,Ecuador
                 AndKitKatz,1,Estados Unidos
-            "#,
+            ",
         )]);
 
         let actual = nu!(
         cwd: dirs.test(), pipeline(
-        r#"
+        "
             open nu_times.csv
             | get origin
             | each { |it| nu --testbin cococo $it | nu --testbin chop }
             | get 2
-            "#
+            "
         ));
 
         // chop will remove the last escaped double quote from \"Estados Unidos\"
@@ -37,21 +37,21 @@ fn treats_dot_dot_as_path_not_range() {
     Playground::setup("dot_dot_dir", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "nu_times.csv",
-            r#"
+            "
                 name,rusty_luck,origin
                 Jason,1,Canada
-            "#,
+            ",
         )]);
 
         let actual = nu!(
         cwd: dirs.test(), pipeline(
-        r#"
+        "
             mkdir temp;
             cd temp;
             print (open ../nu_times.csv).name.0 | table;
             cd ..;
             rmdir temp
-            "#
+            "
         ));
 
         // chop will remove the last escaped double quote from \"Estados Unidos\"
@@ -79,9 +79,9 @@ fn argument_subexpression() {
 
 #[test]
 fn for_loop() {
-    let actual = nu!(r#"
+    let actual = nu!("
             for i in 1..3 { print $i }
-        "#);
+        ");
 
     assert_eq!(actual.out, "123");
 }
@@ -91,23 +91,23 @@ fn subexpression_handles_dot() {
     Playground::setup("subexpression_handles_dot", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "nu_times.csv",
-            r#"
+            "
                 name,rusty_luck,origin
                 Jason,1,Canada
                 JT,1,New Zealand
                 Andrés,1,Ecuador
                 AndKitKatz,1,Estados Unidos
-            "#,
+            ",
         )]);
 
         let actual = nu!(
         cwd: dirs.test(), pipeline(
-        r#"
+        "
             echo (open nu_times.csv)
             | get name
             | each { |it| nu --testbin chop $it }
             | get 3
-            "#
+            "
         ));
 
         assert_eq!(actual.out, "AndKitKat");
@@ -164,9 +164,9 @@ fn string_interpolation_with_unicode() {
 
 #[test]
 fn run_custom_command() {
-    let actual = nu!(r#"
+    let actual = nu!("
             def add-me [x y] { $x + $y}; add-me 10 5
-        "#);
+        ");
 
     assert_eq!(actual.out, "15");
 }
@@ -200,18 +200,18 @@ fn run_custom_subcommand() {
 
 #[test]
 fn run_inner_custom_command() {
-    let actual = nu!(r#"
+    let actual = nu!("
           def outer [x] { def inner [y] { echo $y }; inner $x }; outer 10
-        "#);
+        ");
 
     assert_eq!(actual.out, "10");
 }
 
 #[test]
 fn run_broken_inner_custom_command() {
-    let actual = nu!(r#"
+    let actual = nu!("
         def outer [x] { def inner [y] { echo $y }; inner $x }; inner 10
-        "#);
+        ");
 
     assert!(!actual.err.is_empty());
 }
@@ -245,9 +245,9 @@ fn run_custom_command_with_rest_and_flag() {
 
 #[test]
 fn run_custom_command_with_empty_rest() {
-    let actual = nu!(r#"
+    let actual = nu!("
             def rest-me-with-empty-rest [...rest: string] { $rest }; rest-me-with-empty-rest | is-empty
-        "#);
+        ");
 
     assert_eq!(actual.out, "true");
     assert_eq!(actual.err, "");
@@ -267,35 +267,35 @@ fn run_custom_command_with_rest_other_name() {
             say-hello Salutations E D C A B
         "#);
 
-    assert_eq!(actual.out, r#"Salutations, ABCDE"#);
+    assert_eq!(actual.out, "Salutations, ABCDE");
     assert_eq!(actual.err, "");
 }
 
 #[test]
 fn alias_a_load_env() {
-    let actual = nu!(r#"
+    let actual = nu!("
             def activate-helper [] { {BOB: SAM} }; alias activate = load-env (activate-helper); activate; $env.BOB
-        "#);
+        ");
 
     assert_eq!(actual.out, "SAM");
 }
 
 #[test]
 fn let_variable() {
-    let actual = nu!(r#"
+    let actual = nu!("
             let x = 5
             let y = 12
             $x + $y
-        "#);
+        ");
 
     assert_eq!(actual.out, "17");
 }
 
 #[test]
 fn let_doesnt_leak() {
-    let actual = nu!(r#"
+    let actual = nu!("
         do { let x = 5 }; echo $x
-        "#);
+        ");
 
     assert!(actual.err.contains("variable not found"));
 }
@@ -352,9 +352,9 @@ fn unlet_env_variable() {
 #[test]
 #[ignore]
 fn unlet_nonexistent_variable() {
-    let actual = nu!(r#"
+    let actual = nu!("
             hide-env NONEXISTENT_VARIABLE
-        "#);
+        ");
 
     assert!(actual.err.contains("did not find"));
 }
@@ -465,23 +465,23 @@ fn load_env_can_hide_var_envs_in_parent_scope() {
 
 #[test]
 fn proper_shadow_let_aliases() {
-    let actual = nu!(r#"
+    let actual = nu!("
         let DEBUG = false; print $DEBUG | table; do { let DEBUG = true; print $DEBUG } | table; print $DEBUG
-        "#);
+        ");
     assert_eq!(actual.out, "falsetruefalse");
 }
 
 #[test]
 fn block_params_override() {
-    let actual = nu!(r#"
+    let actual = nu!("
         [1, 2, 3] | each { |a| echo $it }
-        "#);
+        ");
     assert!(actual.err.contains("variable not found"));
 }
 
 #[test]
 fn alias_reuse() {
-    let actual = nu!(r#"alias foo = echo bob; foo; foo"#);
+    let actual = nu!("alias foo = echo bob; foo; foo");
 
     assert!(actual.out.contains("bob"));
     assert!(actual.err.is_empty());
@@ -489,9 +489,9 @@ fn alias_reuse() {
 
 #[test]
 fn block_params_override_correct() {
-    let actual = nu!(r#"
+    let actual = nu!("
         [1, 2, 3] | each { |a| echo $a } | to json --raw
-        "#);
+        ");
     assert_eq!(actual.out, "[1,2,3]");
 }
 
@@ -544,27 +544,27 @@ fn can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external() {
 
 #[test]
 fn bad_operator() {
-    let actual = nu!(r#"
+    let actual = nu!("
             2 $ 2
-        "#);
+        ");
 
     assert!(actual.err.contains("operator"));
 }
 
 #[test]
 fn index_out_of_bounds() {
-    let actual = nu!(r#"
+    let actual = nu!("
             let foo = [1, 2, 3]; echo $foo.5
-        "#);
+        ");
 
     assert!(actual.err.contains("too large"));
 }
 
 #[test]
 fn negative_decimal_start() {
-    let actual = nu!(r#"
+    let actual = nu!("
             -1.3 + 4
-        "#);
+        ");
 
     assert_eq!(actual.out, "2.7");
 }
@@ -589,162 +589,162 @@ fn string_not_inside_of() {
 
 #[test]
 fn index_row() {
-    let actual = nu!(r#"
+    let actual = nu!("
         let foo = [[name]; [joe] [bob]]; echo $foo.1 | to json --raw
-        "#);
+        ");
 
     assert_eq!(actual.out, r#"{"name": "bob"}"#);
 }
 
 #[test]
 fn index_cell() {
-    let actual = nu!(r#"
+    let actual = nu!("
         let foo = [[name]; [joe] [bob]]; echo $foo.name.1
-        "#);
+        ");
 
     assert_eq!(actual.out, "bob");
 }
 
 #[test]
 fn index_cell_alt() {
-    let actual = nu!(r#"
+    let actual = nu!("
         let foo = [[name]; [joe] [bob]]; echo $foo.1.name
-        "#);
+        ");
 
     assert_eq!(actual.out, "bob");
 }
 
 #[test]
 fn not_echoing_ranges_without_numbers() {
-    let actual = nu!(r#"
+    let actual = nu!("
             echo ..
-        "#);
+        ");
 
     assert_eq!(actual.out, "..");
 }
 
 #[test]
 fn not_echoing_exclusive_ranges_without_numbers() {
-    let actual = nu!(r#"
+    let actual = nu!("
             echo ..<
-        "#);
+        ");
 
     assert_eq!(actual.out, "..<");
 }
 
 #[test]
 fn echoing_ranges() {
-    let actual = nu!(r#"
+    let actual = nu!("
             echo 1..3 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn echoing_exclusive_ranges() {
-    let actual = nu!(r#"
+    let actual = nu!("
             echo 1..<4 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn table_literals1() {
-    let actual = nu!(r#"
+    let actual = nu!("
             echo [[name age]; [foo 13]] | get age.0
-        "#);
+        ");
 
     assert_eq!(actual.out, "13");
 }
 
 #[test]
 fn table_literals2() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo [[name age] ; [bob 13] [sally 20]] | get age | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "33");
 }
 
 #[test]
 fn list_with_commas() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo [1, 2, 3] | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn range_with_left_var() {
-    let actual = nu!(r#"
+    let actual = nu!("
         ({ size: 3}.size)..10 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "52");
 }
 
 #[test]
 fn range_with_right_var() {
-    let actual = nu!(r#"
+    let actual = nu!("
         4..({ size: 30}.size) | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "459");
 }
 
 #[test]
 fn range_with_open_left() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo ..30 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "465");
 }
 
 #[test]
 fn exclusive_range_with_open_left() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo ..<31 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "465");
 }
 
 #[test]
 fn range_with_open_right() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo 5.. | first 10 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "95");
 }
 
 #[test]
 fn exclusive_range_with_open_right() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo 5..< | first 10 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "95");
 }
 
 #[test]
 fn range_with_mixed_types() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo 1..10.5 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "55");
 }
 
 #[test]
 fn filesize_math() {
-    let actual = nu!(r#"
+    let actual = nu!("
         100 * 10kib
-        "#);
+        ");
 
     assert_eq!(actual.out, "1000.0 KiB");
     // why 1000.0 KB instead of 1.0 MB?
@@ -753,71 +753,71 @@ fn filesize_math() {
 
 #[test]
 fn filesize_math2() {
-    let actual = nu!(r#"
+    let actual = nu!("
         100 / 10kb
-        "#);
+        ");
 
     assert!(actual.err.contains("doesn't support"));
 }
 
 #[test]
 fn filesize_math3() {
-    let actual = nu!(r#"
+    let actual = nu!("
         100kib / 10
-        "#);
+        ");
 
     assert_eq!(actual.out, "10.0 KiB");
 }
 #[test]
 fn filesize_math4() {
-    let actual = nu!(r#"
+    let actual = nu!("
         100kib * 5
-        "#);
+        ");
 
     assert_eq!(actual.out, "500.0 KiB");
 }
 
 #[test]
 fn filesize_math5() {
-    let actual = nu!(r#"
+    let actual = nu!("
         1000 * 1kib
-        "#);
+        ");
 
     assert_eq!(actual.out, "1000.0 KiB");
 }
 
 #[test]
 fn filesize_math6() {
-    let actual = nu!(r#"
+    let actual = nu!("
         1000 * 1mib
-        "#);
+        ");
 
     assert_eq!(actual.out, "1000.0 MiB");
 }
 
 #[test]
 fn filesize_math7() {
-    let actual = nu!(r#"
+    let actual = nu!("
         1000 * 1gib
-        "#);
+        ");
 
     assert_eq!(actual.out, "1000.0 GiB");
 }
 
 #[test]
 fn exclusive_range_with_mixed_types() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo 1..<10.5 | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "55");
 }
 
 #[test]
 fn table_with_commas() {
-    let actual = nu!(r#"
+    let actual = nu!("
         echo [[name, age, height]; [JT, 42, 185] [Unknown, 99, 99]] | get age | math sum
-        "#);
+        ");
 
     assert_eq!(actual.out, "141");
 }
@@ -825,9 +825,9 @@ fn table_with_commas() {
 #[test]
 fn duration_overflow() {
     let actual = nu!(pipeline(
-        r#"
+        "
         ls | get modified | each { |it| $it + 10000000000000000day }
-        "#
+        "
     ));
 
     assert!(actual.err.contains("duration too large"));
@@ -836,9 +836,9 @@ fn duration_overflow() {
 #[test]
 fn date_and_duration_overflow() {
     let actual = nu!(pipeline(
-        r#"
+        "
         ls | get modified | each { |it| $it + 1000000000day }
-        "#
+        "
     ));
 
     // assert_eq!(actual.err, "overflow");
@@ -848,9 +848,9 @@ fn date_and_duration_overflow() {
 #[test]
 fn pipeline_params_simple() {
     let actual = nu!(pipeline(
-        r#"
+        "
         echo 1 2 3 | $in.1 * $in.2
-        "#
+        "
     ));
 
     assert_eq!(actual.out, "6");
@@ -859,9 +859,9 @@ fn pipeline_params_simple() {
 #[test]
 fn pipeline_params_inner() {
     let actual = nu!(pipeline(
-        r#"
+        "
         echo 1 2 3 | (echo $in.2 6 7 | $in.0 * $in.1 * $in.2)
-        "#
+        "
     ));
 
     assert_eq!(actual.out, "126");
@@ -870,7 +870,7 @@ fn pipeline_params_inner() {
 #[test]
 fn better_table_lex() {
     let actual = nu!(pipeline(
-        r#"
+        "
         let table = [
             [name, size];
             [small, 7]
@@ -878,7 +878,7 @@ fn better_table_lex() {
             [large, 12]
         ];
         $table.1.size
-        "#
+        "
     ));
 
     assert_eq!(actual.out, "10");
@@ -887,10 +887,10 @@ fn better_table_lex() {
 #[test]
 fn better_subexpr_lex() {
     let actual = nu!(pipeline(
-        r#"
+        "
         (echo boo
         sam | str length | math sum)
-        "#
+        "
     ));
 
     assert_eq!(actual.out, "6");
@@ -932,7 +932,7 @@ fn nothing_string_1() {
 #[test]
 fn hide_alias_shadowing() {
     let actual = nu!(pipeline(
-        r#"
+        "
         def test-shadowing [] {
             alias greet = echo hello;
             let xyz = {|| greet };
@@ -940,7 +940,7 @@ fn hide_alias_shadowing() {
             do $xyz
         };
         test-shadowing
-        "#
+        "
     ));
     assert_eq!(actual.out, "hello");
 }
@@ -950,14 +950,14 @@ fn hide_alias_shadowing() {
 #[test]
 fn hide_alias_does_not_escape_scope() {
     let actual = nu!(pipeline(
-        r#"
+        "
         def test-alias [] {
             alias greet = echo hello;
             (hide greet);
             greet
         };
         test-alias
-        "#
+        "
     ));
     assert_eq!(actual.out, "hello");
 }
@@ -965,14 +965,14 @@ fn hide_alias_does_not_escape_scope() {
 #[test]
 fn hide_alias_hides_alias() {
     let actual = nu!(pipeline(
-        r#"
+        "
         def test-alias [] {
             alias ll = ls -l;
             hide ll;
             ll
         };
         test-alias
-        "#
+        "
     ));
 
     assert!(actual.err.contains("did you mean 'all'?"));
@@ -1031,9 +1031,9 @@ mod tilde_expansion {
     #[test]
     #[should_panic]
     fn as_home_directory_when_passed_as_argument_and_begins_with_tilde() {
-        let actual = nu!(r#"
+        let actual = nu!("
             echo ~
-        "#);
+        ");
 
         assert!(!actual.out.contains('~'),);
     }
@@ -1070,8 +1070,8 @@ mod variable_scoping {
     #[test]
     fn access_variables_in_scopes() {
         test_variable_scope!(
-            r#" def test [input] { echo [0 1 2] | do { do { echo $input } } }
-                test ZZZ "#
+            " def test [input] { echo [0 1 2] | do { do { echo $input } } }
+                test ZZZ "
                 == "ZZZ"
         );
         test_variable_scope!(
@@ -1085,28 +1085,28 @@ mod variable_scoping {
                 == "ZZZ"
         );
         test_variable_scope!(
-            r#" def test [input] { echo [0 1 2] | do { echo $input } }
-                test ZZZ "#
+            " def test [input] { echo [0 1 2] | do { echo $input } }
+                test ZZZ "
                 == "ZZZ"
         );
         test_variable_scope!(
-            r#" def test [input] { echo [0 1 2] | do { if $input == $input { echo $input } else { echo $input } } }
-                test ZZZ "#
+            " def test [input] { echo [0 1 2] | do { if $input == $input { echo $input } else { echo $input } } }
+                test ZZZ "
                 == "ZZZ"
         );
         test_variable_scope_list!(
-            r#" def test [input] { echo [0 1 2] | each { |_| echo $input } }
-                test ZZZ "#
+            " def test [input] { echo [0 1 2] | each { |_| echo $input } }
+                test ZZZ "
                 == ["ZZZ", "ZZZ", "ZZZ"]
         );
         test_variable_scope_list!(
-            r#" def test [input] { echo [0 1 2] | each { |it| if $it > 0 {echo $input} else {echo $input}} }
-                test ZZZ "#
+            " def test [input] { echo [0 1 2] | each { |it| if $it > 0 {echo $input} else {echo $input}} }
+                test ZZZ "
                 == ["ZZZ", "ZZZ", "ZZZ"]
         );
         test_variable_scope_list!(
-            r#" def test [input] { echo [0 1 2] | each { |_| if $input == $input {echo $input} else {echo $input}} }
-                test ZZZ "#
+            " def test [input] { echo [0 1 2] | each { |_| if $input == $input {echo $input} else {echo $input}} }
+                test ZZZ "
                 == ["ZZZ", "ZZZ", "ZZZ"]
         );
     }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1,6 +1,5 @@
 use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::nu;
-use nu_test_support::pipeline;
+use nu_test_support::{nu, pipeline};
 use nu_test_support::playground::Playground;
 use pretty_assertions::assert_eq;
 

--- a/tests/shell/pipeline/mod.rs
+++ b/tests/shell/pipeline/mod.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 
 #[test]
 fn doesnt_break_on_utf8() {
-    let actual = nu!(cwd: ".", "echo ö");
+    let actual = nu!("echo ö");
 
     assert_eq!(actual.out, "ö", "'{}' should contain ö", actual.out);
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR cleans up tests in the `tests/` directory by removing unnecessary code.
Part of #8670.

- [x]  const_/mod.rs
- [x]  eval/mod.rs
- [x]  hooks/mod.rs
- [x]  modules/mod.rs
- [x]  overlays/mod.rs
- [x]  parsing/mod.rs
- [x]  scope/mod.rs
- [x]  shell/environment/env.rs
- [x]  shell/environment/nu_env.rs
- [x]  shell/mod.rs
- [x]  shell/pipeline/commands/external.rs
- [x]  shell/pipeline/commands/internal.rs
- [x]  shell/pipeline/mod.rs

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
