### PR TITLE
Categorification: move commands histogram and version out of the default category

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -1,6 +1,8 @@
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Example, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value};
+use nu_protocol::{
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value,
+};
 use shadow_rs::shadow;
 
 shadow!(build);
@@ -17,6 +19,7 @@ impl Command for Version {
         Signature::build("version")
             .input_output_types(vec![(Type::Nothing, Type::Record(vec![]))])
             .allow_variants_without_examples(true)
+            .category(Category::Core)
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -4,8 +4,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape,
-    Type, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type, Value,
 };
 use std::collections::HashMap;
 use std::iter;
@@ -29,6 +29,7 @@ impl Command for Histogram {
             .optional("column-name", SyntaxShape::String, "column name to calc frequency, no need to provide if input is just a list")
             .optional("frequency-column-name", SyntaxShape::String, "histogram's frequency column, default to be frequency column output")
             .named("percentage-type", SyntaxShape::String, "percentage calculate method, can be 'normalize' or 'relative', in 'normalize', defaults to be 'normalize'", Some('t'))
+            .category(Category::Chart)
     }
 
     fn usage(&self) -> &str {


### PR DESCRIPTION

* histogram to chart
* version to core

This completes moving commands out of the *Default* category...

When you run 

```rust
nu -n --no-std-lib
```

```rust
help commands | where category == "default"
```

You now get an *Empty List* 😄 