### PR TITLE
Re-align default theme with previous versions

### DIFF
--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -163,7 +163,7 @@ pub enum Transition {
 #[derive(Debug, Clone)]
 pub struct PagerConfig<'a> {
     pub nu_config: &'a NuConfig,
-    pub style_computer: &'a StyleComputer<'a>,
+    pub style_computer: &'a StyleComputer,
     pub lscolors: &'a LsColors,
     pub config: ConfigMap,
     pub style: StyleConfig,

--- a/crates/nu-explore/src/views/mod.rs
+++ b/crates/nu-explore/src/views/mod.rs
@@ -60,7 +60,7 @@ impl ElementInfo {
 #[derive(Debug, Clone, Copy)]
 pub struct ViewConfig<'a> {
     pub nu_config: &'a NuConfig,
-    pub style_computer: &'a StyleComputer<'a>,
+    pub style_computer: &'a StyleComputer,
     pub config: &'a ConfigMap,
     pub lscolors: &'a LsColors,
 }
@@ -68,7 +68,7 @@ pub struct ViewConfig<'a> {
 impl<'a> ViewConfig<'a> {
     pub fn new(
         nu_config: &'a NuConfig,
-        style_computer: &'a StyleComputer<'a>,
+        style_computer: &'a StyleComputer,
         config: &'a ConfigMap,
         lscolors: &'a LsColors,
     ) -> Self {

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -305,10 +305,7 @@ impl View for RecordView<'_> {
     }
 
     fn collect_data(&self) -> Vec<NuText> {
-        // Create a "dummy" style_computer.
-        let dummy_engine_state = EngineState::new();
-        let dummy_stack = Stack::new();
-        let style_computer = StyleComputer::new(&dummy_engine_state, &dummy_stack, HashMap::new());
+        let style_computer = StyleComputer::new(HashMap::new());
 
         let data = convert_records_to_string(
             &self.get_layer_last().records,

--- a/crates/nu-explore/src/views/record/tablew.rs
+++ b/crates/nu-explore/src/views/record/tablew.rs
@@ -28,7 +28,7 @@ pub struct TableW<'a> {
     index_column: usize,
     style: TableStyle,
     head_position: Orientation,
-    style_computer: &'a StyleComputer<'a>,
+    style_computer: &'a StyleComputer,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,7 +60,7 @@ impl<'a> TableW<'a> {
     pub fn new(
         columns: impl Into<Cow<'a, [String]>>,
         data: impl Into<Cow<'a, [Vec<NuText>]>>,
-        style_computer: &'a StyleComputer<'a>,
+        style_computer: &'a StyleComputer,
         index_row: usize,
         index_column: usize,
         style: TableStyle,
@@ -542,7 +542,7 @@ fn check_column_width(
 }
 
 struct IndexColumn<'a> {
-    style_computer: &'a StyleComputer<'a>,
+    style_computer: &'a StyleComputer,
     start: usize,
 }
 

--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -86,7 +86,7 @@ impl ExpandedTable {
 struct Options<'a> {
     ctrlc: Option<Arc<AtomicBool>>,
     config: &'a Config,
-    style_computer: &'a StyleComputer<'a>,
+    style_computer: &'a StyleComputer,
     available_width: usize,
     format: ExpandedTable,
     span: Span,

--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -35,7 +35,7 @@ impl JustTable {
 pub struct BuildConfig<'a> {
     pub(crate) ctrlc: Option<Arc<AtomicBool>>,
     pub(crate) config: &'a Config,
-    pub(crate) style_computer: &'a StyleComputer<'a>,
+    pub(crate) style_computer: &'a StyleComputer,
     pub(crate) span: Span,
     pub(crate) term_width: usize,
 }
@@ -44,7 +44,7 @@ impl<'a> BuildConfig<'a> {
     pub fn new(
         ctrlc: Option<Arc<AtomicBool>>,
         config: &'a Config,
-        style_computer: &'a StyleComputer<'a>,
+        style_computer: &'a StyleComputer,
         span: Span,
         term_width: usize,
     ) -> Self {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -12,8 +12,6 @@ let dark_theme = {
     leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
     header: green_bold
     empty: blue
-    # Closures can be used to choose colors for specific values.
-    # The value (in this case, a bool) is piped into the closure.
     bool: {|| if $in { 'light_cyan' } else { 'light_gray' } }
     int: white
     filesize: {|e|
@@ -96,35 +94,11 @@ let light_theme = {
     leading_trailing_space_bg: { attr: n } # no fg, no bg, attr none effectively turns this off
     header: green_bold
     empty: blue
-    # Closures can be used to choose colors for specific values.
-    # The value (in this case, a bool) is piped into the closure.
-    bool: {|| if $in { 'dark_cyan' } else { 'dark_gray' } }
+    bool: dark_cyan
     int: dark_gray
-    filesize: {|e|
-        if $e == 0b {
-            'dark_gray'
-        } else if $e < 1mb {
-            'cyan_bold'
-        } else { 'blue_bold' }
-    }
+    filesize: cyan_bold
     duration: dark_gray
-    date: {|| (date now) - $in |
-        if $in < 1hr {
-            'purple'
-        } else if $in < 6hr {
-            'red'
-        } else if $in < 1day {
-            'yellow'
-        } else if $in < 3day {
-            'green'
-        } else if $in < 1wk {
-            'light_green'
-        } else if $in < 6wk {
-            'cyan'
-        } else if $in < 52wk {
-            'blue'
-        } else { 'dark_gray' }
-    }
+    date: purple
     range: dark_gray
     float: dark_gray
     string: dark_gray
@@ -275,7 +249,7 @@ $env.config = {
         vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
     }
 
-    color_config: {} # if you want a more interesting theme, you can replace the empty record with `$dark_theme`, `$light_theme` or another custom record
+    color_config: $dark_theme # if you want a more interesting theme, you can replace the empty record with `$dark_theme`, `$light_theme` or another custom record
     use_grid_icons: true
     footer_mode: "25" # always, never, number_of_rows, auto
     float_precision: 2 # the precision for displaying floats in tables


### PR DESCRIPTION
# Description

This re-aligned the default theme styles with previous versions of Nushell, which assumed a pleasantly-styled dark mode for value output.

There are a few differences to make this easier and more efficient:

* We assume dark-mode by default, and use the default config dark mode's values
* We set the default config to choose dark mode as the default style
* Style computation no longer accepts closures to make styling both easier to maintain and more efficient

Here's an example of this new default styling:

![image](https://github.com/nushell/nushell/assets/547158/1e4c3158-452b-45e8-b7c1-3f27fbea6ed8)

Marking this as draft to give us time to discuss removing closures from styling. The trade-off (imho) is probably worth it long-term but wanted to give time to discuss before we take it.

# User-Facing Changes

Adds more styling/colors to the default experience.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
