### PR TITLE
make `append` and `prepend` signatures consistent

### DIFF
--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -16,13 +16,10 @@ impl Command for Append {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("append")
-            .input_output_types(vec![
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-                (Type::Record(vec![]), Type::Table(vec![])),
-            ])
+            .input_output_types(vec![(
+                Type::List(Box::new(Type::Any)),
+                Type::List(Box::new(Type::Any)),
+            )])
             .required("row", SyntaxShape::Any, "the row, list, or table to append")
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -46,7 +46,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[0,1,2,3] | append 4",
+                example: "[0, 1, 2, 3] | append 4",
                 description: "Append one Int item",
                 result: Some(Value::List {
                     vals: vec![
@@ -60,7 +60,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
                 }),
             },
             Example {
-                example: "[0,1] | append [2,3,4]",
+                example: "[0, 1] | append [2, 3, 4]",
                 description: "Append three Int items",
                 result: Some(Value::List {
                     vals: vec![
@@ -74,7 +74,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
                 }),
             },
             Example {
-                example: "[0,1] | append [2,nu,4,shell]",
+                example: "[0, 1] | append [2, nu, 4, shell]",
                 description: "Append Ints and Strings",
                 result: Some(Value::List {
                     vals: vec![

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -22,7 +22,6 @@ impl Command for Append {
                     Type::List(Box::new(Type::Any)),
                 ),
                 (Type::Record(vec![]), Type::Table(vec![])),
-                (Type::String, Type::String),
             ])
             .required("row", SyntaxShape::Any, "the row, list, or table to append")
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -29,7 +29,7 @@ impl Command for Append {
     }
 
     fn usage(&self) -> &str {
-        "Append any number of rows to a table."
+        "Append any number of rows to a list, record or table."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -29,7 +29,7 @@ impl Command for Prepend {
     }
 
     fn usage(&self) -> &str {
-        "Prepend any number of rows to a table."
+        "Prepend any number of rows to a list, record or table."
     }
 
     fn extra_usage(&self) -> &str {
@@ -46,7 +46,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[1,2,3,4] | prepend 0",
+                example: "[1, 2, 3, 4] | prepend 0",
                 description: "Prepend one Int item",
                 result: Some(Value::List {
                     vals: vec![
@@ -60,7 +60,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
                 }),
             },
             Example {
-                example: "[2,3,4] | prepend [0,1]",
+                example: "[2, 3, 4] | prepend [0,1]",
                 description: "Prepend two Int items",
                 result: Some(Value::List {
                     vals: vec![
@@ -74,7 +74,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
                 }),
             },
             Example {
-                example: "[2,nu,4,shell] | prepend [0,1,rocks]",
+                example: "[2, nu, 4, shell] | prepend [0, 1, rocks]",
                 description: "Prepend Ints and Strings",
                 result: Some(Value::List {
                     vals: vec![


### PR DESCRIPTION
related to https://github.com/nushell/nushell/issues/9720#issuecomment-1645321774

# Description
this PR removes `string -> string` and `record -> table` from the types of `append`.
this makes `append` and `prepend` have the same allowed signatures.

this PR also
- updates the usage of the two commands
- adds some spaces in the examples of the two commands, for readability

# User-Facing Changes
1.
```nushell
"foo" | append ["bar" "baz"]
```
is now not allowed, as `"foo" | prepend ["bar" "baz"]` is not

> one should use `["foo"] | append ["bar" "baz"]`

2.
```nushell
{a: 1} | append [{b: 2} {c: 3}]
```
is now not allowed, as `{a: 1} | prepend [{b: 2} {c: 3}]` is not

> one should use `{a: 1} | merge {b: 2, c: 3}` or `{a: 1} | transpose k v | append [{k: b, v: 2}, {k: c, v: 3}] | transpose -r | into record` with `append`

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting