### PR TITLE
allow `into filesize` to take tables as input / output

### DIFF
--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -64,31 +64,31 @@ impl Command for SubCommand {
                             vals: vec![
                                 Value::String {
                                     val: "/dev/sda1".to_string(),
-                                    span: Span::unknown(),
+                                    span: Span::test_data(),
                                 },
                                 Value::Filesize {
                                     val: 200,
-                                    span: Span::unknown(),
+                                    span: Span::test_data(),
                                 },
                             ],
-                            span: Span::unknown(),
+                            span: Span::test_data(),
                         },
                         Value::Record {
                             cols: vec!["device".to_string(), "size".to_string()],
                             vals: vec![
                                 Value::String {
                                     val: "/dev/sda2".to_string(),
-                                    span: Span::unknown(),
+                                    span: Span::test_data(),
                                 },
                                 Value::Filesize {
                                     val: 50,
-                                    span: Span::unknown(),
+                                    span: Span::test_data(),
                                 },
                             ],
-                            span: Span::unknown(),
+                            span: Span::test_data(),
                         },
                     ],
-                    span: Span::unknown(),
+                    span: Span::test_data(),
                 }),
             },
             Example {

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -22,7 +22,6 @@ impl Command for SubCommand {
                 (Type::String, Type::Filesize),
                 (Type::Filesize, Type::Filesize),
                 (Type::Table(vec![]), Type::Table(vec![])),
-                (Type::List(Box::new(Type::Any)), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
             .rest(
@@ -57,39 +56,35 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "Convert string to filesize in table",
-                example: "[[bytes]; ['5'] [3.2] [4] [2kb]] | into filesize bytes",
+                example: r#"[[device size]; ["/dev/sda1" "200"] ["/dev/loop0" "50"]] | into filesize size"#,
                 result: Some(Value::List {
                     vals: vec![
                         Value::Record {
-                            cols: vec!["bytes".to_string()],
-                            vals: vec![Value::Filesize {
-                                val: 5,
-                                span: Span::unknown(),
-                            }],
+                            cols: vec!["device".to_string(), "size".to_string()],
+                            vals: vec![
+                                Value::String {
+                                    val: "/dev/sda1".to_string(),
+                                    span: Span::unknown(),
+                                },
+                                Value::Filesize {
+                                    val: 200,
+                                    span: Span::unknown(),
+                                },
+                            ],
                             span: Span::unknown(),
                         },
                         Value::Record {
-                            cols: vec!["bytes".to_string()],
-                            vals: vec![Value::Filesize {
-                                val: 3,
-                                span: Span::unknown(),
-                            }],
-                            span: Span::unknown(),
-                        },
-                        Value::Record {
-                            cols: vec!["bytes".to_string()],
-                            vals: vec![Value::Filesize {
-                                val: 4,
-                                span: Span::unknown(),
-                            }],
-                            span: Span::unknown(),
-                        },
-                        Value::Record {
-                            cols: vec!["bytes".to_string()],
-                            vals: vec![Value::Filesize {
-                                val: 2000,
-                                span: Span::unknown(),
-                            }],
+                            cols: vec!["device".to_string(), "size".to_string()],
+                            vals: vec![
+                                Value::String {
+                                    val: "/dev/sda2".to_string(),
+                                    span: Span::unknown(),
+                                },
+                                Value::Filesize {
+                                    val: 50,
+                                    span: Span::unknown(),
+                                },
+                            ],
                             span: Span::unknown(),
                         },
                     ],

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -23,6 +23,7 @@ impl Command for SubCommand {
                 (Type::Filesize, Type::Filesize),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .vectorizes_over_list(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -22,6 +22,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Filesize),
                 (Type::Filesize, Type::Filesize),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::List(Box::new(Type::Any)), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
             .rest(

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -21,6 +21,7 @@ impl Command for SubCommand {
                 (Type::Number, Type::Filesize),
                 (Type::String, Type::Filesize),
                 (Type::Filesize, Type::Filesize),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .rest(
                 "rest",

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -56,7 +56,43 @@ impl Command for SubCommand {
             Example {
                 description: "Convert string to filesize in table",
                 example: "[[bytes]; ['5'] [3.2] [4] [2kb]] | into filesize bytes",
-                result: None,
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::Record {
+                            cols: vec!["bytes".to_string()],
+                            vals: vec![Value::Filesize {
+                                val: 5,
+                                span: Span::unknown(),
+                            }],
+                            span: Span::unknown(),
+                        },
+                        Value::Record {
+                            cols: vec!["bytes".to_string()],
+                            vals: vec![Value::Filesize {
+                                val: 3,
+                                span: Span::unknown(),
+                            }],
+                            span: Span::unknown(),
+                        },
+                        Value::Record {
+                            cols: vec!["bytes".to_string()],
+                            vals: vec![Value::Filesize {
+                                val: 4,
+                                span: Span::unknown(),
+                            }],
+                            span: Span::unknown(),
+                        },
+                        Value::Record {
+                            cols: vec!["bytes".to_string()],
+                            vals: vec![Value::Filesize {
+                                val: 2000,
+                                span: Span::unknown(),
+                            }],
+                            span: Span::unknown(),
+                        },
+                    ],
+                    span: Span::unknown(),
+                }),
             },
             Example {
                 description: "Convert string to filesize",

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -77,7 +77,7 @@ impl Command for SubCommand {
                             cols: vec!["device".to_string(), "size".to_string()],
                             vals: vec![
                                 Value::String {
-                                    val: "/dev/sda2".to_string(),
+                                    val: "/dev/loop0".to_string(),
                                     span: Span::test_data(),
                                 },
                                 Value::Filesize {


### PR DESCRIPTION
# Description
i have the following command that should give a table of all the mounted devices with information about their sizes, etc, etc... a glorified output for the `df -h` command:
```nushell
def disk [] {
    df -h
      | str replace "Mounted on" "Mountpoint"
      | detect columns
      | rename filesystem size used avail used% mountpoint
      | into filesize size used avail
      | upsert used% {|it| 100 * (1 - $it.avail / $it.size)}
}
```

this should work given the first example of `into filesize`
```nushell
  Convert string to filesize in table
  > [[bytes]; ['5'] [3.2] [4] [2kb]] | into filesize bytes
```

## before this PR
it does not even parse
```nushell
Error: nu::parser::input_type_mismatch

  × Command does not support table input.
   ╭─[entry #1:5:1]
 5 │       | rename filesystem size used avail used% mountpoint
 6 │       | into filesize size used avail
   ·         ──────┬──────
   ·               ╰── command doesn't support table input
 7 │       | upsert used% {|it| 100 * (1 - $it.avail / $it.size)}
   ╰────
```

> **Note**
> this was working before the recent input / output type changes

## with this PR
it parses again and gives
```nushell
> disk | where mountpoint == "/" | into record
╭────────────┬───────────────────╮
│ filesystem │ /dev/sda2         │
│ size       │ 217.9 GiB         │
│ used       │ 158.3 GiB         │
│ avail      │ 48.4 GiB          │
│ used%      │ 77.77777777777779 │
│ mountpoint │ /                 │
╰────────────┴───────────────────╯
```

> **Note**
> the two following commands also work now and did not before the PR
> ```nushell
> ls | insert name_size {|it| $it.name | str length} | into filesize name_size
> ```
> ```nushell
> [[device size]; ["/dev/sda1" 200] ["/dev/loop0" 50]] | into filesize size
> ```

# User-Facing Changes
`into filesize` works back with tables and this effectively fixes the doc.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

this PR gives a `result` back to the first table example to make sure it works fine.

# After Submitting