### PR TITLE
str-expand: new capability, empty collection item

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "bracoxide"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "218d42d1e9cdf071a7badff501a139dd6f598fe21348e5e5c4e2302e43bdcefb"
+checksum = "ae76c117551a0459f61c57b573271778214287482c346d14591d2ea250ecbea5"
 
 [[package]]
 name = "brotli"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -94,7 +94,7 @@ url = "2.2"
 uuid = { version = "1.3", features = ["v4"] }
 wax = { version = "0.5" }
 which = { version = "4.4", optional = true }
-bracoxide = "0.1.0"
+bracoxide = "0.1.1"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.50"

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -71,7 +71,7 @@ impl Command for SubCommand {
 
             Example {
                 description: "Collection may include an empty item. It can be put at the start of the list.",
-                example: "\"A{,B,C}\" | str example",
+                example: "\"A{,B,C}\" | str expand",
                 result: Some(Value::List{
                     vals: vec![
                         Value::test_string("A"),
@@ -84,7 +84,7 @@ impl Command for SubCommand {
 
             Example {
                 description: "Empty item can be at the end of the collection.",
-                example: "\"A{B,C,}\" | str example",
+                example: "\"A{B,C,}\" | str expand",
                 result: Some(Value::List{
                     vals: vec![
                         Value::test_string("AB"),
@@ -97,7 +97,7 @@ impl Command for SubCommand {
 
             Example {
                 description: "Empty item can be in the middle of the collection.",
-                example: "\"A{B,,C}\" | str example",
+                example: "\"A{B,,C}\" | str expand",
                 result: Some(Value::List{
                     vals: vec![
                         Value::test_string("AB"),

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -70,6 +70,45 @@ impl Command for SubCommand {
             },
 
             Example {
+                description: "Collection may include an empty item. It can be put at the start of the list.",
+                example: "\"A{,B,C}\" | str example",
+                result: Some(Value::List{
+                    vals: vec![
+                        Value::test_string("A"),
+                        Value::test_string("AB"),
+                        Value::test_string("AC"),
+                    ],
+                    span: Span::test_data()
+                },)
+            },
+
+            Example {
+                description: "Empty item can be at the end of the collection.",
+                example: "\"A{B,C,}\" | str example",
+                result: Some(Value::List{
+                    vals: vec![
+                        Value::test_string("AB"),
+                        Value::test_string("AC"),
+                        Value::test_string("A"),
+                    ],
+                    span: Span::test_data()
+                },)
+            },
+
+            Example {
+                description: "Empty item can be in the middle of the collection.",
+                example: "\"A{B,,C}\" | str example",
+                result: Some(Value::List{
+                    vals: vec![
+                        Value::test_string("AB"),
+                        Value::test_string("A"),
+                        Value::test_string("AC"),
+                    ],
+                    span: Span::test_data()
+                },)
+            },
+
+            Example {
                 description: "Also, it is possible to use one inside another. Here is a real-world example, that creates files:",
                 example: "\"A{B{1,3},C{2,5}}D\" | str expand",
                 result: Some(Value::List{


### PR DESCRIPTION
I added a new capability to `bracoxide` which is for `brace expansion` (it's almost like bash brace expressions).

Anyway, this change adds this capability:

`A{,B,C} | str expand`, returns:

```md
- A
- AB
- AC
```


`A{B,,C} | str expand`, returns:

```md
- AB
- A
- AC
```

`A{B,C,} | str expand`, returns:

```md
- AB
- AC
- A
```

Updated examples, according to the new feature.