### PR TITLE
Replace `&Span` with `Span` since `Span` is `Copy`

### DIFF
--- a/crates/nu-cli/src/commands/keybindings_list.rs
+++ b/crates/nu-cli/src/commands/keybindings_list.rs
@@ -62,11 +62,11 @@ impl Command for KeybindingsList {
             let all_options = ["modifiers", "keycodes", "edits", "modes", "events"];
             all_options
                 .iter()
-                .flat_map(|argument| get_records(argument, &call.head))
+                .flat_map(|argument| get_records(argument, call.head))
                 .collect()
         } else {
             call.named_iter()
-                .flat_map(|(argument, _, _)| get_records(argument.item.as_str(), &call.head))
+                .flat_map(|(argument, _, _)| get_records(argument.item.as_str(), call.head))
                 .collect()
         };
 
@@ -78,7 +78,7 @@ impl Command for KeybindingsList {
     }
 }
 
-fn get_records(entry_type: &str, span: &Span) -> Vec<Value> {
+fn get_records(entry_type: &str, span: Span) -> Vec<Value> {
     let values = match entry_type {
         "modifiers" => get_reedline_keybinding_modifiers().sorted(),
         "keycodes" => get_reedline_keycodes().sorted(),
@@ -95,15 +95,15 @@ fn get_records(entry_type: &str, span: &Span) -> Vec<Value> {
         .collect()
 }
 
-fn convert_to_record(edit: &str, entry_type: &str, span: &Span) -> Value {
-    let entry_type = Value::string(entry_type, *span);
+fn convert_to_record(edit: &str, entry_type: &str, span: Span) -> Value {
+    let entry_type = Value::string(entry_type, span);
 
-    let name = Value::string(edit, *span);
+    let name = Value::string(edit, span);
 
     Value::Record {
         cols: vec!["type".to_string(), "name".to_string()],
         vals: vec![entry_type, name],
-        span: *span,
+        span,
     }
 }
 

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -131,7 +131,7 @@ fn add_menu(
     config: &Config,
 ) -> Result<Reedline, ShellError> {
     if let Value::Record { cols, vals, span } = &menu.menu_type {
-        let layout = extract_value("layout", cols, vals, span)?.into_string("", config);
+        let layout = extract_value("layout", cols, vals, *span)?.into_string("", config);
 
         match layout.as_str() {
             "columnar" => add_columnar_menu(line_editor, menu, engine_state, stack, config),
@@ -155,7 +155,7 @@ fn add_menu(
 macro_rules! add_style {
     // first arm match add!(1,2), add!(2,3) etc
     ($name:expr, $cols: expr, $vals:expr, $span:expr, $config: expr, $menu:expr, $f:expr) => {
-        $menu = match extract_value($name, $cols, $vals, $span) {
+        $menu = match extract_value($name, $cols, $vals, *$span) {
             Ok(text) => {
                 let style = match text {
                     Value::String { val, .. } => lookup_ansi_color_style(&val),
@@ -181,7 +181,7 @@ pub(crate) fn add_columnar_menu(
     let mut columnar_menu = ColumnarMenu::default().with_name(&name);
 
     if let Value::Record { cols, vals, span } = &menu.menu_type {
-        columnar_menu = match extract_value("columns", cols, vals, span) {
+        columnar_menu = match extract_value("columns", cols, vals, *span) {
             Ok(columns) => {
                 let columns = columns.as_int()?;
                 columnar_menu.with_columns(columns as u16)
@@ -189,7 +189,7 @@ pub(crate) fn add_columnar_menu(
             Err(_) => columnar_menu,
         };
 
-        columnar_menu = match extract_value("col_width", cols, vals, span) {
+        columnar_menu = match extract_value("col_width", cols, vals, *span) {
             Ok(col_width) => {
                 let col_width = col_width.as_int()?;
                 columnar_menu.with_column_width(Some(col_width as usize))
@@ -197,7 +197,7 @@ pub(crate) fn add_columnar_menu(
             Err(_) => columnar_menu.with_column_width(None),
         };
 
-        columnar_menu = match extract_value("col_padding", cols, vals, span) {
+        columnar_menu = match extract_value("col_padding", cols, vals, *span) {
             Ok(col_padding) => {
                 let col_padding = col_padding.as_int()?;
                 columnar_menu.with_column_padding(col_padding as usize)
@@ -283,7 +283,7 @@ pub(crate) fn add_list_menu(
     let mut list_menu = ListMenu::default().with_name(&name);
 
     if let Value::Record { cols, vals, span } = &menu.menu_type {
-        list_menu = match extract_value("page_size", cols, vals, span) {
+        list_menu = match extract_value("page_size", cols, vals, *span) {
             Ok(page_size) => {
                 let page_size = page_size.as_int()?;
                 list_menu.with_page_size(page_size as usize)
@@ -369,7 +369,7 @@ pub(crate) fn add_description_menu(
     let mut description_menu = DescriptionMenu::default().with_name(&name);
 
     if let Value::Record { cols, vals, span } = &menu.menu_type {
-        description_menu = match extract_value("columns", cols, vals, span) {
+        description_menu = match extract_value("columns", cols, vals, *span) {
             Ok(columns) => {
                 let columns = columns.as_int()?;
                 description_menu.with_columns(columns as u16)
@@ -377,7 +377,7 @@ pub(crate) fn add_description_menu(
             Err(_) => description_menu,
         };
 
-        description_menu = match extract_value("col_width", cols, vals, span) {
+        description_menu = match extract_value("col_width", cols, vals, *span) {
             Ok(col_width) => {
                 let col_width = col_width.as_int()?;
                 description_menu.with_column_width(Some(col_width as usize))
@@ -385,7 +385,7 @@ pub(crate) fn add_description_menu(
             Err(_) => description_menu.with_column_width(None),
         };
 
-        description_menu = match extract_value("col_padding", cols, vals, span) {
+        description_menu = match extract_value("col_padding", cols, vals, *span) {
             Ok(col_padding) => {
                 let col_padding = col_padding.as_int()?;
                 description_menu.with_column_padding(col_padding as usize)
@@ -393,7 +393,7 @@ pub(crate) fn add_description_menu(
             Err(_) => description_menu,
         };
 
-        description_menu = match extract_value("selection_rows", cols, vals, span) {
+        description_menu = match extract_value("selection_rows", cols, vals, *span) {
             Ok(selection_rows) => {
                 let selection_rows = selection_rows.as_int()?;
                 description_menu.with_selection_rows(selection_rows as u16)
@@ -401,7 +401,7 @@ pub(crate) fn add_description_menu(
             Err(_) => description_menu,
         };
 
-        description_menu = match extract_value("description_rows", cols, vals, span) {
+        description_menu = match extract_value("description_rows", cols, vals, *span) {
             Ok(description_rows) => {
                 let description_rows = description_rows.as_int()?;
                 description_menu.with_description_rows(description_rows as usize)
@@ -719,26 +719,26 @@ impl<'config> EventType<'config> {
     fn try_from_columns(
         cols: &'config [String],
         vals: &'config [Value],
-        span: &'config Span,
+        span: Span,
     ) -> Result<Self, ShellError> {
         extract_value("send", cols, vals, span)
             .map(Self::Send)
             .or_else(|_| extract_value("edit", cols, vals, span).map(Self::Edit))
             .or_else(|_| extract_value("until", cols, vals, span).map(Self::Until))
-            .map_err(|_| ShellError::MissingConfigValue("send, edit or until".to_string(), *span))
+            .map_err(|_| ShellError::MissingConfigValue("send, edit or until".to_string(), span))
     }
 }
 
 fn parse_event(value: &Value, config: &Config) -> Result<Option<ReedlineEvent>, ShellError> {
     match value {
         Value::Record { cols, vals, span } => {
-            match EventType::try_from_columns(cols, vals, span)? {
+            match EventType::try_from_columns(cols, vals, *span)? {
                 EventType::Send(value) => event_from_record(
                     value.into_string("", config).to_lowercase().as_str(),
                     cols,
                     vals,
                     config,
-                    span,
+                    *span,
                 )
                 .map(Some),
                 EventType::Edit(value) => {
@@ -747,7 +747,7 @@ fn parse_event(value: &Value, config: &Config) -> Result<Option<ReedlineEvent>, 
                         cols,
                         vals,
                         config,
-                        span,
+                        *span,
                     )?;
                     Ok(Some(ReedlineEvent::Edit(vec![edit])))
                 }
@@ -810,7 +810,7 @@ fn event_from_record(
     cols: &[String],
     vals: &[Value],
     config: &Config,
-    span: &Span,
+    span: Span,
 ) -> Result<ReedlineEvent, ShellError> {
     let event = match name {
         "none" => ReedlineEvent::None,
@@ -853,7 +853,7 @@ fn event_from_record(
             return Err(ShellError::UnsupportedConfigValue(
                 "Reedline event".to_string(),
                 v.to_string(),
-                *span,
+                span,
             ))
         }
     };
@@ -866,7 +866,7 @@ fn edit_from_record(
     cols: &[String],
     vals: &[Value],
     config: &Config,
-    span: &Span,
+    span: Span,
 ) -> Result<EditCommand, ShellError> {
     let edit = match name {
         "movetostart" => EditCommand::MoveToStart,
@@ -968,7 +968,7 @@ fn edit_from_record(
             return Err(ShellError::UnsupportedConfigValue(
                 "reedline EditCommand".to_string(),
                 e.to_string(),
-                *span,
+                span,
             ))
         }
     };
@@ -995,7 +995,7 @@ mod test {
         let vals = vec![Value::test_string("Enter")];
 
         let span = Span::test_data();
-        let b = EventType::try_from_columns(&cols, &vals, &span).unwrap();
+        let b = EventType::try_from_columns(&cols, &vals, span).unwrap();
         assert!(matches!(b, EventType::Send(_)));
 
         let event = Value::Record {
@@ -1015,7 +1015,7 @@ mod test {
         let vals = vec![Value::test_string("Clear")];
 
         let span = Span::test_data();
-        let b = EventType::try_from_columns(&cols, &vals, &span).unwrap();
+        let b = EventType::try_from_columns(&cols, &vals, span).unwrap();
         assert!(matches!(b, EventType::Edit(_)));
 
         let event = Value::Record {
@@ -1041,7 +1041,7 @@ mod test {
         ];
 
         let span = Span::test_data();
-        let b = EventType::try_from_columns(&cols, &vals, &span).unwrap();
+        let b = EventType::try_from_columns(&cols, &vals, span).unwrap();
         assert!(matches!(b, EventType::Send(_)));
 
         let event = Value::Record {
@@ -1091,7 +1091,7 @@ mod test {
         }];
 
         let span = Span::test_data();
-        let b = EventType::try_from_columns(&cols, &vals, &span).unwrap();
+        let b = EventType::try_from_columns(&cols, &vals, span).unwrap();
         assert!(matches!(b, EventType::Until(_)));
 
         let event = Value::Record {
@@ -1159,7 +1159,7 @@ mod test {
         let vals = vec![Value::test_string("Enter")];
 
         let span = Span::test_data();
-        let b = EventType::try_from_columns(&cols, &vals, &span);
+        let b = EventType::try_from_columns(&cols, &vals, span);
         assert!(matches!(b, Err(ShellError::MissingConfigValue(_, _))));
     }
 }

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -59,7 +59,7 @@ impl Highlighter for NuHighlighter {
                 ($shape:expr, $span:expr, $text:expr) => {{
                     let spans = split_span_by_highlight_positions(
                         line,
-                        &$span,
+                        $span,
                         &matching_brackets_pos,
                         global_span_offset,
                     );
@@ -143,7 +143,7 @@ impl Highlighter for NuHighlighter {
 
 fn split_span_by_highlight_positions(
     line: &str,
-    span: &Span,
+    span: Span,
     highlight_positions: &Vec<usize>,
     global_span_offset: usize,
 ) -> Vec<(Span, bool)> {

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -105,7 +105,7 @@ fn gather_env_vars(
             span: full_span,
         } = token
         {
-            let contents = engine_state.get_span_contents(&full_span);
+            let contents = engine_state.get_span_contents(full_span);
             let (parts, _) = lex(contents, full_span.start, &[], &[b'='], true);
 
             let name = if let Some(Token {

--- a/crates/nu-cmd-extra/src/extra/platform/ansi/gradient.rs
+++ b/crates/nu-cmd-extra/src/extra/platform/ansi/gradient.rs
@@ -125,13 +125,13 @@ fn operate(
     input.map(
         move |v| {
             if column_paths.is_empty() {
-                action(&v, fgs_hex, fge_hex, bgs_hex, bge_hex, &head)
+                action(&v, fgs_hex, fge_hex, bgs_hex, bge_hex, head)
             } else {
                 let mut ret = v;
                 for path in &column_paths {
                     let r = ret.update_cell_path(
                         &path.members,
-                        Box::new(move |old| action(old, fgs_hex, fge_hex, bgs_hex, bge_hex, &head)),
+                        Box::new(move |old| action(old, fgs_hex, fge_hex, bgs_hex, bge_hex, head)),
                     );
                     if let Err(error) = r {
                         return Value::Error {
@@ -152,10 +152,11 @@ fn action(
     fg_end: Option<Rgb>,
     bg_start: Option<Rgb>,
     bg_end: Option<Rgb>,
-    command_span: &Span,
+    command_span: Span,
 ) -> Value {
     match input {
         Value::String { val, span } => {
+            let span = *span;
             match (fg_start, fg_end, bg_start, bg_end) {
                 (None, None, None, None) => {
                     // Error - no colors
@@ -163,7 +164,7 @@ fn action(
                         error: Box::new(ShellError::MissingParameter {
                             param_name:
                                 "please supply foreground and/or background color parameters".into(),
-                            span: *command_span,
+                            span: command_span,
                         }),
                     }
                 }
@@ -172,27 +173,27 @@ fn action(
                     let bg_start = Rgb::new(0, 0, 0);
                     let gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = gradient.build(val, TargetGround::Background);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (None, None, Some(bg_start), None) => {
                     // Error - missing bg_end, so assume black
                     let bg_end = Rgb::new(0, 0, 0);
                     let gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = gradient.build(val, TargetGround::Background);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (None, None, Some(bg_start), Some(bg_end)) => {
                     // Background Only
                     let gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = gradient.build(val, TargetGround::Background);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (None, Some(fg_end), None, None) => {
                     // Error - missing fg_start, so assume black
                     let fg_start = Rgb::new(0, 0, 0);
                     let gradient = Gradient::new(fg_start, fg_end);
                     let gradient_string = gradient.build(val, TargetGround::Foreground);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (None, Some(fg_end), None, Some(bg_end)) => {
                     // missing fg_start and bg_start, so assume black
@@ -201,7 +202,7 @@ fn action(
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (None, Some(fg_end), Some(bg_start), None) => {
                     // Error - missing fg_start and bg_end
@@ -210,7 +211,7 @@ fn action(
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (None, Some(fg_end), Some(bg_start), Some(bg_end)) => {
                     // Error - missing fg_start, so assume black
@@ -218,14 +219,14 @@ fn action(
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (Some(fg_start), None, None, None) => {
                     // Error - missing fg_end, so assume black
                     let fg_end = Rgb::new(0, 0, 0);
                     let gradient = Gradient::new(fg_start, fg_end);
                     let gradient_string = gradient.build(val, TargetGround::Foreground);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (Some(fg_start), None, None, Some(bg_end)) => {
                     // Error - missing fg_end, bg_start, so assume black
@@ -234,7 +235,7 @@ fn action(
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (Some(fg_start), None, Some(bg_start), None) => {
                     // Error - missing fg_end, bg_end, so assume black
@@ -243,7 +244,7 @@ fn action(
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (Some(fg_start), None, Some(bg_start), Some(bg_end)) => {
                     // Error - missing fg_end, so assume black
@@ -251,13 +252,13 @@ fn action(
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (Some(fg_start), Some(fg_end), None, None) => {
                     // Foreground Only
                     let gradient = Gradient::new(fg_start, fg_end);
                     let gradient_string = gradient.build(val, TargetGround::Foreground);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (Some(fg_start), Some(fg_end), None, Some(bg_end)) => {
                     // Error - missing bg_start, so assume black
@@ -265,7 +266,7 @@ fn action(
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (Some(fg_start), Some(fg_end), Some(bg_start), None) => {
                     // Error - missing bg_end, so assume black
@@ -273,14 +274,14 @@ fn action(
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
                 (Some(fg_start), Some(fg_end), Some(bg_start), Some(bg_end)) => {
                     // Foreground and Background Gradient
                     let fg_gradient = Gradient::new(fg_start, fg_end);
                     let bg_gradient = Gradient::new(bg_start, bg_end);
                     let gradient_string = build_all_gradient_text(val, fg_gradient, bg_gradient);
-                    Value::string(gradient_string, *span)
+                    Value::string(gradient_string, span)
                 }
             }
         }
@@ -290,7 +291,7 @@ fn action(
             Value::Error {
                 error: Box::new(ShellError::TypeMismatch {
                     err_message: got,
-                    span: other.span().unwrap_or(*command_span),
+                    span: other.span().unwrap_or(command_span),
                 }),
             }
         }
@@ -322,7 +323,7 @@ mod tests {
             Some(fg_end),
             None,
             None,
-            &Span::test_data(),
+            Span::test_data(),
         );
         assert_eq!(actual, expected);
     }

--- a/crates/nu-cmd-extra/src/extra/platform/ansi/link.rs
+++ b/crates/nu-cmd-extra/src/extra/platform/ansi/link.rs
@@ -99,12 +99,12 @@ fn operate(
 
     if column_paths.is_empty() {
         input.map(
-            move |v| process_value(&v, &text, &command_span),
+            move |v| process_value(&v, &text, command_span),
             engine_state.ctrlc.clone(),
         )
     } else {
         input.map(
-            move |v| process_each_path(v, &column_paths, &text, &command_span),
+            move |v| process_each_path(v, &column_paths, &text, command_span),
             engine_state.ctrlc.clone(),
         )
     }
@@ -114,7 +114,7 @@ fn process_each_path(
     mut value: Value,
     column_paths: &Vec<CellPath>,
     text: &Option<String>,
-    command_span: &Span,
+    command_span: Span,
 ) -> Value {
     for path in column_paths {
         let ret = value.update_cell_path(
@@ -130,7 +130,7 @@ fn process_each_path(
     value
 }
 
-fn process_value(value: &Value, text: &Option<String>, command_span: &Span) -> Value {
+fn process_value(value: &Value, text: &Option<String>, command_span: Span) -> Value {
     match value {
         Value::String { val, span } => {
             let text = text.as_deref().unwrap_or(val.as_str());
@@ -143,7 +143,7 @@ fn process_value(value: &Value, text: &Option<String>, command_span: &Span) -> V
             Value::Error {
                 error: Box::new(ShellError::TypeMismatch {
                     err_message: got,
-                    span: other.span().unwrap_or(*command_span),
+                    span: other.span().unwrap_or(command_span),
                 }),
             }
         }

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -71,7 +71,7 @@ This command is a parser keyword. For details, check:
 
                 // See if the module is a file
                 let module_arg_str = String::from_utf8_lossy(
-                    engine_state.get_span_contents(&import_pattern.head.span),
+                    engine_state.get_span_contents(import_pattern.head.span),
                 );
 
                 let maybe_file_path = find_in_dirs_env(

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -70,10 +70,10 @@ pub fn get_pipeline_elements(
         while i < pipeline.elements.len() {
             let pipeline_element = &pipeline.elements[i];
             let pipeline_expression = pipeline_element.expression().clone();
-            let pipeline_span = &pipeline_element.span();
+            let pipeline_span = pipeline_element.span();
             let element_str =
                 String::from_utf8_lossy(engine_state.get_span_contents(pipeline_span));
-            let value = Value::string(element_str.to_string(), *pipeline_span);
+            let value = Value::string(element_str.to_string(), pipeline_span);
             let expr = pipeline_expression.expr.clone();
             let (command_name, command_args_value) = if let Expr::Call(call) = expr {
                 let command = engine_state.get_decl(call.decl_id);

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -41,7 +41,7 @@ impl Command for ViewSource {
                 let block = engine_state.get_block(block_id);
 
                 if let Some(span) = block.span {
-                    let contents = engine_state.get_span_contents(&span);
+                    let contents = engine_state.get_span_contents(span);
                     Ok(Value::string(String::from_utf8_lossy(contents), call.head)
                         .into_pipeline_data())
                 } else {
@@ -61,7 +61,7 @@ impl Command for ViewSource {
                     if let Some(block_id) = decl.get_block_id() {
                         let block = engine_state.get_block(block_id);
                         if let Some(block_span) = block.span {
-                            let contents = engine_state.get_span_contents(&block_span);
+                            let contents = engine_state.get_span_contents(block_span);
                             // name of function
                             let mut final_contents = format!("def {val} [ ");
                             for n in vec_of_required {
@@ -117,7 +117,7 @@ impl Command for ViewSource {
                     // arg is a module
                     let module = engine_state.get_module(module_id);
                     if let Some(module_span) = module.span {
-                        let contents = engine_state.get_span_contents(&module_span);
+                        let contents = engine_state.get_span_contents(module_span);
                         Ok(Value::string(String::from_utf8_lossy(contents), call.head)
                             .into_pipeline_data())
                     } else {

--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -42,7 +42,7 @@ impl Command for ViewSpan {
 
         if start_span.item < end_span.item {
             let bin_contents =
-                engine_state.get_span_contents(&Span::new(start_span.item, end_span.item));
+                engine_state.get_span_contents(Span::new(start_span.item, end_span.item));
             Ok(
                 Value::string(String::from_utf8_lossy(bin_contents), call.head)
                     .into_pipeline_data(),

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -295,7 +295,7 @@ fn highlight_terms_in_record_with_search_columns(
     search_cols: &Vec<String>,
     cols: &[String],
     vals: &[Value],
-    span: &Span,
+    span: Span,
     config: &Config,
     terms: &[Value],
     string_style: Style,
@@ -332,7 +332,7 @@ fn highlight_terms_in_record_with_search_columns(
 
             Value::String {
                 val: highlighted_str,
-                span: *span,
+                span,
             }
         })
         .map(|v| v.unwrap_or_else(|v| v));
@@ -340,7 +340,7 @@ fn highlight_terms_in_record_with_search_columns(
     Value::Record {
         cols: cols.to_vec(),
         vals: new_vals.collect(),
-        span: *span,
+        span,
     }
 }
 
@@ -397,7 +397,7 @@ fn find_with_rest_and_highlight(
                             &cols_to_search_in_map,
                             cols,
                             vals,
-                            span,
+                            *span,
                             &config,
                             &terms,
                             string_style,
@@ -414,7 +414,7 @@ fn find_with_rest_and_highlight(
                         value,
                         &filter_config,
                         &lower_terms,
-                        &span,
+                        span,
                         &cols_to_search_in_filter,
                         invert,
                     )
@@ -429,7 +429,7 @@ fn find_with_rest_and_highlight(
                             &cols_to_search_in_map,
                             cols,
                             vals,
-                            span,
+                            *span,
                             &config,
                             &terms,
                             string_style,
@@ -443,7 +443,7 @@ fn find_with_rest_and_highlight(
                         value,
                         &filter_config,
                         &lower_terms,
-                        &span,
+                        span,
                         &cols_to_search_in_filter,
                         invert,
                     )
@@ -509,7 +509,7 @@ fn value_should_be_printed(
     value: &Value,
     filter_config: &Config,
     lower_terms: &[Value],
-    span: &Span,
+    span: Span,
     columns_to_search: &Vec<String>,
     invert: bool,
 ) -> bool {
@@ -556,13 +556,13 @@ fn value_should_be_printed(
     match_found
 }
 
-fn term_contains_value(term: &Value, value: &Value, span: &Span) -> bool {
-    term.r#in(*span, value, *span)
+fn term_contains_value(term: &Value, value: &Value, span: Span) -> bool {
+    term.r#in(span, value, span)
         .map_or(false, |value| value.is_true())
 }
 
-fn term_equals_value(term: &Value, value: &Value, span: &Span) -> bool {
-    term.eq(*span, value, *span)
+fn term_equals_value(term: &Value, value: &Value, span: Span) -> bool {
+    term.eq(span, value, span)
         .map_or(false, |value| value.is_true())
 }
 
@@ -572,7 +572,7 @@ fn record_matches_term(
     columns_to_search: &Vec<String>,
     filter_config: &Config,
     term: &Value,
-    span: &Span,
+    span: Span,
 ) -> bool {
     let cols_to_search = if columns_to_search.is_empty() {
         cols.to_vec()

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -12,9 +12,9 @@ fn from_value_to_delimited_string(
 ) -> Result<String, ShellError> {
     match value {
         Value::Record { cols, vals, span } => {
-            record_to_delimited(cols, vals, span, separator, config, head)
+            record_to_delimited(cols, vals, *span, separator, config, head)
         }
-        Value::List { vals, span } => table_to_delimited(vals, span, separator, config, head),
+        Value::List { vals, span } => table_to_delimited(vals, *span, separator, config, head),
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { error } => Err(*error.clone()),
         v => Err(make_unsupported_input_error(v, head, v.expect_span())),
@@ -24,7 +24,7 @@ fn from_value_to_delimited_string(
 fn record_to_delimited(
     cols: &[String],
     vals: &[Value],
-    span: &Span,
+    span: Span,
     separator: char,
     config: &Config,
     head: Span,
@@ -38,7 +38,7 @@ fn record_to_delimited(
     for (k, v) in cols.iter().zip(vals.iter()) {
         fields.push_back(k.clone());
 
-        values.push_back(to_string_tagged_value(v, config, head, *span)?);
+        values.push_back(to_string_tagged_value(v, config, head, span)?);
     }
 
     wtr.write_record(fields).expect("can not write.");
@@ -49,13 +49,13 @@ fn record_to_delimited(
 
 fn table_to_delimited(
     vals: &Vec<Value>,
-    span: &Span,
+    span: Span,
     separator: char,
     config: &Config,
     head: Span,
 ) -> Result<String, ShellError> {
     if let Some(val) = find_non_record(vals) {
-        return Err(make_unsupported_input_error(val, head, *span));
+        return Err(make_unsupported_input_error(val, head, span));
     }
 
     let mut wtr = WriterBuilder::new()
@@ -68,7 +68,7 @@ fn table_to_delimited(
         let vals = vals
             .iter()
             .map(|ele| {
-                to_string_tagged_value(ele, config, head, *span).unwrap_or_else(|_| String::new())
+                to_string_tagged_value(ele, config, head, span).unwrap_or_else(|_| String::new())
             })
             .collect::<Vec<_>>();
         wtr.write_record(vals).expect("can not write");
@@ -80,7 +80,7 @@ fn table_to_delimited(
             let mut row = vec![];
             for desc in &merged_descriptors {
                 row.push(match l.to_owned().get_data_by_key(desc) {
-                    Some(s) => to_string_tagged_value(&s, config, head, *span)?,
+                    Some(s) => to_string_tagged_value(&s, config, head, span)?,
                     None => String::new(),
                 });
             }
@@ -94,11 +94,11 @@ fn writer_to_string(writer: Writer<Vec<u8>>) -> Result<String, Box<dyn Error>> {
     Ok(String::from_utf8(writer.into_inner()?)?)
 }
 
-fn make_conversion_error(type_from: &str, span: &Span) -> ShellError {
+fn make_conversion_error(type_from: &str, span: Span) -> ShellError {
     ShellError::CantConvert {
         to_type: type_from.to_string(),
         from_type: "string".to_string(),
-        span: *span,
+        span,
         help: None,
     }
 }

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -67,12 +67,12 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
         }
         Value::List { vals, .. } => toml::Value::Array(toml_list(engine_state, vals)?),
         Value::Block { span, .. } => {
-            let code = engine_state.get_span_contents(span);
+            let code = engine_state.get_span_contents(*span);
             let code = String::from_utf8_lossy(code).to_string();
             toml::Value::String(code)
         }
         Value::Closure { span, .. } => {
-            let code = engine_state.get_span_contents(span);
+            let code = engine_state.get_span_contents(*span);
             let code = String::from_utf8_lossy(code).to_string();
             toml::Value::String(code)
         }

--- a/crates/nu-command/src/help/help_aliases.rs
+++ b/crates/nu-command/src/help/help_aliases.rs
@@ -131,7 +131,7 @@ pub fn help_aliases(
         };
 
         let alias_expansion =
-            String::from_utf8_lossy(engine_state.get_span_contents(&alias.wrapped_call.span));
+            String::from_utf8_lossy(engine_state.get_span_contents(alias.wrapped_call.span));
         let usage = alias.usage();
         let extra_usage = alias.extra_usage();
 

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -50,9 +50,9 @@ impl Command for SubCommand {
     }
 }
 
-pub fn average(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellError> {
+pub fn average(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let sum = reducer_for(Reduce::Summation);
-    let total = &sum(Value::int(0, *head), values.to_vec(), span, *head)?;
+    let total = &sum(Value::int(0, head), values.to_vec(), span, head)?;
     match total {
         Value::Filesize { val, span } => Ok(Value::Filesize {
             val: val / values.len() as i64,
@@ -62,7 +62,7 @@ pub fn average(values: &[Value], span: Span, head: &Span) -> Result<Value, Shell
             val: val / values.len() as i64,
             span: *span,
         }),
-        _ => total.div(*head, &Value::int(values.len() as i64, *head), *head),
+        _ => total.div(head, &Value::int(values.len() as i64, head), head),
     }
 }
 

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -60,9 +60,9 @@ impl Command for SubCommand {
     }
 }
 
-pub fn maximum(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellError> {
+pub fn maximum(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let max_func = reducer_for(Reduce::Maximum);
-    max_func(Value::nothing(*head), values.to_vec(), span, *head)
+    max_func(Value::nothing(head), values.to_vec(), span, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -67,7 +67,7 @@ enum Pick {
     Median,
 }
 
-pub fn median(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellError> {
+pub fn median(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let take = if values.len() % 2 == 0 {
         Pick::MedianAverage
     } else {
@@ -85,7 +85,7 @@ pub fn median(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellE
         .map(|elem| {
             if elem[0].partial_cmp(&elem[1]).is_none() {
                 return Err(ShellError::OperatorMismatch {
-                    op_span: *head,
+                    op_span: head,
                     lhs_ty: elem[0].get_type().to_string(),
                     lhs_span: elem[0].span()?,
                     rhs_ty: elem[1].get_type().to_string(),
@@ -108,7 +108,7 @@ pub fn median(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellE
                 ShellError::UnsupportedInput(
                     "Empty input".to_string(),
                     "value originates from here".into(),
-                    *head,
+                    head,
                     span,
                 )
             })?;
@@ -124,7 +124,7 @@ pub fn median(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellE
                     ShellError::UnsupportedInput(
                         "Empty input".to_string(),
                         "value originates from here".into(),
-                        *head,
+                        head,
                         span,
                     )
                 })?
@@ -136,7 +136,7 @@ pub fn median(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellE
                     ShellError::UnsupportedInput(
                         "Empty input".to_string(),
                         "value originates from here".into(),
-                        *head,
+                        head,
                         span,
                     )
                 })?

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -60,9 +60,9 @@ impl Command for SubCommand {
     }
 }
 
-pub fn minimum(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellError> {
+pub fn minimum(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let min_func = reducer_for(Reduce::Minimum);
-    min_func(Value::nothing(*head), values.to_vec(), span, *head)
+    min_func(Value::nothing(head), values.to_vec(), span, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -99,13 +99,13 @@ impl Command for SubCommand {
     }
 }
 
-pub fn mode(values: &[Value], _span: Span, head: &Span) -> Result<Value, ShellError> {
+pub fn mode(values: &[Value], _span: Span, head: Span) -> Result<Value, ShellError> {
     if let Some(Err(values)) = values
         .windows(2)
         .map(|elem| {
             if elem[0].partial_cmp(&elem[1]).is_none() {
                 return Err(ShellError::OperatorMismatch {
-                    op_span: *head,
+                    op_span: head,
                     lhs_ty: elem[0].get_type().to_string(),
                     lhs_span: elem[0].span()?,
                     rhs_ty: elem[1].get_type().to_string(),
@@ -138,7 +138,7 @@ pub fn mode(values: &[Value], _span: Span, head: &Span) -> Result<Value, ShellEr
             other => Err(ShellError::UnsupportedInput(
                 "Unable to give a result with this input".to_string(),
                 "value originates from here".into(),
-                *head,
+                head,
                 other.expect_span(),
             )),
         })
@@ -157,10 +157,10 @@ pub fn mode(values: &[Value], _span: Span, head: &Span) -> Result<Value, ShellEr
             Ordering::Less => {
                 max_freq = *frequency;
                 modes.clear();
-                modes.push(recreate_value(value, *head));
+                modes.push(recreate_value(value, head));
             }
             Ordering::Equal => {
-                modes.push(recreate_value(value, *head));
+                modes.push(recreate_value(value, head));
             }
             Ordering::Greater => (),
         }
@@ -169,7 +169,7 @@ pub fn mode(values: &[Value], _span: Span, head: &Span) -> Result<Value, ShellEr
     modes.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
     Ok(Value::List {
         vals: modes,
-        span: *head,
+        span: head,
     })
 }
 

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -46,9 +46,9 @@ impl Command for SubCommand {
 }
 
 /// Calculate product of given values
-pub fn product(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellError> {
+pub fn product(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let product_func = reducer_for(Reduce::Product);
-    product_func(Value::nothing(*head), values.to_vec(), span, *head)
+    product_func(Value::nothing(head), values.to_vec(), span, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -65,8 +65,8 @@ impl Command for SubCommand {
     }
 }
 
-pub fn compute_stddev(sample: bool) -> impl Fn(&[Value], Span, &Span) -> Result<Value, ShellError> {
-    move |values: &[Value], span: Span, head: &Span| {
+pub fn compute_stddev(sample: bool) -> impl Fn(&[Value], Span, Span) -> Result<Value, ShellError> {
+    move |values: &[Value], span: Span, head: Span| {
         let variance = variance(sample)(values, span, head);
         match variance {
             Ok(Value::Float { val, span }) => Ok(Value::Float {

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -57,9 +57,9 @@ impl Command for SubCommand {
     }
 }
 
-pub fn summation(values: &[Value], span: Span, head: &Span) -> Result<Value, ShellError> {
+pub fn summation(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let sum_func = reducer_for(Reduce::Summation);
-    sum_func(Value::nothing(*head), values.to_vec(), span, *head)
+    sum_func(Value::nothing(head), values.to_vec(), span, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -57,10 +57,10 @@ impl Command for SubCommand {
     }
 }
 
-fn sum_of_squares(values: &[Value], span: &Span) -> Result<Value, ShellError> {
-    let n = Value::int(values.len() as i64, *span);
-    let mut sum_x = Value::int(0, *span);
-    let mut sum_x2 = Value::int(0, *span);
+fn sum_of_squares(values: &[Value], span: Span) -> Result<Value, ShellError> {
+    let n = Value::int(values.len() as i64, span);
+    let mut sum_x = Value::int(0, span);
+    let mut sum_x2 = Value::int(0, span);
     for value in values {
         let v = match &value {
             Value::Int { .. } | Value::Float { .. } => Ok(value),
@@ -69,36 +69,36 @@ fn sum_of_squares(values: &[Value], span: &Span) -> Result<Value, ShellError> {
                 "Attempted to compute the sum of squares of a non-integer, non-float value"
                     .to_string(),
                 "value originates from here".into(),
-                *span,
+                span,
                 value.expect_span(),
             )),
         }?;
-        let v_squared = &v.mul(*span, v, *span)?;
-        sum_x2 = sum_x2.add(*span, v_squared, *span)?;
-        sum_x = sum_x.add(*span, v, *span)?;
+        let v_squared = &v.mul(span, v, span)?;
+        sum_x2 = sum_x2.add(span, v_squared, span)?;
+        sum_x = sum_x.add(span, v, span)?;
     }
 
-    let sum_x_squared = sum_x.mul(*span, &sum_x, *span)?;
-    let sum_x_squared_div_n = sum_x_squared.div(*span, &n, *span)?;
+    let sum_x_squared = sum_x.mul(span, &sum_x, span)?;
+    let sum_x_squared_div_n = sum_x_squared.div(span, &n, span)?;
 
-    let ss = sum_x2.sub(*span, &sum_x_squared_div_n, *span)?;
+    let ss = sum_x2.sub(span, &sum_x_squared_div_n, span)?;
 
     Ok(ss)
 }
 
 pub fn compute_variance(
     sample: bool,
-) -> impl Fn(&[Value], Span, &Span) -> Result<Value, ShellError> {
-    move |values: &[Value], span: Span, head: &Span| {
+) -> impl Fn(&[Value], Span, Span) -> Result<Value, ShellError> {
+    move |values: &[Value], span: Span, head: Span| {
         let n = if sample {
             values.len() - 1
         } else {
             values.len()
         };
         // sum_of_squares() needs the span of the original value, not the call head.
-        let ss = sum_of_squares(values, &span)?;
-        let n = Value::int(n as i64, *head);
-        ss.div(*head, &n, *head)
+        let ss = sum_of_squares(values, span)?;
+        let n = Value::int(n as i64, head);
+        ss.div(head, &n, head)
     }
 }
 

--- a/crates/nu-command/src/platform/dir_info.rs
+++ b/crates/nu-command/src/platform/dir_info.rs
@@ -204,10 +204,10 @@ impl From<DirInfo> for Value {
         });
 
         cols.push("directories".into());
-        vals.push(value_from_vec(d.dirs, &d.tag));
+        vals.push(value_from_vec(d.dirs, d.tag));
 
         cols.push("files".into());
-        vals.push(value_from_vec(d.files, &d.tag));
+        vals.push(value_from_vec(d.files, d.tag));
 
         // if !d.errors.is_empty() {
         //     let v = d
@@ -271,17 +271,17 @@ impl From<FileInfo> for Value {
     }
 }
 
-fn value_from_vec<V>(vec: Vec<V>, tag: &Span) -> Value
+fn value_from_vec<V>(vec: Vec<V>, tag: Span) -> Value
 where
     V: Into<Value>,
 {
     if vec.is_empty() {
-        Value::nothing(*tag)
+        Value::nothing(tag)
     } else {
         let values = vec.into_iter().map(Into::into).collect::<Vec<Value>>();
         Value::List {
             vals: values,
-            span: *tag,
+            span: tag,
         }
     }
 }

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -262,7 +262,7 @@ impl Command for Char {
                     .positional_nth(i)
                     .expect("Unexpected missing argument")
                     .span;
-                multi_byte.push(integer_to_unicode_char(arg, &span)?)
+                multi_byte.push(integer_to_unicode_char(arg, span)?)
             }
             Ok(Value::string(multi_byte, call_span).into_pipeline_data())
         } else if call.has_flag("unicode") {
@@ -279,7 +279,7 @@ impl Command for Char {
                     .positional_nth(i)
                     .expect("Unexpected missing argument")
                     .span;
-                multi_byte.push(string_to_unicode_char(arg, &span)?)
+                multi_byte.push(string_to_unicode_char(arg, span)?)
             }
             Ok(Value::string(multi_byte, call_span).into_pipeline_data())
         } else {
@@ -306,7 +306,7 @@ impl Command for Char {
     }
 }
 
-fn integer_to_unicode_char(value: i64, t: &Span) -> Result<char, ShellError> {
+fn integer_to_unicode_char(value: i64, t: Span) -> Result<char, ShellError> {
     let decoded_char = value.try_into().ok().and_then(std::char::from_u32);
 
     if let Some(ch) = decoded_char {
@@ -314,12 +314,12 @@ fn integer_to_unicode_char(value: i64, t: &Span) -> Result<char, ShellError> {
     } else {
         Err(ShellError::TypeMismatch {
             err_message: "not a valid Unicode codepoint".into(),
-            span: *t,
+            span: t,
         })
     }
 }
 
-fn string_to_unicode_char(s: &str, t: &Span) -> Result<char, ShellError> {
+fn string_to_unicode_char(s: &str, t: Span) -> Result<char, ShellError> {
     let decoded_char = u32::from_str_radix(s, 16)
         .ok()
         .and_then(std::char::from_u32);
@@ -329,7 +329,7 @@ fn string_to_unicode_char(s: &str, t: &Span) -> Result<char, ShellError> {
     } else {
         Err(ShellError::TypeMismatch {
             err_message: "error decoding Unicode character".into(),
-            span: *t,
+            span: t,
         })
     }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -329,7 +329,7 @@ pub fn eval_expression(
         Expr::ImportPattern(_) => Ok(Value::Nothing { span: expr.span }),
         Expr::Overlay(_) => {
             let name =
-                String::from_utf8_lossy(engine_state.get_span_contents(&expr.span)).to_string();
+                String::from_utf8_lossy(engine_state.get_span_contents(expr.span)).to_string();
 
             Ok(Value::String {
                 val: name,
@@ -1128,7 +1128,7 @@ pub fn eval_block(
             {
                 let element_span = pipeline.elements[i].span();
                 let element_str = String::from_utf8_lossy(
-                    engine_state.get_span_contents(&pipeline.elements[i].span()),
+                    engine_state.get_span_contents(pipeline.elements[i].span()),
                 )
                 .to_string();
 

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -548,8 +548,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                             Value::String { val: key, span },
                             Value::String {
                                 val: String::from_utf8_lossy(
-                                    self.engine_state
-                                        .get_span_contents(&alias.wrapped_call.span),
+                                    self.engine_state.get_span_contents(alias.wrapped_call.span),
                                 )
                                 .to_string(),
                                 span,

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -267,9 +267,9 @@ impl Value {
                 if let Ok(b) = &$vals[$index].as_bool() {
                     config.$setting = *b;
                 } else {
-                    invalid!(Some(*$span), "should be a bool");
+                    invalid!(Some($span), "should be a bool");
                     // Reconstruct
-                    $vals[$index] = Value::bool(config.$setting, *$span);
+                    $vals[$index] = Value::bool(config.$setting, $span);
                 }
             };
         }
@@ -278,9 +278,9 @@ impl Value {
                 if let Ok(b) = &$vals[$index].as_int() {
                     config.$setting = *b;
                 } else {
-                    invalid!(Some(*$span), "should be an int");
+                    invalid!(Some($span), "should be an int");
                     // Reconstruct
-                    $vals[$index] = Value::int(config.$setting, *$span);
+                    $vals[$index] = Value::int(config.$setting, $span);
                 }
             };
         }
@@ -311,6 +311,7 @@ impl Value {
         // the current use_ls_colors config setting is converted to a Value::Boolean and inserted in the
         // record in place of the 2.
         if let Value::Record { cols, vals, span } = self {
+            let span = *span;
             // Because this whole algorithm removes while iterating, this must iterate in reverse.
             for index in (0..cols.len()).rev() {
                 let value = &vals[index];
@@ -319,6 +320,7 @@ impl Value {
                     // Grouped options
                     "ls" => {
                         if let Value::Record { cols, vals, span } = &mut vals[index] {
+                            let span = *span;
                             for index in (0..cols.len()).rev() {
                                 let value = &vals[index];
                                 let key2 = cols[index].as_str();
@@ -350,10 +352,10 @@ impl Value {
                             vals[index] = Value::record(
                                 vec!["use_ls_colors".into(), "clickable_links".into()],
                                 vec![
-                                    Value::bool(config.use_ls_colors, *span),
-                                    Value::bool(config.show_clickable_links_in_ls, *span),
+                                    Value::bool(config.use_ls_colors, span),
+                                    Value::bool(config.show_clickable_links_in_ls, span),
                                 ],
-                                *span,
+                                span,
                             );
                         }
                     }
@@ -364,7 +366,7 @@ impl Value {
                                 let key2 = cols[index].as_str();
                                 match key2 {
                                     "abbreviations" => {
-                                        try_bool!(cols, vals, index, span, cd_with_abbreviations)
+                                        try_bool!(cols, vals, index, *span, cd_with_abbreviations)
                                     }
                                     x => {
                                         invalid_key!(
@@ -383,10 +385,10 @@ impl Value {
                             vals[index] = Value::record(
                                 vec!["use_ls_colors".into(), "clickable_links".into()],
                                 vec![
-                                    Value::bool(config.use_ls_colors, *span),
-                                    Value::bool(config.show_clickable_links_in_ls, *span),
+                                    Value::bool(config.use_ls_colors, span),
+                                    Value::bool(config.show_clickable_links_in_ls, span),
                                 ],
-                                *span,
+                                span,
                             );
                         }
                     }
@@ -397,7 +399,7 @@ impl Value {
                                 let key2 = cols[index].as_str();
                                 match key2 {
                                     "always_trash" => {
-                                        try_bool!(cols, vals, index, span, rm_always_trash)
+                                        try_bool!(cols, vals, index, *span, rm_always_trash)
                                     }
                                     x => {
                                         invalid_key!(
@@ -415,8 +417,8 @@ impl Value {
                             // Reconstruct
                             vals[index] = Value::record(
                                 vec!["always_trash".into()],
-                                vec![Value::bool(config.rm_always_trash, *span)],
-                                *span,
+                                vec![Value::bool(config.rm_always_trash, span)],
+                                span,
                             );
                         }
                     }
@@ -428,11 +430,12 @@ impl Value {
                                         HistoryFileFormat::Sqlite => "sqlite",
                                         HistoryFileFormat::PlainText => "plaintext",
                                     },
-                                    *$span,
+                                    $span,
                                 )
                             };
                         }
                         if let Value::Record { cols, vals, span } = &mut vals[index] {
+                            let span = *span;
                             for index in (0..cols.len()).rev() {
                                 let value = &vals[index];
                                 let key2 = cols[index].as_str();
@@ -459,7 +462,7 @@ impl Value {
                                                         HistoryFileFormat::PlainText
                                                 }
                                                 _ => {
-                                                    invalid!(Some(*span),
+                                                    invalid!(Some(span),
                                                         "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'sqlite' or 'plaintext'"
                                                     );
                                                     // Reconstruct
@@ -468,7 +471,7 @@ impl Value {
                                                 }
                                             };
                                         } else {
-                                            invalid!(Some(*span), "should be a string");
+                                            invalid!(Some(span), "should be a string");
                                             // Reconstruct
                                             vals[index] = reconstruct_history_file_format!(span);
                                         }
@@ -495,12 +498,12 @@ impl Value {
                                     "isolation".into(),
                                 ],
                                 vec![
-                                    Value::bool(config.sync_history_on_enter, *span),
-                                    Value::int(config.max_history_size, *span),
+                                    Value::bool(config.sync_history_on_enter, span),
+                                    Value::int(config.max_history_size, span),
                                     reconstruct_history_file_format!(span),
-                                    Value::bool(config.history_isolation, *span),
+                                    Value::bool(config.history_isolation, span),
                                 ],
-                                *span,
+                                span,
                             );
                         }
                     }
@@ -510,10 +513,10 @@ impl Value {
                                 if let Some(block) = config.external_completer {
                                     Value::Block {
                                         val: block,
-                                        span: *$span,
+                                        span: $span,
                                     }
                                 } else {
-                                    Value::Nothing { span: *$span }
+                                    Value::Nothing { span: $span }
                                 }
                             };
                         }
@@ -522,15 +525,16 @@ impl Value {
                                 Value::record(
                                     vec!["max_results".into(), "completer".into(), "enable".into()],
                                     vec![
-                                        Value::int(config.max_external_completion_results, *$span),
+                                        Value::int(config.max_external_completion_results, $span),
                                         reconstruct_external_completer!($span),
-                                        Value::bool(config.enable_external_completion, *$span),
+                                        Value::bool(config.enable_external_completion, $span),
                                     ],
-                                    *$span,
+                                    $span,
                                 )
                             };
                         }
                         if let Value::Record { cols, vals, span } = &mut vals[index] {
+                            let span = *span;
                             for index in (0..cols.len()).rev() {
                                 let value = &vals[index];
                                 let key2 = cols[index].as_str();
@@ -550,22 +554,22 @@ impl Value {
                                                     config.completion_algorithm = val_str
                                                 }
                                                 _ => {
-                                                    invalid!( Some(*span),
+                                                    invalid!( Some(span),
                                                         "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'prefix' or 'fuzzy'"
                                                     );
                                                     // Reconstruct
                                                     vals[index] = Value::string(
                                                         config.completion_algorithm.clone(),
-                                                        *span,
+                                                        span,
                                                     );
                                                 }
                                             };
                                         } else {
-                                            invalid!(Some(*span), "should be a string");
+                                            invalid!(Some(span), "should be a string");
                                             // Reconstruct
                                             vals[index] = Value::string(
                                                 config.completion_algorithm.clone(),
-                                                *span,
+                                                span,
                                             );
                                         }
                                     }
@@ -581,6 +585,7 @@ impl Value {
                                     "external" => {
                                         if let Value::Record { cols, vals, span } = &mut vals[index]
                                         {
+                                            let span = *span;
                                             for index in (0..cols.len()).rev() {
                                                 let value = &vals[index];
                                                 let key3 = cols[index].as_str();
@@ -602,7 +607,7 @@ impl Value {
                                                                 Value::Nothing { .. } => {}
                                                                 _ => {
                                                                     invalid!(
-                                                                        Some(*span),
+                                                                        Some(span),
                                                                         "should be a block or null"
                                                                     );
                                                                     // Reconstruct
@@ -634,7 +639,7 @@ impl Value {
                                                 }
                                             }
                                         } else {
-                                            invalid!(Some(*span), "should be a record");
+                                            invalid!(Some(span), "should be a record");
                                             // Reconstruct
                                             vals[index] = reconstruct_external!(span);
                                         }
@@ -662,13 +667,13 @@ impl Value {
                                     "external".into(),
                                 ],
                                 vec![
-                                    Value::bool(config.quick_completions, *span),
-                                    Value::bool(config.partial_completions, *span),
-                                    Value::string(config.completion_algorithm.clone(), *span),
-                                    Value::bool(config.case_sensitive_completions, *span),
+                                    Value::bool(config.quick_completions, span),
+                                    Value::bool(config.partial_completions, span),
+                                    Value::string(config.completion_algorithm.clone(), span),
+                                    Value::bool(config.case_sensitive_completions, span),
                                     reconstruct_external!(span),
                                 ],
-                                *span,
+                                span,
                             );
                         }
                     }
@@ -684,11 +689,12 @@ impl Value {
                                         NuCursorShape::BlinkBlock => "blink_block",
                                         NuCursorShape::BlinkUnderScore => "blink_underscore",
                                     },
-                                    *$span,
+                                    $span,
                                 )
                             };
                         }
                         if let Value::Record { cols, vals, span } = &mut vals[index] {
+                            let span = *span;
                             for index in (0..cols.len()).rev() {
                                 let value = &vals[index];
                                 let key2 = cols[index].as_str();
@@ -722,7 +728,7 @@ impl Value {
                                                         NuCursorShape::BlinkUnderScore;
                                                 }
                                                 _ => {
-                                                    invalid!(Some(*span),
+                                                    invalid!(Some(span),
                                                         "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
                                                     );
                                                     // Reconstruct
@@ -733,7 +739,7 @@ impl Value {
                                                 }
                                             };
                                         } else {
-                                            invalid!(Some(*span), "should be a string");
+                                            invalid!(Some(span), "should be a string");
                                             // Reconstruct
                                             vals[index] = reconstruct_cursor_shape!(
                                                 config.cursor_shape_vi_insert,
@@ -770,7 +776,7 @@ impl Value {
                                                         NuCursorShape::BlinkUnderScore;
                                                 }
                                                 _ => {
-                                                    invalid!(Some(*span),
+                                                    invalid!(Some(span),
                                                         "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
                                                     );
                                                     // Reconstruct
@@ -781,7 +787,7 @@ impl Value {
                                                 }
                                             };
                                         } else {
-                                            invalid!(Some(*span), "should be a string");
+                                            invalid!(Some(span), "should be a string");
                                             // Reconstruct
                                             vals[index] = reconstruct_cursor_shape!(
                                                 config.cursor_shape_vi_normal,
@@ -817,7 +823,7 @@ impl Value {
                                                         NuCursorShape::BlinkUnderScore;
                                                 }
                                                 _ => {
-                                                    invalid!(Some(*span),
+                                                    invalid!(Some(span),
                                                         "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
                                                     );
                                                     // Reconstruct
@@ -828,7 +834,7 @@ impl Value {
                                                 }
                                             };
                                         } else {
-                                            invalid!(Some(*span), "should be a string");
+                                            invalid!(Some(span), "should be a string");
                                             // Reconstruct
                                             vals[index] = reconstruct_cursor_shape!(
                                                 config.cursor_shape_emacs,
@@ -857,7 +863,7 @@ impl Value {
                                     reconstruct_cursor_shape!(config.cursor_shape_vi_normal, span),
                                     reconstruct_cursor_shape!(config.cursor_shape_emacs, span),
                                 ],
-                                *span,
+                                span,
                             );
                         }
                     }
@@ -870,7 +876,7 @@ impl Value {
                                         TableIndexMode::Never => "never",
                                         TableIndexMode::Auto => "auto",
                                     },
-                                    *$span,
+                                    $span,
                                 )
                             };
                         }
@@ -883,29 +889,30 @@ impl Value {
                                             "wrapping_try_keep_words".into(),
                                         ],
                                         vec![
-                                            Value::string("wrapping", *$span),
-                                            Value::bool(*try_to_keep_words, *$span),
+                                            Value::string("wrapping", $span),
+                                            Value::bool(*try_to_keep_words, $span),
                                         ],
-                                        *$span,
+                                        $span,
                                     ),
                                     TrimStrategy::Truncate { suffix } => Value::record(
                                         vec!["methodology".into(), "truncating_suffix".into()],
                                         match suffix {
                                             Some(s) => vec![
-                                                Value::string("truncating", *$span),
-                                                Value::string(s.clone(), *$span),
+                                                Value::string("truncating", $span),
+                                                Value::string(s.clone(), $span),
                                             ],
                                             None => vec![
-                                                Value::string("truncating", *$span),
-                                                Value::Nothing { span: *span },
+                                                Value::string("truncating", $span),
+                                                Value::Nothing { span: $span },
                                             ],
                                         },
-                                        *$span,
+                                        $span,
                                     ),
                                 }
                             };
                         }
                         if let Value::Record { cols, vals, span } = &mut vals[index] {
+                            let span = *span;
                             for index in (0..cols.len()).rev() {
                                 let value = &vals[index];
                                 let key2 = cols[index].as_str();
@@ -914,9 +921,9 @@ impl Value {
                                         if let Ok(v) = value.as_string() {
                                             config.table_mode = v;
                                         } else {
-                                            invalid!(Some(*span), "should be a string");
+                                            invalid!(Some(span), "should be a string");
                                             vals[index] =
-                                                Value::string(config.table_mode.clone(), *span);
+                                                Value::string(config.table_mode.clone(), span);
                                         }
                                     }
                                     "index_mode" => {
@@ -933,14 +940,14 @@ impl Value {
                                                     config.table_index_mode = TableIndexMode::Auto
                                                 }
                                                 _ => {
-                                                    invalid!( Some(*span),
+                                                    invalid!( Some(span),
                                                         "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'never', 'always' or 'auto'"
                                                     );
                                                     vals[index] = reconstruct_index_mode!(span);
                                                 }
                                             }
                                         } else {
-                                            invalid!(Some(*span), "should be a string");
+                                            invalid!(Some(span), "should be a string");
                                             vals[index] = reconstruct_index_mode!(span);
                                         }
                                     }
@@ -979,17 +986,18 @@ impl Value {
                                     "show_empty".into(),
                                 ],
                                 vec![
-                                    Value::string(config.table_mode.clone(), *span),
+                                    Value::string(config.table_mode.clone(), span),
                                     reconstruct_index_mode!(span),
                                     reconstruct_trim_strategy!(span),
-                                    Value::bool(config.table_show_empty, *span),
+                                    Value::bool(config.table_show_empty, span),
                                 ],
-                                *span,
+                                span,
                             )
                         }
                     }
                     "filesize" => {
                         if let Value::Record { cols, vals, span } = &mut vals[index] {
+                            let span = *span;
                             for index in (0..cols.len()).rev() {
                                 let value = &vals[index];
                                 let key2 = cols[index].as_str();
@@ -1001,12 +1009,10 @@ impl Value {
                                         if let Ok(v) = value.as_string() {
                                             config.filesize_format = v.to_lowercase();
                                         } else {
-                                            invalid!(Some(*span), "should be a string");
+                                            invalid!(Some(span), "should be a string");
                                             // Reconstruct
-                                            vals[index] = Value::string(
-                                                config.filesize_format.clone(),
-                                                *span,
-                                            );
+                                            vals[index] =
+                                                Value::string(config.filesize_format.clone(), span);
                                         }
                                     }
                                     x => {
@@ -1026,10 +1032,10 @@ impl Value {
                             vals[index] = Value::record(
                                 vec!["metric".into(), "format".into()],
                                 vec![
-                                    Value::bool(config.filesize_metric, *span),
-                                    Value::string(config.filesize_format.clone(), *span),
+                                    Value::bool(config.filesize_metric, span),
+                                    Value::string(config.filesize_format.clone(), span),
                                 ],
-                                *span,
+                                span,
                             );
                         }
                     }
@@ -1039,7 +1045,7 @@ impl Value {
                         } else {
                             invalid!(vals[index].span().ok(), "should be a record");
                             // Reconstruct
-                            vals[index] = Value::record_from_hashmap(&config.explore, *span);
+                            vals[index] = Value::record_from_hashmap(&config.explore, span);
                         }
                     }
                     // Misc. options
@@ -1049,7 +1055,7 @@ impl Value {
                         } else {
                             invalid!(vals[index].span().ok(), "should be a record");
                             // Reconstruct
-                            vals[index] = Value::record_from_hashmap(&config.color_config, *span);
+                            vals[index] = Value::record_from_hashmap(&config.color_config, span);
                         }
                     }
                     "use_grid_icons" => {
@@ -1068,7 +1074,7 @@ impl Value {
                                 },
                             };
                         } else {
-                            invalid!(Some(*span), "should be a string");
+                            invalid!(Some(span), "should be a string");
                             // Reconstruct
                             vals[index] = Value::String {
                                 val: match config.footer_mode {
@@ -1077,7 +1083,7 @@ impl Value {
                                     FooterMode::Always => "always".into(),
                                     FooterMode::RowCount(number) => number.to_string(),
                                 },
-                                span: *span,
+                                span,
                             };
                         }
                     }
@@ -1091,9 +1097,9 @@ impl Value {
                         if let Ok(v) = value.as_string() {
                             config.edit_mode = v.to_lowercase();
                         } else {
-                            invalid!(Some(*span), "should be a string");
+                            invalid!(Some(span), "should be a string");
                             // Reconstruct
-                            vals[index] = Value::string(config.edit_mode.clone(), *span);
+                            vals[index] = Value::string(config.edit_mode.clone(), span);
                         }
                     }
                     "shell_integration" => {
@@ -1103,7 +1109,7 @@ impl Value {
                         if let Ok(v) = value.as_string() {
                             config.buffer_editor = v.to_lowercase();
                         } else {
-                            invalid!(Some(*span), "should be a string");
+                            invalid!(Some(span), "should be a string");
                         }
                     }
                     "show_banner" => {
@@ -1119,7 +1125,7 @@ impl Value {
                     "menus" => match create_menus(value) {
                         Ok(map) => config.menus = map,
                         Err(e) => {
-                            invalid!(Some(*span), "should be a valid list of menus");
+                            invalid!(Some(span), "should be a valid list of menus");
                             errors.push(e);
                             // Reconstruct
                             vals[index] = Value::List {
@@ -1152,12 +1158,12 @@ impl Value {
                                                     menu_type.clone(),
                                                     source.clone(),
                                                 ],
-                                                span: *span,
+                                                span,
                                             }
                                         },
                                     )
                                     .collect(),
-                                span: *span,
+                                span,
                             }
                         }
                     },
@@ -1165,7 +1171,7 @@ impl Value {
                     "keybindings" => match create_keybindings(value) {
                         Ok(keybindings) => config.keybindings = keybindings,
                         Err(e) => {
-                            invalid!(Some(*span), "should be a valid keybindings list");
+                            invalid!(Some(span), "should be a valid keybindings list");
                             errors.push(e);
                             // Reconstruct
                             vals[index] = Value::List {
@@ -1192,12 +1198,12 @@ impl Value {
                                                     mode.clone(),
                                                     event.clone(),
                                                 ],
-                                                span: *span,
+                                                span,
                                             }
                                         },
                                     )
                                     .collect(),
-                                span: *span,
+                                span,
                             }
                         }
                     },
@@ -1205,7 +1211,7 @@ impl Value {
                     "hooks" => match create_hooks(value) {
                         Ok(hooks) => config.hooks = hooks,
                         Err(e) => {
-                            invalid!(Some(*span), "should be a valid hooks list");
+                            invalid!(Some(span), "should be a valid hooks list");
                             errors.push(e);
                             // Reconstruct
                             let mut hook_cols = vec![];
@@ -1229,7 +1235,7 @@ impl Value {
                             vals.push(Value::Record {
                                 cols: hook_cols,
                                 vals: hook_vals,
-                                span: *span,
+                                span,
                             });
                         }
                     },
@@ -1270,10 +1276,10 @@ impl Value {
                             vals[index] = Value::record(
                                 vec!["metric".into(), "format".into()],
                                 vec![
-                                    Value::bool(config.filesize_metric, *span),
-                                    Value::string(config.filesize_format.clone(), *span),
+                                    Value::bool(config.filesize_metric, span),
+                                    Value::string(config.filesize_format.clone(), span),
                                 ],
-                                *span,
+                                span,
                             );
                         }
                     }
@@ -1458,6 +1464,7 @@ fn create_hooks(value: &Value) -> Result<Hooks, ShellError> {
 fn create_keybindings(value: &Value) -> Result<Vec<ParsedKeybinding>, ShellError> {
     match value {
         Value::Record { cols, vals, span } => {
+            let span = *span;
             // Finding the modifier value in the record
             let modifier = extract_value("modifier", cols, vals, span)?.clone();
             let keycode = extract_value("keycode", cols, vals, span)?.clone();
@@ -1495,6 +1502,7 @@ fn create_keybindings(value: &Value) -> Result<Vec<ParsedKeybinding>, ShellError
 pub fn create_menus(value: &Value) -> Result<Vec<ParsedMenu>, ShellError> {
     match value {
         Value::Record { cols, vals, span } => {
+            let span = *span;
             // Finding the modifier value in the record
             let name = extract_value("name", cols, vals, span)?.clone();
             let marker = extract_value("marker", cols, vals, span)?.clone();
@@ -1506,7 +1514,7 @@ pub fn create_menus(value: &Value) -> Result<Vec<ParsedMenu>, ShellError> {
             // Source is an optional value
             let source = match extract_value("source", cols, vals, span) {
                 Ok(source) => source.clone(),
-                Err(_) => Value::Nothing { span: *span },
+                Err(_) => Value::Nothing { span },
             };
 
             let menu = ParsedMenu {
@@ -1538,10 +1546,10 @@ pub fn extract_value<'record>(
     name: &str,
     cols: &'record [String],
     vals: &'record [Value],
-    span: &Span,
+    span: Span,
 ) -> Result<&'record Value, ShellError> {
     cols.iter()
         .position(|col| col.as_str() == name)
         .and_then(|index| vals.get(index))
-        .ok_or_else(|| ShellError::MissingConfigValue(name.to_string(), *span))
+        .ok_or_else(|| ShellError::MissingConfigValue(name.to_string(), span))
 }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -724,7 +724,7 @@ impl EngineState {
         output
     }
 
-    pub fn get_span_contents(&self, span: &Span) -> &[u8] {
+    pub fn get_span_contents(&self, span: Span) -> &[u8] {
         for (contents, start, finish) in &self.file_contents {
             if span.start >= *start && span.end <= *finish {
                 return &contents[(span.start - start)..(span.end - start)];
@@ -902,7 +902,7 @@ impl EngineState {
     pub fn build_usage(&self, spans: &[Span]) -> (String, String) {
         let comment_lines: Vec<&[u8]> = spans
             .iter()
-            .map(|span| self.get_span_contents(span))
+            .map(|span| self.get_span_contents(*span))
             .collect();
         build_usage(&comment_lines)
     }
@@ -1370,7 +1370,7 @@ impl<'a> StateWorkingSet<'a> {
                 }
             }
         } else {
-            return self.permanent_state.get_span_contents(&span);
+            return self.permanent_state.get_span_contents(span);
         }
 
         panic!("internal error: missing span contents in file cache")

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -480,25 +480,25 @@ impl Value {
     /// Get the span for the current value
     pub fn span(&self) -> Result<Span, ShellError> {
         match self {
+            Value::Bool { span, .. }
+            | Value::Int { span, .. }
+            | Value::Float { span, .. }
+            | Value::Filesize { span, .. }
+            | Value::Duration { span, .. }
+            | Value::Date { span, .. }
+            | Value::Range { span, .. }
+            | Value::String { span, .. }
+            | Value::Record { span, .. }
+            | Value::List { span, .. }
+            | Value::Block { span, .. }
+            | Value::Closure { span, .. }
+            | Value::Nothing { span, .. }
+            | Value::Binary { span, .. }
+            | Value::CellPath { span, .. }
+            | Value::CustomValue { span, .. }
+            | Value::LazyRecord { span, .. }
+            | Value::MatchPattern { span, .. } => Ok(*span),
             Value::Error { error } => Err(*error.clone()),
-            Value::Bool { span, .. } => Ok(*span),
-            Value::Int { span, .. } => Ok(*span),
-            Value::Float { span, .. } => Ok(*span),
-            Value::Filesize { span, .. } => Ok(*span),
-            Value::Duration { span, .. } => Ok(*span),
-            Value::Date { span, .. } => Ok(*span),
-            Value::Range { span, .. } => Ok(*span),
-            Value::String { span, .. } => Ok(*span),
-            Value::Record { span, .. } => Ok(*span),
-            Value::List { span, .. } => Ok(*span),
-            Value::Block { span, .. } => Ok(*span),
-            Value::Closure { span, .. } => Ok(*span),
-            Value::Nothing { span, .. } => Ok(*span),
-            Value::Binary { span, .. } => Ok(*span),
-            Value::CellPath { span, .. } => Ok(*span),
-            Value::CustomValue { span, .. } => Ok(*span),
-            Value::LazyRecord { span, .. } => Ok(*span),
-            Value::MatchPattern { span, .. } => Ok(*span),
         }
     }
 
@@ -512,25 +512,25 @@ impl Value {
     /// Update the value with a new span
     pub fn with_span(mut self, new_span: Span) -> Value {
         match &mut self {
-            Value::Bool { span, .. } => *span = new_span,
-            Value::Int { span, .. } => *span = new_span,
-            Value::Float { span, .. } => *span = new_span,
-            Value::Filesize { span, .. } => *span = new_span,
-            Value::Duration { span, .. } => *span = new_span,
-            Value::Date { span, .. } => *span = new_span,
-            Value::Range { span, .. } => *span = new_span,
-            Value::String { span, .. } => *span = new_span,
-            Value::Record { span, .. } => *span = new_span,
-            Value::LazyRecord { span, .. } => *span = new_span,
-            Value::List { span, .. } => *span = new_span,
-            Value::Closure { span, .. } => *span = new_span,
-            Value::Block { span, .. } => *span = new_span,
-            Value::Nothing { span, .. } => *span = new_span,
-            Value::Error { .. } => {}
-            Value::Binary { span, .. } => *span = new_span,
-            Value::CellPath { span, .. } => *span = new_span,
-            Value::CustomValue { span, .. } => *span = new_span,
-            Value::MatchPattern { span, .. } => *span = new_span,
+            Value::Bool { span, .. }
+            | Value::Int { span, .. }
+            | Value::Float { span, .. }
+            | Value::Filesize { span, .. }
+            | Value::Duration { span, .. }
+            | Value::Date { span, .. }
+            | Value::Range { span, .. }
+            | Value::String { span, .. }
+            | Value::Record { span, .. }
+            | Value::LazyRecord { span, .. }
+            | Value::List { span, .. }
+            | Value::Closure { span, .. }
+            | Value::Block { span, .. }
+            | Value::Nothing { span, .. }
+            | Value::Binary { span, .. }
+            | Value::CellPath { span, .. }
+            | Value::CustomValue { span, .. }
+            | Value::MatchPattern { span, .. } => *span = new_span,
+            Value::Error { .. } => (),
         }
 
         self

--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -27,7 +27,7 @@ impl GStat {
         &self,
         value: &Value,
         path: Option<Spanned<String>>,
-        span: &Span,
+        span: Span,
     ) -> Result<Value, LabeledError> {
         // use std::any::Any;
         // eprintln!("input type: {:?} value: {:#?}", &value.type_id(), &value);
@@ -55,7 +55,7 @@ impl GStat {
             }
             None => Spanned {
                 item: ".".to_string(),
-                span: *span,
+                span,
             },
         };
 
@@ -146,54 +146,51 @@ impl GStat {
         let mut vals = vec![];
 
         cols.push("idx_added_staged".into());
-        vals.push(Value::int(stats.idx_added_staged as i64, *span));
+        vals.push(Value::int(stats.idx_added_staged as i64, span));
         cols.push("idx_modified_staged".into());
-        vals.push(Value::int(stats.idx_modified_staged as i64, *span));
+        vals.push(Value::int(stats.idx_modified_staged as i64, span));
         cols.push("idx_deleted_staged".into());
-        vals.push(Value::int(stats.idx_deleted_staged as i64, *span));
+        vals.push(Value::int(stats.idx_deleted_staged as i64, span));
         cols.push("idx_renamed".into());
-        vals.push(Value::int(stats.idx_renamed as i64, *span));
+        vals.push(Value::int(stats.idx_renamed as i64, span));
         cols.push("idx_type_changed".into());
-        vals.push(Value::int(stats.idx_type_changed as i64, *span));
+        vals.push(Value::int(stats.idx_type_changed as i64, span));
         cols.push("wt_untracked".into());
-        vals.push(Value::int(stats.wt_untracked as i64, *span));
+        vals.push(Value::int(stats.wt_untracked as i64, span));
         cols.push("wt_modified".into());
-        vals.push(Value::int(stats.wt_modified as i64, *span));
+        vals.push(Value::int(stats.wt_modified as i64, span));
         cols.push("wt_deleted".into());
-        vals.push(Value::int(stats.wt_deleted as i64, *span));
+        vals.push(Value::int(stats.wt_deleted as i64, span));
         cols.push("wt_type_changed".into());
-        vals.push(Value::int(stats.wt_type_changed as i64, *span));
+        vals.push(Value::int(stats.wt_type_changed as i64, span));
         cols.push("wt_renamed".into());
-        vals.push(Value::int(stats.wt_renamed as i64, *span));
+        vals.push(Value::int(stats.wt_renamed as i64, span));
         cols.push("ignored".into());
-        vals.push(Value::int(stats.ignored as i64, *span));
+        vals.push(Value::int(stats.ignored as i64, span));
         cols.push("conflicts".into());
-        vals.push(Value::int(stats.conflicts as i64, *span));
+        vals.push(Value::int(stats.conflicts as i64, span));
         cols.push("ahead".into());
-        vals.push(Value::int(stats.ahead as i64, *span));
+        vals.push(Value::int(stats.ahead as i64, span));
         cols.push("behind".into());
-        vals.push(Value::int(stats.behind as i64, *span));
+        vals.push(Value::int(stats.behind as i64, span));
         cols.push("stashes".into());
-        vals.push(Value::int(stats.stashes as i64, *span));
+        vals.push(Value::int(stats.stashes as i64, span));
         cols.push("repo_name".into());
         vals.push(Value::String {
             val: repo_name,
-            span: *span,
+            span,
         });
         cols.push("tag".into());
-        vals.push(Value::String {
-            val: tag,
-            span: *span,
-        });
+        vals.push(Value::String { val: tag, span });
         cols.push("branch".into());
         vals.push(Value::String {
             val: stats.branch,
-            span: *span,
+            span,
         });
         cols.push("remote".into());
         vals.push(Value::String {
             val: stats.remote,
-            span: *span,
+            span,
         });
 
         // Leave this in case we want to turn it into a table instead of a list
@@ -206,61 +203,53 @@ impl GStat {
         //     span: *span,
         // })
 
-        Ok(Value::Record {
-            cols,
-            vals,
-            span: *span,
-        })
+        Ok(Value::Record { cols, vals, span })
     }
 
-    fn create_empty_git_status(&self, span: &Span) -> Value {
+    fn create_empty_git_status(&self, span: Span) -> Value {
         let mut cols = vec![];
         let mut vals = vec![];
 
         cols.push("idx_added_staged".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("idx_modified_staged".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("idx_deleted_staged".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("idx_renamed".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("idx_type_changed".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("wt_untracked".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("wt_modified".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("wt_deleted".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("wt_type_changed".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("wt_renamed".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("ignored".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("conflicts".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("ahead".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("behind".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("stashes".into());
-        vals.push(Value::int(-1, *span));
+        vals.push(Value::int(-1, span));
         cols.push("repo_name".into());
-        vals.push(Value::string("no_repository", *span));
+        vals.push(Value::string("no_repository", span));
         cols.push("tag".into());
-        vals.push(Value::string("no_tag", *span));
+        vals.push(Value::string("no_tag", span));
         cols.push("branch".into());
-        vals.push(Value::string("no_branch", *span));
+        vals.push(Value::string("no_branch", span));
         cols.push("remote".into());
-        vals.push(Value::string("no_remote", *span));
+        vals.push(Value::string("no_remote", span));
 
-        Value::Record {
-            cols,
-            vals,
-            span: *span,
-        }
+        Value::Record { cols, vals, span }
     }
 }
 

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -22,6 +22,6 @@ impl Plugin for GStat {
 
         let repo_path: Option<Spanned<String>> = call.opt(0)?;
         // eprintln!("input value: {:#?}", &input);
-        self.gstat(input, repo_path, &call.head)
+        self.gstat(input, repo_path, call.head)
     }
 }

--- a/crates/nu_plugin_query/src/query_json.rs
+++ b/crates/nu_plugin_query/src/query_json.rs
@@ -47,7 +47,7 @@ pub fn execute_json_query(
         let json_str = val.json();
         Ok(Value::string(json_str, call.head))
     } else {
-        Ok(convert_gjson_value_to_nu_value(&val, &call.head))
+        Ok(convert_gjson_value_to_nu_value(&val, call.head))
     }
 }
 
@@ -70,7 +70,7 @@ fn query_contains_modifiers(query: &str) -> bool {
     // @join: Joins multiple objects into a single object.
 }
 
-fn convert_gjson_value_to_nu_value(v: &gjValue, span: &Span) -> Value {
+fn convert_gjson_value_to_nu_value(v: &gjValue, span: Span) -> Value {
     match v.kind() {
         gjson::Kind::Array => {
             let mut vals = vec![];
@@ -79,20 +79,20 @@ fn convert_gjson_value_to_nu_value(v: &gjValue, span: &Span) -> Value {
                 true
             });
 
-            Value::List { vals, span: *span }
+            Value::List { vals, span }
         }
-        gjson::Kind::Null => Value::nothing(*span),
-        gjson::Kind::False => Value::bool(false, *span),
+        gjson::Kind::Null => Value::nothing(span),
+        gjson::Kind::False => Value::bool(false, span),
         gjson::Kind::Number => {
             let str_value = v.str();
             if str_value.contains('.') {
-                Value::float(v.f64(), *span)
+                Value::float(v.f64(), span)
             } else {
-                Value::int(v.i64(), *span)
+                Value::int(v.i64(), span)
             }
         }
-        gjson::Kind::String => Value::string(v.str(), *span),
-        gjson::Kind::True => Value::bool(true, *span),
+        gjson::Kind::String => Value::string(v.str(), span),
+        gjson::Kind::True => Value::bool(true, span),
         gjson::Kind::Object => {
             let mut cols = vec![];
             let mut vals = vec![];
@@ -101,11 +101,7 @@ fn convert_gjson_value_to_nu_value(v: &gjValue, span: &Span) -> Value {
                 vals.push(convert_gjson_value_to_nu_value(&v, span));
                 true
             });
-            Value::Record {
-                cols,
-                vals,
-                span: *span,
-            }
+            Value::Record { cols, vals, span }
         }
     }
 }

--- a/crates/nu_plugin_query/src/query_xml.rs
+++ b/crates/nu_plugin_query/src/query_xml.rs
@@ -10,7 +10,7 @@ pub fn execute_xpath_query(
     query: Option<Spanned<String>>,
 ) -> Result<Value, LabeledError> {
     let (query_string, span) = match &query {
-        Some(v) => (&v.item, &v.span),
+        Some(v) => (&v.item, v.span),
         None => {
             return Err(LabeledError {
                 msg: "problem with input data".to_string(),
@@ -101,20 +101,20 @@ pub fn execute_xpath_query(
     }
 }
 
-fn build_xpath(xpath_str: &str, span: &Span) -> Result<sxd_xpath::XPath, LabeledError> {
+fn build_xpath(xpath_str: &str, span: Span) -> Result<sxd_xpath::XPath, LabeledError> {
     let factory = Factory::new();
 
     if let Ok(xpath) = factory.build(xpath_str) {
         xpath.ok_or_else(|| LabeledError {
             label: "invalid xpath query".to_string(),
             msg: "invalid xpath query".to_string(),
-            span: Some(*span),
+            span: Some(span),
         })
     } else {
         Err(LabeledError {
             label: "expected valid xpath query".to_string(),
             msg: "expected valid xpath query".to_string(),
-            span: Some(*span),
+            span: Some(span),
         })
     }
 }


### PR DESCRIPTION
# Description
`Span` is `Copy`, so we probably should not be passing references of `Span` around. This PR replaces all instances of `&Span` with `Span`, copying spans where necessary.

# User-Facing Changes
This alters some public functions to take `Span` instead of `&Span` as input. Namely, `EngineState::get_span_contents`, `nu_protocol::extract_value`, a bunch of the math commands, and `Gstat::gstat`.
