### PR TITLE
Remove `range -> any` in `first`

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -33,14 +33,12 @@ impl Command for First {
                     Type::Any,
                 ),
                 (Type::Binary, Type::Binary),
-                (Type::Range, Type::Any),
             ])
             .optional(
                 "rows",
                 SyntaxShape::Int,
                 "starting from the front, the number of rows to return",
             )
-            .allow_variants_without_examples(true)
             .category(Category::Filters)
     }
 
@@ -150,17 +148,6 @@ fn first_helper(
                         Value::Binary { val: slice, span },
                         metadata,
                     ))
-                }
-            }
-            Value::Range { val, .. } => {
-                if return_single_element {
-                    Ok(val.from.into_pipeline_data())
-                } else {
-                    Ok(val
-                        .into_range_iter(ctrlc.clone())?
-                        .take(rows_desired)
-                        .into_pipeline_data(ctrlc)
-                        .set_metadata(metadata))
                 }
             }
             // Propagate errors by explicitly matching them before the final case.

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -271,11 +271,6 @@ fn nonshortcircuiting_xor() -> TestResult {
 }
 
 #[test]
-fn open_ended_range() -> TestResult {
-    run_test(r#"1.. | first 100000 | length"#, "100000")
-}
-
-#[test]
 fn default_value1() -> TestResult {
     run_test(r#"def foo [x = 3] { $x }; foo"#, "3")
 }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -696,42 +696,6 @@ fn range_with_right_var() {
 }
 
 #[test]
-fn range_with_open_left() {
-    let actual = nu!("
-        echo ..30 | math sum
-        ");
-
-    assert_eq!(actual.out, "465");
-}
-
-#[test]
-fn exclusive_range_with_open_left() {
-    let actual = nu!("
-        echo ..<31 | math sum
-        ");
-
-    assert_eq!(actual.out, "465");
-}
-
-#[test]
-fn range_with_open_right() {
-    let actual = nu!("
-        echo 5.. | first 10 | math sum
-        ");
-
-    assert_eq!(actual.out, "95");
-}
-
-#[test]
-fn exclusive_range_with_open_right() {
-    let actual = nu!("
-        echo 5..< | first 10 | math sum
-        ");
-
-    assert_eq!(actual.out, "95");
-}
-
-#[test]
 fn range_with_mixed_types() {
     let actual = nu!("
         echo 1..10.5 | math sum


### PR DESCRIPTION
Fixes: #9874 
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR removes `range -> any` type signature in `first` command.
This change will make the `first` and `last` signatures consistent, just like `append` and `prepend`.
Users will still able to take a slice from range by
```nushell
1..3 | take 2
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
