### PR TITLE
Fix signature for `math sum`

### DIFF
--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -16,6 +16,8 @@ impl Command for SubCommand {
         Signature::build("math sum")
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::List(Box::new(Type::Duration)), Type::Duration),
+                (Type::List(Box::new(Type::Filesize)), Type::Filesize),
                 (Type::Range, Type::Number),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])


### PR DESCRIPTION
This also supports filesize and duration.
Filesize is actually used for a non-running example

Work for #9812
