### PR TITLE
fix panic with `lines` on an error

### DIFF
--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -245,7 +245,7 @@ impl Iterator for RawStreamLinesAdapter {
                                 }
                             }
                         }
-                        Err(_) => todo!(),
+                        Err(err) => return Some(Err(err)),
                     }
                 } else {
                     self.inner_complete = true;

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -61,3 +61,10 @@ fn lines_mixed_line_endings() {
 
     assert_eq!(actual.out, "3");
 }
+
+#[test]
+fn lines_on_error() {
+    let actual = nu!("open . | lines");
+
+    assert!(actual.err.contains("Is a directory"));
+}

--- a/crates/nu-command/tests/commands/lines.rs
+++ b/crates/nu-command/tests/commands/lines.rs
@@ -62,6 +62,7 @@ fn lines_mixed_line_endings() {
     assert_eq!(actual.out, "3");
 }
 
+#[cfg(not(windows))]
 #[test]
 fn lines_on_error() {
     let actual = nu!("open . | lines");


### PR DESCRIPTION
should close https://github.com/nushell/nushell/issues/9965

# Description
this PR implements the `todo!()` left in `lines`.

# User-Facing Changes
### before
```nushell
> open . | lines
thread 'main' panicked at 'not yet implemented', crates/nu-command/src/filters/lines.rs:248:35
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### after
```nushell
> open . | lines
Error: nu::shell::io_error

  × I/O error
  help: Is a directory (os error 21)
```

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

this PR adds the `lines_on_error` test to make sure this does not happen again :relieved: 

# After Submitting