### PR TITLE
Fix panic inspect

### DIFF
--- a/crates/nu-command/src/debug/inspect_table.rs
+++ b/crates/nu-command/src/debug/inspect_table.rs
@@ -21,6 +21,9 @@ pub fn build_table(value: Value, description: String, termsize: usize) -> String
 
     let cfg = Table::default().with(Style::modern()).get_config().clone();
     let mut widths = get_data_widths(&data, count_columns);
+    if widths.is_empty() {
+        return String::new();
+    }
     truncate_data(&mut data, &mut widths, &cfg, termsize);
 
     let val_table_width = get_total_width2(&widths, &cfg);

--- a/crates/nu-command/tests/commands/inspect.rs
+++ b/crates/nu-command/tests/commands/inspect.rs
@@ -5,3 +5,21 @@ fn inspect_with_empty_pipeline() {
     let actual = nu!("inspect");
     assert!(actual.err.contains("no input value was piped in"));
 }
+
+#[test]
+fn inspect_with_null() {
+    let actual = nu!("null | inspect");
+    assert!(actual.err.contains("no input value was piped in"));
+}
+
+#[test]
+fn inspect_with_empty_list() {
+    let actual = nu!("[] | inspect");
+    assert!(actual.err.is_empty());
+}
+
+#[test]
+fn inspect_with_empty_table() {
+    let actual = nu!("{} | inspect");
+    assert!(actual.err.is_empty());
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
`{} | inspect` panics.
this PR aims at fixing this.

the panic comes from line 91 of `inspect_table.rs`, in the `increase_widths` function
```rust
    let all = need / widths.len();
```
which is called from `build_table` on line 28.

this PR adds the following check just after the `widths` vector is created:
```rust
    if widths.is_empty() {
        return String::new();
    }
```

# User-Facing Changes
- does not change
```nushell
> inspect
Error: nu::shell::pipeline_mismatch

  × Pipeline empty.
   ╭─[entry #1:1:1]
 1 │ inspect
   · ───┬───
   ·    ╰── no input value was piped in
   ╰────
```
- does not change
```nushell
> null | inspect
Error: nu::shell::pipeline_mismatch

  × Pipeline empty.
   ╭─[entry #2:1:1]
 1 │ null | inspect
   ·        ───┬───
   ·           ╰── no input value was piped in
   ╰────
```
- does not change
```nushell
> [] | inspect
╭─────────────┬───────────╮
│ description │ list<any> │
├─────────────┴───────────┤
│                         │
├─────────────────────────┤
                                                                                                         
╭────────────╮
│ empty list │
╰────────────╯
```
- does change
```nushell
> {} | inspect
                                                                                                         

╭──────────────╮
│ empty record │
╰──────────────╯
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

this PR adds the following tests:
- `inspect_with_null`
- `inspect_with_empty_list`
- `inspect_with_empty_table`


# After Submitting