### PR TITLE
fix the default config for `explore`

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -191,7 +191,7 @@ $env.config = {
             selected_cell: {},
             selected_row: {},
             selected_column: {},
-            cursor: true,
+            show_cursor: true,
             line_head_top: true,
             line_head_bottom: true,
             line_shift: true,


### PR DESCRIPTION
according to https://github.com/nushell/nushell/blob/0674d4960b8b09073b31cca9e62eeeb1a1ddd4a8/crates/nu-explore/src/commands/table.rs#L132-L135

the config should be called `$env.config.explore.table.show_cursor` instead of the current `$env.config.explore.table.cursor` :open_mouth: 

this PR fixes this in the default config.