### PR TITLE
fix input signature of let/mut

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -17,7 +17,7 @@ impl Command for Let {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("let")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Any, Type::Nothing)])
             .allow_variants_without_examples(true)
             .required("var_name", SyntaxShape::VarWithOptType, "variable name")
             .required(

--- a/crates/nu-cmd-lang/src/core_commands/mut_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/mut_.rs
@@ -17,7 +17,7 @@ impl Command for Mut {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("mut")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Any, Type::Nothing)])
             .allow_variants_without_examples(true)
             .required("var_name", SyntaxShape::VarWithOptType, "variable name")
             .required(

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -623,3 +623,35 @@ fn def_with_input_output_broken_1() -> TestResult {
 fn def_with_input_output_broken_2() -> TestResult {
     fail_test(r#"def foo []: int -> { 3 }"#, "expected type")
 }
+
+#[test]
+fn def_with_in_var_let_1() -> TestResult {
+    run_test(
+        r#"def foo []: [int -> int, string -> int] { let x = $in; if ($x | describe) == "int" { 3 } else { 4 } }; "100" | foo"#,
+        "4",
+    )
+}
+
+#[test]
+fn def_with_in_var_let_2() -> TestResult {
+    run_test(
+        r#"def foo []: [int -> int, string -> int] { let x = $in; if ($x | describe) == "int" { 3 } else { 4 } }; 100 | foo"#,
+        "3",
+    )
+}
+
+#[test]
+fn def_with_in_var_mut_1() -> TestResult {
+    run_test(
+        r#"def foo []: [int -> int, string -> int] { mut x = $in; if ($x | describe) == "int" { 3 } else { 4 } }; "100" | foo"#,
+        "4",
+    )
+}
+
+#[test]
+fn def_with_in_var_mut_2() -> TestResult {
+    run_test(
+        r#"def foo []: [int -> int, string -> int] { mut x = $in; if ($x | describe) == "int" { 3 } else { 4 } }; 100 | foo"#,
+        "3",
+    )
+}


### PR DESCRIPTION
# Description

This updates `let` and `mut` to allow for any input. This lets them typecheck any collection they do.

For example, this now compiles:

```
def foo []: [int -> int, string -> int] {
  let x = $in
  if ($x | describe) == "int" { 3 } else { 4 }
}

100 | foo
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
