### PR TITLE
nushell should be non-interactive if `--testbin` is supplied

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,9 @@ fn main() -> Result<()> {
 
     // keep this condition in sync with the branches at the end
     engine_state.is_interactive = parsed_nu_cli_args.interactive_shell.is_some()
-        || (parsed_nu_cli_args.commands.is_none() && script_name.is_empty());
+        || (parsed_nu_cli_args.testbin.is_none()
+            && parsed_nu_cli_args.commands.is_none()
+            && script_name.is_empty());
 
     engine_state.is_login = parsed_nu_cli_args.login_shell.is_some();
 


### PR DESCRIPTION
# Description
After #9693, tests will stop and go into the background if run locally in bash, since nushell is being run in interactive mode even though `--testbin` is supplied. This makes nushell run in non-interactive mode if `--testbin` is supplied.