### PR TITLE
Clean up tests containing unnecessary `cwd:` tokens

### DIFF
--- a/crates/nu-cmd-extra/tests/commands/bytes/starts_with.rs
+++ b/crates/nu-cmd-extra/tests/commands/bytes/starts_with.rs
@@ -2,24 +2,18 @@ use nu_test_support::nu;
 
 #[test]
 fn basic_binary_starts_with() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             "hello world" | into binary | bytes starts-with 0x[68 65 6c 6c 6f]
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn basic_string_fails() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             "hello world" | bytes starts-with 0x[68 65 6c 6c 6f]
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("command doesn't support"));
     assert_eq!(actual.out, "");
@@ -27,48 +21,36 @@ fn basic_string_fails() {
 
 #[test]
 fn short_stream_binary() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             nu --testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101]
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn short_stream_mismatch() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             nu --testbin repeater (0x[010203]) 5 | bytes starts-with 0x[010204]
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn short_stream_binary_overflow() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             nu --testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101010101]
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn long_stream_binary() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             nu --testbin repeater (0x[01]) 32768 | bytes starts-with 0x[010101]
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "true");
 }
@@ -76,12 +58,9 @@ fn long_stream_binary() {
 #[test]
 fn long_stream_binary_overflow() {
     // .. ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             nu --testbin repeater (0x[01]) 32768 | bytes starts-with (0..32768 | each {|| 0x[01] } | bytes collect)
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "false");
 }
@@ -89,12 +68,9 @@ fn long_stream_binary_overflow() {
 #[test]
 fn long_stream_binary_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             nu --testbin repeater (0x[01020304]) 8192 | bytes starts-with (0..<8192 | each {|| 0x[01020304] } | bytes collect)
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "true");
 }
@@ -102,12 +78,9 @@ fn long_stream_binary_exact() {
 #[test]
 fn long_stream_string_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             nu --testbin repeater hell 8192 | bytes starts-with (0..<8192 | each {|| "hell" | into binary } | bytes collect)
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "true");
 }
@@ -115,15 +88,12 @@ fn long_stream_string_exact() {
 #[test]
 fn long_stream_mixed_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             let binseg = (0..<2048 | each {|| 0x[003d9fbf] } | bytes collect)
             let strseg = (0..<2048 | each {|| "hell" | into binary } | bytes collect)
 
             nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg)
-        "#
-    );
+        "#);
 
     assert_eq!(
         actual.err, "",
@@ -135,15 +105,12 @@ fn long_stream_mixed_exact() {
 #[test]
 fn long_stream_mixed_overflow() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             let binseg = (0..<2048 | each {|| 0x[003d9fbf] } | bytes collect)
             let strseg = (0..<2048 | each {|| "hell" | into binary } | bytes collect)
 
             nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg 0x[01])
-        "#
-    );
+        "#);
 
     assert_eq!(
         actual.err, "",

--- a/crates/nu-command/tests/commands/assignment/append_assign.rs
+++ b/crates/nu-command/tests/commands/assignment/append_assign.rs
@@ -2,21 +2,15 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn append_assign_int() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             mut a = [1 2];
             $a ++= [3 4];
             $a
-        "#
-    ));
+        "#);
 
-    let expected = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let expected = nu!(r#"
             [1 2 3 4]
-        "#
-    ));
+        "#);
 
     print!("{}", actual.out);
     print!("{}", expected.out);
@@ -25,21 +19,15 @@ fn append_assign_int() {
 
 #[test]
 fn append_assign_string() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             mut a = [a b];
             $a ++= [c d];
             $a
-        "#
-    ));
+        "#);
 
-    let expected = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let expected = nu!(r#"
             [a b c d]
-        "#
-    ));
+        "#);
 
     print!("{}", actual.out);
     print!("{}", expected.out);
@@ -48,21 +36,15 @@ fn append_assign_string() {
 
 #[test]
 fn append_assign_any() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             mut a = [1 2 a];
             $a ++= [b 3];
             $a
-        "#
-    ));
+        "#);
 
-    let expected = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let expected = nu!(r#"
             [1 2 a b 3]
-        "#
-    ));
+        "#);
 
     print!("{}", actual.out);
     print!("{}", expected.out);
@@ -71,21 +53,15 @@ fn append_assign_any() {
 
 #[test]
 fn append_assign_both_empty() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             mut a = [];
             $a ++= [];
             $a
-        "#
-    ));
+        "#);
 
-    let expected = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let expected = nu!(r#"
             []
-        "#
-    ));
+        "#);
 
     print!("{}", actual.out);
     print!("{}", expected.out);
@@ -94,14 +70,11 @@ fn append_assign_both_empty() {
 
 #[test]
 fn append_assign_type_mismatch() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             mut a = [1 2];
             $a ++= [a];
             $a | to json -r;
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, r#"[1,2,"a"]"#);
 }

--- a/crates/nu-command/tests/commands/assignment/append_assign.rs
+++ b/crates/nu-command/tests/commands/assignment/append_assign.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn append_assign_int() {

--- a/crates/nu-command/tests/commands/date/format.rs
+++ b/crates/nu-command/tests/commands/date/format.rs
@@ -2,26 +2,18 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn formatter_not_valid() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         date now | date format '%N'
-        "#
-        )
-    );
+        "#);
 
     assert!(actual.err.contains("invalid format"));
 }
 
 #[test]
 fn fails_without_input() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         date format "%c"
-        "#
-        )
-    );
+        "#);
 
     assert!(actual.err.contains("Pipeline empty"));
 }

--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -4,8 +4,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn flatten_nested_tables_with_columns() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo [[origin, people]; [Ecuador, ('Andres' | wrap name)]]
                  [[origin, people]; [Nu, ('nuno' | wrap name)]]
@@ -20,8 +19,7 @@ fn flatten_nested_tables_with_columns() {
 
 #[test]
 fn flatten_nested_tables_that_have_many_columns() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo [[origin, people]; [Ecuador, (echo [[name, meal]; ['Andres', 'arepa']])]]
             [[origin, people]; [USA, (echo [[name, meal]; ['Katz', 'nurepa']])]]
@@ -36,8 +34,7 @@ fn flatten_nested_tables_that_have_many_columns() {
 
 #[test]
 fn flatten_nested_tables() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo [[Andrés, Nicolás, Robalino]] | flatten | get 1
         "#

--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -2,13 +2,10 @@ use nu_test_support::nu;
 
 #[test]
 fn for_doesnt_auto_print_in_each_iteration() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         for i in 1..2 {
             echo 1
-        }"#
-    );
+        }"#);
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert!(!actual.out.contains('1'));
@@ -16,14 +13,11 @@ fn for_doesnt_auto_print_in_each_iteration() {
 
 #[test]
 fn for_break_on_external_failed() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         for i in 1..2 {
             print 1;
             nu --testbin fail
-        }"#
-    );
+        }"#);
     // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`
     assert_eq!(actual.out, "1");
@@ -31,24 +25,18 @@ fn for_break_on_external_failed() {
 
 #[test]
 fn failed_for_should_break_running() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         for i in 1..2 {
             nu --testbin fail
         }
-        print 3"#
-    );
+        print 3"#);
     assert!(!actual.out.contains('3'));
 
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         let x = [1 2]
         for i in $x {
             nu --testbin fail
         }
-        print 3"#
-    );
+        print 3"#);
     assert!(!actual.out.contains('3'));
 }

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -183,7 +183,6 @@ fn errors_fetching_by_accessing_empty_list() {
 #[test]
 fn quoted_column_access() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         r#"'[{"foo bar": {"baz": 4}}]' | from json | get "foo bar".baz.0 "#
     );
 

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -182,9 +182,7 @@ fn errors_fetching_by_accessing_empty_list() {
 
 #[test]
 fn quoted_column_access() {
-    let actual = nu!(
-        r#"'[{"foo bar": {"baz": 4}}]' | from json | get "foo bar".baz.0 "#
-    );
+    let actual = nu!(r#"'[{"foo bar": {"baz": 4}}]' | from json | get "foo bar".baz.0 "#);
 
     assert_eq!(actual.out, "4");
 }

--- a/crates/nu-command/tests/commands/hash_/mod.rs
+++ b/crates/nu-command/tests/commands/hash_/mod.rs
@@ -2,39 +2,27 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn base64_defaults_to_encoding_with_standard_character_type() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 'username:password' | encode base64
-        "#
-        )
-    );
+        "#);
 
     assert_eq!(actual.out, "dXNlcm5hbWU6cGFzc3dvcmQ=");
 }
 
 #[test]
 fn base64_encode_characterset_binhex() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 'username:password' | encode base64 --character-set binhex
-        "#
-        )
-    );
+        "#);
 
     assert_eq!(actual.out, "F@0NEPjJD97kE\'&bEhFZEP3");
 }
 
 #[test]
 fn error_when_invalid_character_set_given() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 'username:password' | encode base64 --character-set 'this is invalid'
-        "#
-        )
-    );
+        "#);
 
     assert!(actual
         .err
@@ -43,26 +31,18 @@ fn error_when_invalid_character_set_given() {
 
 #[test]
 fn base64_decode_characterset_binhex() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo "F@0NEPjJD97kE'&bEhFZEP3" | decode base64 --character-set binhex --binary | decode utf-8
-        "#
-        )
-    );
+        "#);
 
     assert_eq!(actual.out, "username:password");
 }
 
 #[test]
 fn error_invalid_decode_value() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo "this should not be a valid encoded value" | decode base64 --character-set url-safe
-        "#
-        )
-    );
+        "#);
 
     assert!(actual
         .err

--- a/crates/nu-command/tests/commands/headers.rs
+++ b/crates/nu-command/tests/commands/headers.rs
@@ -45,8 +45,7 @@ fn headers_handles_missing_values() {
 
 #[test]
 fn headers_invalid_column_type_empty_record() {
-    let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[a b]; [{}, 2], [3,4] ]
             | headers"#
@@ -59,8 +58,7 @@ fn headers_invalid_column_type_empty_record() {
 
 #[test]
 fn headers_invalid_column_type_record() {
-    let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[a b]; [1 (scope aliases)] [2 2]]
             | headers"#
@@ -73,8 +71,7 @@ fn headers_invalid_column_type_record() {
 
 #[test]
 fn headers_invalid_column_type_array() {
-    let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[a b]; [[f,g], 2], [3,4] ]
             | headers"#
@@ -87,8 +84,7 @@ fn headers_invalid_column_type_array() {
 
 #[test]
 fn headers_invalid_column_type_range() {
-    let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[a b]; [(1..5), 2], [3,4] ]
             | headers"#
@@ -101,8 +97,7 @@ fn headers_invalid_column_type_range() {
 
 #[test]
 fn headers_invalid_column_type_duration() {
-    let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[a b]; [((date now) - (date now)), 2], [3,4] ]
             | headers"#
@@ -115,8 +110,7 @@ fn headers_invalid_column_type_duration() {
 
 #[test]
 fn headers_invalid_column_type_binary() {
-    let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[a b]; [("aa" | into binary), 2], [3,4] ]
             | headers"#

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -4,12 +4,7 @@ use nu_test_support::{nu, nu_repl_code, pipeline};
 
 #[test]
 fn help_commands_length() {
-    let actual = nu!(
-    cwd: ".", pipeline(
-        r#"
-        help commands | length
-        "#
-    ));
+    let actual = nu!("help commands | length");
 
     let output = actual.out;
     let output_int: i32 = output.parse().unwrap();
@@ -68,7 +63,7 @@ fn help_alias_usage_2() {
         "alias SPAM = print 'spam'  # line2",
         "help aliases | where name == SPAM | get 0.usage",
     ];
-    let actual = nu!(cwd: ".", nu_repl_code(code));
+    let actual = nu!(nu_repl_code(code));
 
     assert_eq!(actual.out, "line2");
 }
@@ -368,7 +363,7 @@ fn help_modules_main_2() {
         "help modules | where name == spam | get 0.commands.0",
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(pipeline(&inp.join("; ")));
 
     assert_eq!(actual.out, "spam");
 }
@@ -381,7 +376,7 @@ fn help_alias_before_command() {
         "def SPAM [] { 'spam' }",
         "help SPAM",
     ];
-    let actual = nu!(cwd: ".", nu_repl_code(code));
+    let actual = nu!(nu_repl_code(code));
 
     assert!(actual.out.contains("Alias"));
 }

--- a/crates/nu-command/tests/commands/histogram.rs
+++ b/crates/nu-command/tests/commands/histogram.rs
@@ -121,8 +121,7 @@ fn count() {
 
 #[test]
 fn count_with_normalize_percentage() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo [[bit];  [1] [0] [0] [0] [0] [0] [0] [1]]
             | histogram bit --percentage-type normalize

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -16,9 +16,7 @@ fn insert_the_column() {
 
 #[test]
 fn doesnt_convert_record_to_table() {
-    let actual = nu!(
-        cwd: ".", r#"{a:1} | insert b 2 | to nuon"#
-    );
+    let actual = nu!(r#"{a:1} | insert b 2 | to nuon"#);
 
     assert_eq!(actual.out, "{a: 1, b: 2}");
 }
@@ -40,48 +38,36 @@ fn insert_the_column_conflict() {
 
 #[test]
 fn insert_into_list() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             [1, 2, 3] | insert 1 abc | to json -r
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, r#"[1,"abc",2,3]"#);
 }
 
 #[test]
 fn insert_into_list_begin() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             [1, 2, 3] | insert 0 abc | to json -r
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, r#"["abc",1,2,3]"#);
 }
 
 #[test]
 fn insert_into_list_end() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             [1, 2, 3] | insert 3 abc | to json -r
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, r#"[1,2,3,"abc"]"#);
 }
 
 #[test]
 fn insert_past_end_list() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             [1, 2, 3] | insert 5 abc | to json -r
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, r#"[1,2,3,null,null,"abc"]"#);
 }
@@ -89,9 +75,8 @@ fn insert_past_end_list() {
 #[test]
 fn insert_uses_enumerate_index() {
     let actual = nu!(
-        cwd: ".", pipeline(
         r#"[[a]; [7] [6]] | enumerate | insert b {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"#
-    ));
+    );
 
     assert_eq!(actual.out, "[[index, a, b]; [0, 7, 8], [1, 6, 8]]");
 }

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -2,44 +2,34 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn into_filesize_int() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         1 | into filesize
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("1 B"));
 }
 
 #[test]
 fn into_filesize_decimal() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         1.2 | into filesize
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("1 B"));
 }
 
 #[test]
 fn into_filesize_str() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         '2000' | into filesize
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("2.0 KiB"));
 }
 
 #[test]
 fn into_filesize_str_newline() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         "2000
 " | into filesize
@@ -51,8 +41,7 @@ fn into_filesize_str_newline() {
 
 #[test]
 fn into_filesize_str_many_newlines() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         "2000
 
@@ -65,24 +54,18 @@ fn into_filesize_str_many_newlines() {
 
 #[test]
 fn into_filesize_filesize() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         3kib | into filesize
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("3.0 KiB"));
 }
 
 #[test]
 fn into_filesize_negative_filesize() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         -3kib | into filesize
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("-3.0 KiB"));
 }

--- a/crates/nu-command/tests/commands/into_int.rs
+++ b/crates/nu-command/tests/commands/into_int.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, FixedOffset, NaiveDate, TimeZone};
 use rstest::rstest;
 
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn into_int_filesize() {

--- a/crates/nu-command/tests/commands/into_int.rs
+++ b/crates/nu-command/tests/commands/into_int.rs
@@ -5,48 +5,36 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn into_int_filesize() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 1kb | into int | each { |it| $it / 1000 }
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains('1'));
 }
 
 #[test]
 fn into_int_filesize2() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 1kib | into int | each { |it| $it / 1024 }
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains('1'));
 }
 
 #[test]
 fn into_int_int() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 1024 | into int | each { |it| $it / 1024 }
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains('1'));
 }
 
 #[test]
 fn into_int_binary() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 0x[01010101] | into int
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("16843009"));
 }
@@ -80,9 +68,8 @@ fn into_int_datetime1() {
 #[case("2052-04-13T12:09:14.123456789-05:00", "2596640954123456789")] // future date > 2038 epoch
 #[case("1902-04-13T12:09:14.123456789-05:00", "-2137042245876543211")] // past date < 1970
 fn into_int_datetime(#[case] time_in: &str, #[case] int_out: &str) {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        &format!(r#""{time_in}" | into datetime --format "%+" | into int"#)
+    let actual = nu!(&format!(
+        r#""{time_in}" | into datetime --format "%+" | into int"#
     ));
 
     assert_eq!(int_out, actual.out);

--- a/crates/nu-command/tests/commands/length.rs
+++ b/crates/nu-command/tests/commands/length.rs
@@ -2,24 +2,14 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn length_columns_in_cal_table() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        cal | length -c
-        "#
-    ));
+    let actual = nu!("cal | length -c");
 
     assert_eq!(actual.out, "7");
 }
 
 #[test]
 fn length_columns_no_rows() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        echo [] | length -c
-        "#
-    ));
+    let actual = nu!("echo [] | length -c");
 
     assert_eq!(actual.out, "0");
 }

--- a/crates/nu-command/tests/commands/length.rs
+++ b/crates/nu-command/tests/commands/length.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn length_columns_in_cal_table() {

--- a/crates/nu-command/tests/commands/loop_.rs
+++ b/crates/nu-command/tests/commands/loop_.rs
@@ -2,9 +2,7 @@ use nu_test_support::nu;
 
 #[test]
 fn loop_doesnt_auto_print_in_each_iteration() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         mut total = 0;
         loop {
             if $total == 3 {
@@ -13,8 +11,7 @@ fn loop_doesnt_auto_print_in_each_iteration() {
                 $total += 1;
             }
             echo 1
-        }"#
-    );
+        }"#);
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert!(!actual.out.contains('1'));
@@ -22,9 +19,7 @@ fn loop_doesnt_auto_print_in_each_iteration() {
 
 #[test]
 fn loop_break_on_external_failed() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         mut total = 0;
         loop {
             if $total == 3 {
@@ -34,8 +29,7 @@ fn loop_break_on_external_failed() {
             }
             print 1;
             nu --testbin fail;
-        }"#
-    );
+        }"#);
     // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`.
     assert_eq!(actual.out, "1");
@@ -43,9 +37,7 @@ fn loop_break_on_external_failed() {
 
 #[test]
 fn failed_loop_should_break_running() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
         mut total = 0;
         loop {
             if $total == 3 {
@@ -55,7 +47,6 @@ fn failed_loop_should_break_running() {
             }
             nu --testbin fail;
         }
-        print 3"#
-    );
+        print 3"#);
     assert!(!actual.out.contains('3'));
 }

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -558,12 +558,7 @@ fn list_ignores_ansi() {
 
 #[test]
 fn list_unknown_flag() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-                ls -r
-            "#
-    ));
+    let actual = nu!("ls -r");
 
     assert!(actual
         .err

--- a/crates/nu-command/tests/commands/match_.rs
+++ b/crates/nu-command/tests/commands/match_.rs
@@ -2,10 +2,7 @@ use nu_test_support::nu;
 
 #[test]
 fn match_for_range() {
-    let actual = nu!(
-        cwd: ".",
-        r#"match 3 { 1..10 => { print "success" } }"#
-    );
+    let actual = nu!(r#"match 3 { 1..10 => { print "success" } }"#);
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert_eq!(actual.out, "success");
@@ -13,10 +10,7 @@ fn match_for_range() {
 
 #[test]
 fn match_for_range_unmatched() {
-    let actual = nu!(
-        cwd: ".",
-        r#"match 11 { 1..10 => { print "failure" }, _ => { print "success" }}"#
-    );
+    let actual = nu!(r#"match 11 { 1..10 => { print "failure" }, _ => { print "success" }}"#);
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert_eq!(actual.out, "success");
@@ -24,10 +18,7 @@ fn match_for_range_unmatched() {
 
 #[test]
 fn match_for_record() {
-    let actual = nu!(
-        cwd: ".",
-        r#"match {a: 11} { {a: $b} => { print $b }}"#
-    );
+    let actual = nu!(r#"match {a: 11} { {a: $b} => { print $b }}"#);
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert_eq!(actual.out, "11");
@@ -35,10 +26,7 @@ fn match_for_record() {
 
 #[test]
 fn match_for_record_shorthand() {
-    let actual = nu!(
-        cwd: ".",
-        r#"match {a: 12} { {$a} => { print $a }}"#
-    );
+    let actual = nu!(r#"match {a: 12} { {$a} => { print $a }}"#);
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert_eq!(actual.out, "12");
@@ -47,7 +35,6 @@ fn match_for_record_shorthand() {
 #[test]
 fn match_list() {
     let actual = nu!(
-        cwd: ".",
         r#"match [1, 2] { [$a] => { print $"single: ($a)" }, [$b, $c] => {print $"double: ($b) ($c)"}}"#
     );
     // Make sure we don't see any of these values in the output
@@ -58,7 +45,6 @@ fn match_list() {
 #[test]
 fn match_list_rest_ignore() {
     let actual = nu!(
-        cwd: ".",
         r#"match [1, 2] { [$a, ..] => { print $"single: ($a)" }, [$b, $c] => {print $"double: ($b) ($c)"}}"#
     );
     // Make sure we don't see any of these values in the output
@@ -69,7 +55,6 @@ fn match_list_rest_ignore() {
 #[test]
 fn match_list_rest() {
     let actual = nu!(
-        cwd: ".",
         r#"match [1, 2, 3] { [$a, ..$remainder] => { print $"single: ($a) ($remainder | math sum)" }, [$b, $c] => {print $"double: ($b) ($c)"}}"#
     );
     // Make sure we don't see any of these values in the output
@@ -80,7 +65,6 @@ fn match_list_rest() {
 #[test]
 fn match_constant_1() {
     let actual = nu!(
-        cwd: ".",
         r#"match 2 { 1 => { print "failure"}, 2 => { print "success" }, 3 => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -91,7 +75,6 @@ fn match_constant_1() {
 #[test]
 fn match_constant_2() {
     let actual = nu!(
-        cwd: ".",
         r#"match 2.3 { 1.4 => { print "failure"}, 2.3 => { print "success" }, 3 => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -102,7 +85,6 @@ fn match_constant_2() {
 #[test]
 fn match_constant_3() {
     let actual = nu!(
-        cwd: ".",
         r#"match true { false => { print "failure"}, true => { print "success" }, 3 => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -113,7 +95,6 @@ fn match_constant_3() {
 #[test]
 fn match_constant_4() {
     let actual = nu!(
-        cwd: ".",
         r#"match "def" { "abc" => { print "failure"}, "def" => { print "success" }, "ghi" => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -124,7 +105,6 @@ fn match_constant_4() {
 #[test]
 fn match_constant_5() {
     let actual = nu!(
-        cwd: ".",
         r#"match 2019-08-23 { 2010-01-01 => { print "failure"}, 2019-08-23 => { print "success" }, 2020-02-02 => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -135,7 +115,6 @@ fn match_constant_5() {
 #[test]
 fn match_constant_6() {
     let actual = nu!(
-        cwd: ".",
         r#"match 6sec { 2sec => { print "failure"}, 6sec => { print "success" }, 1min => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -146,7 +125,6 @@ fn match_constant_6() {
 #[test]
 fn match_constant_7() {
     let actual = nu!(
-        cwd: ".",
         r#"match 1kib { 1kb => { print "failure"}, 1kib => { print "success" }, 2kb => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -157,7 +135,6 @@ fn match_constant_7() {
 #[test]
 fn match_or_pattern() {
     let actual = nu!(
-        cwd: ".",
         r#"match {b: 7} { {a: $a} | {b: $b} => { print $"success: ($b)" }, _ => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -168,7 +145,6 @@ fn match_or_pattern() {
 #[test]
 fn match_or_pattern_overlap_1() {
     let actual = nu!(
-        cwd: ".",
         r#"match {a: 7} { {a: $b} | {b: $b} => { print $"success: ($b)" }, _ => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -179,7 +155,6 @@ fn match_or_pattern_overlap_1() {
 #[test]
 fn match_or_pattern_overlap_2() {
     let actual = nu!(
-        cwd: ".",
         r#"match {b: 7} { {a: $b} | {b: $b} => { print $"success: ($b)" }, _ => { print "failure" }}"#
     );
     // Make sure we don't see any of these values in the output
@@ -189,10 +164,7 @@ fn match_or_pattern_overlap_2() {
 
 #[test]
 fn match_doesnt_overwrite_variable() {
-    let actual = nu!(
-        cwd: ".",
-        r#"let b = 100; match 55 { $b => {} }; print $b"#
-    );
+    let actual = nu!(r#"let b = 100; match 55 { $b => {} }; print $b"#);
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert_eq!(actual.out, "100");

--- a/crates/nu-command/tests/commands/math/avg.rs
+++ b/crates/nu-command/tests/commands/math/avg.rs
@@ -17,7 +17,6 @@ fn can_average_numbers() {
 #[test]
 fn can_average_bytes() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         "[100kb, 10b, 100mib] | math avg | to json -r"
     );
 

--- a/crates/nu-command/tests/commands/math/avg.rs
+++ b/crates/nu-command/tests/commands/math/avg.rs
@@ -16,9 +16,7 @@ fn can_average_numbers() {
 
 #[test]
 fn can_average_bytes() {
-    let actual = nu!(
-        "[100kb, 10b, 100mib] | math avg | to json -r"
-    );
+    let actual = nu!("[100kb, 10b, 100mib] | math avg | to json -r");
 
     assert_eq!(actual.out, "34985870");
 }

--- a/crates/nu-command/tests/commands/math/median.rs
+++ b/crates/nu-command/tests/commands/math/median.rs
@@ -2,8 +2,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn median_numbers_with_even_rows() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
              echo [10 6 19 21 4]
              | math median
@@ -15,8 +14,7 @@ fn median_numbers_with_even_rows() {
 
 #[test]
 fn median_numbers_with_odd_rows() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
              echo [3 8 9 12 12 15]
              | math median
@@ -28,8 +26,7 @@ fn median_numbers_with_odd_rows() {
 
 #[test]
 fn median_mixed_numbers() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
              echo [-11.5 -13.5 10]
              | math median

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -8,8 +8,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn one_arg() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1
         "#
@@ -20,8 +19,7 @@ fn one_arg() {
 
 #[test]
 fn add() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 + 1
         "#
@@ -32,8 +30,7 @@ fn add() {
 
 #[test]
 fn add_compound() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 + 2 + 2
         "#
@@ -44,8 +41,7 @@ fn add_compound() {
 
 #[test]
 fn precedence_of_operators() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 + 2 * 2
         "#
@@ -56,8 +52,7 @@ fn precedence_of_operators() {
 
 #[test]
 fn precedence_of_operators2() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 + 2 * 2 + 1
         "#
@@ -68,8 +63,7 @@ fn precedence_of_operators2() {
 
 #[test]
 fn precedence_of_operators3() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             5 - 5 * 10 + 5
         "#
@@ -80,8 +74,7 @@ fn precedence_of_operators3() {
 
 #[test]
 fn precedence_of_operators4() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             5 - (5 * 10) + 5
         "#
@@ -92,8 +85,7 @@ fn precedence_of_operators4() {
 
 #[test]
 fn division_of_ints() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             4 / 2
         "#
@@ -104,8 +96,7 @@ fn division_of_ints() {
 
 #[test]
 fn division_of_ints2() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 / 4
         "#
@@ -116,8 +107,7 @@ fn division_of_ints2() {
 
 #[test]
 fn error_zero_division_int_int() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 / 0
         "#
@@ -128,8 +118,7 @@ fn error_zero_division_int_int() {
 
 #[test]
 fn error_zero_division_decimal_int() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1.0 / 0
         "#
@@ -140,8 +129,7 @@ fn error_zero_division_decimal_int() {
 
 #[test]
 fn error_zero_division_int_decimal() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 / 0.0
         "#
@@ -152,8 +140,7 @@ fn error_zero_division_int_decimal() {
 
 #[test]
 fn error_zero_division_decimal_decimal() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1.0 / 0.0
         "#
@@ -164,8 +151,7 @@ fn error_zero_division_decimal_decimal() {
 
 #[test]
 fn floor_division_of_ints() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             5 // 2
         "#
@@ -176,8 +162,7 @@ fn floor_division_of_ints() {
 
 #[test]
 fn floor_division_of_ints2() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             -3 // 2
         "#
@@ -188,8 +173,7 @@ fn floor_division_of_ints2() {
 
 #[test]
 fn floor_division_of_floats() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             -3.0 // 2.0
         "#
@@ -200,8 +184,7 @@ fn floor_division_of_floats() {
 
 #[test]
 fn error_zero_floor_division_int_int() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 // 0
         "#
@@ -212,8 +195,7 @@ fn error_zero_floor_division_int_int() {
 
 #[test]
 fn error_zero_floor_division_decimal_int() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1.0 // 0
         "#
@@ -224,8 +206,7 @@ fn error_zero_floor_division_decimal_int() {
 
 #[test]
 fn error_zero_floor_division_int_decimal() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 // 0.0
         "#
@@ -236,8 +217,7 @@ fn error_zero_floor_division_int_decimal() {
 
 #[test]
 fn error_zero_floor_division_decimal_decimal() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1.0 // 0.0
         "#
@@ -247,8 +227,7 @@ fn error_zero_floor_division_decimal_decimal() {
 }
 #[test]
 fn proper_precedence_history() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             2 / 2 / 2 + 1
         "#
@@ -259,8 +238,7 @@ fn proper_precedence_history() {
 
 #[test]
 fn parens_precedence() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             4 * (6 - 3)
         "#
@@ -271,8 +249,7 @@ fn parens_precedence() {
 
 #[test]
 fn modulo() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             9 mod 2
         "#
@@ -283,8 +260,7 @@ fn modulo() {
 
 #[test]
 fn unit_multiplication_math() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1mb * 2
         "#
@@ -295,8 +271,7 @@ fn unit_multiplication_math() {
 
 #[test]
 fn unit_multiplication_float_math() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1mb * 1.2
         "#
@@ -307,8 +282,7 @@ fn unit_multiplication_float_math() {
 
 #[test]
 fn unit_float_floor_division_math() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1mb // 3.0
         "#
@@ -319,8 +293,7 @@ fn unit_float_floor_division_math() {
 
 #[test]
 fn unit_division_math() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1mb / 4
         "#
@@ -331,8 +304,7 @@ fn unit_division_math() {
 
 #[test]
 fn unit_float_division_math() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1mb / 3.1
         "#
@@ -343,8 +315,7 @@ fn unit_float_division_math() {
 
 #[test]
 fn duration_math() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1wk + 1day
         "#
@@ -355,8 +326,7 @@ fn duration_math() {
 
 #[test]
 fn duration_decimal_math() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             5.5day + 0.5day
         "#
@@ -367,8 +337,7 @@ fn duration_decimal_math() {
 
 #[test]
 fn duration_math_with_nanoseconds() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1wk + 10ns
         "#
@@ -379,8 +348,7 @@ fn duration_math_with_nanoseconds() {
 
 #[test]
 fn duration_decimal_math_with_nanoseconds() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1.5wk + 10ns
         "#
@@ -391,8 +359,7 @@ fn duration_decimal_math_with_nanoseconds() {
 
 #[test]
 fn duration_decimal_math_with_all_units() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1wk + 3day + 8hr + 10min + 16sec + 121ms + 11us + 12ns
         "#
@@ -403,8 +370,7 @@ fn duration_decimal_math_with_all_units() {
 
 #[test]
 fn duration_decimal_dans_test() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             3.14sec
         "#
@@ -415,8 +381,7 @@ fn duration_decimal_dans_test() {
 
 #[test]
 fn duration_math_with_negative() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1day - 1wk
         "#
@@ -427,8 +392,7 @@ fn duration_math_with_negative() {
 
 #[test]
 fn compound_comparison() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             4 > 3 and 2 > 1
         "#
@@ -439,8 +403,7 @@ fn compound_comparison() {
 
 #[test]
 fn compound_comparison2() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             4 < 3 or 2 > 1
         "#
@@ -451,8 +414,7 @@ fn compound_comparison2() {
 
 #[test]
 fn compound_where() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo '[{"a": 1, "b": 1}, {"a": 2, "b": 1}, {"a": 2, "b": 2}]' | from json | where a == 2 and b == 1 | to json -r
         "#
@@ -463,8 +425,7 @@ fn compound_where() {
 
 #[test]
 fn compound_where_paren() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo '[{"a": 1, "b": 1}, {"a": 2, "b": 1}, {"a": 2, "b": 2}]' | from json | where ($it.a == 2 and $it.b == 1) or $it.b == 2 | to json -r
         "#
@@ -477,8 +438,7 @@ fn compound_where_paren() {
 
 #[test]
 fn adding_lists() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             [1 3] ++ [5 6] | to nuon
         "#
@@ -489,8 +449,7 @@ fn adding_lists() {
 
 #[test]
 fn adding_list_and_value() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             [1 3] ++ 5 | to nuon
         "#
@@ -501,8 +460,7 @@ fn adding_list_and_value() {
 
 #[test]
 fn adding_value_and_list() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1 ++ [3 5] | to nuon
         "#
@@ -513,8 +471,7 @@ fn adding_value_and_list() {
 
 #[test]
 fn adding_tables() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[a b]; [1 2]] ++ [[c d]; [10 11]] | to nuon
         "#
@@ -524,8 +481,7 @@ fn adding_tables() {
 
 #[test]
 fn append_strings() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "foo" ++ "bar"
         "#
@@ -535,8 +491,7 @@ fn append_strings() {
 
 #[test]
 fn append_binary_values() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             0x[01 02] ++ 0x[03 04] | to nuon
         "#
@@ -546,28 +501,16 @@ fn append_binary_values() {
 
 #[test]
 fn int_multiple_string() {
-    let actual = nu!(
-        pipeline(
-        r#"3 * "ab""#
-    ));
+    let actual = nu!(pipeline(r#"3 * "ab""#));
     assert_eq!(actual.out, "ababab");
-    let actual = nu!(
-        pipeline(
-        r#""ab" * 3"#
-    ));
+    let actual = nu!(pipeline(r#""ab" * 3"#));
     assert_eq!(actual.out, "ababab");
 }
 
 #[test]
 fn int_multiple_list() {
-    let actual = nu!(
-        pipeline(
-        r#"3 * [1 2] | to nuon"#
-    ));
+    let actual = nu!(pipeline(r#"3 * [1 2] | to nuon"#));
     assert_eq!(actual.out, "[1, 2, 1, 2, 1, 2]");
-    let actual = nu!(
-        pipeline(
-        r#"[1 2] * 3 | to nuon"#
-    ));
+    let actual = nu!(pipeline(r#"[1 2] * 3 | to nuon"#));
     assert_eq!(actual.out, "[1, 2, 1, 2, 1, 2]");
 }

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -9,7 +9,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn one_arg() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1
         "#
@@ -21,7 +21,7 @@ fn one_arg() {
 #[test]
 fn add() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 + 1
         "#
@@ -33,7 +33,7 @@ fn add() {
 #[test]
 fn add_compound() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 + 2 + 2
         "#
@@ -45,7 +45,7 @@ fn add_compound() {
 #[test]
 fn precedence_of_operators() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 + 2 * 2
         "#
@@ -57,7 +57,7 @@ fn precedence_of_operators() {
 #[test]
 fn precedence_of_operators2() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 + 2 * 2 + 1
         "#
@@ -69,7 +69,7 @@ fn precedence_of_operators2() {
 #[test]
 fn precedence_of_operators3() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             5 - 5 * 10 + 5
         "#
@@ -81,7 +81,7 @@ fn precedence_of_operators3() {
 #[test]
 fn precedence_of_operators4() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             5 - (5 * 10) + 5
         "#
@@ -93,7 +93,7 @@ fn precedence_of_operators4() {
 #[test]
 fn division_of_ints() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             4 / 2
         "#
@@ -105,7 +105,7 @@ fn division_of_ints() {
 #[test]
 fn division_of_ints2() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 / 4
         "#
@@ -117,7 +117,7 @@ fn division_of_ints2() {
 #[test]
 fn error_zero_division_int_int() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 / 0
         "#
@@ -129,7 +129,7 @@ fn error_zero_division_int_int() {
 #[test]
 fn error_zero_division_decimal_int() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1.0 / 0
         "#
@@ -141,7 +141,7 @@ fn error_zero_division_decimal_int() {
 #[test]
 fn error_zero_division_int_decimal() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 / 0.0
         "#
@@ -153,7 +153,7 @@ fn error_zero_division_int_decimal() {
 #[test]
 fn error_zero_division_decimal_decimal() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1.0 / 0.0
         "#
@@ -165,7 +165,7 @@ fn error_zero_division_decimal_decimal() {
 #[test]
 fn floor_division_of_ints() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             5 // 2
         "#
@@ -177,7 +177,7 @@ fn floor_division_of_ints() {
 #[test]
 fn floor_division_of_ints2() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             -3 // 2
         "#
@@ -189,7 +189,7 @@ fn floor_division_of_ints2() {
 #[test]
 fn floor_division_of_floats() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             -3.0 // 2.0
         "#
@@ -201,7 +201,7 @@ fn floor_division_of_floats() {
 #[test]
 fn error_zero_floor_division_int_int() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 // 0
         "#
@@ -213,7 +213,7 @@ fn error_zero_floor_division_int_int() {
 #[test]
 fn error_zero_floor_division_decimal_int() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1.0 // 0
         "#
@@ -225,7 +225,7 @@ fn error_zero_floor_division_decimal_int() {
 #[test]
 fn error_zero_floor_division_int_decimal() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 // 0.0
         "#
@@ -237,7 +237,7 @@ fn error_zero_floor_division_int_decimal() {
 #[test]
 fn error_zero_floor_division_decimal_decimal() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1.0 // 0.0
         "#
@@ -248,7 +248,7 @@ fn error_zero_floor_division_decimal_decimal() {
 #[test]
 fn proper_precedence_history() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             2 / 2 / 2 + 1
         "#
@@ -260,7 +260,7 @@ fn proper_precedence_history() {
 #[test]
 fn parens_precedence() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             4 * (6 - 3)
         "#
@@ -272,7 +272,7 @@ fn parens_precedence() {
 #[test]
 fn modulo() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             9 mod 2
         "#
@@ -284,7 +284,7 @@ fn modulo() {
 #[test]
 fn unit_multiplication_math() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1mb * 2
         "#
@@ -296,7 +296,7 @@ fn unit_multiplication_math() {
 #[test]
 fn unit_multiplication_float_math() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1mb * 1.2
         "#
@@ -308,7 +308,7 @@ fn unit_multiplication_float_math() {
 #[test]
 fn unit_float_floor_division_math() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1mb // 3.0
         "#
@@ -320,7 +320,7 @@ fn unit_float_floor_division_math() {
 #[test]
 fn unit_division_math() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1mb / 4
         "#
@@ -332,7 +332,7 @@ fn unit_division_math() {
 #[test]
 fn unit_float_division_math() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1mb / 3.1
         "#
@@ -344,7 +344,7 @@ fn unit_float_division_math() {
 #[test]
 fn duration_math() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1wk + 1day
         "#
@@ -356,7 +356,7 @@ fn duration_math() {
 #[test]
 fn duration_decimal_math() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             5.5day + 0.5day
         "#
@@ -368,7 +368,7 @@ fn duration_decimal_math() {
 #[test]
 fn duration_math_with_nanoseconds() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1wk + 10ns
         "#
@@ -380,7 +380,7 @@ fn duration_math_with_nanoseconds() {
 #[test]
 fn duration_decimal_math_with_nanoseconds() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1.5wk + 10ns
         "#
@@ -392,7 +392,7 @@ fn duration_decimal_math_with_nanoseconds() {
 #[test]
 fn duration_decimal_math_with_all_units() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1wk + 3day + 8hr + 10min + 16sec + 121ms + 11us + 12ns
         "#
@@ -404,7 +404,7 @@ fn duration_decimal_math_with_all_units() {
 #[test]
 fn duration_decimal_dans_test() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             3.14sec
         "#
@@ -416,7 +416,7 @@ fn duration_decimal_dans_test() {
 #[test]
 fn duration_math_with_negative() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1day - 1wk
         "#
@@ -428,7 +428,7 @@ fn duration_math_with_negative() {
 #[test]
 fn compound_comparison() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             4 > 3 and 2 > 1
         "#
@@ -440,7 +440,7 @@ fn compound_comparison() {
 #[test]
 fn compound_comparison2() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             4 < 3 or 2 > 1
         "#
@@ -452,7 +452,7 @@ fn compound_comparison2() {
 #[test]
 fn compound_where() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             echo '[{"a": 1, "b": 1}, {"a": 2, "b": 1}, {"a": 2, "b": 2}]' | from json | where a == 2 and b == 1 | to json -r
         "#
@@ -464,7 +464,7 @@ fn compound_where() {
 #[test]
 fn compound_where_paren() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             echo '[{"a": 1, "b": 1}, {"a": 2, "b": 1}, {"a": 2, "b": 2}]' | from json | where ($it.a == 2 and $it.b == 1) or $it.b == 2 | to json -r
         "#
@@ -478,7 +478,7 @@ fn compound_where_paren() {
 #[test]
 fn adding_lists() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             [1 3] ++ [5 6] | to nuon
         "#
@@ -490,7 +490,7 @@ fn adding_lists() {
 #[test]
 fn adding_list_and_value() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             [1 3] ++ 5 | to nuon
         "#
@@ -502,7 +502,7 @@ fn adding_list_and_value() {
 #[test]
 fn adding_value_and_list() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1 ++ [3 5] | to nuon
         "#
@@ -514,7 +514,7 @@ fn adding_value_and_list() {
 #[test]
 fn adding_tables() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             [[a b]; [1 2]] ++ [[c d]; [10 11]] | to nuon
         "#
@@ -525,7 +525,7 @@ fn adding_tables() {
 #[test]
 fn append_strings() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "foo" ++ "bar"
         "#
@@ -536,7 +536,7 @@ fn append_strings() {
 #[test]
 fn append_binary_values() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             0x[01 02] ++ 0x[03 04] | to nuon
         "#
@@ -547,12 +547,12 @@ fn append_binary_values() {
 #[test]
 fn int_multiple_string() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"3 * "ab""#
     ));
     assert_eq!(actual.out, "ababab");
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#""ab" * 3"#
     ));
     assert_eq!(actual.out, "ababab");
@@ -561,12 +561,12 @@ fn int_multiple_string() {
 #[test]
 fn int_multiple_list() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"3 * [1 2] | to nuon"#
     ));
     assert_eq!(actual.out, "[1, 2, 1, 2, 1, 2]");
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"[1 2] * 3 | to nuon"#
     ));
     assert_eq!(actual.out, "[1, 2, 1, 2, 1, 2]");

--- a/crates/nu-command/tests/commands/math/sqrt.rs
+++ b/crates/nu-command/tests/commands/math/sqrt.rs
@@ -2,30 +2,21 @@ use nu_test_support::nu;
 
 #[test]
 fn can_sqrt_numbers() {
-    let actual = nu!(
-        cwd: ".",
-        "echo [0.25 2 4] | math sqrt | math sum"
-    );
+    let actual = nu!("echo [0.25 2 4] | math sqrt | math sum");
 
     assert_eq!(actual.out, "3.914213562373095");
 }
 
 #[test]
 fn can_sqrt_irrational() {
-    let actual = nu!(
-        cwd: ".",
-        "echo 2 | math sqrt"
-    );
+    let actual = nu!("echo 2 | math sqrt");
 
     assert_eq!(actual.out, "1.4142135623730951");
 }
 
 #[test]
 fn can_sqrt_perfect_square() {
-    let actual = nu!(
-        cwd: ".",
-        "echo 4 | math sqrt"
-    );
+    let actual = nu!("echo 4 | math sqrt");
 
     assert_eq!(actual.out, "2");
 }

--- a/crates/nu-command/tests/commands/merge.rs
+++ b/crates/nu-command/tests/commands/merge.rs
@@ -44,12 +44,9 @@ fn row() {
 #[test]
 fn single_record_no_overwrite() {
     assert_eq!(
-        nu!(
-            cwd: ".", pipeline(
-            r#"
+        nu!(r#"
             {a: 1, b: 5} | merge {c: 2} | to nuon
-            "#
-        ))
+            "#)
         .out,
         "{a: 1, b: 5, c: 2}"
     );
@@ -58,12 +55,9 @@ fn single_record_no_overwrite() {
 #[test]
 fn single_record_overwrite() {
     assert_eq!(
-        nu!(
-            cwd: ".", pipeline(
-            r#"
+        nu!(r#"
             {a: 1, b: 2} | merge {a: 2} | to nuon
-            "#
-        ))
+            "#)
         .out,
         "{a: 2, b: 2}"
     );
@@ -72,12 +66,9 @@ fn single_record_overwrite() {
 #[test]
 fn single_row_table_overwrite() {
     assert_eq!(
-        nu!(
-            cwd: ".", pipeline(
-            r#"
+        nu!(r#"
             [[a b]; [1 4]] | merge [[a b]; [2 4]] | to nuon
-            "#
-        ))
+            "#)
         .out,
         "[[a, b]; [2, 4]]"
     );
@@ -86,12 +77,9 @@ fn single_row_table_overwrite() {
 #[test]
 fn single_row_table_no_overwrite() {
     assert_eq!(
-        nu!(
-            cwd: ".", pipeline(
-            r#"
+        nu!(r#"
             [[a b]; [1 4]] | merge [[c d]; [2 4]] | to nuon
-            "#
-        ))
+            "#)
         .out,
         "[[a, b, c, d]; [1, 4, 2, 4]]"
     );
@@ -100,12 +88,9 @@ fn single_row_table_no_overwrite() {
 #[test]
 fn multi_row_table_no_overwrite() {
     assert_eq!(
-        nu!(
-            cwd: ".", pipeline(
-            r#"
+        nu!(r#"
             [[a b]; [1 4] [8 9] [9 9]] | merge [[c d]; [2 4]]  | to nuon
-            "#
-        ))
+            "#)
         .out,
         "[{a: 1, b: 4, c: 2, d: 4}, {a: 8, b: 9}, {a: 9, b: 9}]"
     );
@@ -114,12 +99,9 @@ fn multi_row_table_no_overwrite() {
 #[test]
 fn multi_row_table_overwrite() {
     assert_eq!(
-        nu!(
-            cwd: ".", pipeline(
-            r#"
+        nu!(r#"
             [[a b]; [1 4] [8 9] [9 9]] | merge  [[a b]; [7 7]]  | to nuon
-            "#
-        ))
+            "#)
         .out,
         "[[a, b]; [7, 7], [8, 9], [9, 9]]"
     );

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn mut_variable() {

--- a/crates/nu-command/tests/commands/mut_.rs
+++ b/crates/nu-command/tests/commands/mut_.rs
@@ -2,24 +2,18 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn mut_variable() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut x = 3; $x = $x + 1; $x
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "4");
 }
 
 #[test]
 fn mut_name_builtin_var() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut in = 3
-        "#
-    ));
+        "#);
 
     assert!(actual
         .err
@@ -28,12 +22,9 @@ fn mut_name_builtin_var() {
 
 #[test]
 fn mut_name_builtin_var_with_dollar() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut $env = 3
-        "#
-    ));
+        "#);
 
     assert!(actual
         .err
@@ -42,139 +33,106 @@ fn mut_name_builtin_var_with_dollar() {
 
 #[test]
 fn mut_variable_in_loop() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut x = 1; for i in 1..10 { $x = $x + $i}; $x
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "56");
 }
 
 #[test]
 fn capture_of_mutable_var() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut x = 123; {|| $x }
-        "#
-    ));
+        "#);
 
     assert!(actual.err.contains("capture of mutable variable"));
 }
 
 #[test]
 fn mut_add_assign() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut y = 3; $y += 2; $y
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "5");
 }
 
 #[test]
 fn mut_minus_assign() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut y = 3; $y -= 2; $y
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "1");
 }
 
 #[test]
 fn mut_multiply_assign() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut y = 3; $y *= 2; $y
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "6");
 }
 
 #[test]
 fn mut_divide_assign() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut y = 8; $y /= 2; $y
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "4");
 }
 
 #[test]
 fn mut_path_insert() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut y = {abc: 123}; $y.abc = 456; $y.abc
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "456");
 }
 
 #[test]
 fn mut_path_insert_list() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut a = [0 1 2]; $a.3 = 3; $a | to nuon
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "[0, 1, 2, 3]");
 }
 
 #[test]
 fn mut_path_upsert() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut a = {b:[{c:1}]}; $a.b.0.d = 11; $a.b.0.d
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "11");
 }
 
 #[test]
 fn mut_path_upsert_list() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut a = [[[3] 2] 1]; $a.0.0.1 = 0; $a.0.2 = 0; $a.2 = 0; $a | to nuon
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "[[[3, 0], 2, 0], 1, 0]");
 }
 
 #[test]
 fn mut_path_operator_assign() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         mut a = {b:1}; $a.b += 3; $a.b -= 2; $a.b *= 10; $a.b /= 4; $a.b
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "5");
 }
 
 #[test]
 fn mut_records_update_properly() {
-    let actual = nu!(pipeline("mut a = {}; $a.b.c = 100; $a.b.c"));
+    let actual = nu!("mut a = {}; $a.b.c = 100; $a.b.c");
     assert_eq!(actual.out, "100");
 }
 

--- a/crates/nu-command/tests/commands/network/port.rs
+++ b/crates/nu-command/tests/commands/network/port.rs
@@ -4,12 +4,7 @@ use std::sync::mpsc;
 
 #[test]
 fn port_with_invalid_range() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        port 4000 3999
-        "#
-    ));
+    let actual = nu!("port 4000 3999");
 
     assert!(actual.err.contains("Invalid range"))
 }
@@ -29,9 +24,7 @@ fn port_with_already_usage() {
             let _listener = TcpListener::bind(format!("127.0.0.1:{free_port}"));
             let _ = rx.recv();
         });
-        let actual = nu!(
-            cwd: ".", pipeline(&format!("port {free_port} {free_port}"))
-        );
+        let actual = nu!(pipeline(&format!("port {free_port} {free_port}")));
         let _ = tx.send(true);
         // make sure that the thread is closed and we release the port.
         handler.join().unwrap();
@@ -46,12 +39,7 @@ fn port_with_already_usage() {
 
 #[test]
 fn port_from_system_given() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        port
-        "#
-    ));
+    let actual = nu!("port");
 
     // check that we can get an integer port from system.
     assert!(actual.out.parse::<u16>().unwrap() > 0)

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -292,7 +292,6 @@ fn open_ignore_ansi() {
 #[test]
 fn open_no_parameter() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         r#"
             open
         "#

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -291,11 +291,9 @@ fn open_ignore_ansi() {
 
 #[test]
 fn open_no_parameter() {
-    let actual = nu!(
-        r#"
+    let actual = nu!(r#"
             open
-        "#
-    );
+        "#);
 
     assert!(actual.err.contains("needs filename"));
 }

--- a/crates/nu-command/tests/commands/par_each.rs
+++ b/crates/nu-command/tests/commands/par_each.rs
@@ -3,10 +3,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn par_each_does_not_flatten_nested_structures() {
     // This is a regression test for issue #8497
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"[1 2 3] | par-each { |it| [$it, $it] } | sort | to json --raw"#
-    ));
+    let actual = nu!(r#"[1 2 3] | par-each { |it| [$it, $it] } | sort | to json --raw"#);
 
     assert_eq!(actual.out, "[[1,1],[2,2],[3,3]]");
 }

--- a/crates/nu-command/tests/commands/par_each.rs
+++ b/crates/nu-command/tests/commands/par_each.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn par_each_does_not_flatten_nested_structures() {

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -192,10 +192,8 @@ mod regex {
 
     #[test]
     fn parse_works_with_streaming() {
-        let actual = nu!(
-            cwd: ".", pipeline(
-               r#"seq char a z | each {|c| $c + " a"} | parse '{letter} {a}' | describe"#
-        ));
+        let actual =
+            nu!(r#"seq char a z | each {|c| $c + " a"} | parse '{letter} {a}' | describe"#);
 
         assert_eq!(actual.out, "table<letter: string, a: string> (stream)")
     }

--- a/crates/nu-command/tests/commands/path/exists.rs
+++ b/crates/nu-command/tests/commands/path/exists.rs
@@ -54,6 +54,6 @@ fn checks_if_double_dot_exists() {
 
 #[test]
 fn checks_tilde_relative_path_exists() {
-    let actual = nu!(cwd: ".", "'~' | path exists");
+    let actual = nu!("'~' | path exists");
     assert_eq!(actual.out, "true");
 }

--- a/crates/nu-command/tests/commands/platform/ansi_.rs
+++ b/crates/nu-command/tests/commands/platform/ansi_.rs
@@ -3,7 +3,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn test_ansi_shows_error_on_escape() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             ansi -e \
         "#

--- a/crates/nu-command/tests/commands/platform/ansi_.rs
+++ b/crates/nu-command/tests/commands/platform/ansi_.rs
@@ -2,8 +2,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn test_ansi_shows_error_on_escape() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             ansi -e \
         "#

--- a/crates/nu-command/tests/commands/print.rs
+++ b/crates/nu-command/tests/commands/print.rs
@@ -1,23 +1,15 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn print_to_stdout() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            "print 'hello world'"
-        )
-    );
+    let actual = nu!("print 'hello world'");
     assert!(actual.out.contains("hello world"));
     assert!(actual.err.is_empty());
 }
 
 #[test]
 fn print_to_stderr() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            "print -e 'hello world'"
-        )
-    );
+    let actual = nu!("print -e 'hello world'");
     assert!(actual.out.is_empty());
     assert!(actual.err.contains("hello world"));
 }

--- a/crates/nu-command/tests/commands/random/bool.rs
+++ b/crates/nu-command/tests/commands/random/bool.rs
@@ -1,13 +1,8 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn generates_a_bool() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        random bool
-        "#
-    ));
+    let actual = nu!("random bool");
 
     let output = actual.out;
     let is_boolean_output = output == "true" || output == "false";

--- a/crates/nu-command/tests/commands/random/chars.rs
+++ b/crates/nu-command/tests/commands/random/chars.rs
@@ -2,12 +2,9 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn generates_chars_of_specified_length() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         random chars -l 15 | size | get chars
-        "#
-    ));
+        "#);
 
     let result = actual.out;
     assert_eq!(result, "15");

--- a/crates/nu-command/tests/commands/random/chars.rs
+++ b/crates/nu-command/tests/commands/random/chars.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn generates_chars_of_specified_length() {

--- a/crates/nu-command/tests/commands/random/decimal.rs
+++ b/crates/nu-command/tests/commands/random/decimal.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn generates_a_decimal() {

--- a/crates/nu-command/tests/commands/random/decimal.rs
+++ b/crates/nu-command/tests/commands/random/decimal.rs
@@ -2,36 +2,21 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn generates_a_decimal() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        random decimal 42..43
-        "#
-    ));
+    let actual = nu!("random decimal 42..43");
 
     assert!(actual.out.contains("42") || actual.out.contains("43"));
 }
 
 #[test]
 fn generates_55() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        random decimal 55..55
-        "#
-    ));
+    let actual = nu!("random decimal 55..55");
 
     assert!(actual.out.contains("55"));
 }
 
 #[test]
 fn generates_0() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        random decimal ..<1
-        "#
-    ));
+    let actual = nu!(" random decimal ..<1 ");
 
     assert!(actual.out.contains('0'));
 }

--- a/crates/nu-command/tests/commands/random/dice.rs
+++ b/crates/nu-command/tests/commands/random/dice.rs
@@ -2,12 +2,9 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn rolls_4_roll() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         random dice -d 4 -s 10 | length
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "4");
 }

--- a/crates/nu-command/tests/commands/random/dice.rs
+++ b/crates/nu-command/tests/commands/random/dice.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn rolls_4_roll() {

--- a/crates/nu-command/tests/commands/random/integer.rs
+++ b/crates/nu-command/tests/commands/random/integer.rs
@@ -1,37 +1,22 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn generates_an_integer() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        random integer 42..43
-        "#
-    ));
+    let actual = nu!("random integer 42..43");
 
     assert!(actual.out.contains("42") || actual.out.contains("43"));
 }
 
 #[test]
 fn generates_55() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        random integer 55..55
-        "#
-    ));
+    let actual = nu!("random integer 55..55");
 
     assert!(actual.out.contains("55"));
 }
 
 #[test]
 fn generates_0() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        random integer ..<1
-        "#
-    ));
+    let actual = nu!("random integer ..<1");
 
     assert!(actual.out.contains('0'));
 }

--- a/crates/nu-command/tests/commands/random/uuid.rs
+++ b/crates/nu-command/tests/commands/random/uuid.rs
@@ -3,12 +3,7 @@ use uuid_crate::Uuid;
 
 #[test]
 fn generates_valid_uuid4() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        random uuid
-        "#
-    ));
+    let actual = nu!("random uuid");
 
     let result = Uuid::parse_str(actual.out.as_str());
 

--- a/crates/nu-command/tests/commands/reduce.rs
+++ b/crates/nu-command/tests/commands/reduce.rs
@@ -2,8 +2,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn reduce_table_column() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo "[{month:2,total:30}, {month:3,total:10}, {month:4,total:3}, {month:5,total:60}]"
         | from json
@@ -11,45 +10,39 @@ fn reduce_table_column() {
         | reduce -f 20 { |it, acc| $it + $acc ** 1.05}
         | into string -d 1
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "180.6");
 }
 
 #[test]
 fn reduce_table_column_with_path() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         [{month:2,total:30}, {month:3,total:10}, {month:4,total:3}, {month:5,total:60}]
         | reduce -f 20 { |it, acc| $it.total + $acc ** 1.05}
         | into string -d 1
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "180.6");
 }
 
 #[test]
 fn reduce_rows_example() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         [[a,b]; [1,2] [3,4]]
         | reduce -f 1.6 { |it, acc| $acc * ($it.a | into int) + ($it.b | into int) }
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "14.8");
 }
 
 #[test]
 fn reduce_with_return_in_closure() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         [1, 2] | reduce --fold null { |it, state|
             if $it == 1 {
@@ -58,8 +51,7 @@ fn reduce_with_return_in_closure() {
             return ($it * $state)
         }
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "20");
     assert!(actual.err.is_empty());
@@ -67,39 +59,34 @@ fn reduce_with_return_in_closure() {
 
 #[test]
 fn reduce_enumerate_example() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo one longest three bar | enumerate
         | reduce { |it, acc| if ($it.item | str length) > ($acc.item | str length) {echo $it} else {echo $acc}}
         | get index
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "1");
 }
 
 #[test]
 fn reduce_enumerate_integer_addition_example() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo [1 2 3 4]
         | enumerate
         | reduce { |it, acc| { index: ($it.index) item: ($acc.item + $it.item)} }
         | get item
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "10");
 }
 
 #[test]
 fn folding_with_tables() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo [10 20 30 40]
         | reduce -f [] { |it, acc|
@@ -109,47 +96,40 @@ fn folding_with_tables() {
           }
         | math sum
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "1000");
 }
 
 #[test]
 fn error_reduce_fold_type_mismatch() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo a b c | reduce -f 0 { |it, acc| $acc + $it }
         "#
-        )
-    );
+    ));
 
     assert!(actual.err.contains("mismatch"));
 }
 
 #[test]
 fn error_reduce_empty() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         reduce { |it, acc| $acc + $it }
         "#
-        )
-    );
+    ));
 
     assert!(actual.err.contains("needs input"));
 }
 
 #[test]
 fn enumerate_reduce_example() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         [one longest three bar] | enumerate | reduce {|it, acc| if ($it.item | str length) > ($acc.item | str length) { $it } else { $acc }} | get index
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "1");
 }

--- a/crates/nu-command/tests/commands/return_.rs
+++ b/crates/nu-command/tests/commands/return_.rs
@@ -2,24 +2,18 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn early_return_if_true() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         def foo [x] { if true { return 2 }; $x }; foo 100
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, r#"2"#);
 }
 
 #[test]
 fn early_return_if_false() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         def foo [x] { if false { return 2 }; $x }; foo 100
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, r#"100"#);
 }

--- a/crates/nu-command/tests/commands/reverse.rs
+++ b/crates/nu-command/tests/commands/reverse.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn can_get_reverse_first() {

--- a/crates/nu-command/tests/commands/reverse.rs
+++ b/crates/nu-command/tests/commands/reverse.rs
@@ -12,7 +12,7 @@ fn can_get_reverse_first() {
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | reverse"));
+    let actual = nu!("1 | reverse");
 
     assert!(actual.err.contains("command doesn't support"));
 }

--- a/crates/nu-command/tests/commands/roll.rs
+++ b/crates/nu-command/tests/commands/roll.rs
@@ -19,26 +19,34 @@ mod rows {
 
     #[test]
     fn can_roll_down() {
-        let actual = nu!(
-        cwd: ".",
-        format!("{} | {}", table(), pipeline(r#"
+        let actual = nu!(format!(
+            "{} | {}",
+            table(),
+            pipeline(
+                r#"
             roll down
             | first
             | get status
-        "#)));
+        "#
+            )
+        ));
 
         assert_eq!(actual.out, "HERE");
     }
 
     #[test]
     fn can_roll_up() {
-        let actual = nu!(
-        cwd: ".",
-        format!("{} | {}", table(), pipeline(r#"
+        let actual = nu!(format!(
+            "{} | {}",
+            table(),
+            pipeline(
+                r#"
             roll up --by 3
             | first
             | get status
-        "#)));
+        "#
+            )
+        ));
 
         assert_eq!(actual.out, "HERE");
     }
@@ -64,26 +72,34 @@ mod columns {
 
     #[test]
     fn can_roll_left() {
-        let actual = nu!(
-        cwd: ".",
-        format!("{} | {}", table(), pipeline(r#"
+        let actual = nu!(format!(
+            "{} | {}",
+            table(),
+            pipeline(
+                r#"
             roll left
             | columns
             | str join "-"
-        "#)));
+        "#
+            )
+        ));
 
         assert_eq!(actual.out, "origin-stars-commit_author");
     }
 
     #[test]
     fn can_roll_right() {
-        let actual = nu!(
-        cwd: ".",
-        format!("{} | {}", table(), pipeline(r#"
+        let actual = nu!(format!(
+            "{} | {}",
+            table(),
+            pipeline(
+                r#"
             roll right --by 2
             | columns
             | str join "-"
-        "#)));
+        "#
+            )
+        ));
 
         assert_eq!(actual.out, "origin-stars-commit_author");
     }
@@ -95,10 +111,9 @@ mod columns {
         let four_bitstring = bitstring_to_nu_row_pipeline("00000100");
         let expected_value = ThirtyTwo(32, "bit1-bit2-bit3-bit4-bit5-bit6-bit7-bit8");
 
-        let actual = nu!(
-            cwd: ".",
-            format!("{four_bitstring} | roll right --by 3 --cells-only | columns | str join '-' ")
-        );
+        let actual = nu!(format!(
+            "{four_bitstring} | roll right --by 3 --cells-only | columns | str join '-' "
+        ));
 
         assert_eq!(actual.out, expected_value.1);
     }
@@ -146,7 +161,6 @@ mod columns {
             "{bitstring_as_nu_row_pipeline} | roll left --by 3 | {nu_row_literal_bitstring_to_decimal_value_pipeline}"
         );
         nu!(
-            cwd: ".",
             format!("{bitstring_as_nu_row_pipeline} | roll left --by 3 | {nu_row_literal_bitstring_to_decimal_value_pipeline}")
         ).out
     }

--- a/crates/nu-command/tests/commands/rotate.rs
+++ b/crates/nu-command/tests/commands/rotate.rs
@@ -14,7 +14,7 @@ fn counter_clockwise() {
     "#,
     );
 
-    let expected = nu!(cwd: ".", pipeline(
+    let expected = nu!(pipeline(
         r#"
         echo [
             [  column0, column1, column2, column3];
@@ -29,14 +29,18 @@ fn counter_clockwise() {
         "#,
     ));
 
-    let actual = nu!(
-        cwd: ".",
-        format!("{} | {}", table, pipeline(r#"
+    let actual = nu!(format!(
+        "{} | {}",
+        table,
+        pipeline(
+            r#"
             rotate --ccw
             | where column0 == EXPECTED
             | get column1 column2 column3
             | str join "-"
-        "#)));
+        "#
+        )
+    ));
 
     assert_eq!(actual.out, expected.out);
 }
@@ -55,7 +59,7 @@ fn clockwise() {
     "#,
     );
 
-    let expected = nu!(cwd: ".", pipeline(
+    let expected = nu!(pipeline(
         r#"
         echo [
             [ column0, column1, column2,  column3];
@@ -70,14 +74,18 @@ fn clockwise() {
         "#,
     ));
 
-    let actual = nu!(
-        cwd: ".",
-        format!("{} | {}", table, pipeline(r#"
+    let actual = nu!(format!(
+        "{} | {}",
+        table,
+        pipeline(
+            r#"
             rotate
             | where column3 == EXPECTED
             | get column0 column1 column2
             | str join "-"
-        "#)));
+        "#
+        )
+    ));
 
     assert_eq!(actual.out, expected.out);
 }

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -312,7 +312,7 @@ fn can_run_batch_files_without_bat_extension() {
 #[test]
 fn quotes_trimmed_when_shelling_out() {
     // regression test for a bug where we weren't trimming quotes around string args before shelling out to cmd.exe
-    let actual = nu!(cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             ^echo "foo"
         "#

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -17,7 +17,7 @@ fn binary_skip() {
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | skip 2"));
+    let actual = nu!("1 | skip 2");
 
     assert!(actual.err.contains("command doesn't support"));
 }

--- a/crates/nu-command/tests/commands/skip/until.rs
+++ b/crates/nu-command/tests/commands/skip/until.rs
@@ -52,7 +52,7 @@ fn condition_is_met() {
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | skip until {|row| $row == 2}"));
+    let actual = nu!("1 | skip until {|row| $row == 2}");
 
     assert!(actual.err.contains("command doesn't support"));
 }

--- a/crates/nu-command/tests/commands/skip/while_.rs
+++ b/crates/nu-command/tests/commands/skip/while_.rs
@@ -52,7 +52,7 @@ fn condition_is_met() {
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | skip while {|row| $row == 2}"));
+    let actual = nu!("1 | skip while {|row| $row == 2}");
 
     assert!(actual.err.contains("command doesn't support"));
 }

--- a/crates/nu-command/tests/commands/str_/collect.rs
+++ b/crates/nu-command/tests/commands/str_/collect.rs
@@ -2,39 +2,33 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn test_1() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo 1..5 | into string | str join
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "12345");
 }
 
 #[test]
 fn test_2() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo [a b c d] | str join "<sep>"
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "a<sep>b<sep>c<sep>d");
 }
 
 #[test]
 fn construct_a_path() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo [sample txt] | str join "."
         "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "sample.txt");
 }

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -4,65 +4,45 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn from_range() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 1..5 | into string | to json -r
-        "#
-        )
-    );
+        "#);
 
     assert_eq!(actual.out, "[\"1\",\"2\",\"3\",\"4\",\"5\"]");
 }
 
 #[test]
 fn from_number() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 5 | into string
-        "#
-        )
-    );
+        "#);
 
     assert_eq!(actual.out, "5");
 }
 
 #[test]
 fn from_decimal() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo 1.5 | into string
-        "#
-        )
-    );
+        "#);
 
     assert_eq!(actual.out, "1.5");
 }
 
 #[test]
 fn from_boolean() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo true | into string
-        "#
-        )
-    );
+        "#);
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn from_string() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo "one" | into string
-        "#
-        )
-    );
+        "#);
 
     assert_eq!(actual.out, "one");
 }
@@ -111,44 +91,34 @@ fn from_filesize() {
 
 #[test]
 fn from_decimal_correct_trailing_zeros() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         1.23000 | into string -d 3
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("1.230"));
 }
 
 #[test]
 fn from_int_decimal_correct_trailing_zeros() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         1.00000 | into string -d 3
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("1.000"));
 }
 
 #[test]
 fn from_int_decimal_trim_trailing_zeros() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         1.00000 | into string | $"($in) flat"
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("1 flat")); // "1" would match "1.0"
 }
 
 #[test]
 fn from_table() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo '[{"name": "foo", "weight": 32.377}, {"name": "bar", "weight": 15.2}]'
         | from json
@@ -162,24 +132,18 @@ fn from_table() {
 
 #[test]
 fn from_nothing() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         null | into string
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "");
 }
 
 #[test]
 fn int_into_string() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         10 | into string
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "10");
 }

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -27,13 +27,11 @@ fn trims() {
 
 #[test]
 fn error_trim_multiple_chars() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
         echo "does it work now?!" | str trim -c "?!"
         "#
-        )
-    );
+    ));
 
     assert!(actual.err.contains("char"));
 }
@@ -366,24 +364,18 @@ fn substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given(
 
 #[test]
 fn str_reverse() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         echo "nushell" | str reverse
-        "#
-    ));
+        "#);
 
     assert!(actual.out.contains("llehsun"));
 }
 
 #[test]
 fn test_redirection_trim() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
         let x = (nu --testbin cococo niceone); $x | str trim | str length
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "7");
 }

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -118,8 +118,7 @@ fn camelcases() {
 
 #[test]
 fn converts_to_int() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo '[{number_as_string: "1"}]'
             | from json
@@ -136,8 +135,7 @@ fn converts_to_int() {
 
 #[test]
 fn converts_to_decimal() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo "3.1, 0.0415"
             | split row ","

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -119,7 +119,7 @@ fn camelcases() {
 #[test]
 fn converts_to_int() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             echo '[{number_as_string: "1"}]'
             | from json
@@ -137,7 +137,7 @@ fn converts_to_int() {
 #[test]
 fn converts_to_decimal() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             echo "3.1, 0.0415"
             | split row ","

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -32,24 +32,14 @@ fn rows() {
 
 #[test]
 fn rows_with_no_arguments_should_lead_to_error() {
-    Playground::setup("take_test_2", |dirs, _sandbox| {
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"[1 2 3] | take"#
-        ));
+    let actual = nu!("[1 2 3] | take");
 
-        assert!(actual.err.contains("missing_positional"));
-    })
+    assert!(actual.err.contains("missing_positional"));
 }
 
 #[test]
 fn fails_on_string() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-                "foo bar" | take 2
-            "#
-    ));
+    let actual = nu!(r#""foo bar" | take 2"#);
 
     assert!(actual.err.contains("command doesn't support"));
 }
@@ -57,12 +47,9 @@ fn fails_on_string() {
 #[test]
 // covers a situation where `take` used to behave strangely on list<binary> input
 fn works_with_binary_list() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        ([0x[01 11]] | take 1 | get 0) == 0x[01 11]
-            "#
-    ));
+    let actual = nu!(r#"
+            ([0x[01 11]] | take 1 | get 0) == 0x[01 11]
+        "#);
 
     assert_eq!(actual.out, "true");
 }

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -53,7 +53,7 @@ fn condition_is_met() {
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | take until {|row| $row == 2}"));
+    let actual = nu!("1 | take until {|row| $row == 2}");
 
     assert!(actual.err.contains("command doesn't support"));
 }

--- a/crates/nu-command/tests/commands/take/while_.rs
+++ b/crates/nu-command/tests/commands/take/while_.rs
@@ -52,7 +52,7 @@ fn condition_is_met() {
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline("1 | take while {|row| $row == 2}"));
+    let actual = nu!("1 | take while {|row| $row == 2}");
 
     assert!(actual.err.contains("command doesn't support"));
 }

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -2,83 +2,61 @@ use nu_test_support::nu;
 
 #[test]
 fn try_succeed() {
-    let output = nu!(
-        cwd: ".",
-        "try { 345 } catch { echo 'hello' }"
-    );
+    let output = nu!("try { 345 } catch { echo 'hello' }");
 
     assert!(output.out.contains("345"));
 }
 
 #[test]
 fn try_catch() {
-    let output = nu!(
-        cwd: ".",
-        "try { foobarbaz } catch { echo 'hello' }"
-    );
+    let output = nu!("try { foobarbaz } catch { echo 'hello' }");
 
     assert!(output.out.contains("hello"));
 }
 
 #[test]
 fn catch_can_access_error() {
-    let output = nu!(
-        cwd: ".",
-        "try { foobarbaz } catch { |err| $err | get raw }"
-    );
+    let output = nu!("try { foobarbaz } catch { |err| $err | get raw }");
 
     assert!(output.err.contains("External command failed"));
 }
 
 #[test]
 fn catch_can_access_error_as_dollar_in() {
-    let output = nu!(
-        cwd: ".",
-        "try { foobarbaz } catch { $in | get raw }"
-    );
+    let output = nu!("try { foobarbaz } catch { $in | get raw }");
 
     assert!(output.err.contains("External command failed"));
 }
 
 #[test]
 fn external_failed_should_be_caught() {
-    let output = nu!(
-        cwd: ".",
-        "try { nu --testbin fail; echo 'success' } catch { echo 'fail' }"
-    );
+    let output = nu!("try { nu --testbin fail; echo 'success' } catch { echo 'fail' }");
 
     assert!(output.out.contains("fail"));
 }
 
 #[test]
 fn loop_try_break_should_be_successful() {
-    let output = nu!(
-        cwd: ".",
-        "loop { try { print 'successful'; break } catch { print 'failed'; continue } }"
-    );
+    let output =
+        nu!("loop { try { print 'successful'; break } catch { print 'failed'; continue } }");
 
     assert_eq!(output.out, "successful");
 }
 
 #[test]
 fn loop_catch_break_should_show_failed() {
-    let output = nu!(
-        cwd: ".",
-        "loop {
+    let output = nu!("loop {
             try { invalid 1;
             continue; } catch { print 'failed'; break }
         }
-        "
-    );
+        ");
 
     assert_eq!(output.out, "failed");
 }
 
 #[test]
 fn loop_try_ignores_continue() {
-    let output = nu!(
-        cwd: ".",
-        "mut total = 0;
+    let output = nu!("mut total = 0;
         for i in 0..10 {
             try { if ($i mod 2) == 0 {
             continue;}
@@ -86,27 +64,20 @@ fn loop_try_ignores_continue() {
         } catch { echo 'failed'; break }
         }
         echo $total
-        "
-    );
+        ");
 
     assert_eq!(output.out, "5");
 }
 
 #[test]
 fn loop_try_break_on_command_should_show_successful() {
-    let output = nu!(
-        cwd: ".",
-        "loop { try { ls; break } catch { echo 'failed';continue }}"
-    );
+    let output = nu!("loop { try { ls; break } catch { echo 'failed';continue }}");
 
     assert!(!output.out.contains("failed"));
 }
 
 #[test]
 fn catch_block_can_use_error_object() {
-    let output = nu!(
-        cwd: ".",
-        "try {1 / 0} catch {|err| print ($err | get msg)}"
-    );
+    let output = nu!("try {1 / 0} catch {|err| print ($err | get msg)}");
     assert_eq!(output.out, "Division by zero.")
 }

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -68,9 +68,8 @@ fn sets_the_column_from_a_subexpression() {
 #[test]
 fn upsert_uses_enumerate_index_inserting() {
     let actual = nu!(
-        cwd: ".", pipeline(
         r#"[[a]; [7] [6]] | enumerate | upsert b {|el| $el.index + 1 + $el.item.a } | flatten | to nuon"#
-    ));
+    );
 
     assert_eq!(actual.out, "[[index, a, b]; [0, 7, 8], [1, 6, 8]]");
 }

--- a/crates/nu-command/tests/commands/url/join.rs
+++ b/crates/nu-command/tests/commands/url/join.rs
@@ -2,9 +2,8 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn url_join_simple() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "",
@@ -13,17 +12,15 @@ fn url_join_simple() {
                     "port": "",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "http://localhost");
 }
 
 #[test]
 fn url_join_with_only_user() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -32,17 +29,15 @@ fn url_join_with_only_user() {
                     "port": "",
                 } | url join 
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "http://localhost");
 }
 
 #[test]
 fn url_join_with_only_pwd() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "",
@@ -51,17 +46,15 @@ fn url_join_with_only_pwd() {
                     "port": "",
                 } | url join 
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "http://localhost");
 }
 
 #[test]
 fn url_join_with_user_and_pwd() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -70,17 +63,15 @@ fn url_join_with_user_and_pwd() {
                     "port": "",
                 } | url join 
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "http://usr:pwd@localhost");
 }
 
 #[test]
 fn url_join_with_query() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -90,17 +81,15 @@ fn url_join_with_query() {
                     "port": "",
                 } | url join 
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "http://usr:pwd@localhost?par_1=aaa&par_2=bbb");
 }
 
 #[test]
 fn url_join_with_params() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -113,8 +102,7 @@ fn url_join_with_params() {
                     "port": "1234",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert_eq!(
         actual.out,
@@ -124,9 +112,8 @@ fn url_join_with_params() {
 
 #[test]
 fn url_join_with_same_query_and_params() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -140,8 +127,7 @@ fn url_join_with_same_query_and_params() {
                     "port": "1234",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert_eq!(
         actual.out,
@@ -151,9 +137,8 @@ fn url_join_with_same_query_and_params() {
 
 #[test]
 fn url_join_with_different_query_and_params() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -167,8 +152,7 @@ fn url_join_with_different_query_and_params() {
                     "port": "1234",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert!(actual
         .err
@@ -177,9 +161,8 @@ fn url_join_with_different_query_and_params() {
         .err
         .contains("instead query is: ?par_1=aaa&par_2=bbb"));
 
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -193,8 +176,7 @@ fn url_join_with_different_query_and_params() {
                     "port": "1234",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert!(actual
         .err
@@ -206,9 +188,8 @@ fn url_join_with_different_query_and_params() {
 
 #[test]
 fn url_join_with_invalid_params() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -218,72 +199,63 @@ fn url_join_with_invalid_params() {
                     "port": "1234",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert!(actual.err.contains("Key params has to be a record"));
 }
 
 #[test]
 fn url_join_with_port() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "host": "localhost",
                     "port": "1234",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "http://localhost:1234");
 
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "host": "localhost",
                     "port": 1234,
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "http://localhost:1234");
 }
 
 #[test]
 fn url_join_with_invalid_port() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "host": "localhost",
                     "port": "aaaa",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert!(actual
         .err
         .contains("Port parameter should represent an unsigned integer"));
 
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "host": "localhost",
                     "port": [],
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert!(actual
         .err
@@ -292,39 +264,34 @@ fn url_join_with_invalid_port() {
 
 #[test]
 fn url_join_with_missing_scheme() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "host": "localhost"
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert!(actual.err.contains("missing parameter: scheme"));
 }
 
 #[test]
 fn url_join_with_missing_host() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "https"
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert!(actual.err.contains("missing parameter: host"));
 }
 
 #[test]
 fn url_join_with_fragment() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -334,17 +301,15 @@ fn url_join_with_fragment() {
                     "port": "1234",
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "http://usr:pwd@localhost:1234#frag");
 }
 
 #[test]
 fn url_join_with_fragment_and_params() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 {
                     "scheme": "http",
                     "username": "usr",
@@ -358,8 +323,7 @@ fn url_join_with_fragment_and_params() {
                     "fragment": "frag"
                 } | url join
             "#
-        )
-    );
+    ));
 
     assert_eq!(
         actual.out,
@@ -369,9 +333,8 @@ fn url_join_with_fragment_and_params() {
 
 #[test]
 fn url_join_with_empty_params() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
             {
                 "scheme": "https",
                 "host": "localhost",
@@ -379,8 +342,7 @@ fn url_join_with_empty_params() {
                 "params": {}
             } | url join
             "#
-        )
-    );
+    ));
 
     assert_eq!(actual.out, "https://localhost/foo");
 }

--- a/crates/nu-command/tests/commands/url/parse.rs
+++ b/crates/nu-command/tests/commands/url/parse.rs
@@ -2,9 +2,8 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn url_parse_simple() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 ("https://www.abc.com"
                 | url parse)
                 == {
@@ -25,9 +24,8 @@ fn url_parse_simple() {
 
 #[test]
 fn url_parse_with_port() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 ("https://www.abc.com:8011"
                 | url parse)
                 == {
@@ -49,9 +47,8 @@ fn url_parse_with_port() {
 
 #[test]
 fn url_parse_with_path() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 ("http://www.abc.com:8811/def/ghj"
                 | url parse)
                 == {
@@ -73,9 +70,8 @@ fn url_parse_with_path() {
 
 #[test]
 fn url_parse_with_params() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 ("http://www.abc.com:8811/def/ghj?param1=11&param2="
                 | url parse)
                 == {
@@ -97,9 +93,8 @@ fn url_parse_with_params() {
 
 #[test]
 fn url_parse_with_fragment() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 ("http://www.abc.com:8811/def/ghj?param1=11&param2=#hello-fragment"
                 | url parse)
                 == {
@@ -121,9 +116,8 @@ fn url_parse_with_fragment() {
 
 #[test]
 fn url_parse_with_username_and_password() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 ("http://user123:password567@www.abc.com:8811/def/ghj?param1=11&param2=#hello-fragment"
                 | url parse)
                 == {
@@ -145,13 +139,7 @@ fn url_parse_with_username_and_password() {
 
 #[test]
 fn url_parse_error_empty_url() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
-                ""
-                | url parse
-            "#
-    ));
+    let actual = nu!(r#""" | url parse"#);
 
     assert!(actual.err.contains(
         "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com"

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -186,13 +186,9 @@ fn use_export_env_combined() {
 
 #[test]
 fn use_module_creates_accurate_did_you_mean_1() {
-    let actual = nu!(
-    cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             module spam { export def foo [] { "foo" } }; use spam; foo
-        "#
-        )
-    );
+        "#);
     assert!(actual.err.contains(
         "command 'foo' was not found but it was imported from module 'spam'; try using `spam foo`"
     ));
@@ -200,13 +196,9 @@ fn use_module_creates_accurate_did_you_mean_1() {
 
 #[test]
 fn use_module_creates_accurate_did_you_mean_2() {
-    let actual = nu!(
-    cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             module spam { export def foo [] { "foo" } }; foo
-        "#
-        )
-    );
+        "#);
     assert!(actual.err.contains(
         "command 'foo' was not found but it exists in module 'spam'; try importing it with `use`"
     ));
@@ -220,7 +212,7 @@ fn use_main_1() {
         r#"spam"#,
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -233,7 +225,7 @@ fn use_main_2() {
         r#"spam"#,
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -246,7 +238,7 @@ fn use_main_3() {
         r#"spam"#,
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -259,7 +251,7 @@ fn use_main_4() {
         r#"spam"#,
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -273,7 +265,7 @@ fn use_main_def_env() {
         r#"$env.SPAM"#,
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }
@@ -287,7 +279,7 @@ fn use_main_def_known_external() {
         r#"cargo --version"#,
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.out.contains("cargo"));
 }
@@ -300,7 +292,7 @@ fn use_main_not_exported() {
         r#"spam"#,
     ];
 
-    let actual = nu!(cwd: ".", pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert!(actual.err.contains("external_command"));
 }

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -22,10 +22,7 @@ fn filters_with_nothing_comparison() {
 
 #[test]
 fn where_inside_block_works() {
-    let actual = nu!(
-        cwd: ".",
-        "{|x| ls | where $it =~ 'foo' } | describe"
-    );
+    let actual = nu!("{|x| ls | where $it =~ 'foo' } | describe");
 
     assert_eq!(actual.out, "closure");
 }
@@ -178,7 +175,7 @@ fn contains_operator() {
 
 #[test]
 fn fail_on_non_iterator() {
-    let actual = nu!(cwd: ".", pipeline(r#"{"name": "foo", "size": 3} | where name == "foo""#));
+    let actual = nu!(r#"{"name": "foo", "size": 3} | where name == "foo""#);
 
     assert!(actual.err.contains("command doesn't support"));
 }

--- a/crates/nu-command/tests/commands/which.rs
+++ b/crates/nu-command/tests/commands/which.rs
@@ -2,10 +2,7 @@ use nu_test_support::nu;
 
 #[test]
 fn which_ls() {
-    let actual = nu!(
-        cwd: ".",
-        "which ls | get path.0 | str trim"
-    );
+    let actual = nu!("which ls | get path.0 | str trim");
 
     assert_eq!(actual.out, "Nushell built-in command");
 }
@@ -13,20 +10,14 @@ fn which_ls() {
 #[ignore = "TODO: Can't have alias recursion"]
 #[test]
 fn which_alias_ls() {
-    let actual = nu!(
-        cwd: ".",
-        "alias ls = ls -a; which ls | get path.0 | str trim"
-    );
+    let actual = nu!("alias ls = ls -a; which ls | get path.0 | str trim");
 
     assert_eq!(actual.out, "Nushell alias: ls -a");
 }
 
 #[test]
 fn which_custom_alias() {
-    let actual = nu!(
-        cwd: ".",
-        r#"alias foo = print "foo!"; which foo | to nuon"#
-    );
+    let actual = nu!(r#"alias foo = print "foo!"; which foo | to nuon"#);
 
     assert_eq!(
         actual.out,
@@ -36,10 +27,7 @@ fn which_custom_alias() {
 
 #[test]
 fn which_def_ls() {
-    let actual = nu!(
-        cwd: ".",
-        "def ls [] {echo def}; which ls | get path.0 | str trim"
-    );
+    let actual = nu!("def ls [] {echo def}; which ls | get path.0 | str trim");
 
     assert_eq!(actual.out, "Nushell custom command");
 }
@@ -47,10 +35,8 @@ fn which_def_ls() {
 #[ignore = "TODO: Can't have alias with the same name as command"]
 #[test]
 fn correct_precedence_alias_def_custom() {
-    let actual = nu!(
-        cwd: ".",
-        "def ls [] {echo def}; alias ls = echo alias; which ls | get path.0 | str trim"
-    );
+    let actual =
+        nu!("def ls [] {echo def}; alias ls = echo alias; which ls | get path.0 | str trim");
 
     assert_eq!(actual.out, "Nushell alias: echo alias");
 }
@@ -58,10 +44,7 @@ fn correct_precedence_alias_def_custom() {
 #[ignore = "TODO: Can't have alias with the same name as command"]
 #[test]
 fn multiple_reports_for_alias_def_custom() {
-    let actual = nu!(
-        cwd: ".",
-        "def ls [] {echo def}; alias ls = echo alias; which -a ls | length"
-    );
+    let actual = nu!("def ls [] {echo def}; alias ls = echo alias; which -a ls | length");
 
     let length: i32 = actual.out.parse().unwrap();
     assert!(length >= 2);
@@ -75,30 +58,24 @@ fn multiple_reports_for_alias_def_custom() {
 #[ignore]
 #[test]
 fn correctly_report_of_shadowed_alias() {
-    let actual = nu!(
-        cwd: ".",
-        r#"alias xaz = echo alias1
+    let actual = nu!(r#"alias xaz = echo alias1
         def helper [] {
             alias xaz = echo alias2
             which -a xaz
         }
-        helper | get path | str contains alias2"#
-    );
+        helper | get path | str contains alias2"#);
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn one_report_of_multiple_defs() {
-    let actual = nu!(
-        cwd: ".",
-        r#"def xaz [] { echo def1 }
+    let actual = nu!(r#"def xaz [] { echo def1 }
         def helper [] {
             def xaz [] { echo def2 }
             which -a xaz
         }
-        helper | length"#
-    );
+        helper | length"#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 1);
@@ -106,10 +83,7 @@ fn one_report_of_multiple_defs() {
 
 #[test]
 fn def_only_seen_once() {
-    let actual = nu!(
-        cwd: ".",
-        "def xaz [] {echo def1}; which -a xaz | length"
-    );
+    let actual = nu!("def xaz [] {echo def1}; which -a xaz | length");
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 1);
@@ -117,12 +91,9 @@ fn def_only_seen_once() {
 
 #[test]
 fn do_not_show_hidden_aliases() {
-    let actual = nu!(
-        cwd: ".",
-        r#"alias foo = echo foo
+    let actual = nu!(r#"alias foo = echo foo
         hide foo
-        which foo | length"#
-    );
+        which foo | length"#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);
@@ -130,12 +101,9 @@ fn do_not_show_hidden_aliases() {
 
 #[test]
 fn do_not_show_hidden_commands() {
-    let actual = nu!(
-        cwd: ".",
-        r#"def foo [] { echo foo }
+    let actual = nu!(r#"def foo [] { echo foo }
         hide foo
-        which foo | length"#
-    );
+        which foo | length"#);
 
     let length: i32 = actual.out.parse().unwrap();
     assert_eq!(length, 0);

--- a/crates/nu-command/tests/commands/while_.rs
+++ b/crates/nu-command/tests/commands/while_.rs
@@ -3,7 +3,6 @@ use nu_test_support::nu;
 #[test]
 fn while_sum() {
     let actual = nu!(
-        cwd: ".",
         "mut total = 0; mut x = 0; while $x <= 10 { $total = $total + $x; $x = $x + 1 }; $total"
     );
 
@@ -12,10 +11,7 @@ fn while_sum() {
 
 #[test]
 fn while_doesnt_auto_print_in_each_iteration() {
-    let actual = nu!(
-        cwd: ".",
-        "mut total = 0; while $total < 2 { $total = $total + 1; echo 1 }"
-    );
+    let actual = nu!("mut total = 0; while $total < 2 { $total = $total + 1; echo 1 }");
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert!(!actual.out.contains('1'));
@@ -23,10 +19,8 @@ fn while_doesnt_auto_print_in_each_iteration() {
 
 #[test]
 fn while_break_on_external_failed() {
-    let actual = nu!(
-        cwd: ".",
-        "mut total = 0; while $total < 2 { $total = $total + 1; print 1; nu --testbin fail }"
-    );
+    let actual =
+        nu!("mut total = 0; while $total < 2 { $total = $total + 1; print 1; nu --testbin fail }");
     // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`
     assert_eq!(actual.out, "1");
@@ -34,9 +28,7 @@ fn while_break_on_external_failed() {
 
 #[test]
 fn failed_while_should_break_running() {
-    let actual = nu!(
-        cwd: ".",
-        "mut total = 0; while $total < 2 { $total = $total + 1; nu --testbin fail }; print 3"
-    );
+    let actual =
+        nu!("mut total = 0; while $total < 2 { $total = $total + 1; nu --testbin fail }; print 3");
     assert!(!actual.out.contains('3'));
 }

--- a/crates/nu-command/tests/commands/with_env.rs
+++ b/crates/nu-command/tests/commands/with_env.rs
@@ -2,88 +2,71 @@ use nu_test_support::nu;
 
 #[test]
 fn with_env_extends_environment() {
-    let actual = nu!(
-        "with-env [FOO BARRRR] {echo $env} | get FOO"
-    );
+    let actual = nu!("with-env [FOO BARRRR] {echo $env} | get FOO");
 
     assert_eq!(actual.out, "BARRRR");
 }
 
 #[test]
 fn with_env_shorthand() {
-    let actual = nu!(
-        "FOO=BARRRR echo $env | get FOO"
-    );
+    let actual = nu!("FOO=BARRRR echo $env | get FOO");
 
     assert_eq!(actual.out, "BARRRR");
 }
 
 #[test]
 fn shorthand_doesnt_reorder_arguments() {
-    let actual = nu!(
-        "FOO=BARRRR nu --testbin cococo first second"
-    );
+    let actual = nu!("FOO=BARRRR nu --testbin cococo first second");
 
     assert_eq!(actual.out, "first second");
 }
 
 #[test]
 fn with_env_shorthand_trims_quotes() {
-    let actual = nu!(
-        "FOO='BARRRR' echo $env | get FOO"
-    );
+    let actual = nu!("FOO='BARRRR' echo $env | get FOO");
 
     assert_eq!(actual.out, "BARRRR");
 }
 
 #[test]
 fn with_env_and_shorthand_same_result() {
-    let actual_shorthand = nu!(
-        "FOO='BARRRR' echo $env | get FOO"
-    );
+    let actual_shorthand = nu!("FOO='BARRRR' echo $env | get FOO");
 
-    let actual_normal = nu!(
-        "with-env [FOO BARRRR] {echo $env} | get FOO"
-    );
+    let actual_normal = nu!("with-env [FOO BARRRR] {echo $env} | get FOO");
 
     assert_eq!(actual_shorthand.out, actual_normal.out);
 }
 
 #[test]
 fn test_redirection2() {
-    let actual = nu!(
-        "let x = (FOO=BAR nu --testbin cococo niceenvvar); $x | str trim | str length"
-    );
+    let actual =
+        nu!("let x = (FOO=BAR nu --testbin cococo niceenvvar); $x | str trim | str length");
 
     assert_eq!(actual.out, "10");
 }
 
 #[test]
 fn with_env_hides_variables_in_parent_scope() {
-    let actual = nu!(
-        r#"
+    let actual = nu!(r#"
         $env.FOO = "1"
         print $env.FOO
         with-env [FOO null] {
             echo $env.FOO
         }
         print $env.FOO
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "11");
 }
 
 #[test]
 fn with_env_shorthand_can_not_hide_variables() {
-    let actual = nu!(
-        r#"
+    let actual = nu!(r#"
         $env.FOO = "1"
         print $env.FOO
         FOO=null print $env.FOO
         print $env.FOO
-        "#
-    );
+        "#);
 
     assert_eq!(actual.out, "1null1");
 }

--- a/crates/nu-command/tests/commands/with_env.rs
+++ b/crates/nu-command/tests/commands/with_env.rs
@@ -3,7 +3,6 @@ use nu_test_support::nu;
 #[test]
 fn with_env_extends_environment() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         "with-env [FOO BARRRR] {echo $env} | get FOO"
     );
 
@@ -13,7 +12,6 @@ fn with_env_extends_environment() {
 #[test]
 fn with_env_shorthand() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         "FOO=BARRRR echo $env | get FOO"
     );
 
@@ -23,7 +21,6 @@ fn with_env_shorthand() {
 #[test]
 fn shorthand_doesnt_reorder_arguments() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         "FOO=BARRRR nu --testbin cococo first second"
     );
 
@@ -33,7 +30,6 @@ fn shorthand_doesnt_reorder_arguments() {
 #[test]
 fn with_env_shorthand_trims_quotes() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         "FOO='BARRRR' echo $env | get FOO"
     );
 
@@ -43,12 +39,10 @@ fn with_env_shorthand_trims_quotes() {
 #[test]
 fn with_env_and_shorthand_same_result() {
     let actual_shorthand = nu!(
-        cwd: "tests/fixtures/formats",
         "FOO='BARRRR' echo $env | get FOO"
     );
 
     let actual_normal = nu!(
-        cwd: "tests/fixtures/formats",
         "with-env [FOO BARRRR] {echo $env} | get FOO"
     );
 
@@ -58,7 +52,6 @@ fn with_env_and_shorthand_same_result() {
 #[test]
 fn test_redirection2() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         "let x = (FOO=BAR nu --testbin cococo niceenvvar); $x | str trim | str length"
     );
 
@@ -68,7 +61,6 @@ fn test_redirection2() {
 #[test]
 fn with_env_hides_variables_in_parent_scope() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         r#"
         $env.FOO = "1"
         print $env.FOO
@@ -85,7 +77,6 @@ fn with_env_hides_variables_in_parent_scope() {
 #[test]
 fn with_env_shorthand_can_not_hide_variables() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats",
         r#"
         $env.FOO = "1"
         print $env.FOO

--- a/crates/nu-command/tests/commands/zip.rs
+++ b/crates/nu-command/tests/commands/zip.rs
@@ -22,10 +22,8 @@ fn zips_two_tables() {
             &format!("{ZIP_POWERED_TEST_ASSERTION_SCRIPT}\n"),
         )]);
 
-        let actual = nu!(
-            cwd: ".", pipeline(
-            &format!(
-                r#"
+        let actual = nu!(pipeline(&format!(
+            r#"
                 use {} expect ;
 
                 let contributors = ([
@@ -38,9 +36,8 @@ fn zips_two_tables() {
 
                 expect $actual --to-eq [[name, commits]; [andres, 20] [jt, 30]]
                 "#,
-                dirs.test().join("zip_test.nu").display()
-            )
-        ));
+            dirs.test().join("zip_test.nu").display()
+        )));
 
         assert_eq!(actual.out, "true");
     })
@@ -48,12 +45,9 @@ fn zips_two_tables() {
 
 #[test]
 fn zips_two_lists() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo [0 2 4 6 8] | zip [1 3 5 7 9] | flatten | into string | str join '-'
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "0-1-2-3-4-5-6-7-8-9");
 }

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -372,8 +372,7 @@ fn from_csv_text_with_wrong_type_separator() {
 
 #[test]
 fn table_with_record_error() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[a b]; [1 2] [3 {a: 1 b: 2}]] 
             | to csv
@@ -385,8 +384,7 @@ fn table_with_record_error() {
 
 #[test]
 fn list_not_table_error() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             [{a: 1 b: 2} {a: 3 b: 4} 1]
             | to csv
@@ -398,8 +396,7 @@ fn list_not_table_error() {
 
 #[test]
 fn string_to_csv_error() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             'qwe' | to csv
         "#

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -373,7 +373,7 @@ fn from_csv_text_with_wrong_type_separator() {
 #[test]
 fn table_with_record_error() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             [[a b]; [1 2] [3 {a: 1 b: 2}]] 
             | to csv
@@ -386,7 +386,7 @@ fn table_with_record_error() {
 #[test]
 fn list_not_table_error() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             [{a: 1 b: 2} {a: 3 b: 4} 1]
             | to csv
@@ -399,7 +399,7 @@ fn list_not_table_error() {
 #[test]
 fn string_to_csv_error() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             'qwe' | to csv
         "#

--- a/crates/nu-command/tests/format_conversions/html.rs
+++ b/crates/nu-command/tests/format_conversions/html.rs
@@ -2,8 +2,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn out_html_simple() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             echo 3 | to html
         "#
@@ -17,12 +16,9 @@ fn out_html_simple() {
 
 #[test]
 fn out_html_partial() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo 3 | to html -p
-        "#
-    ));
+        "#);
 
     assert_eq!(
         actual.out,
@@ -32,12 +28,9 @@ fn out_html_partial() {
 
 #[test]
 fn out_html_table() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo '{"name": "darren"}' | from json | to html
-        "#
-    ));
+        "#);
 
     assert_eq!(
         actual.out,
@@ -48,13 +41,9 @@ fn out_html_table() {
 #[test]
 #[ignore]
 fn test_cd_html_color_flag_dark_false() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(r#"
                 cd --help | to html --html-color
-            "#
-        )
-    );
+            "#);
     assert_eq!(
         actual.out,
         r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br><span style='color:green;'>Usage<span style='color:black;font-weight:normal;'>:<br>  &gt; cd (path) <br><br></span></span><span style='color:green;'>Flags<span style='color:black;font-weight:normal;'>:<br>  </span></span><span style='color:#037979;'>-h</span>,<span style='color:black;font-weight:normal;'> </span><span style='color:#037979;'>--help<span style='color:black;font-weight:normal;'> - Display the help message for this command<br><br></span><span style='color:green;'>Signatures<span style='color:black;font-weight:normal;'>:<br>  &lt;nothing&gt; | cd &lt;string?&gt; -&gt; &lt;nothing&gt;<br>  &lt;string&gt; | cd &lt;string?&gt; -&gt; &lt;nothing&gt;<br><br></span></span><span style='color:green;'>Parameters<span style='color:black;font-weight:normal;'>:<br>  (optional) </span></span></span><span style='color:#037979;'>path<span style='color:black;font-weight:normal;'> &lt;</span><span style='color:blue;font-weight:bold;'>directory<span style='color:black;font-weight:normal;'>&gt;: the path to change to<br><br></span></span><span style='color:green;'>Examples<span style='color:black;font-weight:normal;'>:<br>  Change to your home directory<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span></span><span style='color:#037979;'>~<span style='color:black;font-weight:normal;'><br><br>  Change to a directory via abbreviations<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>d/s/9<span style='color:black;font-weight:normal;'><br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; </span><span style='color:#037979;font-weight:bold;'>cd<span style='color:black;font-weight:normal;'> </span></span></span><span style='color:#037979;'>-<span style='color:black;font-weight:normal;'><br><br></body></html></span></span>"
@@ -63,13 +52,9 @@ fn test_cd_html_color_flag_dark_false() {
 
 #[test]
 fn test_no_color_flag() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-            r#"
+    let actual = nu!(r#"
                 cd --help | to html --no-color
-            "#
-        )
-    );
+            "#);
     assert_eq!(
         actual.out,
         r"<html><style>body { background-color:white;color:black; }</style><body>Change directory.<br><br>Usage:<br>  &gt; cd (path) <br><br>Flags:<br>  -h, --help - Display the help message for this command<br><br>Signatures:<br>  &lt;nothing&gt; | cd &lt;string?&gt; -&gt; &lt;nothing&gt;<br>  &lt;string&gt; | cd &lt;string?&gt; -&gt; &lt;nothing&gt;<br><br>Parameters:<br>  path &lt;directory&gt;: the path to change to (optional)<br><br>Examples:<br>  Change to your home directory<br>  &gt; cd ~<br><br>  Change to a directory via abbreviations<br>  &gt; cd d/s/9<br><br>  Change to the previous working directory ($OLDPWD)<br>  &gt; cd -<br><br></body></html>"
@@ -78,10 +63,7 @@ fn test_no_color_flag() {
 
 #[test]
 fn test_list() {
-    let actual = nu!(
-        cwd: ".",
-        r#"to html --list | where name == C64 | get 0 | to nuon"#
-    );
+    let actual = nu!(r#"to html --list | where name == C64 | get 0 | to nuon"#);
     assert_eq!(
         actual.out,
         r##"{name: "C64", black: "#090300", red: "#883932", green: "#55a049", yellow: "#bfce72", blue: "#40318d", purple: "#8b3f96", cyan: "#67b6bd", white: "#ffffff", brightBlack: "#000000", brightRed: "#883932", brightGreen: "#55a049", brightYellow: "#bfce72", brightBlue: "#40318d", brightPurple: "#8b3f96", brightCyan: "#67b6bd", brightWhite: "#f7f7f7", background: "#40318d", foreground: "#7869c4"}"##

--- a/crates/nu-command/tests/format_conversions/markdown.rs
+++ b/crates/nu-command/tests/format_conversions/markdown.rs
@@ -2,80 +2,61 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn md_empty() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo [[]; []] | from json | to md
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "");
 }
 
 #[test]
 fn md_empty_pretty() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo "{}" | from json | to md -p
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "");
 }
 
 #[test]
 fn md_simple() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo 3 | to md
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "3");
 }
 
 #[test]
 fn md_simple_pretty() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo 3 | to md -p
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "3");
 }
 
 #[test]
 fn md_table() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo [[name]; [jason]] | to md
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "|name||-||jason|");
 }
 
 #[test]
 fn md_table_pretty() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
+    let actual = nu!(r#"
             echo [[name]; [joseph]] | to md -p
-        "#
-    ));
+        "#);
 
     assert_eq!(actual.out, "| name   || ------ || joseph |");
 }
 
 #[test]
 fn md_combined() {
-    let actual = nu!(
-        cwd: ".", pipeline(
+    let actual = nu!(pipeline(
         r#"
             def title [] {
                 echo [[H1]; ["Nu top meals"]]

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -18,7 +18,7 @@ fn to_nuon_correct_compaction() {
 #[test]
 fn to_nuon_list_of_numbers() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             [1, 2, 3, 4]
             | to nuon
@@ -33,7 +33,7 @@ fn to_nuon_list_of_numbers() {
 #[test]
 fn to_nuon_list_of_strings() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             [abc, xyz, def]
             | to nuon
@@ -48,7 +48,7 @@ fn to_nuon_list_of_strings() {
 #[test]
 fn to_nuon_table() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             [[my, columns]; [abc, xyz], [def, ijk]]
             | to nuon
@@ -63,7 +63,7 @@ fn to_nuon_table() {
 #[test]
 fn to_nuon_bool() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             false
             | to nuon
@@ -77,7 +77,7 @@ fn to_nuon_bool() {
 #[test]
 fn to_nuon_escaping() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "hello\"world"
             | to nuon
@@ -91,7 +91,7 @@ fn to_nuon_escaping() {
 #[test]
 fn to_nuon_escaping2() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "hello\\world"
             | to nuon
@@ -105,7 +105,7 @@ fn to_nuon_escaping2() {
 #[test]
 fn to_nuon_escaping3() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             ["hello\\world"]
             | to nuon
@@ -120,7 +120,7 @@ fn to_nuon_escaping3() {
 #[test]
 fn to_nuon_escaping4() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             ["hello\"world"]
             | to nuon
@@ -135,7 +135,7 @@ fn to_nuon_escaping4() {
 #[test]
 fn to_nuon_escaping5() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             {s: "hello\"world"}
             | to nuon
@@ -150,7 +150,7 @@ fn to_nuon_escaping5() {
 #[test]
 fn to_nuon_negative_int() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             -1
             | to nuon
@@ -164,7 +164,7 @@ fn to_nuon_negative_int() {
 #[test]
 fn to_nuon_records() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             {name: "foo bar", age: 100, height: 10}
             | to nuon
@@ -179,7 +179,7 @@ fn to_nuon_records() {
 #[test]
 fn to_nuon_range() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1..42
             | to nuon
@@ -192,7 +192,7 @@ fn to_nuon_range() {
 #[test]
 fn from_nuon_range() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "1..42"
             | from nuon
@@ -206,7 +206,7 @@ fn from_nuon_range() {
 #[test]
 fn to_nuon_filesize() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1kib
             | to nuon
@@ -219,7 +219,7 @@ fn to_nuon_filesize() {
 #[test]
 fn from_nuon_filesize() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "1024b"
             | from nuon
@@ -233,7 +233,7 @@ fn from_nuon_filesize() {
 #[test]
 fn to_nuon_duration() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1min
             | to nuon
@@ -246,7 +246,7 @@ fn to_nuon_duration() {
 #[test]
 fn from_nuon_duration() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "60000000000ns"
             | from nuon
@@ -260,7 +260,7 @@ fn from_nuon_duration() {
 #[test]
 fn to_nuon_datetime() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             2019-05-10
             | to nuon
@@ -273,7 +273,7 @@ fn to_nuon_datetime() {
 #[test]
 fn from_nuon_datetime() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "2019-05-10T00:00:00+00:00"
             | from nuon
@@ -287,7 +287,7 @@ fn from_nuon_datetime() {
 #[test]
 fn to_nuon_errs_on_closure() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             {|| to nuon}
             | to nuon
@@ -300,7 +300,7 @@ fn to_nuon_errs_on_closure() {
 #[test]
 fn binary_to() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             0x[ab cd ef] | to nuon
         "#
@@ -312,7 +312,7 @@ fn binary_to() {
 #[test]
 fn binary_roundtrip() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "0x[1f ff]" | from nuon | to nuon
         "#
@@ -360,7 +360,7 @@ fn read_bool() {
 #[test]
 fn float_doesnt_become_int() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             1.0 | to nuon
         "#
@@ -372,7 +372,7 @@ fn float_doesnt_become_int() {
 #[test]
 fn float_inf_parsed_properly() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             inf | to nuon
         "#
@@ -384,7 +384,7 @@ fn float_inf_parsed_properly() {
 #[test]
 fn float_neg_inf_parsed_properly() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             -inf | to nuon
         "#
@@ -396,7 +396,7 @@ fn float_neg_inf_parsed_properly() {
 #[test]
 fn float_nan_parsed_properly() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             NaN | to nuon
         "#
@@ -408,7 +408,7 @@ fn float_nan_parsed_properly() {
 #[test]
 fn to_nuon_converts_columns_with_spaces() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
             r#"
     let test = [[a, b, "c d"]; [1 2 3] [4 5 6]]; $test | to nuon | from nuon
     "#
@@ -419,7 +419,7 @@ fn to_nuon_converts_columns_with_spaces() {
 #[test]
 fn to_nuon_quotes_empty_string() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
             r#"
     let test = ""; $test | to nuon
     "#
@@ -431,7 +431,7 @@ fn to_nuon_quotes_empty_string() {
 #[test]
 fn to_nuon_quotes_empty_string_in_list() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
             r#"
     let test = [""]; $test | to nuon | from nuon | $in == [""]
     "#
@@ -443,7 +443,7 @@ fn to_nuon_quotes_empty_string_in_list() {
 #[test]
 fn to_nuon_quotes_empty_string_in_table() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
             r#"
     let test = [[a, b]; ['', la] [le lu]]; $test | to nuon | from nuon
     "#
@@ -454,14 +454,14 @@ fn to_nuon_quotes_empty_string_in_table() {
 #[test]
 fn does_not_quote_strings_unnecessarily() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
             r#"
         let test = [["a", "b", "c d"]; [1 2 3] [4 5 6]]; $test | to nuon
     "#
     ));
     assert_eq!(actual.out, "[[a, b, \"c d\"]; [1, 2, 3], [4, 5, 6]]");
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
             r#"
          let a = {"ro name": "sam" rank: 10}; $a | to nuon
     "#
@@ -472,7 +472,7 @@ fn does_not_quote_strings_unnecessarily() {
 #[test]
 fn quotes_some_strings_necessarily() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             ['true','false','null',
             'NaN','NAN','nan','+nan','-nan',

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -17,8 +17,7 @@ fn to_nuon_correct_compaction() {
 
 #[test]
 fn to_nuon_list_of_numbers() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             [1, 2, 3, 4]
             | to nuon
@@ -32,8 +31,7 @@ fn to_nuon_list_of_numbers() {
 
 #[test]
 fn to_nuon_list_of_strings() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             [abc, xyz, def]
             | to nuon
@@ -47,8 +45,7 @@ fn to_nuon_list_of_strings() {
 
 #[test]
 fn to_nuon_table() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             [[my, columns]; [abc, xyz], [def, ijk]]
             | to nuon
@@ -62,8 +59,7 @@ fn to_nuon_table() {
 
 #[test]
 fn to_nuon_bool() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             false
             | to nuon
@@ -76,8 +72,7 @@ fn to_nuon_bool() {
 
 #[test]
 fn to_nuon_escaping() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "hello\"world"
             | to nuon
@@ -90,8 +85,7 @@ fn to_nuon_escaping() {
 
 #[test]
 fn to_nuon_escaping2() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "hello\\world"
             | to nuon
@@ -104,8 +98,7 @@ fn to_nuon_escaping2() {
 
 #[test]
 fn to_nuon_escaping3() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             ["hello\\world"]
             | to nuon
@@ -119,8 +112,7 @@ fn to_nuon_escaping3() {
 
 #[test]
 fn to_nuon_escaping4() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             ["hello\"world"]
             | to nuon
@@ -134,8 +126,7 @@ fn to_nuon_escaping4() {
 
 #[test]
 fn to_nuon_escaping5() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             {s: "hello\"world"}
             | to nuon
@@ -149,8 +140,7 @@ fn to_nuon_escaping5() {
 
 #[test]
 fn to_nuon_negative_int() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             -1
             | to nuon
@@ -163,8 +153,7 @@ fn to_nuon_negative_int() {
 
 #[test]
 fn to_nuon_records() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             {name: "foo bar", age: 100, height: 10}
             | to nuon
@@ -178,8 +167,7 @@ fn to_nuon_records() {
 
 #[test]
 fn to_nuon_range() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1..42
             | to nuon
@@ -191,8 +179,7 @@ fn to_nuon_range() {
 
 #[test]
 fn from_nuon_range() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "1..42"
             | from nuon
@@ -205,8 +192,7 @@ fn from_nuon_range() {
 
 #[test]
 fn to_nuon_filesize() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1kib
             | to nuon
@@ -218,8 +204,7 @@ fn to_nuon_filesize() {
 
 #[test]
 fn from_nuon_filesize() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "1024b"
             | from nuon
@@ -232,8 +217,7 @@ fn from_nuon_filesize() {
 
 #[test]
 fn to_nuon_duration() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1min
             | to nuon
@@ -245,8 +229,7 @@ fn to_nuon_duration() {
 
 #[test]
 fn from_nuon_duration() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "60000000000ns"
             | from nuon
@@ -259,8 +242,7 @@ fn from_nuon_duration() {
 
 #[test]
 fn to_nuon_datetime() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             2019-05-10
             | to nuon
@@ -272,8 +254,7 @@ fn to_nuon_datetime() {
 
 #[test]
 fn from_nuon_datetime() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "2019-05-10T00:00:00+00:00"
             | from nuon
@@ -286,8 +267,7 @@ fn from_nuon_datetime() {
 
 #[test]
 fn to_nuon_errs_on_closure() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             {|| to nuon}
             | to nuon
@@ -299,8 +279,7 @@ fn to_nuon_errs_on_closure() {
 
 #[test]
 fn binary_to() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             0x[ab cd ef] | to nuon
         "#
@@ -311,8 +290,7 @@ fn binary_to() {
 
 #[test]
 fn binary_roundtrip() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "0x[1f ff]" | from nuon | to nuon
         "#
@@ -359,8 +337,7 @@ fn read_bool() {
 
 #[test]
 fn float_doesnt_become_int() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             1.0 | to nuon
         "#
@@ -371,8 +348,7 @@ fn float_doesnt_become_int() {
 
 #[test]
 fn float_inf_parsed_properly() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             inf | to nuon
         "#
@@ -383,8 +359,7 @@ fn float_inf_parsed_properly() {
 
 #[test]
 fn float_neg_inf_parsed_properly() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             -inf | to nuon
         "#
@@ -395,8 +370,7 @@ fn float_neg_inf_parsed_properly() {
 
 #[test]
 fn float_nan_parsed_properly() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             NaN | to nuon
         "#
@@ -407,9 +381,8 @@ fn float_nan_parsed_properly() {
 
 #[test]
 fn to_nuon_converts_columns_with_spaces() {
-    let actual = nu!(
-        pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
     let test = [[a, b, "c d"]; [1 2 3] [4 5 6]]; $test | to nuon | from nuon
     "#
     ));
@@ -418,9 +391,8 @@ fn to_nuon_converts_columns_with_spaces() {
 
 #[test]
 fn to_nuon_quotes_empty_string() {
-    let actual = nu!(
-        pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
     let test = ""; $test | to nuon
     "#
     ));
@@ -430,9 +402,8 @@ fn to_nuon_quotes_empty_string() {
 
 #[test]
 fn to_nuon_quotes_empty_string_in_list() {
-    let actual = nu!(
-        pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
     let test = [""]; $test | to nuon | from nuon | $in == [""]
     "#
     ));
@@ -442,9 +413,8 @@ fn to_nuon_quotes_empty_string_in_list() {
 
 #[test]
 fn to_nuon_quotes_empty_string_in_table() {
-    let actual = nu!(
-        pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
     let test = [[a, b]; ['', la] [le lu]]; $test | to nuon | from nuon
     "#
     ));
@@ -453,16 +423,14 @@ fn to_nuon_quotes_empty_string_in_table() {
 
 #[test]
 fn does_not_quote_strings_unnecessarily() {
-    let actual = nu!(
-        pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
         let test = [["a", "b", "c d"]; [1 2 3] [4 5 6]]; $test | to nuon
     "#
     ));
     assert_eq!(actual.out, "[[a, b, \"c d\"]; [1, 2, 3], [4, 5, 6]]");
-    let actual = nu!(
-        pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
          let a = {"ro name": "sam" rank: 10}; $a | to nuon
     "#
     ));
@@ -471,8 +439,7 @@ fn does_not_quote_strings_unnecessarily() {
 
 #[test]
 fn quotes_some_strings_necessarily() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             ['true','false','null',
             'NaN','NAN','nan','+nan','-nan',

--- a/crates/nu-command/tests/format_conversions/toml.rs
+++ b/crates/nu-command/tests/format_conversions/toml.rs
@@ -3,7 +3,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn record_map_to_toml() {
     let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    pipeline(
         r#"
             {a: 1 b: 2 c: 'qwe'} 
             | to toml
@@ -18,7 +18,7 @@ fn record_map_to_toml() {
 #[test]
 fn nested_records_to_toml() {
     let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    pipeline(
         r#"
             {a: {a: a b: b} c: 1} 
             | to toml
@@ -33,7 +33,7 @@ fn nested_records_to_toml() {
 #[test]
 fn records_with_tables_to_toml() {
     let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    pipeline(
         r#"
             {a: [[a b]; [1 2] [3 4]] b: [[c d e]; [1 2 3]]}
             | to toml
@@ -48,7 +48,7 @@ fn records_with_tables_to_toml() {
 #[test]
 fn nested_tables_to_toml() {
     let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    pipeline(
         r#"
             {c: [[f g]; [[[h k]; [1 2] [3 4]] 1]]}
             | to toml
@@ -64,7 +64,7 @@ fn nested_tables_to_toml() {
 fn table_to_toml_fails() {
     // Tables can't be represented in toml
     let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    pipeline(
         r#"
         try { [[a b]; [1 2] [5 6]] | to toml | false } catch { true }
         "#
@@ -77,7 +77,7 @@ fn table_to_toml_fails() {
 fn string_to_toml_fails() {
     // Strings are not a top-level toml structure
     let actual = nu!(
-    cwd: "tests/fixtures/formats", pipeline(
+    pipeline(
         r#"
         try { 'not a valid toml' | to toml | false } catch { true }
         "#

--- a/crates/nu-command/tests/format_conversions/toml.rs
+++ b/crates/nu-command/tests/format_conversions/toml.rs
@@ -2,8 +2,7 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn record_map_to_toml() {
-    let actual = nu!(
-    pipeline(
+    let actual = nu!(pipeline(
         r#"
             {a: 1 b: 2 c: 'qwe'} 
             | to toml
@@ -17,8 +16,7 @@ fn record_map_to_toml() {
 
 #[test]
 fn nested_records_to_toml() {
-    let actual = nu!(
-    pipeline(
+    let actual = nu!(pipeline(
         r#"
             {a: {a: a b: b} c: 1} 
             | to toml
@@ -32,8 +30,7 @@ fn nested_records_to_toml() {
 
 #[test]
 fn records_with_tables_to_toml() {
-    let actual = nu!(
-    pipeline(
+    let actual = nu!(pipeline(
         r#"
             {a: [[a b]; [1 2] [3 4]] b: [[c d e]; [1 2 3]]}
             | to toml
@@ -47,8 +44,7 @@ fn records_with_tables_to_toml() {
 
 #[test]
 fn nested_tables_to_toml() {
-    let actual = nu!(
-    pipeline(
+    let actual = nu!(pipeline(
         r#"
             {c: [[f g]; [[[h k]; [1 2] [3 4]] 1]]}
             | to toml
@@ -63,8 +59,7 @@ fn nested_tables_to_toml() {
 #[test]
 fn table_to_toml_fails() {
     // Tables can't be represented in toml
-    let actual = nu!(
-    pipeline(
+    let actual = nu!(pipeline(
         r#"
         try { [[a b]; [1 2] [5 6]] | to toml | false } catch { true }
         "#
@@ -76,8 +71,7 @@ fn table_to_toml_fails() {
 #[test]
 fn string_to_toml_fails() {
     // Strings are not a top-level toml structure
-    let actual = nu!(
-    pipeline(
+    let actual = nu!(pipeline(
         r#"
         try { 'not a valid toml' | to toml | false } catch { true }
         "#

--- a/crates/nu-command/tests/format_conversions/yaml.rs
+++ b/crates/nu-command/tests/format_conversions/yaml.rs
@@ -17,8 +17,7 @@ fn table_to_yaml_text_and_from_yaml_text_back_into_table() {
 
 #[test]
 fn convert_dict_to_yaml_with_boolean_key() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "true: BooleanKey " | from yaml
         "#
@@ -29,8 +28,7 @@ fn convert_dict_to_yaml_with_boolean_key() {
 
 #[test]
 fn convert_dict_to_yaml_with_integer_key() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "200: [] " | from yaml
         "#
@@ -42,8 +40,7 @@ fn convert_dict_to_yaml_with_integer_key() {
 
 #[test]
 fn convert_dict_to_yaml_with_integer_floats_key() {
-    let actual = nu!(
-        pipeline(
+    let actual = nu!(pipeline(
         r#"
             "2.11: "1" " | from yaml
         "#

--- a/crates/nu-command/tests/format_conversions/yaml.rs
+++ b/crates/nu-command/tests/format_conversions/yaml.rs
@@ -18,7 +18,7 @@ fn table_to_yaml_text_and_from_yaml_text_back_into_table() {
 #[test]
 fn convert_dict_to_yaml_with_boolean_key() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "true: BooleanKey " | from yaml
         "#
@@ -30,7 +30,7 @@ fn convert_dict_to_yaml_with_boolean_key() {
 #[test]
 fn convert_dict_to_yaml_with_integer_key() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "200: [] " | from yaml
         "#
@@ -43,7 +43,7 @@ fn convert_dict_to_yaml_with_integer_key() {
 #[test]
 fn convert_dict_to_yaml_with_integer_floats_key() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
+        pipeline(
         r#"
             "2.11: "1" " | from yaml
         "#

--- a/crates/nu-protocol/tests/into_config.rs
+++ b/crates/nu-protocol/tests/into_config.rs
@@ -2,27 +2,33 @@ use nu_test_support::{nu, nu_repl_code};
 
 #[test]
 fn config_is_mutable() {
-    let actual = nu!(cwd: ".", nu_repl_code(&[r"$env.config = { ls: { clickable_links: true } }",
+    let actual = nu!(nu_repl_code(&[
+        r"$env.config = { ls: { clickable_links: true } }",
         "$env.config.ls.clickable_links = false;",
-        "$env.config.ls.clickable_links"]));
+        "$env.config.ls.clickable_links"
+    ]));
 
     assert_eq!(actual.out, "false");
 }
 
 #[test]
 fn config_preserved_after_do() {
-    let actual = nu!(cwd: ".", nu_repl_code(&[r"$env.config = { ls: { clickable_links: true } }",
+    let actual = nu!(nu_repl_code(&[
+        r"$env.config = { ls: { clickable_links: true } }",
         "do -i { $env.config.ls.clickable_links = false }",
-        "$env.config.ls.clickable_links"]));
+        "$env.config.ls.clickable_links"
+    ]));
 
     assert_eq!(actual.out, "true");
 }
 
 #[test]
 fn config_affected_when_mutated() {
-    let actual = nu!(cwd: ".", nu_repl_code(&[r#"$env.config = { filesize: { metric: false, format:"auto" } }"#,
+    let actual = nu!(nu_repl_code(&[
+        r#"$env.config = { filesize: { metric: false, format:"auto" } }"#,
         r#"$env.config = { filesize: { metric: true, format:"auto" } }"#,
-        "20mib | into string"]));
+        "20mib | into string"
+    ]));
 
     assert_eq!(actual.out, "21.0 MB");
 }

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -6,7 +6,7 @@ fn filesize_metric_true() {
         r#"$env.config = { filesize: { metric: true, format:"mb" } }"#,
         r#"20mib | into string"#,
     ];
-    let actual = nu!(cwd: ".", nu_repl_code( code ));
+    let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, "21.0 MB");
 }
 
@@ -16,7 +16,7 @@ fn filesize_metric_false() {
         r#"$env.config = { filesize: { metric: false, format:"mib" } }"#,
         r#"20mib | into string"#,
     ];
-    let actual = nu!(cwd: ".", nu_repl_code( code ));
+    let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, "20.0 MiB");
 }
 
@@ -26,7 +26,7 @@ fn filesize_metric_overrides_format() {
         r#"$env.config = { filesize: { metric: false, format:"mb" } }"#,
         r#"20mib | into string"#,
     ];
-    let actual = nu!(cwd: ".", nu_repl_code( code ));
+    let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, "20.0 MiB");
 }
 
@@ -36,7 +36,7 @@ fn filesize_format_auto_metric_true() {
         r#"$env.config = { filesize: { metric: true, format:"auto" } }"#,
         r#"[2mb 2gb 2tb] | into string | to nuon"#,
     ];
-    let actual = nu!(cwd: ".", nu_repl_code( code ));
+    let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, r#"["2.0 MB", "2.0 GB", "2.0 TB"]"#);
 }
 
@@ -46,6 +46,6 @@ fn filesize_format_auto_metric_false() {
         r#"$env.config = { filesize: { metric: false, format:"auto" } }"#,
         r#"[2mb 2gb 2tb] | into string | to nuon"#,
     ];
-    let actual = nu!(cwd: ".", nu_repl_code( code ));
+    let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, r#"["1.9 MiB", "1.9 GiB", "1.8 TiB"]"#);
 }

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -143,7 +143,7 @@ fn override_table() -> TestResult {
 
 #[test]
 fn override_table_eval_file() {
-    let actual = nu!(cwd: ".", r#"def table [] { "hi" }; table"#);
+    let actual = nu!(r#"def table [] { "hi" }; table"#);
     assert_eq!(actual.out, "hi");
 }
 
@@ -153,11 +153,8 @@ fn override_table_eval_file() {
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn infinite_recursion_does_not_panic() {
-    let actual = nu!(
-        cwd: ".",
-        r#"
+    let actual = nu!(r#"
             def bang [] { bang }; bang
-        "#
-    );
+        "#);
     assert!(actual.err.contains("Recursion limit (50) reached"));
 }


### PR DESCRIPTION
# Description
The working directory doesn't have to be set for those tests (or would
be the default anyways). When appropriate also remove calls to the
`pipeline()` function. In most places kept the diff minimal and only
removed the superfluous part to not pollute the blame view. With simpler
tests also simplified things to make them more readable overall (this
included removal of the raw string literal).

Work for #8670

