### PR TITLE
Fixup dataframe build after #9971

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ nu-cli = { path = "./crates/nu-cli", version = "0.83.2" }
 nu-color-config = { path = "./crates/nu-color-config", version = "0.83.2" }
 nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.83.2" }
 nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.83.2" }
-nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.83.2", optional = true }
+nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.83.2", features = ["dataframe"], optional = true }
 nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.83.2", optional = true }
 nu-command = { path = "./crates/nu-command", version = "0.83.2" }
 nu-engine = { path = "./crates/nu-engine", version = "0.83.2" }


### PR DESCRIPTION
# Description
Building broke silently.

`nu` needs to enable the `dataframe` feature of `nu-cmd-dataframe`

# User-Facing Changes
Building with `cargo build --features dataframe` works again.

# Tests + Formatting
Still worth investigating if we can harden the CI against this.
