### PR TITLE
add support for Vim motions in `explore`

### DIFF
--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -742,10 +742,6 @@ fn handle_exit_key_event(key: &KeyEvent) -> bool {
     matches!(
         key,
         KeyEvent {
-            code: KeyCode::Char('d'),
-            modifiers: KeyModifiers::CONTROL,
-            ..
-        } | KeyEvent {
             code: KeyCode::Char('z'),
             modifiers: KeyModifiers::CONTROL,
             ..

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -473,42 +473,42 @@ fn handle_key_event_view_mode(view: &mut RecordView, key: &KeyEvent) -> Option<T
             Some(Transition::Ok)
         }
         KeyCode::Char('e') => Some(Transition::Cmd(String::from("expand"))),
-        KeyCode::Up => {
+        KeyCode::Up | KeyCode::Char('k') => {
             view.get_layer_last_mut().cursor.prev_row_i();
 
             Some(Transition::Ok)
         }
-        KeyCode::Down => {
+        KeyCode::Down | KeyCode::Char('j') => {
             view.get_layer_last_mut().cursor.next_row_i();
 
             Some(Transition::Ok)
         }
-        KeyCode::Left => {
+        KeyCode::Left | KeyCode::Char('h') => {
             view.get_layer_last_mut().cursor.prev_column_i();
 
             Some(Transition::Ok)
         }
-        KeyCode::Right => {
+        KeyCode::Right | KeyCode::Char('l') => {
             view.get_layer_last_mut().cursor.next_column_i();
 
             Some(Transition::Ok)
         }
-        KeyCode::PageUp => {
+        KeyCode::PageUp | KeyCode::Char('u') => {
             view.get_layer_last_mut().cursor.prev_row_page();
 
             Some(Transition::Ok)
         }
-        KeyCode::PageDown => {
+        KeyCode::PageDown | KeyCode::Char('d') => {
             view.get_layer_last_mut().cursor.next_row_page();
 
             Some(Transition::Ok)
         }
-        KeyCode::Home => {
+        KeyCode::Home | KeyCode::Char('g') => {
             view.get_layer_last_mut().cursor.row_move_to_start();
 
             Some(Transition::Ok)
         }
-        KeyCode::End => {
+        KeyCode::End | KeyCode::Char('G') => {
             view.get_layer_last_mut().cursor.row_move_to_end();
 
             Some(Transition::Ok)
@@ -524,42 +524,42 @@ fn handle_key_event_cursor_mode(view: &mut RecordView, key: &KeyEvent) -> Option
 
             Some(Transition::Ok)
         }
-        KeyCode::Up => {
+        KeyCode::Up | KeyCode::Char('k') => {
             view.get_layer_last_mut().cursor.prev_row();
 
             Some(Transition::Ok)
         }
-        KeyCode::Down => {
+        KeyCode::Down | KeyCode::Char('j') => {
             view.get_layer_last_mut().cursor.next_row();
 
             Some(Transition::Ok)
         }
-        KeyCode::Left => {
+        KeyCode::Left | KeyCode::Char('h') => {
             view.get_layer_last_mut().cursor.prev_column();
 
             Some(Transition::Ok)
         }
-        KeyCode::Right => {
+        KeyCode::Right | KeyCode::Char('l') => {
             view.get_layer_last_mut().cursor.next_column();
 
             Some(Transition::Ok)
         }
-        KeyCode::PageUp => {
+        KeyCode::PageUp | KeyCode::Char('u') => {
             view.get_layer_last_mut().cursor.prev_row_page();
 
             Some(Transition::Ok)
         }
-        KeyCode::PageDown => {
+        KeyCode::PageDown | KeyCode::Char('d') => {
             view.get_layer_last_mut().cursor.next_row_page();
 
             Some(Transition::Ok)
         }
-        KeyCode::Home => {
+        KeyCode::Home | KeyCode::Char('g') => {
             view.get_layer_last_mut().cursor.row_move_to_start();
 
             Some(Transition::Ok)
         }
-        KeyCode::End => {
+        KeyCode::End | KeyCode::Char('G') => {
             view.get_layer_last_mut().cursor.row_move_to_end();
 
             Some(Transition::Ok)

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use std::collections::HashMap;
 
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use nu_color_config::{get_color_map, StyleComputer};
 use nu_protocol::{
     engine::{EngineState, Stack},
@@ -451,6 +451,36 @@ impl<'a> RecordLayer<'a> {
 }
 
 fn handle_key_event_view_mode(view: &mut RecordView, key: &KeyEvent) -> Option<Transition> {
+    match key {
+        KeyEvent {
+            code: KeyCode::Char('u'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::PageUp,
+            ..
+        } => {
+            view.get_layer_last_mut().cursor.prev_row_page();
+
+            return Some(Transition::Ok);
+        }
+        KeyEvent {
+            code: KeyCode::Char('d'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::PageDown,
+            ..
+        } => {
+            view.get_layer_last_mut().cursor.next_row_page();
+
+            return Some(Transition::Ok);
+        }
+        _ => {}
+    }
+
     match key.code {
         KeyCode::Esc => {
             if view.layer_stack.len() > 1 {
@@ -493,16 +523,6 @@ fn handle_key_event_view_mode(view: &mut RecordView, key: &KeyEvent) -> Option<T
 
             Some(Transition::Ok)
         }
-        KeyCode::PageUp | KeyCode::Char('u') => {
-            view.get_layer_last_mut().cursor.prev_row_page();
-
-            Some(Transition::Ok)
-        }
-        KeyCode::PageDown | KeyCode::Char('d') => {
-            view.get_layer_last_mut().cursor.next_row_page();
-
-            Some(Transition::Ok)
-        }
         KeyCode::Home | KeyCode::Char('g') => {
             view.get_layer_last_mut().cursor.row_move_to_start();
 
@@ -518,6 +538,36 @@ fn handle_key_event_view_mode(view: &mut RecordView, key: &KeyEvent) -> Option<T
 }
 
 fn handle_key_event_cursor_mode(view: &mut RecordView, key: &KeyEvent) -> Option<Transition> {
+    match key {
+        KeyEvent {
+            code: KeyCode::Char('u'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::PageUp,
+            ..
+        } => {
+            view.get_layer_last_mut().cursor.prev_row_page();
+
+            return Some(Transition::Ok);
+        }
+        KeyEvent {
+            code: KeyCode::Char('d'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::PageDown,
+            ..
+        } => {
+            view.get_layer_last_mut().cursor.next_row_page();
+
+            return Some(Transition::Ok);
+        }
+        _ => {}
+    }
+
     match key.code {
         KeyCode::Esc => {
             view.set_view_mode();
@@ -541,16 +591,6 @@ fn handle_key_event_cursor_mode(view: &mut RecordView, key: &KeyEvent) -> Option
         }
         KeyCode::Right | KeyCode::Char('l') => {
             view.get_layer_last_mut().cursor.next_column();
-
-            Some(Transition::Ok)
-        }
-        KeyCode::PageUp | KeyCode::Char('u') => {
-            view.get_layer_last_mut().cursor.prev_row_page();
-
-            Some(Transition::Ok)
-        }
-        KeyCode::PageDown | KeyCode::Char('d') => {
-            view.get_layer_last_mut().cursor.next_row_page();
 
             Some(Transition::Ok)
         }


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/issues/7819

# Description
this PR does not quite address https://github.com/nushell/nushell/issues/7819 because it does not implement configurable keybindings for `explore` but rather only adds support for Vim-like motions *out of the box*.

# User-Facing Changes
in *view* and *cursor* modes,
- `h`, `j`, `k` and `l` give standard Qwerty-based Vim motions
- `g` and `G` go to the top and the end respectively
- `u` and `d` scroll up and down

> **Note**
> the bindings do not support the use of modifiers for now, so it's not `c-u` and `c-d` which scroll pages but rather `u` and `d`

# Tests + Formatting

# After Submitting