### PR TITLE
normalize default_config/env formatting

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -176,7 +176,7 @@ let light_theme = {
 
 # External completer example
 # let carapace_completer = {|spans|
-#         carapace $spans.0 nushell $spans | from json
+#     carapace $spans.0 nushell $spans | from json
 # }
 
 
@@ -213,7 +213,7 @@ $env.config = {
     # showing something like "a day ago."
     datetime_format: {
         # normal: '%a, %d %b %Y %H:%M:%S %z'    # shows up in displays of variables or other datetime's outside of tables
-        # table: '%m/%d/%y %I:%M:%S%p'                # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
+        # table: '%m/%d/%y %I:%M:%S%p'          # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
     }
 
     explore: {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -7,108 +7,23 @@
 # And here is the theme collection
 # https://github.com/nushell/nu_scripts/tree/main/themes
 let dark_theme = {
-    # color for nushell primitives
-    separator: white
-    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
-    header: green_bold
-    empty: blue
-    # Closures can be used to choose colors for specific values.
-    # The value (in this case, a bool) is piped into the closure.
-    bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
-    int: white
-    filesize: {|e|
-      if $e == 0b {
-        'white'
-      } else if $e < 1mb {
-        'cyan'
-      } else { 'blue' }
-    }
-    duration: white
-    date: {|| (date now) - $in |
-      if $in < 1hr {
-        'purple'
-      } else if $in < 6hr {
-        'red'
-      } else if $in < 1day {
-        'yellow'
-      } else if $in < 3day {
-        'green'
-      } else if $in < 1wk {
-        'light_green'
-      } else if $in < 6wk {
-        'cyan'
-      } else if $in < 52wk {
-        'blue'
-      } else { 'dark_gray' }
-    }
-    range: white
-    float: white
-    string: white
-    nothing: white
-    binary: white
-    cellpath: white
-    row_index: green_bold
-    record: white
-    list: white
-    block: white
-    hints: dark_gray
-    search_result: {bg: red fg: white}
-
-    shape_and: purple_bold
-    shape_binary: purple_bold
-    shape_block: blue_bold
-    shape_bool: light_cyan
-    shape_closure: green_bold
-    shape_custom: green
-    shape_datetime: cyan_bold
-    shape_directory: cyan
-    shape_external: cyan
-    shape_externalarg: green_bold
-    shape_filepath: cyan
-    shape_flag: blue_bold
-    shape_float: purple_bold
-    # shapes are used to change the cli syntax highlighting
-    shape_garbage: { fg: white bg: red attr: b}
-    shape_globpattern: cyan_bold
-    shape_int: purple_bold
-    shape_internalcall: cyan_bold
-    shape_list: cyan_bold
-    shape_literal: blue
-    shape_match_pattern: green
-    shape_matching_brackets: { attr: u }
-    shape_nothing: light_cyan
-    shape_operator: yellow
-    shape_or: purple_bold
-    shape_pipe: purple_bold
-    shape_range: yellow_bold
-    shape_record: cyan_bold
-    shape_redirection: purple_bold
-    shape_signature: green_bold
-    shape_string: green
-    shape_string_interpolation: cyan_bold
-    shape_table: blue_bold
-    shape_variable: purple
-    shape_vardecl: purple
-}
-
-let light_theme = {
-    # color for nushell primitives
-    separator: dark_gray
-    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
-    header: green_bold
-    empty: blue
-    # Closures can be used to choose colors for specific values.
-    # The value (in this case, a bool) is piped into the closure.
-    bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
-    int: dark_gray
-    filesize: {|e|
-      if $e == 0b {
-        'dark_gray'
-      } else if $e < 1mb {
-        'cyan_bold'
-      } else { 'blue_bold' }
-    }
-    duration: dark_gray
+  # color for nushell primitives
+  separator: white
+  leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+  header: green_bold
+  empty: blue
+  # Closures can be used to choose colors for specific values.
+  # The value (in this case, a bool) is piped into the closure.
+  bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
+  int: white
+  filesize: {|e|
+    if $e == 0b {
+      'white'
+    } else if $e < 1mb {
+      'cyan'
+    } else { 'blue' }
+  }
+  duration: white
   date: {|| (date now) - $in |
     if $in < 1hr {
       'purple'
@@ -126,54 +41,137 @@ let light_theme = {
       'blue'
     } else { 'dark_gray' }
   }
-    range: dark_gray
-    float: dark_gray
-    string: dark_gray
-    nothing: dark_gray
-    binary: dark_gray
-    cellpath: dark_gray
-    row_index: green_bold
-    record: white
-    list: white
-    block: white
-    hints: dark_gray
-    search_result: {fg: white bg: red}
+  range: white
+  float: white
+  string: white
+  nothing: white
+  binary: white
+  cellpath: white
+  row_index: green_bold
+  record: white
+  list: white
+  block: white
+  hints: dark_gray
+  search_result: {bg: red fg: white}  
+  shape_and: purple_bold
+  shape_binary: purple_bold
+  shape_block: blue_bold
+  shape_bool: light_cyan
+  shape_closure: green_bold
+  shape_custom: green
+  shape_datetime: cyan_bold
+  shape_directory: cyan
+  shape_external: cyan
+  shape_externalarg: green_bold
+  shape_filepath: cyan
+  shape_flag: blue_bold
+  shape_float: purple_bold
+  # shapes are used to change the cli syntax highlighting
+  shape_garbage: { fg: white bg: red attr: b}
+  shape_globpattern: cyan_bold
+  shape_int: purple_bold
+  shape_internalcall: cyan_bold
+  shape_list: cyan_bold
+  shape_literal: blue
+  shape_match_pattern: green
+  shape_matching_brackets: { attr: u }
+  shape_nothing: light_cyan
+  shape_operator: yellow
+  shape_or: purple_bold
+  shape_pipe: purple_bold
+  shape_range: yellow_bold
+  shape_record: cyan_bold
+  shape_redirection: purple_bold
+  shape_signature: green_bold
+  shape_string: green
+  shape_string_interpolation: cyan_bold
+  shape_table: blue_bold
+  shape_variable: purple
+  shape_vardecl: purple
+}
 
-    shape_and: purple_bold
-    shape_binary: purple_bold
-    shape_block: blue_bold
-    shape_bool: light_cyan
-    shape_closure: green_bold
-    shape_custom: green
-    shape_datetime: cyan_bold
-    shape_directory: cyan
-    shape_external: cyan
-    shape_externalarg: green_bold
-    shape_filepath: cyan
-    shape_flag: blue_bold
-    shape_float: purple_bold
-    # shapes are used to change the cli syntax highlighting
-    shape_garbage: { fg: white bg: red attr: b}
-    shape_globpattern: cyan_bold
-    shape_int: purple_bold
-    shape_internalcall: cyan_bold
-    shape_list: cyan_bold
-    shape_literal: blue
-    shape_match_pattern: green
-    shape_matching_brackets: { attr: u }
-    shape_nothing: light_cyan
-    shape_operator: yellow
-    shape_or: purple_bold
-    shape_pipe: purple_bold
-    shape_range: yellow_bold
-    shape_record: cyan_bold
-    shape_redirection: purple_bold
-    shape_signature: green_bold
-    shape_string: green
-    shape_string_interpolation: cyan_bold
-    shape_table: blue_bold
-    shape_variable: purple
-    shape_vardecl: purple
+let light_theme = {
+  # color for nushell primitives
+  separator: dark_gray
+  leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+  header: green_bold
+  empty: blue
+  # Closures can be used to choose colors for specific values.
+  # The value (in this case, a bool) is piped into the closure.
+  bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
+  int: dark_gray
+  filesize: {|e|
+    if $e == 0b {
+      'dark_gray'
+    } else if $e < 1mb {
+      'cyan_bold'
+    } else { 'blue_bold' }
+  }
+  duration: dark_gray
+  date: {|| (date now) - $in |
+    if $in < 1hr {
+      'purple'
+    } else if $in < 6hr {
+      'red'
+    } else if $in < 1day {
+      'yellow'
+    } else if $in < 3day {
+      'green'
+    } else if $in < 1wk {
+      'light_green'
+    } else if $in < 6wk {
+      'cyan'
+    } else if $in < 52wk {
+      'blue'
+    } else { 'dark_gray' }
+  }
+  range: dark_gray
+  float: dark_gray
+  string: dark_gray
+  nothing: dark_gray
+  binary: dark_gray
+  cellpath: dark_gray
+  row_index: green_bold
+  record: white
+  list: white
+  block: white
+  hints: dark_gray
+  search_result: {fg: white bg: red}  
+  shape_and: purple_bold
+  shape_binary: purple_bold
+  shape_block: blue_bold
+  shape_bool: light_cyan
+  shape_closure: green_bold
+  shape_custom: green
+  shape_datetime: cyan_bold
+  shape_directory: cyan
+  shape_external: cyan
+  shape_externalarg: green_bold
+  shape_filepath: cyan
+  shape_flag: blue_bold
+  shape_float: purple_bold
+  # shapes are used to change the cli syntax highlighting
+  shape_garbage: { fg: white bg: red attr: b}
+  shape_globpattern: cyan_bold
+  shape_int: purple_bold
+  shape_internalcall: cyan_bold
+  shape_list: cyan_bold
+  shape_literal: blue
+  shape_match_pattern: green
+  shape_matching_brackets: { attr: u }
+  shape_nothing: light_cyan
+  shape_operator: yellow
+  shape_or: purple_bold
+  shape_pipe: purple_bold
+  shape_range: yellow_bold
+  shape_record: cyan_bold
+  shape_redirection: purple_bold
+  shape_signature: green_bold
+  shape_string: green
+  shape_string_interpolation: cyan_bold
+  shape_table: blue_bold
+  shape_variable: purple
+  shape_vardecl: purple
 }
 
 # External completer example
@@ -220,30 +218,30 @@ $env.config = {
 
   explore: {
     try: {
-        border_color: {fg: "white"}
+      border_color: {fg: "white"}
     },
     status_bar_background: {fg: "#1D1F21", bg: "#C4C9C6"},
     command_bar_text: {fg: "#C4C9C6"},
     highlight: {fg: "black", bg: "yellow"},
     status: {
-        error: {fg: "white", bg: "red"},
-        warn: {}
-        info: {}
+      error: {fg: "white", bg: "red"},
+      warn: {}
+      info: {}
     },
     table: {
-        split_line: {fg: "#404040"},
-        selected_cell: {},
-        selected_row: {},
-        selected_column: {},
-        cursor: true,
-        line_head_top: true,
-        line_head_bottom: true,
-        line_shift: true,
-        line_index: true,
+      split_line: {fg: "#404040"},
+      selected_cell: {},
+      selected_row: {},
+      selected_column: {},
+      cursor: true,
+      line_head_top: true,
+      line_head_bottom: true,
+      line_shift: true,
+      line_index: true,
     },
     config: {
-        border_color: {fg: "white"}
-        cursor_color: {fg: "black", bg: "light_yellow"}
+      border_color: {fg: "white"}
+      cursor_color: {fg: "black", bg: "light_yellow"}
     },
   }
 
@@ -299,56 +297,56 @@ $env.config = {
   }
 
   menus: [
-      # Configuration for default nushell menus
-      # Note the lack of source parameter
-      {
-        name: completion_menu
-        only_buffer_difference: false
-        marker: "| "
-        type: {
-            layout: columnar
-            columns: 4
-            col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-            col_padding: 2
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
+    # Configuration for default nushell menus
+    # Note the lack of source parameter
+    {
+      name: completion_menu
+      only_buffer_difference: false
+      marker: "| "
+      type: {
+        layout: columnar
+        columns: 4
+        col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
+        col_padding: 2
       }
-      {
-        name: history_menu
-        only_buffer_difference: true
-        marker: "? "
-        type: {
-            layout: list
-            page_size: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
+      style: {
+        text: green
+        selected_text: green_reverse
+        description_text: yellow
       }
-      {
-        name: help_menu
-        only_buffer_difference: true
-        marker: "? "
-        type: {
-            layout: description
-            columns: 4
-            col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-            col_padding: 2
-            selection_rows: 4
-            description_rows: 10
-        }
-        style: {
-            text: green
-            selected_text: green_reverse
-            description_text: yellow
-        }
+    }
+    {
+      name: history_menu
+      only_buffer_difference: true
+      marker: "? "
+      type: {
+        layout: list
+        page_size: 10
       }
+      style: {
+        text: green
+        selected_text: green_reverse
+        description_text: yellow
+      }
+    }
+    {
+      name: help_menu
+      only_buffer_difference: true
+      marker: "? "
+      type: {
+        layout: description
+        columns: 4
+        col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
+        col_padding: 2
+        selection_rows: 4
+        description_rows: 10
+      }
+      style: {
+        text: green
+        selected_text: green_reverse
+        description_text: yellow
+      }
+    }
   ]
 
   keybindings: [
@@ -402,9 +400,8 @@ $env.config = {
           { send: menupageprevious }
           { edit: undo }
         ]
-       }
+      }
     }
-
     {
       name: escape
       modifier: none
@@ -447,7 +444,6 @@ $env.config = {
       mode: [emacs, vi_normal, vi_insert]
       event: { send: openeditor }
     }
-
     {
       name: move_up
       modifier: none
@@ -511,8 +507,8 @@ $env.config = {
       mode: [emacs, vi_normal, vi_insert]
       event: {
         until: [
-            {send: historyhintwordcomplete}
-            {edit: movewordright}
+          {send: historyhintwordcomplete}
+          {edit: movewordright}
         ]
       }
     }
@@ -537,8 +533,8 @@ $env.config = {
       mode: [emacs, vi_normal, vi_insert]
       event: {
         until: [
-            {send: historyhintcomplete}
-            {edit: movetolineend}
+          {send: historyhintcomplete}
+          {edit: movetolineend}
         ]
       }
     }
@@ -549,8 +545,8 @@ $env.config = {
       mode: [emacs, vi_normal, vi_insert]
       event: {
         until: [
-            {send: historyhintcomplete}
-            {edit: movetolineend}
+          {send: historyhintcomplete}
+          {edit: movetolineend}
         ]
       }
     }
@@ -575,8 +571,8 @@ $env.config = {
       mode: [emacs, vi_normal, vi_insert]
       event: {
         until: [
-            {send: menuup}
-            {send: up}
+          {send: menuup}
+          {send: up}
         ]
       }
     }
@@ -587,230 +583,227 @@ $env.config = {
       mode: [emacs, vi_normal, vi_insert]
       event: {
         until: [
-            {send: menudown}
-            {send: down}
+          {send: menudown}
+          {send: down}
         ]
       }
     }
-
     {
-        name: delete_one_character_backward
-        modifier: none
-        keycode: backspace
-        mode: [emacs, vi_insert]
-        event: {edit: backspace}
+      name: delete_one_character_backward
+      modifier: none
+      keycode: backspace
+      mode: [emacs, vi_insert]
+      event: {edit: backspace}
     }
     {
-        name: delete_one_word_backward
-        modifier: control
-        keycode: backspace
-        mode: [emacs, vi_insert]
-        event: {edit: backspaceword}
+      name: delete_one_word_backward
+      modifier: control
+      keycode: backspace
+      mode: [emacs, vi_insert]
+      event: {edit: backspaceword}
     }
     {
-        name: delete_one_character_forward
-        modifier: none
-        keycode: delete
-        mode: [emacs, vi_insert]
-        event: {edit: delete}
+      name: delete_one_character_forward
+      modifier: none
+      keycode: delete
+      mode: [emacs, vi_insert]
+      event: {edit: delete}
     }
     {
-        name: delete_one_character_forward
-        modifier: control
-        keycode: delete
-        mode: [emacs, vi_insert]
-        event: {edit: delete}
+      name: delete_one_character_forward
+      modifier: control
+      keycode: delete
+      mode: [emacs, vi_insert]
+      event: {edit: delete}
     }
     {
-        name: delete_one_character_forward
-        modifier: control
-        keycode: char_h
-        mode: [emacs, vi_insert]
-        event: {edit: backspace}
+      name: delete_one_character_forward
+      modifier: control
+      keycode: char_h
+      mode: [emacs, vi_insert]
+      event: {edit: backspace}
     }
     {
-        name: delete_one_word_backward
-        modifier: control
-        keycode: char_w
-        mode: [emacs, vi_insert]
-        event: {edit: backspaceword}
-    }
-
-    {
-        name: move_left
-        modifier: none
-        keycode: backspace
-        mode: vi_normal
-        event: {edit: moveleft}
-    }
-
-    {
-        name: newline_or_run_command
-        modifier: none
-        keycode: enter
-        mode: emacs
-        event: {send: enter}
+      name: delete_one_word_backward
+      modifier: control
+      keycode: char_w
+      mode: [emacs, vi_insert]
+      event: {edit: backspaceword}
     }
     {
-        name: move_left
-        modifier: control
-        keycode: char_b
-        mode: emacs
-        event: {
-            until: [
-                {send: menuleft}
-                {send: left}
-            ]
-        }
+      name: move_left
+      modifier: none
+      keycode: backspace
+      mode: vi_normal
+      event: {edit: moveleft}
     }
     {
-        name: move_right_or_take_history_hint
-        modifier: control
-        keycode: char_f
-        mode: emacs
-        event: {
-            until: [
-                {send: historyhintcomplete}
-                {send: menuright}
-                {send: right}
-            ]
-        }
+      name: newline_or_run_command
+      modifier: none
+      keycode: enter
+      mode: emacs
+      event: {send: enter}
     }
     {
-        name: redo_change
-        modifier: control
-        keycode: char_g
-        mode: emacs
-        event: {edit: redo}
+      name: move_left
+      modifier: control
+      keycode: char_b
+      mode: emacs
+      event: {
+        until: [
+          {send: menuleft}
+          {send: left}
+        ]
+      }
     }
     {
-        name: undo_change
-        modifier: control
-        keycode: char_z
-        mode: emacs
-        event: {edit: undo}
+      name: move_right_or_take_history_hint
+      modifier: control
+      keycode: char_f
+      mode: emacs
+      event: {
+        until: [
+          {send: historyhintcomplete}
+          {send: menuright}
+          {send: right}
+        ]
+      }
     }
     {
-        name: paste_before
-        modifier: control
-        keycode: char_y
-        mode: emacs
-        event: {edit: pastecutbufferbefore}
+      name: redo_change
+      modifier: control
+      keycode: char_g
+      mode: emacs
+      event: {edit: redo}
     }
     {
-        name: cut_word_left
-        modifier: control
-        keycode: char_w
-        mode: emacs
-        event: {edit: cutwordleft}
+      name: undo_change
+      modifier: control
+      keycode: char_z
+      mode: emacs
+      event: {edit: undo}
     }
     {
-        name: cut_line_to_end
-        modifier: control
-        keycode: char_k
-        mode: emacs
-        event: {edit: cuttoend}
+      name: paste_before
+      modifier: control
+      keycode: char_y
+      mode: emacs
+      event: {edit: pastecutbufferbefore}
     }
     {
-        name: cut_line_from_start
-        modifier: control
-        keycode: char_u
-        mode: emacs
-        event: {edit: cutfromstart}
+      name: cut_word_left
+      modifier: control
+      keycode: char_w
+      mode: emacs
+      event: {edit: cutwordleft}
     }
     {
-        name: swap_graphemes
-        modifier: control
-        keycode: char_t
-        mode: emacs
-        event: {edit: swapgraphemes}
+      name: cut_line_to_end
+      modifier: control
+      keycode: char_k
+      mode: emacs
+      event: {edit: cuttoend}
     }
     {
-        name: move_one_word_left
-        modifier: alt
-        keycode: left
-        mode: emacs
-        event: {edit: movewordleft}
+      name: cut_line_from_start
+      modifier: control
+      keycode: char_u
+      mode: emacs
+      event: {edit: cutfromstart}
     }
     {
-        name: move_one_word_right_or_take_history_hint
-        modifier: alt
-        keycode: right
-        mode: emacs
-        event: {
-            until: [
-                {send: historyhintwordcomplete}
-                {send: movewordright}
-            ]
-        }
+      name: swap_graphemes
+      modifier: control
+      keycode: char_t
+      mode: emacs
+      event: {edit: swapgraphemes}
     }
     {
-        name: move_one_word_left
-        modifier: alt
-        keycode: char_b
-        mode: emacs
-        event: {edit: movewordleft}
+      name: move_one_word_left
+      modifier: alt
+      keycode: left
+      mode: emacs
+      event: {edit: movewordleft}
     }
     {
-        name: move_one_word_right_or_take_history_hint
-        modifier: alt
-        keycode: char_f
-        mode: emacs
-        event: {
-            until: [
-                {send: historyhintwordcomplete}
-                {send: movewordright}
-            ]
-        }
+      name: move_one_word_right_or_take_history_hint
+      modifier: alt
+      keycode: right
+      mode: emacs
+      event: {
+        until: [
+          {send: historyhintwordcomplete}
+          {send: movewordright}
+        ]
+      }
     }
     {
-        name: delete_one_word_forward
-        modifier: alt
-        keycode: delete
-        mode: emacs
-        event: {edit: deleteword}
+      name: move_one_word_left
+      modifier: alt
+      keycode: char_b
+      mode: emacs
+      event: {edit: movewordleft}
     }
     {
-        name: delete_one_word_backward
-        modifier: alt
-        keycode: backspace
-        mode: emacs
-        event: {edit: backspaceword}
+      name: move_one_word_right_or_take_history_hint
+      modifier: alt
+      keycode: char_f
+      mode: emacs
+      event: {
+        until: [
+          {send: historyhintwordcomplete}
+          {send: movewordright}
+        ]
+      }
     }
     {
-        name: delete_one_word_backward
-        modifier: alt
-        keycode: char_m
-        mode: emacs
-        event: {edit: backspaceword}
+      name: delete_one_word_forward
+      modifier: alt
+      keycode: delete
+      mode: emacs
+      event: {edit: deleteword}
     }
     {
-        name: cut_word_to_right
-        modifier: alt
-        keycode: char_d
-        mode: emacs
-        event: {edit: cutwordright}
+      name: delete_one_word_backward
+      modifier: alt
+      keycode: backspace
+      mode: emacs
+      event: {edit: backspaceword}
     }
     {
-        name: upper_case_word
-        modifier: alt
-        keycode: char_u
-        mode: emacs
-        event: {edit: uppercaseword}
+      name: delete_one_word_backward
+      modifier: alt
+      keycode: char_m
+      mode: emacs
+      event: {edit: backspaceword}
     }
     {
-        name: lower_case_word
-        modifier: alt
-        keycode: char_l
-        mode: emacs
-        event: {edit: lowercaseword}
+      name: cut_word_to_right
+      modifier: alt
+      keycode: char_d
+      mode: emacs
+      event: {edit: cutwordright}
     }
     {
-        name: capitalize_char
-        modifier: alt
-        keycode: char_c
-        mode: emacs
-        event: {edit: capitalizechar}
+      name: upper_case_word
+      modifier: alt
+      keycode: char_u
+      mode: emacs
+      event: {edit: uppercaseword}
+    }
+    {
+      name: lower_case_word
+      modifier: alt
+      keycode: char_l
+      mode: emacs
+      event: {edit: lowercaseword}
+    }
+    {
+      name: capitalize_char
+      modifier: alt
+      keycode: char_c
+      mode: emacs
+      event: {edit: capitalizechar}
     }
   ]
 }

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -7,803 +7,803 @@
 # And here is the theme collection
 # https://github.com/nushell/nu_scripts/tree/main/themes
 let dark_theme = {
-  # color for nushell primitives
-  separator: white
-  leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
-  header: green_bold
-  empty: blue
-  # Closures can be used to choose colors for specific values.
-  # The value (in this case, a bool) is piped into the closure.
-  bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
-  int: white
-  filesize: {|e|
-    if $e == 0b {
-      'white'
-    } else if $e < 1mb {
-      'cyan'
-    } else { 'blue' }
-  }
-  duration: white
-  date: {|| (date now) - $in |
-    if $in < 1hr {
-      'purple'
-    } else if $in < 6hr {
-      'red'
-    } else if $in < 1day {
-      'yellow'
-    } else if $in < 3day {
-      'green'
-    } else if $in < 1wk {
-      'light_green'
-    } else if $in < 6wk {
-      'cyan'
-    } else if $in < 52wk {
-      'blue'
-    } else { 'dark_gray' }
-  }
-  range: white
-  float: white
-  string: white
-  nothing: white
-  binary: white
-  cellpath: white
-  row_index: green_bold
-  record: white
-  list: white
-  block: white
-  hints: dark_gray
-  search_result: {bg: red fg: white}  
-  shape_and: purple_bold
-  shape_binary: purple_bold
-  shape_block: blue_bold
-  shape_bool: light_cyan
-  shape_closure: green_bold
-  shape_custom: green
-  shape_datetime: cyan_bold
-  shape_directory: cyan
-  shape_external: cyan
-  shape_externalarg: green_bold
-  shape_filepath: cyan
-  shape_flag: blue_bold
-  shape_float: purple_bold
-  # shapes are used to change the cli syntax highlighting
-  shape_garbage: { fg: white bg: red attr: b}
-  shape_globpattern: cyan_bold
-  shape_int: purple_bold
-  shape_internalcall: cyan_bold
-  shape_list: cyan_bold
-  shape_literal: blue
-  shape_match_pattern: green
-  shape_matching_brackets: { attr: u }
-  shape_nothing: light_cyan
-  shape_operator: yellow
-  shape_or: purple_bold
-  shape_pipe: purple_bold
-  shape_range: yellow_bold
-  shape_record: cyan_bold
-  shape_redirection: purple_bold
-  shape_signature: green_bold
-  shape_string: green
-  shape_string_interpolation: cyan_bold
-  shape_table: blue_bold
-  shape_variable: purple
-  shape_vardecl: purple
+    # color for nushell primitives
+    separator: white
+    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+    header: green_bold
+    empty: blue
+    # Closures can be used to choose colors for specific values.
+    # The value (in this case, a bool) is piped into the closure.
+    bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
+    int: white
+    filesize: {|e|
+        if $e == 0b {
+            'white'
+        } else if $e < 1mb {
+            'cyan'
+        } else { 'blue' }
+    }
+    duration: white
+    date: {|| (date now) - $in |
+        if $in < 1hr {
+            'purple'
+        } else if $in < 6hr {
+            'red'
+        } else if $in < 1day {
+            'yellow'
+        } else if $in < 3day {
+            'green'
+        } else if $in < 1wk {
+            'light_green'
+        } else if $in < 6wk {
+            'cyan'
+        } else if $in < 52wk {
+            'blue'
+        } else { 'dark_gray' }
+    }
+    range: white
+    float: white
+    string: white
+    nothing: white
+    binary: white
+    cellpath: white
+    row_index: green_bold
+    record: white
+    list: white
+    block: white
+    hints: dark_gray
+    search_result: {bg: red fg: white}    
+    shape_and: purple_bold
+    shape_binary: purple_bold
+    shape_block: blue_bold
+    shape_bool: light_cyan
+    shape_closure: green_bold
+    shape_custom: green
+    shape_datetime: cyan_bold
+    shape_directory: cyan
+    shape_external: cyan
+    shape_externalarg: green_bold
+    shape_filepath: cyan
+    shape_flag: blue_bold
+    shape_float: purple_bold
+    # shapes are used to change the cli syntax highlighting
+    shape_garbage: { fg: white bg: red attr: b}
+    shape_globpattern: cyan_bold
+    shape_int: purple_bold
+    shape_internalcall: cyan_bold
+    shape_list: cyan_bold
+    shape_literal: blue
+    shape_match_pattern: green
+    shape_matching_brackets: { attr: u }
+    shape_nothing: light_cyan
+    shape_operator: yellow
+    shape_or: purple_bold
+    shape_pipe: purple_bold
+    shape_range: yellow_bold
+    shape_record: cyan_bold
+    shape_redirection: purple_bold
+    shape_signature: green_bold
+    shape_string: green
+    shape_string_interpolation: cyan_bold
+    shape_table: blue_bold
+    shape_variable: purple
+    shape_vardecl: purple
 }
 
 let light_theme = {
-  # color for nushell primitives
-  separator: dark_gray
-  leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
-  header: green_bold
-  empty: blue
-  # Closures can be used to choose colors for specific values.
-  # The value (in this case, a bool) is piped into the closure.
-  bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
-  int: dark_gray
-  filesize: {|e|
-    if $e == 0b {
-      'dark_gray'
-    } else if $e < 1mb {
-      'cyan_bold'
-    } else { 'blue_bold' }
-  }
-  duration: dark_gray
-  date: {|| (date now) - $in |
-    if $in < 1hr {
-      'purple'
-    } else if $in < 6hr {
-      'red'
-    } else if $in < 1day {
-      'yellow'
-    } else if $in < 3day {
-      'green'
-    } else if $in < 1wk {
-      'light_green'
-    } else if $in < 6wk {
-      'cyan'
-    } else if $in < 52wk {
-      'blue'
-    } else { 'dark_gray' }
-  }
-  range: dark_gray
-  float: dark_gray
-  string: dark_gray
-  nothing: dark_gray
-  binary: dark_gray
-  cellpath: dark_gray
-  row_index: green_bold
-  record: white
-  list: white
-  block: white
-  hints: dark_gray
-  search_result: {fg: white bg: red}  
-  shape_and: purple_bold
-  shape_binary: purple_bold
-  shape_block: blue_bold
-  shape_bool: light_cyan
-  shape_closure: green_bold
-  shape_custom: green
-  shape_datetime: cyan_bold
-  shape_directory: cyan
-  shape_external: cyan
-  shape_externalarg: green_bold
-  shape_filepath: cyan
-  shape_flag: blue_bold
-  shape_float: purple_bold
-  # shapes are used to change the cli syntax highlighting
-  shape_garbage: { fg: white bg: red attr: b}
-  shape_globpattern: cyan_bold
-  shape_int: purple_bold
-  shape_internalcall: cyan_bold
-  shape_list: cyan_bold
-  shape_literal: blue
-  shape_match_pattern: green
-  shape_matching_brackets: { attr: u }
-  shape_nothing: light_cyan
-  shape_operator: yellow
-  shape_or: purple_bold
-  shape_pipe: purple_bold
-  shape_range: yellow_bold
-  shape_record: cyan_bold
-  shape_redirection: purple_bold
-  shape_signature: green_bold
-  shape_string: green
-  shape_string_interpolation: cyan_bold
-  shape_table: blue_bold
-  shape_variable: purple
-  shape_vardecl: purple
+    # color for nushell primitives
+    separator: dark_gray
+    leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
+    header: green_bold
+    empty: blue
+    # Closures can be used to choose colors for specific values.
+    # The value (in this case, a bool) is piped into the closure.
+    bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
+    int: dark_gray
+    filesize: {|e|
+        if $e == 0b {
+            'dark_gray'
+        } else if $e < 1mb {
+            'cyan_bold'
+        } else { 'blue_bold' }
+    }
+    duration: dark_gray
+    date: {|| (date now) - $in |
+        if $in < 1hr {
+            'purple'
+        } else if $in < 6hr {
+            'red'
+        } else if $in < 1day {
+            'yellow'
+        } else if $in < 3day {
+            'green'
+        } else if $in < 1wk {
+            'light_green'
+        } else if $in < 6wk {
+            'cyan'
+        } else if $in < 52wk {
+            'blue'
+        } else { 'dark_gray' }
+    }
+    range: dark_gray
+    float: dark_gray
+    string: dark_gray
+    nothing: dark_gray
+    binary: dark_gray
+    cellpath: dark_gray
+    row_index: green_bold
+    record: white
+    list: white
+    block: white
+    hints: dark_gray
+    search_result: {fg: white bg: red}    
+    shape_and: purple_bold
+    shape_binary: purple_bold
+    shape_block: blue_bold
+    shape_bool: light_cyan
+    shape_closure: green_bold
+    shape_custom: green
+    shape_datetime: cyan_bold
+    shape_directory: cyan
+    shape_external: cyan
+    shape_externalarg: green_bold
+    shape_filepath: cyan
+    shape_flag: blue_bold
+    shape_float: purple_bold
+    # shapes are used to change the cli syntax highlighting
+    shape_garbage: { fg: white bg: red attr: b}
+    shape_globpattern: cyan_bold
+    shape_int: purple_bold
+    shape_internalcall: cyan_bold
+    shape_list: cyan_bold
+    shape_literal: blue
+    shape_match_pattern: green
+    shape_matching_brackets: { attr: u }
+    shape_nothing: light_cyan
+    shape_operator: yellow
+    shape_or: purple_bold
+    shape_pipe: purple_bold
+    shape_range: yellow_bold
+    shape_record: cyan_bold
+    shape_redirection: purple_bold
+    shape_signature: green_bold
+    shape_string: green
+    shape_string_interpolation: cyan_bold
+    shape_table: blue_bold
+    shape_variable: purple
+    shape_vardecl: purple
 }
 
 # External completer example
 # let carapace_completer = {|spans|
-#     carapace $spans.0 nushell $spans | from json
+#         carapace $spans.0 nushell $spans | from json
 # }
 
 
 # The default config record. This is where much of your global configuration is setup.
 $env.config = {
-  show_banner: true # true or false to enable or disable the welcome banner at startup
+    show_banner: true # true or false to enable or disable the welcome banner at startup
 
-  ls: {
-    use_ls_colors: true # use the LS_COLORS environment variable to colorize output
-    clickable_links: true # enable or disable clickable links. Your terminal has to support links.
-  }
-
-  rm: {
-    always_trash: false # always act as if -t was given. Can be overridden with -p
-  }
-
-  cd: {
-    abbreviations: false # allows `cd s/o/f` to expand to `cd some/other/folder`
-  }
-
-  table: {
-    mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
-    index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
-    show_empty: true # show 'empty list' and 'empty record' placeholders for command output
-    trim: {
-      methodology: wrapping # wrapping or truncating
-      wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
-      truncating_suffix: "..." # A suffix used by the 'truncating' methodology
+    ls: {
+        use_ls_colors: true # use the LS_COLORS environment variable to colorize output
+        clickable_links: true # enable or disable clickable links. Your terminal has to support links.
     }
-  }
 
-  # datetime_format determines what a datetime rendered in the shell would look like.
-  # Behavior without this configuration point will be to "humanize" the datetime display,
-  # showing something like "a day ago."
-  datetime_format: {
-    # normal: '%a, %d %b %Y %H:%M:%S %z'  # shows up in displays of variables or other datetime's outside of tables
-    # table: '%m/%d/%y %I:%M:%S%p'        # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
-  }
+    rm: {
+        always_trash: false # always act as if -t was given. Can be overridden with -p
+    }
 
-  explore: {
-    try: {
-      border_color: {fg: "white"}
-    },
-    status_bar_background: {fg: "#1D1F21", bg: "#C4C9C6"},
-    command_bar_text: {fg: "#C4C9C6"},
-    highlight: {fg: "black", bg: "yellow"},
-    status: {
-      error: {fg: "white", bg: "red"},
-      warn: {}
-      info: {}
-    },
+    cd: {
+        abbreviations: false # allows `cd s/o/f` to expand to `cd some/other/folder`
+    }
+
     table: {
-      split_line: {fg: "#404040"},
-      selected_cell: {},
-      selected_row: {},
-      selected_column: {},
-      cursor: true,
-      line_head_top: true,
-      line_head_bottom: true,
-      line_shift: true,
-      line_index: true,
-    },
-    config: {
-      border_color: {fg: "white"}
-      cursor_color: {fg: "black", bg: "light_yellow"}
-    },
-  }
+        mode: rounded # basic, compact, compact_double, light, thin, with_love, rounded, reinforced, heavy, none, other
+        index_mode: always # "always" show indexes, "never" show indexes, "auto" = show indexes when a table has "index" column
+        show_empty: true # show 'empty list' and 'empty record' placeholders for command output
+        trim: {
+            methodology: wrapping # wrapping or truncating
+            wrapping_try_keep_words: true # A strategy used by the 'wrapping' methodology
+            truncating_suffix: "..." # A suffix used by the 'truncating' methodology
+        }
+    }
 
-  history: {
-    max_size: 100_000 # Session has to be reloaded for this to take effect
-    sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
-    file_format: "plaintext" # "sqlite" or "plaintext"
-    isolation: true # true enables history isolation, false disables it. true will allow the history to be isolated to the current session. false will allow the history to be shared across all sessions.
-  }
+    # datetime_format determines what a datetime rendered in the shell would look like.
+    # Behavior without this configuration point will be to "humanize" the datetime display,
+    # showing something like "a day ago."
+    datetime_format: {
+        # normal: '%a, %d %b %Y %H:%M:%S %z'    # shows up in displays of variables or other datetime's outside of tables
+        # table: '%m/%d/%y %I:%M:%S%p'                # generally shows up in tabular outputs such as ls. commenting this out will change it to the default human readable datetime format
+    }
 
-  completions: {
-    case_sensitive: false # set to true to enable case-sensitive completions
-    quick: true  # set this to false to prevent auto-selecting completions when only one remains
-    partial: true  # set this to false to prevent partial filling of the prompt
-    algorithm: "prefix"  # prefix or fuzzy
-    external: {
-      enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up may be very slow
-      max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
-      completer: null # check 'carapace_completer' above as an example
+    explore: {
+        try: {
+            border_color: {fg: "white"}
+        },
+        status_bar_background: {fg: "#1D1F21", bg: "#C4C9C6"},
+        command_bar_text: {fg: "#C4C9C6"},
+        highlight: {fg: "black", bg: "yellow"},
+        status: {
+            error: {fg: "white", bg: "red"},
+            warn: {}
+            info: {}
+        },
+        table: {
+            split_line: {fg: "#404040"},
+            selected_cell: {},
+            selected_row: {},
+            selected_column: {},
+            cursor: true,
+            line_head_top: true,
+            line_head_bottom: true,
+            line_shift: true,
+            line_index: true,
+        },
+        config: {
+            border_color: {fg: "white"}
+            cursor_color: {fg: "black", bg: "light_yellow"}
+        },
     }
-  }
 
-  filesize: {
-    metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
-    format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
-  }
+    history: {
+        max_size: 100_000 # Session has to be reloaded for this to take effect
+        sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
+        file_format: "plaintext" # "sqlite" or "plaintext"
+        isolation: true # true enables history isolation, false disables it. true will allow the history to be isolated to the current session. false will allow the history to be shared across all sessions.
+    }
 
-  cursor_shape: {
-    emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)
-    vi_insert: block # block, underscore, line , blink_block, blink_underscore, blink_line (block is the default)
-    vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
-  }
+    completions: {
+        case_sensitive: false # set to true to enable case-sensitive completions
+        quick: true    # set this to false to prevent auto-selecting completions when only one remains
+        partial: true    # set this to false to prevent partial filling of the prompt
+        algorithm: "prefix"    # prefix or fuzzy
+        external: {
+            enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up may be very slow
+            max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options
+            completer: null # check 'carapace_completer' above as an example
+        }
+    }
 
-  color_config: {} # if you want a more interesting theme, you can replace the empty record with `$dark_theme`, `$light_theme` or another custom record
-  use_grid_icons: true
-  footer_mode: "25" # always, never, number_of_rows, auto
-  float_precision: 2 # the precision for displaying floats in tables
-  buffer_editor: "" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
-  use_ansi_coloring: true
-  bracketed_paste: true # enable bracketed paste, currently useless on windows
-  edit_mode: emacs # emacs, vi
-  shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.
-  render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
+    filesize: {
+        metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
+        format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
+    }
 
-  hooks: {
-    pre_prompt: [{ null }] # run before the prompt is shown
-    pre_execution: [{ null }] # run before the repl input is run
-    env_change: {
-      PWD: [{|before, after| null }] # run if the PWD environment is different since the last repl input
+    cursor_shape: {
+        emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)
+        vi_insert: block # block, underscore, line , blink_block, blink_underscore, blink_line (block is the default)
+        vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
     }
-    display_output: { table } # run before the output of a command is drawn, example: `{ if (term size).columns >= 100 { table -e } else { table } }`
-    command_not_found: { null } # return an error message when a command is not found
-  }
 
-  menus: [
-    # Configuration for default nushell menus
-    # Note the lack of source parameter
-    {
-      name: completion_menu
-      only_buffer_difference: false
-      marker: "| "
-      type: {
-        layout: columnar
-        columns: 4
-        col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-        col_padding: 2
-      }
-      style: {
-        text: green
-        selected_text: green_reverse
-        description_text: yellow
-      }
-    }
-    {
-      name: history_menu
-      only_buffer_difference: true
-      marker: "? "
-      type: {
-        layout: list
-        page_size: 10
-      }
-      style: {
-        text: green
-        selected_text: green_reverse
-        description_text: yellow
-      }
-    }
-    {
-      name: help_menu
-      only_buffer_difference: true
-      marker: "? "
-      type: {
-        layout: description
-        columns: 4
-        col_width: 20   # Optional value. If missing all the screen width is used to calculate column width
-        col_padding: 2
-        selection_rows: 4
-        description_rows: 10
-      }
-      style: {
-        text: green
-        selected_text: green_reverse
-        description_text: yellow
-      }
-    }
-  ]
+    color_config: {} # if you want a more interesting theme, you can replace the empty record with `$dark_theme`, `$light_theme` or another custom record
+    use_grid_icons: true
+    footer_mode: "25" # always, never, number_of_rows, auto
+    float_precision: 2 # the precision for displaying floats in tables
+    buffer_editor: "" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
+    use_ansi_coloring: true
+    bracketed_paste: true # enable bracketed paste, currently useless on windows
+    edit_mode: emacs # emacs, vi
+    shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.
+    render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
 
-  keybindings: [
-    {
-      name: completion_menu
-      modifier: none
-      keycode: tab
-      mode: [emacs vi_normal vi_insert]
-      event: {
-        until: [
-          { send: menu name: completion_menu }
-          { send: menunext }
-        ]
-      }
+    hooks: {
+        pre_prompt: [{ null }] # run before the prompt is shown
+        pre_execution: [{ null }] # run before the repl input is run
+        env_change: {
+            PWD: [{|before, after| null }] # run if the PWD environment is different since the last repl input
+        }
+        display_output: { table } # run before the output of a command is drawn, example: `{ if (term size).columns >= 100 { table -e } else { table } }`
+        command_not_found: { null } # return an error message when a command is not found
     }
-    {
-      name: history_menu
-      modifier: control
-      keycode: char_r
-      mode: [emacs, vi_insert, vi_normal]
-      event: { send: menu name: history_menu }
-    }
-    {
-      name: help_menu
-      modifier: none
-      keycode: f1
-      mode: [emacs, vi_insert, vi_normal]
-      event: { send: menu name: help_menu }
-    }
-    {
-      name: completion_previous_menu
-      modifier: shift
-      keycode: backtab
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: menuprevious }
-    }
-    {
-      name: next_page_menu
-      modifier: control
-      keycode: char_x
-      mode: emacs
-      event: { send: menupagenext }
-    }
-    {
-      name: undo_or_previous_page_menu
-      modifier: control
-      keycode: char_z
-      mode: emacs
-      event: {
-        until: [
-          { send: menupageprevious }
-          { edit: undo }
-        ]
-      }
-    }
-    {
-      name: escape
-      modifier: none
-      keycode: escape
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: esc }  # NOTE: does not appear to work
-    }
-    {
-      name: cancel_command
-      modifier: control
-      keycode: char_c
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: ctrlc }
-    }
-    {
-      name: quit_shell
-      modifier: control
-      keycode: char_d
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: ctrld }
-    }
-    {
-      name: clear_screen
-      modifier: control
-      keycode: char_l
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: clearscreen }
-    }
-    {
-      name: search_history
-      modifier: control
-      keycode: char_r
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: searchhistory }
-    }
-    {
-      name: open_command_editor
-      modifier: control
-      keycode: char_o
-      mode: [emacs, vi_normal, vi_insert]
-      event: { send: openeditor }
-    }
-    {
-      name: move_up
-      modifier: none
-      keycode: up
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: menuup}
-          {send: up}
-        ]
-      }
-    }
-    {
-      name: move_down
-      modifier: none
-      keycode: down
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: menudown}
-          {send: down}
-        ]
-      }
-    }
-    {
-      name: move_left
-      modifier: none
-      keycode: left
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: menuleft}
-          {send: left}
-        ]
-      }
-    }
-    {
-      name: move_right_or_take_history_hint
-      modifier: none
-      keycode: right
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: historyhintcomplete}
-          {send: menuright}
-          {send: right}
-        ]
-      }
-    }
-    {
-      name: move_one_word_left
-      modifier: control
-      keycode: left
-      mode: [emacs, vi_normal, vi_insert]
-      event: {edit: movewordleft}
-    }
-    {
-      name: move_one_word_right_or_take_history_hint
-      modifier: control
-      keycode: right
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: historyhintwordcomplete}
-          {edit: movewordright}
-        ]
-      }
-    }
-    {
-      name: move_to_line_start
-      modifier: none
-      keycode: home
-      mode: [emacs, vi_normal, vi_insert]
-      event: {edit: movetolinestart}
-    }
-    {
-      name: move_to_line_start
-      modifier: control
-      keycode: char_a
-      mode: [emacs, vi_normal, vi_insert]
-      event: {edit: movetolinestart}
-    }
-    {
-      name: move_to_line_end_or_take_history_hint
-      modifier: none
-      keycode: end
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: historyhintcomplete}
-          {edit: movetolineend}
-        ]
-      }
-    }
-    {
-      name: move_to_line_end_or_take_history_hint
-      modifier: control
-      keycode: char_e
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: historyhintcomplete}
-          {edit: movetolineend}
-        ]
-      }
-    }
-    {
-      name: move_to_line_start
-      modifier: control
-      keycode: home
-      mode: [emacs, vi_normal, vi_insert]
-      event: {edit: movetolinestart}
-    }
-    {
-      name: move_to_line_end
-      modifier: control
-      keycode: end
-      mode: [emacs, vi_normal, vi_insert]
-      event: {edit: movetolineend}
-    }
-    {
-      name: move_up
-      modifier: control
-      keycode: char_p
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: menuup}
-          {send: up}
-        ]
-      }
-    }
-    {
-      name: move_down
-      modifier: control
-      keycode: char_t
-      mode: [emacs, vi_normal, vi_insert]
-      event: {
-        until: [
-          {send: menudown}
-          {send: down}
-        ]
-      }
-    }
-    {
-      name: delete_one_character_backward
-      modifier: none
-      keycode: backspace
-      mode: [emacs, vi_insert]
-      event: {edit: backspace}
-    }
-    {
-      name: delete_one_word_backward
-      modifier: control
-      keycode: backspace
-      mode: [emacs, vi_insert]
-      event: {edit: backspaceword}
-    }
-    {
-      name: delete_one_character_forward
-      modifier: none
-      keycode: delete
-      mode: [emacs, vi_insert]
-      event: {edit: delete}
-    }
-    {
-      name: delete_one_character_forward
-      modifier: control
-      keycode: delete
-      mode: [emacs, vi_insert]
-      event: {edit: delete}
-    }
-    {
-      name: delete_one_character_forward
-      modifier: control
-      keycode: char_h
-      mode: [emacs, vi_insert]
-      event: {edit: backspace}
-    }
-    {
-      name: delete_one_word_backward
-      modifier: control
-      keycode: char_w
-      mode: [emacs, vi_insert]
-      event: {edit: backspaceword}
-    }
-    {
-      name: move_left
-      modifier: none
-      keycode: backspace
-      mode: vi_normal
-      event: {edit: moveleft}
-    }
-    {
-      name: newline_or_run_command
-      modifier: none
-      keycode: enter
-      mode: emacs
-      event: {send: enter}
-    }
-    {
-      name: move_left
-      modifier: control
-      keycode: char_b
-      mode: emacs
-      event: {
-        until: [
-          {send: menuleft}
-          {send: left}
-        ]
-      }
-    }
-    {
-      name: move_right_or_take_history_hint
-      modifier: control
-      keycode: char_f
-      mode: emacs
-      event: {
-        until: [
-          {send: historyhintcomplete}
-          {send: menuright}
-          {send: right}
-        ]
-      }
-    }
-    {
-      name: redo_change
-      modifier: control
-      keycode: char_g
-      mode: emacs
-      event: {edit: redo}
-    }
-    {
-      name: undo_change
-      modifier: control
-      keycode: char_z
-      mode: emacs
-      event: {edit: undo}
-    }
-    {
-      name: paste_before
-      modifier: control
-      keycode: char_y
-      mode: emacs
-      event: {edit: pastecutbufferbefore}
-    }
-    {
-      name: cut_word_left
-      modifier: control
-      keycode: char_w
-      mode: emacs
-      event: {edit: cutwordleft}
-    }
-    {
-      name: cut_line_to_end
-      modifier: control
-      keycode: char_k
-      mode: emacs
-      event: {edit: cuttoend}
-    }
-    {
-      name: cut_line_from_start
-      modifier: control
-      keycode: char_u
-      mode: emacs
-      event: {edit: cutfromstart}
-    }
-    {
-      name: swap_graphemes
-      modifier: control
-      keycode: char_t
-      mode: emacs
-      event: {edit: swapgraphemes}
-    }
-    {
-      name: move_one_word_left
-      modifier: alt
-      keycode: left
-      mode: emacs
-      event: {edit: movewordleft}
-    }
-    {
-      name: move_one_word_right_or_take_history_hint
-      modifier: alt
-      keycode: right
-      mode: emacs
-      event: {
-        until: [
-          {send: historyhintwordcomplete}
-          {send: movewordright}
-        ]
-      }
-    }
-    {
-      name: move_one_word_left
-      modifier: alt
-      keycode: char_b
-      mode: emacs
-      event: {edit: movewordleft}
-    }
-    {
-      name: move_one_word_right_or_take_history_hint
-      modifier: alt
-      keycode: char_f
-      mode: emacs
-      event: {
-        until: [
-          {send: historyhintwordcomplete}
-          {send: movewordright}
-        ]
-      }
-    }
-    {
-      name: delete_one_word_forward
-      modifier: alt
-      keycode: delete
-      mode: emacs
-      event: {edit: deleteword}
-    }
-    {
-      name: delete_one_word_backward
-      modifier: alt
-      keycode: backspace
-      mode: emacs
-      event: {edit: backspaceword}
-    }
-    {
-      name: delete_one_word_backward
-      modifier: alt
-      keycode: char_m
-      mode: emacs
-      event: {edit: backspaceword}
-    }
-    {
-      name: cut_word_to_right
-      modifier: alt
-      keycode: char_d
-      mode: emacs
-      event: {edit: cutwordright}
-    }
-    {
-      name: upper_case_word
-      modifier: alt
-      keycode: char_u
-      mode: emacs
-      event: {edit: uppercaseword}
-    }
-    {
-      name: lower_case_word
-      modifier: alt
-      keycode: char_l
-      mode: emacs
-      event: {edit: lowercaseword}
-    }
-    {
-      name: capitalize_char
-      modifier: alt
-      keycode: char_c
-      mode: emacs
-      event: {edit: capitalizechar}
-    }
-  ]
+
+    menus: [
+        # Configuration for default nushell menus
+        # Note the lack of source parameter
+        {
+            name: completion_menu
+            only_buffer_difference: false
+            marker: "| "
+            type: {
+                layout: columnar
+                columns: 4
+                col_width: 20     # Optional value. If missing all the screen width is used to calculate column width
+                col_padding: 2
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+        }
+        {
+            name: history_menu
+            only_buffer_difference: true
+            marker: "? "
+            type: {
+                layout: list
+                page_size: 10
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+        }
+        {
+            name: help_menu
+            only_buffer_difference: true
+            marker: "? "
+            type: {
+                layout: description
+                columns: 4
+                col_width: 20     # Optional value. If missing all the screen width is used to calculate column width
+                col_padding: 2
+                selection_rows: 4
+                description_rows: 10
+            }
+            style: {
+                text: green
+                selected_text: green_reverse
+                description_text: yellow
+            }
+        }
+    ]
+
+    keybindings: [
+        {
+            name: completion_menu
+            modifier: none
+            keycode: tab
+            mode: [emacs vi_normal vi_insert]
+            event: {
+                until: [
+                    { send: menu name: completion_menu }
+                    { send: menunext }
+                ]
+            }
+        }
+        {
+            name: history_menu
+            modifier: control
+            keycode: char_r
+            mode: [emacs, vi_insert, vi_normal]
+            event: { send: menu name: history_menu }
+        }
+        {
+            name: help_menu
+            modifier: none
+            keycode: f1
+            mode: [emacs, vi_insert, vi_normal]
+            event: { send: menu name: help_menu }
+        }
+        {
+            name: completion_previous_menu
+            modifier: shift
+            keycode: backtab
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: menuprevious }
+        }
+        {
+            name: next_page_menu
+            modifier: control
+            keycode: char_x
+            mode: emacs
+            event: { send: menupagenext }
+        }
+        {
+            name: undo_or_previous_page_menu
+            modifier: control
+            keycode: char_z
+            mode: emacs
+            event: {
+                until: [
+                    { send: menupageprevious }
+                    { edit: undo }
+                ]
+            }
+        }
+        {
+            name: escape
+            modifier: none
+            keycode: escape
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: esc }    # NOTE: does not appear to work
+        }
+        {
+            name: cancel_command
+            modifier: control
+            keycode: char_c
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: ctrlc }
+        }
+        {
+            name: quit_shell
+            modifier: control
+            keycode: char_d
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: ctrld }
+        }
+        {
+            name: clear_screen
+            modifier: control
+            keycode: char_l
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: clearscreen }
+        }
+        {
+            name: search_history
+            modifier: control
+            keycode: char_r
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: searchhistory }
+        }
+        {
+            name: open_command_editor
+            modifier: control
+            keycode: char_o
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: openeditor }
+        }
+        {
+            name: move_up
+            modifier: none
+            keycode: up
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: menuup}
+                    {send: up}
+                ]
+            }
+        }
+        {
+            name: move_down
+            modifier: none
+            keycode: down
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: menudown}
+                    {send: down}
+                ]
+            }
+        }
+        {
+            name: move_left
+            modifier: none
+            keycode: left
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: menuleft}
+                    {send: left}
+                ]
+            }
+        }
+        {
+            name: move_right_or_take_history_hint
+            modifier: none
+            keycode: right
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: historyhintcomplete}
+                    {send: menuright}
+                    {send: right}
+                ]
+            }
+        }
+        {
+            name: move_one_word_left
+            modifier: control
+            keycode: left
+            mode: [emacs, vi_normal, vi_insert]
+            event: {edit: movewordleft}
+        }
+        {
+            name: move_one_word_right_or_take_history_hint
+            modifier: control
+            keycode: right
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: historyhintwordcomplete}
+                    {edit: movewordright}
+                ]
+            }
+        }
+        {
+            name: move_to_line_start
+            modifier: none
+            keycode: home
+            mode: [emacs, vi_normal, vi_insert]
+            event: {edit: movetolinestart}
+        }
+        {
+            name: move_to_line_start
+            modifier: control
+            keycode: char_a
+            mode: [emacs, vi_normal, vi_insert]
+            event: {edit: movetolinestart}
+        }
+        {
+            name: move_to_line_end_or_take_history_hint
+            modifier: none
+            keycode: end
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: historyhintcomplete}
+                    {edit: movetolineend}
+                ]
+            }
+        }
+        {
+            name: move_to_line_end_or_take_history_hint
+            modifier: control
+            keycode: char_e
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: historyhintcomplete}
+                    {edit: movetolineend}
+                ]
+            }
+        }
+        {
+            name: move_to_line_start
+            modifier: control
+            keycode: home
+            mode: [emacs, vi_normal, vi_insert]
+            event: {edit: movetolinestart}
+        }
+        {
+            name: move_to_line_end
+            modifier: control
+            keycode: end
+            mode: [emacs, vi_normal, vi_insert]
+            event: {edit: movetolineend}
+        }
+        {
+            name: move_up
+            modifier: control
+            keycode: char_p
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: menuup}
+                    {send: up}
+                ]
+            }
+        }
+        {
+            name: move_down
+            modifier: control
+            keycode: char_t
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: menudown}
+                    {send: down}
+                ]
+            }
+        }
+        {
+            name: delete_one_character_backward
+            modifier: none
+            keycode: backspace
+            mode: [emacs, vi_insert]
+            event: {edit: backspace}
+        }
+        {
+            name: delete_one_word_backward
+            modifier: control
+            keycode: backspace
+            mode: [emacs, vi_insert]
+            event: {edit: backspaceword}
+        }
+        {
+            name: delete_one_character_forward
+            modifier: none
+            keycode: delete
+            mode: [emacs, vi_insert]
+            event: {edit: delete}
+        }
+        {
+            name: delete_one_character_forward
+            modifier: control
+            keycode: delete
+            mode: [emacs, vi_insert]
+            event: {edit: delete}
+        }
+        {
+            name: delete_one_character_forward
+            modifier: control
+            keycode: char_h
+            mode: [emacs, vi_insert]
+            event: {edit: backspace}
+        }
+        {
+            name: delete_one_word_backward
+            modifier: control
+            keycode: char_w
+            mode: [emacs, vi_insert]
+            event: {edit: backspaceword}
+        }
+        {
+            name: move_left
+            modifier: none
+            keycode: backspace
+            mode: vi_normal
+            event: {edit: moveleft}
+        }
+        {
+            name: newline_or_run_command
+            modifier: none
+            keycode: enter
+            mode: emacs
+            event: {send: enter}
+        }
+        {
+            name: move_left
+            modifier: control
+            keycode: char_b
+            mode: emacs
+            event: {
+                until: [
+                    {send: menuleft}
+                    {send: left}
+                ]
+            }
+        }
+        {
+            name: move_right_or_take_history_hint
+            modifier: control
+            keycode: char_f
+            mode: emacs
+            event: {
+                until: [
+                    {send: historyhintcomplete}
+                    {send: menuright}
+                    {send: right}
+                ]
+            }
+        }
+        {
+            name: redo_change
+            modifier: control
+            keycode: char_g
+            mode: emacs
+            event: {edit: redo}
+        }
+        {
+            name: undo_change
+            modifier: control
+            keycode: char_z
+            mode: emacs
+            event: {edit: undo}
+        }
+        {
+            name: paste_before
+            modifier: control
+            keycode: char_y
+            mode: emacs
+            event: {edit: pastecutbufferbefore}
+        }
+        {
+            name: cut_word_left
+            modifier: control
+            keycode: char_w
+            mode: emacs
+            event: {edit: cutwordleft}
+        }
+        {
+            name: cut_line_to_end
+            modifier: control
+            keycode: char_k
+            mode: emacs
+            event: {edit: cuttoend}
+        }
+        {
+            name: cut_line_from_start
+            modifier: control
+            keycode: char_u
+            mode: emacs
+            event: {edit: cutfromstart}
+        }
+        {
+            name: swap_graphemes
+            modifier: control
+            keycode: char_t
+            mode: emacs
+            event: {edit: swapgraphemes}
+        }
+        {
+            name: move_one_word_left
+            modifier: alt
+            keycode: left
+            mode: emacs
+            event: {edit: movewordleft}
+        }
+        {
+            name: move_one_word_right_or_take_history_hint
+            modifier: alt
+            keycode: right
+            mode: emacs
+            event: {
+                until: [
+                    {send: historyhintwordcomplete}
+                    {edit: movewordright}
+                ]
+            }
+        }
+        {
+            name: move_one_word_left
+            modifier: alt
+            keycode: char_b
+            mode: emacs
+            event: {edit: movewordleft}
+        }
+        {
+            name: move_one_word_right_or_take_history_hint
+            modifier: alt
+            keycode: char_f
+            mode: emacs
+            event: {
+                until: [
+                    {send: historyhintwordcomplete}
+                    {edit: movewordright}
+                ]
+            }
+        }
+        {
+            name: delete_one_word_forward
+            modifier: alt
+            keycode: delete
+            mode: emacs
+            event: {edit: deleteword}
+        }
+        {
+            name: delete_one_word_backward
+            modifier: alt
+            keycode: backspace
+            mode: emacs
+            event: {edit: backspaceword}
+        }
+        {
+            name: delete_one_word_backward
+            modifier: alt
+            keycode: char_m
+            mode: emacs
+            event: {edit: backspaceword}
+        }
+        {
+            name: cut_word_to_right
+            modifier: alt
+            keycode: char_d
+            mode: emacs
+            event: {edit: cutwordright}
+        }
+        {
+            name: upper_case_word
+            modifier: alt
+            keycode: char_u
+            mode: emacs
+            event: {edit: uppercaseword}
+        }
+        {
+            name: lower_case_word
+            modifier: alt
+            keycode: char_l
+            mode: emacs
+            event: {edit: lowercaseword}
+        }
+        {
+            name: capitalize_char
+            modifier: alt
+            keycode: char_c
+            mode: emacs
+            event: {edit: capitalizechar}
+        }
+    ]
 }

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -3,43 +3,43 @@
 # version = 0.82.1
 
 def create_left_prompt [] {
-  mut home = ""
-  try {
-    if $nu.os-info.name == "windows" {
-      $home = $env.USERPROFILE
-    } else {
-      $home = $env.HOME
+    mut home = ""
+    try {
+        if $nu.os-info.name == "windows" {
+            $home = $env.USERPROFILE
+        } else {
+            $home = $env.HOME
+        }
     }
-  }
 
-  let dir = ([
-    ($env.PWD | str substring 0..($home | str length) | str replace --string $home "~"),
-    ($env.PWD | str substring ($home | str length)..)
-  ] | str join)
+    let dir = ([
+        ($env.PWD | str substring 0..($home | str length) | str replace --string $home "~"),
+        ($env.PWD | str substring ($home | str length)..)
+    ] | str join)
 
-  let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
-  let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
-  let path_segment = $"($path_color)($dir)"
+    let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
+    let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
+    let path_segment = $"($path_color)($dir)"
 
-  $path_segment | str replace --all --string (char path_sep) $"($separator_color)/($path_color)"
+    $path_segment | str replace --all --string (char path_sep) $"($separator_color)/($path_color)"
 }
 
 def create_right_prompt [] {
-  # create a right prompt in magenta with green separators and am/pm underlined
-  let time_segment = ([
-    (ansi reset)
-    (ansi magenta)
-    (date now | date format '%Y/%m/%d %r')
-  ] | str join | str replace --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
-    str replace --all "([AP]M)" $"(ansi magenta_underline)${1}")
+    # create a right prompt in magenta with green separators and am/pm underlined
+    let time_segment = ([
+        (ansi reset)
+        (ansi magenta)
+        (date now | date format '%Y/%m/%d %r')
+    ] | str join | str replace --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
+        str replace --all "([AP]M)" $"(ansi magenta_underline)${1}")
 
-  let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
-    (ansi rb)
-    ($env.LAST_EXIT_CODE)
-  ] | str join)
-  } else { "" }
+    let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
+        (ansi rb)
+        ($env.LAST_EXIT_CODE)
+    ] | str join)
+    } else { "" }
 
-  ([$last_exit_code, (char space), $time_segment] | str join)
+    ([$last_exit_code, (char space), $time_segment] | str join)
 }
 
 # Use nushell functions to define your right and left prompt
@@ -58,14 +58,14 @@ $env.PROMPT_MULTILINE_INDICATOR = {|| "::: " }
 # - converted from a value back to a string when running external commands (to_string)
 # Note: The conversions happen *after* config.nu is loaded
 $env.ENV_CONVERSIONS = {
-  "PATH": {
-    from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
-    to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
-  }
-  "Path": {
-    from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
-    to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
-  }
+    "PATH": {
+        from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
+        to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
+    }
+    "Path": {
+        from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
+        to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
+    }
 }
 
 # Directories to search for scripts when calling source or use

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -3,43 +3,43 @@
 # version = 0.82.1
 
 def create_left_prompt [] {
-    mut home = ""
-    try {
-        if $nu.os-info.name == "windows" {
-            $home = $env.USERPROFILE
-        } else {
-            $home = $env.HOME
-        }
+  mut home = ""
+  try {
+    if $nu.os-info.name == "windows" {
+      $home = $env.USERPROFILE
+    } else {
+      $home = $env.HOME
     }
+  }
 
-    let dir = ([
-        ($env.PWD | str substring 0..($home | str length) | str replace --string $home "~"),
-        ($env.PWD | str substring ($home | str length)..)
-    ] | str join)
+  let dir = ([
+    ($env.PWD | str substring 0..($home | str length) | str replace --string $home "~"),
+    ($env.PWD | str substring ($home | str length)..)
+  ] | str join)
 
-    let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
-    let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
-    let path_segment = $"($path_color)($dir)"
+  let path_color = (if (is-admin) { ansi red_bold } else { ansi green_bold })
+  let separator_color = (if (is-admin) { ansi light_red_bold } else { ansi light_green_bold })
+  let path_segment = $"($path_color)($dir)"
 
-    $path_segment | str replace --all --string (char path_sep) $"($separator_color)/($path_color)"
+  $path_segment | str replace --all --string (char path_sep) $"($separator_color)/($path_color)"
 }
 
 def create_right_prompt [] {
-    # create a right prompt in magenta with green separators and am/pm underlined
-    let time_segment = ([
-        (ansi reset)
-        (ansi magenta)
-        (date now | date format '%Y/%m/%d %r')
-    ] | str join | str replace --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
-        str replace --all "([AP]M)" $"(ansi magenta_underline)${1}")
+  # create a right prompt in magenta with green separators and am/pm underlined
+  let time_segment = ([
+    (ansi reset)
+    (ansi magenta)
+    (date now | date format '%Y/%m/%d %r')
+  ] | str join | str replace --all "([/:])" $"(ansi green)${1}(ansi magenta)" |
+    str replace --all "([AP]M)" $"(ansi magenta_underline)${1}")
 
-    let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
-        (ansi rb)
-        ($env.LAST_EXIT_CODE)
-    ] | str join)
-    } else { "" }
+  let last_exit_code = if ($env.LAST_EXIT_CODE != 0) {([
+    (ansi rb)
+    ($env.LAST_EXIT_CODE)
+  ] | str join)
+  } else { "" }
 
-    ([$last_exit_code, (char space), $time_segment] | str join)
+  ([$last_exit_code, (char space), $time_segment] | str join)
 }
 
 # Use nushell functions to define your right and left prompt


### PR DESCRIPTION
# Description

This PR just tried to normalize the formatting. Everything should be 4 spaces now for those people that can't live with 2 spaces in the default config files. I also remove some unneeded line breaks and changed two places that should've been `edit` vs `send`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
