### PR TITLE
allow `ls -s` to have ls_colors

### DIFF
--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -78,7 +78,7 @@ impl Command for Metadata {
                 if let Some(x) = input.metadata().as_deref() {
                     match x {
                         PipelineMetadata {
-                            data_source: DataSource::Ls,
+                            data_source: DataSource::Ls(_full_paths),
                         } => {
                             cols.push("source".into());
                             vals.push(Value::string("ls", head))
@@ -153,7 +153,7 @@ fn build_metadata_record(
     if let Some(x) = metadata.as_deref() {
         match x {
             PipelineMetadata {
-                data_source: DataSource::Ls,
+                data_source: DataSource::Ls(_full_paths),
             } => {
                 cols.push("source".into());
                 vals.push(Value::string("ls", head))

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -441,7 +441,7 @@ pub(crate) fn dir_entry_dict(
         span,
     });
 
-    cols.push("filename".into());
+    cols.push("fullpath".into());
     vals.push(Value::String {
         val: filename.display().to_string(),
         span,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -195,10 +195,8 @@ impl Command for Ls {
                         return None;
                     }
 
-                    let display_name = if short_names {
-                        path.file_name().map(|os| os.to_string_lossy().to_string())
-                    } else if full_paths || absolute_path {
-                        Some(path.to_string_lossy().to_string())
+                    let display_name = if short_names || absolute_path {
+                        Some(path.display().to_string())
                     } else if let Some(prefix) = &prefix {
                         if let Ok(remainder) = path.strip_prefix(prefix) {
                             if directory {
@@ -269,7 +267,7 @@ impl Command for Ls {
             })
             .into_pipeline_data_with_metadata(
                 Box::new(PipelineMetadata {
-                    data_source: DataSource::Ls,
+                    data_source: DataSource::Ls(full_paths),
                 }),
                 engine_state.ctrlc.clone(),
             ))
@@ -436,12 +434,6 @@ pub(crate) fn dir_entry_dict(
     let mut file_type = "unknown".to_string();
 
     cols.push("name".into());
-    vals.push(Value::String {
-        val: display_name.to_string(),
-        span,
-    });
-
-    cols.push("fullpath".into());
     vals.push(Value::String {
         val: filename.display().to_string(),
         span,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -441,6 +441,12 @@ pub(crate) fn dir_entry_dict(
         span,
     });
 
+    cols.push("filename".into());
+    vals.push(Value::String {
+        val: filename.display().to_string(),
+        span,
+    });
+
     if let Some(md) = metadata {
         file_type = get_file_type(md, display_name, use_mime_type);
         cols.push("type".into());

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -470,17 +470,17 @@ fn handle_row_stream(
                                     // We get the filename index and value here so that we can use that information
                                     // to pass into lscolors so that even if `ls -s` is used, we still know the full
                                     // path and can color it appropriately
-                                    let filename_idx = cols
+                                    let fullpath_idx = cols
                                         .iter()
-                                        .position(|r| r.clone() == "filename")
+                                        .position(|r| r.clone() == "fullpath")
                                         .unwrap_or(idx);
-                                    let filename_val = vals
-                                        .get(filename_idx)
+                                    let fullpath_val = vals
+                                        .get(fullpath_idx)
                                         .unwrap_or(vals.get(idx).expect("cant fail"))
                                         .into_string("", &config);
 
                                     let val = render_path_name(
-                                        &filename_val,
+                                        &fullpath_val,
                                         val,
                                         &config,
                                         &ls_colors,
@@ -493,7 +493,7 @@ fn handle_row_stream(
                             }
                             // Now that we've rendered the path, we don't need the filename column
                             // in the output, so let's remove it.
-                            if cols[idx] == "filename" {
+                            if cols[idx] == "fullpath" {
                                 cols.remove(idx);
                                 vals.remove(idx);
                             }
@@ -811,7 +811,7 @@ impl Iterator for PagingTableCreator {
 }
 
 fn render_path_name(
-    filename: &str,
+    fullpath: &str,
     display_name: &str,
     config: &Config,
     ls_colors: &LsColors,
@@ -821,7 +821,7 @@ fn render_path_name(
         return None;
     }
 
-    let stripped_path = nu_utils::strip_ansi_unlikely(filename);
+    let stripped_path = nu_utils::strip_ansi_unlikely(fullpath);
 
     let (style, has_metadata) = match std::fs::symlink_metadata(stripped_path.as_ref()) {
         Ok(metadata) => (

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -62,7 +62,7 @@ pub struct PipelineMetadata {
 
 #[derive(Debug, Clone)]
 pub enum DataSource {
-    Ls,
+    Ls(bool), // full_paths
     HtmlThemes,
     Profiling(Vec<Value>),
 }


### PR DESCRIPTION
# Description

This PR allows `ls -s /some/path` to apply ls colors. This could be considered innovative or hackery. You be the judge.

I noticed that when we do a `ls` we have a display name and a file name. So, I took the filename and passed it through the pipeline up to the point where ls_colors happens. Then I use the filename to color the display name and before it's printed out, I remove the filename column.

### Before
![image](https://github.com/nushell/nushell/assets/343840/8cbd71e7-8e32-4e36-9bbd-68a29ce44828)

### After
![image](https://github.com/nushell/nushell/assets/343840/0964cccf-b5b5-49c8-b7da-41cda8d4a519)


closes #4319


Windows folder maintaining colors.
![image](https://github.com/nushell/nushell/assets/343840/92838e4b-210a-49b6-8def-54d619b0550f)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
