### PR TITLE
Remove underused devdep `getset`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,18 +1466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "gimli"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2967,7 +2955,6 @@ dependencies = [
 name = "nu-test-support"
 version = "0.82.1"
 dependencies = [
- "getset",
  "hamcrest2",
  "nu-glob",
  "nu-path",
@@ -3966,30 +3953,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df593470e3ef502e48cb0cfc9a3a61e5f61e967b78e1ed35a67ac615cfbd208"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -18,6 +18,5 @@ nu-utils = { path="../nu-utils", version = "0.82.1"  }
 
 num-format = "0.4"
 which = "4.3"
-getset = "0.1"
 tempfile = "3.2"
 hamcrest2 = "0.3"

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -49,7 +49,7 @@ impl Dirs {
     pub fn root(&self) -> &PathBuf {
         &self.root
     }
-    
+
     pub fn test(&self) -> &PathBuf {
         &self.test
     }

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -1,7 +1,6 @@
 use super::Director;
 use crate::fs;
 use crate::fs::Stub;
-use getset::Getters;
 use nu_glob::glob;
 use std::path::{Path, PathBuf};
 use std::str;
@@ -31,8 +30,7 @@ pub struct Playground<'a> {
     dirs: &'a Dirs,
 }
 
-#[derive(Default, Getters, Clone)]
-#[get = "pub"]
+#[derive(Default, Clone)]
 pub struct Dirs {
     pub root: PathBuf,
     pub test: PathBuf,
@@ -46,6 +44,14 @@ impl Dirs {
 
     pub fn config_fixtures(&self) -> PathBuf {
         self.fixtures.join("playground/config")
+    }
+
+    pub fn root(&self) -> &PathBuf {
+        &self.root
+    }
+    
+    pub fn test(&self) -> &PathBuf {
+        &self.test
     }
 }
 


### PR DESCRIPTION
# Description
We only used this procmacro crate in one place to generate two trivial
getters. Straightforward to replace. Should reduce test-compilation
requirements a bit.

# User-Facing Changes
None
