### PR TITLE
allow `print` to take data as input again

### DIFF
--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -16,7 +16,11 @@ impl Command for Print {
 
     fn signature(&self) -> Signature {
         Signature::build("print")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::Any, Type::Nothing),
+            ])
+            .allow_variants_without_examples(true)
             .rest("rest", SyntaxShape::Any, "the values to print")
             .switch(
                 "no-newline",

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1111,3 +1111,9 @@ mod variable_scoping {
         );
     }
 }
+
+#[test]
+fn pipe_input_to_print() {
+    assert_eq!(nu!(r#""foo" | print"#).out, "");
+    assert_eq!(nu!(r#""foo" | print a b c"#).out, "");
+}

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1114,6 +1114,7 @@ mod variable_scoping {
 
 #[test]
 fn pipe_input_to_print() {
-    assert_eq!(nu!(r#""foo" | print"#).out, "");
-    assert_eq!(nu!(r#""foo" | print a b c"#).out, "");
+    let actual = nu!(r#""foo" | print"#);
+    assert_eq!(actual.out, "foo");
+    assert!(actual.err.is_empty());
 }


### PR DESCRIPTION
related to https://discord.com/channels/601130461678272522/601130461678272524/1134079115134251129

# Description
before 0.83.0, `print` used to allow piping data into it, e.g.
```nushell
"foo" | print
```
instead of 
```nushell
print "foo"
```

this PR enables the `any -> nothing` input / output type to allow this again.

i've double checked and `print` is essentially the following snippet
```rust
        if !args.is_empty() {
            for arg in args {
                arg.into_pipeline_data()
                    .print(engine_state, stack, no_newline, to_stderr)?;
            }
        } else if !input.is_nothing() {
            input.print(engine_state, stack, no_newline, to_stderr)?;
        }
```
1. the first part is for `print a b c`
2. the second part is for `"foo" | print`

# User-Facing Changes
```nushell
"foo" | print
```
works again

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting