### PR TITLE
Fix type signature of median

### DIFF
--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -18,6 +18,8 @@ impl Command for SubCommand {
         Signature::build("math median")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::List(Box::new(Type::Duration)), Type::Duration),
+                (Type::List(Box::new(Type::Filesize)), Type::Filesize),
                 (Type::Table(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)


### PR DESCRIPTION
Still support forming the median over homogeneous lists of `Duration` or
`Filesize`. Don't advertise `list<any>` as this can become funky when
given an even number of elements...

Work for #9812
