### PR TITLE
str-expand: update examples, add escaping example

### DIFF
--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -49,6 +49,18 @@ impl Command for SubCommand {
             },
 
             Example {
+                description: "Ignore the next character after the backslash ('\\')",
+                example: "'A{B\\,,C}' | str expand",
+                result: Some(Value::List{
+                    vals: vec![
+                        Value::test_string("AB,"),
+                        Value::test_string("AC"),
+                    ],
+                    span: Span::test_data()
+                },)
+            },
+
+            Example {
                 description: "Export comma separated values inside braces (`{}`) to a string list.",
                 example: "\"{apple,banana,cherry}\" | str expand",
                 result: Some(Value::List{


### PR DESCRIPTION
**Related Issue: #9838**

Adds an **example**, how bracoxide/str-expand handles the escaping char `\`.