### PR TITLE
Bump `trash` in lockfile due to yank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5270,9 +5270,9 @@ dependencies = [
 
 [[package]]
 name = "trash"
-version = "3.0.5"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85931d0ad541fa457c3f94c7cc5f14920f17a385832a7ef7621762c23cbf9729"
+checksum = "af3663fb8f476d674b9c61d1d2796acec725bef6bec4b41402a904252a25971e"
 dependencies = [
  "chrono",
  "libc",


### PR DESCRIPTION
The previous version has been yanked.
To make sure `cargo install --locked` will pass.
