### PR TITLE
Make `Value::columns` return slice instead of cloned Vec

### DIFF
--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -261,7 +261,7 @@ fn convert_to_list(
     let mut iter = iter.into_iter().peekable();
 
     if let Some(first) = iter.peek() {
-        let mut headers = first.columns();
+        let mut headers = first.columns().to_vec();
 
         if !headers.is_empty() {
             headers.insert(0, "#".into());

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1732,10 +1732,10 @@ impl Value {
         matches!(self, Value::Bool { val: false, .. })
     }
 
-    pub fn columns(&self) -> Vec<String> {
+    pub fn columns(&self) -> &[String] {
         match self {
-            Value::Record { cols, .. } => cols.clone(),
-            _ => vec![],
+            Value::Record { cols, .. } => cols,
+            _ => &[],
         }
     }
 


### PR DESCRIPTION
# Description
This PR changes `Value::columns` to return a slice of columns instead of cloning said columns.  If the caller needs an owned copy, they can use `slice::to_vec` or the like. This eliminates unnecessary Vec clones (e.g., in `update cells`).

# User-Facing Changes
Breaking change for `nu_protocol` API.
