### PR TITLE
Change input/output types in help to a table

### DIFF
--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -20,13 +20,11 @@ fn help_commands_length() {
 #[test]
 fn help_shows_signature() {
     let actual = nu!("help str distance");
-    assert!(actual
-        .out
-        .contains("<string> | str distance <string> -> <int>"));
+    assert!(actual.out.contains("Input/output types"));
 
     // don't show signature for parser keyword
     let actual = nu!("help alias");
-    assert!(!actual.out.contains("Signatures"));
+    assert!(!actual.out.contains("Input/output types"));
 }
 
 #[ignore = "TODO: Need to decide how to do help messages of new aliases"]

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -55,7 +55,7 @@ fn in_and_if_else() -> TestResult {
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
     // `each while` is part of the *extra* feature and adds 3 lines
-    let expected_length = if cfg!(feature = "extra") { "66" } else { "63" };
+    let expected_length = if cfg!(feature = "extra") { "70" } else { "67" };
     run_test(r#"each --help | lines | length"#, expected_length)
 }
 


### PR DESCRIPTION
# Description

Updates `help` to more clearly show input/output types.

Before:

![image](https://github.com/nushell/nushell/assets/547158/5f11ca5c-54a0-414d-b3de-1a8b4dd7fcbd)

After:

![image](https://github.com/nushell/nushell/assets/547158/afc0eb1e-fad8-43b1-9382-c2a0d8e9334e)

# User-Facing Changes

See above

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
