### PR TITLE
add `any -> record` to `metadata`

### DIFF
--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -20,7 +20,10 @@ impl Command for Metadata {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("metadata")
-            .input_output_types(vec![(Type::Nothing, Type::Record(vec![]))])
+            .input_output_types(vec![
+                (Type::Nothing, Type::Record(vec![])),
+                (Type::Any, Type::Record(vec![])),
+            ])
             .allow_variants_without_examples(true)
             .optional(
                 "expression",

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -20,10 +20,7 @@ impl Command for Metadata {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("metadata")
-            .input_output_types(vec![
-                (Type::Nothing, Type::Record(vec![])),
-                (Type::Any, Type::Record(vec![])),
-            ])
+            .input_output_types(vec![(Type::Any, Type::Record(vec![]))])
             .allow_variants_without_examples(true)
             .optional(
                 "expression",


### PR DESCRIPTION
# Description
in the help page of `metadata`, there is the following example
```nushell
ls | metadata
```
which gives the following error
```
Error: nu::parser::input_type_mismatch

  × Command does not support table input.
   ╭─[entry #2:1:1]
 1 │ ls | metadata
   ·      ────┬───
   ·          ╰── command doesn't support table input
   ╰────
```

this PR adds `any -> record` to the signatures of `metadata` to allow the use of that kind of example.

# User-Facing Changes
`ls | metadata` will work again

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting