### PR TITLE
update `strip-ansi-escapes` to 0.2.0 and the latest reedline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,7 +4124,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.22.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#541698fb74c249cd540583fab2425c91700481fa"
+source = "git+https://github.com/nushell/reedline.git?branch=main#e7ee24a2b01d041feefb5eb58ba2377a20412f94"
 dependencies = [
  "chrono",
  "crossterm",
@@ -4822,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "strip-ansi-escapes"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad0ed65755f6fdd06f7afd1afefe7b2b220c2b197844687c2ea9d6d4807305e"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
 dependencies = [
  "vte 0.11.1",
 ]

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -17,11 +17,11 @@ nu-parser = { path = "../nu-parser", version = "0.83.2" }
 nu-color-config = { path = "../nu-color-config", version = "0.83.2" }
 nu-engine = { path = "../nu-engine", version = "0.83.2" }
 nu-table = { path = "../nu-table", version = "0.83.2" }
-nu-json = { path = "../nu-json", version = "0.83.2"  }
-nu-utils = { path = "../nu-utils", version = "0.83.2"  }
+nu-json = { path = "../nu-json", version = "0.83.2" }
+nu-utils = { path = "../nu-utils", version = "0.83.2" }
 
 terminal_size = "0.2"
-strip-ansi-escapes = "0.1"
+strip-ansi-escapes = "0.2.0"
 crossterm = "0.26"
 ratatui = "0.20"
 ansi-str = "0.8"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 log = "0.4"
 lscolors = { version = "0.15", default-features = false, features = ["nu-ansi-term"] }
 num-format = { version = "0.4" }
-strip-ansi-escapes = "0.1"
+strip-ansi-escapes = "0.2.0"
 sys-locale = "0.3"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
# Description

This PR fixes the semver issues with `strip-ansi-escapes` and updates it to 0.2.0 as well as updating to the latest reedline which just landed an identical patch.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
