### PR TITLE
Apply nightly clippy lints

### DIFF
--- a/crates/nu-cli/src/commands/keybindings_list.rs
+++ b/crates/nu-cli/src/commands/keybindings_list.rs
@@ -59,7 +59,7 @@ impl Command for KeybindingsList {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let records = if call.named_len() == 0 {
-            let all_options = vec!["modifiers", "keycodes", "edits", "modes", "events"];
+            let all_options = ["modifiers", "keycodes", "edits", "modes", "events"];
             all_options
                 .iter()
                 .flat_map(|argument| get_records(argument, &call.head))

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -205,10 +205,7 @@ impl Completer for CommandCompletion {
             vec![]
         };
 
-        subcommands
-            .into_iter()
-            .chain(commands)
-            .collect::<Vec<_>>()
+        subcommands.into_iter().chain(commands).collect::<Vec<_>>()
     }
 
     fn get_sort_by(&self) -> SortBy {

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -207,7 +207,7 @@ impl Completer for CommandCompletion {
 
         subcommands
             .into_iter()
-            .chain(commands.into_iter())
+            .chain(commands)
             .collect::<Vec<_>>()
     }
 

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -294,7 +294,7 @@ fn recursive_value(val: Value, sublevels: Vec<Vec<u8>>) -> Value {
                 vals,
                 span: _,
             } => {
-                for item in cols.into_iter().zip(vals.into_iter()) {
+                for item in cols.into_iter().zip(vals) {
                     // Check if index matches with sublevel
                     if item.0.as_bytes().to_vec() == next_sublevel {
                         // If matches try to fetch recursively the next

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/sql_context.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/sql_context.rs
@@ -150,7 +150,7 @@ impl SQLContext {
             let agg_df = df.groupby(group_by).agg(agg_projection);
             let mut final_proj_pos = groupby_pos
                 .into_iter()
-                .chain(agg_proj_pos.into_iter())
+                .chain(agg_proj_pos)
                 .collect::<Vec<_>>();
 
             final_proj_pos.sort_by(|(proj_pa, _), (proj_pb, _)| proj_pa.cmp(proj_pb));

--- a/crates/nu-cmd-extra/src/extra/filters/update_cells.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/update_cells.rs
@@ -150,7 +150,7 @@ impl Command for UpdateCells {
                     .iter()
                     .map(|val| val.as_string())
                     .collect::<Result<Vec<String>, ShellError>>()?;
-                Some(HashSet::from_iter(cols.into_iter()))
+                Some(HashSet::from_iter(cols))
             }
             None => None,
         };
@@ -197,7 +197,7 @@ impl Iterator for UpdateCellIterator {
                     Value::Record { vals, cols, span } => Some(Value::Record {
                         vals: cols
                             .iter()
-                            .zip(vals.into_iter())
+                            .zip(vals)
                             .map(|(col, val)| match &self.columns {
                                 Some(cols) if !cols.contains(col) => val,
                                 _ => process_cell(

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -188,8 +188,7 @@ pub fn check_all_signature_input_output_types_entries_have_examples(
     signature: Signature,
     witnessed_type_transformations: HashSet<(Type, Type)>,
 ) {
-    let declared_type_transformations =
-        HashSet::from_iter(signature.input_output_types);
+    let declared_type_transformations = HashSet::from_iter(signature.input_output_types);
     assert!(
         witnessed_type_transformations.is_subset(&declared_type_transformations),
         "This should not be possible (bug in test): the type transformations \

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -189,7 +189,7 @@ pub fn check_all_signature_input_output_types_entries_have_examples(
     witnessed_type_transformations: HashSet<(Type, Type)>,
 ) {
     let declared_type_transformations =
-        HashSet::from_iter(signature.input_output_types.into_iter());
+        HashSet::from_iter(signature.input_output_types);
     assert!(
         witnessed_type_transformations.is_subset(&declared_type_transformations),
         "This should not be possible (bug in test): the type transformations \

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -67,7 +67,7 @@ impl Command for Start {
             } else {
                 // open crate does not allow opening URL without prefix
                 let path_with_prefix = Path::new("https://").join(&path.item);
-                let common_domains = vec!["com", "net", "org", "edu", "sh"];
+                let common_domains = ["com", "net", "org", "edu", "sh"];
                 if let Some(url) = path_with_prefix.to_str() {
                     let url = url::Url::parse(url).map_err(|_| {
                         ShellError::GenericError(

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -98,7 +98,7 @@ impl Command for Items {
             PipelineData::Empty => Ok(PipelineData::Empty),
             PipelineData::Value(Value::Record { cols, vals, .. }, ..) => Ok(cols
                 .into_iter()
-                .zip(vals.into_iter())
+                .zip(vals)
                 .map_while(run_for_each_item)
                 .into_pipeline_data(ctrlc)),
             // Errors

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -250,8 +250,6 @@ fn move_record_columns(
         }
     }
 
-    if columns.is_empty() {}
-
     let mut out_cols: Vec<String> = Vec::with_capacity(inp_cols.len());
     let mut out_vals: Vec<Value> = Vec::with_capacity(inp_vals.len());
 

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -105,7 +105,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
 
         Ok(vec
             .into_iter()
-            .chain(input.into_iter())
+            .chain(input)
             .into_pipeline_data(engine_state.ctrlc.clone())
             .set_metadata(metadata))
     }

--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -98,7 +98,7 @@ impl Command for Zip {
 
         Ok(input
             .into_iter()
-            .zip(other.into_pipeline_data().into_iter())
+            .zip(other.into_pipeline_data())
             .map(move |(x, y)| Value::List {
                 vals: vec![x, y],
                 span: head,

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -355,7 +355,7 @@ fn parse_attributes(
     vals: Vec<Value>,
 ) -> Result<IndexMap<String, String>, ShellError> {
     let mut h = IndexMap::new();
-    for (k, v) in cols.into_iter().zip(vals.into_iter()) {
+    for (k, v) in cols.into_iter().zip(vals) {
         if let Value::String { val, .. } = v {
             h.insert(k, val);
         } else {

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -155,9 +155,9 @@ pub fn highlight_search_in_table(
             });
         };
 
-        let has_match = cols.iter().zip(vals.iter_mut()).fold(
-            Ok(false),
-            |acc: Result<bool, ShellError>, (col, val)| {
+        let has_match = cols.iter().zip(vals.iter_mut()).try_fold(
+            false,
+            |acc: bool, (col, val)| -> Result<bool, ShellError> {
                 if searched_cols.contains(&col.as_str()) {
                     if let Value::String { val: s, span } = val {
                         if s.to_lowercase().contains(&search_string) {
@@ -173,15 +173,15 @@ pub fn highlight_search_in_table(
                             Ok(true)
                         } else {
                             // column does not contain the searched string
-                            acc
+                            Ok(acc)
                         }
                     } else {
                         // ignore non-string values
-                        acc
+                        Ok(acc)
                     }
                 } else {
                     // don't search this column
-                    acc
+                    Ok(acc)
                 }
             },
         )?;

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -158,31 +158,27 @@ pub fn highlight_search_in_table(
         let has_match = cols.iter().zip(vals.iter_mut()).try_fold(
             false,
             |acc: bool, (col, val)| -> Result<bool, ShellError> {
-                if searched_cols.contains(&col.as_str()) {
-                    if let Value::String { val: s, span } = val {
-                        if s.to_lowercase().contains(&search_string) {
-                            *val = Value::String {
-                                val: highlight_search_string(
-                                    s,
-                                    orig_search_string,
-                                    string_style,
-                                    highlight_style,
-                                )?,
-                                span: *span,
-                            };
-                            Ok(true)
-                        } else {
-                            // column does not contain the searched string
-                            Ok(acc)
-                        }
-                    } else {
-                        // ignore non-string values
-                        Ok(acc)
-                    }
-                } else {
+                if !searched_cols.contains(&col.as_str()) {
                     // don't search this column
-                    Ok(acc)
+                    return Ok(acc);
                 }
+                if let Value::String { val: s, span } = val {
+                    if s.to_lowercase().contains(&search_string) {
+                        *val = Value::String {
+                            val: highlight_search_string(
+                                s,
+                                orig_search_string,
+                                string_style,
+                                highlight_style,
+                            )?,
+                            span: *span,
+                        };
+                        return Ok(true);
+                    }
+                }
+                // column does not contain the searched string
+                // ignore non-string values
+                Ok(acc)
             },
         )?;
 

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -100,8 +100,8 @@ impl Command for SubCommand {
                     let url_components = cols
                         .iter()
                         .zip(vals.iter())
-                        .fold(Ok(UrlComponents::new()), |url, (k, v)| {
-                            url?.add_component(k.clone(), v.clone(), span)
+                        .try_fold(UrlComponents::new(), |url, (k, v)| {
+                            url.add_component(k.clone(), v.clone(), span)
                         });
 
                     url_components?.to_url(span)

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -515,12 +515,12 @@ impl Command for AnsiCommand {
             )
             .switch(
                 "escape", // \x1b[
-                r#"escape sequence without the escape character(s) ('\x1b[' is not required)"#,
+                r"escape sequence without the escape character(s) ('\x1b[' is not required)",
                 Some('e'),
             )
             .switch(
                 "osc", // \x1b]
-                r#"operating system command (osc) escape sequence without the escape character(s) ('\x1b]' is not required)"#,
+                r"operating system command (osc) escape sequence without the escape character(s) ('\x1b]' is not required)",
                 Some('o'),
             )
             .switch("list", "list available ansi code names", Some('l'))

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -128,12 +128,12 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Find and replace contents without using the replace parameter as a regular expression",
-                example: r#"'dogs_$1_cats' | str replace '\$1' '$2' -n"#,
+                example: r"'dogs_$1_cats' | str replace '\$1' '$2' -n",
                 result: Some(Value::test_string("dogs_$2_cats")),
             },
             Example {
                 description: "Find and replace the first occurrence using string replacement *not* regular expressions",
-                example: r#"'c:\some\cool\path' | str replace 'c:\some\cool' '~' -s"#,
+                example: r"'c:\some\cool\path' | str replace 'c:\some\cool' '~' -s",
                 result: Some(Value::test_string("~\\path")),
             },
             Example {
@@ -148,7 +148,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Find and replace with fancy-regex",
-                example: r#"'a successful b' | str replace '\b([sS])uc(?:cs|s?)e(ed(?:ed|ing|s?)|ss(?:es|ful(?:ly)?|i(?:ons?|ve(?:ly)?)|ors?)?)\b' '${1}ucce$2'"#,
+                example: r"'a successful b' | str replace '\b([sS])uc(?:cs|s?)e(ed(?:ed|ing|s?)|ss(?:es|ful(?:ly)?|i(?:ons?|ve(?:ly)?)|ors?)?)\b' '${1}ucce$2'",
                 result: Some(Value::test_string("a successful b")),
             },
             Example {

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -114,7 +114,7 @@ prints out the list properly."#
                 // dbg!("value::record");
                 let mut items = vec![];
 
-                for (i, (c, v)) in cols.into_iter().zip(vals.into_iter()).enumerate() {
+                for (i, (c, v)) in cols.into_iter().zip(vals).enumerate() {
                     items.push((i, c, v.into_string(", ", config)))
                 }
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4023,7 +4023,7 @@ fn parse_table_expression(working_set: &mut StateWorkingSet, span: Span) -> Expr
 
     let ty = if working_set.parse_errors.len() == errors {
         let (ty, errs) = table_type(&head, &rows);
-        working_set.parse_errors.extend(errs.into_iter());
+        working_set.parse_errors.extend(errs);
         ty
     } else {
         Type::Table(vec![])
@@ -5039,7 +5039,7 @@ pub fn parse_expression(
                     String::from_utf8(bytes)
                         .expect("builtin commands bytes should be able to convert to string"),
                     String::from_utf8_lossy(match spans.len() {
-                        1 | 2 | 3 => b"value",
+                        1..=3 => b"value",
                         _ => working_set.get_span_contents(spans[3]),
                     })
                     .to_string(),

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -64,11 +64,7 @@ impl RawStream {
     pub fn chain(self, stream: RawStream) -> RawStream {
         RawStream {
             stream: Box::new(self.stream.chain(stream.stream)),
-            leftover: self
-                .leftover
-                .into_iter()
-                .chain(stream.leftover)
-                .collect(),
+            leftover: self.leftover.into_iter().chain(stream.leftover).collect(),
             ctrlc: self.ctrlc,
             is_binary: self.is_binary,
             span: self.span,

--- a/crates/nu-protocol/src/value/stream.rs
+++ b/crates/nu-protocol/src/value/stream.rs
@@ -67,7 +67,7 @@ impl RawStream {
             leftover: self
                 .leftover
                 .into_iter()
-                .chain(stream.leftover.into_iter())
+                .chain(stream.leftover)
                 .collect(),
             ctrlc: self.ctrlc,
             is_binary: self.is_binary,

--- a/tests/plugins/formats/vcf.rs
+++ b/tests/plugins/formats/vcf.rs
@@ -8,7 +8,7 @@ fn infers_types() {
     Playground::setup("filter_from_vcf_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "contacts.vcf",
-            r#"
+            r"
                 BEGIN:VCARD
                 VERSION:3.0
                 FN:John Doe
@@ -29,7 +29,7 @@ fn infers_types() {
                 TEL;TYPE=CELL:(890) 123-4567
                 CATEGORIES:Band,myContacts
                 END:VCARD
-            "#,
+            ",
         )]);
 
         let cwd = dirs.test();
@@ -48,7 +48,7 @@ fn from_vcf_text_to_table() {
     Playground::setup("filter_from_vcf_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
             "contacts.txt",
-            r#"
+            r"
                 BEGIN:VCARD
                 VERSION:3.0
                 FN:John Doe
@@ -62,7 +62,7 @@ fn from_vcf_text_to_table() {
                 NOTE:Facebook: john.doe.3\nWebsite: \nHometown: Cleveland\, Ohio
                 CATEGORIES:myContacts
                 END:VCARD
-            "#,
+            ",
         )]);
 
         let cwd = dirs.test();


### PR DESCRIPTION
# Description
- A new one is the removal of unnecessary `#` in raw strings without `"` inside.
- https://rust-lang.github.io/rust-clippy/master/index.html#/needless_raw_string_hashes
- The automatically applied removal of `.into_iter()` touched several places where #9648 will change to the use of the record API.  If necessary I can remove them @IanManske to avoid churn with this PR.
- Manually applied `.try_fold` in two places
- Removed a dead `if`
- Manual: Combat rightward-drift with early return
