### PR TITLE
add `nothing -> any` to the input / output types of `return`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -19,7 +19,10 @@ impl Command for Return {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("return")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::Nothing, Type::Any),
+            ])
             .optional("return_value", SyntaxShape::Any, "optional value to return")
             .category(Category::Core)
     }

--- a/crates/nu-command/tests/commands/return_.rs
+++ b/crates/nu-command/tests/commands/return_.rs
@@ -1,37 +1,24 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn early_return_if_true() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        def foo [x] { if true { return 2 }; $x }; foo 100
-        "#
-    ));
+    let actual = nu!("def foo [x] { if true { return 2 }; $x }; foo 100");
 
-    assert_eq!(actual.out, r#"2"#);
+    assert_eq!(actual.out, "2");
 }
 
 #[test]
 fn early_return_if_false() {
-    let actual = nu!(
-        cwd: ".", pipeline(
-        r#"
-        def foo [x] { if false { return 2 }; $x }; foo 100
-        "#
-    ));
+    let actual = nu!("def foo [x] { if false { return 2 }; $x }; foo 100");
 
-    assert_eq!(actual.out, r#"100"#);
+    assert_eq!(actual.out, "100");
 }
 
 #[test]
 fn return_works_in_script_without_def_main() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            nu early_return.nu
-        "#
-    ));
+        cwd: "tests/fixtures/formats", "nu early_return.nu"
+    );
 
     assert!(actual.err.is_empty());
 }

--- a/crates/nu-command/tests/commands/return_.rs
+++ b/crates/nu-command/tests/commands/return_.rs
@@ -22,3 +22,10 @@ fn return_works_in_script_without_def_main() {
 
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn return_with_type_annotation() {
+    let actual = nu!("def f [x: int]: any -> int { return (2 * $x) }; f 10");
+
+    assert_eq!(actual.out, "20");
+}


### PR DESCRIPTION
this should close https://github.com/nushell/nushell/issues/9697

# Description
this PR allows to write something like
```nushell
def f [x: int]: any -> int { return (2 * $x) }
```
without having a parser error like
```nushell
Error: nu::parser::output_type_mismatch

  × Command output doesn't match int.
   ╭─[entry #13:1:1]
 1 │ def f [x: int]: any -> int { return (2 * $x) }
   ·                              ───────┬───────
   ·                                     ╰── command doesn't output int
   ╰────
```
by adding `nothing -> any` to the input output types of `return`.

this PR also adds a test to make sure the feature keeps working in the futute :ok_hand: 

> **Note**  
> this PR also removes some useless `cwd` and `pipeline` calls the `nu!` calls of the tests for `return` as part of https://github.com/nushell/nushell/issues/8670.
> there might be a slight clash with [#9692](https://github.com/nushell/nushell/pull/9692/files#diff-c06902e36726dcac43ea731406e02b16ed77148be6c26f203e7d4eb7d220c372) => i've also removed useless `r#"..."#`

# User-Facing Changes

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting