### PR TITLE
Abort type determination for List early

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -563,7 +563,8 @@ impl Value {
                                 if x.is_numeric() && val_ty.is_numeric() {
                                     ty = Some(Type::Number)
                                 } else {
-                                    ty = Some(Type::Any)
+                                    ty = Some(Type::Any);
+                                    break;
                                 }
                             }
                         }
@@ -574,7 +575,7 @@ impl Value {
                 match ty {
                     Some(Type::Record(columns)) => Type::Table(columns),
                     Some(ty) => Type::List(Box::new(ty)),
-                    None => Type::List(Box::new(ty.unwrap_or(Type::Any))),
+                    None => Type::List(Box::new(Type::Any)),
                 }
             }
             Value::LazyRecord { val, .. } => match val.collect() {


### PR DESCRIPTION
# Description
If we reach the conclusion that the fields of a list are of `Type::Any`
there is no need to continue as the type will remain `Type::Any`

This should improve runtimes of `Value.get_type()` for lists with mixed types.

# User-Facing Changes
None, a speedup in some cases.

# Tests + Formatting
Relies on existing tests
