### PR TITLE
change signature of `enumerate` to `any -> table`

### DIFF
--- a/crates/nu-command/src/filters/enumerate.rs
+++ b/crates/nu-command/src/filters/enumerate.rs
@@ -23,7 +23,7 @@ impl Command for Enumerate {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("enumerate")
-            .input_output_types(vec![(Type::Any, Type::Any)])
+            .input_output_types(vec![(Type::Any, Type::Table(vec![]))])
             .category(Category::Filters)
     }
 


### PR DESCRIPTION
related to https://discord.com/channels/601130461678272522/1134054657086464072

# Description
the `enumerate` command always returns a table but its signature is `any -> any` which can be confusing :confused: 
this PR changes the signature to `any -> table`

i've double checked and the source of `enumerate` returns a list of records, a.k.a. a table :ok_hand: 

# User-Facing Changes
this shouldn't change anything apart from the help page of `enumerate` showing now
```
Input/output types:
  ╭───┬───────┬────────╮
  │ # │ input │ output │
  ├───┼───────┼────────┤
  │ 0 │ any   │ table  │
  ╰───┴───────┴────────╯
```
instead of 
```
Input/output types:
  ╭───┬───────┬────────╮
  │ # │ input │ output │
  ├───┼───────┼────────┤
  │ 0 │ any   │ any    │
  ╰───┴───────┴────────╯
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting