### PR TITLE
support env assignment and mutable variable assignment with `if` block and `match` guard

### DIFF
--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -180,14 +180,12 @@ fn mut_records_update_properly() {
 
 #[test]
 fn mut_value_with_if() {
-    let actual = nu!(pipeline("mut a = 3; $a = if 3 == 3 { 10 }; echo $a"));
+    let actual = nu!("mut a = 3; $a = if 3 == 3 { 10 }; echo $a");
     assert_eq!(actual.out, "10");
 }
 
 #[test]
 fn mut_value_with_match() {
-    let actual = nu!(pipeline(
-        "mut a = 3; $a = match 3 { 1 => { 'yes!' }, _ => { 'no!' } }; echo $a"
-    ));
+    let actual = nu!("mut a = 3; $a = match 3 { 1 => { 'yes!' }, _ => { 'no!' } }; echo $a");
     assert_eq!(actual.out, "no!");
 }

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -177,3 +177,17 @@ fn mut_records_update_properly() {
     let actual = nu!(pipeline("mut a = {}; $a.b.c = 100; $a.b.c"));
     assert_eq!(actual.out, "100");
 }
+
+#[test]
+fn mut_value_with_if() {
+    let actual = nu!(pipeline("mut a = 3; $a = if 3 == 3 { 10 }; echo $a"));
+    assert_eq!(actual.out, "10");
+}
+
+#[test]
+fn mut_value_with_match() {
+    let actual = nu!(pipeline(
+        "mut a = 3; $a = match 3 { 1 => { 'yes!' }, _ => { 'no!' } }; echo $a"
+    ));
+    assert_eq!(actual.out, "no!");
+}

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4956,7 +4956,6 @@ pub fn parse_math_expression(
         });
     }
 
-    log::warn!("final stack: {expr_stack:?}, {}", expr_stack.len());
     expr_stack
         .pop()
         .expect("internal error: expression stack empty")

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4870,6 +4870,14 @@ pub fn parse_math_expression(
             break;
         }
 
+        let content = working_set.get_span_contents(spans[idx]);
+        // allow `if` to be a special value for assignment.
+        if content == b"if" || content == b"match" {
+            let rhs = parse_call(working_set, &spans[idx..], spans[0], false);
+            expr_stack.push(op);
+            expr_stack.push(rhs);
+            break;
+        }
         let rhs = parse_value(working_set, spans[idx], &SyntaxShape::Any);
 
         while op_prec <= last_prec && expr_stack.len() > 1 {
@@ -4948,6 +4956,7 @@ pub fn parse_math_expression(
         });
     }
 
+    log::warn!("final stack: {expr_stack:?}, {}", expr_stack.len());
     expr_stack
         .pop()
         .expect("internal error: expression stack empty")

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -87,6 +87,22 @@ fn env_assignment() {
 }
 
 #[test]
+fn env_assignment_with_if() {
+    let actual = nu!(cwd: ".", r#"
+        $env.FOOBAR = if 3 == 4 { "bar" } else { "baz" }; $env.FOOBAR
+    "#);
+    assert_eq!(actual.out, "baz");
+}
+
+#[test]
+fn env_assignment_with_match() {
+    let actual = nu!(cwd: ".", r#"
+        $env.FOOBAR = match 1 { 1 => { 'yes!' }, _ => { 'no!' } }; $env.FOOBAR
+    "#);
+    assert_eq!(actual.out, "yes!");
+}
+
+#[test]
 fn mutate_env_file_pwd_env_var_fails() {
     let actual = nu!(cwd: ".", r#"$env.FILE_PWD = 'foo'"#);
 

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -88,17 +88,13 @@ fn env_assignment() {
 
 #[test]
 fn env_assignment_with_if() {
-    let actual = nu!(cwd: ".", r#"
-        $env.FOOBAR = if 3 == 4 { "bar" } else { "baz" }; $env.FOOBAR
-    "#);
+    let actual = nu!(r#"$env.FOOBAR = if 3 == 4 { "bar" } else { "baz" }; $env.FOOBAR"#);
     assert_eq!(actual.out, "baz");
 }
 
 #[test]
 fn env_assignment_with_match() {
-    let actual = nu!(cwd: ".", r#"
-        $env.FOOBAR = match 1 { 1 => { 'yes!' }, _ => { 'no!' } }; $env.FOOBAR
-    "#);
+    let actual = nu!(r#"$env.FOOBAR = match 1 { 1 => { 'yes!' }, _ => { 'no!' } }; $env.FOOBAR"#);
     assert_eq!(actual.out, "yes!");
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Fixes: https://github.com/nushell/nushell/issues/9595

So we can do the following in nushell:
```nushell
mut a = 3
$a = if 4 == 3 { 10 } else {20}
```
or
```nushell
$env.BUILD_EXT = match 3 { 1 => { 'yes!' }, _ => { 'no!' } }
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- crates/nu-std/tests/run.nu` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
