### PR TITLE
remove warning: unused import pipeline

### DIFF
--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn let_name_builtin_var() {


### PR DESCRIPTION

Fix a compiler warning caused by this file...

```rust
crates/nu-command/tests/commands/let_.rs
```