### PR TITLE
Fix signature for `math abs`

### DIFF
--- a/crates/nu-command/src/math/abs.rs
+++ b/crates/nu-command/src/math/abs.rs
@@ -14,9 +14,14 @@ impl Command for SubCommand {
         Signature::build("math abs")
             .input_output_types(vec![
                 (Type::Number, Type::Number),
+                (Type::Duration, Type::Duration),
                 (
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Number)),
+                ),
+                (
+                    Type::List(Box::new(Type::Duration)),
+                    Type::List(Box::new(Type::Duration)),
                 ),
             ])
             .allow_variants_without_examples(true)


### PR DESCRIPTION
This only supports number or duration

Make sure duration still works with the stricter type system

Work for #9812
