### PR TITLE
add more input_output_types found from breaking scripts

### DIFF
--- a/crates/nu-cli/src/commands/commandline.rs
+++ b/crates/nu-cli/src/commands/commandline.rs
@@ -16,7 +16,10 @@ impl Command for Commandline {
 
     fn signature(&self) -> Signature {
         Signature::build("commandline")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::String, Type::String),
+            ])
             .switch(
                 "cursor",
                 "Set or get the current cursor position",

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -67,6 +67,7 @@ impl Command for SubCommand {
         .input_output_types(vec![
             (Type::Int, Type::Date),
             (Type::String, Type::Date),
+            (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Date))),
         ])
         .named(
                 "timezone",

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -189,6 +189,39 @@ impl Command for SubCommand {
                 #[allow(clippy::inconsistent_digit_grouping)]
                 result: example_result_1(1614434140_000000000),
             },
+            Example {
+                description: "Convert list of timestamps to datetimes",
+                example: r#"["2023-03-30 10:10:07 -05:00", "2023-05-05 13:43:49 -05:00", "2023-06-05 01:37:42 -05:00"] | into datetime"#,
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::Date {
+                            val: DateTime::parse_from_str(
+                                "2023-03-30 10:10:07 -05:00",
+                                "%Y-%m-%d %H:%M:%S %z",
+                            )
+                            .expect("date calculation should not fail in test"),
+                            span: Span::test_data(),
+                        },
+                        Value::Date {
+                            val: DateTime::parse_from_str(
+                                "2023-05-05 13:43:49 -05:00",
+                                "%Y-%m-%d %H:%M:%S %z",
+                            )
+                            .expect("date calculation should not fail in test"),
+                            span: Span::test_data(),
+                        },
+                        Value::Date {
+                            val: DateTime::parse_from_str(
+                                "2023-06-05 01:37:42 -05:00",
+                                "%Y-%m-%d %H:%M:%S %z",
+                            )
+                            .expect("date calculation should not fail in test"),
+                            span: Span::test_data(),
+                        },
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -22,6 +22,7 @@ impl Command for Append {
                     Type::List(Box::new(Type::Any)),
                 ),
                 (Type::Record(vec![]), Type::Table(vec![])),
+                (Type::String, Type::String),
             ])
             .required("row", SyntaxShape::Any, "the row, list, or table to append")
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -23,7 +23,6 @@ impl Command for Length {
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Any)), Type::Int),
                 (Type::Table(vec![]), Type::Int),
-                (Type::String, Type::Int),
             ])
             .switch("column", "Show the number of columns in a table", Some('c'))
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -23,6 +23,7 @@ impl Command for Length {
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Any)), Type::Int),
                 (Type::Table(vec![]), Type::Int),
+                (Type::String, Type::Int),
             ])
             .switch("column", "Show the number of columns in a table", Some('c'))
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -75,6 +75,12 @@ impl Command for Reduce {
                     "Add ascending numbers to each of the filenames, and join with semicolons.",
                 result: Some(Value::test_string("1-foo.gz; 2-bar.gz; 3-baz.gz")),
             },
+            Example {
+                example: r#"let s = "Str"; 0..2 | reduce -f '' {|it, acc| $acc + $s}"#,
+                description:
+                    "Concatenate a string with itself, using a range to determine the number of times.",
+                result: Some(Value::test_string("StrStrStr")),
+            },
         ]
     }
 

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -19,6 +19,7 @@ impl Command for Reduce {
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Any)), Type::Any),
                 (Type::Table(vec![]), Type::Any),
+                (Type::Range, Type::Any),
             ])
             .named(
                 "fold",

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -36,6 +36,7 @@ impl Command for Reduce {
                 ])),
                 "reducing function",
             )
+            .allow_variants_without_examples(true)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -37,6 +37,10 @@ impl Command for SubCommand {
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
             ])
             .vectorizes_over_list(true)
             .required("find", SyntaxShape::String, "the pattern to find")

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -66,6 +66,7 @@ impl Command for SubCommand {
                 "multi-line regex mode: ^ and $ match begin/end of line; equivalent to (?m)",
                 Some('m'),
             )
+            .allow_variants_without_examples(true)
             .category(Category::Strings)
     }
 


### PR DESCRIPTION
# Description

This PR fixes some problems I found in scripts by adding some additional input_output_types.

Here's a list of nushell scripts that it fixed. Look for `# broke here:` below.

This PR fixes 3, 4, 6, 7 by adding additional input_output_types. 1 was fixed by changing the script. 2. just doesn't work anymore because mkdir return type has changed. 5, is a problem with the script, the datatype for `...rest` needed to be removed.

```nushell
# 1.
def terminal-size [] {
    let sz = (input (ansi size) --bytes-until 'R')
    # $sz should look like this
    # Length: 9 (0x9) bytes | printable whitespace ascii_other non_ascii
    # 00000000:   1b 5b 33 38  3b 31 35 30  52                         •[38;150R
    let sz_len = ($sz | bytes length)

    # let's skip the esc[ and R
    let r = ($sz | bytes at 2..($sz_len - 2) | into string)

    # $r should look like 38;150
    # broke here: because $r needed to be a string for split row
    let size = ($r | split row ';')

    # output in record syntax
    {
        rows: ($size | get 0)
        columns: ($size | get 1)
    }
}

# 2.
# make and cd to a folder
def-env mkcd [name: path] {
    # broke here: but apparently doesn't work anymore
    # It looks like  mkdir returns nothing where it used to return a value
    cd (mkdir $name -v | first) 
}

# 3.
# changed 'into datetime'
def get-monday [] {
  (seq date -r --days 7 |
  # broke here: because into datetime didn't support list input
   into datetime | 
   where { |e| 
   ($e | date format %u) == "1" }).0 | 
   date format "%Y-%m-%d"
}

# 4.
# Delete all branches that are not in the excepts list
# Usage: del-branches [main]
def del-branches [
    excepts:list  # don't delete branch in the list
    --dry-run(-d) # do a dry-run
 ] {
    let branches = (git branch | lines | str trim)
    # broke here: because str replace didn't support list<string>
    let remote_branches = (git branch -r | lines | str replace '^.+?/' '' | uniq)
    if $dry_run {
        print "Starting Dry-Run"
    } else {
        print "Deleting for real"
    }
    $branches | each {|it|
        if ($it not-in $excepts) and ($it not-in $remote_branches) and (not ($it | str starts-with "*")) {
            # git branch -D $it
            if $dry_run {
                print $"git branch -D ($it)"
            } else {
                print $"Deleting ($it) for real"
                #git branch -D $it
            }
        }
    }
}

# 5.
# zoxide script
def-env __zoxide_z [...rest] {
  # `z -` does not work yet, see https://github.com/nushell/nushell/issues/4769
  # broke here: 'append doesn't support string input'
  let arg0 = ($rest | append '~').0
  # broke here: 'length doesn't support string input' so change `...rest:string` to `...rest`
  let path = if (($rest | length) <= 1) and ($arg0 == '-' or ($arg0 | path expand | path type) == dir) {
    $arg0
  } else {
    (zoxide query --exclude $env.PWD -- $rest | str trim -r -c "\n")
  }
  cd $path
}

# 6.
def a [] { 
    let x = (commandline)
    if ($x | is-empty) { return }
    # broke here: because commandline was previously only returning Type::Nothing
    if not ($x | str starts-with "aaa") { print "bbb" }
}

# 7.
# repeat a string x amount of times
def repeat [arg: string, dupe: int] {
  # broke here: 'command does not support range input'
  0..<$dupe | reduce -f '' {|i acc| $acc + $arg}
}
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
