### PR TITLE
Fix `match` example whitespace

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/match_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/match_.rs
@@ -121,12 +121,11 @@ impl Command for Match {
             },
             Example {
                 description: "Match with a guard",
-                example: "
-                    match [1 2 3] {
-                        [$x, ..$y] if $x == 1 => { 'good list' },
-                        _ => { 'not a very good list' }
-                    }
-                    ",
+                example: "match [1 2 3] {
+        [$x, ..$y] if $x == 1 => { 'good list' },
+        _ => { 'not a very good list' }
+    }
+    ",
                 result: Some(Value::test_string("good list")),
             },
         ]


### PR DESCRIPTION
I was looking up `match` documentation and noticed that the formatting was a bit off for the last example (starts on the wrong line, is several columns too far to the right).

## Before:
![image](https://github.com/nushell/nushell/assets/26268125/cea55875-894c-442f-aa93-d5c18a0cdfa5)

## After:

![image](https://github.com/nushell/nushell/assets/26268125/064c9f80-6a70-4748-a877-5344ec6e6a80)
