### PR TITLE
Adjust signatures for cellpath access of tables

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/into.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/into.rs
@@ -36,6 +36,7 @@ impl Command for BitsInto {
                 (Type::String, Type::String),
                 (Type::Bool, Type::String),
                 (Type::Date, Type::String),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .allow_variants_without_examples(true) // TODO: supply exhaustive examples
             .rest(

--- a/crates/nu-cmd-extra/src/extra/bytes/add.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/add.rs
@@ -36,6 +36,7 @@ impl Command for BytesAdd {
                     Type::List(Box::new(Type::Binary)),
                     Type::List(Box::new(Type::Binary)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-cmd-extra/src/extra/bytes/at.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/at.rs
@@ -43,6 +43,7 @@ impl Command for BytesAt {
                     Type::List(Box::new(Type::Binary)),
                     Type::List(Box::new(Type::Binary)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
             .required("range", SyntaxShape::Range, "the range to get bytes")

--- a/crates/nu-cmd-extra/src/extra/bytes/ends_with.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/ends_with.rs
@@ -28,7 +28,10 @@ impl Command for BytesEndsWith {
 
     fn signature(&self) -> Signature {
         Signature::build("bytes ends-with")
-            .input_output_types(vec![(Type::Binary, Type::Bool)])
+            .input_output_types(vec![(Type::Binary, Type::Bool),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
+            .allow_variants_without_examples(true)
             .required("pattern", SyntaxShape::Binary, "the pattern to match")
             .rest(
                 "rest",

--- a/crates/nu-cmd-extra/src/extra/bytes/length.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/length.rs
@@ -22,7 +22,9 @@ impl Command for BytesLen {
                     Type::List(Box::new(Type::Binary)),
                     Type::List(Box::new(Type::Int)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .rest(
                 "rest",

--- a/crates/nu-cmd-extra/src/extra/bytes/reverse.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/reverse.rs
@@ -17,7 +17,11 @@ impl Command for BytesReverse {
 
     fn signature(&self) -> Signature {
         Signature::build("bytes reverse")
-            .input_output_types(vec![(Type::Binary, Type::Binary)])
+            .input_output_types(vec![
+                (Type::Binary, Type::Binary),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-cmd-extra/src/extra/bytes/starts_with.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/starts_with.rs
@@ -29,7 +29,11 @@ impl Command for BytesStartsWith {
 
     fn signature(&self) -> Signature {
         Signature::build("bytes starts-with")
-            .input_output_types(vec![(Type::Binary, Type::Bool)])
+            .input_output_types(vec![
+                (Type::Binary, Type::Bool),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
+            .allow_variants_without_examples(true)
             .required("pattern", SyntaxShape::Binary, "the pattern to match")
             .rest(
                 "rest",

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
@@ -21,6 +21,7 @@ impl Command for DecodeHex {
                     Type::List(Box::new(Type::String)),
                     Type::List(Box::new(Type::Binary)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
@@ -21,6 +21,7 @@ impl Command for EncodeHex {
                     Type::List(Box::new(Type::Binary)),
                     Type::List(Box::new(Type::String)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-cmd-extra/src/extra/strings/format/filesize.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/filesize.rs
@@ -28,7 +28,11 @@ impl Command for FileSize {
 
     fn signature(&self) -> Signature {
         Signature::build("format filesize")
-            .input_output_types(vec![(Type::Filesize, Type::String)])
+            .input_output_types(vec![
+                (Type::Filesize, Type::String),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
+            .allow_variants_without_examples(true)
             .required(
                 "format value",
                 SyntaxShape::String,

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -35,6 +35,7 @@ impl Command for SubCommand {
                 (Type::Bool, Type::Binary),
                 (Type::Filesize, Type::Binary),
                 (Type::Date, Type::Binary),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .allow_variants_without_examples(true) // TODO: supply exhaustive examples
             .rest(

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -24,6 +24,7 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::Any)), Type::Table(vec![])),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -22,6 +22,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Bool),
                 (Type::Bool, Type::Bool),
                 (Type::List(Box::new(Type::Any)), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .rest(
                 "rest",

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -44,6 +44,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::String)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .allow_variants_without_examples(true) // https://github.com/nushell/nushell/issues/7032
             .rest(

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -56,6 +56,7 @@ where
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::String, Type::Binary),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .switch(
                 "binary",

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -58,6 +58,7 @@ where
                 (Type::String, Type::Binary),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .switch(
                 "binary",
                 "Output binary instead of hexadecimal representation",

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -17,7 +17,11 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("url encode")
-            .input_output_types(vec![(Type::String, Type::String), (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String)))])
+            .input_output_types(vec![
+                (Type::String, Type::String),
+                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .vectorizes_over_list(true)
             .switch(
             "all",

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -22,6 +22,7 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .switch(
             "all",

--- a/crates/nu-command/src/network/url/parse.rs
+++ b/crates/nu-command/src/network/url/parse.rs
@@ -17,7 +17,10 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("url parse")
-            .input_output_types(vec![(Type::String, Type::Record(vec![]))])
+            .input_output_types(vec![
+                (Type::String, Type::Record(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/network/url/parse.rs
+++ b/crates/nu-command/src/network/url/parse.rs
@@ -21,6 +21,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Record(vec![])),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -15,7 +15,11 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("ansi strip")
-            .input_output_types(vec![(Type::String, Type::String), (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String)))])
+            .input_output_types(vec![
+                (Type::String, Type::String),
+                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .rest(
                 "cell path",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -26,6 +26,7 @@ impl Command for DecodeBase64 {
                     Type::List(Box::new(Type::String)),
                     Type::List(Box::new(Type::Binary)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -32,6 +32,7 @@ impl Command for EncodeBase64 {
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::String)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -31,6 +31,7 @@ impl Command for SubCommand {
             .input_output_types(vec![
                 (Type::String, Type::Bool),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool))),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
             .required("string", SyntaxShape::String, "the string to match")

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -33,6 +33,7 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool))),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .required("string", SyntaxShape::String, "the string to match")
             .rest(

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -37,7 +37,11 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str index-of")
-            .input_output_types(vec![(Type::String, Type::Int),(Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int)))])
+            .input_output_types(vec![
+                (Type::String, Type::Int),
+                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int))),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .vectorizes_over_list(true) // TODO: no test coverage
             .allow_variants_without_examples(true)
             .required("string", SyntaxShape::String, "the string to find in the input")

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -34,6 +34,7 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int))),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .switch(
                 "grapheme-clusters",

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -29,7 +29,11 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str length")
-            .input_output_types(vec![(Type::String, Type::Int), (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int)))])
+            .input_output_types(vec![
+                (Type::String, Type::Int),
+                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int))),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .vectorizes_over_list(true)
             .switch(
                 "grapheme-clusters",

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -24,6 +24,7 @@ impl Command for SubCommand {
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .vectorizes_over_list(true)
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -22,6 +22,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                     Type::List(Box::new(Type::String)),
                 ),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .vectorizes_over_list(true)
             .rest(

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -30,7 +30,11 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str starts-with")
-            .input_output_types(vec![(Type::String, Type::Bool),(Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool)))])
+            .input_output_types(vec![
+                (Type::String, Type::Bool),
+                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool))),
+                (Type::Table(vec![]), Type::Table(vec![])),
+            ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .required("string", SyntaxShape::String, "the string to match")


### PR DESCRIPTION
# Description
Reallow the commands that take cellpaths as rest parameters to operate
on table input data.

Went through all commands returned by

```
scope commands |
  filter { |cmd| $cmd.signatures |
    values |
    any {|sig| $sig |
      any {|$sig| $sig.parameter_type == rest and $sig.syntax_shape ==
cellpath }
    }
  } | get name
```

Only exception to that was `is-empty` that returns a bool.
# User-Facing Changes
Same table operations as in `0.82` should still be possible
Mitigates effects of #9680
