### PR TITLE
Pin `reedline` to `0.22.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,8 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.21.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#f15f0fb413f57fa9da86d656cf8c2eb761b3cfdf"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2fde955d11817fdcb79d703932fb6b473192cb36b6a92ba21f7f4ac0513374e"
 dependencies = [
  "chrono",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.82.1" }
 nu-std = { path = "./crates/nu-std", version = "0.82.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.82.1" }
 nu-ansi-term = "0.49.0"
-reedline = { version = "0.21.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.22.0", features = ["bashisms", "sqlite"]}
 
 mimalloc = { version = "0.1.37", default-features = false, optional = true}
 
@@ -165,7 +165,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
+# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Criterion benchmarking setup

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -25,7 +25,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.82.1" }
 nu-utils = { path = "../nu-utils", version = "0.82.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
 nu-ansi-term = "0.49.0"
-reedline = { version = "0.21.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.22.0", features = ["bashisms", "sqlite"]}
 
 chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.26"


### PR DESCRIPTION
See release notes:

https://github.com/nushell/reedline/releases/tag/v0.22.0
