### PR TITLE
Categorification: move uncategorized String commands to Category::Strings

### DIFF
--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -2,6 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::ast::CellPath;
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::Category;
 use nu_protocol::{Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value};
 
 #[derive(Clone)]
@@ -29,6 +30,7 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "For a data structure input, convert strings at the given cell paths",
             )
+            .category(Category::Strings)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -5,6 +5,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::ast::CellPath;
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::Category;
 use nu_protocol::{
     Example, PipelineData, Range, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
@@ -69,6 +70,7 @@ impl Command for SubCommand {
                 SyntaxShape::CellPath,
                 "For a data structure input, turn strings at the given cell paths into substrings",
             )
+            .category(Category::Strings)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::CallExt;
+use nu_protocol::Category;
 use nu_protocol::{
     ast::{Call, CellPath},
     engine::{Command, EngineState, Stack},
@@ -66,6 +67,7 @@ impl Command for SubCommand {
                 "trims characters only from the end of the string",
                 Some('r'),
             )
+            .category(Category::Strings)
     }
     fn usage(&self) -> &str {
         "Trim whitespace or specific character."


### PR DESCRIPTION

In an effort to go through and review all of the remaining commands to find anything else that could possibly
be moved to *nu-cmd-extra*

I noticed that there are still some commands that have not been categorized...

I am going to *Categorize* the remaining commands that still *do not have Category homes*

In PR land I will call this *Categorification* as a play off of *Cratification*

* str substring
* str trim
* str upcase

were in the *default* category because for some reason they had not yet been categorized.
I went ahead and moved them to the

```rust
.category(Category::Strings)
```