### PR TITLE
fix the signature of `input list`

### DIFF
--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -44,7 +44,7 @@ impl Command for InputList {
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
-                (Type::List(Box::new(Type::String)), Type::String),
+                (Type::List(Box::new(Type::Any)), Type::Any),
             ])
             .optional("prompt", SyntaxShape::String, "the prompt to display")
             .switch(


### PR DESCRIPTION
# Description
in its documentation, `input list` says it only accepts the following signatures
- `list<any> -> list<any>`
- `list<string> -> string`

however this is incorrect as the following is allowed and even in the help page
```nushell
[1 2 3] | input list  # -> returns an `int`
```

this PR fixes the signature of `input list`.
- with no option or `--fuzzy`, `input list` takes a `list<any>` and outputs a single `any`
- with `--multi`, `input list` takes a `list<any>` and outputs a `list<any>`

# User-Facing Changes
the input output signature of `input list` is now
```
  ╭───┬───────────┬───────────╮
  │ # │   input   │  output   │
  ├───┼───────────┼───────────┤
  │ 0 │ list<any> │ list<any> │
  │ 1 │ list<any> │ any       │
  ╰───┴───────────┴───────────╯
```
# Tests + Formatting
this shouldn't change anything as `[1 2 3] | input list` already works.

# After Submitting