### PR TITLE
add input_output_type to ansi command

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -507,7 +507,9 @@ impl Command for AnsiCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("ansi")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![
+                (Type::Nothing, Type::String),
+                (Type::Nothing, Type::Table(vec![]))])
             .optional(
                 "code",
                 SyntaxShape::Any,
@@ -524,6 +526,7 @@ impl Command for AnsiCommand {
                 Some('o'),
             )
             .switch("list", "list available ansi code names", Some('l'))
+            .allow_variants_without_examples(true)
             .category(Category::Platform)
     }
 

--- a/crates/nu-command/tests/commands/platform/ansi_.rs
+++ b/crates/nu-command/tests/commands/platform/ansi_.rs
@@ -10,3 +10,14 @@ fn test_ansi_shows_error_on_escape() {
 
     assert!(actual.err.contains("no need for escape characters"))
 }
+
+#[test]
+fn test_ansi_list_outputs_table() {
+    let actual = nu!(pipeline(
+        r#"
+            ansi --list | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "424");
+}


### PR DESCRIPTION
# Description

This PR fixes this not working `ansi --list | columns`. I originally thought that this was a problem with `columns` but it turned out to be a problem with the input output type of `ansi`. Since `ansi` was only allowed to return strings, `columns` thought it was getting a string, but it was a table.

closes #9808

tracking #9812

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
