### PR TITLE
updates `let-env` signature to remove required params

### DIFF
--- a/crates/nu-command/src/deprecated/let_env.rs
+++ b/crates/nu-command/src/deprecated/let_env.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, ShellError, Signature, Type};
+use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape, Type};
 
 #[derive(Clone)]
 pub struct LetEnvDeprecated;
@@ -14,6 +14,12 @@ impl Command for LetEnvDeprecated {
         Signature::build(self.name())
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
+            .optional("var_name", SyntaxShape::String, "variable name")
+            .optional(
+                "initial_value",
+                SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
+                "equals sign followed by value",
+            )
             .category(Category::Deprecated)
     }
 

--- a/crates/nu-command/src/deprecated/let_env.rs
+++ b/crates/nu-command/src/deprecated/let_env.rs
@@ -1,6 +1,6 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, PipelineData, ShellError, Signature, SyntaxShape, Type};
+use nu_protocol::{Category, PipelineData, ShellError, Signature, Type};
 
 #[derive(Clone)]
 pub struct LetEnvDeprecated;
@@ -14,12 +14,6 @@ impl Command for LetEnvDeprecated {
         Signature::build(self.name())
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("var_name", SyntaxShape::String, "variable name")
-            .required(
-                "initial_value",
-                SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
-                "equals sign followed by value",
-            )
             .category(Category::Deprecated)
     }
 


### PR DESCRIPTION
# Description

This PR changes the signature of the deprecated command `let-env` so that it does not mislead people when invoking it without parameters.

### Before
```nushell
> let-env
Error: nu::parser::missing_positional

  × Missing required positional argument.
   ╭─[entry #2:1:1]
 1 │ let-env
   ╰────
  help: Usage: let-env <var_name> = <initial_value>
```

### After
```nushell
❯ let-env
Error: nu::shell::deprecated_command

  × Deprecated command let-env
   ╭─[entry #1:1:1]
 1 │ let-env
   · ───┬───
   ·    ╰── 'let-env' is deprecated. Please use '$env.<environment variable> = ...' instead.
   ╰────
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
