### PR TITLE
add a test to make sure "nothing" shows up as "nothing" in help

### DIFF
--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -383,6 +383,11 @@ fn help_alias_before_command() {
 
 #[test]
 fn nothing_type_annotation() {
-    let actual = nu!("def foo []: nothing -> nothing {}; help foo");
-    assert!(actual.out.contains("│ 0 │ nothing │ nothing │"));
+    let actual = nu!(pipeline(
+        "
+        def foo []: nothing -> nothing {};
+        help commands | where name == foo | get input_output.0.output.0
+    "
+    ));
+    assert_eq!(actual.out, "nothing");
 }

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -380,3 +380,9 @@ fn help_alias_before_command() {
 
     assert!(actual.out.contains("Alias"));
 }
+
+#[test]
+fn nothing_type_annotation() {
+    let actual = nu!("def foo []: nothing -> nothing {}; help foo");
+    assert!(actual.out.contains("│ 0 │ nothing │ nothing │"));
+}


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell/pull/9935

# Description
this PR just adds a test to make sure type annotations in `def`s show as `nothing` in the help pages of commands.

# User-Facing Changes

# Tests + Formatting
adds a new test `nothing_type_annotation`.

# After Submitting