### PR TITLE
add missing `$.` in front of *cell paths* when displaying

### DIFF
--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -56,7 +56,7 @@ pub struct CellPath {
 
 impl CellPath {
     pub fn into_string(&self) -> String {
-        let mut output = String::new();
+        let mut output = String::from("$.");
 
         for (idx, elem) in self.members.iter().enumerate() {
             if idx > 0 {


### PR DESCRIPTION
related to a question and confusing in the Discord server:
- https://discord.com/channels/601130461678272522/601130461678272524/1130449527082602578

# Description
when printing a *cell path*, e.g. `$.foo.bar`, the output would lose the `$.`.
this PR adds it back to see we are dealing with a *cell path*.

# User-Facing Changes
```nushell
print $.foo.bar
```
will now give
```nushell
$.foo.bar
```
instead of the previous
```nushell
foo.bar
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting