### PR TITLE
Fix `math min`/`max` signatures

### DIFF
--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -15,7 +15,7 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("math max")
             .input_output_types(vec![
-                (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::List(Box::new(Type::Any)), Type::Any),
                 (Type::Table(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
@@ -23,7 +23,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Returns the maximum of a list of numbers, or of columns in a table."
+        "Returns the maximum of a list of values, or of columns in a table."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -15,7 +15,7 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("math min")
             .input_output_types(vec![
-                (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::List(Box::new(Type::Any)), Type::Any),
                 (Type::Table(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
@@ -23,7 +23,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Finds the minimum within a list of numbers or tables."
+        "Finds the minimum within a list of values or tables."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -55,6 +55,11 @@ impl Command for SubCommand {
                     vals: vec![Value::test_int(1), Value::test_int(-1)],
                     span: Span::test_data(),
                 }),
+            },
+            Example {
+                description: "Find the minimum of a list of arbitrary values (Warning: Weird)",
+                example: "[-50 'hello' true] | math min",
+                result: Some(Value::test_bool(true)),
             },
         ]
     }


### PR DESCRIPTION
# Description
Under the hood those are just `Value::partial_cmp` and this is defined
for all values and defines a partial order over `any`

Should address part of https://github.com/nushell/nushell/issues/9813

# User-Facing Changes
Reenable all behavior before `0.83`

# Tests + Formatting
Added an example to `math min` showing this cursedness
