### PR TITLE
Put heavy dataframe dependencies behind feature flag

### DIFF
--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -56,8 +56,8 @@ optional = true
 version = "0.30.0"
 
 [features]
-dataframe = ["default"]
-default = ["num", "polars", "sqlparser"]
+dataframe = ["num", "polars", "sqlparser"]
+default = []
 
 [dev-dependencies]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.83.2" }

--- a/crates/nu-cmd-dataframe/src/lib.rs
+++ b/crates/nu-cmd-dataframe/src/lib.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "dataframe")]
 pub mod dataframe;
+#[cfg(feature = "dataframe")]
 pub use dataframe::*;


### PR DESCRIPTION
Context from Discord: https://discord.com/channels/601130461678272522/615962413203718156/1138694933545504819

I was working on Nu for the first time in a while and I noticed that sometimes rust-analyzer takes a really long time to run `cargo check` on the entire workspace. I dug in and it was checking a bunch of dataframe-related dependencies even though the `dataframe` feature is not built by default.

It looks like this is a regression of sorts, introduced by https://github.com/nushell/nushell/pull/9241. Thankfully the fix is pretty easy, we can make it so everything important in `nu-cmd-dataframe` is only used when the `dataframe` feature is enabled.

### Impact on `cargo check --workspace`

Before this PR: 635 crates, 33.59s
After this PR: 498 crates, ~20s

(with the `mold` linker and a `cargo clean` before each run, the relative difference for incremental checks will likely be much larger)