### PR TITLE
Fix example for `extern-wrapped`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/extern_wrapped.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_wrapped.rs
@@ -11,7 +11,7 @@ impl Command for ExternWrapped {
     }
 
     fn usage(&self) -> &str {
-        "Define a signature for an external command."
+        "Define a signature for an external command with a custom code block."
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -19,7 +19,7 @@ impl Command for ExternWrapped {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("def_name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
-            .required("body", SyntaxShape::Block, "wrapper function block")
+            .required("body", SyntaxShape::Block, "wrapper block")
             .category(Category::Core)
     }
 
@@ -44,9 +44,19 @@ impl Command for ExternWrapped {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Write a signature for an external command",
-            example: r#"extern-wrapped echo [text: string] { print $text }"#,
+            description: "Define a custom wrapper for an external command",
+            example: r#"extern-wrapped my-echo [...rest] { ^echo $rest }"#,
             result: None,
         }]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::ExternWrapped;
+        use crate::test_examples;
+        test_examples(ExternWrapped {})
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/extern_wrapped.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_wrapped.rs
@@ -19,7 +19,7 @@ impl Command for ExternWrapped {
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("def_name", SyntaxShape::String, "definition name")
             .required("params", SyntaxShape::Signature, "parameters")
-            .required("body", SyntaxShape::Block, "wrapper block")
+            .required("body", SyntaxShape::Block, "wrapper code block")
             .category(Category::Core)
     }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes example and some signature text of `extern-wrapped`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Minor help text changes

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
