### PR TITLE
allow range as a input_output_type on filter

### DIFF
--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -32,6 +32,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                     Type::List(Box::new(Type::Any)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Range, Type::List(Box::new(Type::Any))),
             ])
             .required(
                 "closure",

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -225,6 +225,14 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                     span: Span::test_data(),
                 }),
             },
+            Example {
+                description: "Filter items of a range according to a condition",
+                example: "9..13 | filter {|el| $el mod 2 != 0}",
+                result: Some(Value::List {
+                    vals: vec![Value::test_int(9), Value::test_int(11), Value::test_int(13)],
+                    span: Span::test_data(),
+                }),
+            },
             // TODO: This should work but does not. (Note that `Let` must be present in the working_set in `example_test.rs`).
             // See https://github.com/nushell/nushell/issues/7034
             // Example {


### PR DESCRIPTION
# Description

This PR allows `Type::Range` on the `filter` command so you can do things like this:
```nushell
❯ 9..17 | filter {|el| $el mod 2 != 0}
╭───┬────╮
│ 0 │  9 │
│ 1 │ 11 │
│ 2 │ 13 │
│ 3 │ 15 │
│ 4 │ 17 │
╰───┴────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
