### PR TITLE
Fix transpose input/output types

### DIFF
--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -27,8 +27,7 @@ impl Command for Transpose {
     fn signature(&self) -> Signature {
         Signature::build("transpose")
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
-                (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Table(vec![]), Type::Any),
                 (Type::Record(vec![]), Type::Table(vec![])),
             ])
             .switch(

--- a/src/tests/test_type_check.rs
+++ b/src/tests/test_type_check.rs
@@ -86,3 +86,11 @@ fn record_subtyping_3() -> TestResult {
         "expected",
     )
 }
+
+#[test]
+fn transpose_into_load_env() -> TestResult {
+    run_test(
+        "[[col1, col2]; [a, 10], [b, 20]] | transpose -i -r -d | load-env; $env.a",
+        "10",
+    )
+}


### PR DESCRIPTION
# Description

As the typechecker doesn't currently support having the same input type but two different output types, collapse the `transpose` input/output signatures for now so that we don't mistakenly think that when given a `table` a `table is always returned.

fixes https://github.com/nushell/nushell/issues/9710

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
