### PR TITLE
Set the default `filesize_metric` to `true`

### DIFF
--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -141,8 +141,8 @@ impl Command for SubCommand {
             },
             Example {
                 description: "convert filesize to string",
-                example: "1KiB | into string",
-                result: Some(Value::test_string("1,024 B")),
+                example: "1KB | into string",
+                result: Some(Value::test_string("1,000 B")),
             },
         ]
     }

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -20,7 +20,7 @@ fn into_filesize_str() {
         '2000' | into filesize
         "#);
 
-    assert!(actual.out.contains("2.0 KiB"));
+    assert!(actual.out.contains("2.0 KB"));
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn into_filesize_str_newline() {
         "#
     ));
 
-    assert!(actual.out.contains("2.0 KiB"));
+    assert!(actual.out.contains("2.0 KB"));
 }
 
 #[test]
@@ -45,19 +45,19 @@ fn into_filesize_str_many_newlines() {
         "#
     ));
 
-    assert!(actual.out.contains("2.0 KiB"));
+    assert!(actual.out.contains("2.0 KB"));
 }
 
 #[test]
 fn into_filesize_filesize() {
-    let actual = nu!("3kib | into filesize");
+    let actual = nu!("3kb | into filesize");
 
-    assert!(actual.out.contains("3.0 KiB"));
+    assert!(actual.out.contains("3.0 KB"));
 }
 
 #[test]
 fn into_filesize_negative_filesize() {
-    let actual = nu!("-3kib | into filesize");
+    let actual = nu!("-3kb | into filesize");
 
-    assert!(actual.out.contains("-3.0 KiB"));
+    assert!(actual.out.contains("-3.0 KB"));
 }

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -266,7 +266,7 @@ fn unit_multiplication_math() {
         "#
     ));
 
-    assert_eq!(actual.out, "1.9 MiB");
+    assert_eq!(actual.out, "2.0 MB");
 }
 
 #[test]
@@ -277,7 +277,7 @@ fn unit_multiplication_float_math() {
         "#
     ));
 
-    assert_eq!(actual.out, "1.1 MiB");
+    assert_eq!(actual.out, "1.2 MB");
 }
 
 #[test]
@@ -288,7 +288,7 @@ fn unit_float_floor_division_math() {
         "#
     ));
 
-    assert_eq!(actual.out, "325.5 KiB");
+    assert_eq!(actual.out, "333.3 KB");
 }
 
 #[test]
@@ -299,7 +299,7 @@ fn unit_division_math() {
         "#
     ));
 
-    assert_eq!(actual.out, "244.1 KiB");
+    assert_eq!(actual.out, "250.0 KB");
 }
 
 #[test]
@@ -310,7 +310,7 @@ fn unit_float_division_math() {
         "#
     ));
 
-    assert_eq!(actual.out, "315.0 KiB");
+    assert_eq!(actual.out, "322.6 KB");
 }
 
 #[test]

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -145,7 +145,7 @@ impl Default for Config {
             max_external_completion_results: 100,
             external_completer: None,
 
-            filesize_metric: false,
+            filesize_metric: true,
             filesize_format: "auto".into(),
 
             cursor_shape_emacs: NuCursorShape::Line,

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -554,12 +554,12 @@ fn duration_with_faulty_number() -> TestResult {
 
 #[test]
 fn filesize_with_underscores_1() -> TestResult {
-    run_test("420_mb", "400.5 MiB")
+    run_test("400.5_mib", "420.0 MB")
 }
 
 #[test]
 fn filesize_with_underscores_2() -> TestResult {
-    run_test("1_000_000B", "976.6 KiB")
+    run_test("1_000_000B", "1000.0 KB")
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -743,10 +743,10 @@ fn range_with_mixed_types() {
 #[test]
 fn filesize_math() {
     let actual = nu!("
-        100 * 10kib
+        100 * 10kb
         ");
 
-    assert_eq!(actual.out, "1000.0 KiB");
+    assert_eq!(actual.out, "1000.0 KB");
     // why 1000.0 KB instead of 1.0 MB?
     // looks like `byte.get_appropriate_unit(false)` behaves this way
 }
@@ -763,45 +763,45 @@ fn filesize_math2() {
 #[test]
 fn filesize_math3() {
     let actual = nu!("
-        100kib / 10
+        100kb / 10
         ");
 
-    assert_eq!(actual.out, "10.0 KiB");
+    assert_eq!(actual.out, "10.0 KB");
 }
 #[test]
 fn filesize_math4() {
     let actual = nu!("
-        100kib * 5
+        100kb * 5
         ");
 
-    assert_eq!(actual.out, "500.0 KiB");
+    assert_eq!(actual.out, "500.0 KB");
 }
 
 #[test]
 fn filesize_math5() {
     let actual = nu!("
-        1000 * 1kib
+        1000 * 1kb
         ");
 
-    assert_eq!(actual.out, "1000.0 KiB");
+    assert_eq!(actual.out, "1000.0 KB");
 }
 
 #[test]
 fn filesize_math6() {
     let actual = nu!("
-        1000 * 1mib
+        1000 * 1mb
         ");
 
-    assert_eq!(actual.out, "1000.0 MiB");
+    assert_eq!(actual.out, "1000.0 MB");
 }
 
 #[test]
 fn filesize_math7() {
     let actual = nu!("
-        1000 * 1gib
+        1000 * 1gb
         ");
 
-    assert_eq!(actual.out, "1000.0 GiB");
+    assert_eq!(actual.out, "1000.0 GB");
 }
 
 #[test]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
See also: #9676

This PR synchronizes the `filesize_metric` value in `config.rs` and `default_config.nu` to `true`. 
This change means the default behavior is now 1KB = 1000 bytes instead of 1KiB = 1024 bytes.

IEC 80000-13 standard(kibibyte, mebibyte, gibibyte, etc.) [is rarely used and adopted by the public](https://devblogs.microsoft.com/oldnewthing/20090611-00/?p=17933),
which could create confusion.
For instance, a simple math operation like `100 * 10kb` returns `976.6 KiB` instead of `1000.0 KB`,
`[1 5 3kb 4 3Mb] | find 5 3kb` returns [`2.9KiB` instead of `3.0KB`](https://github.com/nushell/nushell/issues/6533). 


Ubuntu's [Unit Policy](https://wiki.ubuntu.com/UnitsPolicy) says:

>  For file sizes there are two possibilities:
>
> - Show both, base-10 and base-2 (in this order). An example is the Linux kernel: "2930277168 512-byte hardware sectors: (1.50 TB/1.36 TiB)"
> - Only show base-10, or give the user the opportunity to decide between base-10 and base-2 (the default must be base-10).

While some command-line tools that predates this policy uses base-2 for backwards compatibility,
Nu, as a modern shell, should use base-10 units(kilobyte, megabyte, gigabyte, etc.) by default in my opinion.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
