### PR TITLE
Update `nu-ansi-term`, `lscolors`, and `reedline`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,11 +2172,11 @@ dependencies = [
 
 [[package]]
 name = "lscolors"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a9df1d1fb6d9e92fa043e9eb9a3ecf6892c7b542bae5137cd1e419e40aa8bf"
+checksum = "bf7015a04103ad78abb77e4b79ed151e767922d1cfde5f62640471c629a2320d"
 dependencies = [
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
 ]
 
 [[package]]
@@ -2513,7 +2513,7 @@ dependencies = [
  "miette",
  "mimalloc",
  "nix",
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "nu-cli",
  "nu-cmd-base",
  "nu-cmd-dataframe",
@@ -2550,18 +2550,9 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.47.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df031e117bca634c262e9bd3173776844b6c17a90b3741c9163663b4385af76"
-dependencies = [
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "nu-ansi-term"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8e83967c32f9210ce85ac7e9c4b731048c1f51c4262e08bad01af30097a424"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
 dependencies = [
  "windows-sys 0.48.0",
 ]
@@ -2578,7 +2569,7 @@ dependencies = [
  "is_executable",
  "log",
  "miette",
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "nu-cmd-base",
  "nu-cmd-lang",
  "nu-color-config",
@@ -2632,7 +2623,7 @@ dependencies = [
  "ahash 0.8.3",
  "fancy-regex",
  "htmlescape",
- "nu-ansi-term 0.48.0",
+ "nu-ansi-term",
  "nu-cmd-base",
  "nu-cmd-lang",
  "nu-command",
@@ -2655,7 +2646,7 @@ version = "0.82.1"
 dependencies = [
  "fancy-regex",
  "itertools",
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "nu-engine",
  "nu-parser",
  "nu-protocol",
@@ -2667,7 +2658,7 @@ dependencies = [
 name = "nu-color-config"
 version = "0.82.1"
 dependencies = [
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "nu-engine",
  "nu-json",
  "nu-protocol",
@@ -2717,7 +2708,7 @@ dependencies = [
  "native-tls",
  "nix",
  "notify-debouncer-full",
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "nu-cmd-base",
  "nu-cmd-lang",
  "nu-color-config",
@@ -2794,7 +2785,7 @@ dependencies = [
  "ansi-str",
  "crossterm",
  "lscolors",
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "nu-color-config",
  "nu-engine",
  "nu-json",
@@ -2865,7 +2856,7 @@ name = "nu-pretty-hex"
 version = "0.82.1"
 dependencies = [
  "heapless",
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "rand",
 ]
 
@@ -2922,7 +2913,7 @@ dependencies = [
 name = "nu-table"
 version = "0.82.1"
 dependencies = [
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "nu-color-config",
  "nu-engine",
  "nu-protocol",
@@ -4140,13 +4131,13 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.21.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#cf841beb92affc7cb5cdc16bddefdebcd001f8c9"
+source = "git+https://github.com/nushell/reedline.git?branch=main#f15f0fb413f57fa9da86d656cf8c2eb761b3cfdf"
 dependencies = [
  "chrono",
  "crossterm",
  "fd-lock",
  "itertools",
- "nu-ansi-term 0.47.0",
+ "nu-ansi-term",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ nu-table = { path = "./crates/nu-table", version = "0.82.1" }
 nu-term-grid = { path = "./crates/nu-term-grid", version = "0.82.1" }
 nu-std = { path = "./crates/nu-std", version = "0.82.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.82.1" }
-nu-ansi-term = "0.47.0"
+nu-ansi-term = "0.49.0"
 reedline = { version = "0.21.0", features = ["bashisms", "sqlite"]}
 
 mimalloc = { version = "0.1.37", default-features = false, optional = true}

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -24,7 +24,7 @@ nu-parser = { path = "../nu-parser", version = "0.82.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.82.1" }
 nu-utils = { path = "../nu-utils", version = "0.82.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
-nu-ansi-term = "0.47.0"
+nu-ansi-term = "0.49.0"
 reedline = { version = "0.21.0", features = ["bashisms", "sqlite"]}
 
 chrono = { default-features = false, features = ["std"], version = "0.4" }

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -22,7 +22,7 @@ nu-utils = { path = "../nu-utils", version = "0.82.1" }
 # Potential dependencies for extras
 num-traits = "0.2"
 ahash = "0.8.3"
-nu-ansi-term = "0.48.0"
+nu-ansi-term = "0.49.0"
 fancy-regex = "0.11.0"
 rust-embed = "6.7.0"
 serde = "1.0.164"

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -16,7 +16,7 @@ nu-engine = { path = "../nu-engine", version = "0.82.1" }
 nu-parser = { path = "../nu-parser", version = "0.82.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.82.1"  }
 nu-utils = { path = "../nu-utils", version = "0.82.1" }
-nu-ansi-term = "0.47.0"
+nu-ansi-term = "0.49.0"
 
 fancy-regex = "0.11"
 itertools = "0.10"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 
 [dependencies]
 nu-protocol = { path = "../nu-protocol", version = "0.82.1"  }
-nu-ansi-term = "0.47.0"
+nu-ansi-term = "0.49.0"
 nu-utils = { path = "../nu-utils", version = "0.82.1" }
 nu-engine = { path = "../nu-engine", version = "0.82.1" }
 nu-json = { path="../nu-json", version = "0.82.1"  }

--- a/crates/nu-color-config/src/matching_brackets_style.rs
+++ b/crates/nu-color-config/src/matching_brackets_style.rs
@@ -26,5 +26,6 @@ fn merge_styles(base: Style, extra: Style) -> Style {
         is_reverse: extra.is_reverse || base.is_reverse,
         is_hidden: extra.is_hidden || base.is_hidden,
         is_strikethrough: extra.is_strikethrough || base.is_strikethrough,
+        prefix_with_reset: false,
     }
 }

--- a/crates/nu-color-config/src/text_style.rs
+++ b/crates/nu-color-config/src/text_style.rs
@@ -186,6 +186,7 @@ impl TextStyle {
                 is_reverse: style.is_reverse,
                 is_hidden: style.is_hidden,
                 is_strikethrough: style.is_strikethrough,
+                prefix_with_reset: false,
             }),
         }
     }
@@ -235,6 +236,7 @@ impl TextStyle {
             is_reverse: style.is_reverse,
             is_hidden: style.is_hidden,
             is_strikethrough: style.is_strikethrough,
+            prefix_with_reset: false,
         })
     }
 }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.82.1"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.47.0"
+nu-ansi-term = "0.49.0"
 nu-cmd-base = { path = "../nu-cmd-base", version = "0.82.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
 nu-engine = { path = "../nu-engine", version = "0.82.1" }
@@ -53,7 +53,7 @@ indicatif = "0.17"
 is-terminal = "0.4.8"
 itertools = "0.10"
 log = "0.4"
-lscolors = { version = "0.14", default-features = false, features = ["nu-ansi-term"] }
+lscolors = { version = "0.15", default-features = false, features = ["nu-ansi-term"] }
 md5 = { package = "md-5", version = "0.10" }
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }
 mime = "0.3"

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.82.1"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.47.0"
+nu-ansi-term = "0.49.0"
 nu-protocol = { path = "../nu-protocol", version = "0.82.1" }
 nu-parser = { path = "../nu-parser", version = "0.82.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
@@ -25,4 +25,4 @@ strip-ansi-escapes = "0.1"
 crossterm = "0.26"
 ratatui = "0.20"
 ansi-str = "0.8"
-lscolors = { version = "0.14", default-features = false, features = ["nu-ansi-term"] }
+lscolors = { version = "0.15", default-features = false, features = ["nu-ansi-term"] }

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -317,6 +317,7 @@ const fn color(foreground: Option<Color>, background: Option<Color>) -> Style {
         is_reverse: false,
         is_strikethrough: false,
         is_underline: false,
+        prefix_with_reset: false,
     }
 }
 

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.47.0"
+nu-ansi-term = "0.49.0"
 
 [dev-dependencies]
 heapless = { version = "0.7", default-features = false }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -15,7 +15,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.82.1" }
 nu-utils = { path = "../nu-utils", version = "0.82.1" }
 nu-engine = { path = "../nu-engine", version = "0.82.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
-nu-ansi-term = "0.47.0"
+nu-ansi-term = "0.49.0"
 tabled = { version = "0.12.2", features = ["color"], default-features = false }
 
 [dev-dependencies]

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 
 [dependencies]
 log = "0.4"
-lscolors = { version = "0.14", default-features = false, features = ["nu-ansi-term"] }
+lscolors = { version = "0.15", default-features = false, features = ["nu-ansi-term"] }
 num-format = { version = "0.4" }
 strip-ansi-escapes = "0.1"
 sys-locale = "0.3"


### PR DESCRIPTION
# Description
Now use `nu-ansi-term` 0.49
Small adjustments to accommodate breaking changes.


# User-Facing Changes
None
