### PR TITLE
deprecate `--format` and `--list` in `into datetime`

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -4,9 +4,8 @@ use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::ast::CellPath;
-use nu_protocol::engine::StateWorkingSet;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::report_error;
+use nu_protocol::report_error_new;
 use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned,
     SyntaxShape, Type, Value,
@@ -113,8 +112,8 @@ impl Command for SubCommand {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         if call.has_flag("list") {
-            report_error(
-                &StateWorkingSet::new(engine_state),
+            report_error_new(
+                engine_state,
                 &ShellError::GenericError(
                     "Deprecated option".into(),
                     "`into datetime --list` is deprecated and will be removed in 0.85".into(),
@@ -144,8 +143,8 @@ impl Command for SubCommand {
                 };
 
             if call.has_flag("format") {
-                report_error(
-                    &StateWorkingSet::new(engine_state),
+                report_error_new(
+                    engine_state,
                     &ShellError::GenericError(
                         "Deprecated option".into(),
                         "`into datetime --format` is deprecated and will be removed in 0.85".into(),

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -93,12 +93,12 @@ impl Command for SubCommand {
             .named(
                 "format",
                 SyntaxShape::String,
-                format!("{YELLOW}deprecated option{RESET}, will be {RED}removed in 0.85{RESET}: see {DEFAULT_DIMMED_ITALIC}format date{RESET}"),
+                format!("DEPRECATED option, will be removed in 0.85: see `format date`"),
                 Some('f'),
             )
             .switch(
                 "list",
-                format!("{YELLOW}deprecated option{RESET}, will be {RED}removed in 0.85{RESET}: see {DEFAULT_DIMMED_ITALIC}format date --list{RESET}"),
+                format!("DEPRECATED option, will be removed in 0.85: see `format date --list`"),
                 Some('l'),
                 )
             .rest(
@@ -116,9 +116,18 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let use_ansi_coloring = engine_state.get_config().use_ansi_coloring;
+
         if call.has_flag("list") {
-            eprintln!("{YELLOW}WARNING{RESET}: {DEFAULT_DIMMED_ITALIC}into datetime --list{RESET} is deprecated and will be {RED}removed in 0.85{RESET}");
-            eprintln!("    {CYAN}help{RESET}: see {DEFAULT_DIMMED_ITALIC}format datetime --list{RESET} instead");
+            if use_ansi_coloring {
+                eprintln!("{YELLOW}WARNING{RESET}: {DEFAULT_DIMMED_ITALIC}into datetime --list{RESET} is deprecated and will be {RED}removed in 0.85{RESET}");
+                eprintln!("    {CYAN}help{RESET}: see {DEFAULT_DIMMED_ITALIC}format datetime --list{RESET} instead");
+            } else {
+                eprintln!(
+                    "WARNING: `into datetime --list` is deprecated and will be removed in 0.85"
+                );
+                eprintln!("    help: see `format datetime --list` instead");
+            }
             Ok(generate_strftime_list(call.head, true).into_pipeline_data())
         } else {
             let cell_paths = call.rest(engine_state, stack, 0)?;
@@ -139,8 +148,15 @@ impl Command for SubCommand {
                 };
 
             if call.has_flag("format") {
-                eprintln!("{YELLOW}WARNING{RESET}: {DEFAULT_DIMMED_ITALIC}into datetime --format{RESET} is deprecated and will be {RED}removed in 0.85{RESET}");
-                eprintln!("    {CYAN}help{RESET}: see {DEFAULT_DIMMED_ITALIC}format datetime{RESET} instead");
+                if use_ansi_coloring {
+                    eprintln!("{YELLOW}WARNING{RESET}: {DEFAULT_DIMMED_ITALIC}into datetime --format{RESET} is deprecated and will be {RED}removed in 0.85{RESET}");
+                    eprintln!("    {CYAN}help{RESET}: see {DEFAULT_DIMMED_ITALIC}format datetime{RESET} instead");
+                } else {
+                    eprintln!(
+                        "WARNING: `into datetime --format` is deprecated and will be removed in 0.85"
+                    );
+                    eprintln!("    help: see `format datetime` instead");
+                }
             }
 
             let format_options = call
@@ -187,7 +203,7 @@ impl Command for SubCommand {
             },
             Example {
                 description:
-                    "Convert non-standard timestamp string to datetime using a custom format",
+                    "Convert non-standard timestamp string to datetime using a custom format (DEPRECATED: will be removed in 0.85)",
                 example: "'20210227_135540+0000' | into datetime -f '%Y%m%d_%H%M%S%z'",
                 #[allow(clippy::inconsistent_digit_grouping)]
                 result: example_result_1(1614434140_000000000),

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -93,12 +93,12 @@ impl Command for SubCommand {
             .named(
                 "format",
                 SyntaxShape::String,
-                "deprecated option, will be removed in 0.85: see `format date`",
+                format!("{YELLOW}deprecated option{RESET}, will be {RED}removed in 0.85{RESET}: see {DEFAULT_DIMMED_ITALIC}format date{RESET}"),
                 Some('f'),
             )
             .switch(
                 "list",
-                "deprecated option, will be removed in 0.85: see `format date --list`",
+                format!("{YELLOW}deprecated option{RESET}, will be {RED}removed in 0.85{RESET}: see {DEFAULT_DIMMED_ITALIC}format date --list{RESET}"),
                 Some('l'),
                 )
             .rest(

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -93,12 +93,12 @@ impl Command for SubCommand {
             .named(
                 "format",
                 SyntaxShape::String,
-                format!("DEPRECATED option, will be removed in 0.85: see `format date`"),
+                "DEPRECATED option, will be removed in 0.85: see `format date`",
                 Some('f'),
             )
             .switch(
                 "list",
-                format!("DEPRECATED option, will be removed in 0.85: see `format date --list`"),
+                "DEPRECATED option, will be removed in 0.85: see `format date --list`",
                 Some('l'),
                 )
             .rest(

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -10,6 +10,12 @@ use nu_protocol::{
     SyntaxShape, Type, Value,
 };
 
+const RED: &str = "\x1b[31m";
+const YELLOW: &str = "\x1b[33m";
+const CYAN: &str = "\x1b[36m";
+const DEFAULT_DIMMED_ITALIC: &str = "\x1b[2;3;39m";
+const RESET: &str = "\x1b[0m";
+
 struct Arguments {
     zone_options: Option<Spanned<Zone>>,
     format_options: Option<DatetimeFormat>,
@@ -87,12 +93,12 @@ impl Command for SubCommand {
             .named(
                 "format",
                 SyntaxShape::String,
-                "Specify expected format of string input to parse to datetime. Use --list to see options",
+                "deprecated option, will be removed in 0.85: see `format date`",
                 Some('f'),
             )
             .switch(
                 "list",
-                "Show all possible variables for use in --format flag",
+                "deprecated option, will be removed in 0.85: see `format date --list`",
                 Some('l'),
                 )
             .rest(
@@ -111,6 +117,8 @@ impl Command for SubCommand {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         if call.has_flag("list") {
+            eprintln!("{YELLOW}WARNING{RESET}: {DEFAULT_DIMMED_ITALIC}into datetime --list{RESET} is deprecated and will be {RED}removed in 0.85{RESET}");
+            eprintln!("    {CYAN}help{RESET}: see {DEFAULT_DIMMED_ITALIC}format datetime --list{RESET} instead");
             Ok(generate_strftime_list(call.head, true).into_pipeline_data())
         } else {
             let cell_paths = call.rest(engine_state, stack, 0)?;
@@ -129,6 +137,11 @@ impl Command for SubCommand {
                         span: zone.span,
                     }),
                 };
+
+            if call.has_flag("format") {
+                eprintln!("{YELLOW}WARNING{RESET}: {DEFAULT_DIMMED_ITALIC}into datetime --format{RESET} is deprecated and will be {RED}removed in 0.85{RESET}");
+                eprintln!("    {CYAN}help{RESET}: see {DEFAULT_DIMMED_ITALIC}format datetime{RESET} instead");
+            }
 
             let format_options = call
                 .get_flag::<String>(engine_state, stack, "format")?


### PR DESCRIPTION
related to
- https://discord.com/channels/601130461678272522/614593951969574961/1141009665266831470

# Description
this PR
- prints a colorful warning when a user uses either `--format` or `--list` on `into datetime`
- does NOT remove the features for now, i.e. the two options still work
- redirect to the `format date` command instead

i propose to
- land this now
- prepare a removal PR right after this
- land the removal PR in between 0.84 and 0.85

# User-Facing Changes
`into datetime --format` and `into datetime --list` will be deprecated in 0.85.

## how it looks
- `into datetime --list` in the REPL
```nushell
> into datetime --list | first
Error:   × Deprecated option
   ╭─[entry #1:1:1]
 1 │ into datetime --list | first
   · ──────┬──────
   ·       ╰── `into datetime --list` is deprecated and will be removed in 0.85
   ╰────
  help: see `format datetime --list` instead


╭───────────────┬────────────────────────────────────────────╮
│ Specification │ %Y                                         │
│ Example       │ 2023                                       │
│ Description   │ The full proleptic Gregorian year,         │
│               │ zero-padded to 4 digits.                   │
╰───────────────┴────────────────────────────────────────────╯
```

- `into datetime --list` in a script
```nushell
> nu /tmp/foo.nu
Error:   × Deprecated option
   ╭─[/tmp/foo.nu:4:1]
 4 │ #
 5 │ into datetime --list | first
   · ──────┬──────
   ·       ╰── `into datetime --list` is deprecated and will be removed in 0.85
   ╰────
  help: see `format datetime --list` instead


╭───────────────┬────────────────────────────────────────────╮
│ Specification │ %Y                                         │
│ Example       │ 2023                                       │
│ Description   │ The full proleptic Gregorian year,         │
│               │ zero-padded to 4 digits.                   │
╰───────────────┴────────────────────────────────────────────╯
```

- `help into datetime`

![baz](https://github.com/nushell/nushell/assets/44101798/08beece0-9c89-4665-bfe4-76a32207470f)

# Tests + Formatting

# After Submitting