### PR TITLE
fix the command `cp -u src dst`/`mv -u src dst` doesn't work when the…

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -184,7 +184,7 @@ impl Command for Cp {
                             canonicalize_with(dst.as_path(), &current_dir_path).unwrap_or(dst);
 
                         // ignore when source file is not newer than target file
-                        if update_mode && super::util::is_older(&src, &dst) {
+                        if update_mode && super::util::is_older(&src, &dst).unwrap_or_else(|| false) {
                             continue;
                         }
 

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -313,7 +313,7 @@ fn move_file(
         }
     }
 
-    if update_mode && super::util::is_older(&from, &to) {
+    if update_mode && super::util::is_older(&from, &to).unwrap_or_else(|| false) {
         Ok(false)
     } else {
         match move_item(&from, from_span, &to) {

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -133,9 +133,11 @@ fn get_interactive_confirmation(prompt: String) -> Result<bool, Box<dyn Error>> 
     }
 }
 
-pub fn is_older(src: &Path, dst: &Path) -> bool {
-    if !dst.exists() {
-        return true;
+/// Return `Some(true)` if the last change time of the `src` old than the `dst`,  
+/// otherwisie return `Some(false)`. Return `None` if the `src` or `dst` doesn't exist.
+pub fn is_older(src: &Path, dst: &Path) -> Option<bool> {
+    if !dst.exists() || !src.exists() {
+        return None;
     }
     #[cfg(unix)]
     {
@@ -146,7 +148,7 @@ pub fn is_older(src: &Path, dst: &Path) -> bool {
         let dst_ctime = std::fs::metadata(dst)
             .map(|m| m.ctime())
             .unwrap_or(i64::MAX);
-        src_ctime <= dst_ctime
+        Some(src_ctime <= dst_ctime)
     }
     #[cfg(windows)]
     {
@@ -157,7 +159,7 @@ pub fn is_older(src: &Path, dst: &Path) -> bool {
         let dst_ctime = std::fs::metadata(dst)
             .map(|m| m.last_write_time())
             .unwrap_or(u64::MAX);
-        src_ctime <= dst_ctime
+        Some(src_ctime <= dst_ctime)
     }
 }
 


### PR DESCRIPTION
… `dst` doesn't exist;

[The cmd cp -u src dst and mv -u src dst doesn't work when the dst doesn't exist #9655](https://github.com/nushell/nushell/issues/9655)

- this PR should close #9655 
- fixes the command `cp -u src dst`/`mv -u src dst` doesn't work when the `dst` doesn't exist.
