### PR TITLE
allow `select` to take a $variable with a list of columns

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -152,88 +152,12 @@ produce a table, a list will produce a list, and a record will produce a record.
             Example {
                 description: "Select columns by a provided list of columns",
                 example: "let cols = [name type];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select $cols",
-                result: Some(
-                    Value::List {
-                        vals: vec![
-                            Value::Record {
-                                cols: vec!["name".into(), "type".into()],
-                                vals: vec![
-                                    Value::String {
-                                        val: "Cargo.toml".into(),
-                                        span: Span::unknown(),
-                                    },
-                                    Value::String {
-                                        val: "toml".into(),
-                                        span: Span::unknown(),
-                                    },
-                                ],
-                                span: Span::unknown(),
-                            },
-                            Value::Record {
-                                cols: vec!["name".into(), "type".into()],
-                                vals: vec![
-                                    Value::String {
-                                        val: "Cargo.lock".into(),
-                                        span: Span::unknown(),
-                                    },
-                                    Value::String {
-                                        val: "toml".into(),
-                                        span: Span::unknown(),
-                                    },
-                                ],
-                                span: Span::unknown(),
-                            },
-                        ],
-                        span: Span::unknown(),
-                    }
-                ),
+                result: None
             },
             Example {
                 description: "Select rows by a provided list of rows",
                 example: "let rows = [0 2];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb] [file.json json 3kb]] | select $rows",
-                result: Some(
-                    Value::List {
-                        vals: vec![
-                            Value::Record {
-                                cols: vec!["name".into(), "type".into(), "size".into()],
-                                vals: vec![
-                                    Value::String {
-                                        val: "Cargo.toml".into(),
-                                        span: Span::unknown(),
-                                    },
-                                    Value::String {
-                                        val: "toml".into(),
-                                        span: Span::unknown(),
-                                    },
-                                    Value::String {
-                                        val: "1kb".into(),
-                                        span: Span::unknown(),
-                                    },
-                                ],
-                                span: Span::unknown(),
-                            },
-                            Value::Record {
-                                cols: vec!["name".into(), "type".into(), "size".into()],
-                                vals: vec![
-                                    Value::String {
-                                        val: "file.json".into(),
-                                        span: Span::unknown(),
-                                    },
-                                    Value::String {
-                                        val: "json".into(),
-                                        span: Span::unknown(),
-                                    },
-                                    Value::String {
-                                        val: "3kb".into(),
-                                        span: Span::unknown(),
-                                    },
-                                ],
-                                span: Span::unknown(),
-                            },
-                        ],
-                        span: Span::unknown(),
-                    }
-                ),
+                result: None
             },
         ]
     }

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -97,10 +97,20 @@ produce a table, a list will produce a list, and a record will produce a record.
                                     from_type: y.get_type().to_string(),
                                     span: y.span()?,
                                     help: None,
-                                })
+                                });
                             }
                         }
                     }
+                }
+                Value::String { val, .. } => {
+                    let cv = CellPath {
+                        members: vec![PathMember::String {
+                            val: val.clone(),
+                            span: Span::unknown(),
+                            optional: false,
+                        }],
+                    };
+                    new_columns.push(cv.clone());
                 }
                 x => {
                     return Err(ShellError::CantConvert {
@@ -108,7 +118,7 @@ produce a table, a list will produce a list, and a record will produce a record.
                         from_type: x.get_type().to_string(),
                         span: x.span()?,
                         help: None,
-                    })
+                    });
                 }
             }
         }

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -244,3 +244,23 @@ fn select_on_empty_list_returns_empty_list() {
     let actual = nu!("[] | each {|i| $i} | select foo | to nuon");
     assert_eq!(actual.out, "[]");
 }
+
+#[test]
+fn select_columns_with_variable_list() {
+    let actual = nu!(r#"
+        let columns = [a c];
+        echo [[a b c]; [1 2 3]] | select $columns | to nuon
+        "#);
+
+    assert_eq!(actual.out, "[[a, c]; [1, 3]]");
+}
+
+#[test]
+fn select_rows_with_variable_list() {
+    let actual = nu!(r#"
+        let rows = [0 2];
+        echo [[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select $rows | to nuon
+        "#);
+
+    assert_eq!(actual.out, "[[a, b, c]; [1, 2, 3], [7, 8, 9]]");
+}


### PR DESCRIPTION
# Description

This PR enables `select` to take a constructed list of columns as a variable.

```nushell
> let cols = [name type];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select $cols
  ╭#┬───name───┬type╮
  │0│Cargo.toml│toml│
  │1│Cargo.lock│toml│
  ╰─┴──────────┴────╯
```
and rows
```nushell
> let rows = [0 2];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb] [file.json json 3kb]] | select $rows
  ╭#┬───name───┬type┬size╮
  │0│Cargo.toml│toml│1kb │
  │1│file.json │json│3kb │
  ╰─┴──────────┴────┴────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
