### PR TITLE
Fix `watch` not handling all file changes

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -251,7 +251,8 @@ impl Command for Watch {
                                 .pop()
                                 .map(|path| event_handler("Remove", path, None))
                                 .unwrap_or(Ok(())),
-                            EventKind::Modify(ModifyKind::Data(DataChange::Content)) => one_event
+                            EventKind::Modify(ModifyKind::Data(DataChange::Content))
+                            | EventKind::Modify(ModifyKind::Data(DataChange::Any)) => one_event
                                 .paths
                                 .pop()
                                 .map(|path| event_handler("Write", path, None))


### PR DESCRIPTION
Closes https://github.com/nushell/nushell/issues/9910

I noticed that`watch` was not catching all filesystem changes, because some are reported as `ModifyKind::Data(DataChange::Any)` and we were only handling `ModifyKind::Data(DataChange::Content)`. Easy fix.

This was happening on Ubuntu 23.04, ext4.