### PR TITLE
Fix `math log` signature

### DIFF
--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -22,10 +22,9 @@ impl Command for SubCommand {
             )
             .input_output_types(vec![
                 (Type::Number, Type::Float),
-                (Type::Number, Type::Int),
                 (
                     Type::List(Box::new(Type::Number)),
-                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
                 ),
             ])
             .allow_variants_without_examples(true)


### PR DESCRIPTION
While we are at it also fix `math log` to a more narrow type.

This supersedes part of #9740
