### PR TITLE
Set the rest variable to the correct type

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3695,7 +3695,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     Arg::RestPositional(PositionalArg {
                                         shape, var_id, ..
                                     }) => {
-                                        working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), syntax_shape.to_type());
+                                        working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), Type::List(Box::new(syntax_shape.to_type())));
                                         *shape = syntax_shape;
                                     }
                                     Arg::Flag(Flag { arg, var_id, .. }) => {

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -665,3 +665,11 @@ fn properly_nest_captures() -> TestResult {
 fn properly_nest_captures_call_first() -> TestResult {
     run_test(r#"do { let b = 3; c; def c [] { $b }; c }"#, "3")
 }
+
+#[test]
+fn properly_typecheck_rest_param() -> TestResult {
+    run_test(
+        r#"def foo [...rest: string] { $rest | length }; foo "a" "b" "c""#,
+        "3",
+    )
+}


### PR DESCRIPTION
# Description

This fixes the type of `$rest` to be a `List<...>` so that it properly is checked in function bodies.

fixes https://github.com/nushell/nushell/issues/9809

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
