### PR TITLE
Bump deps to transitively use hashbrown 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,12 +975,12 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -2229,11 +2229,11 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "lru"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718e8fae447df0c7e1ba7f5189829e63fd536945c8988d61444c19039f16b670"
+checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4", features = [ "serde", "std", "unstable-locales" ], d
 chrono-humanize = "0.2"
 fancy-regex = "0.11"
 indexmap = "2.0"
-lru = "0.10"
+lru = "0.11"
 miette = { version = "5.9", features = ["fancy-no-backtrace"] }
 num-format = "0.4"
 serde = { version = "1.0", default-features = false }


### PR DESCRIPTION
# Description
Update `lru` to `0.11`: `cargo build` will now not need `hashbrown 0.13`
Update `dashmap`: upgrades `hashbrown` for dev-dependency

-1 dependency in the `cargo install` path
