### PR TITLE
str-expand: add path flag

### DIFF
--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -168,7 +168,7 @@ impl Command for SubCommand {
                 };
                 match v.as_string() {
                     Ok(s) => {
-                        let contents = if is_path { s.replace("\\", "\\\\") } else { s };
+                        let contents = if is_path { s.replace('\\', "\\\\") } else { s };
                         str_expand(&contents, span, v.expect_span())
                     }
                     Err(_) => Value::Error {

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -68,7 +68,7 @@ impl Command for SubCommand {
 
             Example {
                 description: "If the piped data is path, you may want to use --path flag, or else manually replace the backslashes with double backslashes.",
-                example: "'C:\\{Users,Windows}' | str expand --flag",
+                example: "'C:\\{Users,Windows}' | str expand --path",
                 result: Some(Value::List{
                     vals: vec![
                         Value::test_string("C:\\Users"),

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -71,9 +71,8 @@ impl Command for SubCommand {
                 example: "'C:\\{Users,Windows}' | str expand --flag",
                 result: Some(Value::List{
                     vals: vec![
-                        Value::test_string("apple"),
-                        Value::test_string("banana"),
-                        Value::test_string("cherry")
+                        Value::test_string("C:\\Users"),
+                        Value::test_string("C:\\Windows"),
                     ],
                     span: Span::test_data()
                 },)


### PR DESCRIPTION
Related issues: #9838

Changes:

- added `--path` flag, for ease of use if the piped data is Path (replaces all backslashes with double backslashes)