### PR TITLE
Categorification: move from Default category to Filters

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -2,7 +2,8 @@ use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
-    Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
+    Type, Value,
 };
 
 use indexmap::IndexMap;
@@ -35,6 +36,7 @@ impl Command for GroupBy {
                 ]),
                 "the path to the column to group on",
             )
+            .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -2,7 +2,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Config, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
+    Category, Config, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -53,6 +53,7 @@ impl Command for Join {
             .switch("right", "Right-outer join", Some('r'))
             .switch("outer", "Outer join", Some('o'))
             .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -3,7 +3,8 @@ use nu_engine::{eval_block_with_early_return, CallExt};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
-    Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type,
+    Value,
 };
 
 #[derive(Clone)]
@@ -37,6 +38,7 @@ impl Command for Reduce {
                 "reducing function",
             )
             .allow_variants_without_examples(true)
+            .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -3,8 +3,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape,
-    Type, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -19,6 +19,7 @@ impl Command for SplitBy {
         Signature::build("split-by")
             .input_output_types(vec![(Type::Record(vec![]), Type::Record(vec![]))])
             .optional("splitter", SyntaxShape::Any, "the splitter value to use")
+            .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -3,8 +3,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span, Spanned,
-    SyntaxShape, Type, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
+    Spanned, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -61,6 +61,7 @@ impl Command for Transpose {
                 SyntaxShape::String,
                 "the names to give columns once transposed",
             )
+            .category(Category::Filters)
     }
 
     fn usage(&self) -> &str {


### PR DESCRIPTION

The following *Filters* commands were incorrectly in the category *Default*

* group-by
* join
* reduce
* split-by
* transpose

This continues the effort of moving commands out of default and into their proper category...

