### PR TITLE
Narrow signature of `math ceil`/`floor`

### DIFF
--- a/crates/nu-command/src/math/ceil.rs
+++ b/crates/nu-command/src/math/ceil.rs
@@ -16,7 +16,7 @@ impl Command for SubCommand {
                 (Type::Number, Type::Int),
                 (
                     Type::List(Box::new(Type::Number)),
-                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Int)),
                 ),
             ])
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/math/floor.rs
+++ b/crates/nu-command/src/math/floor.rs
@@ -16,7 +16,7 @@ impl Command for SubCommand {
                 (Type::Number, Type::Int),
                 (
                     Type::List(Box::new(Type::Number)),
-                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Int)),
                 ),
             ])
             .allow_variants_without_examples(true)


### PR DESCRIPTION
# Description
More narrow attempt than #9740
This doesn't cause issues with the current `test_examples` infrastructure.
But allows the output of those clearly integer producing commands to be used with functions declaring `list<int>` or `int`

# User-Facing Changes
see above

# Tests + Formatting
None