### PR TITLE
Fix signature of `split row`

### DIFF
--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -18,7 +18,10 @@ impl Command for SubCommand {
         Signature::build("split row")
             .input_output_types(vec![
                 (Type::String, Type::List(Box::new(Type::String))),
-                (Type::List(Box::new(Type::String)), Type::Table(vec![])),
+                (
+                    Type::List(Box::new(Type::String)),
+                    (Type::List(Box::new(Type::String))),
+                ),
             ])
             .vectorizes_over_list(true)
             .allow_variants_without_examples(true)

--- a/crates/nu-command/tests/commands/split_row.rs
+++ b/crates/nu-command/tests/commands/split_row.rs
@@ -46,14 +46,12 @@ fn to_row() {
 
         assert!(actual.out.contains('5'));
 
-        let actual = nu!(
-            r#"
+        let actual = nu!(r#"
                 def foo [a: list<string>] {
                     $a | describe
                 }
                 foo (["a b", "c d"] | split row " ")
-            "#
-        );
+            "#);
 
         assert!(actual.out.contains("list<string>"));
     })

--- a/crates/nu-command/tests/commands/split_row.rs
+++ b/crates/nu-command/tests/commands/split_row.rs
@@ -47,15 +47,13 @@ fn to_row() {
         assert!(actual.out.contains('5'));
 
         let actual = nu!(
-            cwd: dirs.test(), pipeline(
             r#"
-                open sample2.txt
-                | lines
-                | str trim
-                | split row -r '\s*,\s*'
-                | describe
+                def foo [a: list<string>] {
+                    $a | describe
+                }
+                foo (["a b", "c d"] | split row " ")
             "#
-        ));
+        );
 
         assert!(actual.out.contains("list<string>"));
     })

--- a/crates/nu-command/tests/commands/split_row.rs
+++ b/crates/nu-command/tests/commands/split_row.rs
@@ -45,5 +45,18 @@ fn to_row() {
         ));
 
         assert!(actual.out.contains('5'));
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open sample2.txt
+                | lines
+                | str trim
+                | split row -r '\s*,\s*'
+                | describe
+            "#
+        ));
+
+        assert!(actual.out.contains("list<string>"));
     })
 }


### PR DESCRIPTION
# Description
This command also flat-maps and doesn't create a table like `split
column`

We should probably reconsider the flatmap behavior like in #9739
but for the #9812 hotfix this is an unwelcome breaking change.

# User-Facing Changes
None

# Tests + Formatting
- Fix signature of `split row`
- Add test for output signature
