### PR TITLE
handle sqlite tables better by surrounding with brackets

### DIFF
--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -157,7 +157,7 @@ fn action(
 
             // create a string for sql table creation
             let create_statement =
-                format!("CREATE TABLE IF NOT EXISTS {table_name} ({table_columns_creation})");
+                format!("CREATE TABLE IF NOT EXISTS [{table_name}] ({table_columns_creation})");
 
             // prepare the string as a sqlite statement
             let mut stmt = conn.prepare(&create_statement).map_err(|e| {
@@ -189,7 +189,7 @@ fn action(
             // ('dd', 'ee', 'ff')
 
             // create the string for inserting data into the table
-            let insert_statement = format!("INSERT INTO {table_name} VALUES {table_values}");
+            let insert_statement = format!("INSERT INTO [{table_name}] VALUES {table_values}");
 
             // prepare the string as a sqlite statement
             let mut stmt = conn.prepare(&insert_statement).map_err(|e| {

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -364,7 +364,7 @@ fn read_single_table(
     call_span: Span,
     ctrlc: Option<Arc<AtomicBool>>,
 ) -> Result<Value, rusqlite::Error> {
-    let stmt = conn.prepare(&format!("SELECT * FROM {table_name}"))?;
+    let stmt = conn.prepare(&format!("SELECT * FROM [{table_name}]"))?;
     prepared_statement_to_nu_list(stmt, call_span, ctrlc)
 }
 


### PR DESCRIPTION
# Description

This PR helps the sqlite handling better by surrounding table names with brackets. This makes it easier to have table names with spaces like `Basin / profile`.

Closes #9751 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
