### PR TITLE
Fix cross-compiling with cross-rs

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,9 +1,18 @@
 # Configuration for cross-rs: https://github.com/cross-rs/cross
 # Run cross-rs like this:
-# cross build --target aarch64-unknown-linux-musl --release
+# cross build --target aarch64-unknown-linux-gnu --release
+# or
+# cross build --target aarch64-unknown-linux-musl --release --features=static-link-openssl
 
 [target.aarch64-unknown-linux-gnu]
-dockerfile = "./docker/cross-rs/aarch64-unknown-linux-gnu.dockerfile"
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes libssl-dev:$CROSS_DEB_ARCH clang"
+]
 
+#  NOTE: for musl you will need to build with --features=static-link-openssl
 [target.aarch64-unknown-linux-musl]
-dockerfile = "./docker/cross-rs/aarch64-unknown-linux-musl.dockerfile"
+pre-build = [
+    "dpkg --add-architecture $CROSS_DEB_ARCH",
+    "apt-get update && apt-get install --assume-yes clang"
+]

--- a/docker/cross-rs/aarch64-unknown-linux-gnu.dockerfile
+++ b/docker/cross-rs/aarch64-unknown-linux-gnu.dockerfile
@@ -1,5 +1,0 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest
-
-RUN dpkg --add-architecture arm64 && \
-    apt-get update && \
-    apt-get install --assume-yes libssl-dev:arm64 clang

--- a/docker/cross-rs/aarch64-unknown-linux-musl.dockerfile
+++ b/docker/cross-rs/aarch64-unknown-linux-musl.dockerfile
@@ -1,5 +1,0 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-musl:latest
-
-RUN dpkg --add-architecture arm64 && \
-    apt-get update && \
-    apt-get install --assume-yes libssl-dev:arm64 clang


### PR DESCRIPTION
I cross-compiled Nushell (from x64 to ARM64) for the first time in a while and noticed that our [`cross-rs`](https://github.com/cross-rs) setup was no longer working. I've fixed that by following [the latest `cross-rs` docs](https://github.com/cross-rs/cross/wiki/Recipes#openssl).