### PR TITLE
Add an option to move header on borders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,7 +2751,7 @@ dependencies = [
  "sha2",
  "sqlparser",
  "sysinfo",
- "tabled",
+ "tabled 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.2.6",
  "titlecase",
  "toml",
@@ -2918,7 +2918,7 @@ dependencies = [
  "nu-engine",
  "nu-protocol",
  "nu-utils",
- "tabled",
+ "tabled 0.13.0 (git+https://github.com/zhiburt/tabled/?rev=6c51e3eaa362914a71b868ccb78e7addbebd3657)",
 ]
 
 [[package]]
@@ -4964,6 +4964,17 @@ name = "tabled"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d38d39c754ae037a9bc3ca1580a985db7371cd14f1229172d1db9093feb6739"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "papergrid",
+ "unicode-width",
+]
+
+[[package]]
+name = "tabled"
+version = "0.13.0"
+source = "git+https://github.com/zhiburt/tabled/?rev=6c51e3eaa362914a71b868ccb78e7addbebd3657#6c51e3eaa362914a71b868ccb78e7addbebd3657"
 dependencies = [
  "ansi-str",
  "ansitok",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,9 +3303,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "papergrid"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
+checksum = "a2ccbe15f2b6db62f9a9871642746427e297b0ceb85f9a7f1ee5ff47d184d0c8"
 dependencies = [
  "ansi-str",
  "ansitok",
@@ -4961,9 +4961,9 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce69a5028cd9576063ec1f48edb2c75339fd835e6094ef3e05b3a079bf594a6"
+checksum = "4d38d39c754ae037a9bc3ca1580a985db7371cd14f1229172d1db9093feb6739"
 dependencies = [
  "ansi-str",
  "ansitok",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -84,7 +84,7 @@ serde_yaml = "0.9"
 sha2 = "0.10"
 sqlparser = { version = "0.34", features = ["serde"], optional = true }
 sysinfo = "0.29"
-tabled = { version = "0.12.2", features = ["color"], default-features = false }
+tabled = { version = "0.13.0", features = ["color"], default-features = false }
 terminal_size = "0.2"
 titlecase = "2.0"
 toml = "0.7"

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -861,7 +861,7 @@ fn create_empty_placeholder(
     let cell = NuTableCell::new(format!("empty {}", value_type_name));
     let data = vec![vec![cell]];
     let mut table = NuTable::from(data);
-    table.set_cell_style((0, 0), TextStyle::default().dimmed());
+    table.set_data_style(TextStyle::default().dimmed());
     let out = TableOutput::new(table, false, false);
 
     let style_computer = &StyleComputer::from_config(engine_state, stack);

--- a/crates/nu-explore/src/nu_common/table.rs
+++ b/crates/nu-explore/src/nu_common/table.rs
@@ -1,6 +1,9 @@
 use nu_color_config::StyleComputer;
 use nu_protocol::{Span, Value};
-use nu_table::{value_to_clean_styled_string, value_to_styled_string, BuildConfig, ExpandedTable};
+use nu_table::{
+    common::{nu_value_to_string, nu_value_to_string_clean},
+    ExpandedTable, TableOpts,
+};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
@@ -18,9 +21,9 @@ pub fn try_build_table(
             try_build_map(cols, vals, span, style_computer, ctrlc, config)
         }
         val if matches!(val, Value::String { .. }) => {
-            value_to_clean_styled_string(&val, config, style_computer).0
+            nu_value_to_string_clean(&val, config, style_computer).0
         }
-        val => value_to_styled_string(&val, config, style_computer).0,
+        val => nu_value_to_string(&val, config, style_computer).0,
     }
 }
 
@@ -32,12 +35,19 @@ fn try_build_map(
     ctrlc: Option<Arc<AtomicBool>>,
     config: &NuConfig,
 ) -> String {
-    let opts = BuildConfig::new(ctrlc, config, style_computer, Span::unknown(), usize::MAX);
+    let opts = TableOpts::new(
+        config,
+        style_computer,
+        ctrlc,
+        Span::unknown(),
+        0,
+        usize::MAX,
+    );
     let result = ExpandedTable::new(None, false, String::new()).build_map(&cols, &vals, opts);
     match result {
         Ok(Some(result)) => result,
         Ok(None) | Err(_) => {
-            value_to_styled_string(&Value::Record { cols, vals, span }, config, style_computer).0
+            nu_value_to_string(&Value::Record { cols, vals, span }, config, style_computer).0
         }
     }
 }
@@ -49,13 +59,20 @@ fn try_build_list(
     span: Span,
     style_computer: &StyleComputer,
 ) -> String {
-    let opts = BuildConfig::new(ctrlc, config, style_computer, Span::unknown(), usize::MAX);
-    let result = ExpandedTable::new(None, false, String::new()).build_list(&vals, opts, 0);
+    let opts = TableOpts::new(
+        config,
+        style_computer,
+        ctrlc,
+        Span::unknown(),
+        0,
+        usize::MAX,
+    );
+    let result = ExpandedTable::new(None, false, String::new()).build_list(&vals, opts);
     match result {
         Ok(Some(out)) => out,
         Ok(None) | Err(_) => {
             // it means that the list is empty
-            value_to_styled_string(&Value::List { vals, span }, config, style_computer).0
+            nu_value_to_string(&Value::List { vals, span }, config, style_computer).0
         }
     }
 }

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -70,6 +70,7 @@ pub struct Config {
     pub external_completer: Option<usize>,
     pub filesize_metric: bool,
     pub table_mode: String,
+    pub table_move_header: bool,
     pub table_show_empty: bool,
     pub use_ls_colors: bool,
     pub color_config: HashMap<String, Value>,
@@ -126,6 +127,7 @@ impl Default for Config {
             table_index_mode: TableIndexMode::Always,
             table_show_empty: true,
             trim_strategy: TRIM_STRATEGY_DEFAULT,
+            table_move_header: false,
 
             datetime_normal_format: None,
             datetime_table_format: None,
@@ -918,6 +920,9 @@ impl Value {
                                             vals[index] =
                                                 Value::string(config.table_mode.clone(), *span);
                                         }
+                                    }
+                                    "move_header" => {
+                                        try_bool!(cols, vals, index, span, table_move_header)
                                     }
                                     "index_mode" => {
                                         if let Ok(b) = value.as_string() {

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -921,7 +921,7 @@ impl Value {
                                                 Value::string(config.table_mode.clone(), *span);
                                         }
                                     }
-                                    "move_header" => {
+                                    "header_on_separator" => {
                                         try_bool!(cols, vals, index, span, table_move_header)
                                     }
                                     "index_mode" => {

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -16,7 +16,7 @@ nu-utils = { path = "../nu-utils", version = "0.82.1" }
 nu-engine = { path = "../nu-engine", version = "0.82.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
 nu-ansi-term = "0.49.0"
-tabled = { version = "0.13.0", features = ["color"], default-features = false }
+tabled = { git = "https://github.com/zhiburt/tabled/", rev = "6c51e3eaa362914a71b868ccb78e7addbebd3657", features = ["color"], default-features = false }
 
 [dev-dependencies]
 # nu-test-support = { path="../nu-test-support", version = "0.82.1"  }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -16,7 +16,7 @@ nu-utils = { path = "../nu-utils", version = "0.82.1" }
 nu-engine = { path = "../nu-engine", version = "0.82.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.82.1" }
 nu-ansi-term = "0.49.0"
-tabled = { version = "0.12.2", features = ["color"], default-features = false }
+tabled = { version = "0.13.0", features = ["color"], default-features = false }
 
 [dev-dependencies]
 # nu-test-support = { path="../nu-test-support", version = "0.82.1"  }

--- a/crates/nu-table/examples/table_demo.rs
+++ b/crates/nu-table/examples/table_demo.rs
@@ -1,6 +1,6 @@
 use nu_ansi_term::{Color, Style};
 use nu_color_config::TextStyle;
-use nu_table::{NuTable, TableConfig, TableTheme};
+use nu_table::{NuTable, NuTableConfig, TableTheme};
 use tabled::grid::records::vec_records::CellInfo;
 
 fn main() {
@@ -29,8 +29,11 @@ fn main() {
     table.set_data_style(TextStyle::basic_left());
     table.set_header_style(TextStyle::basic_center().style(Style::new().on(Color::Blue)));
 
-    let theme = TableTheme::rounded();
-    let table_cfg = TableConfig::new().theme(theme).with_header(true);
+    let table_cfg = NuTableConfig {
+        theme: TableTheme::rounded(),
+        with_header: true,
+        ..Default::default()
+    };
 
     let output_table = table
         .draw(table_cfg, width)

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -1,0 +1,175 @@
+use nu_color_config::{Alignment, StyleComputer, TextStyle};
+use nu_protocol::TrimStrategy;
+use nu_protocol::{Config, FooterMode, ShellError, Span, Value};
+
+use crate::{clean_charset, string_wrap, NuTableConfig, TableOutput, TableTheme};
+
+pub type NuText = (String, TextStyle);
+pub type TableResult = Result<Option<TableOutput>, ShellError>;
+pub type StringResult = Result<Option<String>, ShellError>;
+
+pub const INDEX_COLUMN_NAME: &str = "index";
+
+pub fn create_nu_table_config(
+    config: &Config,
+    comp: &StyleComputer,
+    out: &TableOutput,
+    expand: bool,
+) -> NuTableConfig {
+    NuTableConfig {
+        theme: load_theme_from_config(config),
+        with_footer: with_footer(config, out.with_header, out.table.count_rows()),
+        with_index: out.with_index,
+        with_header: out.with_header,
+        split_color: Some(lookup_separator_color(comp)),
+        trim: config.trim_strategy.clone(),
+        header_on_border: config.table_move_header,
+        expand,
+    }
+}
+
+pub fn nu_value_to_string(val: &Value, cfg: &Config, style: &StyleComputer) -> NuText {
+    let float_precision = cfg.float_precision as usize;
+    let text = val.into_abbreviated_string(cfg);
+    make_styled_string(style, text, Some(val), float_precision)
+}
+
+pub fn nu_value_to_string_clean(val: &Value, cfg: &Config, style: &StyleComputer) -> NuText {
+    let (text, style) = nu_value_to_string(val, cfg, style);
+    let text = clean_charset(&text);
+    (text, style)
+}
+
+pub fn error_sign(style_computer: &StyleComputer) -> (String, TextStyle) {
+    make_styled_string(style_computer, String::from("❎"), None, 0)
+}
+
+pub fn wrap_text(text: &str, width: usize, config: &Config) -> String {
+    string_wrap(text, width, is_cfg_trim_keep_words(config))
+}
+
+pub fn get_header_style(style_computer: &StyleComputer) -> TextStyle {
+    TextStyle::with_style(
+        Alignment::Center,
+        style_computer.compute("header", &Value::string("", Span::unknown())),
+    )
+}
+
+pub fn get_index_style(style_computer: &StyleComputer) -> TextStyle {
+    TextStyle::with_style(
+        Alignment::Right,
+        style_computer.compute("row_index", &Value::string("", Span::unknown())),
+    )
+}
+
+pub fn get_value_style(value: &Value, config: &Config, style_computer: &StyleComputer) -> NuText {
+    match value {
+        // Float precision is required here.
+        Value::Float { val, .. } => (
+            format!("{:.prec$}", val, prec = config.float_precision as usize),
+            style_computer.style_primitive(value),
+        ),
+        _ => (
+            value.into_abbreviated_string(config),
+            style_computer.style_primitive(value),
+        ),
+    }
+}
+
+pub fn get_empty_style(style_computer: &StyleComputer) -> NuText {
+    (
+        String::from("❎"),
+        TextStyle::with_style(
+            Alignment::Right,
+            style_computer.compute("empty", &Value::nothing(Span::unknown())),
+        ),
+    )
+}
+
+fn make_styled_string(
+    style_computer: &StyleComputer,
+    text: String,
+    value: Option<&Value>, // None represents table holes.
+    float_precision: usize,
+) -> NuText {
+    match value {
+        Some(value) => {
+            match value {
+                Value::Float { .. } => {
+                    // set dynamic precision from config
+                    let precise_number = match convert_with_precision(&text, float_precision) {
+                        Ok(num) => num,
+                        Err(e) => e.to_string(),
+                    };
+                    (precise_number, style_computer.style_primitive(value))
+                }
+                _ => (text, style_computer.style_primitive(value)),
+            }
+        }
+        None => {
+            // Though holes are not the same as null, the closure for "empty" is passed a null anyway.
+            (
+                text,
+                TextStyle::with_style(
+                    Alignment::Center,
+                    style_computer.compute("empty", &Value::nothing(Span::unknown())),
+                ),
+            )
+        }
+    }
+}
+
+fn convert_with_precision(val: &str, precision: usize) -> Result<String, ShellError> {
+    // vall will always be a f64 so convert it with precision formatting
+    let val_float = match val.trim().parse::<f64>() {
+        Ok(f) => f,
+        Err(e) => {
+            return Err(ShellError::GenericError(
+                format!("error converting string [{}] to f64", &val),
+                "".to_string(),
+                None,
+                Some(e.to_string()),
+                Vec::new(),
+            ));
+        }
+    };
+    Ok(format!("{val_float:.precision$}"))
+}
+
+fn is_cfg_trim_keep_words(config: &Config) -> bool {
+    matches!(
+        config.trim_strategy,
+        TrimStrategy::Wrap {
+            try_to_keep_words: true
+        }
+    )
+}
+
+pub fn load_theme_from_config(config: &Config) -> TableTheme {
+    match config.table_mode.as_str() {
+        "basic" => TableTheme::basic(),
+        "thin" => TableTheme::thin(),
+        "light" => TableTheme::light(),
+        "compact" => TableTheme::compact(),
+        "with_love" => TableTheme::with_love(),
+        "compact_double" => TableTheme::compact_double(),
+        "rounded" => TableTheme::rounded(),
+        "reinforced" => TableTheme::reinforced(),
+        "heavy" => TableTheme::heavy(),
+        "none" => TableTheme::none(),
+        _ => TableTheme::rounded(),
+    }
+}
+
+fn lookup_separator_color(style_computer: &StyleComputer) -> nu_ansi_term::Style {
+    style_computer.compute("separator", &Value::nothing(Span::unknown()))
+}
+
+fn with_footer(config: &Config, with_header: bool, count_records: usize) -> bool {
+    with_header && need_footer(config, count_records as u64)
+}
+
+fn need_footer(config: &Config, count_records: u64) -> bool {
+    matches!(config.footer_mode, FooterMode::RowCount(limit) if count_records > limit)
+        || matches!(config.footer_mode, FooterMode::Always)
+}

--- a/crates/nu-table/src/lib.rs
+++ b/crates/nu-table/src/lib.rs
@@ -4,12 +4,12 @@ mod types;
 mod unstructured_table;
 mod util;
 
+pub mod common;
+
+pub use common::{StringResult, TableResult};
 pub use nu_color_config::TextStyle;
-pub use table::{Alignments, Cell, NuTable, TableConfig};
+pub use table::{NuTable, NuTableCell, NuTableConfig};
 pub use table_theme::TableTheme;
-pub use types::{
-    clean_charset, value_to_clean_styled_string, value_to_styled_string, BuildConfig,
-    CollapsedTable, ExpandedTable, JustTable, NuText, StringResult, TableOutput, TableResult,
-};
+pub use types::{CollapsedTable, ExpandedTable, JustTable, TableOpts, TableOutput};
 pub use unstructured_table::UnstructuredTable;
 pub use util::*;

--- a/crates/nu-table/src/table_theme.rs
+++ b/crates/nu-table/src/table_theme.rs
@@ -191,6 +191,10 @@ impl TableTheme {
         self.has_inner
     }
 
+    pub fn has_horizontals(&self) -> bool {
+        self.full_theme.get_borders().has_horizontal()
+    }
+
     pub fn get_theme_full(&self) -> RawStyle {
         self.full_theme.clone()
     }

--- a/crates/nu-table/src/types/collapse.rs
+++ b/crates/nu-table/src/types/collapse.rs
@@ -3,16 +3,17 @@ use nu_protocol::{Config, Span, Value};
 
 use crate::UnstructuredTable;
 
-use super::{
-    clean_charset, general::BuildConfig, get_index_style, load_theme_from_config,
-    value_to_styled_string, StringResult,
+use crate::common::nu_value_to_string_clean;
+use crate::{
+    common::{get_index_style, load_theme_from_config},
+    StringResult, TableOpts,
 };
 
 pub struct CollapsedTable;
 
 impl CollapsedTable {
-    pub fn build(value: Value, opts: BuildConfig<'_>) -> StringResult {
-        collapsed_table(value, opts.config, opts.term_width, opts.style_computer)
+    pub fn build(value: Value, opts: TableOpts<'_>) -> StringResult {
+        collapsed_table(value, opts.config, opts.width, opts.style_computer)
     }
 }
 
@@ -56,20 +57,7 @@ fn colorize_value(value: &mut Value, config: &Config, style_computer: &StyleComp
             }
         }
         value => {
-            let (text, style) = value_to_styled_string(value, config, style_computer);
-
-            let is_string = matches!(value, Value::String { .. });
-            if is_string {
-                let mut text = clean_charset(&text);
-                if let Some(color) = style.color_style {
-                    text = color.paint(text).to_string();
-                }
-
-                let span = value.span().unwrap_or(Span::unknown());
-                *value = Value::string(text, span);
-                return;
-            }
-
+            let (text, style) = nu_value_to_string_clean(value, config, style_computer);
             if let Some(color) = style.color_style {
                 let text = color.paint(text).to_string();
                 let span = value.span().unwrap_or(Span::unknown());

--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -576,7 +576,7 @@ fn maybe_expand_table(out: TableOutput, term_width: usize, opts: &TableOpts<'_>)
 
 fn set_data_styles(table: &mut NuTable, styles: HashMap<Position, TextStyle>) {
     for (pos, style) in styles {
-        table.set_cell_style(pos, style);
+        table.insert_style(pos, style);
     }
 }
 

--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -135,7 +135,7 @@ fn to_table_with_header(
             let (text, style) = get_string_value_with_header(item, header, &opts);
 
             table.insert((row + 1, col), text);
-            table.set_cell_style((row + 1, col), style);
+            table.insert_style((row + 1, col), style);
         }
     }
 
@@ -169,7 +169,7 @@ fn to_table_with_no_header(
 
         let pos = (row, with_index as usize);
         table.insert(pos, text);
-        table.set_cell_style(pos, style);
+        table.insert_style(pos, style);
     }
 
     Ok(Some(table))

--- a/crates/nu-table/src/types/mod.rs
+++ b/crates/nu-table/src/types/mod.rs
@@ -2,20 +2,15 @@ mod collapse;
 mod expanded;
 mod general;
 
-use nu_color_config::{Alignment, StyleComputer, TextStyle};
-use nu_protocol::TrimStrategy;
-use nu_protocol::{Config, FooterMode, ShellError, Span, Value};
-use std::collections::HashMap;
-
-use crate::{string_wrap, NuTable, TableConfig, TableTheme};
+use std::sync::{atomic::AtomicBool, Arc};
 
 pub use collapse::CollapsedTable;
 pub use expanded::ExpandedTable;
-pub use general::{BuildConfig, JustTable};
+pub use general::JustTable;
+use nu_color_config::StyleComputer;
+use nu_protocol::{Config, Span};
 
-pub type NuText = (String, TextStyle);
-pub type TableResult = Result<Option<TableOutput>, ShellError>;
-pub type StringResult = Result<Option<String>, ShellError>;
+use crate::NuTable;
 
 pub struct TableOutput {
     pub table: NuTable,
@@ -33,178 +28,32 @@ impl TableOutput {
     }
 }
 
-pub fn value_to_styled_string(val: &Value, cfg: &Config, style: &StyleComputer) -> NuText {
-    let float_precision = cfg.float_precision as usize;
-    let text = val.into_abbreviated_string(cfg);
-    make_styled_string(style, text, Some(val), float_precision)
+#[derive(Debug, Clone)]
+pub struct TableOpts<'a> {
+    ctrlc: Option<Arc<AtomicBool>>,
+    config: &'a Config,
+    style_computer: &'a StyleComputer<'a>,
+    span: Span,
+    row_offset: usize,
+    width: usize,
 }
 
-pub fn value_to_clean_styled_string(val: &Value, cfg: &Config, style: &StyleComputer) -> NuText {
-    let (text, style) = value_to_styled_string(val, cfg, style);
-    let text = clean_charset(&text);
-    (text, style)
-}
-
-pub fn clean_charset(text: &str) -> String {
-    // todo: optimize, I bet it can be done in 1 path
-    text.replace('\t', "    ").replace('\r', "")
-}
-
-const INDEX_COLUMN_NAME: &str = "index";
-
-fn error_sign(style_computer: &StyleComputer) -> (String, TextStyle) {
-    make_styled_string(style_computer, String::from("❎"), None, 0)
-}
-
-fn wrap_text(text: &str, width: usize, config: &Config) -> String {
-    string_wrap(text, width, is_cfg_trim_keep_words(config))
-}
-
-fn make_styled_string(
-    style_computer: &StyleComputer,
-    text: String,
-    value: Option<&Value>, // None represents table holes.
-    float_precision: usize,
-) -> NuText {
-    match value {
-        Some(value) => {
-            match value {
-                Value::Float { .. } => {
-                    // set dynamic precision from config
-                    let precise_number = match convert_with_precision(&text, float_precision) {
-                        Ok(num) => num,
-                        Err(e) => e.to_string(),
-                    };
-                    (precise_number, style_computer.style_primitive(value))
-                }
-                _ => (text, style_computer.style_primitive(value)),
-            }
-        }
-        None => {
-            // Though holes are not the same as null, the closure for "empty" is passed a null anyway.
-            (
-                text,
-                TextStyle::with_style(
-                    Alignment::Center,
-                    style_computer.compute("empty", &Value::nothing(Span::unknown())),
-                ),
-            )
+impl<'a> TableOpts<'a> {
+    pub fn new(
+        config: &'a Config,
+        style_computer: &'a StyleComputer<'a>,
+        ctrlc: Option<Arc<AtomicBool>>,
+        span: Span,
+        row_offset: usize,
+        available_width: usize,
+    ) -> Self {
+        Self {
+            ctrlc,
+            config,
+            style_computer,
+            span,
+            row_offset,
+            width: available_width,
         }
     }
-}
-
-fn convert_with_precision(val: &str, precision: usize) -> Result<String, ShellError> {
-    // vall will always be a f64 so convert it with precision formatting
-    let val_float = match val.trim().parse::<f64>() {
-        Ok(f) => f,
-        Err(e) => {
-            return Err(ShellError::GenericError(
-                format!("error converting string [{}] to f64", &val),
-                "".to_string(),
-                None,
-                Some(e.to_string()),
-                Vec::new(),
-            ));
-        }
-    };
-    Ok(format!("{val_float:.precision$}"))
-}
-
-fn is_cfg_trim_keep_words(config: &Config) -> bool {
-    matches!(
-        config.trim_strategy,
-        TrimStrategy::Wrap {
-            try_to_keep_words: true
-        }
-    )
-}
-
-fn load_theme_from_config(config: &Config) -> TableTheme {
-    match config.table_mode.as_str() {
-        "basic" => TableTheme::basic(),
-        "thin" => TableTheme::thin(),
-        "light" => TableTheme::light(),
-        "compact" => TableTheme::compact(),
-        "with_love" => TableTheme::with_love(),
-        "compact_double" => TableTheme::compact_double(),
-        "rounded" => TableTheme::rounded(),
-        "reinforced" => TableTheme::reinforced(),
-        "heavy" => TableTheme::heavy(),
-        "none" => TableTheme::none(),
-        _ => TableTheme::rounded(),
-    }
-}
-
-fn create_table_config(config: &Config, comp: &StyleComputer, out: &TableOutput) -> TableConfig {
-    let theme = load_theme_from_config(config);
-    let footer = with_footer(config, out.with_header, out.table.count_rows());
-    let line_style = lookup_separator_color(comp);
-    let trim = config.trim_strategy.clone();
-    let move_header = config.table_move_header;
-
-    TableConfig::new()
-        .theme(theme)
-        .with_footer(footer)
-        .with_header(out.with_header)
-        .with_index(out.with_index)
-        .with_border_header(move_header)
-        .line_style(line_style)
-        .trim(trim)
-}
-
-fn lookup_separator_color(style_computer: &StyleComputer) -> nu_ansi_term::Style {
-    style_computer.compute("separator", &Value::nothing(Span::unknown()))
-}
-
-fn with_footer(config: &Config, with_header: bool, count_records: usize) -> bool {
-    with_header && need_footer(config, count_records as u64)
-}
-
-fn need_footer(config: &Config, count_records: u64) -> bool {
-    matches!(config.footer_mode, FooterMode::RowCount(limit) if count_records > limit)
-        || matches!(config.footer_mode, FooterMode::Always)
-}
-
-fn set_data_styles(table: &mut NuTable, styles: HashMap<(usize, usize), TextStyle>) {
-    for (pos, style) in styles {
-        table.set_cell_style(pos, style);
-    }
-}
-
-fn get_header_style(style_computer: &StyleComputer) -> TextStyle {
-    TextStyle::with_style(
-        Alignment::Center,
-        style_computer.compute("header", &Value::string("", Span::unknown())),
-    )
-}
-
-fn get_index_style(style_computer: &StyleComputer) -> TextStyle {
-    TextStyle::with_style(
-        Alignment::Right,
-        style_computer.compute("row_index", &Value::string("", Span::unknown())),
-    )
-}
-
-fn get_value_style(value: &Value, config: &Config, style_computer: &StyleComputer) -> NuText {
-    match value {
-        // Float precision is required here.
-        Value::Float { val, .. } => (
-            format!("{:.prec$}", val, prec = config.float_precision as usize),
-            style_computer.style_primitive(value),
-        ),
-        _ => (
-            value.into_abbreviated_string(config),
-            style_computer.style_primitive(value),
-        ),
-    }
-}
-
-fn get_empty_style(style_computer: &StyleComputer) -> NuText {
-    (
-        String::from("❎"),
-        TextStyle::with_style(
-            Alignment::Right,
-            style_computer.compute("empty", &Value::nothing(Span::unknown())),
-        ),
-    )
 }

--- a/crates/nu-table/src/types/mod.rs
+++ b/crates/nu-table/src/types/mod.rs
@@ -140,12 +140,14 @@ fn create_table_config(config: &Config, comp: &StyleComputer, out: &TableOutput)
     let footer = with_footer(config, out.with_header, out.table.count_rows());
     let line_style = lookup_separator_color(comp);
     let trim = config.trim_strategy.clone();
+    let move_header = config.table_move_header;
 
     TableConfig::new()
         .theme(theme)
         .with_footer(footer)
         .with_header(out.with_header)
         .with_index(out.with_index)
+        .with_border_header(move_header)
         .line_style(line_style)
         .trim(trim)
 }

--- a/crates/nu-table/src/util.rs
+++ b/crates/nu-table/src/util.rs
@@ -42,3 +42,8 @@ pub fn string_truncate(text: &str, width: usize) -> String {
 
     Truncate::truncate_text(line, width).into_owned()
 }
+
+pub fn clean_charset(text: &str) -> String {
+    // todo: optimize, I bet it can be done in 1 path
+    text.replace('\t', "    ").replace('\r', "")
+}

--- a/crates/nu-table/tests/common.rs
+++ b/crates/nu-table/tests/common.rs
@@ -1,16 +1,16 @@
 #![allow(dead_code)]
 
-use nu_table::{string_width, NuTable, TableConfig};
+use nu_table::{string_width, NuTable, NuTableConfig};
 use tabled::grid::records::vec_records::CellInfo;
 
 pub struct TestCase {
-    cfg: TableConfig,
+    cfg: NuTableConfig,
     termwidth: usize,
     expected: Option<String>,
 }
 
 impl TestCase {
-    pub fn new(cfg: TableConfig, termwidth: usize, expected: Option<String>) -> Self {
+    pub fn new(cfg: NuTableConfig, termwidth: usize, expected: Option<String>) -> Self {
         Self {
             cfg,
             termwidth,
@@ -37,7 +37,7 @@ pub fn test_table<I: IntoIterator<Item = TestCase>>(data: Data, tests: I) {
     }
 }
 
-pub fn create_table(data: Data, config: TableConfig, termwidth: usize) -> Option<String> {
+pub fn create_table(data: Data, config: NuTableConfig, termwidth: usize) -> Option<String> {
     let table = NuTable::from(data);
     table.draw(config, termwidth)
 }

--- a/crates/nu-table/tests/expand.rs
+++ b/crates/nu-table/tests/expand.rs
@@ -2,16 +2,18 @@ mod common;
 
 use common::{create_row, create_table};
 
-use nu_table::{TableConfig, TableTheme as theme};
+use nu_table::{NuTableConfig, TableTheme as theme};
 
 #[test]
 fn test_expand() {
     let table = create_table(
         vec![create_row(4); 3],
-        TableConfig::new()
-            .theme(theme::rounded())
-            .with_header(true)
-            .expand(true),
+        NuTableConfig {
+            theme: theme::rounded(),
+            with_header: true,
+            expand: true,
+            ..Default::default()
+        },
         50,
     );
 

--- a/crates/nu-table/tests/style.rs
+++ b/crates/nu-table/tests/style.rs
@@ -1,7 +1,7 @@
 mod common;
 
 use common::create_row as row;
-use nu_table::{NuTable, TableConfig, TableTheme as theme};
+use nu_table::{NuTable, NuTableConfig, TableTheme as theme};
 use tabled::grid::records::vec_records::CellInfo;
 
 #[test]
@@ -476,10 +476,11 @@ fn test_with_love() {
 }
 
 fn create_table(data: Vec<Vec<CellInfo<String>>>, with_header: bool, theme: theme) -> String {
-    let mut config = TableConfig::new().theme(theme);
-    if with_header {
-        config = config.with_header(true);
-    }
+    let config = NuTableConfig {
+        theme,
+        with_header,
+        ..Default::default()
+    };
 
     let out = common::create_table(data, config, usize::MAX);
 
@@ -491,10 +492,11 @@ fn create_table_with_size(
     with_header: bool,
     theme: theme,
 ) -> String {
-    let mut config = TableConfig::new().theme(theme);
-    if with_header {
-        config = config.with_header(true);
-    }
+    let config = NuTableConfig {
+        theme,
+        with_header,
+        ..Default::default()
+    };
 
     let table = NuTable::from(data);
 


### PR DESCRIPTION
A patch to play with.
Need to make a few tests after all.

The question is what shall be done with `table.mode = none`, as it has no borders.

```nu
$env.config.table.move_header = true
```

![image](https://github.com/nushell/nushell/assets/20165848/cdcffa6d-989c-4368-a436-fdf7d3400e31)

cc: @fdncred 