### PR TITLE
Sync the default `filesize_metric` to false

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -265,7 +265,7 @@ $env.config = {
     }
 
     filesize: {
-        metric: false # true => KB, MB, GB (1KB = 1000bytes), false => KiB, MiB, GiB (1KiB = 1024bytes)
+        metric: false # true => KB, MB, GB (1KB = 1000B), false => KiB, MiB, GiB (1KiB = 1024B)
         format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
     }
 

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -265,7 +265,7 @@ $env.config = {
     }
 
     filesize: {
-        metric: true # true => KB, MB, GB (ISO standard), false => KiB, MiB, GiB (Windows standard)
+        metric: false # true => KB, MB, GB (1KB = 1000bytes), false => KiB, MiB, GiB (1KiB = 1024bytes)
         format: "auto" # b, kb, kib, mb, mib, gb, gib, tb, tib, pb, pib, eb, eib, auto
     }
 


### PR DESCRIPTION
See also: #9676
Supersedes: #9815 

# Description
This PR synchronizes the `filesize_metric` value in `config.rs` and `default_config.nu` to false. 
This clears up last remaining bit of different behaviors between `config.rs` and `default_config.nu`.
I've also edited the comment to provide a clearer explanation.

# User-Facing Changes
# Tests + Formatting
# After Submitting