### PR TITLE
Add tests for script subcommands

### DIFF
--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -1,4 +1,4 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, nu_repl_code, pipeline};
 use pretty_assertions::assert_eq;
@@ -286,4 +286,46 @@ fn run_in_noninteractive_mode() {
         .expect("false");
 
     assert!(child_output.stderr.is_empty());
+}
+
+#[test]
+fn main_script_can_have_subcommands1() {
+    Playground::setup("main_subcommands", |dirs, sandbox| {
+        sandbox.mkdir("main_subcommands");
+        sandbox.with_files(vec![FileWithContent(
+            "script.nu",
+            r#"def "main foo" [x: int] {
+                    print ($x + 100)
+                  }
+                  
+                  def "main" [] {
+                    print "usage: script.nu <command name>"
+                  }"#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu script.nu foo 123"));
+
+        assert_eq!(actual.out, "223");
+    })
+}
+
+#[test]
+fn main_script_can_have_subcommands2() {
+    Playground::setup("main_subcommands", |dirs, sandbox| {
+        sandbox.mkdir("main_subcommands");
+        sandbox.with_files(vec![FileWithContent(
+            "script.nu",
+            r#"def "main foo" [x: int] {
+                    print ($x + 100)
+                  }
+                  
+                  def "main" [] {
+                    print "usage: script.nu <command name>"
+                  }"#,
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu script.nu"));
+
+        assert!(actual.out.contains("usage: script.nu"));
+    })
 }


### PR DESCRIPTION
# Description

Add a few tests to ensure that you can add subcommands to scripts. We've supported this for a long time, though I'm not sure if anyone has actually tried it. As we weren't testing the support, this PR adds a few tests to ensure it stays working.

Example script subcommand:

```
def "main addten" [x: int] {
  print ($x + 10)
}
```

then call it with:

```
> nu ./script.nu addten 5
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
