### PR TITLE
force version to update when installing with toolkit

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -341,6 +341,7 @@ export def install [
     ...features: string@"nu-complete list features"  # a space-separated list of feature to install with Nushell
     --all: bool  # install all plugins with Nushell
 ] {
+    touch crates/nu-cmd-lang/build.rs # needed to make sure `version` has the correct `commit_hash`
     cargo install --path . --features ($features | str join ",")
     if not $all {
         return


### PR DESCRIPTION
# Description
`version` has always been a bit off regarding the `commit_hash` :confused: 

i think it was @fdncred who found this trick: `touch`ing the `crates/nu-cmd-lang/build.rs` file
- won't change the Git index
- will force Nushell to recompile the `version` information correctly

this PR adds a call to `touch` on that file to `toolkit install`.

# User-Facing Changes
`version` should be correct when installing locally with the `toolkit`.

# Tests + Formatting

# After Submitting