### PR TITLE
Fix prepend type, fix typos

### DIFF
--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -41,7 +41,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
         vec![
             Example {
                 example: "[0,1,2,3] | append 4",
-                description: "Append one Int item",
+                description: "Append one integer to a list",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_int(0),
@@ -76,7 +76,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[0,1] | append [2,3,4]",
-                description: "Append three Int items",
+                description: "Append three integer items",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_int(0),
@@ -90,7 +90,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[0,1] | append [2,nu,4,shell]",
-                description: "Append Ints and Strings",
+                description: "Append integers and strings",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_int(0),

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -16,10 +16,7 @@ impl Command for Prepend {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("prepend")
-            .input_output_types(vec![(
-                Type::List(Box::new(Type::Any)),
-                Type::List(Box::new(Type::Any)),
-            )])
+            .input_output_types(vec![(Type::Any, Type::List(Box::new(Type::Any)))])
             .required(
                 "row",
                 SyntaxShape::Any,
@@ -46,8 +43,29 @@ only unwrap the outer list, and leave the variable's contents untouched."#
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
+                example: "0 | prepend [1 2 3]",
+                description: "prepend a list to an item",
+                result: Some(Value::List {
+                    vals: vec![
+                        Value::test_int(1),
+                        Value::test_int(2),
+                        Value::test_int(3),
+                        Value::test_int(0),
+                    ],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
+                example: r#""a" | prepend ["b"] "#,
+                description: "Prepend a list of strings to a string",
+                result: Some(Value::List {
+                    vals: vec![Value::test_string("b"), Value::test_string("a")],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
                 example: "[1,2,3,4] | prepend 0",
-                description: "Prepend one Int item",
+                description: "Prepend one integer item",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_int(0),
@@ -61,7 +79,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[2,3,4] | prepend [0,1]",
-                description: "Prepend two Int items",
+                description: "Prepend two integer items",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_int(0),
@@ -75,7 +93,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[2,nu,4,shell] | prepend [0,1,rocks]",
-                description: "Prepend Ints and Strings",
+                description: "Prepend integers and strings",
                 result: Some(Value::List {
                     vals: vec![
                         Value::test_int(0),


### PR DESCRIPTION
# Description

This PR does two (somewhat related) things:

* Fixes the `prepend` signature in the same way we fixed `append`
* Fixes a few typos in the examples of `prepend` and `append`

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
