### PR TITLE
Fix the implied collect type to 'any'

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6176,7 +6176,7 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
                 parser_info: HashMap::new(),
             })),
             span,
-            ty: Type::String,
+            ty: Type::Any,
             custom_completion: None,
         }
     } else {

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -673,3 +673,8 @@ fn properly_typecheck_rest_param() -> TestResult {
         "3",
     )
 }
+
+#[test]
+fn implied_collect_has_compatible_type() -> TestResult {
+    run_test(r#"let idx = 3 | $in; $idx < 1"#, "false")
+}


### PR DESCRIPTION
# Description

Previously, we had a bug slip in about implied collection caused by `$in`, that this output type would be of type `string`. 

The type system fixes in 0.83 now make this more visible and cause issues. This PR changes the output of the implied collection to `any`. At some point in the future, we may want to carry the type through where we can, but `any` should unblock using `$in`.

fixes #9825

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
