### PR TITLE
Fix default prompt indicators

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -143,11 +143,11 @@ impl Prompt for NushellPrompt {
             PromptEditMode::Vi(vi_mode) => match vi_mode {
                 PromptViMode::Normal => match &self.default_vi_normal_prompt_indicator {
                     Some(indicator) => indicator,
-                    None => ": ",
+                    None => "> ",
                 },
                 PromptViMode::Insert => match &self.default_vi_insert_prompt_indicator {
                     Some(indicator) => indicator,
-                    None => "> ",
+                    None => ": ",
                 },
             }
             .into(),

--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -109,8 +109,7 @@ impl Prompt for NushellPrompt {
             let prompt = default
                 .render_prompt_left()
                 .to_string()
-                .replace('\n', "\r\n")
-                + " ";
+                .replace('\n', "\r\n");
 
             prompt.into()
         }


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/9907

# Description
https://github.com/nushell/nushell/pull/9907 removed the front space from all `PROMPT_INDICATOR`s but this is not what the default behaviour of Nushell is, i.e. in `nu --no-config-file`.

this PR
- removes the space that is prepended by Nushell before the prompt indicator to match the `default_env.nu`
- swaps INSERT and NORMAL in the Rust code to match the `:` and `>` respectively in `default_env.nu`

## :mag: try the changes
> **Warning**
> i had to comment out in my config all the `$env.PROMPT_INDICATOR... = ...` to avoid these variables to propagate to `cargo run -- -n`

in either `cargo run -- -n` or `cargo run -- --config crates/nu-utils/src/sample_config/default_config.nu --env-config crates/nu-utils/src/sample_config/default_env.nu`,
- see `/path/to/nushell>` as the prompt with the default `emacs` edit mode
- run `$env.config.edit_mode = vi`
- see `/path/to/nushell:` as the INSERT prompt in Vi mode
- press Escape to go into NORMAL mode
- see `/path/to/nushell>` as the NORMAL prompt in Vi mode
- press I to go back into INSERT mode
- see `/path/to/nushell:` as the INSERT prompt in Vi mode

# User-Facing Changes
the prompts in `nu --no-config-file` and `nu --config default_config.nu --env-config default_env.nu` should be the same :relieved: 

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting