### PR TITLE
test: clear parent envs to prevent leakage to tests

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -431,7 +431,7 @@ pub enum ShellError {
     #[diagnostic(
         code(nu::shell::automatic_env_var_set_manually),
         help(
-            r#"The environment variable '{envvar_name}' is set automatically by Nushell and cannot not be set manually."#
+            r#"The environment variable '{envvar_name}' is set automatically by Nushell and cannot be set manually."#
         )
     )]
     AutomaticEnvVarSetManually {

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -161,6 +161,7 @@ macro_rules! nu {
 
         let mut command = Command::new($crate::fs::executable_path());
         command
+            .env_clear()
             .env("PWD", &target_cwd)
             .env(nu_utils::locale::LOCALE_OVERRIDE_ENV_VAR, locale)
             .current_dir(target_cwd)

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -161,10 +161,10 @@ macro_rules! nu {
 
         let mut command = Command::new($crate::fs::executable_path());
         command
+            .current_dir(&target_cwd)
             .env_clear()
             .env("PWD", &target_cwd)
             .env(nu_utils::locale::LOCALE_OVERRIDE_ENV_VAR, locale)
-            .current_dir(target_cwd)
             .env(NATIVE_PATH_ENV_VAR, paths_joined)
             // .arg("--skip-plugins")
             // .arg("--no-history")
@@ -323,9 +323,10 @@ macro_rules! nu_with_std {
 
         let mut command = Command::new($crate::fs::executable_path());
         command
+            .current_dir(&target_cwd)
+            .env_clear()
             .env("PWD", &target_cwd)
             .env(nu_utils::locale::LOCALE_OVERRIDE_ENV_VAR, locale)
-            .current_dir(target_cwd)
             .env(NATIVE_PATH_ENV_VAR, paths_joined)
             // .arg("--skip-plugins")
             // .arg("--no-history")
@@ -439,6 +440,7 @@ macro_rules! nu_with_plugins {
         }
         let mut process = match Command::new(executable_path)
             .current_dir(&target_cwd)
+            .env_clear()
             .env("PWD", &target_cwd) // setting PWD is enough to set cwd
             .arg("--commands")
             .arg(commands)

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -190,7 +190,7 @@ fn hides_env_in_block() {
 #[test]
 fn env_var_not_var() {
     let actual = nu!("
-        echo $PATH
+        echo $PWD
         ");
-    assert!(actual.err.contains("use $env.PATH instead of $PATH"));
+    assert!(actual.err.contains("use $env.PWD instead of $PWD"));
 }

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -190,7 +190,7 @@ fn hides_env_in_block() {
 #[test]
 fn env_var_not_var() {
     let actual = nu!("
-        echo $CARGO
+        echo $PATH
         ");
-    assert!(actual.err.contains("use $env.CARGO instead of $CARGO"));
+    assert!(actual.err.contains("use $env.PATH instead of $PATH"));
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Running tests locally from nushell with customizations (i.e. $env.PROMPT_COMMAND etc) may lead to failing tests as that customization leaks to the sandboxed nu itself.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No

# Tests + Formatting

Tests are now passing locally without issue in my case
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
No actions are needed
