### PR TITLE
add `table -> table` to `into datetime`

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -68,6 +68,7 @@ impl Command for SubCommand {
             (Type::Int, Type::Date),
             (Type::String, Type::Date),
             (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Date))),
+            (Type::Table(vec![]), Type::Table(vec![])),
         ])
         .named(
                 "timezone",

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -70,6 +70,7 @@ impl Command for SubCommand {
             (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Date))),
             (Type::Table(vec![]), Type::Table(vec![])),
         ])
+        .allow_variants_without_examples(true)
         .named(
                 "timezone",
                 SyntaxShape::String,

--- a/crates/nu-command/tests/commands/into_datetime.rs
+++ b/crates/nu-command/tests/commands/into_datetime.rs
@@ -4,6 +4,5 @@ use nu_test_support::nu;
 fn into_datetime_table_column() {
     let actual = nu!(r#"[[date]; ["2022-01-01"] ["2023-01-01"]] | into datetime date"#);
 
-    assert!(actual.out.contains("Sat, 01 Jan 2022"));
-    assert!(actual.out.contains("Sun, 01 Jan 2023"));
+    assert!(actual.out.contains(" ago"));
 }

--- a/crates/nu-command/tests/commands/into_datetime.rs
+++ b/crates/nu-command/tests/commands/into_datetime.rs
@@ -1,0 +1,9 @@
+use nu_test_support::nu;
+
+#[test]
+fn into_datetime_table_column() {
+    let actual = nu!(r#"[[date]; ["2022-01-01"] ["2023-01-01"]] | into datetime date"#);
+
+    assert!(actual.out.contains("Sat, 01 Jan 2022"));
+    assert!(actual.out.contains("Sun, 01 Jan 2023"));
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -39,6 +39,7 @@ mod help;
 mod histogram;
 mod insert;
 mod inspect;
+mod into_datetime;
 mod into_filesize;
 mod into_int;
 mod join;


### PR DESCRIPTION
should close https://github.com/nushell/nushell/issues/9774

# Description
given the help page of `into datetime`, 
```
Parameters:
  ...rest <cellpath>: for a data structure input, convert data at the given cell paths
```
it looks like `into datetime` should accept tables as input :thinking: 

this PR
- adds the `table -> table` signature to `into datetime`
- adds a test to make sure the behaviour stays there

# User-Facing Changes
## before
```nushell
> [[date]; ["2022-01-01"] ["2023-01-01"]] | into datetime date
Error: nu::parser::input_type_mismatch

  × Command does not support table<date: string> input.
   ╭─[entry #1:1:1]
 1 │ [[date]; ["2022-01-01"] ["2023-01-01"]] | into datetime date
   ·                                           ──────┬──────
   ·                                                 ╰── command doesn't support table<date: string> input
   ╰────
```

### after
```nushell
> [[date]; ["2022-01-01"] ["2023-01-01"]] | into datetime date
╭───┬──────────────╮
│ # │     date     │
├───┼──────────────┤
│ 0 │ 2 years ago  │
│ 1 │ 6 months ago │
╰───┴──────────────╯
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

the `into_datetime::into_datetime_table_column` test has been added.

# After Submitting