### PR TITLE
Use `is-terminal` crate for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,17 +279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,17 +657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b0e9222c0cdf2c6ac27d73f664f9520266fa911c3106329d359f8861cb8bde9"
 dependencies = [
  "encoding_rs",
-]
-
-[[package]]
-name = "colored"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
-dependencies = [
- "is-terminal",
- "lazy_static",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1651,15 +1629,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -1880,7 +1849,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1910,7 +1879,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]
@@ -2425,7 +2394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c762b6267c4593555bb38f1df19e9318985bc4de60b5e8462890856a9a5b4c"
 dependencies = [
  "assert-json-diff",
- "colored",
  "futures",
  "hyper",
  "lazy_static",
@@ -2572,10 +2540,10 @@ name = "nu"
 version = "0.82.1"
 dependencies = [
  "assert_cmd",
- "atty",
  "criterion",
  "crossterm",
  "ctrlc",
+ "is-terminal",
  "log",
  "miette",
  "mimalloc",
@@ -2637,11 +2605,11 @@ dependencies = [
 name = "nu-cli"
 version = "0.82.1"
 dependencies = [
- "atty",
  "chrono",
  "crossterm",
  "fancy-regex",
  "fuzzy-matcher",
+ "is-terminal",
  "is_executable",
  "log",
  "miette",
@@ -2749,7 +2717,6 @@ version = "0.82.1"
 dependencies = [
  "Inflector",
  "alphanumeric-sort",
- "atty",
  "base64",
  "bracoxide",
  "byteorder",
@@ -2773,6 +2740,7 @@ dependencies = [
  "indexmap 2.0.0",
  "indicatif",
  "is-root",
+ "is-terminal",
  "itertools",
  "libc",
  "log",
@@ -2973,8 +2941,8 @@ dependencies = [
 name = "nu-system"
 version = "0.82.1"
 dependencies = [
- "atty",
  "chrono",
+ "is-terminal",
  "libc",
  "libproc",
  "log",
@@ -3233,7 +3201,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ nix = { version = "0.26", default-features = false, features = [
 	"fs",
 	"term",
 ] }
-atty = "0.2"
+is-terminal = "0.4.8"
 
 [dev-dependencies]
 nu-test-support = { path = "./crates/nu-test-support", version = "0.82.1" }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -27,12 +27,12 @@ nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
 nu-ansi-term = "0.47.0"
 reedline = { version = "0.21.0", features = ["bashisms", "sqlite"]}
 
-atty = "0.2"
 chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.26"
 fancy-regex = "0.11"
 fuzzy-matcher = "0.3"
 is_executable = "1.0"
+is-terminal = "0.4.8"
 log = "0.4"
 miette = { version = "5.9", features = ["fancy-no-backtrace"] }
 once_cell = "1.18"

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -6,6 +6,7 @@ use crate::{
     NuHighlighter, NuValidator, NushellPrompt,
 };
 use crossterm::cursor::SetCursorStyle;
+use is_terminal::IsTerminal;
 use log::{trace, warn};
 use miette::{ErrReport, IntoDiagnostic, Result};
 use nu_cmd_base::util::get_guaranteed_cwd;
@@ -56,7 +57,7 @@ pub fn evaluate_repl(
 
     // Guard against invocation without a connected terminal.
     // reedline / crossterm event polling will fail without a connected tty
-    if !atty::is(atty::Stream::Stdin) {
+    if !std::io::stdin().is_terminal() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "Nushell launched as a REPL, but STDIN is not a TTY; either launch in a valid terminal or provide arguments to invoke a script!",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -30,7 +30,6 @@ nu-utils = { path = "../nu-utils", version = "0.82.1" }
 
 Inflector = "0.11"
 alphanumeric-sort = "1.5"
-atty = "0.2"
 base64 = "0.21"
 byteorder = "1.4"
 bytesize = "1.2"
@@ -52,6 +51,7 @@ htmlescape = "0.3"
 indexmap = "2.0"
 indicatif = "0.17"
 is-root = "0.1"
+is-terminal = "0.4.8"
 itertools = "0.10"
 log = "0.4"
 lscolors = { version = "0.14", default-features = false, features = ["nu-ansi-term"] }
@@ -124,7 +124,7 @@ nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.82.1" }
 nu-test-support = { path = "../nu-test-support", version = "0.82.1" }
 
 dirs-next = "2.0"
-mockito = "1.1"
+mockito = { version = "1.1", default-features = false }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 rstest = { version = "0.17", default-features = false }

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -1,3 +1,4 @@
+use is_terminal::IsTerminal;
 use lscolors::{LsColors, Style};
 use nu_color_config::color_from_hex;
 use nu_color_config::{StyleComputer, TextStyle};
@@ -848,8 +849,8 @@ enum TableView {
 
 #[allow(clippy::manual_filter)]
 fn maybe_strip_color(output: String, config: &Config) -> String {
-    // the atty is for when people do ls from vim, there should be no coloring there
-    if !config.use_ansi_coloring || !atty::is(atty::Stream::Stdout) {
+    // the terminal is for when people do ls from vim, there should be no coloring there
+    if !config.use_ansi_coloring || !std::io::stdout().is_terminal() {
         // Draw the table without ansi colors
         nu_utils::strip_ansi_string_likely(output)
     } else {

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -17,8 +17,8 @@ libc = "0.2"
 log = "0.4"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-atty = "0.2"
 nix = { version = "0.26", default-features = false, features = ["fs", "term", "process", "signal"]}
+is-terminal = "0.4.8"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs  = "0.15"

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -82,6 +82,7 @@ impl Drop for ForegroundChild {
 // Note: we exclude macos because the techniques below seem to have issues in macos 13 currently.
 #[cfg(all(target_family = "unix", not(target_os = "macos")))]
 mod fg_process_setup {
+    use is_terminal::IsTerminal;
     use nix::{
         sys::signal,
         unistd::{self, Pid},
@@ -138,7 +139,7 @@ mod fg_process_setup {
 
     pub(super) fn set_foreground(process: &std::process::Child, existing_pgrp: u32) {
         // called from the parent shell process - do the stdin tty check here
-        if atty::is(atty::Stream::Stdin) {
+        if std::io::stdin().is_terminal() {
             set_foreground_pid(
                 Pid::from_raw(process.id() as i32),
                 existing_pgrp,
@@ -163,7 +164,7 @@ mod fg_process_setup {
 
     /// Reset the foreground process group to the shell
     pub(super) fn reset_foreground_id() {
-        if atty::is(atty::Stream::Stdin) {
+        if std::io::stdin().is_terminal() {
             if let Err(e) = nix::unistd::tcsetpgrp(nix::libc::STDIN_FILENO, unistd::getpgrp()) {
                 println!("ERROR: reset foreground id failed, tcsetpgrp result: {e:?}");
             }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,8 +1,9 @@
 #[cfg(unix)]
 pub(crate) fn acquire_terminal(interactive: bool) {
+    use is_terminal::IsTerminal;
     use nix::sys::signal::{signal, SigHandler, Signal};
 
-    if !atty::is(atty::Stream::Stdin) {
+    if !std::io::stdin().is_terminal() {
         return;
     }
 


### PR DESCRIPTION
# Description
Until we bump our minimal Rust version to `1.70.0` we can't use
`std::io::IsTerminal`. The crate `is-terminal` (depending on `rustix` or
`windows-sys`) can provide the same.
Get's rid of the dependency on the outdated `atty` crate.
We already transitively depend on it (e.g. through `miette`)

As soon as we reach the new Rust version we can supersede this with
@nibon7's #9550
