### PR TITLE
remove `$env.config.bracketed_paste`

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -107,12 +107,9 @@ pub fn evaluate_repl(
     );
 
     let config = engine_state.get_config();
-    if config.bracketed_paste {
-        // try to enable bracketed paste
-        // It doesn't work on windows system: https://github.com/crossterm-rs/crossterm/issues/737
-        #[cfg(not(target_os = "windows"))]
-        let _ = line_editor.enable_bracketed_paste();
-    }
+
+    #[cfg(not(target_os = "windows"))]
+    let _ = line_editor.enable_bracketed_paste();
 
     // Setup history_isolation aka "history per session"
     let history_isolation = config.history_isolation;
@@ -592,10 +589,8 @@ pub fn evaluate_repl(
                         PipelineData::empty(),
                         false,
                     );
-                    if engine_state.get_config().bracketed_paste {
-                        #[cfg(not(target_os = "windows"))]
-                        let _ = line_editor.enable_bracketed_paste();
-                    }
+                    #[cfg(not(target_os = "windows"))]
+                    let _ = line_editor.enable_bracketed_paste();
                 }
                 let cmd_duration = start_time.elapsed();
 

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -99,7 +99,6 @@ pub struct Config {
     pub enable_external_completion: bool,
     pub trim_strategy: TrimStrategy,
     pub show_banner: bool,
-    pub bracketed_paste: bool,
     pub show_clickable_links_in_ls: bool,
     pub render_right_prompt_on_last_line: bool,
     pub explore: HashMap<String, Value>,
@@ -158,7 +157,6 @@ impl Default for Config {
             float_precision: 2,
             buffer_editor: String::new(),
             use_ansi_coloring: true,
-            bracketed_paste: true,
             edit_mode: "emacs".into(),
             shell_integration: false,
             render_right_prompt_on_last_line: false,
@@ -1111,9 +1109,6 @@ impl Value {
                     }
                     "render_right_prompt_on_last_line" => {
                         try_bool!(cols, vals, index, span, render_right_prompt_on_last_line);
-                    }
-                    "bracketed_paste" => {
-                        try_bool!(cols, vals, index, span, bracketed_paste);
                     }
                     // Menus
                     "menus" => match create_menus(value) {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -281,7 +281,6 @@ $env.config = {
     float_precision: 2 # the precision for displaying floats in tables
     buffer_editor: "" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
     use_ansi_coloring: true
-    bracketed_paste: true # enable bracketed paste, currently useless on windows
     edit_mode: emacs # emacs, vi
     shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.
     render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.


### PR DESCRIPTION
# Description
setting `$env.config.bracketed_paste` simply appears to break the pasting of multiline pipelines with pipe symbols on the left.
i propose to remove this config entry point and make bracketed paste the default in all *nix systems.

> **Note**
> as before, this does not affect Windows systems as bracketed paste is not supported there

# User-Facing Changes
bracketed paste is supported by default.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting