### PR TITLE
Nothing return type

### DIFF
--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -156,7 +156,7 @@ impl SyntaxShape {
             SyntaxShape::Number => Type::Number,
             SyntaxShape::OneOf(_) => Type::Any,
             SyntaxShape::Operator => Type::Any,
-            SyntaxShape::Range => Type::Any,
+            SyntaxShape::Range => Type::Range,
             SyntaxShape::Record(entries) => Type::Record(mk_ty(entries)),
             SyntaxShape::RowCondition => Type::Bool,
             SyntaxShape::Boolean => Type::Bool,

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -152,7 +152,7 @@ impl SyntaxShape {
             SyntaxShape::MatchBlock => Type::Any,
             SyntaxShape::MatchPattern => Type::Any,
             SyntaxShape::MathExpression => Type::Any,
-            SyntaxShape::Nothing => Type::Any,
+            SyntaxShape::Nothing => Type::Nothing,
             SyntaxShape::Number => Type::Number,
             SyntaxShape::OneOf(_) => Type::Any,
             SyntaxShape::Operator => Type::Any,


### PR DESCRIPTION
# Description
Fix #9928. When parsing input/output types `nothing` was incorrectly coerced to `any`. This is addressed by changing how [to_type](https://github.com/NotLebedev/nushell/blob/0ad1ad4277a29e2dcc33bda309459994f4f78b6b/crates/nu-protocol/src/syntax_shape.rs#L121) method handles `nothing` syntax shape. Also `range` syntax shape is addressed the same way.

# User-Facing Changes
`nothing` and `range` are correctly displayed in help and strictly processed by type checking. This will break definitions that were not in fact output nothing or range and incorrect uses of functions which input nothing or range.

Examples of correctly defined functions:
![image](https://github.com/nushell/nushell/assets/17511668/d9f73438-d8a7-487f-981a-7e791b42766e)
![image](https://github.com/nushell/nushell/assets/17511668/2d5fe3a2-94be-4d25-9522-2ea38e528fe4)

Examples of incorrect definitions and uses of functions:
![image](https://github.com/nushell/nushell/assets/17511668/6a2f9fba-abfa-47fe-8b53-bb348e532cd8)
![image](https://github.com/nushell/nushell/assets/17511668/b1fbf9f6-fd75-4b80-9f38-26cc7c2ecc25)
![image](https://github.com/nushell/nushell/assets/17511668/718ef98b-3d7a-433d-af97-39a225ef34e5)


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
