### PR TITLE
Make `http -f` display the request headers. Closes #9912

### DIFF
--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -194,7 +194,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, args.data, args.content_type, ctrl_c);
+    let response = send_request(request.clone(), args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,
@@ -209,6 +209,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
+        request,
     )
 }
 

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -178,7 +178,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, None, None, ctrl_c);
+    let response = send_request(request.clone(), None, None, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,
@@ -193,6 +193,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
+        request,
     )
 }
 

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -167,7 +167,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, None, None, ctrl_c);
+    let response = send_request(request.clone(), None, None, ctrl_c);
 
     // http options' response always showed in header, so we set full to true.
     // And `raw` is useless too because options method doesn't return body, here we set to true
@@ -185,6 +185,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
+        request,
     )
 }
 

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -184,7 +184,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, Some(args.data), args.content_type, ctrl_c);
+    let response = send_request(request.clone(), Some(args.data), args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,
@@ -199,6 +199,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
+        request,
     )
 }
 

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -184,7 +184,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, Some(args.data), args.content_type, ctrl_c);
+    let response = send_request(request.clone(), Some(args.data), args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,
@@ -199,6 +199,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
+        request,
     )
 }
 

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -184,7 +184,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, Some(args.data), args.content_type, ctrl_c);
+    let response = send_request(request.clone(), Some(args.data), args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,
@@ -199,6 +199,7 @@ fn helper(
         &requested_url,
         request_flags,
         response,
+        request,
     )
 }
 


### PR DESCRIPTION
# Description
As described in https://github.com/nushell/nushell/issues/9912, the `http` command could display the request headers with the `--full` flag, which could help in debugging the requests. This PR adds such functionality.

# User-Facing Changes
If `http get` or other `http` command which supports the `--full` flag is invoked with the flag, it used to display the `headers` key which contained an table of response headers. Now this key contains two nested keys: `response` and `request`, each of them being a table of the response and request headers accordingly.

![image](https://github.com/nushell/nushell/assets/24980/d3cfc4c3-6c27-4634-8552-2cdfbdfc7076)
