### PR TITLE
Do not attempt to take control of terminal in non-interactive mode

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -235,7 +235,7 @@ impl ExternalCommand {
                             cmd,
                             engine_state.pipeline_externals_state.clone(),
                         );
-                        child = cmd_process.spawn();
+                        child = cmd_process.spawn(engine_state.is_interactive);
                     } else {
                         #[cfg(feature = "which-support")]
                         {
@@ -269,7 +269,8 @@ impl ExternalCommand {
                                                     cmd,
                                                     engine_state.pipeline_externals_state.clone(),
                                                 );
-                                                child = cmd_process.spawn();
+                                                child =
+                                                    cmd_process.spawn(engine_state.is_interactive);
                                             }
                                         }
                                     }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -213,7 +213,7 @@ impl ExternalCommand {
             // fails to be run as a normal executable:
             // 1. "shell out" to cmd.exe if the command is a known cmd.exe internal command
             // 2. Otherwise, use `which-rs` to look for batch files etc. then run those in cmd.exe
-            match fg_process.spawn() {
+            match fg_process.spawn(engine_state.is_interactive) {
                 Err(err) => {
                     // set the default value, maybe we'll override it later
                     child = Err(err);
@@ -286,7 +286,7 @@ impl ExternalCommand {
 
         #[cfg(not(windows))]
         {
-            child = fg_process.spawn()
+            child = fg_process.spawn(engine_state.is_interactive)
         }
 
         match child {

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -182,9 +182,9 @@ mod fg_process_setup {
 
 #[cfg(any(not(target_family = "unix"), target_os = "macos"))]
 mod fg_process_setup {
-    pub(super) fn prepare_to_foreground(_: &mut std::process::Command, _: u32) {}
+    pub(super) fn prepare_to_foreground(_: &mut std::process::Command, _: u32, _: bool) {}
 
-    pub(super) fn set_foreground(_: &std::process::Child, _: u32) {}
+    pub(super) fn set_foreground(_: &std::process::Child, _: u32, _: bool) {}
 
     pub(super) fn reset_foreground_id() {}
 }

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -106,7 +106,7 @@ mod fg_process_setup {
         interactive: bool,
     ) {
         let tty = TtyHandle(unistd::dup(nix::libc::STDIN_FILENO).expect("dup"));
-        let interactive = std::io::stdin().is_terminal() && interactive;
+        let interactive = interactive && std::io::stdin().is_terminal();
         unsafe {
             // Safety:
             // POSIX only allows async-signal-safe functions to be called.
@@ -149,7 +149,7 @@ mod fg_process_setup {
         interactive: bool,
     ) {
         // called from the parent shell process - do the stdin tty check here
-        if std::io::stdin().is_terminal() && interactive {
+        if interactive && std::io::stdin().is_terminal() {
             set_foreground_pid(
                 Pid::from_raw(process.id() as i32),
                 existing_pgrp,
@@ -174,7 +174,7 @@ mod fg_process_setup {
 
     /// Reset the foreground process group to the shell
     pub(super) fn reset_foreground_id(interactive: bool) {
-        if std::io::stdin().is_terminal() && interactive {
+        if interactive && std::io::stdin().is_terminal() {
             if let Err(e) = nix::unistd::tcsetpgrp(nix::libc::STDIN_FILENO, unistd::getpgrp()) {
                 println!("ERROR: reset foreground id failed, tcsetpgrp result: {e:?}");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,10 @@ fn main() -> Result<()> {
 
     start_time = std::time::Instant::now();
     // keep this condition in sync with the branches below
-    acquire_terminal(parsed_nu_cli_args.commands.is_none() && script_name.is_empty());
+    acquire_terminal(
+        engine_state.is_interactive
+            || (parsed_nu_cli_args.commands.is_none() && script_name.is_empty()),
+    );
     perf(
         "acquire_terminal",
         start_time,

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,10 @@ fn main() -> Result<()> {
     let parsed_nu_cli_args = parse_commandline_args(&args_to_nushell.join(" "), &mut engine_state)
         .unwrap_or_else(|_| std::process::exit(1));
 
-    engine_state.is_interactive = parsed_nu_cli_args.interactive_shell.is_some();
+    // keep this condition in sync with the branches at the end
+    engine_state.is_interactive = parsed_nu_cli_args.interactive_shell.is_some()
+        || (parsed_nu_cli_args.commands.is_none() && script_name.is_empty());
+
     engine_state.is_login = parsed_nu_cli_args.login_shell.is_some();
 
     let use_color = engine_state.get_config().use_ansi_coloring;
@@ -142,11 +145,7 @@ fn main() -> Result<()> {
     );
 
     start_time = std::time::Instant::now();
-    // keep this condition in sync with the branches below
-    acquire_terminal(
-        engine_state.is_interactive
-            || (parsed_nu_cli_args.commands.is_none() && script_name.is_empty()),
-    );
+    acquire_terminal(engine_state.is_interactive);
     perf(
         "acquire_terminal",
         start_time,
@@ -292,7 +291,6 @@ fn main() -> Result<()> {
             input,
         )
     } else {
-        engine_state.is_interactive = true;
         run_repl(&mut engine_state, parsed_nu_cli_args, entire_start_time)
     }
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -4,6 +4,8 @@ pub(crate) fn acquire_terminal(interactive: bool) {
     use nix::sys::signal::{signal, SigHandler, Signal};
 
     if interactive && std::io::stdin().is_terminal() {
+        // see also: https://www.gnu.org/software/libc/manual/html_node/Initializing-the-Shell.html
+
         take_control();
 
         unsafe {


### PR DESCRIPTION
# Description
Fixes a regression from #9681 where nushell will attempt to place itself into the background or take control of the terminal even in non-interactive mode.

Using the same [reference](https://www.gnu.org/software/libc/manual/html_node/Initializing-the-Shell.html) from #6584:

>A subshell that runs *interactively* has to ensure that it has been placed in the foreground...

>A subshell that runs *non-interactively* cannot and should not support job control.

`fish` [code](https://github.com/fish-shell/fish-shell/blob/54fa1ad6ec7adb0d9c14076843ef5e51c18ecc7a/src/reader.cpp#L4862) also seems to follow this.

This *partially* fixes [9026](https://github.com/nushell/nushell/issues/9026). That is, nushell will no longer set the foreground process group in non-interactive mode.
