### PR TITLE
Fix signatures for cellpath access of records

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/into.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/into.rs
@@ -37,6 +37,7 @@ impl Command for BitsInto {
                 (Type::Bool, Type::String),
                 (Type::Date, Type::String),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true) // TODO: supply exhaustive examples
             .rest(

--- a/crates/nu-cmd-extra/src/extra/bytes/add.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/add.rs
@@ -37,6 +37,7 @@ impl Command for BytesAdd {
                     Type::List(Box::new(Type::Binary)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-cmd-extra/src/extra/bytes/at.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/at.rs
@@ -44,6 +44,7 @@ impl Command for BytesAt {
                     Type::List(Box::new(Type::Binary)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .required("range", SyntaxShape::Range, "the range to get bytes")
@@ -108,11 +109,11 @@ impl Command for BytesAt {
             },
             Example {
                 description: "Get the remaining characters from a starting index",
-                example: " 0x[33 44 55 10 01 13] | bytes at 3..",
-                result: Some(Value::Binary {
-                    val: vec![0x10, 0x01, 0x13],
-                    span: Span::test_data(),
-                }),
+                example: " { data: 0x[33 44 55 10 01 13] } | bytes at 3.. data",
+                result: Some(Value::test_record(
+                    vec!["data"],
+                    vec![Value::test_binary(vec![0x10, 0x01, 0x13])],
+                )),
             },
             Example {
                 description: "Get the characters from the beginning until ending index",

--- a/crates/nu-cmd-extra/src/extra/bytes/ends_with.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/ends_with.rs
@@ -30,6 +30,7 @@ impl Command for BytesEndsWith {
         Signature::build("bytes ends-with")
             .input_output_types(vec![(Type::Binary, Type::Bool),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .required("pattern", SyntaxShape::Binary, "the pattern to match")

--- a/crates/nu-cmd-extra/src/extra/bytes/index_of.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/index_of.rs
@@ -35,7 +35,9 @@ impl Command for BytesIndexOf {
                 // FIXME: this shouldn't be needed, cell paths should work with the two
                 // above
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .required(
                 "pattern",
                 SyntaxShape::Binary,

--- a/crates/nu-cmd-extra/src/extra/bytes/length.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/length.rs
@@ -23,6 +23,7 @@ impl Command for BytesLen {
                     Type::List(Box::new(Type::Int)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-cmd-extra/src/extra/bytes/remove.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/remove.rs
@@ -33,6 +33,7 @@ impl Command for BytesRemove {
             .input_output_types(vec![
                 (Type::Binary, Type::Binary),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .required("pattern", SyntaxShape::Binary, "the pattern to find")
             .rest(
@@ -92,12 +93,10 @@ impl Command for BytesRemove {
                 }),
             },
             Example {
-                description: "Remove all occurrences of find binary",
-                example: "0x[10 AA 10 BB 10] | bytes remove -a 0x[10]",
-                result: Some(Value::Binary {
-                    val: vec![0xAA, 0xBB],
-                    span: Span::test_data(),
-                }),
+                description: "Remove all occurrences of find binary in record field",
+                example: "{ data: 0x[10 AA 10 BB 10] } | bytes remove -a 0x[10] data",
+                result: Some(Value::test_record(vec!["data"], 
+                    vec![Value::test_binary(vec![0xAA, 0xBB])])),
             },
             Example {
                 description: "Remove occurrences of find binary from end",

--- a/crates/nu-cmd-extra/src/extra/bytes/replace.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/replace.rs
@@ -33,7 +33,9 @@ impl Command for BytesReplace {
             .input_output_types(vec![
                 (Type::Binary, Type::Binary),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .required("find", SyntaxShape::Binary, "the pattern to find")
             .required("replace", SyntaxShape::Binary, "the replacement pattern")
             .rest(

--- a/crates/nu-cmd-extra/src/extra/bytes/reverse.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/reverse.rs
@@ -20,6 +20,7 @@ impl Command for BytesReverse {
             .input_output_types(vec![
                 (Type::Binary, Type::Binary),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .rest(

--- a/crates/nu-cmd-extra/src/extra/bytes/starts_with.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/starts_with.rs
@@ -32,6 +32,7 @@ impl Command for BytesStartsWith {
             .input_output_types(vec![
                 (Type::Binary, Type::Bool),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .required("pattern", SyntaxShape::Binary, "the pattern to match")

--- a/crates/nu-cmd-extra/src/extra/platform/ansi/gradient.rs
+++ b/crates/nu-cmd-extra/src/extra/platform/ansi/gradient.rs
@@ -51,6 +51,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/decode_hex.rs
@@ -22,6 +22,7 @@ impl Command for DecodeHex {
                     Type::List(Box::new(Type::Binary)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/encode_hex.rs
@@ -22,6 +22,7 @@ impl Command for EncodeHex {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-cmd-extra/src/extra/strings/format/filesize.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/filesize.rs
@@ -31,6 +31,7 @@ impl Command for FileSize {
             .input_output_types(vec![
                 (Type::Filesize, Type::String),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .required(

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -36,6 +36,7 @@ impl Command for SubCommand {
                 (Type::Filesize, Type::Binary),
                 (Type::Date, Type::Binary),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true) // TODO: supply exhaustive examples
             .rest(

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -23,6 +23,7 @@ impl Command for SubCommand {
                 (Type::Bool, Type::Bool),
                 (Type::List(Box::new(Type::Any)), Type::Table(vec![])),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .rest(

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -69,6 +69,7 @@ impl Command for SubCommand {
             (Type::String, Type::Date),
             (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Date))),
             (Type::Table(vec![]), Type::Table(vec![])),
+            (Type::Record(vec![]), Type::Record(vec![])),
         ])
         .allow_variants_without_examples(true)
         .named(

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -21,6 +21,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Number),
                 (Type::Bool, Type::Number),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Number)),

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -24,7 +24,9 @@ impl Command for SubCommand {
                 (Type::String, Type::String),
                 (Type::Duration, Type::String),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .named(
                 "convert",
                 SyntaxShape::String,

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -22,6 +22,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Filesize),
                 (Type::Filesize, Type::Filesize),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
                 (
                     Type::List(Box::new(Type::Int)),
                     Type::List(Box::new(Type::Filesize)),

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -39,6 +39,7 @@ impl Command for SubCommand {
                 (Type::Duration, Type::Int),
                 (Type::Filesize, Type::Int),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
                 (
                     Type::List(Box::new(Type::String)),
                     Type::List(Box::new(Type::Int)),

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -45,6 +45,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true) // https://github.com/nushell/nushell/issues/7032
             .rest(

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -57,6 +57,7 @@ where
                 (Type::String, Type::String),
                 (Type::String, Type::Binary),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .switch(

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -21,6 +21,7 @@ impl Command for SubCommand {
                 (Type::String, Type::String),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/network/url/parse.rs
+++ b/crates/nu-command/src/network/url/parse.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
             .input_output_types(vec![
                 (Type::String, Type::Record(vec![])),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .rest(

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -19,6 +19,7 @@ impl Command for SubCommand {
                 (Type::String, Type::String),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .rest(
                 "cell path",

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -27,6 +27,7 @@ impl Command for DecodeBase64 {
                     Type::List(Box::new(Type::Binary)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -33,6 +33,7 @@ impl Command for EncodeBase64 {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/case/camel_case.rs
+++ b/crates/nu-command/src/strings/str_/case/camel_case.rs
@@ -24,6 +24,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -22,6 +22,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -22,6 +22,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/case/kebab_case.rs
+++ b/crates/nu-command/src/strings/str_/case/kebab_case.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
                 (
                     Type::List(Box::new(Type::String)),
                     Type::List(Box::new(Type::String)),

--- a/crates/nu-command/src/strings/str_/case/pascal_case.rs
+++ b/crates/nu-command/src/strings/str_/case/pascal_case.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
             .input_output_types(vec![
                 (Type::String, Type::String),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
                 (
                     Type::List(Box::new(Type::String)),
                     Type::List(Box::new(Type::String)),

--- a/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/screaming_snake_case.rs
@@ -23,6 +23,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/case/snake_case.rs
+++ b/crates/nu-command/src/strings/str_/case/snake_case.rs
@@ -23,6 +23,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/case/title_case.rs
+++ b/crates/nu-command/src/strings/str_/case/title_case.rs
@@ -24,6 +24,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -21,6 +21,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -33,6 +33,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Bool),
                 // TODO figure out cell-path type behavior
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool)))
             ])
             .vectorizes_over_list(true)
@@ -86,14 +87,11 @@ impl Command for SubCommand {
                 result: Some(Value::test_bool(true)),
             },
             Example {
-                description: "Check if input contains string in a table",
-                example: " [[ColA ColB]; [test 100]] | str contains 'e' ColA",
-                result: Some(Value::List {
-                    vals: vec![Value::Record {
-                        cols: vec!["ColA".to_string(), "ColB".to_string()],
-                        vals: vec![Value::test_bool(true), Value::test_int(100)],
-                        span: Span::test_data(),
-                    }],
+                description: "Check if input contains string in a record",
+                example: "{ ColA: test, ColB: 100 } | str contains 'e' ColA",
+                result: Some(Value::Record {
+                    cols: vec!["ColA".to_string(), "ColB".to_string()],
+                    vals: vec![Value::test_bool(true), Value::test_int(100)],
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -31,6 +31,7 @@ impl Command for SubCommand {
             .input_output_types(vec![
                 (Type::String, Type::Int),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .required(
                 "compare-string",
@@ -77,7 +78,7 @@ impl Command for SubCommand {
             result: Some(Value::test_int(1)),
         },
         Example {
-            description: "Compute edit distance between strings in record and another string, using cell paths",
+            description: "Compute edit distance between strings in table and another string, using cell paths",
             example: "[{a: 'nutshell' b: 'numetal'}] | str distance 'nushell' 'a' 'b'",
             result: Some(Value::List {
                 vals: vec![
@@ -89,6 +90,17 @@ impl Command for SubCommand {
                 ],
                 span: Span::test_data(),
             }),
+        },
+        Example {
+            description: "Compute edit distance between strings in record and another string, using cell paths",
+            example: "{a: 'nutshell' b: 'numetal'} | str distance 'nushell' a b",
+            result: Some(
+                    Value::Record {
+                        cols: vec!["a".to_string(), "b".to_string()],
+                        vals: vec![Value::test_int(1), Value::test_int(4)],
+                        span: Span::test_data(),
+                    }
+                ),
         }]
     }
 }

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -32,6 +32,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Bool),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool))),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -41,6 +41,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Int),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int))),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true) // TODO: no test coverage
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -33,6 +33,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Int),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Int))),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -38,6 +38,7 @@ impl Command for SubCommand {
                 (Type::String, Type::String),
                 // TODO: clarify behavior with cellpath-rest argument
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
                 (
                     Type::List(Box::new(Type::String)),
                     Type::List(Box::new(Type::String)),
@@ -134,6 +135,20 @@ impl Command for SubCommand {
                     }],
                     span: Span::test_data(),
                 }),
+            },
+            Example {
+                description: "Find and replace all occurrences of find string in record",
+                example:
+                    "{ KeyA: abc, KeyB: abc, KeyC: ads } | str replace -a 'b' 'z' KeyA KeyC",
+                result: Some(Value::Record {
+                        cols: vec!["KeyA".to_string(), "KeyB".to_string(), "KeyC".to_string()],
+                        vals: vec![
+                            Value::test_string("azc"),
+                            Value::test_string("abc"),
+                            Value::test_string("ads"),
+                        ],
+                        span: Span::test_data(),
+                    }),
             },
             Example {
                 description: "Find and replace contents without using the replace parameter as a regular expression",

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -23,6 +23,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .vectorizes_over_list(true)

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -34,6 +34,7 @@ impl Command for SubCommand {
                 (Type::String, Type::Bool),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool))),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -42,7 +42,12 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("str substring")
-            .input_output_types(vec![(Type::String, Type::String), (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))), (Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![
+                (Type::String, Type::String),
+                (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::String))),
+                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
+            ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)
             .switch(

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -42,6 +42,7 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)


### PR DESCRIPTION
# Description
The same procedure as for #9778 repeated for records.

# User-Facing Changes
Commands that directly supported applying their work directly to record fields via cell paths, that worked before #9680 will now work again

# Tests + Formatting
Tried to limit the need to add new `.allow_variants_without_examples()`
by adjusting or adding tests to also use some records with access.
