### PR TITLE
Dataframe: rename lazyframe expressions relative commands with `dfexp` prefix.

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/filter_with.rs
@@ -53,8 +53,7 @@ impl Command for FilterWith {
             },
             Example {
                 description: "Filter dataframe using an expression",
-                example:
-                    "[[a b]; [1 2] [3 4]] | dfr into-df | dfr filter-with ((dfrexp col a) > 1)",
+                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr filter-with ((dfexp col a) > 1)",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(3)]),

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/filter_with.rs
@@ -53,7 +53,8 @@ impl Command for FilterWith {
             },
             Example {
                 description: "Filter dataframe using an expression",
-                example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr filter-with ((dfr col a) > 1)",
+                example:
+                    "[[a b]; [1 2] [3 4]] | dfr into-df | dfr filter-with ((dfrexp col a) > 1)",
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("a".to_string(), vec![Value::test_int(3)]),

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_nu.rs
@@ -75,7 +75,7 @@ impl Command for ToNu {
             },
             Example {
                 description: "Convert a col expression into a nushell value",
-                example: "dfrexp col a | dfr into-nu",
+                example: "dfexp col a | dfr into-nu",
                 result: Some(Value::Record {
                     cols: vec!["expr".into(), "value".into()],
                     vals: vec![Value::test_string("column"), Value::test_string("a")],

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_nu.rs
@@ -75,7 +75,7 @@ impl Command for ToNu {
             },
             Example {
                 description: "Convert a col expression into a nushell value",
-                example: "dfr col a | dfr into-nu",
+                example: "dfrexp col a | dfr into-nu",
                 result: Some(Value::Record {
                     cols: vec!["expr".into(), "value".into()],
                     vals: vec![Value::test_string("column"), Value::test_string("a")],

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/with_column.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/with_column.rs
@@ -65,8 +65,8 @@ impl Command for WithColumn {
                 example: r#"[[a b]; [1 2] [3 4]]
     | dfr into-lazy
     | dfr with-column [
-        ((dfr col a) * 2 | dfr as "c")
-        ((dfr col a) * 3 | dfr as "d")
+        ((dfrexp col a) * 2 | dfrexp as "c")
+        ((dfrexp col a) * 3 | dfrexp as "d")
       ]
     | dfr collect"#,
                 result: Some(

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/with_column.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/with_column.rs
@@ -65,8 +65,8 @@ impl Command for WithColumn {
                 example: r#"[[a b]; [1 2] [3 4]]
     | dfr into-lazy
     | dfr with-column [
-        ((dfrexp col a) * 2 | dfrexp as "c")
-        ((dfrexp col a) * 3 | dfrexp as "d")
+        ((dfexp col a) * 2 | dfexp as "c")
+        ((dfexp col a) * 3 | dfexp as "d")
       ]
     | dfr collect"#,
                 result: Some(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/alias.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/alias.rs
@@ -12,7 +12,7 @@ pub struct ExprAlias;
 
 impl Command for ExprAlias {
     fn name(&self) -> &str {
-        "dfrexp as"
+        "dfexp as"
     }
 
     fn usage(&self) -> &str {
@@ -36,7 +36,7 @@ impl Command for ExprAlias {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates and alias expression",
-            example: "dfrexp col a | dfrexp as new_a | dfr into-nu",
+            example: "dfexp col a | dfexp as new_a | dfr into-nu",
             result: {
                 let cols = vec!["expr".into(), "value".into()];
                 let expr = Value::test_string("column");

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/alias.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/alias.rs
@@ -12,7 +12,7 @@ pub struct ExprAlias;
 
 impl Command for ExprAlias {
     fn name(&self) -> &str {
-        "dfr as"
+        "dfrexp as"
     }
 
     fn usage(&self) -> &str {
@@ -36,7 +36,7 @@ impl Command for ExprAlias {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates and alias expression",
-            example: "dfr col a | dfr as new_a | dfr into-nu",
+            example: "dfrexp col a | dfrexp as new_a | dfr into-nu",
             result: {
                 let cols = vec!["expr".into(), "value".into()];
                 let expr = Value::test_string("column");

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/arg_where.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/arg_where.rs
@@ -12,7 +12,7 @@ pub struct ExprArgWhere;
 
 impl Command for ExprArgWhere {
     fn name(&self) -> &str {
-        "dfr arg-where"
+        "dfrexp arg-where"
     }
 
     fn usage(&self) -> &str {
@@ -29,8 +29,8 @@ impl Command for ExprArgWhere {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Return a dataframe where the value match the expression",
-            example: "let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
-    $df | dfr select (dfr arg-where ((dfr col b) >= 2) | dfr as b_arg)",
+            example: "let df = ([[a b]; [one 1] [two 2] [three 3]] | dfrexp into-df);
+    $df | dfrexp select (dfrexp arg-where ((dfrexp col b) >= 2) | dfrexp as b_arg)",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "b_arg".to_string(),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/arg_where.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/arg_where.rs
@@ -12,7 +12,7 @@ pub struct ExprArgWhere;
 
 impl Command for ExprArgWhere {
     fn name(&self) -> &str {
-        "dfrexp arg-where"
+        "dfexp arg-where"
     }
 
     fn usage(&self) -> &str {
@@ -30,7 +30,7 @@ impl Command for ExprArgWhere {
         vec![Example {
             description: "Return a dataframe where the value match the expression",
             example: "let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
-    $df | dfr select (dfrexp arg-where ((dfrexp col b) >= 2) | dfrexp as b_arg)",
+    $df | dfr select (dfexp arg-where ((dfexp col b) >= 2) | dfexp as b_arg)",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "b_arg".to_string(),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/arg_where.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/arg_where.rs
@@ -30,7 +30,7 @@ impl Command for ExprArgWhere {
         vec![Example {
             description: "Return a dataframe where the value match the expression",
             example: "let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
-    $df | dfrexp select (dfrexp arg-where ((dfrexp col b) >= 2) | dfrexp as b_arg)",
+    $df | dfr select (dfrexp arg-where ((dfrexp col b) >= 2) | dfrexp as b_arg)",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(
                     "b_arg".to_string(),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/arg_where.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/arg_where.rs
@@ -29,7 +29,7 @@ impl Command for ExprArgWhere {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Return a dataframe where the value match the expression",
-            example: "let df = ([[a b]; [one 1] [two 2] [three 3]] | dfrexp into-df);
+            example: "let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
     $df | dfrexp select (dfrexp arg-where ((dfrexp col b) >= 2) | dfrexp as b_arg)",
             result: Some(
                 NuDataFrame::try_from_columns(vec![Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/col.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/col.rs
@@ -12,7 +12,7 @@ pub struct ExprCol;
 
 impl Command for ExprCol {
     fn name(&self) -> &str {
-        "dfrexp col"
+        "dfexp col"
     }
 
     fn usage(&self) -> &str {
@@ -33,7 +33,7 @@ impl Command for ExprCol {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a named column expression and converts it to a nu object",
-            example: "dfrexp col a | dfr into-nu",
+            example: "dfexp col a | dfr into-nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![Value::test_string("column"), Value::test_string("a")],

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/col.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/col.rs
@@ -12,7 +12,7 @@ pub struct ExprCol;
 
 impl Command for ExprCol {
     fn name(&self) -> &str {
-        "dfr col"
+        "dfrexp col"
     }
 
     fn usage(&self) -> &str {
@@ -33,7 +33,7 @@ impl Command for ExprCol {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a named column expression and converts it to a nu object",
-            example: "dfr col a | dfr into-nu",
+            example: "dfrexp col a | dfr into-nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![Value::test_string("column"), Value::test_string("a")],

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/concat_str.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/concat_str.rs
@@ -38,7 +38,7 @@ impl Command for ExprConcatStr {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a concat string expression",
-            example: r#"let df = ([[a b c]; [one two 1] [three four 2]] | dfrexp into-df);
+            example: r#"let df = ([[a b c]; [one two 1] [three four 2]] | dfr into-df);
     $df | dfrexp with-column ((dfrexp concat-str "-" [(dfrexp col a) (dfrexp col b) ((dfrexp col c) * 2)]) | dfrexp as concat)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/concat_str.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/concat_str.rs
@@ -39,7 +39,7 @@ impl Command for ExprConcatStr {
         vec![Example {
             description: "Creates a concat string expression",
             example: r#"let df = ([[a b c]; [one two 1] [three four 2]] | dfr into-df);
-    $df | dfrexp with-column ((dfrexp concat-str "-" [(dfrexp col a) (dfrexp col b) ((dfrexp col c) * 2)]) | dfrexp as concat)"#,
+    $df | dfr with-column ((dfrexp concat-str "-" [(dfrexp col a) (dfrexp col b) ((dfrexp col c) * 2)]) | dfrexp as concat)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/concat_str.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/concat_str.rs
@@ -12,7 +12,7 @@ pub struct ExprConcatStr;
 
 impl Command for ExprConcatStr {
     fn name(&self) -> &str {
-        "dfr concat-str"
+        "dfrexp concat-str"
     }
 
     fn usage(&self) -> &str {
@@ -38,8 +38,8 @@ impl Command for ExprConcatStr {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a concat string expression",
-            example: r#"let df = ([[a b c]; [one two 1] [three four 2]] | dfr into-df);
-    $df | dfr with-column ((dfr concat-str "-" [(dfr col a) (dfr col b) ((dfr col c) * 2)]) | dfr as concat)"#,
+            example: r#"let df = ([[a b c]; [one two 1] [three four 2]] | dfrexp into-df);
+    $df | dfrexp with-column ((dfrexp concat-str "-" [(dfrexp col a) (dfrexp col b) ((dfrexp col c) * 2)]) | dfrexp as concat)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/concat_str.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/concat_str.rs
@@ -12,7 +12,7 @@ pub struct ExprConcatStr;
 
 impl Command for ExprConcatStr {
     fn name(&self) -> &str {
-        "dfrexp concat-str"
+        "dfexp concat-str"
     }
 
     fn usage(&self) -> &str {
@@ -39,7 +39,7 @@ impl Command for ExprConcatStr {
         vec![Example {
             description: "Creates a concat string expression",
             example: r#"let df = ([[a b c]; [one two 1] [three four 2]] | dfr into-df);
-    $df | dfr with-column ((dfrexp concat-str "-" [(dfrexp col a) (dfrexp col b) ((dfrexp col c) * 2)]) | dfrexp as concat)"#,
+    $df | dfr with-column ((dfexp concat-str "-" [(dfexp col a) (dfexp col b) ((dfexp col c) * 2)]) | dfexp as concat)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
@@ -45,7 +45,7 @@ impl Command for ExprDatePart {
         vec![
             Example {
                 description: "Creates an expression to capture the year date part",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfr with-column [(dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year )]"#,
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfr with-column [(dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year )]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("datetime".to_string(), vec![Value::test_date(dt)]),
@@ -57,7 +57,7 @@ impl Command for ExprDatePart {
             },
             Example {
                 description: "Creates an expression to capture multiple date parts",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%8f" |
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%8f" |
                 dfr with-column [ (dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year ),
                 (dfrexp col datetime | dfrexp datepart month | dfrexp as datetime_month ),
                 (dfrexp col datetime | dfrexp datepart day | dfrexp as datetime_day ),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
@@ -45,7 +45,7 @@ impl Command for ExprDatePart {
         vec![
             Example {
                 description: "Creates an expression to capture the year date part",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfrexp into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfrexp with-column [(dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year )]"#,
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfrexp with-column [(dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year )]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("datetime".to_string(), vec![Value::test_date(dt)]),
@@ -57,7 +57,7 @@ impl Command for ExprDatePart {
             },
             Example {
                 description: "Creates an expression to capture multiple date parts",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfrexp into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%9f" |
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%8f" |
                 dfrexp with-column [ (dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year ),
                 (dfrexp col datetime | dfrexp datepart month | dfrexp as datetime_month ),
                 (dfrexp col datetime | dfrexp datepart day | dfrexp as datetime_day ),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
@@ -57,7 +57,7 @@ impl Command for ExprDatePart {
             },
             Example {
                 description: "Creates an expression to capture multiple date parts",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%8f" |
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%9f" |
                 dfr with-column [ (dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year ),
                 (dfrexp col datetime | dfrexp datepart month | dfrexp as datetime_month ),
                 (dfrexp col datetime | dfrexp datepart day | dfrexp as datetime_day ),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
@@ -15,7 +15,7 @@ pub struct ExprDatePart;
 
 impl Command for ExprDatePart {
     fn name(&self) -> &str {
-        "dfr datepart"
+        "dfrexp datepart"
     }
 
     fn usage(&self) -> &str {
@@ -45,7 +45,7 @@ impl Command for ExprDatePart {
         vec![
             Example {
                 description: "Creates an expression to capture the year date part",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfr with-column [(dfr col datetime | dfr datepart year | dfr as datetime_year )]"#,
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfrexp into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfrexp with-column [(dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year )]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("datetime".to_string(), vec![Value::test_date(dt)]),
@@ -57,14 +57,14 @@ impl Command for ExprDatePart {
             },
             Example {
                 description: "Creates an expression to capture multiple date parts",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%9f" |
-                dfr with-column [ (dfr col datetime | dfr datepart year | dfr as datetime_year ),
-                (dfr col datetime | dfr datepart month | dfr as datetime_month ),
-                (dfr col datetime | dfr datepart day | dfr as datetime_day ),
-                (dfr col datetime | dfr datepart hour | dfr as datetime_hour ),
-                (dfr col datetime | dfr datepart minute | dfr as datetime_minute ),
-                (dfr col datetime | dfr datepart second | dfr as datetime_second ),
-                (dfr col datetime | dfr datepart nanosecond | dfr as datetime_ns ) ]"#,
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfrexp into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%9f" |
+                dfrexp with-column [ (dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year ),
+                (dfrexp col datetime | dfrexp datepart month | dfrexp as datetime_month ),
+                (dfrexp col datetime | dfrexp datepart day | dfrexp as datetime_day ),
+                (dfrexp col datetime | dfrexp datepart hour | dfrexp as datetime_hour ),
+                (dfrexp col datetime | dfrexp datepart minute | dfrexp as datetime_minute ),
+                (dfrexp col datetime | dfrexp datepart second | dfrexp as datetime_second ),
+                (dfrexp col datetime | dfrexp datepart nanosecond | dfrexp as datetime_ns ) ]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("datetime".to_string(), vec![Value::test_date(dt)]),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
@@ -45,7 +45,7 @@ impl Command for ExprDatePart {
         vec![
             Example {
                 description: "Creates an expression to capture the year date part",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfrexp with-column [(dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year )]"#,
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfr with-column [(dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year )]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("datetime".to_string(), vec![Value::test_date(dt)]),
@@ -58,7 +58,7 @@ impl Command for ExprDatePart {
             Example {
                 description: "Creates an expression to capture multiple date parts",
                 example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfrexp as-datetime "%Y-%m-%dT%H:%M:%S.%8f" |
-                dfrexp with-column [ (dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year ),
+                dfr with-column [ (dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year ),
                 (dfrexp col datetime | dfrexp datepart month | dfrexp as datetime_month ),
                 (dfrexp col datetime | dfrexp datepart day | dfrexp as datetime_day ),
                 (dfrexp col datetime | dfrexp datepart hour | dfrexp as datetime_hour ),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
@@ -15,7 +15,7 @@ pub struct ExprDatePart;
 
 impl Command for ExprDatePart {
     fn name(&self) -> &str {
-        "dfrexp datepart"
+        "dfexp datepart"
     }
 
     fn usage(&self) -> &str {
@@ -45,7 +45,7 @@ impl Command for ExprDatePart {
         vec![
             Example {
                 description: "Creates an expression to capture the year date part",
-                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfr with-column [(dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year )]"#,
+                example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%9f" | dfr with-column [(dfexp col datetime | dfexp datepart year | dfexp as datetime_year )]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("datetime".to_string(), vec![Value::test_date(dt)]),
@@ -58,13 +58,13 @@ impl Command for ExprDatePart {
             Example {
                 description: "Creates an expression to capture multiple date parts",
                 example: r#"[["2021-12-30T01:02:03.123456789"]] | dfr into-df | dfr as-datetime "%Y-%m-%dT%H:%M:%S.%9f" |
-                dfr with-column [ (dfrexp col datetime | dfrexp datepart year | dfrexp as datetime_year ),
-                (dfrexp col datetime | dfrexp datepart month | dfrexp as datetime_month ),
-                (dfrexp col datetime | dfrexp datepart day | dfrexp as datetime_day ),
-                (dfrexp col datetime | dfrexp datepart hour | dfrexp as datetime_hour ),
-                (dfrexp col datetime | dfrexp datepart minute | dfrexp as datetime_minute ),
-                (dfrexp col datetime | dfrexp datepart second | dfrexp as datetime_second ),
-                (dfrexp col datetime | dfrexp datepart nanosecond | dfrexp as datetime_ns ) ]"#,
+                dfr with-column [ (dfexp col datetime | dfexp datepart year | dfexp as datetime_year ),
+                (dfexp col datetime | dfexp datepart month | dfexp as datetime_month ),
+                (dfexp col datetime | dfexp datepart day | dfexp as datetime_day ),
+                (dfexp col datetime | dfexp datepart hour | dfexp as datetime_hour ),
+                (dfexp col datetime | dfexp datepart minute | dfexp as datetime_minute ),
+                (dfexp col datetime | dfexp datepart second | dfexp as datetime_second ),
+                (dfexp col datetime | dfexp datepart nanosecond | dfexp as datetime_ns ) ]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new("datetime".to_string(), vec![Value::test_date(dt)]),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/expressions_macro.rs
@@ -308,9 +308,9 @@ expr_command!(
     vec![Example {
         description: "Max aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfrexp into-df
-    | dfrexp group-by a
-    | dfrexp agg (dfrexp col b | dfrexp max)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfrexp col b | dfrexp max)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -339,9 +339,9 @@ expr_command!(
     vec![Example {
         description: "Min aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfrexp into-df
-    | dfrexp group-by a
-    | dfrexp agg (dfrexp col b | dfrexp min)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfrexp col b | dfrexp min)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -370,9 +370,9 @@ expr_command!(
     vec![Example {
         description: "Sum aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfrexp into-df
-    | dfrexp group-by a
-    | dfrexp agg (dfrexp col b | dfrexp sum)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfrexp col b | dfrexp sum)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -401,9 +401,9 @@ expr_command!(
     vec![Example {
         description: "Mean aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfrexp into-df
-    | dfrexp group-by a
-    | dfrexp agg (dfrexp col b | dfrexp mean)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfrexp col b | dfrexp mean)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -432,9 +432,9 @@ expr_command!(
     vec![Example {
         description: "Median aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfrexp into-df
-    | dfrexp group-by a
-    | dfrexp agg (dfrexp col b | dfrexp median)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfrexp col b | dfrexp median)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -463,9 +463,9 @@ expr_command!(
     vec![Example {
         description: "Std aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | dfrexp into-df
-    | dfrexp group-by a
-    | dfrexp agg (dfrexp col b | dfrexp std)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfrexp col b | dfrexp std)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -495,9 +495,9 @@ expr_command!(
     vec![Example {
         description: "Var aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | dfrexp into-df
-    | dfrexp group-by a
-    | dfrexp agg (dfrexp col b | dfrexp var)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfrexp col b | dfrexp var)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/expressions_macro.rs
@@ -138,7 +138,7 @@ macro_rules! expr_command {
 // Expands to a command definition for a list expression
 expr_command!(
     ExprList,
-    "dfrexp implode",
+    "dfexp implode",
     "Aggregates a group to a Series",
     vec![Example {
         description: "",
@@ -153,7 +153,7 @@ expr_command!(
 // Expands to a command definition for a agg groups expression
 expr_command!(
     ExprAggGroups,
-    "dfrexp agg-groups",
+    "dfexp agg-groups",
     "creates an agg_groups expression",
     vec![Example {
         description: "",
@@ -168,7 +168,7 @@ expr_command!(
 // Expands to a command definition for a flatten expression
 expr_command!(
     ExprFlatten,
-    "dfrexp flatten",
+    "dfexp flatten",
     "creates a flatten expression",
     vec![Example {
         description: "",
@@ -183,7 +183,7 @@ expr_command!(
 // Expands to a command definition for a explode expression
 expr_command!(
     ExprExplode,
-    "dfrexp explode",
+    "dfexp explode",
     "creates an explode expression",
     vec![Example {
         description: "",
@@ -198,7 +198,7 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprCount,
-    "dfrexp count",
+    "dfexp count",
     "creates a count expression",
     vec![Example {
         description: "",
@@ -213,11 +213,11 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprFirst,
-    "dfrexp first",
+    "dfexp first",
     "creates a first expression",
     vec![Example {
         description: "Creates a first expression from a column",
-        example: "dfrexp col a | dfrexp first",
+        example: "dfexp col a | dfexp first",
         result: None,
     },],
     first,
@@ -228,11 +228,11 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprLast,
-    "dfrexp last",
+    "dfexp last",
     "creates a last expression",
     vec![Example {
         description: "Creates a last expression from a column",
-        example: "dfrexp col a | dfrexp last",
+        example: "dfexp col a | dfexp last",
         result: None,
     },],
     last,
@@ -243,11 +243,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprNUnique,
-    "dfrexp n-unique",
+    "dfexp n-unique",
     "creates a n-unique expression",
     vec![Example {
         description: "Creates a is n-unique expression from a column",
-        example: "dfrexp col a | dfrexp n-unique",
+        example: "dfexp col a | dfexp n-unique",
         result: None,
     },],
     n_unique,
@@ -258,11 +258,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprIsNotNull,
-    "dfrexp is-not-null",
+    "dfexp is-not-null",
     "creates a is not null expression",
     vec![Example {
         description: "Creates a is not null expression from a column",
-        example: "dfrexp col a | dfrexp is-not-null",
+        example: "dfexp col a | dfexp is-not-null",
         result: None,
     },],
     is_not_null,
@@ -273,11 +273,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprIsNull,
-    "dfrexp is-null",
+    "dfexp is-null",
     "creates a is null expression",
     vec![Example {
         description: "Creates a is null expression from a column",
-        example: "dfrexp col a | dfrexp is-null",
+        example: "dfexp col a | dfexp is-null",
         result: None,
     },],
     is_null,
@@ -288,11 +288,11 @@ expr_command!(
 // Expands to a command definition for a not expression
 expr_command!(
     ExprNot,
-    "dfrexp expr-not",
+    "dfexp expr-not",
     "creates a not expression",
     vec![Example {
         description: "Creates a not expression",
-        example: "(dfrexp col a) > 2) | dfrexp expr-not",
+        example: "(dfexp col a) > 2) | dfexp expr-not",
         result: None,
     },],
     not,
@@ -303,14 +303,14 @@ expr_command!(
 // Expands to a command definition for max aggregation
 expr_command!(
     ExprMax,
-    "dfrexp max",
+    "dfexp max",
     "Creates a max expression",
     vec![Example {
         description: "Max aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | dfr into-df
     | dfr group-by a
-    | dfr agg (dfrexp col b | dfrexp max)"#,
+    | dfr agg (dfexp col b | dfexp max)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -334,14 +334,14 @@ expr_command!(
 // Expands to a command definition for min aggregation
 expr_command!(
     ExprMin,
-    "dfrexp min",
+    "dfexp min",
     "Creates a min expression",
     vec![Example {
         description: "Min aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | dfr into-df
     | dfr group-by a
-    | dfr agg (dfrexp col b | dfrexp min)"#,
+    | dfr agg (dfexp col b | dfexp min)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -365,14 +365,14 @@ expr_command!(
 // Expands to a command definition for sum aggregation
 expr_command!(
     ExprSum,
-    "dfrexp sum",
+    "dfexp sum",
     "Creates a sum expression for an aggregation",
     vec![Example {
         description: "Sum aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | dfr into-df
     | dfr group-by a
-    | dfr agg (dfrexp col b | dfrexp sum)"#,
+    | dfr agg (dfexp col b | dfexp sum)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -396,14 +396,14 @@ expr_command!(
 // Expands to a command definition for mean aggregation
 expr_command!(
     ExprMean,
-    "dfrexp mean",
+    "dfexp mean",
     "Creates a mean expression for an aggregation",
     vec![Example {
         description: "Mean aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | dfr into-df
     | dfr group-by a
-    | dfr agg (dfrexp col b | dfrexp mean)"#,
+    | dfr agg (dfexp col b | dfexp mean)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -427,14 +427,14 @@ expr_command!(
 // Expands to a command definition for median aggregation
 expr_command!(
     ExprMedian,
-    "dfrexp median",
+    "dfexp median",
     "Creates a median expression for an aggregation",
     vec![Example {
         description: "Median aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | dfr into-df
     | dfr group-by a
-    | dfr agg (dfrexp col b | dfrexp median)"#,
+    | dfr agg (dfexp col b | dfexp median)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -458,14 +458,14 @@ expr_command!(
 // Expands to a command definition for std aggregation
 expr_command!(
     ExprStd,
-    "dfrexp std",
+    "dfexp std",
     "Creates a std expression for an aggregation",
     vec![Example {
         description: "Std aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
     | dfr into-df
     | dfr group-by a
-    | dfr agg (dfrexp col b | dfrexp std)"#,
+    | dfr agg (dfexp col b | dfexp std)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -490,14 +490,14 @@ expr_command!(
 // Expands to a command definition for var aggregation
 expr_command!(
     ExprVar,
-    "dfrexp var",
+    "dfexp var",
     "Create a var expression for an aggregation",
     vec![Example {
         description: "Var aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
     | dfr into-df
     | dfr group-by a
-    | dfr agg (dfrexp col b | dfrexp var)"#,
+    | dfr agg (dfexp col b | dfexp var)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/expressions_macro.rs
@@ -138,7 +138,7 @@ macro_rules! expr_command {
 // Expands to a command definition for a list expression
 expr_command!(
     ExprList,
-    "dfr implode",
+    "dfrexp implode",
     "Aggregates a group to a Series",
     vec![Example {
         description: "",
@@ -153,7 +153,7 @@ expr_command!(
 // Expands to a command definition for a agg groups expression
 expr_command!(
     ExprAggGroups,
-    "dfr agg-groups",
+    "dfrexp agg-groups",
     "creates an agg_groups expression",
     vec![Example {
         description: "",
@@ -168,7 +168,7 @@ expr_command!(
 // Expands to a command definition for a flatten expression
 expr_command!(
     ExprFlatten,
-    "dfr flatten",
+    "dfrexp flatten",
     "creates a flatten expression",
     vec![Example {
         description: "",
@@ -183,7 +183,7 @@ expr_command!(
 // Expands to a command definition for a explode expression
 expr_command!(
     ExprExplode,
-    "dfr explode",
+    "dfrexp explode",
     "creates an explode expression",
     vec![Example {
         description: "",
@@ -198,7 +198,7 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprCount,
-    "dfr count",
+    "dfrexp count",
     "creates a count expression",
     vec![Example {
         description: "",
@@ -213,11 +213,11 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprFirst,
-    "dfr first",
+    "dfrexp first",
     "creates a first expression",
     vec![Example {
         description: "Creates a first expression from a column",
-        example: "dfr col a | dfr first",
+        example: "dfrexp col a | dfrexp first",
         result: None,
     },],
     first,
@@ -228,11 +228,11 @@ expr_command!(
 // Expands to a command definition for a count expression
 expr_command!(
     ExprLast,
-    "dfr last",
+    "dfrexp last",
     "creates a last expression",
     vec![Example {
         description: "Creates a last expression from a column",
-        example: "dfr col a | dfr last",
+        example: "dfrexp col a | dfrexp last",
         result: None,
     },],
     last,
@@ -243,11 +243,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprNUnique,
-    "dfr n-unique",
+    "dfrexp n-unique",
     "creates a n-unique expression",
     vec![Example {
         description: "Creates a is n-unique expression from a column",
-        example: "dfr col a | dfr n-unique",
+        example: "dfrexp col a | dfrexp n-unique",
         result: None,
     },],
     n_unique,
@@ -258,11 +258,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprIsNotNull,
-    "dfr is-not-null",
+    "dfrexp is-not-null",
     "creates a is not null expression",
     vec![Example {
         description: "Creates a is not null expression from a column",
-        example: "dfr col a | dfr is-not-null",
+        example: "dfrexp col a | dfrexp is-not-null",
         result: None,
     },],
     is_not_null,
@@ -273,11 +273,11 @@ expr_command!(
 // Expands to a command definition for a n-unique expression
 expr_command!(
     ExprIsNull,
-    "dfr is-null",
+    "dfrexp is-null",
     "creates a is null expression",
     vec![Example {
         description: "Creates a is null expression from a column",
-        example: "dfr col a | dfr is-null",
+        example: "dfrexp col a | dfrexp is-null",
         result: None,
     },],
     is_null,
@@ -288,11 +288,11 @@ expr_command!(
 // Expands to a command definition for a not expression
 expr_command!(
     ExprNot,
-    "dfr expr-not",
+    "dfrexp expr-not",
     "creates a not expression",
     vec![Example {
         description: "Creates a not expression",
-        example: "(dfr col a) > 2) | dfr expr-not",
+        example: "(dfrexp col a) > 2) | dfrexp expr-not",
         result: None,
     },],
     not,
@@ -303,14 +303,14 @@ expr_command!(
 // Expands to a command definition for max aggregation
 expr_command!(
     ExprMax,
-    "dfr max",
+    "dfrexp max",
     "Creates a max expression",
     vec![Example {
         description: "Max aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfr into-df
-    | dfr group-by a
-    | dfr agg (dfr col b | dfr max)"#,
+    | dfrexp into-df
+    | dfrexp group-by a
+    | dfrexp agg (dfrexp col b | dfrexp max)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -334,14 +334,14 @@ expr_command!(
 // Expands to a command definition for min aggregation
 expr_command!(
     ExprMin,
-    "dfr min",
+    "dfrexp min",
     "Creates a min expression",
     vec![Example {
         description: "Min aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfr into-df
-    | dfr group-by a
-    | dfr agg (dfr col b | dfr min)"#,
+    | dfrexp into-df
+    | dfrexp group-by a
+    | dfrexp agg (dfrexp col b | dfrexp min)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -365,14 +365,14 @@ expr_command!(
 // Expands to a command definition for sum aggregation
 expr_command!(
     ExprSum,
-    "dfr sum",
+    "dfrexp sum",
     "Creates a sum expression for an aggregation",
     vec![Example {
         description: "Sum aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfr into-df
-    | dfr group-by a
-    | dfr agg (dfr col b | dfr sum)"#,
+    | dfrexp into-df
+    | dfrexp group-by a
+    | dfrexp agg (dfrexp col b | dfrexp sum)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -396,14 +396,14 @@ expr_command!(
 // Expands to a command definition for mean aggregation
 expr_command!(
     ExprMean,
-    "dfr mean",
+    "dfrexp mean",
     "Creates a mean expression for an aggregation",
     vec![Example {
         description: "Mean aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfr into-df
-    | dfr group-by a
-    | dfr agg (dfr col b | dfr mean)"#,
+    | dfrexp into-df
+    | dfrexp group-by a
+    | dfrexp agg (dfrexp col b | dfrexp mean)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -427,14 +427,14 @@ expr_command!(
 // Expands to a command definition for median aggregation
 expr_command!(
     ExprMedian,
-    "dfr median",
+    "dfrexp median",
     "Creates a median expression for an aggregation",
     vec![Example {
         description: "Median aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfr into-df
-    | dfr group-by a
-    | dfr agg (dfr col b | dfr median)"#,
+    | dfrexp into-df
+    | dfrexp group-by a
+    | dfrexp agg (dfrexp col b | dfrexp median)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -458,14 +458,14 @@ expr_command!(
 // Expands to a command definition for std aggregation
 expr_command!(
     ExprStd,
-    "dfr std",
+    "dfrexp std",
     "Creates a std expression for an aggregation",
     vec![Example {
         description: "Std aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | dfr into-df
-    | dfr group-by a
-    | dfr agg (dfr col b | dfr std)"#,
+    | dfrexp into-df
+    | dfrexp group-by a
+    | dfrexp agg (dfrexp col b | dfrexp std)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(
@@ -490,14 +490,14 @@ expr_command!(
 // Expands to a command definition for var aggregation
 expr_command!(
     ExprVar,
-    "dfr var",
+    "dfrexp var",
     "Create a var expression for an aggregation",
     vec![Example {
         description: "Var aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 2] [two 1] [two 1]]
-    | dfr into-df
-    | dfr group-by a
-    | dfr agg (dfr col b | dfr var)"#,
+    | dfrexp into-df
+    | dfrexp group-by a
+    | dfrexp agg (dfrexp col b | dfrexp var)"#,
         result: Some(
             NuDataFrame::try_from_columns(vec![
                 Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/is_in.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/is_in.rs
@@ -36,7 +36,7 @@ impl Command for ExprIsIn {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a is-in expression",
-            example: r#"let df = ([[a b]; [one 1] [two 2] [three 3]] | dfrexp into-df);
+            example: r#"let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
     $df | dfrexp with-column (dfrexp col a | dfrexp is-in [one two] | dfrexp as a_in)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/is_in.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/is_in.rs
@@ -12,7 +12,7 @@ pub struct ExprIsIn;
 
 impl Command for ExprIsIn {
     fn name(&self) -> &str {
-        "dfrexp is-in"
+        "dfexp is-in"
     }
 
     fn usage(&self) -> &str {
@@ -37,7 +37,7 @@ impl Command for ExprIsIn {
         vec![Example {
             description: "Creates a is-in expression",
             example: r#"let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
-    $df | dfr with-column (dfrexp col a | dfrexp is-in [one two] | dfrexp as a_in)"#,
+    $df | dfr with-column (dfexp col a | dfexp is-in [one two] | dfexp as a_in)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/is_in.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/is_in.rs
@@ -37,7 +37,7 @@ impl Command for ExprIsIn {
         vec![Example {
             description: "Creates a is-in expression",
             example: r#"let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
-    $df | dfrexp with-column (dfrexp col a | dfrexp is-in [one two] | dfrexp as a_in)"#,
+    $df | dfr with-column (dfrexp col a | dfrexp is-in [one two] | dfrexp as a_in)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/is_in.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/is_in.rs
@@ -12,7 +12,7 @@ pub struct ExprIsIn;
 
 impl Command for ExprIsIn {
     fn name(&self) -> &str {
-        "dfr is-in"
+        "dfrexp is-in"
     }
 
     fn usage(&self) -> &str {
@@ -36,8 +36,8 @@ impl Command for ExprIsIn {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Creates a is-in expression",
-            example: r#"let df = ([[a b]; [one 1] [two 2] [three 3]] | dfr into-df);
-    $df | dfr with-column (dfr col a | dfr is-in [one two] | dfr as a_in)"#,
+            example: r#"let df = ([[a b]; [one 1] [two 2] [three 3]] | dfrexp into-df);
+    $df | dfrexp with-column (dfrexp col a | dfrexp is-in [one two] | dfrexp as a_in)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/lit.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/lit.rs
@@ -32,7 +32,7 @@ impl Command for ExprLit {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Created a literal expression and converts it to a nu object",
-            example: "dfrexp lit 2 | dfrexp into-nu",
+            example: "dfrexp lit 2 | dfr into-nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![Value::test_string("literal"), Value::test_string("2")],

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/lit.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/lit.rs
@@ -11,7 +11,7 @@ pub struct ExprLit;
 
 impl Command for ExprLit {
     fn name(&self) -> &str {
-        "dfrexp lit"
+        "dfexp lit"
     }
 
     fn usage(&self) -> &str {
@@ -32,7 +32,7 @@ impl Command for ExprLit {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Created a literal expression and converts it to a nu object",
-            example: "dfrexp lit 2 | dfr into-nu",
+            example: "dfexp lit 2 | dfr into-nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![Value::test_string("literal"), Value::test_string("2")],

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/lit.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/lit.rs
@@ -11,7 +11,7 @@ pub struct ExprLit;
 
 impl Command for ExprLit {
     fn name(&self) -> &str {
-        "dfr lit"
+        "dfrexp lit"
     }
 
     fn usage(&self) -> &str {
@@ -32,7 +32,7 @@ impl Command for ExprLit {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Created a literal expression and converts it to a nu object",
-            example: "dfr lit 2 | dfr into-nu",
+            example: "dfrexp lit 2 | dfrexp into-nu",
             result: Some(Value::Record {
                 cols: vec!["expr".into(), "value".into()],
                 vals: vec![Value::test_string("literal"), Value::test_string("2")],

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
@@ -46,10 +46,10 @@ impl Command for ExprOtherwise {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
    | dfrexp into-lazy
-   | dfrexp with-column (
+   | dfr with-column (
     dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5 | dfrexp as c
      )
-   | dfrexp with-column (
+   | dfr with-column (
     dfrexp when ((dfrexp col a) > 5) 10 | dfrexp when ((dfrexp col a) < 2) 6 | dfrexp otherwise 0 | dfrexp as d
      )
    | dfrexp collect"#,

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
@@ -11,7 +11,7 @@ pub struct ExprOtherwise;
 
 impl Command for ExprOtherwise {
     fn name(&self) -> &str {
-        "dfrexp otherwise"
+        "dfexp otherwise"
     }
 
     fn usage(&self) -> &str {
@@ -33,13 +33,13 @@ impl Command for ExprOtherwise {
         vec![
             Example {
                 description: "Create a when conditions",
-                example: "dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5",
+                example: "dfexp when ((dfexp col a) > 2) 4 | dfexp otherwise 5",
                 result: None,
             },
             Example {
                 description: "Create a when conditions",
                 example:
-                    "dfrexp when ((dfrexp col a) > 2) 4 | dfrexp when ((dfrexp col a) < 0) 6 | dfrexp otherwise 0",
+                    "dfexp when ((dfexp col a) > 2) 4 | dfexp when ((dfexp col a) < 0) 6 | dfexp otherwise 0",
                 result: None,
             },
             Example {
@@ -47,10 +47,10 @@ impl Command for ExprOtherwise {
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
    | dfr into-lazy
    | dfr with-column (
-    dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5 | dfrexp as c
+    dfexp when ((dfexp col a) > 2) 4 | dfexp otherwise 5 | dfexp as c
      )
    | dfr with-column (
-    dfrexp when ((dfrexp col a) > 5) 10 | dfrexp when ((dfrexp col a) < 2) 6 | dfrexp otherwise 0 | dfrexp as d
+    dfexp when ((dfexp col a) > 5) 10 | dfexp when ((dfexp col a) < 2) 6 | dfexp otherwise 0 | dfexp as d
      )
    | dfr collect"#,
                 result: Some(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
@@ -11,7 +11,7 @@ pub struct ExprOtherwise;
 
 impl Command for ExprOtherwise {
     fn name(&self) -> &str {
-        "dfr otherwise"
+        "dfrexp otherwise"
     }
 
     fn usage(&self) -> &str {
@@ -33,26 +33,26 @@ impl Command for ExprOtherwise {
         vec![
             Example {
                 description: "Create a when conditions",
-                example: "dfr when ((dfr col a) > 2) 4 | dfr otherwise 5",
+                example: "dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5",
                 result: None,
             },
             Example {
                 description: "Create a when conditions",
                 example:
-                    "dfr when ((dfr col a) > 2) 4 | dfr when ((dfr col a) < 0) 6 | dfr otherwise 0",
+                    "dfrexp when ((dfrexp col a) > 2) 4 | dfrexp when ((dfrexp col a) < 0) 6 | dfrexp otherwise 0",
                 result: None,
             },
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | dfr into-lazy
-   | dfr with-column (
-    dfr when ((dfr col a) > 2) 4 | dfr otherwise 5 | dfr as c
+   | dfrexp into-lazy
+   | dfrexp with-column (
+    dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5 | dfrexp as c
      )
-   | dfr with-column (
-    dfr when ((dfr col a) > 5) 10 | dfr when ((dfr col a) < 2) 6 | dfr otherwise 0 | dfr as d
+   | dfrexp with-column (
+    dfrexp when ((dfrexp col a) > 5) 10 | dfrexp when ((dfrexp col a) < 2) 6 | dfrexp otherwise 0 | dfrexp as d
      )
-   | dfr collect"#,
+   | dfrexp collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
@@ -45,14 +45,14 @@ impl Command for ExprOtherwise {
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | dfrexp into-lazy
+   | dfr into-lazy
    | dfr with-column (
     dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5 | dfrexp as c
      )
    | dfr with-column (
     dfrexp when ((dfrexp col a) > 5) 10 | dfrexp when ((dfrexp col a) < 2) 6 | dfrexp otherwise 0 | dfrexp as d
      )
-   | dfrexp collect"#,
+   | dfr collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/quantile.rs
@@ -37,9 +37,9 @@ impl Command for ExprQuantile {
         vec![Example {
             description: "Quantile aggregation for a group-by",
             example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfrexp into-df
-    | dfrexp group-by a
-    | dfrexp agg (dfrexp col b | dfrexp quantile 0.5)"#,
+    | dfr into-df
+    | dfr group-by a
+    | dfr agg (dfrexp col b | dfrexp quantile 0.5)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/quantile.rs
@@ -12,7 +12,7 @@ pub struct ExprQuantile;
 
 impl Command for ExprQuantile {
     fn name(&self) -> &str {
-        "dfrexp quantile"
+        "dfexp quantile"
     }
 
     fn usage(&self) -> &str {
@@ -39,7 +39,7 @@ impl Command for ExprQuantile {
             example: r#"[[a b]; [one 2] [one 4] [two 1]]
     | dfr into-df
     | dfr group-by a
-    | dfr agg (dfrexp col b | dfrexp quantile 0.5)"#,
+    | dfr agg (dfexp col b | dfexp quantile 0.5)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/quantile.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/quantile.rs
@@ -12,7 +12,7 @@ pub struct ExprQuantile;
 
 impl Command for ExprQuantile {
     fn name(&self) -> &str {
-        "dfr quantile"
+        "dfrexp quantile"
     }
 
     fn usage(&self) -> &str {
@@ -37,9 +37,9 @@ impl Command for ExprQuantile {
         vec![Example {
             description: "Quantile aggregation for a group-by",
             example: r#"[[a b]; [one 2] [one 4] [two 1]]
-    | dfr into-df
-    | dfr group-by a
-    | dfr agg (dfr col b | dfr quantile 0.5)"#,
+    | dfrexp into-df
+    | dfrexp group-by a
+    | dfrexp agg (dfrexp col b | dfrexp quantile 0.5)"#,
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
@@ -53,14 +53,14 @@ impl Command for ExprWhen {
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | dfrexp into-lazy
+   | dfr into-lazy
    | dfr with-column (
     dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5 | dfrexp as c
      )
    | dfr with-column (
     dfrexp when ((dfrexp col a) > 5) 10 | dfrexp when ((dfrexp col a) < 2) 6 | dfrexp otherwise 0 | dfrexp as d
      )
-   | dfrexp collect"#,
+   | dfr collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
@@ -12,7 +12,7 @@ pub struct ExprWhen;
 
 impl Command for ExprWhen {
     fn name(&self) -> &str {
-        "dfrexp when"
+        "dfexp when"
     }
 
     fn usage(&self) -> &str {
@@ -42,12 +42,12 @@ impl Command for ExprWhen {
         vec![
             Example {
                 description: "Create a when conditions",
-                example: "dfrexp when ((dfrexp col a) > 2) 4",
+                example: "dfexp when ((dfexp col a) > 2) 4",
                 result: None,
             },
             Example {
                 description: "Create a when conditions",
-                example: "dfrexp when ((dfrexp col a) > 2) 4 | dfrexp when ((dfrexp col a) < 0) 6",
+                example: "dfexp when ((dfexp col a) > 2) 4 | dfexp when ((dfexp col a) < 0) 6",
                 result: None,
             },
             Example {
@@ -55,10 +55,10 @@ impl Command for ExprWhen {
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
    | dfr into-lazy
    | dfr with-column (
-    dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5 | dfrexp as c
+    dfexp when ((dfexp col a) > 2) 4 | dfexp otherwise 5 | dfexp as c
      )
    | dfr with-column (
-    dfrexp when ((dfrexp col a) > 5) 10 | dfrexp when ((dfrexp col a) < 2) 6 | dfrexp otherwise 0 | dfrexp as d
+    dfexp when ((dfexp col a) > 5) 10 | dfexp when ((dfexp col a) < 2) 6 | dfexp otherwise 0 | dfexp as d
      )
    | dfr collect"#,
                 result: Some(

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
@@ -54,10 +54,10 @@ impl Command for ExprWhen {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
    | dfrexp into-lazy
-   | dfrexp with-column (
+   | dfr with-column (
     dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5 | dfrexp as c
      )
-   | dfrexp with-column (
+   | dfr with-column (
     dfrexp when ((dfrexp col a) > 5) 10 | dfrexp when ((dfrexp col a) < 2) 6 | dfrexp otherwise 0 | dfrexp as d
      )
    | dfrexp collect"#,

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
@@ -12,7 +12,7 @@ pub struct ExprWhen;
 
 impl Command for ExprWhen {
     fn name(&self) -> &str {
-        "dfr when"
+        "dfrexp when"
     }
 
     fn usage(&self) -> &str {
@@ -42,25 +42,25 @@ impl Command for ExprWhen {
         vec![
             Example {
                 description: "Create a when conditions",
-                example: "dfr when ((dfr col a) > 2) 4",
+                example: "dfrexp when ((dfrexp col a) > 2) 4",
                 result: None,
             },
             Example {
                 description: "Create a when conditions",
-                example: "dfr when ((dfr col a) > 2) 4 | dfr when ((dfr col a) < 0) 6",
+                example: "dfrexp when ((dfrexp col a) > 2) 4 | dfrexp when ((dfrexp col a) < 0) 6",
                 result: None,
             },
             Example {
                 description: "Create a new column for the dataframe",
                 example: r#"[[a b]; [6 2] [1 4] [4 1]]
-   | dfr into-lazy
-   | dfr with-column (
-    dfr when ((dfr col a) > 2) 4 | dfr otherwise 5 | dfr as c
+   | dfrexp into-lazy
+   | dfrexp with-column (
+    dfrexp when ((dfrexp col a) > 2) 4 | dfrexp otherwise 5 | dfrexp as c
      )
-   | dfr with-column (
-    dfr when ((dfr col a) > 5) 10 | dfr when ((dfr col a) < 2) 6 | dfr otherwise 0 | dfr as d
+   | dfrexp with-column (
+    dfrexp when ((dfrexp col a) > 5) 10 | dfrexp when ((dfrexp col a) < 2) 6 | dfrexp otherwise 0 | dfrexp as d
      )
-   | dfr collect"#,
+   | dfrexp collect"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
                         Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/aggregate.rs
@@ -42,9 +42,9 @@ impl Command for LazyAggregate {
     | dfr into-df
     | dfr group-by a
     | dfr agg [
-        (dfr col b | dfr min | dfr as "b_min")
-        (dfr col b | dfr max | dfr as "b_max")
-        (dfr col b | dfr sum | dfr as "b_sum")
+        (dfrexp col b | dfrexp min | dfrexp as "b_min")
+        (dfrexp col b | dfrexp max | dfrexp as "b_max")
+        (dfrexp col b | dfrexp sum | dfrexp as "b_sum")
      ]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -75,9 +75,9 @@ impl Command for LazyAggregate {
     | dfr into-lazy
     | dfr group-by a
     | dfr agg [
-        (dfr col b | dfr min | dfr as "b_min")
-        (dfr col b | dfr max | dfr as "b_max")
-        (dfr col b | dfr sum | dfr as "b_sum")
+        (dfrexp col b | dfrexp min | dfrexp as "b_min")
+        (dfrexp col b | dfrexp max | dfrexp as "b_max")
+        (dfrexp col b | dfrexp sum | dfrexp as "b_sum")
      ]
     | dfr collect"#,
                 result: Some(

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/aggregate.rs
@@ -42,9 +42,9 @@ impl Command for LazyAggregate {
     | dfr into-df
     | dfr group-by a
     | dfr agg [
-        (dfrexp col b | dfrexp min | dfrexp as "b_min")
-        (dfrexp col b | dfrexp max | dfrexp as "b_max")
-        (dfrexp col b | dfrexp sum | dfrexp as "b_sum")
+        (dfexp col b | dfexp min | dfexp as "b_min")
+        (dfexp col b | dfexp max | dfexp as "b_max")
+        (dfexp col b | dfexp sum | dfexp as "b_sum")
      ]"#,
                 result: Some(
                     NuDataFrame::try_from_columns(vec![
@@ -75,9 +75,9 @@ impl Command for LazyAggregate {
     | dfr into-lazy
     | dfr group-by a
     | dfr agg [
-        (dfrexp col b | dfrexp min | dfrexp as "b_min")
-        (dfrexp col b | dfrexp max | dfrexp as "b_max")
-        (dfrexp col b | dfrexp sum | dfrexp as "b_sum")
+        (dfexp col b | dfexp min | dfexp as "b_min")
+        (dfexp col b | dfexp max | dfexp as "b_max")
+        (dfexp col b | dfexp sum | dfexp as "b_sum")
      ]
     | dfr collect"#,
                 result: Some(

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/filter.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/filter.rs
@@ -36,7 +36,7 @@ impl Command for LazyFilter {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Filter dataframe using an expression",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr filter ((dfr col a) >= 4)",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr filter ((dfrexp col a) >= 4)",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/filter.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/filter.rs
@@ -36,7 +36,7 @@ impl Command for LazyFilter {
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Filter dataframe using an expression",
-            example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr filter ((dfrexp col a) >= 4)",
+            example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr filter ((dfexp col a) >= 4)",
             result: Some(
                 NuDataFrame::try_from_columns(vec![
                     Column::new(


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Relative: #9807 

The issue happened because we have two command which have the same name, take `dfr into-nu` as example, one is for `dataframe`, one is for `lazyframe`.  And we don't allow command overloading for now.

There are two ways to fix the issue:
1. make a runtime dispatch into one `dfr into-nu` command, when user invoke `dfr into-nu`, it checks input type firstly and then delegate to `dataframe` like command or `lazyframe` like command, this is how #9858 works for `dfr into-nu`.
2. change `lazyframe` like command name to different prefix, like `dfexp`, then if user want to express operations on `lazyframe`, he needs to use `dfexp col` rather than `dfr col`, this is how this pr does.

But yeah, we don't need to revert #9858, because we need `dfr into-nu` takes expression as input type to convert it to nushell

# User-Facing Changes
Take the following code as example:
```
let x = [[a b]; [one 2] [one 2] [two 1] [two 1]]
$x | dfr into-df | dfr group-by a | dfr agg (dfr col b | dfr var)
```
After this pr, user have to write something like this:
```
$x | dfr into-df | dfr group-by a | dfr agg (dfexp col b | dfexp var)
```

As we can see, all expression description for `lazyframe` have `dfexp` prefix.  It's more explicit.

But yeah, I have to admit that it's a little hard to migrate, because it's hard to know when to change from `dfr col` to `dfexp col` when he look at current nushell script code.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
