### PR TITLE
Disallow empty record with empty key,value pairs on ini format

### DIFF
--- a/crates/nu_plugin_formats/src/from/ini.rs
+++ b/crates/nu_plugin_formats/src/from/ini.rs
@@ -24,7 +24,10 @@ pub fn from_ini_call(call: &EvaluatedCall, input: &Value) -> Result<Value, Label
                         sections.push(section_name.to_owned());
                     }
                     None => {
-                        sections.push(String::new());
+                        // Section (None) allows for key value pairs without a section
+                        if !properties.is_empty() {
+                            sections.push(String::new());
+                        }
                     }
                 }
 
@@ -38,11 +41,14 @@ pub fn from_ini_call(call: &EvaluatedCall, input: &Value) -> Result<Value, Label
                 }
 
                 // section with its key value pairs
-                sections_key_value_pairs.push(Value::Record {
-                    cols: keys_for_section,
-                    vals: values_for_section,
-                    span,
-                });
+                // Only add section if contains key,value pair
+                if !properties.is_empty() {
+                    sections_key_value_pairs.push(Value::Record {
+                        cols: keys_for_section,
+                        vals: values_for_section,
+                        span,
+                    });
+                }
             }
 
             // all sections with all its key value pairs

--- a/tests/plugins/formats/ini.rs
+++ b/tests/plugins/formats/ini.rs
@@ -10,10 +10,13 @@ fn parses_ini() {
     let actual = nu_with_plugins!(
         cwd: TEST_CWD,
         plugin: ("nu_plugin_formats"),
-        "open sample.ini | get SectionOne.integer"
+        "open sample.ini | to nuon -r"
     );
 
-    assert_eq!(actual.out, "1234")
+    assert_eq!(
+        actual.out,
+        r#"{SectionOne: {key: value, integer: "1234", real: "3.14", "string1": "Case 1", "string2": "Case 2"}, SectionTwo: {key: "new value", integer: "5678", real: "3.14", "string1": "Case 1", "string2": "Case 2", "string3": "Case 3"}}"#
+    )
 }
 
 #[test]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions
-->

# Description
This PR fixes #9556. Now, only a section will be added if it contains a key, value pair.  With this change, `{record with 0 fields}`, should not appear anymore.

For more context on empty sections, see issue on the [crate](https://github.com/zonyitoo/rust-ini/issues/109)

```
open -r whatever | from ini
╭─────────────┬──────────────────────────────────────────────────────────────╮
│             │ ╭───────────────────────┬──────────────────────────────────╮ │
│ placeholder │ │ aws_access_key_id     │ AAAAAAAAAAAAAAAAAAAAA            │ │
│             │ │ aws_secret_access_key │ BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB │ │
│             │ ╰───────────────────────┴──────────────────────────────────╯ │
│             │ ╭───────────────────────┬──────────────────────────╮         │
│ default     │ │ aws_access_key_id     │ AAAAAAAAAAAAAAAAAA       │         │
│             │ │ aws_secret_access_key │ AAAAAAAAAAAAAAAAAAAAAAA  │         │
│             │ │ aws_session_token     │ BBBBBBBBBBBBBBBBBBBBBBBB │         │
│             │ │ region                │ us-east-1                │         │
│             │ │ output                │ json                     │         │
│             │ ╰───────────────────────┴──────────────────────────╯         │
╰─────────────┴──────────────────────────────────────────────────────────────╯
```
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
- [X] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [X] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- [X] `cargo test --workspace` to check that all tests pass
- [X] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:


> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
