### PR TITLE
do not force the extension to be `.nu` in `nu-check`

### DIFF
--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -125,17 +125,6 @@ impl Command for NuCheck {
                     // get the expanded path as a string
                     let path_str = path.to_string_lossy().to_string();
 
-                    let ext: Vec<_> = path_str.rsplitn(2, '.').collect();
-                    if ext[0] != "nu" {
-                        return Err(ShellError::GenericError(
-                            "Cannot parse input".to_string(),
-                            "File extension must be the type of .nu".to_string(),
-                            Some(call.head),
-                            None,
-                            Vec::new(),
-                        ));
-                    }
-
                     // Change currently parsed directory
                     let prev_currently_parsed_cwd = if let Some(parent) = path.parent() {
                         let prev = working_set.currently_parsed_cwd.clone();

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -177,52 +177,6 @@ fn file_not_exist() {
 }
 
 #[test]
-fn parse_unsupported_file() {
-    Playground::setup("nu_check_test_8", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "foo.txt",
-            r#"
-                # foo.nu
-
-                export def hello [name: string {
-                    $"hello ($name)!"
-                }
-
-                export def hi [where: string] {
-                    $"hi ($where)!"
-                }
-            "#,
-        )]);
-
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                nu-check --as-module foo.txt
-            "#
-        ));
-
-        assert!(actual
-            .err
-            .contains("File extension must be the type of .nu"));
-    })
-}
-#[test]
-fn parse_dir_failure() {
-    Playground::setup("nu_check_test_9", |dirs, _sandbox| {
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                nu-check --as-module ~
-            "#
-        ));
-
-        assert!(actual
-            .err
-            .contains("File extension must be the type of .nu"));
-    })
-}
-
-#[test]
 fn parse_module_success_2() {
     Playground::setup("nu_check_test_10", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(


### PR DESCRIPTION
# Description
i have some scripts that do not have the `.nu` extension, but have a shebang for instance.
as they still are Nushell scripts, i think we should be able to `nu-check` them :yum: 

however, i get the following error :thinking: 
```nushell
> nu-check my-script
Error:   × Cannot parse input
   ╭─[entry #1:1:1]
 1 │ nu-check my-script
   · ────┬───
   ·     ╰── File extension must be the type of .nu
   ╰────
```

in this PR, i propose to relax a bit this file extension check :blush: 

# User-Facing Changes
users can now check Nushell scripts that do not have the `.nu` extension.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

this PR removes the new useless `parse_unsupported_file` and `parse_dir_failure` tests.

# After Submitting