### PR TITLE
Restore Ctrl R behavior to history menu

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -433,7 +433,7 @@ $env.config = {
         {
             name: search_history
             modifier: control
-            keycode: char_r
+            keycode: char_q
             mode: [emacs, vi_normal, vi_insert]
             event: { send: searchhistory }
         }


### PR DESCRIPTION
Was changed by https://github.com/nushell/nushell/commit/345c00aa1ee6abeb3591a87a58b809748799d4b2 (hopefully unintentionally). The `search_history` action overrides the history menu action.