### PR TITLE
Fix broken constants in scopes

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/const_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/const_.rs
@@ -47,11 +47,15 @@ impl Command for Const {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let var_id = call
-            .positional_nth(0)
-            .expect("checked through parser")
-            .as_var()
-            .expect("internal error: missing variable");
+        let var_id = if let Some(id) = call.positional_nth(0).and_then(|pos| pos.as_var()) {
+            id
+        } else {
+            return Err(ShellError::NushellFailedSpanned {
+                msg: "Could not get variable".to_string(),
+                label: "variable not added by the parser".to_string(),
+                span: call.head,
+            });
+        };
 
         if let Some(constval) = engine_state.find_constant(var_id, &[]) {
             // Instead of creating a second copy of the value in the stack, we could change

--- a/crates/nu-cmd-lang/src/core_commands/const_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/const_.rs
@@ -57,9 +57,7 @@ impl Command for Const {
             });
         };
 
-        if let Some(constval) = engine_state.find_constant(var_id, &[]) {
-            // Instead of creating a second copy of the value in the stack, we could change
-            // stack.get_var() to check engine_state.find_constant().
+        if let Some(constval) = &engine_state.get_var(var_id).const_val {
             stack.add_var(var_id, constval.clone());
 
             Ok(PipelineData::empty())

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -294,9 +294,7 @@ pub fn find_in_dirs_env(
             .flatten()
     };
 
-    let lib_dirs = dirs_var
-        .and_then(|dirs_var| engine_state.find_constant(dirs_var, &[]))
-        .cloned();
+    let lib_dirs = dirs_var.and_then(|var_id| engine_state.get_var(var_id).const_val.clone());
     // TODO: remove (see #8310)
     let lib_dirs_fallback = stack.get_env_var(engine_state, "NU_LIB_DIRS");
 

--- a/crates/nu-parser/src/eval.rs
+++ b/crates/nu-parser/src/eval.rs
@@ -23,7 +23,7 @@ pub fn eval_constant(
             val: path.clone(),
             span: expr.span,
         }),
-        Expr::Var(var_id) => match working_set.find_constant(*var_id) {
+        Expr::Var(var_id) => match working_set.get_variable(*var_id).const_val.as_ref() {
             Some(val) => Ok(val.clone()),
             None => Err(ParseError::NotAConstant(expr.span)),
         },

--- a/crates/nu-protocol/src/engine/overlay.rs
+++ b/crates/nu-protocol/src/engine/overlay.rs
@@ -1,4 +1,4 @@
-use crate::{DeclId, ModuleId, OverlayId, Value, VarId};
+use crate::{DeclId, ModuleId, OverlayId, VarId};
 use std::collections::HashMap;
 
 pub static DEFAULT_OVERLAY_NAME: &str = "zero";
@@ -177,7 +177,6 @@ impl ScopeFrame {
 #[derive(Debug, Clone)]
 pub struct OverlayFrame {
     pub vars: HashMap<Vec<u8>, VarId>,
-    pub constants: HashMap<VarId, Value>,
     pub predecls: HashMap<Vec<u8>, DeclId>, // temporary storage for predeclarations
     pub decls: HashMap<Vec<u8>, DeclId>,
     pub modules: HashMap<Vec<u8>, ModuleId>,
@@ -190,7 +189,6 @@ impl OverlayFrame {
     pub fn from_origin(origin: ModuleId, prefixed: bool) -> Self {
         Self {
             vars: HashMap::new(),
-            constants: HashMap::new(),
             predecls: HashMap::new(),
             decls: HashMap::new(),
             modules: HashMap::new(),

--- a/crates/nu-protocol/src/variable.rs
+++ b/crates/nu-protocol/src/variable.rs
@@ -1,10 +1,11 @@
-use crate::{Span, Type};
+use crate::{Span, Type, Value};
 
 #[derive(Clone, Debug)]
 pub struct Variable {
     pub declaration_span: Span,
     pub ty: Type,
     pub mutable: bool,
+    pub const_val: Option<Value>,
 }
 
 impl Variable {
@@ -13,6 +14,7 @@ impl Variable {
             declaration_span,
             ty,
             mutable,
+            const_val: None,
         }
     }
 }

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -102,3 +102,12 @@ fn const_unsupported() {
 
     assert!(actual.err.contains("not_a_constant"));
 }
+
+#[test]
+fn const_in_scope() {
+    let inp = &["do { const x = 'x'; $x }"];
+
+    let actual = nu!(&inp.join("; "));
+
+    assert_eq!(actual.out, "x");
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Previously, only constants defined at the top scoped worked correctly. For example, this wouldn't work:
```nushell
do { const x = 'x' }
```
Now, it works.

Fixes https://github.com/nushell/nushell/issues/7810

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Just a bugfix, shouldn't change existing code.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
