### PR TITLE
Improve I/O types of `into decimal`(/float)

### DIFF
--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -77,9 +77,12 @@ impl Command for SubCommand {
                 result: Some(Value::test_float(1.345)),
             },
             Example {
-                description: "Convert decimal to decimal",
-                example: "'-5.9' | into decimal",
-                result: Some(Value::test_float(-5.9)),
+                description: "Coerce list of ints and floats to float",
+                example: "[4 -5.9] | into decimal",
+                result: Some(Value::test_list(vec![
+                    Value::test_float(4.0),
+                    Value::test_float(-5.9),
+                ])),
             },
             Example {
                 description: "Convert boolean to decimal",

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
                 (Type::Int, Type::Number),
                 (Type::String, Type::Number),
                 (Type::Bool, Type::Number),
+                (Type::Float, Type::Float),
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
                 (
@@ -91,6 +92,7 @@ impl Command for SubCommand {
 
 fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
     match input {
+        Value::Float { .. } => input.clone(),
         Value::String { val: s, span } => {
             let other = s.trim();
 

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -17,15 +17,15 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("into decimal")
             .input_output_types(vec![
-                (Type::Int, Type::Number),
-                (Type::String, Type::Number),
-                (Type::Bool, Type::Number),
+                (Type::Int, Type::Float),
+                (Type::String, Type::Float),
+                (Type::Bool, Type::Float),
                 (Type::Float, Type::Float),
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
                 (
                     Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Number)),
+                    Type::List(Box::new(Type::Float)),
                 ),
             ])
             .rest(


### PR DESCRIPTION
# Description
- Add identity cast to `into decimal` (float->float)
- Correct `into decimal` output to concrete float

# User-Facing Changes
`1.23 | into decimal` will now work.
By fixing the output type it can now be used in conjunction with commands that expect `float`/`list<float>`

# Tests + Formatting
Adapts example to do identity cast and heterogeneous cast
