### PR TITLE
Fixed the panic when type a statement similar to `let f = 'f' $` in the nushell

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2817,7 +2817,7 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
             for span in spans.iter().enumerate() {
                 let item = working_set.get_span_contents(*span.1);
                 // https://github.com/nushell/nushell/issues/9596, let = if $
-                // let x = if $, = at least start from index 2
+                // let x = 'f', = at least start from index 2
                 if item == b"=" && spans.len() > (span.0 + 1) && span.0 > 1 {
                     let (tokens, parse_error) = lex(
                         working_set.get_span_contents(nu_protocol::span(&spans[(span.0 + 1)..])),
@@ -2937,7 +2937,8 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
             // so that the var-id created by the variable isn't visible in the expression that init it
             for span in spans.iter().enumerate() {
                 let item = working_set.get_span_contents(*span.1);
-                if item == b"=" && spans.len() > (span.0 + 1) {
+                // const x = 'f', = at least start from index 2
+                if item == b"=" && spans.len() > (span.0 + 1) && span.0 > 1 {
                     let mut idx = span.0;
                     // let rvalue = parse_multispan_value(
                     //     working_set,
@@ -3075,7 +3076,8 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
             // so that the var-id created by the variable isn't visible in the expression that init it
             for span in spans.iter().enumerate() {
                 let item = working_set.get_span_contents(*span.1);
-                if item == b"=" && spans.len() > (span.0 + 1) {
+                // mut x = 'f', = at least start from index 2
+                if item == b"=" && spans.len() > (span.0 + 1) && span.0 > 1 {
                     let (tokens, parse_error) = lex(
                         working_set.get_span_contents(nu_protocol::span(&spans[(span.0 + 1)..])),
                         spans[span.0 + 1].start,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2816,7 +2816,9 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
             // so that the var-id created by the variable isn't visible in the expression that init it
             for span in spans.iter().enumerate() {
                 let item = working_set.get_span_contents(*span.1);
-                if item == b"=" && spans.len() > (span.0 + 1) {
+                // https://github.com/nushell/nushell/issues/9596, let = if $
+                // let x = if $, = at least start from index 2
+                if item == b"=" && spans.len() > (span.0 + 1) && span.0 > 1 {
                     let (tokens, parse_error) = lex(
                         working_set.get_span_contents(nu_protocol::span(&spans[(span.0 + 1)..])),
                         spans[span.0 + 1].start,

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -146,6 +146,25 @@ fn bad_var_name2() -> TestResult {
 }
 
 #[test]
+fn assignment_with_no_var() -> TestResult {
+    let cases = [
+        "let = if $",
+        "mut = if $",
+        "const = if $",
+        "let = 'foo' | $in; $x | describe",
+        "mut = 'foo' | $in; $x | describe",
+    ];
+
+    let expected = "valid variable";
+
+    for case in cases {
+        fail_test(case, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
 fn long_flag() -> TestResult {
     run_test(
         r#"([a, b, c] | enumerate | each --keep-empty { |e| if $e.index != 1 { 100 }}).1 | to nuon"#,


### PR DESCRIPTION
- this PR should close #9596 
- fixes #9596 
- this PR should close #9826 
- fixes #9826 

fixed the following bugs:
```nu
# type following statements in the nushell
let f = 'f' $;
mut f = 'f' $;
const f = 'f' $;

# then remove variable f, it will panics
let = 'f' $;
mut  = 'f' $;
const = 'f' $;
```