### PR TITLE
update `items` signature to allow `any` output

### DIFF
--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -17,10 +17,7 @@ impl Command for Items {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(
-                Type::Record(vec![]),
-                Type::List(Box::new(Type::String)),
-            )])
+            .input_output_types(vec![(Type::Record(vec![]), Type::Any)])
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Any])),

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -23,6 +23,7 @@ impl Command for Items {
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Any])),
                 "the closure to run",
             )
+            .allow_variants_without_examples(true)
             .category(Category::Filters)
     }
 


### PR DESCRIPTION
# Description

This PR updates the `items` command to allow `any` output. items takes a closure so theoretically, any value type of output could be valid.

### Before
```nushell
{a: 1 b: 2} | items {|k,v| {key: $k value: $v}} | transpose
Error: nu::parser::input_type_mismatch

  × Command does not support list<string> input.
   ╭─[entry #2:1:1]
 1 │ {a: 1 b: 2} | items {|k,v| {key: $k value: $v}} | transpose
   ·                                                   ────┬────
   ·                                                       ╰── command doesn't support list<string> input
   ╰────
```

### After
```nushell
❯ {a: 1 b: 2} | items {|k,v| {key: $k value: $v}} | transpose
╭───┬─────────┬─────────┬─────────╮
│ # │ column0 │ column1 │ column2 │
├───┼─────────┼─────────┼─────────┤
│ 0 │ key     │ a       │ b       │
│ 1 │ value   │       1 │       2 │
╰───┴─────────┴─────────┴─────────╯
```
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
