### PR TITLE
remove the "modality" from `explore`

### DIFF
--- a/crates/nu-explore/src/commands/table.rs
+++ b/crates/nu-explore/src/commands/table.rs
@@ -250,9 +250,7 @@ impl ViewCommand for TableCmd {
             view.set_padding_index((c.0, p))
         }
 
-        if self.settings.turn_on_cursor_mode {
-            view.set_cursor_mode();
-        }
+        if self.settings.turn_on_cursor_mode {}
 
         Ok(view)
     }

--- a/crates/nu-explore/src/views/cursor/xycursor.rs
+++ b/crates/nu-explore/src/views/cursor/xycursor.rs
@@ -126,18 +126,6 @@ impl XYCursor {
         self.x.prev(i)
     }
 
-    pub fn next_column_i(&mut self) -> bool {
-        self.x.set_window_at(self.x.starts_at() + 1)
-    }
-
-    pub fn prev_column_i(&mut self) -> bool {
-        if self.x.starts_at() == 0 {
-            return false;
-        }
-
-        self.x.set_window_at(self.x.starts_at() - 1)
-    }
-
     pub fn next_row_i(&mut self) -> bool {
         self.y.set_window_at(self.y.starts_at() + 1)
     }

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -279,7 +279,7 @@ impl View for RecordView<'_> {
         info: &mut ViewInfo,
         key: KeyEvent,
     ) -> Option<Transition> {
-        let result = handle_key_event_cursor_mode(self, &key);
+        let result = handle_key_event(self, &key);
 
         if matches!(&result, Some(Transition::Ok) | Some(Transition::Cmd { .. })) {
             let report = self.create_records_report();
@@ -429,7 +429,7 @@ impl<'a> RecordLayer<'a> {
     }
 }
 
-fn handle_key_event_cursor_mode(view: &mut RecordView, key: &KeyEvent) -> Option<Transition> {
+fn handle_key_event(view: &mut RecordView, key: &KeyEvent) -> Option<Transition> {
     match key.code {
         KeyCode::Esc => Some(Transition::Ok),
         KeyCode::Up => {

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -431,7 +431,15 @@ impl<'a> RecordLayer<'a> {
 
 fn handle_key_event(view: &mut RecordView, key: &KeyEvent) -> Option<Transition> {
     match key.code {
-        KeyCode::Esc => Some(Transition::Ok),
+        KeyCode::Esc => {
+            if view.layer_stack.len() > 1 {
+                view.layer_stack.pop();
+
+                Some(Transition::Ok)
+            } else {
+                Some(Transition::Exit)
+            }
+        }
         KeyCode::Up => {
             view.get_layer_last_mut().cursor.prev_row();
 


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell/issues/8582

if this goes to completion, should close https://github.com/nushell/nushell/issues/8582

# Description
this PR implements the second point of https://github.com/nushell/nushell/issues/8582, i.e. removes the modal aspect of the `explore` command.

# User-Facing Changes
`explore` does not have *view* / *cursor* modes anymore.
the default behaviour is the same as previously in the *cursor* mode, i.e. the arrow keys directly allow to move around in the data structures and a single escape is enough to bring the user back one level higher in the data => with *view* / *cursor*, you had to press escape twice: 1 to go from *cursor* to *view* and 2 to go one level higher.

> **Warning**
> a caveat with this PR when using `explore --peek`:
> - before the changes: it was possible, with `:q` to select either the whole page by being in *view* mode or a single cell path, namely the currently selected one under the cursor, in *cursor* mode
> - after the changes: as now one is always in "*cursor* mode", it's not possible to select the full page, only the cell path under the cursor

# Tests + Formatting

# After Submitting