### PR TITLE
update `format` signature to allow `record` to be passed in

### DIFF
--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use nu_engine::{eval_expression, CallExt};
 use nu_parser::parse_expression;
 use nu_protocol::ast::{Call, PathMember};
@@ -17,15 +19,16 @@ impl Command for Format {
 
     fn signature(&self) -> Signature {
         Signature::build("format")
-            .input_output_types(vec![(
-                Type::Table(vec![]),
-                Type::List(Box::new(Type::String)),
-            )])
+            .input_output_types(vec![
+                (Type::Table(vec![]), Type::List(Box::new(Type::String))),
+                (Type::Record(vec![]), Type::Any),
+            ])
             .required(
                 "pattern",
                 SyntaxShape::String,
                 "the pattern to output. e.g.) \"{foo}: {bar}\"",
             )
+            .allow_variants_without_examples(true)
             .category(Category::Strings)
     }
 

--- a/crates/nu-command/tests/commands/format.rs
+++ b/crates/nu-command/tests/commands/format.rs
@@ -17,6 +17,13 @@ fn creates_the_resulting_string_from_the_given_fields() {
 }
 
 #[test]
+fn format_input_record_output_string() {
+    let actual = nu!(r#"{name: Downloads} | format "{name}""#);
+
+    assert_eq!(actual.out, "Downloads");
+}
+
+#[test]
 fn given_fields_can_be_column_paths() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(

--- a/crates/nu-command/tests/commands/platform/char_.rs
+++ b/crates/nu-command/tests/commands/platform/char_.rs
@@ -1,7 +1,7 @@
 use nu_test_support::{nu, pipeline};
 
 #[test]
-fn test_ansi_list_outputs_table() {
+fn test_char_list_outputs_table() {
     let actual = nu!(pipeline(
         r#"
             char --list | length

--- a/crates/nu-command/tests/commands/platform/char_.rs
+++ b/crates/nu-command/tests/commands/platform/char_.rs
@@ -1,0 +1,12 @@
+use nu_test_support::{nu, pipeline};
+
+#[test]
+fn test_ansi_list_outputs_table() {
+    let actual = nu!(pipeline(
+        r#"
+            char --list | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "107");
+}


### PR DESCRIPTION
# Description

This PR updates the signature of `format` to allow records to be passed in.

Closes #9897 

### Before
```nushell
{name: Downloads} | format "{name}"

  × Command does not support record<name: string> input.
   ╭─[entry #12:1:1]
 1 │ {name: Downloads} | format "{name}"
   ·                       ───┬──
   ·                          ╰── command doesn't support record<name: string> input
   ╰────
```

### After
```nushell
{name: Downloads} | format "{name}"
Downloads
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
