### PR TITLE
allow plugins to work again

### DIFF
--- a/crates/nu-protocol/src/plugin_signature.rs
+++ b/crates/nu-protocol/src/plugin_signature.rs
@@ -143,6 +143,11 @@ impl PluginSignature {
         self
     }
 
+    pub fn vectorizes_over_list(mut self, vectorizes_over_list: bool) -> PluginSignature {
+        self.sig = self.sig.vectorizes_over_list(vectorizes_over_list);
+        self
+    }
+
     /// Set the input-output type signature variants of the command
     pub fn input_output_types(mut self, input_output_types: Vec<(Type, Type)>) -> PluginSignature {
         self.sig = self.sig.input_output_types(input_output_types);

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -112,6 +112,7 @@ pub struct Signature {
     pub required_positional: Vec<PositionalArg>,
     pub optional_positional: Vec<PositionalArg>,
     pub rest_positional: Option<PositionalArg>,
+    pub vectorizes_over_list: bool,
     pub named: Vec<Flag>,
     pub input_output_types: Vec<(Type, Type)>,
     pub allow_variants_without_examples: bool,
@@ -211,6 +212,7 @@ impl Signature {
             required_positional: vec![],
             optional_positional: vec![],
             rest_positional: None,
+            vectorizes_over_list: false,
             input_output_types: vec![],
             allow_variants_without_examples: false,
             named: vec![],
@@ -459,6 +461,11 @@ impl Signature {
     /// Changes the input type of the command signature
     pub fn input_output_type(mut self, input_type: Type, output_type: Type) -> Signature {
         self.input_output_types.push((input_type, output_type));
+        self
+    }
+
+    pub fn vectorizes_over_list(mut self, vectorizes_over_list: bool) -> Signature {
+        self.vectorizes_over_list = vectorizes_over_list;
         self
     }
 


### PR DESCRIPTION
# Description

This PR reverts some of #9777 as an attempt to get the plugin system working again. This PR may not land but it's all I could figure out to get it working again. Maybe @sholderbach has an idea better than this one?

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
