### PR TITLE
Accept records for http subcommand headers (-H)

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -296,6 +296,12 @@ pub fn request_add_custom_headers(
         let mut custom_headers: HashMap<String, Value> = HashMap::new();
 
         match &headers {
+            Value::Record { cols, vals, .. } => {
+                for (k, v) in cols.iter().zip(vals.iter()) {
+                    custom_headers.insert(k.to_string(), v.clone());
+                }
+            }
+
             Value::List { vals: table, .. } => {
                 if table.len() == 1 {
                     // single row([key1 key2]; [val1 val2])

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -113,6 +113,34 @@ fn http_get_with_accept_errors_and_full_json_response() {
     assert!(actual.out.contains("400 => error body"))
 }
 
+#[test]
+fn http_get_with_custom_headers_as_records() {
+    let mut server = Server::new();
+
+    let mock1 = server
+        .mock("GET", "/")
+        .match_header("content-type", "application/json")
+        .with_body(r#"{"hello": "world"}"#)
+        .create();
+
+    let mock2 = server
+        .mock("GET", "/")
+        .match_header("content-type", "text/plain")
+        .with_body("world")
+        .create();
+
+    let _json_response = nu!(format!(
+        "http get -H {{content-type: application/json}} {url}",
+        url = server.url()
+    ));
+
+    let _text_response = nu!(format!(
+        "http get -H {{content-type: text/plain}} {url}",
+        url = server.url()
+    ));
+    mock1.assert();
+    mock2.assert();
+}
 // These tests require network access; they use badssl.com which is a Google-affiliated site for testing various SSL errors.
 // Revisit this if these tests prove to be flaky or unstable.
 


### PR DESCRIPTION
# Description

See also: #9743 
Before: 
`http <subcommand> -H` took a list in the form:

```nushell
[my-header-key-A my-header-value-A my-header-key-B my-header-value-B]
```

Now:
In addition to the old format, Records can be passed, For example,
```nushell
> let reqHeaders = {
    Cookie:  "acc=barfoo",
    User-Agent: "Mozilla/7.0 (Windows NT 33.0; Win64; x64) AppleWebKit/1038.90 (KHTML, like Gecko)"
}
> http get -H $reqHeaders https://example.com
```

is now equivalent to
```nushell
http get -H [Cookie "acc=barfoo" User-Agent "Mozilla/7.0 (Windows NT 33.0; Win64; x64) AppleWebKit/1038.90 (KHTML, like Gecko)"] https://example.com
```

# User-Facing Changes
No breaking changes, but Records can now also be passed to `http <subcommand> -H`.

# Tests + Formatting
# After Submitting
