### PR TITLE
set the right prompt to "" by default

### DIFF
--- a/crates/nu-cli/src/prompt.rs
+++ b/crates/nu-cli/src/prompt.rs
@@ -119,12 +119,7 @@ impl Prompt for NushellPrompt {
         if let Some(prompt_string) = &self.right_prompt_string {
             prompt_string.replace('\n', "\r\n").into()
         } else {
-            let default = DefaultPrompt::default();
-            default
-                .render_prompt_right()
-                .to_string()
-                .replace('\n', "\r\n")
-                .into()
+            "".into()
         }
     }
 

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -44,7 +44,7 @@ def create_right_prompt [] {
 
 # Use nushell functions to define your right and left prompt
 $env.PROMPT_COMMAND = {|| create_left_prompt }
-# $env.PROMPT_COMMAND_RIGHT = {|| create_right_prompt }
+$env.PROMPT_COMMAND_RIGHT = ""  # {|| create_right_prompt }
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt


### PR DESCRIPTION
should close https://github.com/nushell/nushell/issues/9923

# Description
the right prompt appears to cause some issue when resizing and, because it's on by default when not set explicitely, users have to unset it themselves as in https://github.com/nushell/nushell/issues/9923 which can be confusing :open_mouth: 

i propose to set the default "right prompt" to the empty string so that users do not have to unsert it, only set it when they want :yum: 

> **Note**
> this PR does NOT remove the right prompt example from `default_env.nu`, it's only `$env.PROMPT_COMMAND_RIGHT` which is set to `""` but there is the example with the `create_right_prompt` commented out :innocent: 

# User-Facing Changes
the right prompt is empty by default.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :black_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting