### PR TITLE
Remove broken compile-time overload system

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -9,7 +9,7 @@ use nu_protocol::report_error;
 use nu_protocol::{
     ast::Call,
     engine::{EngineState, Stack, StateWorkingSet},
-    Config, PipelineData, ShellError, Span, Type, Value,
+    Config, PipelineData, ShellError, Span, Value,
 };
 use nu_utils::stdout_write_all_and_flush;
 
@@ -102,7 +102,7 @@ pub fn evaluate_file(
     trace!("parsing file: {}", file_path_str);
     let _ = parse(&mut working_set, Some(file_path_str), &file, false);
 
-    if working_set.find_decl(b"main", &Type::Any).is_some() {
+    if working_set.find_decl(b"main").is_some() {
         let args = format!("main {}", args.join(" "));
 
         if !eval_source(

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -52,7 +52,7 @@ pub struct ScopeData<'e, 's> {
     engine_state: &'e EngineState,
     stack: &'s Stack,
     vars_map: HashMap<&'e Vec<u8>, &'e usize>,
-    decls_map: HashMap<&'e (Vec<u8>, Type), &'e usize>,
+    decls_map: HashMap<&'e Vec<u8>, &'e usize>,
     modules_map: HashMap<&'e Vec<u8>, &'e usize>,
     visibility: Visibility,
 }
@@ -108,7 +108,7 @@ impl<'e, 's> ScopeData<'e, 's> {
 
     pub fn collect_commands(&self, span: Span) -> Vec<Value> {
         let mut commands = vec![];
-        for ((command_name, _), decl_id) in &self.decls_map {
+        for (command_name, decl_id) in &self.decls_map {
             if self.visibility.is_decl_id_visible(decl_id)
                 && !self.engine_state.get_decl(**decl_id).is_alias()
             {
@@ -488,7 +488,7 @@ impl<'e, 's> ScopeData<'e, 's> {
 
     pub fn collect_externs(&self, span: Span) -> Vec<Value> {
         let mut externals = vec![];
-        for ((command_name, _), decl_id) in &self.decls_map {
+        for (command_name, decl_id) in &self.decls_map {
             let decl = self.engine_state.get_decl(**decl_id);
 
             if decl.is_known_external() {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -235,7 +235,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expressio
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(b"for", &Type::Nothing) {
+    let (call, call_span) = match working_set.find_decl(b"for") {
         None => {
             working_set.error(ParseError::UnknownState(
                 "internal error: for declaration not found".into(),
@@ -359,7 +359,7 @@ pub fn parse_def(
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(&def_call, &Type::Nothing) {
+    let (call, call_span) = match working_set.find_decl(&def_call) {
         None => {
             working_set.error(ParseError::UnknownState(
                 "internal error: def declaration not found".into(),
@@ -548,7 +548,7 @@ pub fn parse_extern(
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(&extern_call, &Type::Nothing) {
+    let (call, call_span) = match working_set.find_decl(&extern_call) {
         None => {
             working_set.error(ParseError::UnknownState(
                 "internal error: def declaration not found".into(),
@@ -739,7 +739,7 @@ pub fn parse_alias(
         return Pipeline::from_vec(vec![garbage(*span)]);
     }
 
-    if let Some(decl_id) = working_set.find_decl(b"alias", &Type::Nothing) {
+    if let Some(decl_id) = working_set.find_decl(b"alias") {
         let (command_spans, rest_spans) = spans.split_at(split_id);
 
         let original_starting_error_count = working_set.parse_errors.len();
@@ -941,7 +941,7 @@ pub fn parse_export_in_block(
         b"export".to_vec()
     };
 
-    if let Some(decl_id) = working_set.find_decl(&full_name, &Type::Nothing) {
+    if let Some(decl_id) = working_set.find_decl(&full_name) {
         let ParsedInternalCall { call, output, .. } = parse_internal_call(
             working_set,
             if full_name == b"export" {
@@ -1035,7 +1035,7 @@ pub fn parse_export_in_module(
         return (garbage_pipeline(spans), vec![]);
     };
 
-    let export_decl_id = if let Some(id) = working_set.find_decl(b"export", &Type::Nothing) {
+    let export_decl_id = if let Some(id) = working_set.find_decl(b"export") {
         id
     } else {
         working_set.error(ParseError::InternalError(
@@ -1064,16 +1064,15 @@ pub fn parse_export_in_module(
                 };
                 let pipeline = parse_def(working_set, &lite_command, Some(module_name));
 
-                let export_def_decl_id =
-                    if let Some(id) = working_set.find_decl(b"export def", &Type::Nothing) {
-                        id
-                    } else {
-                        working_set.error(ParseError::InternalError(
-                            "missing 'export def' command".into(),
-                            export_span,
-                        ));
-                        return (garbage_pipeline(spans), vec![]);
-                    };
+                let export_def_decl_id = if let Some(id) = working_set.find_decl(b"export def") {
+                    id
+                } else {
+                    working_set.error(ParseError::InternalError(
+                        "missing 'export def' command".into(),
+                        export_span,
+                    ));
+                    return (garbage_pipeline(spans), vec![]);
+                };
 
                 // Trying to warp the 'def' call into the 'export def' in a very clumsy way
                 if let Some(PipelineElement::Expression(
@@ -1101,7 +1100,7 @@ pub fn parse_export_in_module(
                     let decl_name = working_set.get_span_contents(*decl_name_span);
                     let decl_name = trim_quotes(decl_name);
 
-                    if let Some(decl_id) = working_set.find_decl(decl_name, &Type::Nothing) {
+                    if let Some(decl_id) = working_set.find_decl(decl_name) {
                         result.push(Exportable::Decl {
                             name: decl_name.to_vec(),
                             id: decl_id,
@@ -1123,16 +1122,16 @@ pub fn parse_export_in_module(
                 };
                 let pipeline = parse_def(working_set, &lite_command, Some(module_name));
 
-                let export_def_decl_id =
-                    if let Some(id) = working_set.find_decl(b"export def-env", &Type::Nothing) {
-                        id
-                    } else {
-                        working_set.error(ParseError::InternalError(
-                            "missing 'export def-env' command".into(),
-                            export_span,
-                        ));
-                        return (garbage_pipeline(spans), vec![]);
-                    };
+                let export_def_decl_id = if let Some(id) = working_set.find_decl(b"export def-env")
+                {
+                    id
+                } else {
+                    working_set.error(ParseError::InternalError(
+                        "missing 'export def-env' command".into(),
+                        export_span,
+                    ));
+                    return (garbage_pipeline(spans), vec![]);
+                };
 
                 // Trying to warp the 'def' call into the 'export def' in a very clumsy way
                 if let Some(PipelineElement::Expression(
@@ -1162,7 +1161,7 @@ pub fn parse_export_in_module(
                 };
                 let decl_name = trim_quotes(decl_name);
 
-                if let Some(decl_id) = working_set.find_decl(decl_name, &Type::Nothing) {
+                if let Some(decl_id) = working_set.find_decl(decl_name) {
                     result.push(Exportable::Decl {
                         name: decl_name.to_vec(),
                         id: decl_id,
@@ -1183,16 +1182,15 @@ pub fn parse_export_in_module(
                 };
                 let pipeline = parse_extern(working_set, &lite_command, Some(module_name));
 
-                let export_def_decl_id =
-                    if let Some(id) = working_set.find_decl(b"export extern", &Type::Nothing) {
-                        id
-                    } else {
-                        working_set.error(ParseError::InternalError(
-                            "missing 'export extern' command".into(),
-                            export_span,
-                        ));
-                        return (garbage_pipeline(spans), vec![]);
-                    };
+                let export_def_decl_id = if let Some(id) = working_set.find_decl(b"export extern") {
+                    id
+                } else {
+                    working_set.error(ParseError::InternalError(
+                        "missing 'export extern' command".into(),
+                        export_span,
+                    ));
+                    return (garbage_pipeline(spans), vec![]);
+                };
 
                 // Trying to warp the 'def' call into the 'export def' in a very clumsy way
                 if let Some(PipelineElement::Expression(
@@ -1222,7 +1220,7 @@ pub fn parse_export_in_module(
                 };
                 let decl_name = trim_quotes(decl_name);
 
-                if let Some(decl_id) = working_set.find_decl(decl_name, &Type::Nothing) {
+                if let Some(decl_id) = working_set.find_decl(decl_name) {
                     result.push(Exportable::Decl {
                         name: decl_name.to_vec(),
                         id: decl_id,
@@ -1243,16 +1241,16 @@ pub fn parse_export_in_module(
                 };
                 let pipeline = parse_alias(working_set, &lite_command, Some(module_name));
 
-                let export_alias_decl_id =
-                    if let Some(id) = working_set.find_decl(b"export alias", &Type::Nothing) {
-                        id
-                    } else {
-                        working_set.error(ParseError::InternalError(
-                            "missing 'export alias' command".into(),
-                            export_span,
-                        ));
-                        return (garbage_pipeline(spans), vec![]);
-                    };
+                let export_alias_decl_id = if let Some(id) = working_set.find_decl(b"export alias")
+                {
+                    id
+                } else {
+                    working_set.error(ParseError::InternalError(
+                        "missing 'export alias' command".into(),
+                        export_span,
+                    ));
+                    return (garbage_pipeline(spans), vec![]);
+                };
 
                 // Trying to warp the 'alias' call into the 'export alias' in a very clumsy way
                 if let Some(PipelineElement::Expression(
@@ -1282,7 +1280,7 @@ pub fn parse_export_in_module(
                 };
                 let alias_name = trim_quotes(alias_name);
 
-                if let Some(alias_id) = working_set.find_decl(alias_name, &Type::Nothing) {
+                if let Some(alias_id) = working_set.find_decl(alias_name) {
                     result.push(Exportable::Decl {
                         name: alias_name.to_vec(),
                         id: alias_id,
@@ -1303,16 +1301,15 @@ pub fn parse_export_in_module(
                 };
                 let (pipeline, exportables) = parse_use(working_set, &lite_command.parts);
 
-                let export_use_decl_id =
-                    if let Some(id) = working_set.find_decl(b"export use", &Type::Nothing) {
-                        id
-                    } else {
-                        working_set.error(ParseError::InternalError(
-                            "missing 'export use' command".into(),
-                            export_span,
-                        ));
-                        return (garbage_pipeline(spans), vec![]);
-                    };
+                let export_use_decl_id = if let Some(id) = working_set.find_decl(b"export use") {
+                    id
+                } else {
+                    working_set.error(ParseError::InternalError(
+                        "missing 'export use' command".into(),
+                        export_span,
+                    ));
+                    return (garbage_pipeline(spans), vec![]);
+                };
 
                 // Trying to warp the 'use' call into the 'export use' in a very clumsy way
                 if let Some(PipelineElement::Expression(
@@ -1341,7 +1338,7 @@ pub fn parse_export_in_module(
                     parse_module(working_set, lite_command, Some(module_name));
 
                 let export_module_decl_id =
-                    if let Some(id) = working_set.find_decl(b"export module", &Type::Nothing) {
+                    if let Some(id) = working_set.find_decl(b"export module") {
                         id
                     } else {
                         working_set.error(ParseError::InternalError(
@@ -1446,7 +1443,7 @@ pub fn parse_export_env(
         return (garbage_pipeline(spans), None);
     }
 
-    let call = match working_set.find_decl(b"export-env", &Type::Nothing) {
+    let call = match working_set.find_decl(b"export-env") {
         Some(decl_id) => {
             let ParsedInternalCall { call, output } =
                 parse_internal_call(working_set, spans[0], &[spans[1]], decl_id);
@@ -1958,7 +1955,7 @@ pub fn parse_module(
         1
     };
 
-    let (call, call_span) = match working_set.find_decl(b"module", &Type::Nothing) {
+    let (call, call_span) = match working_set.find_decl(b"module") {
         Some(decl_id) => {
             let (command_spans, rest_spans) = spans.split_at(split_id);
 
@@ -2099,7 +2096,7 @@ pub fn parse_module(
     };
 
     let module_decl_id = working_set
-        .find_decl(b"module", &Type::Nothing)
+        .find_decl(b"module")
         .expect("internal error: missing module command");
 
     let call = Box::new(Call {
@@ -2150,7 +2147,7 @@ pub fn parse_use(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeline
         return (garbage_pipeline(spans), vec![]);
     }
 
-    let (call, call_span, args_spans) = match working_set.find_decl(b"use", &Type::Nothing) {
+    let (call, call_span, args_spans) = match working_set.find_decl(b"use") {
         Some(decl_id) => {
             let (command_spans, rest_spans) = spans.split_at(split_id);
 
@@ -2306,7 +2303,7 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline
         return garbage_pipeline(spans);
     }
 
-    let (call, args_spans) = match working_set.find_decl(b"hide", &Type::Nothing) {
+    let (call, args_spans) = match working_set.find_decl(b"hide") {
         Some(decl_id) => {
             let ParsedInternalCall { call, output } =
                 parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
@@ -2365,7 +2362,7 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline
                 (true, working_set.get_module(module_id).clone())
             } else if import_pattern.members.is_empty() {
                 // The pattern head can be:
-                if let Some(id) = working_set.find_decl(&import_pattern.head.name, &Type::Nothing) {
+                if let Some(id) = working_set.find_decl(&import_pattern.head.name) {
                     // a custom command,
                     let mut module = Module::new(b"tmp".to_vec());
                     module.add_decl(import_pattern.head.name.clone(), id);
@@ -2803,7 +2800,7 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
     //     return Pipeline::from_vec(vec![garbage(*span)]);
     // }
 
-    if let Some(decl_id) = working_set.find_decl(b"let", &Type::Nothing) {
+    if let Some(decl_id) = working_set.find_decl(b"let") {
         if spans.len() >= 4 {
             // This is a bit of by-hand parsing to get around the issue where we want to parse in the reverse order
             // so that the var-id created by the variable isn't visible in the expression that init it
@@ -2919,7 +2916,7 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
     //     return Pipeline::from_vec(vec![garbage(*span)]);
     // }
 
-    if let Some(decl_id) = working_set.find_decl(b"const", &Type::Nothing) {
+    if let Some(decl_id) = working_set.find_decl(b"const") {
         let cmd = working_set.get_decl(decl_id);
         let call_signature = cmd.signature().call_signature();
 
@@ -3041,7 +3038,7 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
     //     return Pipeline::from_vec(vec![garbage(*span)]);
     // }
 
-    if let Some(decl_id) = working_set.find_decl(b"mut", &Type::Nothing) {
+    if let Some(decl_id) = working_set.find_decl(b"mut") {
         if spans.len() >= 4 {
             // This is a bit of by-hand parsing to get around the issue where we want to parse in the reverse order
             // so that the var-id created by the variable isn't visible in the expression that init it
@@ -3155,7 +3152,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeli
     if name == b"source" || name == b"source-env" {
         let scoped = name == b"source-env";
 
-        if let Some(decl_id) = working_set.find_decl(name, &Type::Nothing) {
+        if let Some(decl_id) = working_set.find_decl(name) {
             let cwd = working_set.get_cwd();
 
             // Is this the right call to be using here?
@@ -3286,7 +3283,7 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
         return garbage(span(spans));
     }
 
-    let call = match working_set.find_decl(b"where", &Type::List(Box::new(Type::Any))) {
+    let call = match working_set.find_decl(b"where") {
         Some(decl_id) => {
             let ParsedInternalCall { call, output } =
                 parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
@@ -3349,7 +3346,7 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
     // Parsing the spans and checking that they match the register signature
     // Using a parsed call makes more sense than checking for how many spans are in the call
     // Also, by creating a call, it can be checked if it matches the declaration signature
-    let (call, call_span) = match working_set.find_decl(b"register", &Type::Nothing) {
+    let (call, call_span) = match working_set.find_decl(b"register") {
         None => {
             working_set.error(ParseError::UnknownState(
                 "internal error: Register declaration not found".into(),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1052,8 +1052,7 @@ pub fn parse_call(
         pos += 1;
     }
 
-    let input = working_set.type_scope.get_previous();
-    let mut maybe_decl_id = working_set.find_decl(&name, input);
+    let mut maybe_decl_id = working_set.find_decl(&name);
 
     while maybe_decl_id.is_none() {
         // Find the longest command match
@@ -1075,7 +1074,7 @@ pub fn parse_call(
                 name.extend(name_part);
             }
         }
-        maybe_decl_id = working_set.find_decl(&name, input);
+        maybe_decl_id = working_set.find_decl(&name);
     }
 
     if let Some(decl_id) = maybe_decl_id {
@@ -1096,7 +1095,7 @@ pub fn parse_call(
         }
 
         // TODO: Try to remove the clone
-        let decl = working_set.get_decl(decl_id).clone();
+        let decl = working_set.get_decl(decl_id);
 
         let parsed_call = if let Some(alias) = decl.as_alias() {
             if let Expression {
@@ -1104,7 +1103,7 @@ pub fn parse_call(
                 span: _,
                 ty,
                 custom_completion,
-            } = &alias.wrapped_call
+            } = &alias.clone().wrapped_call
             {
                 trace!("parsing: alias of external call");
 
@@ -2742,7 +2741,7 @@ pub fn parse_shape_name(
                     return SyntaxShape::Any;
                 }
 
-                let decl_id = working_set.find_decl(command_name, &Type::Any);
+                let decl_id = working_set.find_decl(command_name);
 
                 if let Some(decl_id) = decl_id {
                     return SyntaxShape::Custom(Box::new(shape), decl_id);
@@ -5088,7 +5087,7 @@ pub fn parse_expression(
         }
     };
 
-    let with_env = working_set.find_decl(b"with-env", &Type::Any);
+    let with_env = working_set.find_decl(b"with-env");
 
     if !shorthand.is_empty() {
         if let Some(decl_id) = with_env {
@@ -5172,7 +5171,7 @@ pub fn parse_builtin_commands(
     {
         trace!("parsing: not math expression or unaliasable parser keyword");
         let name = working_set.get_span_contents(lite_command.parts[0]);
-        if let Some(decl_id) = working_set.find_decl(name, &Type::Nothing) {
+        if let Some(decl_id) = working_set.find_decl(name) {
             let cmd = working_set.get_decl(decl_id);
             if cmd.is_alias() {
                 // Parse keywords that can be aliased. Note that we check for "unaliasable" keywords
@@ -5350,8 +5349,8 @@ pub fn parse_pipeline(
                             parse_builtin_commands(working_set, &new_command, is_subexpression);
 
                         if pipeline_index == 0 {
-                            let let_decl_id = working_set.find_decl(b"let", &Type::Nothing);
-                            let mut_decl_id = working_set.find_decl(b"mut", &Type::Nothing);
+                            let let_decl_id = working_set.find_decl(b"let");
+                            let mut_decl_id = working_set.find_decl(b"mut");
                             for element in pipeline.elements.iter_mut() {
                                 if let PipelineElement::Expression(
                                     _,
@@ -5487,8 +5486,8 @@ pub fn parse_pipeline(
             } => {
                 let mut pipeline = parse_builtin_commands(working_set, command, is_subexpression);
 
-                let let_decl_id = working_set.find_decl(b"let", &Type::Nothing);
-                let mut_decl_id = working_set.find_decl(b"mut", &Type::Nothing);
+                let let_decl_id = working_set.find_decl(b"let");
+                let mut_decl_id = working_set.find_decl(b"mut");
 
                 if pipeline_index == 0 {
                     for element in pipeline.elements.iter_mut() {
@@ -6008,7 +6007,7 @@ fn wrap_element_with_collect(
 fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) -> Expression {
     let span = expr.span;
 
-    if let Some(decl_id) = working_set.find_decl(b"collect", &Type::List(Box::new(Type::Any))) {
+    if let Some(decl_id) = working_set.find_decl(b"collect") {
         let mut output = vec![];
 
         let var_id = IN_VARIABLE_ID;

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1591,177 +1591,6 @@ mod input_types {
     }
 
     #[test]
-    fn call_types_test() {
-        let mut engine_state = EngineState::new();
-        add_declarations(&mut engine_state);
-
-        let mut working_set = StateWorkingSet::new(&engine_state);
-        let input = r#"ls | to-custom | group-by name other"#;
-
-        let block = parse(&mut working_set, None, input.as_bytes(), true);
-
-        assert!(working_set.parse_errors.is_empty());
-        assert_eq!(block.len(), 1);
-
-        let expressions = &block[0];
-        assert_eq!(expressions.len(), 3);
-
-        match &expressions[0] {
-            PipelineElement::Expression(
-                _,
-                Expression {
-                    expr: Expr::Call(call),
-                    ..
-                },
-            ) => {
-                let expected_id = working_set
-                    .find_decl(b"ls", &Type::Nothing)
-                    .expect("Error merging delta");
-                assert_eq!(call.decl_id, expected_id)
-            }
-            _ => panic!("Expected expression Call not found"),
-        }
-
-        match &expressions[1] {
-            PipelineElement::Expression(
-                _,
-                Expression {
-                    expr: Expr::Call(call),
-                    ..
-                },
-            ) => {
-                let expected_id = working_set.find_decl(b"to-custom", &Type::Any).unwrap();
-                assert_eq!(call.decl_id, expected_id)
-            }
-            _ => panic!("Expected expression Call not found"),
-        }
-
-        match &expressions[2] {
-            PipelineElement::Expression(
-                _,
-                Expression {
-                    expr: Expr::Call(call),
-                    ..
-                },
-            ) => {
-                let expected_id = working_set
-                    .find_decl(b"group-by", &Type::Custom("custom".into()))
-                    .unwrap();
-                assert_eq!(call.decl_id, expected_id)
-            }
-            _ => panic!("Expected expression Call not found"),
-        }
-    }
-
-    #[test]
-    fn storing_variable_test() {
-        let mut engine_state = EngineState::new();
-        add_declarations(&mut engine_state);
-
-        let mut working_set = StateWorkingSet::new(&engine_state);
-        let input =
-            r#"let a = (ls | to-custom | group-by name other); let b = (1+3); $a | agg sum"#;
-
-        let block = parse(&mut working_set, None, input.as_bytes(), true);
-
-        assert!(working_set.parse_errors.is_empty());
-        assert_eq!(block.len(), 3);
-
-        let expressions = &block[2];
-        match &expressions[1] {
-            PipelineElement::Expression(
-                _,
-                Expression {
-                    expr: Expr::Call(call),
-                    ..
-                },
-            ) => {
-                let expected_id = working_set
-                    .find_decl(b"agg", &Type::Custom("custom".into()))
-                    .unwrap();
-                assert_eq!(call.decl_id, expected_id)
-            }
-            _ => panic!("Expected expression Call not found"),
-        }
-    }
-
-    #[test]
-    fn stored_variable_operation_test() {
-        let mut engine_state = EngineState::new();
-        add_declarations(&mut engine_state);
-
-        let mut working_set = StateWorkingSet::new(&engine_state);
-        let input = r#"let a = (ls | to-custom | group-by name other); ($a + $a) | agg sum"#;
-
-        let block = parse(&mut working_set, None, input.as_bytes(), true);
-
-        assert!(working_set.parse_errors.is_empty());
-        assert_eq!(block.len(), 2);
-
-        let expressions = &block[1];
-        match &expressions[1] {
-            PipelineElement::Expression(
-                _,
-                Expression {
-                    expr: Expr::Call(call),
-                    ..
-                },
-            ) => {
-                let expected_id = working_set
-                    .find_decl(b"agg", &Type::Custom("custom".into()))
-                    .unwrap();
-                assert_eq!(call.decl_id, expected_id)
-            }
-            _ => panic!("Expected expression Call not found"),
-        }
-    }
-
-    #[test]
-    fn multiple_stored_variable_test() {
-        let mut engine_state = EngineState::new();
-        add_declarations(&mut engine_state);
-
-        let mut working_set = StateWorkingSet::new(&engine_state);
-        let input = r#"
-        let a = (ls | to-custom | group-by name other); [1 2 3] | to-custom; [1 2 3] | to-custom"#;
-
-        let block = parse(&mut working_set, None, input.as_bytes(), true);
-
-        assert!(working_set.parse_errors.is_empty());
-        assert_eq!(block.len(), 3);
-
-        let expressions = &block[1];
-        match &expressions[1] {
-            PipelineElement::Expression(
-                _,
-                Expression {
-                    expr: Expr::Call(call),
-                    ..
-                },
-            ) => {
-                let expected_id = working_set.find_decl(b"to-custom", &Type::Any).unwrap();
-                assert_eq!(call.decl_id, expected_id)
-            }
-            _ => panic!("Expected expression Call not found"),
-        }
-
-        let expressions = &block[2];
-        match &expressions[1] {
-            PipelineElement::Expression(
-                _,
-                Expression {
-                    expr: Expr::Call(call),
-                    ..
-                },
-            ) => {
-                let expected_id = working_set.find_decl(b"to-custom", &Type::Any).unwrap();
-                assert_eq!(call.decl_id, expected_id)
-            }
-            _ => panic!("Expected expression Call not found"),
-        }
-    }
-
-    #[test]
     fn call_non_custom_types_test() {
         let mut engine_state = EngineState::new();
         add_declarations(&mut engine_state);
@@ -1785,7 +1614,7 @@ mod input_types {
                     ..
                 },
             ) => {
-                let expected_id = working_set.find_decl(b"ls", &Type::Nothing).unwrap();
+                let expected_id = working_set.find_decl(b"ls").unwrap();
                 assert_eq!(call.decl_id, expected_id)
             }
             _ => panic!("Expected expression Call not found"),
@@ -1799,7 +1628,7 @@ mod input_types {
                     ..
                 },
             ) => {
-                let expected_id = working_set.find_decl(b"group-by", &Type::Any).unwrap();
+                let expected_id = working_set.find_decl(b"group-by").unwrap();
                 assert_eq!(call.decl_id, expected_id)
             }
             _ => panic!("Expected expression Call not found"),
@@ -1849,8 +1678,7 @@ mod input_types {
                                         },
                                     ) => {
                                         let working_set = StateWorkingSet::new(&engine_state);
-                                        let expected_id =
-                                            working_set.find_decl(b"min", &Type::Any).unwrap();
+                                        let expected_id = working_set.find_decl(b"min").unwrap();
                                         assert_eq!(call.decl_id, expected_id)
                                     }
                                     _ => panic!("Expected expression Call not found"),
@@ -1889,9 +1717,7 @@ mod input_types {
                     ..
                 },
             ) => {
-                let expected_id = working_set
-                    .find_decl(b"with-column", &Type::Custom("custom".into()))
-                    .unwrap();
+                let expected_id = working_set.find_decl(b"with-column").unwrap();
                 assert_eq!(call.decl_id, expected_id)
             }
             _ => panic!("Expected expression Call not found"),
@@ -1905,9 +1731,7 @@ mod input_types {
                     ..
                 },
             ) => {
-                let expected_id = working_set
-                    .find_decl(b"collect", &Type::Custom("custom".into()))
-                    .unwrap();
+                let expected_id = working_set.find_decl(b"collect").unwrap();
                 assert_eq!(call.decl_id, expected_id)
             }
             _ => panic!("Expected expression Call not found"),

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -1,7 +1,5 @@
-use crate::{DeclId, ModuleId, OverlayId, Type, Value, VarId};
-use std::borrow::Borrow;
+use crate::{DeclId, ModuleId, OverlayId, Value, VarId};
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
 
 pub static DEFAULT_OVERLAY_NAME: &str = "zero";
 
@@ -181,7 +179,7 @@ pub struct OverlayFrame {
     pub vars: HashMap<Vec<u8>, VarId>,
     pub constants: HashMap<VarId, Value>,
     pub predecls: HashMap<Vec<u8>, DeclId>, // temporary storage for predeclarations
-    pub decls: HashMap<(Vec<u8>, Type), DeclId>,
+    pub decls: HashMap<Vec<u8>, DeclId>,
     pub modules: HashMap<Vec<u8>, ModuleId>,
     pub visibility: Visibility,
     pub origin: ModuleId, // The original module the overlay was created from
@@ -202,82 +200,16 @@ impl OverlayFrame {
         }
     }
 
-    pub fn insert_decl(&mut self, name: Vec<u8>, input: Type, decl_id: DeclId) -> Option<DeclId> {
-        self.decls.insert((name, input), decl_id)
+    pub fn insert_decl(&mut self, name: Vec<u8>, decl_id: DeclId) -> Option<DeclId> {
+        self.decls.insert(name, decl_id)
     }
 
     pub fn insert_module(&mut self, name: Vec<u8>, module_id: ModuleId) -> Option<ModuleId> {
         self.modules.insert(name, module_id)
     }
 
-    pub fn get_decl(&self, name: &[u8], input: &Type) -> Option<DeclId> {
-        if let Some(decl) = self.decls.get(&(name, input) as &dyn DeclKey) {
-            Some(*decl)
-        } else {
-            // then fallback to not using the input type
-            for decl_key in self.decls.keys() {
-                if decl_key.0 == name {
-                    // FIXME: this fallback may give bad type information
-                    // in the case where no matching type is found. But, at
-                    // least we treat it as a found internal command rather
-                    // than an external command, which would cause further issues
-                    return Some(
-                        *self
-                            .decls
-                            .get(decl_key)
-                            .expect("internal error: found decl not actually found"),
-                    );
-                }
-            }
-
-            None
-        }
-    }
-}
-
-trait DeclKey {
-    fn name(&self) -> &[u8];
-    fn input(&self) -> &Type;
-}
-
-impl Hash for dyn DeclKey + '_ {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.name().hash(state);
-        self.input().hash(state);
-    }
-}
-
-impl PartialEq for dyn DeclKey + '_ {
-    fn eq(&self, other: &Self) -> bool {
-        self.name() == other.name() && self.input() == other.input()
-    }
-}
-
-impl Eq for dyn DeclKey + '_ {}
-
-impl<'a> DeclKey for (&'a [u8], &Type) {
-    fn name(&self) -> &[u8] {
-        self.0
-    }
-
-    fn input(&self) -> &Type {
-        self.1
-    }
-}
-
-impl DeclKey for (Vec<u8>, Type) {
-    fn name(&self) -> &[u8] {
-        &self.0
-    }
-
-    fn input(&self) -> &Type {
-        &self.1
-    }
-}
-
-impl<'a> Borrow<dyn DeclKey + 'a> for (Vec<u8>, Type) {
-    fn borrow(&self) -> &(dyn DeclKey + 'a) {
-        self
+    pub fn get_decl(&self, name: &[u8]) -> Option<DeclId> {
+        self.decls.get(name).cloned()
     }
 }
 


### PR DESCRIPTION
# Description

This PR removes the compile-time overload system. Unfortunately, this system never worked correctly because in a gradual type system where types can be `Any`, you don't have enough information to correctly resolve function calls with overloads. These resolutions must be done at runtime, if they're supported.

That said, there's a bit of work that needs to go into resolving input/output types (here overloads do not execute separate commands, but the same command and each overload explains how each output type corresponds to input types).

This PR also removes the type scope, which would give incorrect answers in cases where multiple subexpressions were used in a pipeline.

# User-Facing Changes

Finishes removing compile-time overloads. These were only used in a few places in the code base, but it's possible it may impact user code. I'll mark this as breaking change so we can review.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
