### PR TITLE
Refactor `scope` commands

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/scope/aliases.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/aliases.rs
@@ -35,7 +35,7 @@ impl Command for ScopeAliases {
         let ctrlc = engine_state.ctrlc.clone();
 
         let mut scope_data = ScopeData::new(engine_state, stack);
-        scope_data.populate_all();
+        scope_data.populate_decls();
 
         Ok(scope_data.collect_aliases(span).into_pipeline_data(ctrlc))
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
@@ -35,7 +35,7 @@ impl Command for ScopeCommands {
         let ctrlc = engine_state.ctrlc.clone();
 
         let mut scope_data = ScopeData::new(engine_state, stack);
-        scope_data.populate_all();
+        scope_data.populate_decls();
 
         Ok(scope_data.collect_commands(span).into_pipeline_data(ctrlc))
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/engine_stats.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/engine_stats.rs
@@ -31,8 +31,7 @@ impl Command for ScopeEngineStats {
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
 
-        let mut scope_data = ScopeData::new(engine_state, stack);
-        scope_data.populate_all();
+        let scope_data = ScopeData::new(engine_state, stack);
 
         Ok(scope_data.collect_engine_state(span).into_pipeline_data())
     }

--- a/crates/nu-cmd-lang/src/core_commands/scope/externs.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/externs.rs
@@ -1,0 +1,62 @@
+use nu_engine::scope::ScopeData;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Type,
+};
+
+#[derive(Clone)]
+pub struct ScopeExterns;
+
+impl Command for ScopeExterns {
+    fn name(&self) -> &str {
+        "scope externs"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("scope externs")
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .allow_variants_without_examples(true)
+            .category(Category::Filters)
+    }
+
+    fn usage(&self) -> &str {
+        "Output info on the known externals in the current scope."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let span = call.head;
+        let ctrlc = engine_state.ctrlc.clone();
+
+        let mut scope_data = ScopeData::new(engine_state, stack);
+        scope_data.populate_decls();
+
+        Ok(scope_data.collect_externs(span).into_pipeline_data(ctrlc))
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Show the known externals in the current scope",
+            example: "scope externs",
+            result: None,
+        }]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(ScopeExterns {})
+    }
+}

--- a/crates/nu-cmd-lang/src/core_commands/scope/mod.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/mod.rs
@@ -2,6 +2,7 @@ mod aliases;
 mod command;
 mod commands;
 mod engine_stats;
+mod externs;
 mod modules;
 mod variables;
 
@@ -9,5 +10,6 @@ pub use aliases::*;
 pub use command::*;
 pub use commands::*;
 pub use engine_stats::*;
+pub use externs::*;
 pub use modules::*;
 pub use variables::*;

--- a/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
@@ -35,7 +35,7 @@ impl Command for ScopeVariables {
         let ctrlc = engine_state.ctrlc.clone();
 
         let mut scope_data = ScopeData::new(engine_state, stack);
-        scope_data.populate_all();
+        scope_data.populate_vars();
 
         Ok(scope_data.collect_vars(span).into_pipeline_data(ctrlc))
     }

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -58,6 +58,7 @@ pub fn create_default_context() -> EngineState {
             ScopeAliases,
             ScopeCommands,
             ScopeEngineStats,
+            ScopeExterns,
             ScopeModules,
             ScopeVariables,
             Try,

--- a/crates/nu-command/src/help/help_aliases.rs
+++ b/crates/nu-command/src/help/help_aliases.rs
@@ -169,7 +169,7 @@ pub fn help_aliases(
 
 fn build_help_aliases(engine_state: &EngineState, stack: &Stack, span: Span) -> Vec<Value> {
     let mut scope_data = ScopeData::new(engine_state, stack);
-    scope_data.populate_all();
+    scope_data.populate_decls();
 
     scope_data.collect_aliases(span)
 }

--- a/crates/nu-command/src/help/help_externs.rs
+++ b/crates/nu-command/src/help/help_externs.rs
@@ -144,7 +144,7 @@ pub fn help_externs(
 
 fn build_help_externs(engine_state: &EngineState, stack: &Stack, span: Span) -> Vec<Value> {
     let mut scope = ScopeData::new(engine_state, stack);
-    scope.populate_all();
+    scope.populate_decls();
     scope.collect_externs(span)
 }
 

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -22,7 +22,6 @@ fn help_shows_signature() {
     assert!(!actual.out.contains("Input/output types"));
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_aliases() {
     let code = &[
@@ -34,7 +33,6 @@ fn help_aliases() {
     assert_eq!(actual.out, "1");
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_alias_usage_1() {
     Playground::setup("help_alias_usage_1", |dirs, sandbox| {
@@ -56,7 +54,6 @@ fn help_alias_usage_1() {
     })
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_alias_usage_2() {
     let code = &[
@@ -68,7 +65,6 @@ fn help_alias_usage_2() {
     assert_eq!(actual.out, "line2");
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_alias_usage_3() {
     Playground::setup("help_alias_usage_3", |dirs, sandbox| {
@@ -91,7 +87,6 @@ fn help_alias_usage_3() {
     })
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_alias_name() {
     Playground::setup("help_alias_name", |dirs, sandbox| {
@@ -113,7 +108,6 @@ fn help_alias_name() {
     })
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_alias_name_f() {
     Playground::setup("help_alias_name_f", |dirs, sandbox| {
@@ -133,7 +127,6 @@ fn help_alias_name_f() {
     })
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_export_alias_name_single_word() {
     Playground::setup("help_export_alias_name_single_word", |dirs, sandbox| {
@@ -155,7 +148,6 @@ fn help_export_alias_name_single_word() {
     })
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_export_alias_name_multi_word() {
     Playground::setup("help_export_alias_name_multi_word", |dirs, sandbox| {
@@ -302,7 +294,6 @@ fn help_usage_extra_usage_command() {
     })
 }
 
-#[ignore = "TODO: Need to decide how to do help messages of new aliases"]
 #[test]
 fn help_usage_extra_usage_alias() {
     Playground::setup("help_usage_extra_usage_alias", |dirs, sandbox| {
@@ -360,25 +351,12 @@ fn help_modules_main_2() {
         r#"module spam {
             export def main [] { 'foo' };
         }"#,
-        "help modules | where name == spam | get 0.commands.0",
+        "help modules | where name == spam | get 0.commands.0.name",
     ];
 
     let actual = nu!(pipeline(&inp.join("; ")));
 
     assert_eq!(actual.out, "spam");
-}
-
-#[ignore = "TODO: Can't have alias with the same name as command"]
-#[test]
-fn help_alias_before_command() {
-    let code = &[
-        "alias SPAM = echo 'spam'",
-        "def SPAM [] { 'spam' }",
-        "help SPAM",
-    ];
-    let actual = nu!(nu_repl_code(code));
-
-    assert!(actual.out.contains("Alias"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -2,6 +2,8 @@ use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, nu_repl_code, pipeline};
 
+// Note: These tests might slightly overlap with tests/scope/mod.rs
+
 #[test]
 fn help_commands_length() {
     let actual = nu!("help commands | length");

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -480,7 +480,7 @@ impl<'e, 's> ScopeData<'e, 's> {
     pub fn collect_aliases(&self, span: Span) -> Vec<Value> {
         let mut aliases = vec![];
 
-        for (_, decl_id) in self.engine_state.get_decls_sorted(false) {
+        for (decl_name, decl_id) in self.engine_state.get_decls_sorted(false) {
             if self.visibility.is_decl_id_visible(&decl_id) {
                 let decl = self.engine_state.get_decl(decl_id);
                 if let Some(alias) = decl.as_alias() {
@@ -493,7 +493,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                         ],
                         vals: vec![
                             Value::String {
-                                val: decl.name().to_string(),
+                                val: String::from_utf8_lossy(&decl_name).to_string(),
                                 span,
                             },
                             Value::String {

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -2,7 +2,6 @@ use nu_protocol::{
     engine::{Command, EngineState, Stack, Visibility},
     Signature, Span, SyntaxShape, Type, Value,
 };
-use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -1,6 +1,6 @@
 use nu_protocol::{
     engine::{Command, EngineState, Stack, Visibility},
-    ShellError, Signature, Span, SyntaxShape, Type, Value,
+    Signature, Span, SyntaxShape, Type, Value,
 };
 use std::borrow::Borrow;
 use std::cmp::Ordering;

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -36,6 +36,14 @@ impl<'e, 's> ScopeData<'e, 's> {
         }
     }
 
+    // decls include all commands, i.e., normal commands, aliases, and externals
+    pub fn populate_decls(&mut self) {
+        for overlay_frame in self.engine_state.active_overlays(&[]) {
+            self.decls_map.extend(&overlay_frame.decls);
+            self.visibility.merge_with(overlay_frame.visibility.clone());
+        }
+    }
+
     pub fn populate_modules(&mut self) {
         for overlay_frame in self.engine_state.active_overlays(&[]) {
             self.modules_map.extend(&overlay_frame.modules);

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -515,7 +515,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                                 span,
                             },
                             Value::String {
-                                val: alias.signature().usage,
+                                val: alias.usage().to_string(),
                                 span,
                             },
                         ],

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -27,12 +27,9 @@ impl<'e, 's> ScopeData<'e, 's> {
         }
     }
 
-    pub fn populate_all(&mut self) {
+    pub fn populate_vars(&mut self) {
         for overlay_frame in self.engine_state.active_overlays(&[]) {
             self.vars_map.extend(&overlay_frame.vars);
-            self.decls_map.extend(&overlay_frame.decls);
-            self.modules_map.extend(&overlay_frame.modules);
-            self.visibility.merge_with(overlay_frame.visibility.clone());
         }
     }
 
@@ -626,6 +623,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                 span,
             ),
         ];
+
         Value::Record {
             cols: engine_state_cols,
             vals: engine_state_vals,

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -86,26 +86,11 @@ impl<'e, 's> ScopeData<'e, 's> {
                 let mut cols = vec![];
                 let mut vals = vec![];
 
-                let mut module_commands = vec![];
-                for module in &self.modules_map {
-                    let module_name = String::from_utf8_lossy(module.0).to_string();
-                    let module_id = self.engine_state.find_module(module.0, &[]);
-                    if let Some(module_id) = module_id {
-                        let module = self.engine_state.get_module(module_id);
-                        if module.has_decl(command_name) {
-                            module_commands.push(module_name);
-                        }
-                    }
-                }
-
                 cols.push("name".into());
                 vals.push(Value::String {
                     val: String::from_utf8_lossy(command_name).to_string(),
                     span,
                 });
-
-                cols.push("module_name".into());
-                vals.push(Value::string(module_commands.join(", "), span));
 
                 let decl = self.engine_state.get_decl(**decl_id);
                 let signature = decl.signature();
@@ -470,27 +455,9 @@ impl<'e, 's> ScopeData<'e, 's> {
                 let mut cols = vec![];
                 let mut vals = vec![];
 
-                let mut module_commands = vec![];
-                for module in &self.modules_map {
-                    let module_name = String::from_utf8_lossy(module.0).to_string();
-                    let module_id = self.engine_state.find_module(module.0, &[]);
-                    if let Some(module_id) = module_id {
-                        let module = self.engine_state.get_module(module_id);
-                        if module.has_decl(command_name) {
-                            module_commands.push(module_name);
-                        }
-                    }
-                }
-
                 cols.push("name".into());
                 vals.push(Value::String {
                     val: String::from_utf8_lossy(command_name).to_string(),
-                    span,
-                });
-
-                cols.push("module_name".into());
-                vals.push(Value::String {
-                    val: module_commands.join(", "),
                     span,
                 });
 

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -6,48 +6,6 @@ use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
-pub fn create_scope(
-    engine_state: &EngineState,
-    stack: &Stack,
-    span: Span,
-) -> Result<Value, ShellError> {
-    let mut scope_data = ScopeData::new(engine_state, stack);
-
-    scope_data.populate_all();
-
-    let mut cols = vec![];
-    let mut vals = vec![];
-
-    cols.push("vars".to_string());
-    vals.push(Value::List {
-        vals: scope_data.collect_vars(span),
-        span,
-    });
-
-    cols.push("commands".to_string());
-    vals.push(Value::List {
-        vals: scope_data.collect_commands(span),
-        span,
-    });
-
-    cols.push("aliases".to_string());
-    vals.push(Value::List {
-        vals: scope_data.collect_aliases(span),
-        span,
-    });
-
-    cols.push("modules".to_string());
-    vals.push(Value::List {
-        vals: scope_data.collect_modules(span),
-        span,
-    });
-
-    cols.push("engine_state".to_string());
-    vals.push(scope_data.collect_engine_state(span));
-
-    Ok(Value::Record { cols, vals, span })
-}
-
 pub struct ScopeData<'e, 's> {
     engine_state: &'e EngineState,
     stack: &'s Stack,

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -501,13 +501,13 @@ impl<'e, 's> ScopeData<'e, 's> {
             if self.visibility.is_decl_id_visible(&decl_id) {
                 let decl = self.engine_state.get_decl(decl_id);
                 if let Some(alias) = decl.as_alias() {
-                    let sig = decl.signature().update_from_command(decl.borrow());
-                    let key = sig.name;
-
                     aliases.push(Value::Record {
                         cols: vec!["name".into(), "expansion".into(), "usage".into()],
                         vals: vec![
-                            Value::String { val: key, span },
+                            Value::String {
+                                val: decl.name().to_string(),
+                                span,
+                            },
                             Value::String {
                                 val: String::from_utf8_lossy(
                                     self.engine_state.get_span_contents(alias.wrapped_call.span),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -749,6 +749,7 @@ pub fn parse_alias(
 
     if let Some(decl_id) = working_set.find_decl(b"alias") {
         let (command_spans, rest_spans) = spans.split_at(split_id);
+        let (usage, extra_usage) = working_set.build_usage(&lite_command.comments);
 
         let original_starting_error_count = working_set.parse_errors.len();
 
@@ -906,6 +907,8 @@ pub fn parse_alias(
                 name: alias_name,
                 command,
                 wrapped_call,
+                usage,
+                extra_usage,
             };
 
             working_set.add_decl(Box::new(decl));

--- a/crates/nu-protocol/src/alias.rs
+++ b/crates/nu-protocol/src/alias.rs
@@ -3,15 +3,16 @@ use crate::PipelineData;
 use crate::{
     ast::{Call, Expression},
     engine::Command,
-    BlockId, Example, ShellError, Signature,
+    ShellError, Signature,
 };
-use std::path::PathBuf;
 
 #[derive(Clone)]
 pub struct Alias {
     pub name: String,
     pub command: Option<Box<dyn Command>>, // None if external call
     pub wrapped_call: Expression,
+    pub usage: String,
+    pub extra_usage: String,
 }
 
 impl Command for Alias {
@@ -28,19 +29,11 @@ impl Command for Alias {
     }
 
     fn usage(&self) -> &str {
-        if let Some(cmd) = &self.command {
-            cmd.usage()
-        } else {
-            "This alias wraps an unknown external command."
-        }
+        &self.usage
     }
 
     fn extra_usage(&self) -> &str {
-        if let Some(cmd) = &self.command {
-            cmd.extra_usage()
-        } else {
-            ""
-        }
+        &self.extra_usage
     }
 
     fn run(
@@ -57,85 +50,11 @@ impl Command for Alias {
         })
     }
 
-    fn examples(&self) -> Vec<Example> {
-        if let Some(cmd) = &self.command {
-            cmd.examples()
-        } else {
-            vec![]
-        }
-    }
-
-    fn is_builtin(&self) -> bool {
-        if let Some(cmd) = &self.command {
-            cmd.is_builtin()
-        } else {
-            false
-        }
-    }
-
-    fn is_known_external(&self) -> bool {
-        if let Some(cmd) = &self.command {
-            cmd.is_known_external()
-        } else {
-            false
-        }
-    }
-
     fn is_alias(&self) -> bool {
         true
     }
 
     fn as_alias(&self) -> Option<&Alias> {
         Some(self)
-    }
-
-    fn is_custom_command(&self) -> bool {
-        if let Some(cmd) = &self.command {
-            cmd.is_custom_command()
-        } else if self.get_block_id().is_some() {
-            true
-        } else {
-            self.is_known_external()
-        }
-    }
-
-    fn is_sub(&self) -> bool {
-        if let Some(cmd) = &self.command {
-            cmd.is_sub()
-        } else {
-            self.name().contains(' ')
-        }
-    }
-
-    fn is_parser_keyword(&self) -> bool {
-        if let Some(cmd) = &self.command {
-            cmd.is_parser_keyword()
-        } else {
-            false
-        }
-    }
-
-    fn is_plugin(&self) -> Option<(&PathBuf, &Option<PathBuf>)> {
-        if let Some(cmd) = &self.command {
-            cmd.is_plugin()
-        } else {
-            None
-        }
-    }
-
-    fn get_block_id(&self) -> Option<BlockId> {
-        if let Some(cmd) = &self.command {
-            cmd.get_block_id()
-        } else {
-            None
-        }
-    }
-
-    fn search_terms(&self) -> Vec<&str> {
-        if let Some(cmd) = &self.command {
-            cmd.search_terms()
-        } else {
-            vec![]
-        }
     }
 }

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -1,5 +1,9 @@
+use nu_test_support::fs::Stub::FileWithContent;
 use nu_test_support::nu;
+use nu_test_support::playground::Playground;
 use pretty_assertions::assert_eq;
+
+// Note: These tests might slightly overlap with crates/nu-command/tests/commands/help.rs
 
 #[test]
 fn scope_shows_alias() {
@@ -70,7 +74,7 @@ fn scope_doesnt_show_hidden_command() {
 }
 
 // same problem as 'which' command
-#[ignore]
+#[ignore = "See https://github.com/nushell/nushell/issues/4837"]
 #[test]
 fn correctly_report_of_shadowed_alias() {
     let actual = nu!("alias xaz = echo alias1
@@ -81,4 +85,164 @@ fn correctly_report_of_shadowed_alias() {
         helper | where alias == xaz | get expansion.0");
 
     assert_eq!(actual.out, "echo alias2");
+}
+
+#[test]
+fn correct_scope_modules_fields() {
+    let module_setup = r#"
+        # nice spam
+
+        export module eggs {
+            export module bacon {
+                export def sausage [] { 'sausage' }
+            }
+        }
+
+        export def main [] { 'foo' };
+        export alias xaz = print
+        export extern git []
+        export const X = 4
+
+        export-env { $env.SPAM = 'spam' }
+    "#;
+
+    Playground::setup("correct_scope_modules_fields", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent("spam.nu", module_setup)]);
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "spam");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.usage",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "nice spam");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.env_block | is-empty",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "false");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.commands.0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "spam");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.aliases.0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "xaz");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.externs.0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "git");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.constants.0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "X");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.submodules.0.submodules.0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "bacon");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.submodules.0.submodules.0.commands.0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "sausage");
+    })
+}
+
+#[test]
+fn correct_scope_aliases_fields() {
+    let module_setup = r#"
+        # nice alias
+        export alias xaz = print
+    "#;
+
+    Playground::setup("correct_scope_aliases_fields", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent("spam.nu", module_setup)]);
+
+        let inp = &[
+            "use spam.nu",
+            "scope aliases | where name == 'spam xaz' | get 0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "spam xaz");
+
+        let inp = &[
+            "use spam.nu",
+            "scope aliases | where name == 'spam xaz' | get 0.expansion",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "print");
+
+        let inp = &[
+            "use spam.nu",
+            "scope aliases | where name == 'spam xaz' | get 0.usage",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "nice alias");
+
+        let inp = &[
+            "use spam.nu",
+            "scope aliases | where name == 'spam xaz' | get 0.decl_id | is-empty",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "false");
+    })
+}
+
+#[test]
+fn correct_scope_externs_fields() {
+    let module_setup = r#"
+        # nice extern
+        export extern git []
+    "#;
+
+    Playground::setup("correct_scope_aliases_fields", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent("spam.nu", module_setup)]);
+
+        let inp = &[
+            "use spam.nu",
+            "scope externs | where name == 'spam git' | get 0.name",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "spam git");
+
+        let inp = &[
+            "use spam.nu",
+            "scope externs | where name == 'spam git' | get 0.usage",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "nice extern");
+
+        let inp = &[
+            "use spam.nu",
+            "scope externs | where name == 'spam git' | get 0.decl_id | is-empty",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "false");
+    })
 }

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -1,7 +1,6 @@
 use nu_test_support::nu;
 use pretty_assertions::assert_eq;
 
-#[ignore = "TODO: This shows old-style aliases. New aliases are under commands"]
 #[test]
 fn scope_shows_alias() {
     let actual = nu!("alias xaz = echo alias1


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

See "User-Facing Changes". Apart from that, it cleans up the code of `scope` a bit and fixes/re-enables some tests. Since `help` uses a similar code as `scope` in most places, most of the improvements can be observed in `help`. I did not tweak `help` further since it is expected `std help` will replace the built-in one anyway.

### How to use the IDs

All definitions in `scope` commands now have their ID. It could be used to perform tasks such as looking up which module contains a given command. Some examples below:

```nushell
# finder.nu

# Find which module a command belongs to
export def find-module [
    cmd_name: string  # name of the command to look up
] {
    let decl_id = try {
        scope commands | where name == $cmd_name | get 0.decl_id
    } catch {
        let span = (metadata $cmd_name).span
        error make {
            msg: $'Command "($cmd_name)" not found'
            label: {
                text: 'could not find command'
                start: $span.start
                end: $span.end
            }
        }
    }

    for row in (scope modules) {
        for cmd in $row.commands {
           if $cmd.decl_id == $decl_id {
               return {
                   name: $row.name            # name of the module
                   module_id: $row.module_id  # module's ID
               }
           }
        }
    }
}

# Find which commands of a module are in active use
#
# Does not recurse to submodules!
export def find-used-commands [
    module_name: string  # name of the module to look up
] {
    let module_commands = try {
        scope modules | where name == $module_name | get 0.commands
    } catch {
        let span = (metadata $module_name).span
        error make {
            msg: $'Module "($module_name)" not found'
            label: {
                text: 'could not find module'
                start: $span.start
                end: $span.end
            }
        }
    }

    mut res = []

    for cmd in $module_commands {
        for row in (scope commands) {
            if $cmd.decl_id == $row.decl_id {
                $res ++= [
                    {
                        used_name: $row.name   # imported name in the current scope
                        name: $cmd.name        # name defined in the module
                        decl_id: $row.decl_id  # command's ID
                    }
                ]
            }
        }
    }

    $res
}
```

```
> use finder.nu *

> find-module banner
 name        std
 module_id   11

> find-used-commands std
 #   used_name    name    decl_id
──────────────────────────────────
 0   banner      banner       424
```

### Benchmarks

Benchmark script
```nushell
# bench_scope.nu

use std bench

{
    aliases      : (bench { scope aliases } | get mean)
    commands     : (bench { scope commands } | get mean)
    engine-stats : (bench { scope engine-stats } | get mean)
    modules      : (bench { scope modules } | get mean)
    variables    : (bench { scope variables } | get mean)
    externs      : (bench { scope externs } | get mean)
}
```


## Performance

Results on my machine with my config. This will be different for each setup, as it depends on how many definitions you have.

| |aliases|commands|engine-stats|modules|variables|externs|
| - |-:|-:|-:|-:|-:|-:|
| baseline | 99µs 942ns|2ms 517µs 333ns|10µs 990ns|62µs 995ns|11µs 123ns||
| https://github.com/nushell/nushell/pull/10023/commits/9fff54c4ade9a1732da9115fee6d16485afff36b | 100µs 192ns|2ms 411µs 832ns|11µs 167ns|62µs 364ns|10µs 909ns||
| https://github.com/nushell/nushell/pull/10023/commits/7fdf5989faed681071acc6dcde140c5007e5736b |97µs 752ns|2ms 333µs 524ns|2µs 652ns|64µs 230ns|2µs 875ns||
| https://github.com/nushell/nushell/pull/10023/commits/2041043418eebccecaa1d850dcacfe9c3aed1ad0 |96µs 514ns|2ms 329µs 78ns|2µs 588ns|63µs 951ns|2µs 840ns||
| https://github.com/nushell/nushell/pull/10023/commits/c3f5037a6d463a43eadfabda06e3bf3365dc3042 |95µs 411ns|2ms 403µs 712ns|2µs 703ns|64µs 580ns|2µs 981ns||
| https://github.com/nushell/nushell/pull/10023/commits/96aeb9f11d9e3e6dc4519ecfa05c50696ba5bb30 |95µs 690ns|2ms 320µs 869ns|2µs 767ns|63µs 415ns|2µs 900ns|15µs 732ns|
| https://github.com/nushell/nushell/pull/10023/commits/0b2f26fa5191ecd7f477bede41ed0adcf0bb1d1c |100µs 598ns|2ms 348µs 30ns|2µs 719ns|121µs 299ns|2µs 918ns|15µs 880ns|
| https://github.com/nushell/nushell/pull/10023/commits/6c428883f66b239ae2e0b9662aa45e5d89f56720 |101µs 464ns|2ms 374µs 293ns|2µs 716ns|280µs 691ns|2µs 925ns|15µs 822ns|
| https://github.com/nushell/nushell/pull/10023/commits/c46c5ca958c7e20b1c21ddb6bfc1c6fc2f58f3c6 |103µs 920ns|2ms 378µs 838ns|2µs 786ns|285µs 213ns|2µs 982ns|16µs 319ns|

* `scope variables` is about 3.5x faster
* `scope modules` is about 4.5x slower (because it contains more stuff now)

Fixes https://github.com/nushell/nushell/issues/10006

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* (minor breaking change) Removes `module_name` field from `scope/help externs` commands (it seemed to be broken anyway).
* Fixes alias entries in `scope` and `help` commands.
* Adds `scope externs`.
* Adds ID for each definition in all `scope` commands.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
