### PR TITLE
show the current MODE in `explore`

### DIFF
--- a/crates/nu-explore/src/commands/config_show.rs
+++ b/crates/nu-explore/src/commands/config_show.rs
@@ -8,7 +8,10 @@ use std::io::Result;
 
 use crate::{
     nu_common::{try_build_table, NuSpan},
-    pager::Frame,
+    pager::{
+        report::{Report, Severity},
+        Frame,
+    },
     util::map_into_value,
     views::{Layout, Preview, View, ViewConfig},
 };
@@ -99,8 +102,19 @@ impl View for ConfigView {
         info: &mut crate::pager::ViewInfo,
         key: crossterm::event::KeyEvent,
     ) -> Option<crate::pager::Transition> {
-        self.preview
-            .handle_input(engine_state, stack, layout, info, key)
+        let transition = self
+            .preview
+            .handle_input(engine_state, stack, layout, info, key);
+
+        let report = Report::new(
+            "CONFIG-SHOW".to_string(),
+            Severity::Info,
+            "".to_string(),
+            "".to_string(),
+        );
+        info.status = Some(report);
+
+        transition
     }
 
     fn setup(&mut self, config: ViewConfig<'_>) {

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -8,6 +8,7 @@ use nu_protocol::{
 };
 use ratatui::layout::Rect;
 
+use crate::pager::report::{Report, Severity};
 use crate::{
     nu_common::{collect_input, NuSpan},
     pager::{Frame, Transition, ViewInfo},
@@ -323,10 +324,20 @@ impl View for HelpView<'_> {
         info: &mut ViewInfo,
         key: KeyEvent,
     ) -> Option<Transition> {
-        match self {
+        let transition = match self {
             HelpView::Records(v) => v.handle_input(engine_state, stack, layout, info, key),
             HelpView::Preview(v) => v.handle_input(engine_state, stack, layout, info, key),
-        }
+        };
+
+        let report = Report::new(
+            "HELP".to_string(),
+            Severity::Info,
+            "".to_string(),
+            "".to_string(),
+        );
+        info.status = Some(report);
+
+        transition
     }
 
     fn show_data(&mut self, i: usize) -> bool {

--- a/crates/nu-explore/src/views/configuration.rs
+++ b/crates/nu-explore/src/views/configuration.rs
@@ -15,7 +15,10 @@ use ratatui::{
 
 use crate::{
     nu_common::{truncate_str, NuText},
-    pager::{Frame, Transition, ViewInfo},
+    pager::{
+        report::{Report, Severity},
+        Frame, Transition, ViewInfo,
+    },
     util::create_map,
     views::util::nu_style_to_tui,
 };
@@ -236,10 +239,10 @@ impl View for ConfigurationView {
         _: &EngineState,
         _: &mut Stack,
         _: &Layout,
-        _: &mut ViewInfo,
+        info: &mut ViewInfo,
         key: KeyEvent,
     ) -> Option<Transition> {
-        match key.code {
+        let transition = match key.code {
             KeyCode::Esc => {
                 if self.peeked_cursor.is_some() {
                     self.peeked_cursor = None;
@@ -298,7 +301,17 @@ impl View for ConfigurationView {
                 Some(Transition::Cmd(build_tweak_cmd(group, opt)))
             }
             _ => None,
-        }
+        };
+
+        let report = Report::new(
+            "CONFIG".to_string(),
+            Severity::Info,
+            "".to_string(),
+            "".to_string(),
+        );
+        info.status = Some(report);
+
+        transition
     }
 
     fn exit(&mut self) -> Option<Value> {

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -245,7 +245,11 @@ impl<'a> RecordView<'a> {
         let layer = self.get_layer_last();
         let covered_percent = report_row_position(layer.cursor);
         let cursor = report_cursor_position(self.mode, layer.cursor);
-        let message = layer.name.clone().unwrap_or_default();
+        let message = match self.mode {
+            UIMode::View => "VIEW",
+            UIMode::Cursor => "CURSOR",
+        }
+        .to_string();
 
         Report {
             message,


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell/issues/8582

if this goes to completion, should close https://github.com/nushell/nushell/issues/8582

# Description
this PR implements the first point of https://github.com/nushell/nushell/issues/8582, i.e. by showing the current mode in the status bar.

# User-Facing Changes
> **Note**
> this PR is incomplete for now.

this PR shows
- `VIEW` + scroll info in *view* mode
- `CURSOR` + scroll info in *cursor* mode
- `HELP` in `:help`
- `CONFIG` in `:config`
- `CONFIG-SHOW` in `:config-show`

> **Warning**
> two caveats:
> - i wanted to have `TRY` and `NU` in `:try` and `:nu` but i'm not sure this will work :thinking:
> for instance, because `:try` is not a regular `View` 
> - for somer reason, `VIEW` and `CURSOR` draw immediately but the others do not and required a user input to refresh :thinking: 

# Tests + Formatting

# After Submitting