### PR TITLE
Fix signature for `math mode`

### DIFF
--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -51,10 +51,6 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Filesize)),
                     Type::List(Box::new(Type::Filesize)),
                 ),
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
                 (Type::Table(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -43,6 +43,18 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::Number)),
                     Type::List(Box::new(Type::Number)),
                 ),
+                (
+                    Type::List(Box::new(Type::Duration)),
+                    Type::List(Box::new(Type::Duration)),
+                ),
+                (
+                    Type::List(Box::new(Type::Filesize)),
+                    Type::List(Box::new(Type::Filesize)),
+                ),
+                (
+                    Type::List(Box::new(Type::Any)),
+                    Type::List(Box::new(Type::Any)),
+                ),
                 (Type::Table(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)


### PR DESCRIPTION
This command will always return a list, either because there are
multiple entries with the same frequency or just one.

It's implementation doesn't care about the composition of types as long
as they are number like, can be heterogeneous, will report
independently.

Work for #9812
