### PR TITLE
rename "nothing" type to `null`

### DIFF
--- a/crates/nu-cli/src/commands/commandline.rs
+++ b/crates/nu-cli/src/commands/commandline.rs
@@ -102,7 +102,7 @@ impl Command for Commandline {
                 repl.buffer = cmd.as_string()?;
                 repl.cursor_pos = repl.buffer.len();
             }
-            Ok(Value::Nothing { span: call.head }.into_pipeline_data())
+            Ok(Value::Null { span: call.head }.into_pipeline_data())
         } else {
             let repl = engine_state.repl_state.lock().expect("repl state mutex");
             if call.has_flag("cursor") {

--- a/crates/nu-cli/src/commands/commandline.rs
+++ b/crates/nu-cli/src/commands/commandline.rs
@@ -16,10 +16,7 @@ impl Command for Commandline {
 
     fn signature(&self) -> Signature {
         Signature::build("commandline")
-            .input_output_types(vec![
-                (Type::Nothing, Type::Nothing),
-                (Type::String, Type::String),
-            ])
+            .input_output_types(vec![(Type::Null, Type::Null), (Type::String, Type::String)])
             .switch(
                 "cursor",
                 "Set or get the current cursor position",

--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -24,8 +24,8 @@ impl Command for History {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("history")
             .input_output_types(vec![
-                (Type::Nothing, Type::Table(vec![])),
-                (Type::Nothing, Type::Nothing),
+                (Type::Null, Type::Table(vec![])),
+                (Type::Null, Type::Null),
             ])
             .allow_variants_without_examples(true)
             .switch("clear", "Clears out the history entries", Some('c'))

--- a/crates/nu-cli/src/commands/history_session.rs
+++ b/crates/nu-cli/src/commands/history_session.rs
@@ -19,7 +19,7 @@ impl Command for HistorySession {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("history session")
             .category(Category::Misc)
-            .input_output_types(vec![(Type::Nothing, Type::Int)])
+            .input_output_types(vec![(Type::Null, Type::Int)])
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cli/src/commands/keybindings.rs
+++ b/crates/nu-cli/src/commands/keybindings.rs
@@ -16,7 +16,7 @@ impl Command for Keybindings {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Platform)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cli/src/commands/keybindings_default.rs
+++ b/crates/nu-cli/src/commands/keybindings_default.rs
@@ -16,7 +16,7 @@ impl Command for KeybindingsDefault {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Platform)
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cli/src/commands/keybindings_list.rs
+++ b/crates/nu-cli/src/commands/keybindings_list.rs
@@ -18,7 +18,7 @@ impl Command for KeybindingsList {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .switch("modifiers", "list of modifiers", Some('m'))
             .switch("keycodes", "list of keycodes", Some('k'))
             .switch("modes", "list of edit modes", Some('o'))

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -22,7 +22,7 @@ impl Command for KeybindingsListen {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Platform)
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -93,7 +93,7 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
     }
     terminal::disable_raw_mode()?;
 
-    Ok(Value::nothing(Span::unknown()))
+    Ok(Value::null(Span::unknown()))
 }
 
 // this fn is totally ripped off from crossterm's examples

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -303,7 +303,7 @@ fn recursive_value(val: Value, sublevels: Vec<Vec<u8>>) -> Value {
                 }
 
                 // Current sublevel value not found
-                return Value::Nothing {
+                return Value::Null {
                     span: Span::unknown(),
                 };
             }
@@ -318,7 +318,7 @@ fn recursive_value(val: Value, sublevels: Vec<Vec<u8>>) -> Value {
                 }
 
                 // Current sublevel value not found
-                return Value::Nothing {
+                return Value::Null {
                     span: Span::unknown(),
                 };
             }
@@ -335,7 +335,7 @@ fn recursive_value(val: Value, sublevels: Vec<Vec<u8>>) -> Value {
                 }
 
                 // Current sublevel value not found
-                return Value::Nothing {
+                return Value::Null {
                     span: Span::unknown(),
                 };
             }

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -54,7 +54,7 @@ impl Completer for NuMenuCompleter {
             }
         }
 
-        let input = Value::nothing(self.span).into_pipeline_data();
+        let input = Value::null(self.span).into_pipeline_data();
         let res = eval_block(
             &self.engine_state,
             &mut self.stack,

--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -60,7 +60,7 @@ Since this command has no output, there is no point in piping it with other comm
                 arg.into_pipeline_data()
                     .print(engine_state, stack, no_newline, to_stderr)?;
             }
-        } else if !input.is_nothing() {
+        } else if !input.is_null() {
             input.print(engine_state, stack, no_newline, to_stderr)?;
         }
 

--- a/crates/nu-cli/src/print.rs
+++ b/crates/nu-cli/src/print.rs
@@ -16,10 +16,7 @@ impl Command for Print {
 
     fn signature(&self) -> Signature {
         Signature::build("print")
-            .input_output_types(vec![
-                (Type::Nothing, Type::Nothing),
-                (Type::Any, Type::Nothing),
-            ])
+            .input_output_types(vec![(Type::Null, Type::Null), (Type::Any, Type::Null)])
             .allow_variants_without_examples(true)
             .rest("rest", SyntaxShape::Any, "the values to print")
             .switch(

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -243,7 +243,7 @@ pub(crate) fn add_columnar_menu(
     columnar_menu = columnar_menu.with_only_buffer_difference(only_buffer_difference);
 
     match &menu.source {
-        Value::Nothing { .. } => {
+        Value::Null { .. } => {
             Ok(line_editor.with_menu(ReedlineMenu::EngineCompleter(Box::new(columnar_menu))))
         }
         Value::Closure {
@@ -329,7 +329,7 @@ pub(crate) fn add_list_menu(
     list_menu = list_menu.with_only_buffer_difference(only_buffer_difference);
 
     match &menu.source {
-        Value::Nothing { .. } => {
+        Value::Null { .. } => {
             Ok(line_editor.with_menu(ReedlineMenu::HistoryMenu(Box::new(list_menu))))
         }
         Value::Closure {
@@ -447,7 +447,7 @@ pub(crate) fn add_description_menu(
     description_menu = description_menu.with_only_buffer_difference(only_buffer_difference);
 
     match &menu.source {
-        Value::Nothing { .. } => {
+        Value::Null { .. } => {
             let completer = Box::new(NuHelpCompleter::new(engine_state));
             Ok(line_editor.with_menu(ReedlineMenu::WithCompleter {
                 menu: Box::new(description_menu),
@@ -802,7 +802,7 @@ fn parse_event(value: &Value, config: &Config) -> Result<Option<ReedlineEvent>, 
 
             Ok(Some(ReedlineEvent::Multiple(events)))
         }
-        Value::Nothing { .. } => Ok(None),
+        Value::Null { .. } => Ok(None),
         v => Err(ShellError::UnsupportedConfigValue(
             "record or list of records, null to unbind key".to_string(),
             v.into_abbreviated_string(config),

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -765,7 +765,7 @@ fn parse_event(value: &Value, config: &Config) -> Result<Option<ReedlineEvent>, 
                                 Ok(inner) => match inner {
                                     None => Err(ShellError::UnsupportedConfigValue(
                                         "List containing valid events".to_string(),
-                                        "Nothing value (null)".to_string(),
+                                        "null".to_string(),
                                         value.span()?,
                                     )),
                                     Some(event) => Ok(event),
@@ -791,7 +791,7 @@ fn parse_event(value: &Value, config: &Config) -> Result<Option<ReedlineEvent>, 
                     Ok(inner) => match inner {
                         None => Err(ShellError::UnsupportedConfigValue(
                             "List containing valid events".to_string(),
-                            "Nothing value (null)".to_string(),
+                            "null".to_string(),
                             value.span()?,
                         )),
                         Some(event) => Ok(event),

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -281,7 +281,7 @@ pub fn evaluate_repl(
         line_editor = if config.use_ansi_coloring {
             line_editor.with_hinter(Box::new({
                 // As of Nov 2022, "hints" color_config closures only get `null` passed in.
-                let style = style_computer.compute("hints", &Value::nothing(Span::unknown()));
+                let style = style_computer.compute("hints", &Value::null(Span::unknown()));
                 DefaultHinter::default().with_style(style)
             }))
         } else {

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -313,7 +313,7 @@ fn find_matching_block_end_in_expr(
             Expr::Signature(_) => None,
             Expr::MatchPattern(_) => None,
             Expr::MatchBlock(_) => None,
-            Expr::Nothing => None,
+            Expr::Null => None,
             Expr::Garbage => None,
 
             Expr::Table(hdr, rows) => {

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -82,7 +82,7 @@ impl Highlighter for NuHighlighter {
 
             match shape.1 {
                 FlatShape::Garbage => add_colored_token(&shape.1, next_token),
-                FlatShape::Nothing => add_colored_token(&shape.1, next_token),
+                FlatShape::Null => add_colored_token(&shape.1, next_token),
                 FlatShape::Binary => add_colored_token(&shape.1, next_token),
                 FlatShape::Bool => add_colored_token(&shape.1, next_token),
                 FlatShape::Int => add_colored_token(&shape.1, next_token),

--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -163,7 +163,7 @@ pub fn merge_input(
         stack,
         &block,
         PipelineData::Value(
-            Value::Nothing {
+            Value::Null {
                 span: Span::unknown(),
             },
             None

--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -27,7 +27,7 @@ type MakeRangeError = fn(&str, Span) -> ShellError;
 pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
     let start = match &range.from {
         Value::Int { val, .. } => isize::try_from(*val).unwrap_or_default(),
-        Value::Nothing { .. } => 0,
+        Value::Null { .. } => 0,
         _ => {
             return Err(|msg, span| ShellError::TypeMismatch {
                 err_message: msg.to_string(),
@@ -44,7 +44,7 @@ pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
                 isize::try_from(*val).unwrap_or(isize::max_value()) - 1
             }
         }
-        Value::Nothing { .. } => isize::max_value(),
+        Value::Null { .. } => isize::max_value(),
         _ => {
             return Err(|msg, span| ShellError::TypeMismatch {
                 err_message: msg.to_string(),

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/when.rs
@@ -106,7 +106,7 @@ impl Command for ExprWhen {
 
         let value = input.into_value(call.head);
         let when_then: NuWhen = match value {
-            Value::Nothing { .. } => when(when_predicate.into_polars())
+            Value::Null { .. } => when(when_predicate.into_polars())
                 .then(then_predicate.into_polars())
                 .into(),
             v => match NuWhen::try_from_value(v)? {

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
@@ -111,7 +111,7 @@ pub fn create_column(
     let size = to_row - from_row;
     match series.dtype() {
         DataType::Null => {
-            let values = std::iter::repeat(Value::Nothing { span })
+            let values = std::iter::repeat(Value::Null { span })
                 .take(size)
                 .collect::<Vec<Value>>();
 
@@ -136,7 +136,7 @@ pub fn create_column(
                         val: a as i64,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -161,7 +161,7 @@ pub fn create_column(
                         val: a as i64,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -186,7 +186,7 @@ pub fn create_column(
                         val: a as i64,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -211,7 +211,7 @@ pub fn create_column(
                         val: a as i64,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -236,7 +236,7 @@ pub fn create_column(
                         val: a as i64,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -261,7 +261,7 @@ pub fn create_column(
                         val: a as i64,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -286,7 +286,7 @@ pub fn create_column(
                         val: a as i64,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -308,7 +308,7 @@ pub fn create_column(
                 .take(size)
                 .map(|v| match v {
                     Some(a) => Value::Int { val: a, span },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -333,7 +333,7 @@ pub fn create_column(
                         val: a as f64,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -355,7 +355,7 @@ pub fn create_column(
                 .take(size)
                 .map(|v| match v {
                     Some(a) => Value::Float { val: a, span },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -378,7 +378,7 @@ pub fn create_column(
                 .take(size)
                 .map(|v| match v {
                     Some(a) => Value::Bool { val: a, span },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -404,7 +404,7 @@ pub fn create_column(
                         val: a.into(),
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -430,7 +430,7 @@ pub fn create_column(
                         .take(size)
                         .map(|v| match v {
                             Some(a) => a.get_value(),
-                            None => Value::Nothing { span },
+                            None => Value::Null { span },
                         })
                         .collect::<Vec<Value>>();
 
@@ -493,7 +493,7 @@ pub fn create_column(
                             span,
                         }
                     }
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -558,7 +558,7 @@ pub fn create_column(
                             span,
                         }
                     }
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 
@@ -584,7 +584,7 @@ pub fn create_column(
                         val: nanoseconds,
                         span,
                     },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 })
                 .collect::<Vec<Value>>();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
@@ -38,7 +38,7 @@ impl Display for DataFrameValue {
 
 impl Default for DataFrameValue {
     fn default() -> Self {
-        Self(Value::Nothing {
+        Self(Value::Null {
             span: Span::unknown(),
         })
     }
@@ -54,7 +54,7 @@ impl Eq for DataFrameValue {}
 impl std::hash::Hash for DataFrameValue {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match &self.0 {
-            Value::Nothing { .. } => 0.hash(state),
+            Value::Null { .. } => 0.hash(state),
             Value::Int { val, .. } => val.hash(state),
             Value::String { val, .. } => val.hash(state),
             // TODO. Define hash for the rest of types
@@ -441,7 +441,7 @@ impl NuDataFrame {
 
                     match col.next() {
                         Some(v) => vals.push(v),
-                        None => vals.push(Value::Nothing { span }),
+                        None => vals.push(Value::Null { span }),
                     };
                 }
 

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/mod.rs
@@ -607,7 +607,7 @@ pub fn expr_to_value(expr: &Expr, span: Span) -> Value {
             let order_by = order_by
                 .as_ref()
                 .map(|e| expr_to_value(e.as_ref(), span))
-                .unwrap_or_else(|| Value::nothing(span));
+                .unwrap_or_else(|| Value::null(span));
 
             let options = Value::String {
                 val: format!("{options:?}"),

--- a/crates/nu-cmd-extra/src/extra/bits/bits_.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/bits_.rs
@@ -16,7 +16,7 @@ impl Command for Bits {
     fn signature(&self) -> Signature {
         Signature::build("bits")
             .category(Category::Bits)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cmd-extra/src/extra/bytes/build_.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/build_.rs
@@ -24,7 +24,7 @@ impl Command for BytesBuild {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("bytes build")
-            .input_output_types(vec![(Type::Nothing, Type::Binary)])
+            .input_output_types(vec![(Type::Null, Type::Binary)])
             .rest("rest", SyntaxShape::Any, "list of bytes")
             .category(Category::Bytes)
     }

--- a/crates/nu-cmd-extra/src/extra/bytes/bytes_.rs
+++ b/crates/nu-cmd-extra/src/extra/bytes/bytes_.rs
@@ -16,7 +16,7 @@ impl Command for Bytes {
     fn signature(&self) -> Signature {
         Signature::build("bytes")
             .category(Category::Bytes)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cmd-extra/src/extra/filters/each_while.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/each_while.rs
@@ -123,7 +123,7 @@ impl Command for EachWhile {
                     ) {
                         Ok(v) => {
                             let value = v.into_value(span);
-                            if value.is_nothing() {
+                            if value.is_null() {
                                 None
                             } else {
                                 Some(value)
@@ -167,7 +167,7 @@ impl Command for EachWhile {
                     ) {
                         Ok(v) => {
                             let value = v.into_value(span);
-                            if value.is_nothing() {
+                            if value.is_null() {
                                 None
                             } else {
                                 Some(value)

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_.rs
@@ -18,7 +18,7 @@ impl Command for Roll {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Filters)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -437,7 +437,7 @@ fn html_table(table: Vec<Value>, headers: Vec<String>, config: &Config) -> Strin
                 let data = row.get_data_by_key(header);
                 output_string.push_str("<td>");
                 output_string.push_str(&html_value(
-                    data.unwrap_or_else(|| Value::nothing(span)),
+                    data.unwrap_or_else(|| Value::null(span)),
                     config,
                 ));
                 output_string.push_str("</td>");

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/str_.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/str_.rs
@@ -16,7 +16,7 @@ impl Command for Str {
     fn signature(&self) -> Signature {
         Signature::build("str")
             .category(Category::Strings)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cmd-lang/src/core_commands/alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/alias.rs
@@ -55,7 +55,7 @@ impl Command for Alias {
         vec![Example {
             description: "Alias ll to ls -l",
             example: "alias ll = ls -l",
-            result: Some(Value::nothing(Span::test_data())),
+            result: Some(Value::null(Span::test_data())),
         }]
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/alias.rs
@@ -18,7 +18,7 @@ impl Command for Alias {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("alias")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("name", SyntaxShape::String, "name of the alias")
             .required(
                 "initial_value",

--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -16,7 +16,7 @@ impl Command for Break {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("break")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/const_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/const_.rs
@@ -16,7 +16,7 @@ impl Command for Const {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("const")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required("const_name", SyntaxShape::VarWithOptType, "constant name")
             .required(

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -16,7 +16,7 @@ impl Command for Continue {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("continue")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -18,7 +18,7 @@ impl Command for Def {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("def")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("def_name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
             .required("body", SyntaxShape::Closure(None), "body of the definition")

--- a/crates/nu-cmd-lang/src/core_commands/def_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def_env.rs
@@ -18,7 +18,7 @@ impl Command for DefEnv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("def-env")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("def_name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
             .required("block", SyntaxShape::Block, "body of the definition")

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -239,7 +239,7 @@ impl Command for Do {
                 let ctrlc = ls.ctrlc.clone();
                 for v in ls {
                     if let Value::Error { .. } = v {
-                        values.push(Value::nothing(call.head));
+                        values.push(Value::null(call.head));
                     } else {
                         values.push(v)
                     }

--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -20,7 +20,7 @@ impl Command for Echo {
 
     fn signature(&self) -> Signature {
         Signature::build("echo")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .rest("rest", SyntaxShape::Any, "the values to echo")
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -15,7 +15,7 @@ impl Command for ErrorMake {
 
     fn signature(&self) -> Signature {
         Signature::build("error make")
-            .input_output_types(vec![(Type::Nothing, Type::Error)])
+            .input_output_types(vec![(Type::Null, Type::Error)])
             .required(
                 "error_struct",
                 SyntaxShape::Record(vec![]),

--- a/crates/nu-cmd-lang/src/core_commands/export.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export.rs
@@ -15,7 +15,7 @@ impl Command for ExportCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("export")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/export_alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_alias.rs
@@ -18,7 +18,7 @@ impl Command for ExportAlias {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export alias")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("name", SyntaxShape::String, "name of the alias")
             .required(
                 "initial_value",

--- a/crates/nu-cmd-lang/src/core_commands/export_alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_alias.rs
@@ -55,7 +55,7 @@ impl Command for ExportAlias {
         vec![Example {
             description: "Alias ll to ls -l and export it from a module",
             example: "module spam { export alias ll = ls -l }",
-            result: Some(Value::nothing(Span::test_data())),
+            result: Some(Value::null(Span::test_data())),
         }]
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/export_const.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_const.rs
@@ -18,7 +18,7 @@ impl Command for ExportConst {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export const")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required("const_name", SyntaxShape::VarWithOptType, "constant name")
             .required(

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -18,7 +18,7 @@ impl Command for ExportDef {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export def")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
             .required("block", SyntaxShape::Block, "body of the definition")

--- a/crates/nu-cmd-lang/src/core_commands/export_def_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def_env.rs
@@ -18,7 +18,7 @@ impl Command for ExportDefEnv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export def-env")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
             .required("block", SyntaxShape::Block, "body of the definition")

--- a/crates/nu-cmd-lang/src/core_commands/export_extern.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_extern.rs
@@ -16,7 +16,7 @@ impl Command for ExportExtern {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export extern")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("def_name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/export_module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_module.rs
@@ -18,7 +18,7 @@ impl Command for ExportModule {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export module")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required("module", SyntaxShape::String, "module name or module path")
             .optional(

--- a/crates/nu-cmd-lang/src/core_commands/export_use.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_use.rs
@@ -18,7 +18,7 @@ impl Command for ExportUse {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export use")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("module", SyntaxShape::String, "Module or module file")
             .optional(
                 "members",

--- a/crates/nu-cmd-lang/src/core_commands/extern_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_.rs
@@ -16,7 +16,7 @@ impl Command for Extern {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("extern")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("def_name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/extern_wrapped.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_wrapped.rs
@@ -16,7 +16,7 @@ impl Command for ExternWrapped {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("extern-wrapped")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("def_name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
             .required("body", SyntaxShape::Block, "wrapper function block")

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -19,7 +19,7 @@ impl Command for For {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("for")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required(
                 "var_name",

--- a/crates/nu-cmd-lang/src/core_commands/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide.rs
@@ -12,7 +12,7 @@ impl Command for Hide {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("hide")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("module", SyntaxShape::String, "Module or module file")
             .optional(
                 "members",

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -16,7 +16,7 @@ impl Command for HideEnv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("hide-env")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .rest(
                 "name",
                 SyntaxShape::String,

--- a/crates/nu-cmd-lang/src/core_commands/ignore.rs
+++ b/crates/nu-cmd-lang/src/core_commands/ignore.rs
@@ -16,7 +16,7 @@ impl Command for Ignore {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("ignore")
-            .input_output_types(vec![(Type::Any, Type::Nothing)])
+            .input_output_types(vec![(Type::Any, Type::Null)])
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/ignore.rs
+++ b/crates/nu-cmd-lang/src/core_commands/ignore.rs
@@ -39,7 +39,7 @@ impl Command for Ignore {
         vec![Example {
             description: "Ignore the output of an echo command",
             example: "echo done | ignore",
-            result: Some(Value::nothing(Span::test_data())),
+            result: Some(Value::null(Span::test_data())),
         }]
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
@@ -141,7 +141,7 @@ impl<'a> LazyRecord<'a> for NuLazyRecord {
         pipeline_result.map(|data| match data {
             PipelineData::Value(value, ..) => value,
             // TODO: Proper error handling.
-            _ => Value::Nothing { span: self.span },
+            _ => Value::Null { span: self.span },
         })
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
@@ -18,7 +18,7 @@ impl Command for LazyMake {
 
     fn signature(&self) -> Signature {
         Signature::build("lazy make")
-            .input_output_types(vec![(Type::Nothing, Type::Record(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Record(vec![]))])
             .required_named(
                 "columns",
                 SyntaxShape::List(Box::new(SyntaxShape::String)),

--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -17,7 +17,7 @@ impl Command for Let {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("let")
-            .input_output_types(vec![(Type::Any, Type::Nothing)])
+            .input_output_types(vec![(Type::Any, Type::Null)])
             .allow_variants_without_examples(true)
             .required("var_name", SyntaxShape::VarWithOptType, "variable name")
             .required(

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -19,7 +19,7 @@ impl Command for Loop {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("loop")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required("block", SyntaxShape::Block, "block to loop")
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/module.rs
@@ -18,7 +18,7 @@ impl Command for Module {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("module")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required("module", SyntaxShape::String, "module name or module path")
             .optional(

--- a/crates/nu-cmd-lang/src/core_commands/mut_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/mut_.rs
@@ -17,7 +17,7 @@ impl Command for Mut {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("mut")
-            .input_output_types(vec![(Type::Any, Type::Nothing)])
+            .input_output_types(vec![(Type::Any, Type::Null)])
             .allow_variants_without_examples(true)
             .required("var_name", SyntaxShape::VarWithOptType, "variable name")
             .required(

--- a/crates/nu-cmd-lang/src/core_commands/overlay/command.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/command.rs
@@ -16,7 +16,7 @@ impl Command for Overlay {
     fn signature(&self) -> Signature {
         Signature::build("overlay")
             .category(Category::Core)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -19,7 +19,7 @@ impl Command for OverlayHide {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay hide")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .optional("name", SyntaxShape::String, "Overlay to hide")
             .switch(
                 "keep-custom",

--- a/crates/nu-cmd-lang/src/core_commands/overlay/list.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/list.rs
@@ -19,7 +19,7 @@ impl Command for OverlayList {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay list")
             .category(Category::Core)
-            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::String)))])
+            .input_output_types(vec![(Type::Null, Type::List(Box::new(Type::String)))])
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
@@ -19,7 +19,7 @@ impl Command for OverlayNew {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay new")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required("name", SyntaxShape::String, "Name of the overlay")
             // TODO:

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -22,7 +22,7 @@ impl Command for OverlayUse {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay use")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required(
                 "name",

--- a/crates/nu-cmd-lang/src/core_commands/register.rs
+++ b/crates/nu-cmd-lang/src/core_commands/register.rs
@@ -16,7 +16,7 @@ impl Command for Register {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("register")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required(
                 "plugin",
                 SyntaxShape::Filepath,

--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -19,7 +19,7 @@ impl Command for Return {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("return")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .optional("return_value", SyntaxShape::Any, "optional value to return")
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -46,7 +46,7 @@ impl Command for Return {
         } else {
             Err(ShellError::Return(
                 call.head,
-                Box::new(Value::nothing(call.head)),
+                Box::new(Value::null(call.head)),
             ))
         }
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/aliases.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/aliases.rs
@@ -15,7 +15,7 @@ impl Command for ScopeAliases {
 
     fn signature(&self) -> Signature {
         Signature::build("scope aliases")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Filters)
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/command.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/command.rs
@@ -16,7 +16,7 @@ impl Command for Scope {
     fn signature(&self) -> Signature {
         Signature::build("scope")
             .category(Category::Core)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
@@ -15,7 +15,7 @@ impl Command for ScopeCommands {
 
     fn signature(&self) -> Signature {
         Signature::build("scope commands")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Filters)
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/engine_stats.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/engine_stats.rs
@@ -13,7 +13,7 @@ impl Command for ScopeEngineStats {
 
     fn signature(&self) -> Signature {
         Signature::build("scope engine-stats")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Filters)
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/modules.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/modules.rs
@@ -15,7 +15,7 @@ impl Command for ScopeModules {
 
     fn signature(&self) -> Signature {
         Signature::build("scope modules")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Filters)
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
@@ -15,7 +15,7 @@ impl Command for ScopeVariables {
 
     fn signature(&self) -> Signature {
         Signature::build("scope variables")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Filters)
     }

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -68,7 +68,7 @@ impl Command for Try {
                     // Because external command errors aren't "real" errors,
                     // (unless do -c is in effect)
                     // they can't be passed in as Nushell values.
-                    let err_value = Value::nothing(call.head);
+                    let err_value = Value::null(call.head);
                     handle_catch(err_value, catch_block, engine_state, stack)
                 } else {
                     Ok(pipeline)

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -19,7 +19,7 @@ impl Command for Use {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("use")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required("module", SyntaxShape::String, "Module or module file")
             .rest(

--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -17,7 +17,7 @@ impl Command for Version {
 
     fn signature(&self) -> Signature {
         Signature::build("version")
-            .input_output_types(vec![(Type::Nothing, Type::Record(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Record(vec![]))])
             .allow_variants_without_examples(true)
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -19,7 +19,7 @@ impl Command for While {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("while")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .required("cond", SyntaxShape::MathExpression, "condition to check")
             .required(

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -81,7 +81,7 @@ fn eval_pipeline_without_terminal_expression(
             let empty_input = PipelineData::empty();
             Some(eval_block(block, empty_input, cwd, engine_state, delta))
         } else {
-            Some(Value::nothing(Span::test_data()))
+            Some(Value::null(Span::test_data()))
         }
     } else {
         // E.g. multiple semicolon-separated statements

--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -144,7 +144,7 @@ mod tests {
 
         // Test case 2: no values are valid
         let cols = vec!["invalid".to_string()];
-        let vals = vec![Value::nothing(Span::unknown())];
+        let vals = vec![Value::null(Span::unknown())];
         assert_eq!(get_style_from_value(&cols, &vals), None);
 
         // Test case 3: some values are valid
@@ -154,7 +154,7 @@ mod tests {
                 val: "green".to_string(),
                 span: Span::unknown(),
             },
-            Value::nothing(Span::unknown()),
+            Value::null(Span::unknown()),
         ];
         let expected_style = NuStyle {
             bg: Some("green".to_string()),

--- a/crates/nu-color-config/src/shape_color.rs
+++ b/crates/nu-color-config/src/shape_color.rs
@@ -26,7 +26,7 @@ pub fn default_shape_color(shape: String) -> Style {
         "shape_list" => Style::new().fg(Color::Cyan).bold(),
         "shape_literal" => Style::new().fg(Color::Blue),
         "shape_match_pattern" => Style::new().fg(Color::Green),
-        "shape_nothing" => Style::new().fg(Color::LightCyan),
+        "shape_null" => Style::new().fg(Color::LightCyan),
         "shape_operator" => Style::new().fg(Color::Yellow),
         "shape_or" => Style::new().fg(Color::Purple).bold(),
         "shape_pipe" => Style::new().fg(Color::Purple).bold(),

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -222,11 +222,11 @@ fn test_computable_style_static() {
         .collect(),
     );
     assert_eq!(
-        style_computer.compute("string", &Value::nothing(Span::unknown())),
+        style_computer.compute("string", &Value::null(Span::unknown())),
         style1
     );
     assert_eq!(
-        style_computer.compute("row_index", &Value::nothing(Span::unknown())),
+        style_computer.compute("row_index", &Value::null(Span::unknown())),
         style2
     );
 }

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -120,7 +120,7 @@ impl<'a> StyleComputer<'a> {
             Value::Range { .. } => TextStyle::with_style(Left, s),
             Value::Float { .. } => TextStyle::with_style(Right, s),
             Value::String { .. } => TextStyle::with_style(Left, s),
-            Value::Nothing { .. } => TextStyle::with_style(Left, s),
+            Value::Null { .. } => TextStyle::with_style(Left, s),
             Value::Binary { .. } => TextStyle::with_style(Left, s),
             Value::CellPath { .. } => TextStyle::with_style(Left, s),
             Value::Record { .. } | Value::List { .. } | Value::Block { .. } => {

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -153,7 +153,7 @@ impl<'a> StyleComputer<'a> {
             ("range".to_string(), ComputableStyle::Static(Color::White.normal())),
             ("float".to_string(), ComputableStyle::Static(Color::White.normal())),
             ("string".to_string(), ComputableStyle::Static(Color::White.normal())),
-            ("nothing".to_string(), ComputableStyle::Static(Color::White.normal())),
+            ("null".to_string(), ComputableStyle::Static(Color::White.normal())),
             ("binary".to_string(), ComputableStyle::Static(Color::White.normal())),
             ("cellpath".to_string(), ComputableStyle::Static(Color::White.normal())),
             ("row_index".to_string(), ComputableStyle::Static(Color::Green.bold())),

--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -234,7 +234,7 @@ mod test {
                 captures: HashMap::new(),
                 span,
             },
-            Value::Nothing { span },
+            Value::Null { span },
             Value::Error {
                 error: Box::new(ShellError::DidYouMean("what?".to_string(), span)),
             },

--- a/crates/nu-command/src/conversions/into/command.rs
+++ b/crates/nu-command/src/conversions/into/command.rs
@@ -16,7 +16,7 @@ impl Command for Into {
     fn signature(&self) -> Signature {
         Signature::build("into")
             .category(Category::Conversions)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -170,7 +170,7 @@ pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
                     error: Box::new(error),
                 },
             },
-            Value::Nothing { .. } => Value::Filesize {
+            Value::Null { .. } => Value::Filesize {
                 val: 0,
                 span: value_span,
             },

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -254,7 +254,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             val: into_code(error).unwrap_or_default(),
             span,
         },
-        Value::Nothing { .. } => Value::String {
+        Value::Null { .. } => Value::String {
             val: "".to_string(),
             span,
         },

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -214,7 +214,7 @@ fn action(
             })?;
 
             // and we're done
-            Ok(Value::Nothing { span: *span })
+            Ok(Value::Null { span: *span })
         }
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { error } => Err(*error.clone()),
@@ -265,7 +265,7 @@ fn nu_value_to_string(value: Value, separator: &str) -> String {
         },
         Value::Block { val, .. } => format!("<Block {val}>"),
         Value::Closure { val, .. } => format!("<Closure {val}>"),
-        Value::Nothing { .. } => String::new(),
+        Value::Null { .. } => String::new(),
         Value::Error { error } => format!("{error:?}"),
         Value::Binary { val, .. } => format!("{val:?}"),
         Value::CellPath { val, .. } => val.into_string(),

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -20,7 +20,7 @@ impl Command for IntoSqliteDb {
 
     fn signature(&self) -> Signature {
         Signature::build("into sqlite")
-            .input_output_types(vec![(Type::Any, Type::Nothing)])
+            .input_output_types(vec![(Type::Any, Type::Null)])
             .allow_variants_without_examples(true)
             // TODO: narrow disallowed types
             .required(
@@ -286,7 +286,7 @@ fn nu_type_to_sqlite_type(nu_type: Type) -> &'static str {
         Type::Float => "REAL",
         Type::String => "TEXT",
         Type::Bool => "TEXT",
-        Type::Nothing => "NULL",
+        Type::Null => "NULL",
         Type::Filesize => "INTEGER",
         Type::Date => "TEXT",
         _ => "TEXT",

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -455,7 +455,7 @@ pub fn convert_sqlite_row_to_nu_value(row: &Row, span: Span, column_names: Vec<S
 
 pub fn convert_sqlite_value_to_nu_value(value: ValueRef, span: Span) -> Value {
     match value {
-        ValueRef::Null => Value::Nothing { span },
+        ValueRef::Null => Value::Null { span },
         ValueRef::Integer(i) => Value::Int { val: i, span },
         ValueRef::Real(f) => Value::Float { val: f, span },
         ValueRef::Text(buf) => {
@@ -552,7 +552,7 @@ mod test {
                 vals: vec![
                     Value::Record {
                         cols: vec!["id".to_string(), "name".to_string()],
-                        vals: vec![Value::Int { val: 123, span }, Value::Nothing { span }],
+                        vals: vec![Value::Int { val: 123, span }, Value::Null { span }],
                         span,
                     },
                     Value::Record {

--- a/crates/nu-command/src/date/date_.rs
+++ b/crates/nu-command/src/date/date_.rs
@@ -16,7 +16,7 @@ impl Command for Date {
     fn signature(&self) -> Signature {
         Signature::build("date")
             .category(Category::Date)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -65,7 +65,7 @@ impl Command for SubCommand {
 
 fn helper(value: Value, head: Span) -> Value {
     match value {
-        Value::Nothing { span: _ } => {
+        Value::Null { span: _ } => {
             let dt = Local::now();
             Value::String {
                 val: humanize_date(dt.with_timezone(dt.offset())),

--- a/crates/nu-command/src/date/list_timezone.rs
+++ b/crates/nu-command/src/date/list_timezone.rs
@@ -16,7 +16,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("date list-timezone")
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .category(Category::Date)
     }
 

--- a/crates/nu-command/src/date/now.rs
+++ b/crates/nu-command/src/date/now.rs
@@ -14,7 +14,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("date now")
-            .input_output_types(vec![(Type::Nothing, Type::Date)])
+            .input_output_types(vec![(Type::Null, Type::Date)])
             .category(Category::Date)
     }
 

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -149,7 +149,7 @@ fn helper(val: Value, head: Span) -> Value {
             let date = parse_date_from_string(&val, val_span);
             parse_date_into_table(date, head)
         }
-        Value::Nothing { span: _ } => {
+        Value::Null { span: _ } => {
             let now = Local::now();
             let n = now.with_timezone(now.offset());
             parse_date_into_table(Ok(n), head)

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -154,7 +154,7 @@ fn helper(val: Value, head: Span) -> Value {
             let date = parse_date_from_string(&val, val_span);
             parse_date_into_table(date, head)
         }
-        Value::Nothing { span: _ } => {
+        Value::Null { span: _ } => {
             let now = Local::now();
             let n = now.with_timezone(now.offset());
             parse_date_into_table(Ok(n), head)

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -123,7 +123,7 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
             }
         }
 
-        Value::Nothing { span: _ } => {
+        Value::Null { span: _ } => {
             let dt = Local::now();
             _to_timezone(dt.with_timezone(dt.offset()), timezone, head)
         }

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -25,7 +25,7 @@ impl Command for Explain {
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 "the closure to run",
             )
-            .input_output_types(vec![(Type::Any, Type::Any), (Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Any, Type::Any), (Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .category(Category::Debug)
     }

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -321,7 +321,7 @@ pub fn debug_string_without_formatting(value: &Value) -> String {
         //TODO: It would be good to drill in deeper to blocks and closures.
         Value::Block { val, .. } => format!("<Block {val}>"),
         Value::Closure { val, .. } => format!("<Closure {val}>"),
-        Value::Nothing { .. } => String::new(),
+        Value::Null { .. } => String::new(),
         Value::Error { error } => format!("{error:?}"),
         Value::Binary { val, .. } => format!("{val:?}"),
         Value::CellPath { val, .. } => val.into_string(),

--- a/crates/nu-command/src/debug/inspect.rs
+++ b/crates/nu-command/src/debug/inspect.rs
@@ -34,7 +34,7 @@ impl Command for Inspect {
     ) -> Result<PipelineData, ShellError> {
         let input_metadata = input.metadata();
         let input_val = input.into_value(call.head);
-        if input_val.is_nothing() {
+        if input_val.is_null() {
             return Err(ShellError::PipelineEmpty {
                 dst_span: call.head,
             });

--- a/crates/nu-command/src/debug/inspect_table.rs
+++ b/crates/nu-command/src/debug/inspect_table.rs
@@ -227,7 +227,7 @@ mod util {
 
                 (vec![String::from("")], lines)
             }
-            Value::Nothing { .. } => (vec![], vec![]),
+            Value::Null { .. } => (vec![], vec![]),
             value => (
                 vec![String::from("")],
                 vec![vec![debug_string_without_formatting(&value)]],

--- a/crates/nu-command/src/debug/profile.rs
+++ b/crates/nu-command/src/debug/profile.rs
@@ -96,7 +96,7 @@ Current known limitations are:
         {
             Value::list(values, call.head)
         } else {
-            Value::nothing(call.head)
+            Value::null(call.head)
         };
 
         Ok(result.into_pipeline_data())

--- a/crates/nu-command/src/debug/timeit.rs
+++ b/crates/nu-command/src/debug/timeit.rs
@@ -28,7 +28,7 @@ impl Command for TimeIt {
             )
             .input_output_types(vec![
                 (Type::Any, Type::Duration),
-                (Type::Nothing, Type::Duration),
+                (Type::Null, Type::Duration),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Debug)

--- a/crates/nu-command/src/debug/view.rs
+++ b/crates/nu-command/src/debug/view.rs
@@ -16,7 +16,7 @@ impl Command for View {
     fn signature(&self) -> Signature {
         Signature::build("view")
             .category(Category::Debug)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/debug/view_files.rs
+++ b/crates/nu-command/src/debug/view_files.rs
@@ -22,7 +22,7 @@ impl Command for ViewFiles {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("view files")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .category(Category::Debug)
     }
 

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -21,7 +21,7 @@ impl Command for ViewSource {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("view source")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .required("item", SyntaxShape::Any, "name or block to view")
             .category(Category::Debug)
     }

--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -24,7 +24,7 @@ impl Command for ViewSpan {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("view span")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .required("start", SyntaxShape::Int, "start of the span")
             .required("end", SyntaxShape::Int, "end of the span")
             .category(Category::Debug)

--- a/crates/nu-command/src/deprecated/let_env.rs
+++ b/crates/nu-command/src/deprecated/let_env.rs
@@ -12,7 +12,7 @@ impl Command for LetEnv {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .optional("var_name", SyntaxShape::String, "variable name")
             .optional(

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -16,7 +16,7 @@ impl Command for ConfigMeta {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Env)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -18,7 +18,7 @@ impl Command for ConfigEnv {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Env)
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
         // TODO: Signature narrower than what run actually supports theoretically
     }
 

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -18,7 +18,7 @@ impl Command for ConfigNu {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Env)
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
         // TODO: Signature narrower than what run actually supports theoretically
     }
 

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -20,7 +20,7 @@ impl Command for ConfigReset {
             .switch("nu", "reset only nu config, config.nu", Some('n'))
             .switch("env", "reset only env config, env.nu", Some('e'))
             .switch("without-backup", "do not make a backup", Some('w'))
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .allow_variants_without_examples(true)
             .category(Category::Env)
     }

--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -15,7 +15,7 @@ impl Command for ExportEnv {
 
     fn signature(&self) -> Signature {
         Signature::build("export-env")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required(
                 "block",
                 SyntaxShape::Block,

--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -58,7 +58,7 @@ impl Command for ExportEnv {
             Example {
                 description: "Set an environment variable",
                 example: r#"export-env { $env.SPAM = 'eggs' }"#,
-                result: Some(Value::Nothing {
+                result: Some(Value::Null {
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -20,8 +20,8 @@ impl Command for LoadEnv {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("load-env")
             .input_output_types(vec![
-                (Type::Record(vec![]), Type::Nothing),
-                (Type::Nothing, Type::Nothing),
+                (Type::Record(vec![]), Type::Null),
+                (Type::Null, Type::Null),
             ])
             .allow_variants_without_examples(true)
             .optional(

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -19,7 +19,7 @@ impl Command for IsAdmin {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("is-admin")
             .category(Category::Core)
-            .input_output_types(vec![(Type::Nothing, Type::Bool)])
+            .input_output_types(vec![(Type::Null, Type::Bool)])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -43,9 +43,8 @@ impl Command for Cd {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("cd")
-            .input_output_types(vec![(Type::Null, Type::Null)])
-            .optional("path", SyntaxShape::Directory, "the path to change to")
             .input_output_types(vec![(Type::Null, Type::Null), (Type::String, Type::Null)])
+            .optional("path", SyntaxShape::Directory, "the path to change to")
             .allow_variants_without_examples(true)
             .category(Category::FileSystem)
     }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -43,12 +43,9 @@ impl Command for Cd {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("cd")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .optional("path", SyntaxShape::Directory, "the path to change to")
-            .input_output_types(vec![
-                (Type::Nothing, Type::Nothing),
-                (Type::String, Type::Nothing),
-            ])
+            .input_output_types(vec![(Type::Null, Type::Null), (Type::String, Type::Null)])
             .allow_variants_without_examples(true)
             .category(Category::FileSystem)
     }

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -44,7 +44,7 @@ impl Command for Cp {
 
     fn signature(&self) -> Signature {
         Signature::build("cp")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("source", SyntaxShape::GlobPattern, "the place to copy from")
             .required("destination", SyntaxShape::Filepath, "the place to copy to")
             .switch(

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -20,7 +20,7 @@ impl Command for Glob {
 
     fn signature(&self) -> Signature {
         Signature::build("glob")
-            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::String)))])
+            .input_output_types(vec![(Type::Null, Type::List(Box::new(Type::String)))])
             .required("glob", SyntaxShape::String, "the glob expression")
             .named(
                 "depth",

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -450,7 +450,7 @@ pub(crate) fn dir_entry_dict(
         });
     } else {
         cols.push("type".into());
-        vals.push(Value::nothing(span));
+        vals.push(Value::null(span));
     }
 
     if long {
@@ -469,7 +469,7 @@ pub(crate) fn dir_entry_dict(
                     });
                 }
             } else {
-                vals.push(Value::nothing(span));
+                vals.push(Value::null(span));
             }
         }
     }
@@ -572,25 +572,25 @@ pub(crate) fn dir_entry_dict(
                     span,
                 });
             } else {
-                vals.push(Value::nothing(span));
+                vals.push(Value::null(span));
             }
         } else {
             let value = if zero_sized {
                 Value::Filesize { val: 0, span }
             } else {
-                Value::nothing(span)
+                Value::null(span)
             };
             vals.push(value);
         }
     } else {
-        vals.push(Value::nothing(span));
+        vals.push(Value::null(span));
     }
 
     if let Some(md) = metadata {
         if long {
             cols.push("created".to_string());
             {
-                let mut val = Value::nothing(span);
+                let mut val = Value::null(span);
                 if let Ok(c) = md.created() {
                     if let Some(local) = try_convert_to_local_date_time(c) {
                         val = Value::Date {
@@ -604,7 +604,7 @@ pub(crate) fn dir_entry_dict(
 
             cols.push("accessed".to_string());
             {
-                let mut val = Value::nothing(span);
+                let mut val = Value::null(span);
                 if let Ok(a) = md.accessed() {
                     if let Some(local) = try_convert_to_local_date_time(a) {
                         val = Value::Date {
@@ -619,7 +619,7 @@ pub(crate) fn dir_entry_dict(
 
         cols.push("modified".to_string());
         {
-            let mut val = Value::nothing(span);
+            let mut val = Value::null(span);
             if let Ok(m) = md.modified() {
                 if let Some(local) = try_convert_to_local_date_time(m) {
                     val = Value::Date {
@@ -633,14 +633,14 @@ pub(crate) fn dir_entry_dict(
     } else {
         if long {
             cols.push("created".to_string());
-            vals.push(Value::nothing(span));
+            vals.push(Value::null(span));
 
             cols.push("accessed".to_string());
-            vals.push(Value::nothing(span));
+            vals.push(Value::null(span));
         }
 
         cols.push("modified".to_string());
-        vals.push(Value::nothing(span));
+        vals.push(Value::null(span));
     }
 
     Ok(Value::Record { cols, vals, span })
@@ -747,7 +747,7 @@ mod windows_helper {
                     });
                 }
             } else {
-                vals.push(Value::nothing(span));
+                vals.push(Value::null(span));
             }
 
             cols.push("readonly".into());
@@ -767,7 +767,7 @@ mod windows_helper {
         if long {
             cols.push("created".to_string());
             {
-                let mut val = Value::nothing(span);
+                let mut val = Value::null(span);
                 let seconds_since_unix_epoch = unix_time_from_filetime(&find_data.ftCreationTime);
                 if let Some(local) = unix_time_to_local_date_time(seconds_since_unix_epoch) {
                     val = Value::Date {
@@ -780,7 +780,7 @@ mod windows_helper {
 
             cols.push("accessed".to_string());
             {
-                let mut val = Value::nothing(span);
+                let mut val = Value::null(span);
                 let seconds_since_unix_epoch = unix_time_from_filetime(&find_data.ftLastAccessTime);
                 if let Some(local) = unix_time_to_local_date_time(seconds_since_unix_epoch) {
                     val = Value::Date {
@@ -794,7 +794,7 @@ mod windows_helper {
 
         cols.push("modified".to_string());
         {
-            let mut val = Value::nothing(span);
+            let mut val = Value::null(span);
             let seconds_since_unix_epoch = unix_time_from_filetime(&find_data.ftLastWriteTime);
             if let Some(local) = unix_time_to_local_date_time(seconds_since_unix_epoch) {
                 val = Value::Date {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -37,7 +37,7 @@ impl Command for Ls {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("ls")
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             // Using a string instead of a glob pattern shape so it won't auto-expand
             .optional("pattern", SyntaxShape::String, "the glob pattern to use")
             .switch("all", "Show hidden files", Some('a'))

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -265,7 +265,7 @@ impl Command for Ls {
                         }),
                     }
                 }
-                _ => Some(Value::Nothing { span: call_span }),
+                _ => Some(Value::Null { span: call_span }),
             })
             .into_pipeline_data_with_metadata(
                 Box::new(PipelineMetadata {

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -19,7 +19,7 @@ impl Command for Mkdir {
 
     fn signature(&self) -> Signature {
         Signature::build("mkdir")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .rest(
                 "rest",
                 SyntaxShape::Directory,

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -35,7 +35,7 @@ impl Command for Mv {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("mv")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required(
                 "source",
                 SyntaxShape::GlobPattern,

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -67,7 +67,7 @@ impl Command for Open {
             path_params.insert(0, filename);
         } else {
             let filename = match input {
-                PipelineData::Value(Value::Nothing { .. }, ..) => {
+                PipelineData::Value(Value::Null { .. }, ..) => {
                     return Err(ShellError::MissingParameter {
                         param_name: "needs filename".to_string(),
                         span: call.head,

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -36,7 +36,7 @@ impl Command for Open {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("open")
-            .input_output_types(vec![(Type::Nothing, Type::Any), (Type::String, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any), (Type::String, Type::Any)])
             .optional("filename", SyntaxShape::Filepath, "the filename to use")
             .rest(
                 "filenames",

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -45,7 +45,7 @@ impl Command for Rm {
 
     fn signature(&self) -> Signature {
         let sig = Signature::build("rm")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required(
                 "filename",
                 SyntaxShape::Filepath,
@@ -467,7 +467,7 @@ fn rm(
                 }
             }
         })
-        .filter(|x| !matches!(x.get_type(), Type::Nothing))
+        .filter(|x| !matches!(x.get_type(), Type::Null))
         .into_pipeline_data(ctrlc)
         .print_not_formatted(engine_state, false, true)?;
 

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -440,7 +440,7 @@ fn rm(
                         let val = format!("{} {:}", msg, f.to_string_lossy());
                         Value::String { val, span }
                     } else {
-                        Value::Nothing { span }
+                        Value::Null { span }
                     }
                 } else {
                     let msg = format!("Cannot remove {:}. try --recursive", f.to_string_lossy());

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -39,7 +39,7 @@ impl Command for Save {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("save")
-            .input_output_types(vec![(Type::Any, Type::Nothing)])
+            .input_output_types(vec![(Type::Any, Type::Null)])
             .required("filename", SyntaxShape::Filepath, "the filename to use")
             .named(
                 "stderr",

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -25,7 +25,7 @@ impl Command for Start {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("start")
-            .input_output_types(vec![(Type::Nothing, Type::Any), (Type::String, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any), (Type::String, Type::Any)])
             .required("path", SyntaxShape::String, "path to open")
             .category(Category::FileSystem)
     }

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -25,7 +25,7 @@ impl Command for Touch {
 
     fn signature(&self) -> Signature {
         Signature::build("touch")
-            .input_output_types(vec![ (Type::Nothing, Type::Nothing) ])
+            .input_output_types(vec![ (Type::Null, Type::Null) ])
             .required(
                 "filename",
                 SyntaxShape::Filepath,

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -213,7 +213,7 @@ impl Command for Watch {
                         engine_state,
                         stack,
                         &block,
-                        Value::Nothing { span: call.span() }.into_pipeline_data(),
+                        Value::Null { span: call.span() }.into_pipeline_data(),
                         call.redirect_stdout,
                         call.redirect_stderr,
                     );

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -39,7 +39,7 @@ impl Command for Watch {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("watch")
-        .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+        .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .required("path", SyntaxShape::Filepath, "the path to watch. Can be a file or directory")
             .required("closure",
             SyntaxShape::Closure(Some(vec![SyntaxShape::String, SyntaxShape::String, SyntaxShape::String])),

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -95,7 +95,7 @@ pub fn compact(
         .filter(
             move |item| {
                 match item {
-                    // Nothing is filtered out
+                    // Null is filtered out
                     Value::Null { .. } => false,
                     Value::Record { .. } => {
                         for column in columns.iter() {
@@ -108,10 +108,10 @@ pub fn compact(
                                 }
                             }
                         }
-                        // No defined columns contained Nothing
+                        // No defined columns contained Null
                         true
                     }
-                    // Any non-Nothing, non-record should be kept
+                    // Any non-Null, non-record should be kept
                     _ => true,
                 }
             },

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -96,13 +96,13 @@ pub fn compact(
             move |item| {
                 match item {
                     // Nothing is filtered out
-                    Value::Nothing { .. } => false,
+                    Value::Null { .. } => false,
                     Value::Record { .. } => {
                         for column in columns.iter() {
                             match item.get_data_by_key(column) {
                                 None => return false,
                                 Some(x) => {
-                                    if let Value::Nothing { .. } = x {
+                                    if let Value::Null { .. } = x {
                                         return false;
                                     }
                                 }

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -65,7 +65,7 @@ impl Command for Compact {
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["Hello".into(), "World".into()],
-                        vals: vec![Value::nothing(Span::test_data()), Value::test_int(3)],
+                        vals: vec![Value::null(Span::test_data()), Value::test_int(3)],
                         span: Span::test_data(),
                     }],
                     span: Span::test_data(),

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -96,7 +96,7 @@ fn default(
                     while idx < cols.len() {
                         if cols[idx] == column.item {
                             found = true;
-                            if matches!(vals[idx], Value::Nothing { .. }) {
+                            if matches!(vals[idx], Value::Null { .. }) {
                                 vals[idx] = value.clone();
                             }
                         }
@@ -117,7 +117,7 @@ fn default(
     } else {
         input.map(
             move |item| match item {
-                Value::Nothing { .. } => value.clone(),
+                Value::Null { .. } => value.clone(),
                 x => x,
             },
             ctrlc,

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -57,11 +57,11 @@ with 'transpose' first."#
         let stream_test_1 = vec![Value::test_int(2), Value::test_int(4), Value::test_int(6)];
 
         let stream_test_2 = vec![
-            Value::Nothing {
+            Value::Null {
                 span: Span::test_data(),
             },
             Value::test_string("found 2!"),
-            Value::Nothing {
+            Value::Null {
                 span: Span::test_data(),
             },
         ];

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -246,7 +246,7 @@ with 'transpose' first."#
         }
         .and_then(|x| {
             x.filter(
-                move |x| if !keep_empty { !x.is_nothing() } else { true },
+                move |x| if !keep_empty { !x.is_null() } else { true },
                 outer_ctrlc,
             )
         })

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -166,7 +166,7 @@ with 'transpose' first."#
                         redirect_stderr,
                     ) {
                         Ok(v) => Some(v.into_value(span)),
-                        Err(ShellError::Continue(v)) => Some(Value::nothing(v)),
+                        Err(ShellError::Continue(v)) => Some(Value::null(v)),
                         Err(ShellError::Break(_)) => None,
                         Err(error) => {
                             let error = chain_error_with_input(error, input_span);
@@ -191,7 +191,7 @@ with 'transpose' first."#
 
                     let x = match x {
                         Ok(x) => x,
-                        Err(ShellError::Continue(v)) => return Some(Value::nothing(v)),
+                        Err(ShellError::Continue(v)) => return Some(Value::null(v)),
                         Err(ShellError::Break(_)) => return None,
                         Err(err) => {
                             return Some(Value::Error {
@@ -216,7 +216,7 @@ with 'transpose' first."#
                         redirect_stderr,
                     ) {
                         Ok(v) => Some(v.into_value(span)),
-                        Err(ShellError::Continue(v)) => Some(Value::nothing(v)),
+                        Err(ShellError::Continue(v)) => Some(Value::null(v)),
                         Err(ShellError::Break(_)) => None,
                         Err(error) => {
                             let error = Box::new(chain_error_with_input(error, input_span));

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -75,7 +75,7 @@ fn empty(
             for column in &columns {
                 let val = val.clone();
                 match val.follow_cell_path(&column.members, false) {
-                    Ok(Value::Nothing { .. }) => {}
+                    Ok(Value::Null { .. }) => {}
                     Ok(_) => return Ok(Value::bool(false, head).into_pipeline_data()),
                     Err(err) => return Err(err),
                 }

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -529,7 +529,7 @@ fn value_should_be_printed(
         | Value::Float { .. }
         | Value::Block { .. }
         | Value::Closure { .. }
-        | Value::Nothing { .. }
+        | Value::Null { .. }
         | Value::Error { .. } => term_equals_value(term, &lower_value, span),
         Value::String { .. }
         | Value::List { .. }

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -168,7 +168,7 @@ pub fn group_cell_path(
         let group_key = value
             .clone()
             .follow_cell_path(&column_name.members, false)?;
-        if matches!(group_key, Value::Nothing { .. }) {
+        if matches!(group_key, Value::Null { .. }) {
             continue; // likely the result of a failed optional access, ignore this value
         }
 

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -135,7 +135,7 @@ fn replace_headers(
 fn is_valid_header(value: &Value) -> bool {
     matches!(
         value,
-        Value::Nothing { span: _ }
+        Value::Null { span: _ }
             | Value::String { val: _, span: _ }
             | Value::Bool { val: _, span: _ }
             | Value::Float { val: _, span: _ }

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -187,7 +187,7 @@ fn insert(
                 if let Some(v) = input.next() {
                     pre_elems.push(v);
                 } else {
-                    pre_elems.push(Value::Nothing { span })
+                    pre_elems.push(Value::Null { span })
                 }
             }
 

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -316,9 +316,9 @@ fn join_rows(
                             if Some(key.as_ref()) == shared_join_key {
                                 this_row
                                     .get_data_by_key(key)
-                                    .unwrap_or_else(|| Value::nothing(span))
+                                    .unwrap_or_else(|| Value::null(span))
                             } else {
-                                Value::nothing(span)
+                                Value::null(span)
                             }
                         })
                         .collect();

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -78,7 +78,7 @@ fn length_col(
 
 fn length_row(call: &Call, input: PipelineData) -> Result<PipelineData, ShellError> {
     match input {
-        PipelineData::Value(Value::Nothing { .. }, ..) => {
+        PipelineData::Value(Value::Null { .. }, ..) => {
             Ok(Value::int(0, call.head).into_pipeline_data())
         }
         _ => {

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -293,7 +293,7 @@ impl Command for ParEach {
                 )
             }
         }
-        .and_then(|x| x.filter(|v| !v.is_nothing(), outer_ctrlc))
+        .and_then(|x| x.filter(|v| !v.is_null(), outer_ctrlc))
         .map(|res| res.set_metadata(metadata))
     }
 }

--- a/crates/nu-command/src/filters/range.rs
+++ b/crates/nu-command/src/filters/range.rs
@@ -99,10 +99,7 @@ impl Command for Range {
             };
 
             if from > to {
-                Ok(PipelineData::Value(
-                    Value::Nothing { span: call.head },
-                    None,
-                ))
+                Ok(PipelineData::Value(Value::Null { span: call.head }, None))
             } else {
                 let iter = v.into_iter().skip(from).take(to - from + 1);
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))
@@ -112,10 +109,7 @@ impl Command for Range {
             let to = rows_to as usize;
 
             if from > to {
-                Ok(PipelineData::Value(
-                    Value::Nothing { span: call.head },
-                    None,
-                ))
+                Ok(PipelineData::Value(Value::Null { span: call.head }, None))
             } else {
                 let iter = input.into_iter().skip(from).take(to - from + 1);
                 Ok(iter.into_pipeline_data(engine_state.ctrlc.clone()))

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -336,14 +336,14 @@ pub fn process(
 
         let left_res = match left_value {
             Some(left_res) => left_res,
-            None => Value::Nothing { span },
+            None => Value::Null { span },
         };
 
         let right_value = right.get_data_by_key(column);
 
         let right_res = match right_value {
             Some(right_res) => right_res,
-            None => Value::Nothing { span },
+            None => Value::Null { span },
         };
 
         let result = if insensitive {

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -307,14 +307,14 @@ pub fn transpose(
                             let new_val = match &vals[index] {
                                 Value::List { vals, span } => {
                                     let mut vals = vals.clone();
-                                    vals.push(Value::nothing(name));
+                                    vals.push(Value::null(name));
                                     Value::List {
                                         vals: vals.to_vec(),
                                         span: *span,
                                     }
                                 }
                                 v => Value::List {
-                                    vals: vec![v.clone(), Value::nothing(name)],
+                                    vals: vec![v.clone(), Value::null(name)],
                                     span: v.expect_span(),
                                 },
                             };
@@ -331,10 +331,10 @@ pub fn transpose(
                             cols.remove(index);
                             vals.remove(index);
                             cols.push(headers[column_num].clone());
-                            vals.push(Value::nothing(name));
+                            vals.push(Value::null(name));
                         } else if !cols.contains(&headers[column_num]) {
                             cols.push(headers[column_num].clone());
-                            vals.push(Value::nothing(name));
+                            vals.push(Value::null(name));
                         }
                     }
                 }

--- a/crates/nu-command/src/formats/from/command.rs
+++ b/crates/nu-command/src/formats/from/command.rs
@@ -18,7 +18,7 @@ impl Command for From {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("from")
             .category(Category::Formats)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -106,7 +106,7 @@ fn convert_nujson_to_value(value: &nu_json::Value, span: Span) -> Value {
         nu_json::Value::Bool(b) => Value::Bool { val: *b, span },
         nu_json::Value::F64(f) => Value::Float { val: *f, span },
         nu_json::Value::I64(i) => Value::Int { val: *i, span },
-        nu_json::Value::Null => Value::Nothing { span },
+        nu_json::Value::Null => Value::Null { span },
         nu_json::Value::Object(k) => {
             let mut cols = vec![];
             let mut vals = vec![];

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -103,7 +103,7 @@ impl Command for FromNuon {
                 expr: Expr::Nothing,
                 span: head,
                 custom_completion: None,
-                ty: Type::Nothing,
+                ty: Type::Null,
             }
         } else {
             let mut pipeline = block.pipelines.remove(0);
@@ -128,7 +128,7 @@ impl Command for FromNuon {
                     expr: Expr::Nothing,
                     span: head,
                     custom_completion: None,
-                    ty: Type::Nothing,
+                    ty: Type::Null,
                 }
             } else {
                 match pipeline.elements.remove(0) {

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -291,7 +291,7 @@ fn convert_to_value(
             "match blocks not supported in nuon".into(),
             expr.span,
         )),
-        Expr::Nothing => Ok(Value::Nothing { span }),
+        Expr::Nothing => Ok(Value::Null { span }),
         Expr::Operator(..) => Err(ShellError::OutsideSpannedLabeledError(
             original_text.to_string(),
             "Error when loading".into(),
@@ -302,19 +302,19 @@ fn convert_to_value(
             let from = if let Some(f) = from {
                 convert_to_value(*f, span, original_text)?
             } else {
-                Value::Nothing { span: expr.span }
+                Value::Null { span: expr.span }
             };
 
             let next = if let Some(s) = next {
                 convert_to_value(*s, span, original_text)?
             } else {
-                Value::Nothing { span: expr.span }
+                Value::Null { span: expr.span }
             };
 
             let to = if let Some(t) = to {
                 convert_to_value(*t, span, original_text)?
             } else {
-                Value::Nothing { span: expr.span }
+                Value::Null { span: expr.span }
             };
 
             Ok(Value::Range {

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -100,7 +100,7 @@ impl Command for FromNuon {
 
         let expr = if block.pipelines.is_empty() {
             Expression {
-                expr: Expr::Nothing,
+                expr: Expr::Null,
                 span: head,
                 custom_completion: None,
                 ty: Type::Null,
@@ -125,7 +125,7 @@ impl Command for FromNuon {
 
             if pipeline.elements.is_empty() {
                 Expression {
-                    expr: Expr::Nothing,
+                    expr: Expr::Null,
                     span: head,
                     custom_completion: None,
                     ty: Type::Null,
@@ -291,7 +291,7 @@ fn convert_to_value(
             "match blocks not supported in nuon".into(),
             expr.span,
         )),
-        Expr::Nothing => Ok(Value::Null { span }),
+        Expr::Null => Ok(Value::Null { span }),
         Expr::Operator(..) => Err(ShellError::OutsideSpannedLabeledError(
             original_text.to_string(),
             "Error when loading".into(),

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -141,12 +141,12 @@ fn from_ods(
                 let mut row_output = IndexMap::new();
                 for (i, cell) in row.iter().enumerate() {
                     let value = match cell {
-                        DataType::Empty => Value::nothing(head),
+                        DataType::Empty => Value::null(head),
                         DataType::String(s) => Value::string(s, head),
                         DataType::Float(f) => Value::float(*f, head),
                         DataType::Int(i) => Value::int(*i, head),
                         DataType::Bool(b) => Value::bool(*b, head),
-                        _ => Value::nothing(head),
+                        _ => Value::null(head),
                     };
 
                     row_output.insert(format!("column{i}"), value);

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -140,12 +140,12 @@ fn from_xlsx(
                 let mut row_output = IndexMap::new();
                 for (i, cell) in row.iter().enumerate() {
                     let value = match cell {
-                        DataType::Empty => Value::nothing(head),
+                        DataType::Empty => Value::null(head),
                         DataType::String(s) => Value::string(s, head),
                         DataType::Float(f) => Value::float(*f, head),
                         DataType::Int(i) => Value::int(*i, head),
                         DataType::Bool(b) => Value::bool(*b, head),
-                        _ => Value::nothing(head),
+                        _ => Value::null(head),
                     };
 
                     row_output.insert(format!("column{i}"), value);

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -88,8 +88,8 @@ string. This way content of every tag is always a table and is easier to parse"#
                                             COLUMN_CONTENT_NAME,
                                         ],
                                         vec![
-                                            Value::test_nothing(),
-                                            Value::test_nothing(),
+                                            Value::test_null(),
+                                            Value::test_null(),
                                             Value::test_string("Event"),
                                         ],
                                     )],

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -164,8 +164,8 @@ fn text_to_value(n: &roxmltree::Node, info: &ParsingInfo) -> Option<Value> {
         let mut node = IndexMap::new();
         let content = Value::string(String::from(text), span);
 
-        node.insert(String::from(COLUMN_TAG_NAME), Value::nothing(span));
-        node.insert(String::from(COLUMN_ATTRS_NAME), Value::nothing(span));
+        node.insert(String::from(COLUMN_TAG_NAME), Value::null(span));
+        node.insert(String::from(COLUMN_ATTRS_NAME), Value::null(span));
         node.insert(String::from(COLUMN_CONTENT_NAME), content);
 
         let result = Value::from(Spanned { item: node, span });
@@ -185,7 +185,7 @@ fn comment_to_value(n: &roxmltree::Node, info: &ParsingInfo) -> Option<Value> {
         let content = Value::string(String::from(text), span);
 
         node.insert(String::from(COLUMN_TAG_NAME), Value::string("!", span));
-        node.insert(String::from(COLUMN_ATTRS_NAME), Value::nothing(span));
+        node.insert(String::from(COLUMN_ATTRS_NAME), Value::null(span));
         node.insert(String::from(COLUMN_CONTENT_NAME), content);
 
         let result = Value::from(Spanned { item: node, span });
@@ -207,10 +207,10 @@ fn processing_instruction_to_value(n: &roxmltree::Node, info: &ParsingInfo) -> O
         let tag = Value::string(tag, span);
         let content = pi
             .value
-            .map_or_else(|| Value::nothing(span), |x| Value::string(x, span));
+            .map_or_else(|| Value::null(span), |x| Value::string(x, span));
 
         node.insert(String::from(COLUMN_TAG_NAME), tag);
-        node.insert(String::from(COLUMN_ATTRS_NAME), Value::nothing(span));
+        node.insert(String::from(COLUMN_ATTRS_NAME), Value::null(span));
         node.insert(String::from(COLUMN_CONTENT_NAME), content);
 
         let result = Value::from(Spanned { item: node, span });
@@ -373,8 +373,8 @@ mod tests {
     fn content_string(value: impl Into<String>) -> Value {
         Value::from(Spanned {
             item: indexmap! {
-                COLUMN_TAG_NAME.into() => Value::nothing(Span::test_data()),
-                COLUMN_ATTRS_NAME.into() => Value::nothing(Span::test_data()),
+                COLUMN_TAG_NAME.into() => Value::null(Span::test_data()),
+                COLUMN_ATTRS_NAME.into() => Value::null(Span::test_data()),
                 COLUMN_CONTENT_NAME.into() => string(value),
             },
             span: Span::test_data(),

--- a/crates/nu-command/src/formats/from/yaml.rs
+++ b/crates/nu-command/src/formats/from/yaml.rs
@@ -199,7 +199,7 @@ fn convert_yaml_value_to_nu_value(
 
             value
         }
-        serde_yaml::Value::Null => Value::nothing(span),
+        serde_yaml::Value::Null => Value::null(span),
         x => unimplemented!("Unsupported YAML case: {:?}", x),
     })
 }
@@ -224,7 +224,7 @@ pub fn from_yaml_string_to_value(
     }
 
     match documents.len() {
-        0 => Ok(Value::nothing(span)),
+        0 => Ok(Value::null(span)),
         1 => Ok(documents.remove(0)),
         _ => Ok(Value::List {
             vals: documents,

--- a/crates/nu-command/src/formats/to/command.rs
+++ b/crates/nu-command/src/formats/to/command.rs
@@ -18,7 +18,7 @@ impl Command for To {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("to")
             .category(Category::Formats)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -120,7 +120,7 @@ fn to_string_tagged_value(
         | Value::CellPath { .. }
         | Value::Float { .. } => Ok(v.clone().into_abbreviated_string(config)),
         Value::Date { val, .. } => Ok(val.to_string()),
-        Value::Nothing { .. } => Ok(String::new()),
+        Value::Null { .. } => Ok(String::new()),
         // Propagate existing errors
         Value::Error { error } => Err(*error.clone()),
         _ => Err(make_unsupported_input_error(v, head, span)),

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -113,7 +113,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
         Value::Date { val, .. } => nu_json::Value::String(val.to_string()),
         Value::Float { val, .. } => nu_json::Value::F64(*val),
         Value::Int { val, .. } => nu_json::Value::I64(*val),
-        Value::Nothing { .. } => nu_json::Value::Null,
+        Value::Null { .. } => nu_json::Value::Null,
         Value::String { val, .. } => nu_json::Value::String(val.to_string()),
         Value::CellPath { val, .. } => nu_json::Value::Array(
             val.members

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -170,7 +170,7 @@ fn table(input: PipelineData, pretty: bool, config: &Config) -> String {
                 for i in 0..headers.len() {
                     let data = row.get_data_by_key(&headers[i]);
                     let value_string = data
-                        .unwrap_or_else(|| Value::nothing(span))
+                        .unwrap_or_else(|| Value::null(span))
                         .into_string(", ", config);
                     let new_column_width = value_string.len();
 
@@ -222,7 +222,7 @@ pub fn group_by(values: PipelineData, head: Span, config: &Config) -> (PipelineD
     let mut output = vec![];
     for (_, mut value) in lists {
         if value.len() == 1 {
-            output.push(value.pop().unwrap_or_else(|| Value::nothing(head)))
+            output.push(value.pop().unwrap_or_else(|| Value::null(head)))
         } else {
             output.push(Value::List {
                 vals: value.to_vec(),

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -248,7 +248,7 @@ pub fn value_to_string(
             span,
             v.expect_span(),
         )),
-        Value::Nothing { .. } => Ok("null".to_string()),
+        Value::Null { .. } => Ok("null".to_string()),
         Value::Range { val, .. } => Ok(format!(
             "{}..{}{}",
             value_to_string(&val.from, span, depth + 1, indent)?,

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -148,7 +148,7 @@ fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
         },
         Value::Block { val, .. } => format!("<Block {val}>"),
         Value::Closure { val, .. } => format!("<Closure {val}>"),
-        Value::Nothing { .. } => String::new(),
+        Value::Null { .. } => String::new(),
         Value::Error { error } => format!("{error:?}"),
         Value::Binary { val, .. } => format!("{val:?}"),
         Value::CellPath { val, .. } => val.into_string(),

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -76,7 +76,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
             let code = String::from_utf8_lossy(code).to_string();
             toml::Value::String(code)
         }
-        Value::Null { .. } => toml::Value::String("<Nothing>".to_string()),
+        Value::Null { .. } => toml::Value::String("<null>".to_string()),
         Value::Error { error } => return Err(*error.clone()),
         Value::Binary { val, .. } => toml::Value::Array(
             val.iter()

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -191,7 +191,7 @@ mod tests {
 
         let mut m = indexmap::IndexMap::new();
         m.insert("rust".to_owned(), Value::test_string("editor"));
-        m.insert("is".to_owned(), Value::nothing(Span::test_data()));
+        m.insert("is".to_owned(), Value::null(Span::test_data()));
         m.insert(
             "features".to_owned(),
             Value::List {

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -76,7 +76,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
             let code = String::from_utf8_lossy(code).to_string();
             toml::Value::String(code)
         }
-        Value::Nothing { .. } => toml::Value::String("<Nothing>".to_string()),
+        Value::Null { .. } => toml::Value::String("<Nothing>".to_string()),
         Value::Error { error } => return Err(*error.clone()),
         Value::Binary { val, .. } => toml::Value::Array(
             val.iter()

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -122,13 +122,13 @@ fn to_xml_entry<W: Write>(
     // of longer {tag: a attributes: {} content: [...]}
     let tag = entry
         .get_data_by_key(COLUMN_TAG_NAME)
-        .unwrap_or_else(|| Value::nothing(Span::unknown()));
+        .unwrap_or_else(|| Value::null(Span::unknown()));
     let attrs = entry
         .get_data_by_key(COLUMN_ATTRS_NAME)
-        .unwrap_or_else(|| Value::nothing(Span::unknown()));
+        .unwrap_or_else(|| Value::null(Span::unknown()));
     let content = entry
         .get_data_by_key(COLUMN_CONTENT_NAME)
-        .unwrap_or_else(|| Value::nothing(Span::unknown()));
+        .unwrap_or_else(|| Value::null(Span::unknown()));
 
     match (tag, attrs, content) {
         (Value::Nothing { .. }, Value::Nothing { .. }, Value::String { val, span }) => {

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -131,7 +131,7 @@ fn to_xml_entry<W: Write>(
         .unwrap_or_else(|| Value::null(Span::unknown()));
 
     match (tag, attrs, content) {
-        (Value::Nothing { .. }, Value::Nothing { .. }, Value::String { val, span }) => {
+        (Value::Null { .. }, Value::Null { .. }, Value::String { val, span }) => {
             // Strings can not appear on top level of document
             if top_level {
                 return Err(ShellError::CantConvert {
@@ -192,7 +192,7 @@ fn to_tag_like<W: Write>(
 
         let content: String = match content {
             Value::String { val, .. } => val,
-            Value::Nothing { .. } => "".into(),
+            Value::Null { .. } => "".into(),
             _ => {
                 return Err(ShellError::CantConvert {
                     to_type: "XML".into(),
@@ -210,7 +210,7 @@ fn to_tag_like<W: Write>(
         // content: null}, {tag: a}. See to_xml_entry for more
         let (attr_cols, attr_values) = match attrs {
             Value::Record { cols, vals, .. } => (cols, vals),
-            Value::Nothing { .. } => (Vec::new(), Vec::new()),
+            Value::Null { .. } => (Vec::new(), Vec::new()),
             _ => {
                 return Err(ShellError::CantConvert {
                     to_type: "XML".into(),
@@ -223,7 +223,7 @@ fn to_tag_like<W: Write>(
 
         let content = match content {
             Value::List { vals, .. } => vals,
-            Value::Nothing { .. } => Vec::new(),
+            Value::Null { .. } => Vec::new(),
             _ => {
                 return Err(ShellError::CantConvert {
                     to_type: "XML".into(),
@@ -253,7 +253,7 @@ fn to_comment<W: Write>(
     writer: &mut quick_xml::Writer<W>,
 ) -> Result<(), ShellError> {
     match (attrs, content) {
-        (Value::Nothing { .. }, Value::String { val, .. }) => {
+        (Value::Null { .. }, Value::String { val, .. }) => {
             let comment_content = BytesText::new(val.as_str());
             writer
                 .write_event(Event::Comment(comment_content))
@@ -280,7 +280,7 @@ fn to_processing_instruction<W: Write>(
     content: String,
     writer: &mut quick_xml::Writer<W>,
 ) -> Result<(), ShellError> {
-    if !matches!(attrs, Value::Nothing { .. }) {
+    if !matches!(attrs, Value::Null { .. }) {
         return Err(ShellError::CantConvert {
             to_type: "XML".into(),
             from_type: Type::Record(vec![]).to_string(),

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -78,7 +78,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
         }
         Value::Block { .. } => serde_yaml::Value::Null,
         Value::Closure { .. } => serde_yaml::Value::Null,
-        Value::Nothing { .. } => serde_yaml::Value::Null,
+        Value::Null { .. } => serde_yaml::Value::Null,
         Value::Error { error } => return Err(*error.clone()),
         Value::Binary { val, .. } => serde_yaml::Value::Sequence(
             val.iter()

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -339,7 +339,7 @@ fn add_month_to_table(
             let should_add_day_number_to_table =
                 (day_number > total_start_offset) && (day_number <= day_limit);
 
-            let mut value = Value::Nothing { span: tag };
+            let mut value = Value::Null { span: tag };
 
             if should_add_day_number_to_table {
                 let adjusted_day_number = day_number - total_start_offset;

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -48,7 +48,7 @@ impl Command for Cal {
                 "Display the month names instead of integers",
                 None,
             )
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .allow_variants_without_examples(true) // TODO: supply exhaustive examples
             .category(Category::Generators)
     }

--- a/crates/nu-command/src/generators/seq.rs
+++ b/crates/nu-command/src/generators/seq.rs
@@ -16,7 +16,7 @@ impl Command for Seq {
 
     fn signature(&self) -> Signature {
         Signature::build("seq")
-            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::Number)))])
+            .input_output_types(vec![(Type::Null, Type::List(Box::new(Type::Number)))])
             .rest("rest", SyntaxShape::Number, "sequence values")
             .category(Category::Generators)
     }

--- a/crates/nu-command/src/generators/seq_char.rs
+++ b/crates/nu-command/src/generators/seq_char.rs
@@ -19,7 +19,7 @@ impl Command for SeqChar {
 
     fn signature(&self) -> Signature {
         Signature::build("seq char")
-            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::String)))])
+            .input_output_types(vec![(Type::Null, Type::List(Box::new(Type::String)))])
             .required(
                 "start",
                 SyntaxShape::String,

--- a/crates/nu-command/src/generators/seq_date.rs
+++ b/crates/nu-command/src/generators/seq_date.rs
@@ -22,7 +22,7 @@ impl Command for SeqDate {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("seq date")
-            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::String)))])
+            .input_output_types(vec![(Type::Null, Type::List(Box::new(Type::String)))])
             .named(
                 "output-format",
                 SyntaxShape::String,

--- a/crates/nu-command/src/hash/hash_.rs
+++ b/crates/nu-command/src/hash/hash_.rs
@@ -14,7 +14,7 @@ impl Command for Hash {
     fn signature(&self) -> Signature {
         Signature::build("hash")
             .category(Category::Hash)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -20,7 +20,7 @@ impl Command for Help {
 
     fn signature(&self) -> Signature {
         Signature::build("help")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .rest(
                 "rest",
                 SyntaxShape::String,

--- a/crates/nu-command/src/help/help_aliases.rs
+++ b/crates/nu-command/src/help/help_aliases.rs
@@ -34,7 +34,7 @@ impl Command for HelpAliases {
                 "string to find in alias names and usage",
                 Some('f'),
             )
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-command/src/help/help_commands.rs
+++ b/crates/nu-command/src/help/help_commands.rs
@@ -35,7 +35,7 @@ impl Command for HelpCommands {
                 "string to find in command names, usage, and search terms",
                 Some('f'),
             )
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-command/src/help/help_externs.rs
+++ b/crates/nu-command/src/help/help_externs.rs
@@ -34,7 +34,7 @@ impl Command for HelpExterns {
                 "string to find in extern names and usage",
                 Some('f'),
             )
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-command/src/help/help_modules.rs
+++ b/crates/nu-command/src/help/help_modules.rs
@@ -40,7 +40,7 @@ are also available in the current scope. Commands/aliases that were imported und
                 "string to find in module names and usage",
                 Some('f'),
             )
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-command/src/help/help_operators.rs
+++ b/crates/nu-command/src/help/help_operators.rs
@@ -19,7 +19,7 @@ impl Command for HelpOperators {
     fn signature(&self) -> Signature {
         Signature::build("help operators")
             .category(Category::Core)
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-command/src/math/math_.rs
+++ b/crates/nu-command/src/math/math_.rs
@@ -16,7 +16,7 @@ impl Command for MathCommand {
     fn signature(&self) -> Signature {
         Signature::build("math")
             .category(Category::Math)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -62,7 +62,7 @@ impl Command for SubCommand {
 
 pub fn maximum(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let max_func = reducer_for(Reduce::Maximum);
-    max_func(Value::nothing(head), values.to_vec(), span, head)
+    max_func(Value::null(head), values.to_vec(), span, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -67,7 +67,7 @@ impl Command for SubCommand {
 
 pub fn minimum(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let min_func = reducer_for(Reduce::Minimum);
-    min_func(Value::nothing(head), values.to_vec(), span, head)
+    min_func(Value::null(head), values.to_vec(), span, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -48,7 +48,7 @@ impl Command for SubCommand {
 /// Calculate product of given values
 pub fn product(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let product_func = reducer_for(Reduce::Product);
-    product_func(Value::nothing(head), values.to_vec(), span, head)
+    product_func(Value::null(head), values.to_vec(), span, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -101,7 +101,7 @@ pub fn sum(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
             head,
             span,
         )),
-        _ => Ok(Value::nothing(head)),
+        _ => Ok(Value::null(head)),
     }?;
 
     for value in &data {
@@ -137,7 +137,7 @@ pub fn product(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellE
             head,
             span,
         )),
-        _ => Ok(Value::nothing(head)),
+        _ => Ok(Value::null(head)),
     }?;
 
     for value in &data {

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -61,7 +61,7 @@ impl Command for SubCommand {
 
 pub fn summation(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
     let sum_func = reducer_for(Reduce::Summation);
-    sum_func(Value::nothing(head), values.to_vec(), span, head)
+    sum_func(Value::null(head), values.to_vec(), span, head)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -17,7 +17,7 @@ impl Command for Tutor {
 
     fn signature(&self) -> Signature {
         Signature::build("tutor")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .allow_variants_without_examples(true)
             .optional(
                 "search",

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -496,7 +496,7 @@ fn request_handle_response_content(
             vals: vec![
                 match response_headers {
                     Some(headers) => headers.into_value(span),
-                    None => Value::nothing(span),
+                    None => Value::null(span),
                 },
                 formatted_content?.into_value(span),
                 Value::int(response_status as i64, span),

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http delete")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "URL",

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http get")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "URL",

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -23,7 +23,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http head")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "URL",

--- a/crates/nu-command/src/network/http/http_.rs
+++ b/crates/nu-command/src/network/http/http_.rs
@@ -15,7 +15,7 @@ impl Command for Http {
 
     fn signature(&self) -> Signature {
         Signature::build("http")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .category(Category::Network)
     }
 

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http options")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "URL",

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http patch")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .required("URL", SyntaxShape::String, "the URL to post to")
             .required("data", SyntaxShape::Any, "the contents of the post body")

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http post")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .required("URL", SyntaxShape::String, "the URL to post to")
             .required("data", SyntaxShape::Any, "the contents of the post body")

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http put")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .required("URL", SyntaxShape::String, "the URL to post to")
             .required("data", SyntaxShape::Any, "the contents of the post body")

--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -18,7 +18,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("port")
-            .input_output_types(vec![(Type::Nothing, Type::Int)])
+            .input_output_types(vec![(Type::Null, Type::Int)])
             .optional(
                 "start",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/network/url/url_.rs
+++ b/crates/nu-command/src/network/url/url_.rs
@@ -15,7 +15,7 @@ impl Command for Url {
 
     fn signature(&self) -> Signature {
         Signature::build("url")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .category(Category::Network)
     }
 

--- a/crates/nu-command/src/path/mod.rs
+++ b/crates/nu-command/src/path/mod.rs
@@ -54,7 +54,7 @@ fn err_from_value(rest: &Value, name: Span) -> ShellError {
             if rest.is_null() {
                 ShellError::OnlySupportsThisInputType {
                     exp_input_type: "string, record or list".into(),
-                    wrong_type: "nothing".into(),
+                    wrong_type: "null".into(),
                     dst_span: name,
                     src_span: span,
                 }

--- a/crates/nu-command/src/path/mod.rs
+++ b/crates/nu-command/src/path/mod.rs
@@ -51,7 +51,7 @@ fn handle_invalid_values(rest: Value, name: Span) -> Value {
 fn err_from_value(rest: &Value, name: Span) -> ShellError {
     match rest.span() {
         Ok(span) => {
-            if rest.is_nothing() {
+            if rest.is_null() {
                 ShellError::OnlySupportsThisInputType {
                     exp_input_type: "string, record or list".into(),
                     wrong_type: "nothing".into(),

--- a/crates/nu-command/src/path/path_.rs
+++ b/crates/nu-command/src/path/path_.rs
@@ -15,7 +15,7 @@ impl Command for PathCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("path")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .category(Category::Path)
     }
 

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -508,8 +508,8 @@ impl Command for AnsiCommand {
     fn signature(&self) -> Signature {
         Signature::build("ansi")
             .input_output_types(vec![
-                (Type::Nothing, Type::String),
-                (Type::Nothing, Type::Table(vec![]))])
+                (Type::Null, Type::String),
+                (Type::Null, Type::Table(vec![]))])
             .optional(
                 "code",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -49,7 +49,7 @@ impl Command for Clear {
                 .map_err(|e| ShellError::IOErrorSpanned(e.to_string(), span))?;
         }
 
-        Ok(Value::Nothing { span }.into_pipeline_data())
+        Ok(Value::Null { span }.into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -20,7 +20,7 @@ impl Command for Clear {
     fn signature(&self) -> Signature {
         Signature::build("clear")
             .category(Category::Platform)
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
     }
 
     fn run(

--- a/crates/nu-command/src/platform/dir_info.rs
+++ b/crates/nu-command/src/platform/dir_info.rs
@@ -255,13 +255,13 @@ impl From<FileInfo> for Value {
         });
 
         cols.push("directories".into());
-        vals.push(Value::nothing(Span::unknown()));
+        vals.push(Value::null(Span::unknown()));
 
         cols.push("files".into());
-        vals.push(Value::nothing(Span::unknown()));
+        vals.push(Value::null(Span::unknown()));
 
         // cols.push("errors".into());
-        // vals.push(Value::nothing(Span::unknown()));
+        // vals.push(Value::null(Span::unknown()));
 
         Value::Record {
             cols,
@@ -276,7 +276,7 @@ where
     V: Into<Value>,
 {
     if vec.is_empty() {
-        Value::nothing(tag)
+        Value::null(tag)
     } else {
         let values = vec.into_iter().map(Into::into).collect::<Vec<Value>>();
         Value::List {

--- a/crates/nu-command/src/platform/du.rs
+++ b/crates/nu-command/src/platform/du.rs
@@ -43,7 +43,7 @@ impl Command for Du {
 
     fn signature(&self) -> Signature {
         Signature::build("du")
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
             .optional("path", SyntaxShape::GlobPattern, "starting directory")
             .switch(

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -27,10 +27,7 @@ impl Command for Input {
 
     fn signature(&self) -> Signature {
         Signature::build("input")
-            .input_output_types(vec![
-                (Type::Nothing, Type::String),
-                (Type::Nothing, Type::Binary),
-            ])
+            .input_output_types(vec![(Type::Null, Type::String), (Type::Null, Type::Binary)])
             .allow_variants_without_examples(true)
             .optional("prompt", SyntaxShape::String, "prompt to show the user")
             .named(

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -39,7 +39,7 @@ impl Command for InputListen {
                 Some('r'),
             )
             .input_output_types(vec![(
-                Type::Nothing,
+                Type::Null,
                 Type::Record(vec![
                     ("keycode".to_string(), Type::String),
                     ("modifiers".to_string(), Type::List(Box::new(Type::String))),

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -21,7 +21,7 @@ impl Command for Kill {
 
     fn signature(&self) -> Signature {
         let signature = Signature::build("kill")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "pid",

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -172,7 +172,7 @@ impl Command for Kill {
                 .trim_end(),
         );
         if val.is_empty() {
-            Ok(Value::Nothing { span: call.head }.into_pipeline_data())
+            Ok(Value::Null { span: call.head }.into_pipeline_data())
         } else {
             Ok(vec![Value::String {
                 val,

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -66,7 +66,7 @@ impl Command for Sleep {
             }
         }
 
-        Ok(Value::Nothing { span: call.head }.into_pipeline_data())
+        Ok(Value::Null { span: call.head }.into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -74,7 +74,7 @@ impl Command for Sleep {
             Example {
                 description: "Sleep for 1sec",
                 example: "sleep 1sec",
-                result: Some(Value::Nothing {
+                result: Some(Value::Null {
                     span: Span::test_data(),
                 }),
             },

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -26,7 +26,7 @@ impl Command for Sleep {
 
     fn signature(&self) -> Signature {
         Signature::build("sleep")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .required("duration", SyntaxShape::Duration, "time to sleep")
             .rest("rest", SyntaxShape::Duration, "additional time")
             .category(Category::Platform)

--- a/crates/nu-command/src/platform/term_size.rs
+++ b/crates/nu-command/src/platform/term_size.rs
@@ -21,7 +21,7 @@ impl Command for TermSize {
         Signature::build("term size")
             .category(Category::Platform)
             .input_output_types(vec![(
-                Type::Nothing,
+                Type::Null,
                 Type::Record(vec![
                     ("columns".into(), Type::Int),
                     ("rows".into(), Type::Int),

--- a/crates/nu-command/src/random/bool.rs
+++ b/crates/nu-command/src/random/bool.rs
@@ -16,7 +16,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random bool")
-            .input_output_types(vec![(Type::Nothing, Type::Bool)])
+            .input_output_types(vec![(Type::Null, Type::Bool)])
             .allow_variants_without_examples(true)
             .named(
                 "bias",

--- a/crates/nu-command/src/random/chars.rs
+++ b/crates/nu-command/src/random/chars.rs
@@ -21,7 +21,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random chars")
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .allow_variants_without_examples(true)
             .named("length", SyntaxShape::Int, "Number of chars", Some('l'))
             .category(Category::Random)

--- a/crates/nu-command/src/random/decimal.rs
+++ b/crates/nu-command/src/random/decimal.rs
@@ -17,7 +17,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random decimal")
-            .input_output_types(vec![(Type::Nothing, Type::Float)])
+            .input_output_types(vec![(Type::Null, Type::Float)])
             .allow_variants_without_examples(true)
             .optional("range", SyntaxShape::Range, "Range of values")
             .category(Category::Random)

--- a/crates/nu-command/src/random/dice.rs
+++ b/crates/nu-command/src/random/dice.rs
@@ -16,7 +16,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random dice")
-            .input_output_types(vec![(Type::Nothing, Type::ListStream)])
+            .input_output_types(vec![(Type::Null, Type::ListStream)])
             .allow_variants_without_examples(true)
             .named(
                 "dice",

--- a/crates/nu-command/src/random/integer.rs
+++ b/crates/nu-command/src/random/integer.rs
@@ -17,7 +17,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("random integer")
-            .input_output_types(vec![(Type::Nothing, Type::Int)])
+            .input_output_types(vec![(Type::Null, Type::Int)])
             .allow_variants_without_examples(true)
             .optional("range", SyntaxShape::Range, "Range of values")
             .category(Category::Random)

--- a/crates/nu-command/src/random/random_.rs
+++ b/crates/nu-command/src/random/random_.rs
@@ -16,7 +16,7 @@ impl Command for RandomCommand {
     fn signature(&self) -> Signature {
         Signature::build("random")
             .category(Category::Random)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/random/uuid.rs
+++ b/crates/nu-command/src/random/uuid.rs
@@ -14,7 +14,7 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("random uuid")
             .category(Category::Random)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
             .allow_variants_without_examples(true)
     }
 

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -13,7 +13,7 @@ impl Command for Exit {
 
     fn signature(&self) -> Signature {
         Signature::build("exit")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![(Type::Null, Type::Null)])
             .optional(
                 "exit_code",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -177,14 +177,14 @@ pub fn compare(
 
         let left_res = match left_value {
             Some(left_res) => left_res,
-            None => Value::Nothing { span },
+            None => Value::Null { span },
         };
 
         let right_value = right.get_data_by_key(column);
 
         let right_res = match right_value {
             Some(right_res) => right_res,
-            None => Value::Nothing { span },
+            None => Value::Null { span },
         };
 
         let result = if insensitive {

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -95,7 +95,7 @@ pub fn sort(
                 for col in &sort_columns {
                     let val = item
                         .get_data_by_key(col)
-                        .unwrap_or_else(|| Value::nothing(Span::unknown()));
+                        .unwrap_or_else(|| Value::null(Span::unknown()));
                     vals.push(val);
                 }
             }

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -158,8 +158,8 @@ impl Command for Char {
     fn signature(&self) -> Signature {
         Signature::build("char")
             .input_output_types(vec![
-                (Type::Nothing, Type::String),
-                (Type::Nothing, Type::Table(vec![])),
+                (Type::Null, Type::String),
+                (Type::Null, Type::Table(vec![])),
             ])
             .optional(
                 "character",

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -181,7 +181,7 @@ fn detect_columns(
                     }
 
                     if !found {
-                        pre_output.push((header.item.to_string(), Value::nothing(name_span)));
+                        pre_output.push((header.item.to_string(), Value::null(name_span)));
                     }
                 }
 

--- a/crates/nu-command/src/strings/split/command.rs
+++ b/crates/nu-command/src/strings/split/command.rs
@@ -16,7 +16,7 @@ impl Command for SplitCommand {
     fn signature(&self) -> Signature {
         Signature::build("split")
             .category(Category::Strings)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/strings/str_/case/str_.rs
+++ b/crates/nu-command/src/strings/str_/case/str_.rs
@@ -16,7 +16,7 @@ impl Command for Str {
     fn signature(&self) -> Signature {
         Signature::build("str")
             .category(Category::Strings)
-            .input_output_types(vec![(Type::Nothing, Type::String)])
+            .input_output_types(vec![(Type::Null, Type::String)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -268,7 +268,7 @@ mod tests {
                 val: 1,
                 span: Span::test_data(),
             },
-            to: Value::Nothing {
+            to: Value::Null {
                 span: Span::test_data(),
             },
             inclusion: RangeInclusion::Inclusive,
@@ -291,7 +291,7 @@ mod tests {
     fn index_does_not_exist_due_to_end_index() {
         let word = Value::test_string("Cargo.Banana");
         let range = Range {
-            from: Value::Nothing {
+            from: Value::Null {
                 span: Span::test_data(),
             },
             inclusion: RangeInclusion::Inclusive,

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -17,7 +17,7 @@ impl Command for Exec {
 
     fn signature(&self) -> Signature {
         Signature::build("exec")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .required("command", SyntaxShape::String, "the command to execute")
             .allows_unknown_args()
             .category(Category::System)

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -17,7 +17,7 @@ impl Command for Ps {
 
     fn signature(&self) -> Signature {
         Signature::build("ps")
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .switch(
                 "long",
                 "list all available columns for each entry",

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -158,7 +158,7 @@ fn registry_query(
                     )),
                 }
             }
-            None => Ok(Value::nothing(call_span).into_pipeline_data()),
+            None => Ok(Value::null(call_span).into_pipeline_data()),
         }
     }
 }
@@ -222,7 +222,7 @@ fn reg_value_to_nu_value(
     call_span: Span,
 ) -> (nu_protocol::Value, winreg::enums::RegType) {
     match reg_value.vtype {
-        REG_NONE => (Value::nothing(call_span), reg_value.vtype),
+        REG_NONE => (Value::null(call_span), reg_value.vtype),
         REG_SZ => (
             Value::string(clean_string(&reg_value.to_string()), call_span),
             reg_value.vtype,

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -31,7 +31,7 @@ impl Command for RegistryQuery {
 
     fn signature(&self) -> Signature {
         Signature::build("registry query")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Null, Type::Any)])
             .switch("hkcr", "query the hkey_classes_root hive", None)
             .switch("hkcu", "query the hkey_current_user hive", None)
             .switch("hklm", "query the hkey_local_machine hive", None)

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -393,7 +393,7 @@ impl ExternalCommand {
                 }
             }
             Ok(mut child) => {
-                if !input.is_nothing() {
+                if !input.is_null() {
                     let mut engine_state = engine_state.clone();
                     let mut stack = stack.clone();
 
@@ -632,7 +632,7 @@ impl ExternalCommand {
 
         // If there is an input from the pipeline. The stdin from the process
         // is piped so it can be used to send the input information
-        if !input.is_nothing() {
+        if !input.is_null() {
             process.stdin(Stdio::piped());
         }
 

--- a/crates/nu-command/src/system/sys.rs
+++ b/crates/nu-command/src/system/sys.rs
@@ -23,7 +23,7 @@ impl Command for Sys {
         Signature::build("sys")
             .filter()
             .category(Category::System)
-            .input_output_types(vec![(Type::Nothing, Type::Record(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Record(vec![]))])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -21,7 +21,7 @@ impl Command for Which {
 
     fn signature(&self) -> Signature {
         Signature::build("which")
-            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Null, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
             .required("application", SyntaxShape::String, "application")
             .rest("rest", SyntaxShape::String, "additional applications")

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -385,9 +385,9 @@ fn help_alias_before_command() {
 fn nothing_type_annotation() {
     let actual = nu!(pipeline(
         "
-        def foo []: nothing -> nothing {};
+        def foo []: null -> null {};
         help commands | where name == foo | get input_output.0.output.0
     "
     ));
-    assert_eq!(actual.out, "nothing");
+    assert_eq!(actual.out, "null");
 }

--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -101,7 +101,7 @@ fn table_to_json_text() {
 
 #[test]
 fn top_level_values_from_json() {
-    for (value, type_name) in [("null", "nothing"), ("true", "bool"), ("false", "bool")] {
+    for (value, type_name) in [("null", "null"), ("true", "bool"), ("false", "bool")] {
         let actual = nu!(r#""{}" | from json | to json"#, value);
         assert_eq!(actual.out, value);
         let actual = nu!(r#""{}" | from json | describe"#, value);

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -84,7 +84,7 @@ pub fn eval_call(
             } else if let Some(value) = &param.default_value {
                 callee_stack.add_var(var_id, value.to_owned());
             } else {
-                callee_stack.add_var(var_id, Value::nothing(call.head));
+                callee_stack.add_var(var_id, Value::null(call.head));
             }
         }
 
@@ -492,7 +492,7 @@ pub fn eval_expression(
                             let var_info = engine_state.get_var(*var_id);
                             if var_info.mutable {
                                 stack.add_var(*var_id, rhs);
-                                Ok(Value::nothing(lhs.span))
+                                Ok(Value::null(lhs.span))
                             } else {
                                 Err(ShellError::AssignmentRequiresMutableVar { lhs_span: lhs.span })
                             }
@@ -544,7 +544,7 @@ pub fn eval_expression(
                                         } else {
                                             stack.add_var(*var_id, lhs);
                                         }
-                                        Ok(Value::nothing(cell_path.head.span))
+                                        Ok(Value::null(cell_path.head.span))
                                     } else {
                                         Err(ShellError::AssignmentRequiresMutableVar {
                                             lhs_span: lhs.span,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -33,7 +33,7 @@ pub fn eval_call(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     if nu_utils::ctrl_c::was_pressed(&engine_state.ctrlc) {
-        return Ok(Value::Nothing { span: call.head }.into_pipeline_data());
+        return Ok(Value::Null { span: call.head }.into_pipeline_data());
     }
     let decl = engine_state.get_decl(call.decl_id);
 
@@ -153,7 +153,7 @@ pub fn eval_call(
                     } else if let Some(value) = named.default_value {
                         callee_stack.add_var(var_id, value);
                     } else {
-                        callee_stack.add_var(var_id, Value::Nothing { span: call.head })
+                        callee_stack.add_var(var_id, Value::Null { span: call.head })
                     }
                 }
             }
@@ -303,19 +303,19 @@ pub fn eval_expression(
             let from = if let Some(f) = from {
                 eval_expression(engine_state, stack, f)?
             } else {
-                Value::Nothing { span: expr.span }
+                Value::Null { span: expr.span }
             };
 
             let next = if let Some(s) = next {
                 eval_expression(engine_state, stack, s)?
             } else {
-                Value::Nothing { span: expr.span }
+                Value::Null { span: expr.span }
             };
 
             let to = if let Some(t) = to {
                 eval_expression(engine_state, stack, t)?
             } else {
-                Value::Nothing { span: expr.span }
+                Value::Null { span: expr.span }
             };
 
             Ok(Value::Range {
@@ -324,7 +324,7 @@ pub fn eval_expression(
             })
         }
         Expr::Var(var_id) => eval_variable(engine_state, stack, *var_id, expr.span),
-        Expr::VarDecl(_) => Ok(Value::Nothing { span: expr.span }),
+        Expr::VarDecl(_) => Ok(Value::Null { span: expr.span }),
         Expr::CellPath(cell_path) => Ok(Value::CellPath {
             val: cell_path.clone(),
             span: expr.span,
@@ -334,7 +334,7 @@ pub fn eval_expression(
 
             value.follow_cell_path(&cell_path.tail, false)
         }
-        Expr::ImportPattern(_) => Ok(Value::Nothing { span: expr.span }),
+        Expr::ImportPattern(_) => Ok(Value::Null { span: expr.span }),
         Expr::Overlay(_) => {
             let name =
                 String::from_utf8_lossy(engine_state.get_span_contents(expr.span)).to_string();
@@ -366,12 +366,12 @@ pub fn eval_expression(
             val: *dt,
             span: expr.span,
         }),
-        Expr::Operator(_) => Ok(Value::Nothing { span: expr.span }),
+        Expr::Operator(_) => Ok(Value::Null { span: expr.span }),
         Expr::MatchPattern(pattern) => Ok(Value::MatchPattern {
             val: pattern.clone(),
             span: expr.span,
         }),
-        Expr::MatchBlock(_) => Ok(Value::Nothing { span: expr.span }), // match blocks are handled by `match`
+        Expr::MatchBlock(_) => Ok(Value::Null { span: expr.span }), // match blocks are handled by `match`
         Expr::UnaryNot(expr) => {
             let lhs = eval_expression(engine_state, stack, expr)?;
             match lhs {
@@ -689,9 +689,9 @@ pub fn eval_expression(
 
             Ok(Value::string(path.to_string_lossy(), expr.span))
         }
-        Expr::Signature(_) => Ok(Value::Nothing { span: expr.span }),
-        Expr::Garbage => Ok(Value::Nothing { span: expr.span }),
-        Expr::Nothing => Ok(Value::Nothing { span: expr.span }),
+        Expr::Signature(_) => Ok(Value::Null { span: expr.span }),
+        Expr::Garbage => Ok(Value::Null { span: expr.span }),
+        Expr::Nothing => Ok(Value::Null { span: expr.span }),
     }
 }
 
@@ -1189,7 +1189,7 @@ pub fn eval_block(
 
         if pipeline_idx < (num_pipelines) - 1 {
             match input {
-                PipelineData::Value(Value::Nothing { .. }, ..) => {}
+                PipelineData::Value(Value::Null { .. }, ..) => {}
                 PipelineData::ExternalStream {
                     ref mut exit_code, ..
                 } => {
@@ -1531,7 +1531,7 @@ fn collect_profiling_metadata(
             Ok((PipelineData::ExternalStream { .. }, ..)) => {
                 Value::string("raw stream", element_span)
             }
-            Ok((PipelineData::Empty, ..)) => Value::Nothing { span: element_span },
+            Ok((PipelineData::Empty, ..)) => Value::Null { span: element_span },
             Err(err) => Value::Error {
                 error: Box::new(err.clone()),
             },

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -691,7 +691,7 @@ pub fn eval_expression(
         }
         Expr::Signature(_) => Ok(Value::Null { span: expr.span }),
         Expr::Garbage => Ok(Value::Null { span: expr.span }),
-        Expr::Nothing => Ok(Value::Null { span: expr.span }),
+        Expr::Null => Ok(Value::Null { span: expr.span }),
     }
 }
 

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -94,7 +94,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             let var_value = if let Ok(val) = self.stack.get_var(**var.1, span) {
                 val
             } else {
-                Value::nothing(span)
+                Value::null(span)
             };
 
             vars.push(Value::Record {
@@ -334,14 +334,14 @@ impl<'e, 's> ScopeData<'e, 's> {
         sig_records.push(Value::Record {
             cols: sig_cols.clone(),
             vals: vec![
-                Value::nothing(span),
+                Value::null(span),
                 Value::string("input", span),
                 Value::string(input_type.to_shape().to_string(), span),
                 Value::bool(false, span),
-                Value::nothing(span),
-                Value::nothing(span),
-                Value::nothing(span),
-                Value::nothing(span),
+                Value::null(span),
+                Value::null(span),
+                Value::null(span),
+                Value::null(span),
             ],
             span,
         });
@@ -353,13 +353,13 @@ impl<'e, 's> ScopeData<'e, 's> {
                 Value::string("positional", span),
                 Value::string(req.shape.to_string(), span),
                 Value::bool(false, span),
-                Value::nothing(span),
+                Value::null(span),
                 Value::string(&req.desc, span),
                 Value::string(
                     extract_custom_completion_from_arg(self.engine_state, &req.shape),
                     span,
                 ),
-                Value::nothing(span),
+                Value::null(span),
             ];
 
             sig_records.push(Value::Record {
@@ -376,7 +376,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                 Value::string("positional", span),
                 Value::string(opt.shape.to_string(), span),
                 Value::bool(true, span),
-                Value::nothing(span),
+                Value::null(span),
                 Value::string(&opt.desc, span),
                 Value::string(
                     extract_custom_completion_from_arg(self.engine_state, &opt.shape),
@@ -385,7 +385,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                 if let Some(val) = &opt.default_value {
                     val.clone()
                 } else {
-                    Value::nothing(span)
+                    Value::null(span)
                 },
             ];
 
@@ -403,13 +403,13 @@ impl<'e, 's> ScopeData<'e, 's> {
                 Value::string("rest", span),
                 Value::string(rest.shape.to_string(), span),
                 Value::bool(true, span),
-                Value::nothing(span),
+                Value::null(span),
                 Value::string(&rest.desc, span),
                 Value::string(
                     extract_custom_completion_from_arg(self.engine_state, &rest.shape),
                     span,
                 ),
-                Value::nothing(span), // rest_positional does have default, but parser prohibits specifying it?!
+                Value::null(span), // rest_positional does have default, but parser prohibits specifying it?!
             ];
 
             sig_records.push(Value::Record {
@@ -436,13 +436,13 @@ impl<'e, 's> ScopeData<'e, 's> {
                 Value::string(arg.to_string(), span)
             } else {
                 flag_type = Value::string("switch", span);
-                Value::nothing(span)
+                Value::null(span)
             };
 
             let short_flag = if let Some(c) = named.short {
                 Value::string(c, span)
             } else {
-                Value::nothing(span)
+                Value::null(span)
             };
 
             let sig_vals = vec![
@@ -456,7 +456,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                 if let Some(val) = &named.default_value {
                     val.clone()
                 } else {
-                    Value::nothing(span)
+                    Value::null(span)
                 },
             ];
 
@@ -471,14 +471,14 @@ impl<'e, 's> ScopeData<'e, 's> {
         sig_records.push(Value::Record {
             cols: sig_cols,
             vals: vec![
-                Value::nothing(span),
+                Value::null(span),
                 Value::string("output", span),
                 Value::string(output_type.to_shape().to_string(), span),
                 Value::bool(false, span),
-                Value::nothing(span),
-                Value::nothing(span),
-                Value::nothing(span),
-                Value::nothing(span),
+                Value::null(span),
+                Value::null(span),
+                Value::null(span),
+                Value::null(span),
             ],
             span,
         });
@@ -595,7 +595,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                 .collect();
 
             let export_env_block = module.env_block.map_or_else(
-                || Value::nothing(span),
+                || Value::null(span),
                 |block_id| Value::Block {
                     val: block_id,
                     span,

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -173,7 +173,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                                 if let Some(result) = x.result {
                                     result
                                 } else {
-                                    Value::Nothing { span }
+                                    Value::Null { span }
                                 },
                             ],
                             span,

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -379,5 +379,5 @@ fn include_nu_config(config: &mut HashMap<String, Value>, style_computer: &Style
 }
 
 fn lookup_color(style_computer: &StyleComputer, key: &str) -> nu_ansi_term::Style {
-    style_computer.compute(key, &Value::nothing(Span::unknown()))
+    style_computer.compute(key, &Value::null(Span::unknown()))
 }

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -128,7 +128,7 @@ pub fn collect_input(value: Value) -> (Vec<String>, Vec<Vec<Value>>) {
                 vec![vec![Value::LazyRecord { val, span }]],
             ),
         },
-        Value::Nothing { .. } => (vec![], vec![]),
+        Value::Null { .. } => (vec![], vec![]),
         value => (vec![String::from("")], vec![vec![value]]),
     }
 }

--- a/crates/nu-explore/src/views/util.rs
+++ b/crates/nu-explore/src/views/util.rs
@@ -140,7 +140,7 @@ pub fn make_styled_string(
                 text,
                 TextStyle::with_style(
                     Alignment::Center,
-                    style_computer.compute("empty", &Value::nothing(nu_protocol::Span::unknown())),
+                    style_computer.compute("empty", &Value::null(nu_protocol::Span::unknown())),
                 ),
             )
         }

--- a/crates/nu-parser/src/eval.rs
+++ b/crates/nu-parser/src/eval.rs
@@ -113,7 +113,7 @@ pub fn eval_constant(
             val: s.clone(),
             span: expr.span,
         }),
-        Expr::Nothing => Ok(Value::Nothing { span: expr.span }),
+        Expr::Nothing => Ok(Value::Null { span: expr.span }),
         Expr::ValueWithUnit(expr, unit) => {
             if let Ok(Value::Int { val, .. }) = eval_constant(working_set, expr) {
                 Ok(unit.item.to_value(val, unit.span))

--- a/crates/nu-parser/src/eval.rs
+++ b/crates/nu-parser/src/eval.rs
@@ -113,7 +113,7 @@ pub fn eval_constant(
             val: s.clone(),
             span: expr.span,
         }),
-        Expr::Nothing => Ok(Value::Null { span: expr.span }),
+        Expr::Null => Ok(Value::Null { span: expr.span }),
         Expr::ValueWithUnit(expr, unit) => {
             if let Ok(Value::Int { val, .. }) = eval_constant(working_set, expr) {
                 Ok(unit.item.to_value(val, unit.span))

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -68,7 +68,7 @@ impl Display for FlatShape {
             FlatShape::List => write!(f, "shape_list"),
             FlatShape::Literal => write!(f, "shape_literal"),
             FlatShape::MatchPattern => write!(f, "shape_match_pattern"),
-            FlatShape::Null => write!(f, "shape_nothing"),
+            FlatShape::Null => write!(f, "shape_null"),
             FlatShape::Operator => write!(f, "shape_operator"),
             FlatShape::Or => write!(f, "shape_or"),
             FlatShape::Pipe => write!(f, "shape_pipe"),

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -29,7 +29,7 @@ pub enum FlatShape {
     List,
     Literal,
     MatchPattern,
-    Nothing,
+    Null,
     Operator,
     Or,
     Pipe,
@@ -68,7 +68,7 @@ impl Display for FlatShape {
             FlatShape::List => write!(f, "shape_list"),
             FlatShape::Literal => write!(f, "shape_literal"),
             FlatShape::MatchPattern => write!(f, "shape_match_pattern"),
-            FlatShape::Nothing => write!(f, "shape_nothing"),
+            FlatShape::Null => write!(f, "shape_nothing"),
             FlatShape::Operator => write!(f, "shape_operator"),
             FlatShape::Or => write!(f, "shape_or"),
             FlatShape::Pipe => write!(f, "shape_pipe"),
@@ -248,7 +248,7 @@ pub fn flatten_expression(
             vec![(expr.span, FlatShape::Garbage)]
         }
         Expr::Nothing => {
-            vec![(expr.span, FlatShape::Nothing)]
+            vec![(expr.span, FlatShape::Null)]
         }
         Expr::DateTime(_) => {
             vec![(expr.span, FlatShape::DateTime)]
@@ -578,10 +578,10 @@ pub fn flatten_pattern(match_pattern: &MatchPattern) -> Vec<(Span, FlatShape)> {
             output.push((match_pattern.span, FlatShape::Garbage));
         }
         Pattern::IgnoreValue => {
-            output.push((match_pattern.span, FlatShape::Nothing));
+            output.push((match_pattern.span, FlatShape::Null));
         }
         Pattern::IgnoreRest => {
-            output.push((match_pattern.span, FlatShape::Nothing));
+            output.push((match_pattern.span, FlatShape::Null));
         }
         Pattern::List(items) => {
             if let Some(first) = items.first() {

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -247,7 +247,7 @@ pub fn flatten_expression(
         Expr::Garbage => {
             vec![(expr.span, FlatShape::Garbage)]
         }
-        Expr::Nothing => {
+        Expr::Null => {
             vec![(expr.span, FlatShape::Null)]
         }
         Expr::DateTime(_) => {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -327,7 +327,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expressio
     Expression {
         expr: Expr::Call(call),
         span: call_span,
-        ty: Type::Nothing,
+        ty: Type::Null,
         custom_completion: None,
     }
 }
@@ -3630,7 +3630,7 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
     Pipeline::from_vec(vec![Expression {
         expr: Expr::Call(call),
         span: call_span,
-        ty: Type::Nothing,
+        ty: Type::Null,
         custom_completion: None,
     }])
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1797,7 +1797,7 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
         return Expression {
             expr: Expr::Nothing,
             span,
-            ty: Type::Nothing,
+            ty: Type::Null,
             custom_completion: None,
         };
     } else if contents == b"$nu" {
@@ -4607,7 +4607,7 @@ pub fn parse_value(
             return Expression {
                 expr: Expr::Nothing,
                 span,
-                ty: Type::Nothing,
+                ty: Type::Null,
                 custom_completion: None,
             };
         }
@@ -5114,7 +5114,7 @@ pub fn parse_expression(
                 Expression {
                     expr: Expr::String(String::new()),
                     span: Span::unknown(),
-                    ty: Type::Nothing,
+                    ty: Type::Null,
                     custom_completion: None,
                 }
             };

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1795,7 +1795,7 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
 
     if contents == b"$nothing" {
         return Expression {
-            expr: Expr::Nothing,
+            expr: Expr::Null,
             span,
             ty: Type::Null,
             custom_completion: None,
@@ -4605,7 +4605,7 @@ pub fn parse_value(
         }
         b"null" => {
             return Expression {
-                expr: Expr::Nothing,
+                expr: Expr::Null,
                 span,
                 ty: Type::Null,
                 custom_completion: None,
@@ -5968,7 +5968,7 @@ pub fn discover_captures_in_expr(
         Expr::ImportPattern(_) => {}
         Expr::Overlay(_) => {}
         Expr::Garbage => {}
-        Expr::Nothing => {}
+        Expr::Null => {}
         Expr::GlobPattern(_) => {}
         Expr::Int(_) => {}
         Expr::Keyword(_, _, expr) => {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2718,7 +2718,7 @@ pub fn parse_shape_name(
         b"keyword" => SyntaxShape::Keyword(vec![], Box::new(SyntaxShape::Any)),
         _ if bytes.starts_with(b"list") => parse_list_shape(working_set, bytes, span),
         b"math" => SyntaxShape::MathExpression,
-        b"nothing" => SyntaxShape::Null,
+        b"null" => SyntaxShape::Null,
         b"number" => SyntaxShape::Number,
         b"one-of" => SyntaxShape::OneOf(vec![]),
         b"operator" => SyntaxShape::Operator,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2718,7 +2718,7 @@ pub fn parse_shape_name(
         b"keyword" => SyntaxShape::Keyword(vec![], Box::new(SyntaxShape::Any)),
         _ if bytes.starts_with(b"list") => parse_list_shape(working_set, bytes, span),
         b"math" => SyntaxShape::MathExpression,
-        b"nothing" => SyntaxShape::Nothing,
+        b"nothing" => SyntaxShape::Null,
         b"number" => SyntaxShape::Number,
         b"one-of" => SyntaxShape::OneOf(vec![]),
         b"operator" => SyntaxShape::Operator,

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -483,8 +483,8 @@ pub fn math_result_type(
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.to_string()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
-                (Type::Nothing, _) => (Type::Nothing, None),
-                (_, Type::Nothing) => (Type::Nothing, None),
+                (Type::Null, _) => (Type::Null, None),
+                (_, Type::Null) => (Type::Null, None),
 
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
@@ -532,8 +532,8 @@ pub fn math_result_type(
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.to_string()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
-                (Type::Nothing, _) => (Type::Nothing, None),
-                (_, Type::Nothing) => (Type::Nothing, None),
+                (Type::Null, _) => (Type::Null, None),
+                (_, Type::Null) => (Type::Null, None),
 
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
@@ -584,8 +584,8 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
 
-                (Type::Nothing, _) => (Type::Nothing, None),
-                (_, Type::Nothing) => (Type::Nothing, None),
+                (Type::Null, _) => (Type::Null, None),
+                (_, Type::Null) => (Type::Null, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
                     *op = Expression::garbage(op.span);
                     (
@@ -633,8 +633,8 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
 
-                (Type::Nothing, _) => (Type::Nothing, None),
-                (_, Type::Nothing) => (Type::Nothing, None),
+                (Type::Null, _) => (Type::Null, None),
+                (_, Type::Null) => (Type::Null, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
                     *op = Expression::garbage(op.span);
                     (
@@ -927,12 +927,12 @@ pub fn math_result_type(
                 }
             },
             Operator::Assignment(_) => match (&lhs.ty, &rhs.ty) {
-                (x, y) if x == y => (Type::Nothing, None),
-                (Type::Any, _) => (Type::Nothing, None),
-                (_, Type::Any) => (Type::Nothing, None),
-                (Type::List(_), Type::List(_)) => (Type::Nothing, None),
+                (x, y) if x == y => (Type::Null, None),
+                (Type::Any, _) => (Type::Null, None),
+                (_, Type::Any) => (Type::Null, None),
+                (Type::List(_), Type::List(_)) => (Type::Null, None),
                 (x, y) => (
-                    Type::Nothing,
+                    Type::Null,
                     Some(ParseError::Mismatch(x.to_string(), y.to_string(), rhs.span)),
                 ),
             },
@@ -1026,13 +1026,13 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
 
     for (input_type, output_type) in &block.signature.input_output_types {
         let mut current_type = input_type.clone();
-        let mut current_output_type = Type::Nothing;
+        let mut current_output_type = Type::Null;
 
         for pipeline in &block.pipelines {
             let (checked_output_type, err) =
                 check_pipeline_type(working_set, pipeline, current_type);
             current_output_type = checked_output_type;
-            current_type = Type::Nothing;
+            current_type = Type::Null;
             if let Some(err) = err {
                 output_errors.extend_from_slice(&err);
             }
@@ -1068,7 +1068,7 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
 
         for pipeline in &block.pipelines {
             let (_, err) = check_pipeline_type(working_set, pipeline, current_type);
-            current_type = Type::Nothing;
+            current_type = Type::Null;
 
             if let Some(err) = err {
                 output_errors.extend_from_slice(&err);

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -203,7 +203,7 @@ pub fn get_signature(
 /// impl Plugin for HelloPlugin {
 ///     fn signature(&self) -> Vec<PluginSignature> {
 ///         let sig = PluginSignature::build("hello")
-///             .input_output_type(Type::Nothing, Type::String);
+///             .input_output_type(Type::Null, Type::String);
 ///
 ///         vec![sig]
 ///     }

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -78,10 +78,10 @@ impl Block {
                     PipelineElement::Or(_, expr) => expr.ty.clone(),
                 }
             } else {
-                Type::Nothing
+                Type::Null
             }
         } else {
-            Type::Nothing
+            Type::Null
         }
     }
 }

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -45,6 +45,6 @@ pub enum Expr {
     Signature(Box<Signature>),
     StringInterpolation(Vec<Expression>),
     MatchPattern(Box<MatchPattern>),
-    Nothing,
+    Null,
     Garbage,
 }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -201,7 +201,7 @@ impl Expression {
                 false
             }
             Expr::Garbage => false,
-            Expr::Nothing => false,
+            Expr::Null => false,
             Expr::GlobPattern(_) => false,
             Expr::Int(_) => false,
             Expr::Keyword(_, _, expr) => expr.has_in_variable(working_set),
@@ -394,7 +394,7 @@ impl Expression {
             Expr::ImportPattern(_) => {}
             Expr::Overlay(_) => {}
             Expr::Garbage => {}
-            Expr::Nothing => {}
+            Expr::Null => {}
             Expr::GlobPattern(_) => {}
             Expr::Int(_) => {}
             Expr::MatchPattern(_) => {}
@@ -556,7 +556,7 @@ impl Expression {
             Expr::ImportPattern(_) => {}
             Expr::Overlay(_) => {}
             Expr::Garbage => {}
-            Expr::Nothing => {}
+            Expr::Null => {}
             Expr::GlobPattern(_) => {}
             Expr::MatchPattern(_) => {}
             Expr::MatchBlock(_) => {}

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -521,7 +521,7 @@ impl Value {
                                         span: $span,
                                     }
                                 } else {
-                                    Value::Nothing { span: $span }
+                                    Value::Null { span: $span }
                                 }
                             };
                         }
@@ -609,7 +609,7 @@ impl Value {
                                                             config.external_completer = Some(v)
                                                         } else {
                                                             match value {
-                                                                Value::Nothing { .. } => {}
+                                                                Value::Null { .. } => {}
                                                                 _ => {
                                                                     invalid!(
                                                                         Some(span),
@@ -908,7 +908,7 @@ impl Value {
                                             ],
                                             None => vec![
                                                 Value::string("truncating", $span),
-                                                Value::Nothing { span: $span },
+                                                Value::Null { span: $span },
                                             ],
                                         },
                                         $span,
@@ -1522,7 +1522,7 @@ pub fn create_menus(value: &Value) -> Result<Vec<ParsedMenu>, ShellError> {
             // Source is an optional value
             let source = match extract_value("source", cols, vals, span) {
                 Ok(source) => source.clone(),
-                Err(_) => Value::Nothing { span },
+                Err(_) => Value::Null { span },
             };
 
             let menu = ParsedMenu {

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -53,7 +53,7 @@ impl Matcher for Pattern {
                             match &items[vals.len()].pattern {
                                 Pattern::IgnoreRest => {}
                                 Pattern::Rest(var_id) => {
-                                    matches.push((*var_id, Value::nothing(items[vals.len()].span)))
+                                    matches.push((*var_id, Value::null(items[vals.len()].span)))
                                 }
                                 _ => {
                                     // There is a pattern which can't skip missing values, so we fail
@@ -227,7 +227,7 @@ impl Matcher for Pattern {
 
                                 if !found {
                                     // FIXME: don't use Span::unknown()
-                                    matches.push((*var, Value::nothing(Span::unknown())))
+                                    matches.push((*var, Value::null(Span::unknown())))
                                 }
                             }
                         }
@@ -245,7 +245,7 @@ impl Matcher for Pattern {
 
                             if !found {
                                 // FIXME: don't use Span::unknown()
-                                matches.push((*var, Value::nothing(Span::unknown())))
+                                matches.push((*var, Value::null(Span::unknown())))
                             }
                         }
                     }

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -113,7 +113,7 @@ impl PipelineData {
         self
     }
 
-    pub fn is_nothing(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         matches!(self, PipelineData::Value(Value::Null { .. }, ..))
             || matches!(self, PipelineData::Empty)
     }

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -130,8 +130,8 @@ impl PipelineData {
 
     pub fn into_value(self, span: Span) -> Value {
         match self {
-            PipelineData::Empty => Value::nothing(span),
-            PipelineData::Value(Value::Nothing { .. }, ..) => Value::nothing(span),
+            PipelineData::Empty => Value::null(span),
+            PipelineData::Value(Value::Nothing{ .. }, ..) => Value::null(span),
             PipelineData::Value(v, ..) => v.with_span(span),
             PipelineData::ListStream(s, ..) => Value::List {
                 vals: s.collect(),

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -69,7 +69,7 @@ pub enum DataSource {
 
 impl PipelineData {
     pub fn new_with_metadata(metadata: Option<Box<PipelineMetadata>>, span: Span) -> PipelineData {
-        PipelineData::Value(Value::Nothing { span }, metadata)
+        PipelineData::Value(Value::Null { span }, metadata)
     }
 
     /// create a `PipelineData::ExternalStream` with proper exit_code
@@ -114,7 +114,7 @@ impl PipelineData {
     }
 
     pub fn is_nothing(&self) -> bool {
-        matches!(self, PipelineData::Value(Value::Nothing { .. }, ..))
+        matches!(self, PipelineData::Value(Value::Null { .. }, ..))
             || matches!(self, PipelineData::Empty)
     }
 
@@ -131,7 +131,7 @@ impl PipelineData {
     pub fn into_value(self, span: Span) -> Value {
         match self {
             PipelineData::Empty => Value::null(span),
-            PipelineData::Value(Value::Nothing{ .. }, ..) => Value::null(span),
+            PipelineData::Value(Value::Null { .. }, ..) => Value::null(span),
             PipelineData::Value(v, ..) => v.with_span(span),
             PipelineData::ListStream(s, ..) => Value::List {
                 vals: s.collect(),
@@ -146,7 +146,7 @@ impl PipelineData {
                 if let Some(exit_code) = exit_code {
                     let _: Vec<_> = exit_code.into_iter().collect();
                 }
-                Value::Nothing { span }
+                Value::Null { span }
             }
             PipelineData::ExternalStream {
                 stdout: Some(mut s),
@@ -589,7 +589,7 @@ impl PipelineData {
                 if f(&v) {
                     Ok(v.into_pipeline_data())
                 } else {
-                    Ok(Value::Nothing { span: v.span()? }.into_pipeline_data())
+                    Ok(Value::Null { span: v.span()? }.into_pipeline_data())
                 }
             }
         }
@@ -926,7 +926,7 @@ impl Iterator for PipelineIterator {
     fn next(&mut self) -> Option<Self::Item> {
         match &mut self.0 {
             PipelineData::Empty => None,
-            PipelineData::Value(Value::Nothing { .. }, ..) => None,
+            PipelineData::Value(Value::Null { .. }, ..) => None,
             PipelineData::Value(v, ..) => Some(std::mem::take(v)),
             PipelineData::ListStream(stream, ..) => stream.next(),
             PipelineData::ExternalStream { stdout: None, .. } => None,

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -79,8 +79,8 @@ pub enum SyntaxShape {
     /// A match pattern, eg `{a: $foo}`
     MatchPattern,
 
-    /// Nothing
-    Nothing,
+    /// Null
+    Null,
 
     /// Only a numeric (integer or decimal) value is allowed
     Number,
@@ -152,7 +152,7 @@ impl SyntaxShape {
             SyntaxShape::MatchBlock => Type::Any,
             SyntaxShape::MatchPattern => Type::Any,
             SyntaxShape::MathExpression => Type::Any,
-            SyntaxShape::Nothing => Type::Nothing,
+            SyntaxShape::Null => Type::Null,
             SyntaxShape::Number => Type::Number,
             SyntaxShape::OneOf(_) => Type::Any,
             SyntaxShape::Operator => Type::Any,
@@ -240,7 +240,7 @@ impl Display for SyntaxShape {
                 let arg_string = arg_vec.join(", ");
                 write!(f, "one_of({arg_string})")
             }
-            SyntaxShape::Nothing => write!(f, "nothing"),
+            SyntaxShape::Null => write!(f, "nothing"),
         }
     }
 }

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -240,7 +240,7 @@ impl Display for SyntaxShape {
                 let arg_string = arg_vec.join(", ");
                 write!(f, "one_of({arg_string})")
             }
-            SyntaxShape::Null => write!(f, "nothing"),
+            SyntaxShape::Null => write!(f, "null"),
         }
     }
 }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -101,7 +101,7 @@ impl Type {
             Type::Filesize => SyntaxShape::Filesize,
             Type::List(x) => SyntaxShape::List(Box::new(x.to_shape())),
             Type::Number => SyntaxShape::Number,
-            Type::Null => SyntaxShape::Nothing,
+            Type::Null => SyntaxShape::Null,
             Type::Record(entries) => SyntaxShape::Record(mk_shape(entries)),
             Type::Table(columns) => SyntaxShape::Table(mk_shape(columns)),
             Type::ListStream => SyntaxShape::List(Box::new(SyntaxShape::Any)),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -26,7 +26,7 @@ pub enum Type {
     ListStream,
     MatchPattern,
     #[default]
-    Nothing,
+    Null,
     Number,
     Range,
     Record(Vec<(String, Type)>),
@@ -101,7 +101,7 @@ impl Type {
             Type::Filesize => SyntaxShape::Filesize,
             Type::List(x) => SyntaxShape::List(Box::new(x.to_shape())),
             Type::Number => SyntaxShape::Number,
-            Type::Nothing => SyntaxShape::Nothing,
+            Type::Null => SyntaxShape::Nothing,
             Type::Record(entries) => SyntaxShape::Record(mk_shape(entries)),
             Type::Table(columns) => SyntaxShape::Table(mk_shape(columns)),
             Type::ListStream => SyntaxShape::List(Box::new(SyntaxShape::Any)),
@@ -132,7 +132,7 @@ impl Type {
             Type::Table(_) => String::from("table"),
             Type::List(_) => String::from("list"),
             Type::MatchPattern => String::from("match pattern"),
-            Type::Nothing => String::from("nothing"),
+            Type::Null => String::from("nothing"),
             Type::Number => String::from("number"),
             Type::String => String::from("string"),
             Type::ListStream => String::from("list stream"),
@@ -189,7 +189,7 @@ impl Display for Type {
                 }
             }
             Type::List(l) => write!(f, "list<{l}>"),
-            Type::Nothing => write!(f, "nothing"),
+            Type::Null => write!(f, "nothing"),
             Type::Number => write!(f, "number"),
             Type::String => write!(f, "string"),
             Type::ListStream => write!(f, "list stream"),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -132,7 +132,7 @@ impl Type {
             Type::Table(_) => String::from("table"),
             Type::List(_) => String::from("list"),
             Type::MatchPattern => String::from("match pattern"),
-            Type::Null => String::from("nothing"),
+            Type::Null => String::from("null"),
             Type::Number => String::from("number"),
             Type::String => String::from("string"),
             Type::ListStream => String::from("list stream"),
@@ -189,7 +189,7 @@ impl Display for Type {
                 }
             }
             Type::List(l) => write!(f, "list<{l}>"),
-            Type::Null => write!(f, "nothing"),
+            Type::Null => write!(f, "null"),
             Type::Number => write!(f, "number"),
             Type::String => write!(f, "string"),
             Type::ListStream => write!(f, "list stream"),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -873,7 +873,7 @@ impl Value {
         }
     }
 
-    pub fn is_nothing(&self) -> bool {
+    pub fn is_null(&self) -> bool {
         matches!(self, Value::Null { .. })
     }
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -92,7 +92,7 @@ pub enum Value {
         captures: HashMap<VarId, Value>,
         span: Span,
     },
-    Nothing {
+    Null {
         span: Span,
     },
     Error {
@@ -171,7 +171,7 @@ impl Clone for Value {
                 captures: captures.clone(),
                 span: *span,
             },
-            Value::Nothing { span } => Value::Nothing { span: *span },
+            Value::Null { span } => Value::Null { span: *span },
             Value::Error { error } => Value::Error {
                 error: error.clone(),
             },
@@ -492,7 +492,7 @@ impl Value {
             | Value::List { span, .. }
             | Value::Block { span, .. }
             | Value::Closure { span, .. }
-            | Value::Nothing { span, .. }
+            | Value::Null { span, .. }
             | Value::Binary { span, .. }
             | Value::CellPath { span, .. }
             | Value::CustomValue { span, .. }
@@ -525,7 +525,7 @@ impl Value {
             | Value::List { span, .. }
             | Value::Closure { span, .. }
             | Value::Block { span, .. }
-            | Value::Nothing { span, .. }
+            | Value::Null { span, .. }
             | Value::Binary { span, .. }
             | Value::CellPath { span, .. }
             | Value::CustomValue { span, .. }
@@ -582,7 +582,7 @@ impl Value {
                 Ok(val) => val.get_type(),
                 Err(..) => Type::Error,
             },
-            Value::Nothing { .. } => Type::Nothing,
+            Value::Null { .. } => Type::Nothing,
             Value::Block { .. } => Type::Block,
             Value::Closure { .. } => Type::Closure,
             Value::Error { .. } => Type::Error,
@@ -695,7 +695,7 @@ impl Value {
             }
             Value::Block { val, .. } => format!("<Block {val}>"),
             Value::Closure { val, .. } => format!("<Closure {val}>"),
-            Value::Nothing { .. } => String::new(),
+            Value::Null { .. } => String::new(),
             Value::Error { error } => format!("{error:?}"),
             Value::Binary { val, .. } => format!("{val:?}"),
             Value::CellPath { val, .. } => val.into_string(),
@@ -750,7 +750,7 @@ impl Value {
             },
             Value::Block { val, .. } => format!("<Block {val}>"),
             Value::Closure { val, .. } => format!("<Closure {val}>"),
-            Value::Nothing { .. } => String::new(),
+            Value::Null { .. } => String::new(),
             Value::Error { error } => format!("{error:?}"),
             Value::Binary { val, .. } => format!("{val:?}"),
             Value::CellPath { val, .. } => val.into_string(),
@@ -852,7 +852,7 @@ impl Value {
             },
             Value::Block { val, .. } => format!("<Block {val}>"),
             Value::Closure { val, .. } => format!("<Closure {val}>"),
-            Value::Nothing { .. } => String::new(),
+            Value::Null { .. } => String::new(),
             Value::Error { error } => format!("{error:?}"),
             Value::Binary { val, .. } => format!("{val:?}"),
             Value::CellPath { val, .. } => val.into_string(),
@@ -868,13 +868,13 @@ impl Value {
             Value::List { vals, .. } => vals.is_empty(),
             Value::Record { cols, .. } => cols.is_empty(),
             Value::Binary { val, .. } => val.is_empty(),
-            Value::Nothing { .. } => true,
+            Value::Null { .. } => true,
             _ => false,
         }
     }
 
     pub fn is_nothing(&self) -> bool {
-        matches!(self, Value::Nothing { .. })
+        matches!(self, Value::Null { .. })
     }
 
     /// Follow a given cell path into the value: for example accessing select elements in a stream or list
@@ -959,7 +959,7 @@ impl Value {
                                 }
                             };
                         }
-                        Value::Nothing { .. } if *optional => {
+                        Value::Null { .. } if *optional => {
                             return Ok(Value::null(*origin_span)); // short-circuit
                         }
                         // Records (and tables) are the only built-in which support column names,
@@ -1054,7 +1054,7 @@ impl Value {
                                         src_span: val.span().unwrap_or(*span),
                                     });
                                 }
-                            } else if *optional && matches!(val, Value::Nothing { .. }) {
+                            } else if *optional && matches!(val, Value::Null { .. }) {
                                 output.push(Value::null(*origin_span));
                             } else {
                                 return Err(ShellError::CantFindColumn {
@@ -1073,7 +1073,7 @@ impl Value {
                     Value::CustomValue { val, .. } => {
                         current = val.follow_path_string(column_name.clone(), *origin_span)?;
                     }
-                    Value::Nothing { .. } if *optional => {
+                    Value::Null { .. } if *optional => {
                         return Ok(Value::null(*origin_span)); // short-circuit
                     }
                     Value::Error { error } => return Err(*error.to_owned()),
@@ -1809,7 +1809,7 @@ impl Value {
 
     /// Create a new `Null` value
     pub fn null(span: Span) -> Value {
-        Value::Nothing { span }
+        Value::Null { span }
     }
 
     pub fn error(error: ShellError) -> Value {
@@ -1959,7 +1959,7 @@ impl Value {
 
 impl Default for Value {
     fn default() -> Self {
-        Value::Nothing {
+        Value::Null {
             span: Span::unknown(),
         }
     }
@@ -1994,7 +1994,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2015,7 +2015,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2036,7 +2036,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2057,7 +2057,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2078,7 +2078,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2099,7 +2099,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2120,7 +2120,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2141,7 +2141,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2194,7 +2194,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Less),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2215,7 +2215,7 @@ impl PartialOrd for Value {
                 Value::List { vals: rhs, .. } => lhs.partial_cmp(rhs),
                 Value::Block { .. } => Some(Ordering::Less),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2236,7 +2236,7 @@ impl PartialOrd for Value {
                 Value::LazyRecord { .. } => Some(Ordering::Greater),
                 Value::Block { val: rhs, .. } => lhs.partial_cmp(rhs),
                 Value::Closure { .. } => Some(Ordering::Less),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2257,14 +2257,14 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Greater),
                 Value::Block { .. } => Some(Ordering::Greater),
                 Value::Closure { val: rhs, .. } => lhs.partial_cmp(rhs),
-                Value::Nothing { .. } => Some(Ordering::Less),
+                Value::Null { .. } => Some(Ordering::Less),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
                 Value::CustomValue { .. } => Some(Ordering::Less),
                 Value::MatchPattern { .. } => Some(Ordering::Less),
             },
-            (Value::Nothing { .. }, rhs) => match rhs {
+            (Value::Null { .. }, rhs) => match rhs {
                 Value::Bool { .. } => Some(Ordering::Greater),
                 Value::Int { .. } => Some(Ordering::Greater),
                 Value::Float { .. } => Some(Ordering::Greater),
@@ -2278,7 +2278,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Greater),
                 Value::Block { .. } => Some(Ordering::Greater),
                 Value::Closure { .. } => Some(Ordering::Greater),
-                Value::Nothing { .. } => Some(Ordering::Equal),
+                Value::Null { .. } => Some(Ordering::Equal),
                 Value::Error { .. } => Some(Ordering::Less),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2299,7 +2299,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Greater),
                 Value::Block { .. } => Some(Ordering::Greater),
                 Value::Closure { .. } => Some(Ordering::Greater),
-                Value::Nothing { .. } => Some(Ordering::Greater),
+                Value::Null { .. } => Some(Ordering::Greater),
                 Value::Error { .. } => Some(Ordering::Equal),
                 Value::Binary { .. } => Some(Ordering::Less),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2320,7 +2320,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Greater),
                 Value::Block { .. } => Some(Ordering::Greater),
                 Value::Closure { .. } => Some(Ordering::Greater),
-                Value::Nothing { .. } => Some(Ordering::Greater),
+                Value::Null { .. } => Some(Ordering::Greater),
                 Value::Error { .. } => Some(Ordering::Greater),
                 Value::Binary { val: rhs, .. } => lhs.partial_cmp(rhs),
                 Value::CellPath { .. } => Some(Ordering::Less),
@@ -2341,7 +2341,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Greater),
                 Value::Block { .. } => Some(Ordering::Greater),
                 Value::Closure { .. } => Some(Ordering::Greater),
-                Value::Nothing { .. } => Some(Ordering::Greater),
+                Value::Null { .. } => Some(Ordering::Greater),
                 Value::Error { .. } => Some(Ordering::Greater),
                 Value::Binary { .. } => Some(Ordering::Greater),
                 Value::CellPath { val: rhs, .. } => lhs.partial_cmp(rhs),
@@ -2370,7 +2370,7 @@ impl PartialOrd for Value {
                 Value::List { .. } => Some(Ordering::Greater),
                 Value::Block { .. } => Some(Ordering::Greater),
                 Value::Closure { .. } => Some(Ordering::Greater),
-                Value::Nothing { .. } => Some(Ordering::Greater),
+                Value::Null { .. } => Some(Ordering::Greater),
                 Value::Error { .. } => Some(Ordering::Greater),
                 Value::Binary { .. } => Some(Ordering::Greater),
                 Value::CellPath { .. } => Some(Ordering::Greater),
@@ -2967,7 +2967,7 @@ impl Value {
             return lhs.operation(*span, Operator::Comparison(Comparison::LessThan), op, rhs);
         }
 
-        if matches!(self, Value::Nothing { .. }) || matches!(rhs, Value::Nothing { .. }) {
+        if matches!(self, Value::Null { .. }) || matches!(rhs, Value::Null { .. }) {
             return Ok(Value::null(span));
         }
 
@@ -3010,7 +3010,7 @@ impl Value {
             );
         }
 
-        if matches!(self, Value::Nothing { .. }) || matches!(rhs, Value::Nothing { .. }) {
+        if matches!(self, Value::Null { .. }) || matches!(rhs, Value::Null { .. }) {
             return Ok(Value::null(span));
         }
 
@@ -3051,7 +3051,7 @@ impl Value {
             );
         }
 
-        if matches!(self, Value::Nothing { .. }) || matches!(rhs, Value::Nothing { .. }) {
+        if matches!(self, Value::Null { .. }) || matches!(rhs, Value::Null { .. }) {
             return Ok(Value::null(span));
         }
 
@@ -3092,7 +3092,7 @@ impl Value {
             );
         }
 
-        if matches!(self, Value::Nothing { .. }) || matches!(rhs, Value::Nothing { .. }) {
+        if matches!(self, Value::Null { .. }) || matches!(rhs, Value::Null { .. }) {
             return Ok(Value::null(span));
         }
 
@@ -3136,7 +3136,7 @@ impl Value {
             })
         } else {
             match (self, rhs) {
-                (Value::Nothing { .. }, _) | (_, Value::Nothing { .. }) => {
+                (Value::Null { .. }, _) | (_, Value::Null { .. }) => {
                     Ok(Value::Bool { val: false, span })
                 }
                 _ => Err(ShellError::OperatorMismatch {
@@ -3162,7 +3162,7 @@ impl Value {
             })
         } else {
             match (self, rhs) {
-                (Value::Nothing { .. }, _) | (_, Value::Nothing { .. }) => {
+                (Value::Null { .. }, _) | (_, Value::Null { .. }) => {
                     Ok(Value::Bool { val: true, span })
                 }
                 _ => Err(ShellError::OperatorMismatch {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -606,9 +606,9 @@ impl Value {
                     match item {
                         Value::Record { .. } => match item.get_data_by_key(name) {
                             Some(v) => out.push(v),
-                            None => out.push(Value::nothing(*span)),
+                            None => out.push(Value::null(*span)),
                         },
-                        _ => out.push(Value::nothing(*span)),
+                        _ => out.push(Value::null(*span)),
                     }
                 }
 
@@ -917,7 +917,7 @@ impl Value {
                             if let Some(item) = val.get(*count) {
                                 current = item.clone();
                             } else if *optional {
-                                return Ok(Value::nothing(*origin_span)); // short-circuit
+                                return Ok(Value::null(*origin_span)); // short-circuit
                             } else if val.is_empty() {
                                 return Err(ShellError::AccessEmptyContent { span: *origin_span })
                             } else {
@@ -928,7 +928,7 @@ impl Value {
                             if let Some(item) = val.get(*count) {
                                 current = Value::int(*item as i64, *origin_span);
                             } else if *optional {
-                                return Ok(Value::nothing(*origin_span)); // short-circuit
+                                return Ok(Value::null(*origin_span)); // short-circuit
                             } else if val.is_empty() {
                                 return Err(ShellError::AccessEmptyContent { span: *origin_span })
                             } else {
@@ -939,7 +939,7 @@ impl Value {
                             if let Some(item) = val.clone().into_range_iter(None)?.nth(*count) {
                                 current = item.clone();
                             } else if *optional {
-                                return Ok(Value::nothing(*origin_span)); // short-circuit
+                                return Ok(Value::null(*origin_span)); // short-circuit
                             } else {
                                 return Err(ShellError::AccessBeyondEndOfStream {
                                     span: *origin_span
@@ -951,7 +951,7 @@ impl Value {
                                 Ok(val) => val,
                                 Err(err) => {
                                     if *optional {
-                                        return Ok(Value::nothing(*origin_span));
+                                        return Ok(Value::null(*origin_span));
                                     // short-circuit
                                     } else {
                                         return Err(err);
@@ -960,7 +960,7 @@ impl Value {
                             };
                         }
                         Value::Nothing { .. } if *optional => {
-                            return Ok(Value::nothing(*origin_span)); // short-circuit
+                            return Ok(Value::null(*origin_span)); // short-circuit
                         }
                         // Records (and tables) are the only built-in which support column names,
                         // so only use this message for them.
@@ -995,7 +995,7 @@ impl Value {
                         }) {
                             current = found.1.clone();
                         } else if *optional {
-                            return Ok(Value::nothing(*origin_span)); // short-circuit
+                            return Ok(Value::null(*origin_span)); // short-circuit
                         } else {
                             if from_user_input {
                                 if let Some(suggestion) = did_you_mean(&cols, column_name) {
@@ -1015,7 +1015,7 @@ impl Value {
                         if columns.contains(&column_name.as_str()) {
                             current = val.get_column_value(column_name)?;
                         } else if *optional {
-                            return Ok(Value::nothing(*origin_span)); // short-circuit
+                            return Ok(Value::null(*origin_span)); // short-circuit
                         } else {
                             if from_user_input {
                                 if let Some(suggestion) = did_you_mean(&columns, column_name) {
@@ -1055,7 +1055,7 @@ impl Value {
                                     });
                                 }
                             } else if *optional && matches!(val, Value::Nothing { .. }) {
-                                output.push(Value::nothing(*origin_span));
+                                output.push(Value::null(*origin_span));
                             } else {
                                 return Err(ShellError::CantFindColumn {
                                     col_name: column_name.to_string(),
@@ -1074,7 +1074,7 @@ impl Value {
                         current = val.follow_path_string(column_name.clone(), *origin_span)?;
                     }
                     Value::Nothing { .. } if *optional => {
-                        return Ok(Value::nothing(*origin_span)); // short-circuit
+                        return Ok(Value::null(*origin_span)); // short-circuit
                     }
                     Value::Error { error } => return Err(*error.to_owned()),
                     x => {
@@ -1807,8 +1807,8 @@ impl Value {
         }
     }
 
-    /// Create a new `Nothing` value
-    pub fn nothing(span: Span) -> Value {
+    /// Create a new `Null` value
+    pub fn null(span: Span) -> Value {
         Value::Nothing { span }
     }
 
@@ -1923,7 +1923,7 @@ impl Value {
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
     /// when used in errors.
     pub fn test_nothing() -> Value {
-        Value::nothing(Span::test_data())
+        Value::null(Span::test_data())
     }
 
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
@@ -2968,7 +2968,7 @@ impl Value {
         }
 
         if matches!(self, Value::Nothing { .. }) || matches!(rhs, Value::Nothing { .. }) {
-            return Ok(Value::nothing(span));
+            return Ok(Value::null(span));
         }
 
         if !type_compatible(self.get_type(), rhs.get_type())
@@ -3011,7 +3011,7 @@ impl Value {
         }
 
         if matches!(self, Value::Nothing { .. }) || matches!(rhs, Value::Nothing { .. }) {
-            return Ok(Value::nothing(span));
+            return Ok(Value::null(span));
         }
 
         if !type_compatible(self.get_type(), rhs.get_type())
@@ -3052,7 +3052,7 @@ impl Value {
         }
 
         if matches!(self, Value::Nothing { .. }) || matches!(rhs, Value::Nothing { .. }) {
-            return Ok(Value::nothing(span));
+            return Ok(Value::null(span));
         }
 
         if !type_compatible(self.get_type(), rhs.get_type())
@@ -3093,7 +3093,7 @@ impl Value {
         }
 
         if matches!(self, Value::Nothing { .. }) || matches!(rhs, Value::Nothing { .. }) {
-            return Ok(Value::nothing(span));
+            return Ok(Value::null(span));
         }
 
         if !type_compatible(self.get_type(), rhs.get_type())

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -582,7 +582,7 @@ impl Value {
                 Ok(val) => val.get_type(),
                 Err(..) => Type::Error,
             },
-            Value::Null { .. } => Type::Nothing,
+            Value::Null { .. } => Type::Null,
             Value::Block { .. } => Type::Block,
             Value::Closure { .. } => Type::Closure,
             Value::Error { .. } => Type::Error,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1922,7 +1922,7 @@ impl Value {
 
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
     /// when used in errors.
-    pub fn test_nothing() -> Value {
+    pub fn test_null() -> Value {
         Value::null(Span::test_data())
     }
 

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -28,13 +28,13 @@ impl Range {
     ) -> Result<Range, ShellError> {
         // Select from & to values if they're not specified
         // TODO: Replace the placeholder values with proper min/max for range based on data type
-        let from = if let Value::Nothing { .. } = from {
+        let from = if let Value::Null { .. } = from {
             Value::int(0i64, expr_span)
         } else {
             from
         };
 
-        let to = if let Value::Nothing { .. } = to {
+        let to = if let Value::Null { .. } = to {
             if let Ok(Value::Bool { val: true, .. }) = next.lt(expr_span, &from, expr_span) {
                 Value::int(i64::MIN, expr_span)
             } else {
@@ -51,7 +51,7 @@ impl Range {
         );
 
         // Convert the next value into the increment
-        let incr = if let Value::Nothing { .. } = next {
+        let incr = if let Value::Null { .. } = next {
             if moves_up {
                 Value::int(1i64, expr_span)
             } else {
@@ -171,12 +171,12 @@ impl RangeIterator {
         let is_end_inclusive = range.is_end_inclusive();
 
         let start = match range.from {
-            Value::Nothing { .. } => Value::Int { val: 0, span },
+            Value::Null { .. } => Value::Int { val: 0, span },
             x => x,
         };
 
         let end = match range.to {
-            Value::Nothing { .. } => Value::Int {
+            Value::Null { .. } => Value::Int {
                 val: i64::MAX,
                 span,
             },
@@ -207,7 +207,7 @@ impl Iterator for RangeIterator {
             return None;
         }
 
-        let ordering = if matches!(self.end, Value::Nothing { .. }) {
+        let ordering = if matches!(self.end, Value::Null { .. }) {
             Some(Ordering::Less)
         } else {
             self.curr.partial_cmp(&self.end)

--- a/crates/nu-protocol/tests/test_value.rs
+++ b/crates/nu-protocol/tests/test_value.rs
@@ -9,7 +9,7 @@ fn test_comparison_nothing() {
         Value::test_float(1.0),
     ];
 
-    let nothing = Value::Nothing {
+    let nothing = Value::Null {
         span: Span::test_data(),
     };
 

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -81,7 +81,7 @@ pub fn get_empty_style(style_computer: &StyleComputer) -> NuText {
         String::from("❎"),
         TextStyle::with_style(
             Alignment::Right,
-            style_computer.compute("empty", &Value::nothing(Span::unknown())),
+            style_computer.compute("empty", &Value::null(Span::unknown())),
         ),
     )
 }
@@ -112,7 +112,7 @@ fn make_styled_string(
                 text,
                 TextStyle::with_style(
                     Alignment::Center,
-                    style_computer.compute("empty", &Value::nothing(Span::unknown())),
+                    style_computer.compute("empty", &Value::null(Span::unknown())),
                 ),
             )
         }
@@ -162,7 +162,7 @@ pub fn load_theme_from_config(config: &Config) -> TableTheme {
 }
 
 fn lookup_separator_color(style_computer: &StyleComputer) -> nu_ansi_term::Style {
-    style_computer.compute("separator", &Value::nothing(Span::unknown()))
+    style_computer.compute("separator", &Value::null(Span::unknown()))
 }
 
 fn with_footer(config: &Config, with_header: bool, count_records: usize) -> bool {

--- a/crates/nu-table/src/unstructured_table.rs
+++ b/crates/nu-table/src/unstructured_table.rs
@@ -54,7 +54,7 @@ fn build_table(val: TableValue, style_computer: &StyleComputer, theme: &TableThe
     ));
 
     // color_config closures for "separator" are just given a null.
-    let color = style_computer.compute("separator", &Value::nothing(Span::unknown()));
+    let color = style_computer.compute("separator", &Value::null(Span::unknown()));
     let color = color.paint(" ").to_string();
     if let Ok(color) = Color::try_from(color) {
         // # SAFETY

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -23,7 +23,7 @@ let dark_theme = {
     range: white
     float: white
     string: white
-    nothing: white
+    "null": white
     binary: white
     cellpath: white
     row_index: green_bold
@@ -86,7 +86,7 @@ let light_theme = {
     range: dark_gray
     float: dark_gray
     string: dark_gray
-    nothing: dark_gray
+    "null": dark_gray
     binary: dark_gray
     cellpath: dark_gray
     row_index: green_bold

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -54,7 +54,7 @@ let dark_theme = {
     shape_literal: blue
     shape_match_pattern: green
     shape_matching_brackets: { attr: u }
-    shape_nothing: light_cyan
+    shape_null: light_cyan
     shape_operator: yellow
     shape_or: purple_bold
     shape_pipe: purple_bold
@@ -117,7 +117,7 @@ let light_theme = {
     shape_literal: blue
     shape_match_pattern: green
     shape_matching_brackets: { attr: u }
-    shape_nothing: light_cyan
+    shape_null: light_cyan
     shape_operator: yellow
     shape_or: purple_bold
     shape_pipe: purple_bold

--- a/crates/nu_plugin_example/src/example.rs
+++ b/crates/nu_plugin_example/src/example.rs
@@ -53,7 +53,7 @@ impl Example {
     pub fn test1(&self, call: &EvaluatedCall, input: &Value) -> Result<Value, LabeledError> {
         self.print_values(1, call, input)?;
 
-        Ok(Value::Nothing { span: call.head })
+        Ok(Value::Null { span: call.head })
     }
 
     pub fn test2(&self, call: &EvaluatedCall, input: &Value) -> Result<Value, LabeledError> {

--- a/crates/nu_plugin_example/src/nu/mod.rs
+++ b/crates/nu_plugin_example/src/nu/mod.rs
@@ -9,7 +9,7 @@ impl Plugin for Example {
         // plugin is registered to nushell
         vec![
             PluginSignature::build("nu-example-1")
-                .usage("PluginSignature test 1 for plugin. Returns Value::Nothing")
+                .usage("PluginSignature test 1 for plugin. Returns Value::Null")
                 .required("a", SyntaxShape::Int, "required integer value")
                 .required("b", SyntaxShape::String, "required string value")
                 .switch("flag", "a flag for the signature", Some('f'))

--- a/crates/nu_plugin_formats/src/from/eml.rs
+++ b/crates/nu_plugin_formats/src/from/eml.rs
@@ -36,7 +36,7 @@ Test' | from eml"
                     Value::Record {
                         cols: vec!["Name".to_string(), "Address".to_string()],
                         vals: vec![
-                            Value::nothing(Span::test_data()),
+                            Value::null(Span::test_data()),
                             Value::test_string("test@email.com"),
                         ],
                         span: Span::test_data(),
@@ -44,7 +44,7 @@ Test' | from eml"
                     Value::Record {
                         cols: vec!["Name".to_string(), "Address".to_string()],
                         vals: vec![
-                            Value::nothing(Span::test_data()),
+                            Value::null(Span::test_data()),
                             Value::test_string("someone@somewhere.com"),
                         ],
                         span: Span::test_data(),
@@ -73,7 +73,7 @@ Test' | from eml -b 1"
                     Value::Record {
                         cols: vec!["Name".to_string(), "Address".to_string()],
                         vals: vec![
-                            Value::nothing(Span::test_data()),
+                            Value::null(Span::test_data()),
                             Value::test_string("test@email.com"),
                         ],
                         span: Span::test_data(),
@@ -81,7 +81,7 @@ Test' | from eml -b 1"
                     Value::Record {
                         cols: vec!["Name".to_string(), "Address".to_string()],
                         vals: vec![
-                            Value::nothing(Span::test_data()),
+                            Value::null(Span::test_data()),
                             Value::test_string("someone@somewhere.com"),
                         ],
                         span: Span::test_data(),
@@ -97,7 +97,7 @@ Test' | from eml -b 1"
 fn emailaddress_to_value(span: Span, email_address: &EmailAddress) -> Value {
     let (n, a) = match email_address {
         EmailAddress::AddressOnly { address } => (
-            Value::nothing(span),
+            Value::null(span),
             Value::String {
                 val: address.to_string(),
                 span,
@@ -135,7 +135,7 @@ fn headerfieldvalue_to_value(head: Span, value: &HeaderFieldValue) -> Value {
             span: head,
         },
         Unstructured(s) => Value::string(s, head),
-        Empty => Value::nothing(head),
+        Empty => Value::null(head),
     }
 }
 

--- a/crates/nu_plugin_formats/src/from/ics.rs
+++ b/crates/nu_plugin_formats/src/from/ics.rs
@@ -261,11 +261,11 @@ fn properties_to_value(properties: Vec<Property>, span: Span) -> Value {
                 };
                 let value = match prop.value {
                     Some(val) => Value::String { val, span },
-                    None => Value::nothing(span),
+                    None => Value::null(span),
                 };
                 let params = match prop.params {
                     Some(param_list) => params_to_value(param_list, span),
-                    None => Value::nothing(span),
+                    None => Value::null(span),
                 };
 
                 row.insert("name".to_string(), name);

--- a/crates/nu_plugin_formats/src/from/vcf.rs
+++ b/crates/nu_plugin_formats/src/from/vcf.rs
@@ -63,7 +63,7 @@ END:VCARD' | from vcf"
                             vals: vec![
                                 Value::test_string("N"),
                                 Value::test_string("Foo"),
-                                Value::Nothing {
+                                Value::Null {
                                     span: Span::test_data(),
                                 },
                             ],
@@ -78,7 +78,7 @@ END:VCARD' | from vcf"
                             vals: vec![
                                 Value::test_string("FN"),
                                 Value::test_string("Bar"),
-                                Value::Nothing {
+                                Value::Null {
                                     span: Span::test_data(),
                                 },
                             ],
@@ -93,7 +93,7 @@ END:VCARD' | from vcf"
                             vals: vec![
                                 Value::test_string("EMAIL"),
                                 Value::test_string("foo@bar.com"),
-                                Value::Nothing {
+                                Value::Null {
                                     span: Span::test_data(),
                                 },
                             ],
@@ -131,11 +131,11 @@ fn properties_to_value(properties: Vec<Property>, span: Span) -> Value {
                 };
                 let value = match prop.value {
                     Some(val) => Value::String { val, span },
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 };
                 let params = match prop.params {
                     Some(param_list) => params_to_value(param_list, span),
-                    None => Value::Nothing { span },
+                    None => Value::Null { span },
                 };
 
                 row.insert("name".to_string(), name);

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -17,7 +17,7 @@ impl Plugin for GStat {
         input: &Value,
     ) -> Result<Value, LabeledError> {
         if name != "gstat" {
-            return Ok(Value::Nothing { span: call.head });
+            return Ok(Value::Null { span: call.head });
         }
 
         let repo_path: Option<Spanned<String>> = call.opt(0)?;

--- a/crates/nu_plugin_inc/src/nu/mod.rs
+++ b/crates/nu_plugin_inc/src/nu/mod.rs
@@ -32,7 +32,7 @@ impl Plugin for Inc {
         input: &Value,
     ) -> Result<Value, LabeledError> {
         if name != "inc" {
-            return Ok(Value::Nothing { span: call.head });
+            return Ok(Value::Null { span: call.head });
         }
 
         let cell_path: Option<CellPath> = call.opt(0)?;

--- a/crates/nu_plugin_query/src/query_json.rs
+++ b/crates/nu_plugin_query/src/query_json.rs
@@ -81,7 +81,7 @@ fn convert_gjson_value_to_nu_value(v: &gjValue, span: Span) -> Value {
 
             Value::List { vals, span }
         }
-        gjson::Kind::Null => Value::nothing(span),
+        gjson::Kind::Null => Value::null(span),
         gjson::Kind::False => Value::bool(false, span),
         gjson::Kind::Number => {
             let str_value = v.str();

--- a/crates/nu_plugin_query/src/query_web.rs
+++ b/crates/nu_plugin_query/src/query_web.rs
@@ -39,7 +39,7 @@ pub fn parse_selector_params(call: &EvaluatedCall, input: &Value) -> Result<Valu
     let attribute = call.get_flag("attribute")?.unwrap_or_default();
     let as_table: Value = call
         .get_flag("as-table")?
-        .unwrap_or_else(|| Value::nothing(head));
+        .unwrap_or_else(|| Value::null(head));
 
     let inspect = call.has_flag("inspect");
 

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -514,7 +514,7 @@ pub fn hover(engine_state: &mut EngineState, file_path: &String, location: &Valu
             FlatShape::Null => println!(
                 "{}",
                 json!({
-                    "hover": "nothing",
+                    "hover": "null",
                     "span": {
                         "start": span.start - offset,
                         "end": span.end - offset

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -511,7 +511,7 @@ pub fn hover(engine_state: &mut EngineState, file_path: &String, location: &Valu
                     }
                 })
             ),
-            FlatShape::Nothing => println!(
+            FlatShape::Null => println!(
                 "{}",
                 json!({
                     "hover": "nothing",

--- a/src/tests/test_cell_path.rs
+++ b/src/tests/test_cell_path.rs
@@ -1,6 +1,6 @@
 use crate::tests::{fail_test, run_test, TestResult};
 
-// Tests for $nothing / null / Value::Nothing
+// Tests for $nothing / null / Value::Null
 #[test]
 fn nothing_fails_string() -> TestResult {
     fail_test("$nothing.foo", "doesn't support cell paths")

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -67,9 +67,9 @@ fn scope_variable() -> TestResult {
     )
 }
 #[rstest]
-#[case("a", "<> nothing")]
+#[case("a", "<> null")]
 #[case("b", "<1.23> float")]
-#[case("flag1", "<> nothing")]
+#[case("flag1", "<> null")]
 #[case("flag2", "<4.56> float")]
 
 fn scope_command_defaults(#[case] var: &str, #[case] exp_result: &str) -> TestResult {

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -598,7 +598,7 @@ fn let_variable_type_mismatch() -> TestResult {
 
 #[test]
 fn def_with_input_output_1() -> TestResult {
-    run_test(r#"def foo []: nothing -> int { 3 }; foo"#, "3")
+    run_test(r#"def foo []: null -> int { 3 }; foo"#, "3")
 }
 
 #[test]

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -91,7 +91,7 @@ fn const_nothing() {
 
     let actual = nu!(&inp.join("; "));
 
-    assert_eq!(actual.out, "nothing");
+    assert_eq!(actual.out, "null");
 }
 
 #[test]


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/9918

# Description
this PR renames the `nothing` type to `null`.

# User-Facing Changes
`nothing` should be replaced by `null` in type annotations, e.g.
```nushell
def foo []: null -> null {}
```
instead of
```nushell
def foo []: nothing -> nothing {}
```

# Tests + Formatting
should not change anything.

# After Submitting