### PR TITLE
Use explicit in/out list types for vectorized commands

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -24,6 +24,7 @@ impl Command for BitsNot {
                 ),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .switch(
                 "signed",
                 "always treat input number as a signed number",

--- a/crates/nu-cmd-extra/src/extra/bytes/add.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/add.rs
@@ -38,6 +38,7 @@ impl Command for BytesAdd {
                 ),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .required("data", SyntaxShape::Binary, "the binary to add")
             .named(
                 "index",

--- a/crates/nu-cmd-extra/src/extra/bytes/add.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/add.rs
@@ -30,7 +30,13 @@ impl Command for BytesAdd {
 
     fn signature(&self) -> Signature {
         Signature::build("bytes add")
-            .input_output_types(vec![(Type::Binary, Type::Binary)])
+            .input_output_types(vec![
+                (Type::Binary, Type::Binary),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .required("data", SyntaxShape::Binary, "the binary to add")
             .named(

--- a/crates/nu-cmd-extra/src/extra/bytes/at.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/at.rs
@@ -37,7 +37,13 @@ impl Command for BytesAt {
 
     fn signature(&self) -> Signature {
         Signature::build("bytes at")
-            .input_output_types(vec![(Type::Binary, Type::Binary)])
+            .input_output_types(vec![
+                (Type::Binary, Type::Binary),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .required("range", SyntaxShape::Range, "the range to get bytes")
             .rest(

--- a/crates/nu-cmd-extra/src/extra/math/arccos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccos.rs
@@ -13,7 +13,13 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("math arccos")
             .switch("degrees", "Return degrees instead of radians", Some('d'))
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arccos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccos.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arccosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccosh.rs
@@ -12,7 +12,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math arccosh")
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arccosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccosh.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arcsin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsin.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arcsin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsin.rs
@@ -13,7 +13,13 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("math arcsin")
             .switch("degrees", "Return degrees instead of radians", Some('d'))
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
@@ -12,7 +12,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math arcsinh")
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arctan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctan.rs
@@ -13,7 +13,13 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("math arctan")
             .switch("degrees", "Return degrees instead of radians", Some('d'))
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arctan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctan.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arctanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctanh.rs
@@ -12,7 +12,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math arctanh")
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/arctanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctanh.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/cosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cosh.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/cosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cosh.rs
@@ -12,7 +12,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math cosh")
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/exp.rs
+++ b/crates/nu-cmd-extra/src/extra/math/exp.rs
@@ -12,7 +12,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math exp")
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/exp.rs
+++ b/crates/nu-cmd-extra/src/extra/math/exp.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/ln.rs
+++ b/crates/nu-cmd-extra/src/extra/math/ln.rs
@@ -12,7 +12,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math ln")
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/ln.rs
+++ b/crates/nu-cmd-extra/src/extra/math/ln.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/sinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sinh.rs
@@ -12,7 +12,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math sinh")
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/sinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sinh.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/tanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tanh.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/math/tanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tanh.rs
@@ -12,7 +12,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math tanh")
-            .input_output_types(vec![(Type::Number, Type::Float)])
+            .input_output_types(vec![
+                (Type::Number, Type::Float),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Math)
     }

--- a/crates/nu-cmd-extra/src/extra/platform/ansi/gradient.rs
+++ b/crates/nu-cmd-extra/src/extra/platform/ansi/gradient.rs
@@ -46,6 +46,10 @@ impl Command for SubCommand {
             )
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
@@ -15,7 +15,13 @@ impl Command for DecodeHex {
 
     fn signature(&self) -> Signature {
         Signature::build("decode hex")
-            .input_output_types(vec![(Type::String, Type::Binary)])
+            .input_output_types(vec![
+                (Type::String, Type::Binary),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .rest(
                 "rest",

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
@@ -22,6 +22,7 @@ impl Command for DecodeHex {
                     Type::List(Box::new(Type::Binary)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .rest(
                 "rest",

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
@@ -15,7 +15,13 @@ impl Command for EncodeHex {
 
     fn signature(&self) -> Signature {
         Signature::build("encode hex")
-            .input_output_types(vec![(Type::Binary, Type::String)])
+            .input_output_types(vec![
+                (Type::Binary, Type::String),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::String)),
+                ),
+            ])
             .vectorizes_over_list(true)
             .rest(
                 "rest",

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
@@ -22,6 +22,7 @@ impl Command for EncodeHex {
                     Type::List(Box::new(Type::String)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -53,6 +53,7 @@ impl Command for Fill {
                 (Type::List(Box::new(Type::Filesize)), Type::List(Box::new(Type::String))),
                 ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .named(
                 "width",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -51,6 +51,8 @@ impl Command for Fill {
                 (Type::List(Box::new(Type::Float)), Type::List(Box::new(Type::String))),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
                 (Type::List(Box::new(Type::Filesize)), Type::List(Box::new(Type::String))),
+                // General case for heterogeneous lists
+                (Type::List(Box::new(Type::Any)), Type::List(Box::new(Type::String))),
                 ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -47,6 +47,10 @@ impl Command for Fill {
                 (Type::Float, Type::String),
                 (Type::String, Type::String),
                 (Type::Filesize, Type::String),
+                (Type::List(Box::new(Type::Int)), Type::List(Box::new(Type::String))),
+                (Type::List(Box::new(Type::Float)), Type::List(Box::new(Type::String))),
+                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
+                (Type::List(Box::new(Type::Filesize)), Type::List(Box::new(Type::String))),
                 ])
             .vectorizes_over_list(true)
             .named(

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -38,6 +38,11 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Filesize)),
                     Type::List(Box::new(Type::Filesize)),
                 ),
+                // Catch all for heterogeneous lists.
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Filesize)),
+                ),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -39,6 +39,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Filesize)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -22,6 +22,22 @@ impl Command for SubCommand {
                 (Type::String, Type::Filesize),
                 (Type::Filesize, Type::Filesize),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (
+                    Type::List(Box::new(Type::Int)),
+                    Type::List(Box::new(Type::Filesize)),
+                ),
+                (
+                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Filesize)),
+                ),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::Filesize)),
+                ),
+                (
+                    Type::List(Box::new(Type::Filesize)),
+                    Type::List(Box::new(Type::Filesize)),
+                ),
             ])
             .vectorizes_over_list(true)
             .rest(

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -23,6 +23,7 @@ impl Command for SubCommand {
                 ),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .named(
                 "precision",
                 SyntaxShape::Number,

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -28,6 +28,7 @@ impl Command for DecodeBase64 {
                 ),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .named(
                 "character-set",
                 SyntaxShape::String,

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -18,6 +18,14 @@ impl Command for DecodeBase64 {
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::String, Type::Binary),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
             ])
             .vectorizes_over_list(true)
             .named(

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -26,6 +26,12 @@ impl Command for EncodeBase64 {
                     Type::List(Box::new(Type::Binary)),
                     Type::List(Box::new(Type::String)),
                 ),
+                // Relaxed for heterogeneous list.
+                // Should be removed as soon as the type system supports better restrictions
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::String)),
+                ),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -18,6 +18,14 @@ impl Command for EncodeBase64 {
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::Binary, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::String)),
+                ),
             ])
             .vectorizes_over_list(true)
             .named(

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -28,6 +28,7 @@ impl Command for EncodeBase64 {
                 ),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .named(
                 "character-set",
                 SyntaxShape::String,

--- a/crates/nu-command/src/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/strings/str_/case/camel_case.rs
@@ -26,6 +26,7 @@ impl Command for SubCommand {
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/strings/str_/case/camel_case.rs
@@ -19,6 +19,10 @@ impl Command for SubCommand {
         Signature::build("str camel-case")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -17,6 +17,10 @@ impl Command for SubCommand {
         Signature::build("str capitalize")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -24,6 +24,7 @@ impl Command for SubCommand {
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -17,6 +17,10 @@ impl Command for SubCommand {
         Signature::build("str downcase")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -24,6 +24,7 @@ impl Command for SubCommand {
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/strings/str_/case/kebab_case.rs
@@ -20,6 +20,10 @@ impl Command for SubCommand {
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
             ])
             .vectorizes_over_list(true)
             .rest(

--- a/crates/nu-command/src/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/strings/str_/case/kebab_case.rs
@@ -26,6 +26,7 @@ impl Command for SubCommand {
                 ),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/strings/str_/case/pascal_case.rs
@@ -20,6 +20,10 @@ impl Command for SubCommand {
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
             ])
             .vectorizes_over_list(true)
             .rest(

--- a/crates/nu-command/src/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/strings/str_/case/pascal_case.rs
@@ -26,6 +26,7 @@ impl Command for SubCommand {
                 ),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -25,6 +25,7 @@ impl Command for SubCommand {
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -18,6 +18,10 @@ impl Command for SubCommand {
         Signature::build("str screaming-snake-case")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -25,6 +25,7 @@ impl Command for SubCommand {
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -18,6 +18,10 @@ impl Command for SubCommand {
         Signature::build("str snake-case")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -26,6 +26,7 @@ impl Command for SubCommand {
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -19,6 +19,10 @@ impl Command for SubCommand {
         Signature::build("str title-case")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -16,6 +16,10 @@ impl Command for SubCommand {
         Signature::build("str upcase")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::String)),
+                ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -31,6 +31,7 @@ impl Command for SubCommand {
         Signature::build("str contains")
             .input_output_types(vec![
                 (Type::String, Type::Bool),
+                // TODO figure out cell-path type behavior
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool)))
             ])

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -76,9 +76,12 @@ impl Command for SubCommand {
                 result: Some(Value::test_bool(true)),
             },
             Example {
-                description: "Checks if string ends with '.txt'",
-                example: "'my_library.rb' | str ends-with '.txt'",
-                result: Some(Value::test_bool(false)),
+                description: "Checks if strings end with '.txt'",
+                example: "['my_library.rb', 'README.txt'] | str ends-with '.txt'",
+                result: Some(Value::test_list(vec![
+                    Value::test_bool(false),
+                    Value::test_bool(true),
+                ])),
             },
             Example {
                 description: "Checks if string ends with '.RB', case-insensitive",

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -28,7 +28,10 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str ends-with")
-            .input_output_types(vec![(Type::String, Type::Bool)])
+            .input_output_types(vec![
+                (Type::String, Type::Bool),
+                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool))),
+            ])
             .vectorizes_over_list(true)
             .required("string", SyntaxShape::String, "the string to match")
             .rest(

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -22,7 +22,13 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str expand")
-            .input_output_types(vec![(Type::String, Type::List(Box::new(Type::String)))])
+            .input_output_types(vec![
+                (Type::String, Type::List(Box::new(Type::String))),
+                (
+                    Type::List(Box::new(Type::String)),
+                    Type::List(Box::new(Type::List(Box::new(Type::String)))),
+                ),
+            ])
             .vectorizes_over_list(true)
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -30,6 +30,7 @@ impl Command for SubCommand {
                 ),
             ])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .category(Category::Strings)
     }
 

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str index-of")
-            .input_output_types(vec![(Type::String, Type::Int)])
+            .input_output_types(vec![(Type::String, Type::Int),(Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int)))])
             .vectorizes_over_list(true) // TODO: no test coverage
             .required("string", SyntaxShape::String, "the string to find in the input")
             .switch(

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -39,6 +39,7 @@ impl Command for SubCommand {
         Signature::build("str index-of")
             .input_output_types(vec![(Type::String, Type::Int),(Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int)))])
             .vectorizes_over_list(true) // TODO: no test coverage
+            .allow_variants_without_examples(true)
             .required("string", SyntaxShape::String, "the string to find in the input")
             .switch(
                 "grapheme-clusters",

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -36,6 +36,7 @@ impl Command for SubCommand {
         Signature::build("str replace")
             .input_output_types(vec![
                 (Type::String, Type::String),
+                // TODO: clarify behavior with cellpath-rest argument
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (
                     Type::List(Box::new(Type::String)),

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -32,6 +32,7 @@ impl Command for SubCommand {
         Signature::build("str starts-with")
             .input_output_types(vec![(Type::String, Type::Bool),(Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool)))])
             .vectorizes_over_list(true)
+            .allow_variants_without_examples(true)
             .required("string", SyntaxShape::String, "the string to match")
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -30,7 +30,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str starts-with")
-            .input_output_types(vec![(Type::String, Type::Bool)])
+            .input_output_types(vec![(Type::String, Type::Bool),(Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool)))])
             .vectorizes_over_list(true)
             .required("string", SyntaxShape::String, "the string to match")
             .rest(

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -42,7 +42,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str substring")
-            .input_output_types(vec![(Type::String, Type::String), (Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![(Type::String, Type::String), (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))), (Type::Table(vec![]), Type::Table(vec![]))])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .switch(


### PR DESCRIPTION
# Description
All commands that declared `.vectorizes_over_list(true)` now also
explicitly declare the list form of their scalar types.

- Explicit in/out list signatures for nu-command
- Explicit in/out list signatures for nu-cmd-extra
- Add comments about cellpath behavior that is still unresolved


# User-Facing Changes
Our type signatures will now be more explicit about which commands support vectorization over lists.
On the downside this is a bit more verbose and less systematic.
