### PR TITLE
add `table -> nothing` to `load-env`

### DIFF
--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -22,6 +22,7 @@ impl Command for LoadEnv {
             .input_output_types(vec![
                 (Type::Record(vec![]), Type::Nothing),
                 (Type::Nothing, Type::Nothing),
+                (Type::Table(vec![]), Type::Nothing),
             ])
             .allow_variants_without_examples(true)
             .optional(

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -104,6 +104,17 @@ impl Command for LoadEnv {
                 example: r#"load-env {NAME: ABE, AGE: UNKNOWN}; $env.NAME"#,
                 result: Some(Value::test_string("ABE")),
             },
+            Example {
+                description: "Start an SSH agent to store connection keys",
+                example: r#"ssh-agent -c
+        | lines
+        | first 2
+        | parse "setenv {name} {value};"
+        | transpose --header-row
+        | into record
+        | load-env"#,
+                result: None,
+            },
         ]
     }
 }


### PR DESCRIPTION
should close #9710

# Description
this PR adds the `table -> nothing` type to `load-env` and allow to write things like
```nushell
ssh-agent -c
    | lines
    | first 2
    | parse "setenv {name} {value};"
    | transpose -i -r -d
    | load-env
```
or
```nushell
ssh-agent -c
    | lines
    | first 2
    | parse "setenv {name} {value};"
    | transpose --header-row
    | into record
    | load-env
```
as advertised in the [cookbook of Nushell](https://www.nushell.sh/cookbook/misc.html#manage-ssh-passphrases) and as it used to work.

# User-Facing Changes
`load-env` can now work with the SSH agent example of the cookbook.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

i've added the SSH agent example from the cookbook as an example for `table -> nothing` in the examples of `load-env`.

# After Submitting