### PR TITLE
update `strip-ansi-escapes` to use new api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
 dependencies = [
  "nom",
- "vte",
+ "vte 0.10.1",
 ]
 
 [[package]]
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.22.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#ed5e48e5374942c5a15ed026bb0ffaf973e47964"
+source = "git+https://github.com/nushell/reedline.git?branch=main#541698fb74c249cd540583fab2425c91700481fa"
 dependencies = [
  "chrono",
  "crossterm",
@@ -4846,11 +4846,11 @@ dependencies = [
 
 [[package]]
 name = "strip-ansi-escapes"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+checksum = "dad0ed65755f6fdd06f7afd1afefe7b2b220c2b197844687c2ea9d6d4807305e"
 dependencies = [
- "vte",
+ "vte 0.11.1",
 ]
 
 [[package]]
@@ -5508,6 +5508,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
 dependencies = [
  "arrayvec 0.5.2",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
  "utf8parse",
  "vte_generate_state_changes",
 ]

--- a/crates/nu-explore/src/views/record/tablew.rs
+++ b/crates/nu-explore/src/views/record/tablew.rs
@@ -772,10 +772,9 @@ fn render_column(
 }
 
 fn strip_string(text: &str) -> String {
-    strip_ansi_escapes::strip(text)
-        .ok()
-        .and_then(|s| String::from_utf8(s).ok())
-        .unwrap_or_else(|| text.to_owned())
+    String::from_utf8(strip_ansi_escapes::strip(text))
+        .map_err(|_| ())
+        .unwrap_or_else(|_| text.to_owned())
 }
 
 fn head_row_text(head: &str, style_computer: &StyleComputer) -> NuText {

--- a/crates/nu-utils/src/deansi.rs
+++ b/crates/nu-utils/src/deansi.rs
@@ -13,10 +13,8 @@ pub fn strip_ansi_unlikely(string: &str) -> Cow<str> {
     // which will be stripped. Includes the primary start of ANSI sequences ESC
     // (0x1B = decimal 27)
     if string.bytes().any(|x| matches!(x, 0..=9 | 11..=31)) {
-        if let Ok(stripped) = strip_ansi_escapes::strip(string) {
-            if let Ok(new_string) = String::from_utf8(stripped) {
-                return Cow::Owned(new_string);
-            }
+        if let Ok(stripped) = String::from_utf8(strip_ansi_escapes::strip(string)) {
+            return Cow::Owned(stripped);
         }
     }
     // Else case includes failures to parse!
@@ -34,10 +32,8 @@ pub fn strip_ansi_likely(string: &str) -> Cow<str> {
     // Check if any ascii control character except LF(0x0A = 10) is present,
     // which will be stripped. Includes the primary start of ANSI sequences ESC
     // (0x1B = decimal 27)
-    if let Ok(stripped) = strip_ansi_escapes::strip(string) {
-        if let Ok(new_string) = String::from_utf8(stripped) {
-            return Cow::Owned(new_string);
-        }
+    if let Ok(stripped) = String::from_utf8(strip_ansi_escapes::strip(string)) {
+        return Cow::Owned(stripped);
     }
     // Else case includes failures to parse!
     Cow::Borrowed(string)
@@ -60,10 +56,8 @@ pub fn strip_ansi_string_unlikely(string: String) -> String {
         .bytes()
         .any(|x| matches!(x, 0..=9 | 11..=31))
     {
-        if let Ok(stripped) = strip_ansi_escapes::strip(&string) {
-            if let Ok(new_string) = String::from_utf8(stripped) {
-                return new_string;
-            }
+        if let Ok(stripped) = String::from_utf8(strip_ansi_escapes::strip(&string)) {
+            return stripped;
         }
     }
     // Else case includes failures to parse!
@@ -81,10 +75,8 @@ pub fn strip_ansi_string_likely(string: String) -> String {
     // Check if any ascii control character except LF(0x0A = 10) is present,
     // which will be stripped. Includes the primary start of ANSI sequences ESC
     // (0x1B = decimal 27)
-    if let Ok(stripped) = strip_ansi_escapes::strip(&string) {
-        if let Ok(new_string) = String::from_utf8(stripped) {
-            return new_string;
-        }
+    if let Ok(stripped) = String::from_utf8(strip_ansi_escapes::strip(&string)) {
+        return stripped;
     }
     // Else case includes failures to parse!
     string


### PR DESCRIPTION
# Description

This PR updates `strip-ansi-escapes` to support their new API. This also updates nushell to the latest reedline after the same fix https://github.com/nushell/reedline/pull/617

closes #9957 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
