### PR TITLE
Redirection: make `o>`, `e>`, `o+e>`'s target support variables and string interpolation

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -795,7 +795,7 @@ pub fn eval_element_with_input(
             redirect_stderr,
         ),
         PipelineElement::Redirection(span, redirection, expr) => match &expr.expr {
-            Expr::String(_) => {
+            Expr::String(_) | Expr::FullCellPath(_) => {
                 let exit_code = match &mut input {
                     PipelineData::ExternalStream { exit_code, .. } => exit_code.take(),
                     _ => None,
@@ -880,7 +880,7 @@ pub fn eval_element_with_input(
             out: (out_span, out_expr),
             err: (err_span, err_expr),
         } => match (&out_expr.expr, &err_expr.expr) {
-            (Expr::String(_), Expr::String(_)) => {
+            (Expr::String(_) | Expr::FullCellPath(_), Expr::String(_) | Expr::FullCellPath(_)) => {
                 if let Some(save_command) = engine_state.find_decl(b"save", &[]) {
                     let exit_code = match &mut input {
                         PipelineData::ExternalStream { exit_code, .. } => exit_code.take(),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -795,7 +795,10 @@ pub fn eval_element_with_input(
             redirect_stderr,
         ),
         PipelineElement::Redirection(span, redirection, expr) => match &expr.expr {
-            Expr::String(_) | Expr::FullCellPath(_) => {
+            Expr::String(_)
+            | Expr::FullCellPath(_)
+            | Expr::StringInterpolation(_)
+            | Expr::Filepath(_) => {
                 let exit_code = match &mut input {
                     PipelineData::ExternalStream { exit_code, .. } => exit_code.take(),
                     _ => None,
@@ -880,7 +883,16 @@ pub fn eval_element_with_input(
             out: (out_span, out_expr),
             err: (err_span, err_expr),
         } => match (&out_expr.expr, &err_expr.expr) {
-            (Expr::String(_) | Expr::FullCellPath(_), Expr::String(_) | Expr::FullCellPath(_)) => {
+            (
+                Expr::String(_)
+                | Expr::FullCellPath(_)
+                | Expr::StringInterpolation(_)
+                | Expr::Filepath(_),
+                Expr::String(_)
+                | Expr::FullCellPath(_)
+                | Expr::StringInterpolation(_)
+                | Expr::Filepath(_),
+            ) => {
                 if let Some(save_command) = engine_state.find_decl(b"save", &[]) {
                     let exit_code = match &mut input {
                         PipelineData::ExternalStream { exit_code, .. } => exit_code.take(),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5522,8 +5522,7 @@ pub fn parse_pipeline(
                     PipelineElement::Expression(*span, expr)
                 }
                 LiteElement::Redirection(span, redirection, command) => {
-                    trace!("parsing: pipeline element: redirection");
-                    let expr = parse_string(working_set, command.parts[0]);
+                    let expr = parse_value(working_set, command.parts[0], &SyntaxShape::Any);
 
                     PipelineElement::Redirection(*span, redirection.clone(), expr)
                 }
@@ -5532,9 +5531,11 @@ pub fn parse_pipeline(
                     err: (err_span, err_command),
                 } => {
                     trace!("parsing: pipeline element: separate redirection");
-                    let out_expr = parse_string(working_set, out_command.parts[0]);
+                    let out_expr =
+                        parse_value(working_set, out_command.parts[0], &SyntaxShape::Any);
 
-                    let err_expr = parse_string(working_set, err_command.parts[0]);
+                    let err_expr =
+                        parse_value(working_set, err_command.parts[0], &SyntaxShape::Any);
 
                     PipelineElement::SeparateRedirection {
                         out: (*out_span, out_expr),
@@ -5547,7 +5548,9 @@ pub fn parse_pipeline(
                 } => {
                     trace!("parsing: pipeline element: same target redirection");
                     let expr = parse_expression(working_set, &command.parts, is_subexpression);
-                    let redirect_expr = parse_string(working_set, redirect_command.parts[0]);
+                    let redirect_expr =
+                        parse_value(working_set, redirect_command.parts[0], &SyntaxShape::Any);
+                    log::warn!("redirect expr: {redirect_expr:?}");
                     PipelineElement::SameTargetRedirection {
                         cmd: (*cmd_span, expr),
                         redirection: (*redirect_span, redirect_expr),
@@ -5636,7 +5639,8 @@ pub fn parse_pipeline(
                 trace!("parsing: pipeline element: same target redirection");
                 let expr = parse_expression(working_set, &command.parts, is_subexpression);
 
-                let redirect_expr = parse_string(working_set, redirect_cmd.parts[0]);
+                let redirect_expr =
+                    parse_value(working_set, redirect_cmd.parts[0], &SyntaxShape::Any);
 
                 Pipeline {
                     elements: vec![PipelineElement::SameTargetRedirection {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5550,7 +5550,6 @@ pub fn parse_pipeline(
                     let expr = parse_expression(working_set, &command.parts, is_subexpression);
                     let redirect_expr =
                         parse_value(working_set, redirect_command.parts[0], &SyntaxShape::Any);
-                    log::warn!("redirect expr: {redirect_expr:?}");
                     PipelineElement::SameTargetRedirection {
                         cmd: (*cmd_span, expr),
                         redirection: (*redirect_span, redirect_expr),


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Fixes:  #8517
Fixes: #9246
Fixes: #9709
Relative: #9723

After the pr: redirection support something like the following:
1. `let a = "x"; cat toolkit.nu o> $a`
2. `let a = "x"; cat toolkit.nu o> $"($a).txt"`
3. `cat toolkit.nu out> ("~/a.txt" | path expand)`

## About the change
Before the pr, nushell only parse redirection target as a string(through `parse_string` call).
In the pr, I'm trying to make the value more generic(using `parse_value` with `SyntaxShape::Any`)

And during eval stage, we guard it to only eval `String`, `StringInterpolation`, `FullCellPath`, `FilePath`, so other type of redirection target like `1ms` won't be permitted.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
