### PR TITLE
Support Termux

### DIFF
--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -16,5 +16,5 @@ dirs-next = "2.0"
 [target.'cfg(windows)'.dependencies]
 omnipath = "0.1"
 
-[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+[target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android")))'.dependencies]
 pwd = "1.3"


### PR DESCRIPTION
# Description

On Android, Nushell currently fails to compile because the `pwd` library attempts to use `getpwent` to fetch a user's home directory from the OS, and this function does not exist on Android. The Termux package currently works around this problem with a [special patch](https://github.com/termux/termux-packages/blob/7f942e3225bde77fd162d2d378e19fe93b895f3c/packages/nushell/user_home_dir.patch). I attempted to patch this [upstream](https://gitlab.com/pwoolcoc/pwd/-/merge_requests/4), but the author of this lib seems unresponsive.

This commit solves this issue by adding platform conditional code to fetch the home dir. Additionally, the logic is refactored and combined for Windows and Mac as well, since all three platforms can benefit from `dirs_next`, and the fallback path differs only by the hardcoded base path.

Additionally, when the platform is specifically Termux, the home directory can be hardcoded altogether, as Termux is single user and always has the same home directory.

# User-Facing Changes

Should be none, except fixing Android.

# Tests + Formatting

* Tested manually with a local build
* Some unit tests fail due to what look like hardcoded target binary paths, but I think those should probably be fixed in a separate PR