### PR TITLE
Add explicit input types for vectorized `into int` form

### DIFF
--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -41,7 +41,29 @@ impl Command for SubCommand {
                 (Type::Filesize, Type::Int),
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (
-                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::Int)),
+                ),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Int)),
+                ),
+                (
+                    Type::List(Box::new(Type::Bool)),
+                    Type::List(Box::new(Type::Int)),
+                ),
+                // Unix timestamp in nanoseconds
+                (
+                    Type::List(Box::new(Type::Date)),
+                    Type::List(Box::new(Type::Int)),
+                ),
+                (
+                    Type::List(Box::new(Type::Duration)),
+                    Type::List(Box::new(Type::Int)),
+                ),
+                // TODO: Users should do this by dividing a Filesize by a Filesize explicitly
+                (
+                    Type::List(Box::new(Type::Filesize)),
                     Type::List(Box::new(Type::Int)),
                 ),
             ])

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -37,7 +37,6 @@ impl Command for SubCommand {
                 // Unix timestamp in nanoseconds
                 (Type::Date, Type::Int),
                 (Type::Duration, Type::Int),
-                // TODO: Users should do this by dividing a Filesize by a Filesize explicitly
                 (Type::Filesize, Type::Int),
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (
@@ -52,7 +51,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Bool)),
                     Type::List(Box::new(Type::Int)),
                 ),
-                // Unix timestamp in nanoseconds
                 (
                     Type::List(Box::new(Type::Date)),
                     Type::List(Box::new(Type::Int)),
@@ -61,9 +59,13 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Duration)),
                     Type::List(Box::new(Type::Int)),
                 ),
-                // TODO: Users should do this by dividing a Filesize by a Filesize explicitly
                 (
                     Type::List(Box::new(Type::Filesize)),
+                    Type::List(Box::new(Type::Int)),
+                ),
+                // Relaxed case to support heterogeneous lists
+                (
+                    Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Int)),
                 ),
             ])


### PR DESCRIPTION
# Description
Don't just use `List<Any>`, be precise for the vectorized form as well.

# User-Facing Changes
More explicit albeit verbose type information in the signature
