### PR TITLE
Remove `Signature.vectorizes_over_list` entirely

### DIFF
--- a/crates/nu-cmd-extra/src/example_test.rs
+++ b/crates/nu-cmd-extra/src/example_test.rs
@@ -43,7 +43,6 @@ mod test_examples {
                     &mut make_engine_state(cmd.clone_box()),
                     &signature.input_output_types,
                     signature.operates_on_cell_paths(),
-                    signature.vectorizes_over_list,
                 ),
             );
             check_example_evaluates_to_expected_output(&example, cwd.as_path(), &mut engine_state);

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -22,7 +22,6 @@ impl Command for BitsAnd {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required(
                 "target",
                 SyntaxShape::Int,

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -23,7 +23,6 @@ impl Command for BitsNot {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .switch(
                 "signed",

--- a/crates/nu-cmd-extra/src/extra/bits/or.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/or.rs
@@ -22,7 +22,6 @@ impl Command for BitsOr {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required(
                 "target",
                 SyntaxShape::Int,

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -25,7 +25,6 @@ impl Command for BitsRol {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required("bits", SyntaxShape::Int, "number of bits to rotate left")
             .switch(
                 "signed",

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -25,7 +25,6 @@ impl Command for BitsRor {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required("bits", SyntaxShape::Int, "number of bits to rotate right")
             .switch(
                 "signed",

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -25,7 +25,6 @@ impl Command for BitsShl {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required("bits", SyntaxShape::Int, "number of bits to shift left")
             .switch(
                 "signed",

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -25,7 +25,6 @@ impl Command for BitsShr {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required("bits", SyntaxShape::Int, "number of bits to shift right")
             .switch(
                 "signed",

--- a/crates/nu-cmd-extra/src/extra/bits/xor.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/xor.rs
@@ -22,7 +22,6 @@ impl Command for BitsXor {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required(
                 "target",
                 SyntaxShape::Int,

--- a/crates/nu-cmd-extra/src/extra/bytes/add.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/add.rs
@@ -37,7 +37,6 @@ impl Command for BytesAdd {
                     Type::List(Box::new(Type::Binary)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .required("data", SyntaxShape::Binary, "the binary to add")
             .named(

--- a/crates/nu-cmd-extra/src/extra/bytes/at.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/at.rs
@@ -44,7 +44,6 @@ impl Command for BytesAt {
                     Type::List(Box::new(Type::Binary)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required("range", SyntaxShape::Range, "the range to get bytes")
             .rest(
                 "rest",

--- a/crates/nu-cmd-extra/src/extra/bytes/length.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/length.rs
@@ -23,7 +23,6 @@ impl Command for BytesLen {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-cmd-extra/src/extra/math/arccos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccos.rs
@@ -21,7 +21,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/arccosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccosh.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/arcsin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsin.rs
@@ -21,7 +21,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsinh.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/arctan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctan.rs
@@ -21,7 +21,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/arctanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctanh.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/cos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cos.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/cosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/cosh.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/exp.rs
+++ b/crates/nu-cmd-extra/src/extra/math/exp.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/ln.rs
+++ b/crates/nu-cmd-extra/src/extra/math/ln.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/sin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sin.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/sinh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/sinh.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/tan.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tan.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Float)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/math/tanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/tanh.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-cmd-extra/src/extra/platform/ansi/gradient.rs
+++ b/crates/nu-cmd-extra/src/extra/platform/ansi/gradient.rs
@@ -52,7 +52,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .category(Category::Platform)
     }

--- a/crates/nu-cmd-extra/src/extra/platform/ansi/link.rs
+++ b/crates/nu-cmd-extra/src/extra/platform/ansi/link.rs
@@ -39,7 +39,6 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "for a data structure input, add links to all strings at the given cell paths",
             )
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .category(Category::Platform)
     }

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
@@ -23,7 +23,6 @@ impl Command for DecodeHex {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
@@ -23,7 +23,6 @@ impl Command for EncodeHex {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -45,20 +45,22 @@ pub fn check_example_input_and_output_types_match_command_signature(
                        // TODO: This is too permissive; it should make use of the signature.input_output_types at least.
                        && example_output_type.to_shape() == example_input_type.to_shape();
 
-            if !(example_matches_signature
-                || example_matches_signature_via_cell_path_operation)
-            {
+            if !(example_matches_signature || example_matches_signature_via_cell_path_operation) {
                 panic!(
-                       "The example `{}` demonstrates a transformation of type {:?} -> {:?}. \
+                    "The example `{}` demonstrates a transformation of type {:?} -> {:?}. \
                        However, this does not match the declared signature: {:?}.{} \
                        For this command `operates_on_cell_paths()` is {}.",
-                       example.example,
-                       example_input_type,
-                       example_output_type,
-                       signature_input_output_types,
-                       if signature_input_output_types.is_empty() { " (Did you forget to declare the input and output types for the command?)" } else { "" },
-                       signature_operates_on_cell_paths
-                   );
+                    example.example,
+                    example_input_type,
+                    example_output_type,
+                    signature_input_output_types,
+                    if signature_input_output_types.is_empty() {
+                        " (Did you forget to declare the input and output types for the command?)"
+                    } else {
+                        ""
+                    },
+                    signature_operates_on_cell_paths
+                );
             };
         };
     }

--- a/crates/nu-cmd-lang/src/example_test.rs
+++ b/crates/nu-cmd-lang/src/example_test.rs
@@ -43,7 +43,6 @@ mod test_examples {
                     &mut make_engine_state(cmd.clone_box()),
                     &signature.input_output_types,
                     signature.operates_on_cell_paths(),
-                    signature.vectorizes_over_list,
                 ),
             );
             check_example_evaluates_to_expected_output(&example, cwd.as_path(), &mut engine_state);

--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -54,7 +54,6 @@ impl Command for Fill {
                 // General case for heterogeneous lists
                 (Type::List(Box::new(Type::Any)), Type::List(Box::new(Type::String))),
                 ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .named(
                 "width",

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -45,7 +45,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -69,7 +69,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Int)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .named("radix", SyntaxShape::Number, "radix of integer", Some('r'))
             .switch("little-endian", "use little-endian byte decoding", None)

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -46,7 +46,6 @@ mod test_examples {
                     &mut make_engine_state(cmd.clone_box()),
                     &signature.input_output_types,
                     signature.operates_on_cell_paths(),
-                    signature.vectorizes_over_list,
                 ),
             );
             check_example_evaluates_to_expected_output(&example, cwd.as_path(), &mut engine_state);

--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -19,7 +19,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Number)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }

--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -19,7 +19,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Number)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -19,7 +19,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Number)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -29,7 +29,6 @@ impl Command for SubCommand {
                 ),
             ])
             .allow_variants_without_examples(true)
-            .vectorizes_over_list(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-command/src/math/round.rs
+++ b/crates/nu-command/src/math/round.rs
@@ -22,7 +22,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Number)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .named(
                 "precision",

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -19,7 +19,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Number)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .category(Category::Math)
     }

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -18,7 +18,6 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("url encode")
             .input_output_types(vec![(Type::String, Type::String), (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String)))])
-            .vectorizes_over_list(true)
             .switch(
             "all",
             "encode all non-alphanumeric chars including `/`, `.`, `:`",

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -27,7 +27,6 @@ impl Command for DecodeBase64 {
                     Type::List(Box::new(Type::Binary)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .named(
                 "character-set",

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -33,7 +33,6 @@ impl Command for EncodeBase64 {
                     Type::List(Box::new(Type::String)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .named(
                 "character-set",

--- a/crates/nu-command/src/strings/split/chars.rs
+++ b/crates/nu-command/src/strings/split/chars.rs
@@ -23,7 +23,6 @@ impl Command for SubCommand {
                 "split on code points (default; splits combined characters)",
                 Some('c'),
             )
-            .vectorizes_over_list(true)
             .category(Category::Strings)
     }
 

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -20,7 +20,6 @@ impl Command for SubCommand {
                 (Type::String, Type::List(Box::new(Type::String))),
                 (Type::List(Box::new(Type::String)), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .required(
                 "separator",

--- a/crates/nu-command/src/strings/split/words.rs
+++ b/crates/nu-command/src/strings/split/words.rs
@@ -19,7 +19,6 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("split words")
             .input_output_types(vec![(Type::String, Type::List(Box::new(Type::String)))])
-            .vectorizes_over_list(true)
             .category(Category::Strings)
             // .switch(
             //     "ignore-hyphenated",

--- a/crates/nu-command/src/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/strings/str_/case/camel_case.rs
@@ -25,7 +25,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -23,7 +23,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -23,7 +23,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/strings/str_/case/kebab_case.rs
@@ -25,7 +25,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/strings/str_/case/pascal_case.rs
@@ -25,7 +25,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -24,7 +24,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -24,7 +24,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -25,7 +25,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -22,7 +22,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -35,7 +35,6 @@ impl Command for SubCommand {
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool)))
             ])
-            .vectorizes_over_list(true)
             .required("string", SyntaxShape::String, "the substring to find")
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -32,7 +32,6 @@ impl Command for SubCommand {
                 (Type::String, Type::Bool),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool))),
             ])
-            .vectorizes_over_list(true)
             .required("string", SyntaxShape::String, "the string to match")
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -29,7 +29,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::List(Box::new(Type::String)))),
                 ),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -38,7 +38,6 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("str index-of")
             .input_output_types(vec![(Type::String, Type::Int),(Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int)))])
-            .vectorizes_over_list(true) // TODO: no test coverage
             .allow_variants_without_examples(true)
             .required("string", SyntaxShape::String, "the string to find in the input")
             .switch(

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -30,7 +30,6 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("str length")
             .input_output_types(vec![(Type::String, Type::Int), (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int)))])
-            .vectorizes_over_list(true)
             .switch(
                 "grapheme-clusters",
                 "count length using grapheme clusters (all visible chars have length 1)",

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -43,7 +43,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .required("find", SyntaxShape::String, "the pattern to find")
             .required("replace", SyntaxShape::String, "the replacement string")
             .rest(

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -23,7 +23,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
             ])
-            .vectorizes_over_list(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -31,7 +31,6 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("str starts-with")
             .input_output_types(vec![(Type::String, Type::Bool),(Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool)))])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .required("string", SyntaxShape::String, "the string to match")
             .rest(

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -43,7 +43,6 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("str substring")
             .input_output_types(vec![(Type::String, Type::String), (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))), (Type::Table(vec![]), Type::Table(vec![]))])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .switch(
                 "grapheme-clusters",

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -43,7 +43,6 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .rest(
                 "rest",

--- a/crates/nu-protocol/src/plugin_signature.rs
+++ b/crates/nu-protocol/src/plugin_signature.rs
@@ -143,11 +143,6 @@ impl PluginSignature {
         self
     }
 
-    pub fn vectorizes_over_list(mut self, vectorizes_over_list: bool) -> PluginSignature {
-        self.sig = self.sig.vectorizes_over_list(vectorizes_over_list);
-        self
-    }
-
     /// Set the input-output type signature variants of the command
     pub fn input_output_types(mut self, input_output_types: Vec<(Type, Type)>) -> PluginSignature {
         self.sig = self.sig.input_output_types(input_output_types);

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -112,7 +112,6 @@ pub struct Signature {
     pub required_positional: Vec<PositionalArg>,
     pub optional_positional: Vec<PositionalArg>,
     pub rest_positional: Option<PositionalArg>,
-    pub vectorizes_over_list: bool,
     pub named: Vec<Flag>,
     pub input_output_types: Vec<(Type, Type)>,
     pub allow_variants_without_examples: bool,
@@ -212,7 +211,6 @@ impl Signature {
             required_positional: vec![],
             optional_positional: vec![],
             rest_positional: None,
-            vectorizes_over_list: false,
             input_output_types: vec![],
             allow_variants_without_examples: false,
             named: vec![],
@@ -461,11 +459,6 @@ impl Signature {
     /// Changes the input type of the command signature
     pub fn input_output_type(mut self, input_type: Type, output_type: Type) -> Signature {
         self.input_output_types.push((input_type, output_type));
-        self
-    }
-
-    pub fn vectorizes_over_list(mut self, vectorizes_over_list: bool) -> Signature {
-        self.vectorizes_over_list = vectorizes_over_list;
         self
     }
 


### PR DESCRIPTION
# Description
With the current typechecking logic this property has no effect.
It was only used in the example testing, and provided some indication of
this vectorizing property.
With #9742 all commands that previously declared it have explicit list
signatures. If we want to get it back in the future we can reconstruct
it from the signature.

Simplifies the example testing a bit.

# User-Facing Changes
Causes a breaking change for plugins that previously declared it. While this causes a compile fail, this was already broken by our more stringent type checking.
This will be a good reminder for plugin authors to update their signature as well to reflect the more stringent type checking.

