### PR TITLE
Fixed `do` with the flag `-i` or `-s` to ignore errors when executed `rm/cp/mv`

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -345,7 +345,7 @@ fn rm(
         }
     }
 
-    all_targets
+    let (out, mut err) = all_targets
         .into_iter()
         .map(move |(f, span)| {
             let is_empty = || match f.read_dir() {
@@ -468,8 +468,32 @@ fn rm(
             }
         })
         .filter(|x| !matches!(x.get_type(), Type::Nothing))
-        .into_pipeline_data(ctrlc)
-        .print_not_formatted(engine_state, false, true)?;
+        .fold((Vec::new(), Vec::new()), |(mut out, mut err), v| {
+            match v {
+                Value::Error { error } => err.push(*error),
+                val => out.push(val),
+            }
 
-    Ok(PipelineData::empty())
+            (out, err)
+        });
+
+    if let Err(e) = out
+        .into_iter()
+        .into_pipeline_data(ctrlc)
+        .print_not_formatted(engine_state, false, true)
+    {
+        err.push(e);
+    }
+
+    match err.len() {
+        0 => Ok(PipelineData::empty()),
+        1 => Err(err.pop().unwrap_or_else(|| unreachable!())),
+        _ => Err(ShellError::GenericError(
+            "Cannot delete some files".to_string(),
+            "Cannot delete some files".to_string(),
+            Some(call.head),
+            None,
+            err,
+        )),
+    }
 }

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -202,7 +202,7 @@ fn ignore_error_works_with_fs_cmd() {
         assert!(files_exist_at(file_names.clone(), test_dir));
         assert!(
             actual.err.is_empty(),
-            "do {{rm test*.txt}} -i shold ignore errors"
+            "do {{rm test*.txt}} -i should ignore errors"
         );
 
         let subdir = dirs.test().join("subdir");
@@ -216,7 +216,7 @@ fn ignore_error_works_with_fs_cmd() {
         assert!(!files_exist_at(file_names.clone(), &subdir));
         assert!(
             actual.err.is_empty(),
-            "do {{cp test*.txt subdir/}} -i shold ignore errors"
+            "do {{cp test*.txt subdir/}} -i should ignore errors"
         );
 
         let actual = nu!(cwd: test_dir, "do {mv test*.txt subdir/} -i");
@@ -224,7 +224,7 @@ fn ignore_error_works_with_fs_cmd() {
         assert!(files_exist_at(file_names.clone(), test_dir));
         assert!(
             actual.err.is_empty(),
-            "do {{mv test*.txt subdir/}} -i shold ignore errors"
+            "do {{mv test*.txt subdir/}} -i should ignore errors"
         );
     });
 }

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -202,7 +202,7 @@ fn ignore_error_works_with_fs_cmd() {
         assert!(files_exist_at(file_names.clone(), test_dir));
         assert!(
             actual.err.is_empty(),
-            "do {{rm test*.txt}} -i shold ignore erros"
+            "do {{rm test*.txt}} -i shold ignore errors"
         );
 
         let subdir = dirs.test().join("subdir");
@@ -216,7 +216,7 @@ fn ignore_error_works_with_fs_cmd() {
         assert!(!files_exist_at(file_names.clone(), &subdir));
         assert!(
             actual.err.is_empty(),
-            "do {{cp test*.txt subdir/}} -i shold ignore erros"
+            "do {{cp test*.txt subdir/}} -i shold ignore errors"
         );
 
         let actual = nu!(cwd: test_dir, "do {mv test*.txt subdir/} -i");
@@ -224,7 +224,7 @@ fn ignore_error_works_with_fs_cmd() {
         assert!(files_exist_at(file_names.clone(), test_dir));
         assert!(
             actual.err.is_empty(),
-            "do {{mv test*.txt subdir/}} -i shold ignore erros"
+            "do {{mv test*.txt subdir/}} -i shold ignore errors"
         );
     });
 }


### PR DESCRIPTION
- this PR should close #9462 
- fixes #9462 
