### PR TITLE
fix(nu-parser): do not update plugin.nu file on nu startup

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3562,68 +3562,55 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
     let stack = Stack::new();
     let current_envs =
         nu_engine::env::env_to_strings(working_set.permanent_state, &stack).unwrap_or_default();
-    let error = match signature {
-        Some(signature) => arguments.and_then(|(path, path_span)| {
-            let path = path.path_buf();
-            // restrict plugin file name starts with `nu_plugin_`
-            let valid_plugin_name = path
-                .file_name()
-                .map(|s| s.to_string_lossy().starts_with("nu_plugin_"));
 
-            if let Some(true) = valid_plugin_name {
-                signature.map(|signature| {
-                    let plugin_decl = PluginDeclaration::new(path, signature, shell);
-                    working_set.add_decl(Box::new(plugin_decl));
+    let error = arguments.and_then(|(path, path_span)| {
+        let path = path.path_buf();
+        // restrict plugin file name starts with `nu_plugin_`
+        let valid_plugin_name = path
+            .file_name()
+            .map(|s| s.to_string_lossy().starts_with("nu_plugin_"));
+
+        let Some(true) = valid_plugin_name else {
+            return Err(ParseError::LabeledError(
+                "Register plugin failed".into(),
+                "plugin name must start with nu_plugin_".into(),
+                path_span,
+            ));
+        };
+
+        let signatures = signature.map_or_else(
+            || {
+                let signatures = get_signature(&path, &shell, &current_envs).map_err(|err| {
+                    ParseError::LabeledError(
+                        "Error getting signatures".into(),
+                        err.to_string(),
+                        spans[0],
+                    )
+                });
+
+                if signatures.is_ok() {
+                    // mark plugins file as dirty only when the user is registering plugins
+                    // and not when we evaluate plugin.nu on shell startup
                     working_set.mark_plugins_file_dirty();
-                })
-            } else {
-                Err(ParseError::LabeledError(
-                    "Register plugin failed".into(),
-                    "plugin name must start with nu_plugin_".into(),
-                    path_span,
-                ))
-            }
-        }),
-        None => arguments.and_then(|(path, path_span)| {
-            let path = path.path_buf();
-            // restrict plugin file name starts with `nu_plugin_`
-            let valid_plugin_name = path
-                .file_name()
-                .map(|s| s.to_string_lossy().starts_with("nu_plugin_"));
+                }
 
-            if let Some(true) = valid_plugin_name {
-                get_signature(&path, &shell, &current_envs)
-                    .map_err(|err| {
-                        ParseError::LabeledError(
-                            "Error getting signatures".into(),
-                            err.to_string(),
-                            spans[0],
-                        )
-                    })
-                    .map(|signatures| {
-                        for signature in signatures {
-                            // create plugin command declaration (need struct impl Command)
-                            // store declaration in working set
-                            let plugin_decl =
-                                PluginDeclaration::new(path.clone(), signature, shell.clone());
+                signatures
+            },
+            |sig| sig.map(|sig| vec![sig]),
+        )?;
 
-                            working_set.add_decl(Box::new(plugin_decl));
-                        }
+        for signature in signatures {
+            // create plugin command declaration (need struct impl Command)
+            // store declaration in working set
+            let plugin_decl = PluginDeclaration::new(path.clone(), signature, shell.clone());
 
-                        working_set.mark_plugins_file_dirty();
-                    })
-            } else {
-                Err(ParseError::LabeledError(
-                    "Register plugin failed".into(),
-                    "plugin name must start with nu_plugin_".into(),
-                    path_span,
-                ))
-            }
-        }),
-    }
-    .err();
+            working_set.add_decl(Box::new(plugin_decl));
+        }
 
-    if let Some(err) = error {
+        Ok(())
+    });
+
+    if let Err(err) = error {
         working_set.error(err);
     }
 

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -164,6 +164,8 @@ macro_rules! nu {
         command
             .env(nu_utils::locale::LOCALE_OVERRIDE_ENV_VAR, locale)
             .env(NATIVE_PATH_ENV_VAR, paths_joined)
+            // TODO: consider adding custom plugin path for tests to
+            // not interfere with user local environment
             // .arg("--skip-plugins")
             // .arg("--no-history")
             // .arg("--config-file")


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

I've been investigating the [issue mentioned](https://github.com/nushell/nushell/pull/9976#issuecomment-1673290467) in my prev pr and I've found that plugin.nu file that is used to cache plugins signatures gets overwritten on every nushell startup and that may actually mess up with the file content if 2 or more instances of nushell will run simultaneously.

To reproduce:
1. register at least 2 plugins in your local nushell
2. remember how many entries you have in plugin.nu with `open $nu.plugin-path | find nu_plugin`
3. run 
    - either `cargo test` inside nushell repo
    - or run smth like this `1..100 | par-each {|it| $"(random integer 1..100)ms" | into duration | sleep $in; nu -c "$nu.plugin-path"}` to simulate parallel access. This approach is not so reliable to reproduce as running test but still a good point that it may effect users actually
4. validate that your `plugin.nu` file was stripped

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# Solution

In this pr I've refactored the code of handling the `register` command to minimize code duplications and make sure that overwrite of `plugin.nu` file is happen only when user calls the command and not on nu startup

Another option would be to use temp `plugin.nu` when running tests, but as the issue actually can affect users I've decided to prevent unnecessary writing at all. Although having isolated `plugin.nu` still worth of doing

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
It changes the behaviour actually as the call `register <plugin> <signature>` now doesn't updates `plugin.nu` and just reads signatures to the memory. But as I understand that kind of call with explicit signature is meant to use only by nushell itself in the `plugin.nu` file only. I've asked about it in [discord](https://discordapp.com/channels/601130461678272522/615962413203718156/1140013448915325018)

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Actually, I think the way plugins are stored might be reworked to prevent or mitigate possible issues further:
- problem with writing to file may still arise if we try to register in parallel as several instances will write to the same file so the lock for the file might be required
- using additional parameters to command like `register` to implement some internal logic could be misleading to the users
- `register` call actually affects global state of nushell that sounds a little bit inconsistent with immutability and isolation of other parts of the nu. See issues [1](https://github.com/nushell/nushell/issues/8581), [2](https://github.com/nushell/nushell/issues/8960)
