### PR TITLE
Simplify virtualenv testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,18 +118,11 @@ jobs:
       - run: python -m pip install tox
 
       - name: Install virtualenv
-        run: git clone https://github.com/pypa/virtualenv.git
+        run: run: pip install virtualenv
         shell: bash
 
       - name: Test Nushell in virtualenv
-        run: |
-          cd virtualenv
-          # if we encounter problems with bleeding edge tests pin to the latest tag
-          # git checkout $(git describe --tags | cut -d - -f 1)
-          # We need to disable failing on coverage levels.
-          nu -c "open pyproject.toml | upsert tool.coverage.report.fail_under 1 | save patchproject.toml"
-          mv patchproject.toml pyproject.toml
-          tox -e ${{ matrix.py }} -- -k nushell
+        run: nu scripts/test_virtualenv.nu
         shell: bash
 
   plugins:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,8 +115,6 @@ jobs:
         with:
           python-version: "3.10"
 
-      - run: python -m pip install tox
-
       - name: Install virtualenv
         run: run: pip install virtualenv
         shell: bash

--- a/scripts/test_virtualenv.nu
+++ b/scripts/test_virtualenv.nu
@@ -1,0 +1,40 @@
+let env_name = 'e-$ èрт🚒♞中片-j'
+
+let test_lines = [
+    "python -c 'import sys; print(sys.executable)'"
+    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'"
+    $"overlay use '([$env.PWD $env_name bin activate.nu] | path join)'"
+    "python -c 'import sys; print(sys.executable)'"
+    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'"
+    "print $env.VIRTUAL_PROMPT"
+    # "pydoc -w pydoc_test"
+    "deactivate"
+    "python -c 'import sys; print(sys.executable)'"
+    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'"
+]
+
+def main [] {
+    let orig_python_interpreter = (python -c 'import sys; print(sys.executable)')
+
+    let expected = [
+        $orig_python_interpreter
+        "None"
+        ([$env.PWD $env_name bin python] | path join)
+        ([$env.PWD $env_name] | path join)
+        $"(char lparen)($env_name)(char rparen)"
+        $orig_python_interpreter
+        "None"
+    ]
+
+    virtualenv $env_name
+
+    $test_lines | save script.nu
+    let out = (nu script.nu | lines)
+
+    let o = ($out | str trim | str join (char nl))
+    let e = ($expected | str trim | str join (char nl))
+    if $o != $e {
+        let msg = $"OUTPUT:\n($o)\n\nEXPECTED:\n($e)"
+        error make {msg: $"Output does not match the expected value:\n($msg)"}
+    }
+}

--- a/scripts/test_virtualenv.nu
+++ b/scripts/test_virtualenv.nu
@@ -1,29 +1,29 @@
 let env_name = 'e-$ èрт🚒♞中片-j'
 
 let test_lines = [
-    "python -c 'import sys; print(sys.executable)'"
-    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'"
+    "python -c 'import sys; print(sys.executable)'"                                  # 1
+    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'" # 2
     $"overlay use '([$env.PWD $env_name bin activate.nu] | path join)'"
-    "python -c 'import sys; print(sys.executable)'"
-    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'"
-    "print $env.VIRTUAL_PROMPT"
+    "python -c 'import sys; print(sys.executable)'"                                  # 3
+    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'" # 4
+    "print $env.VIRTUAL_PROMPT"                                                      # 5
     # "pydoc -w pydoc_test"
     "deactivate"
-    "python -c 'import sys; print(sys.executable)'"
-    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'"
+    "python -c 'import sys; print(sys.executable)'"                                  # 6
+    "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'" # 7
 ]
 
 def main [] {
     let orig_python_interpreter = (python -c 'import sys; print(sys.executable)')
 
     let expected = [
-        $orig_python_interpreter
-        "None"
-        ([$env.PWD $env_name bin python] | path join)
-        ([$env.PWD $env_name] | path join)
-        $"(char lparen)($env_name)(char rparen)"
-        $orig_python_interpreter
-        "None"
+        $orig_python_interpreter                       # 1
+        "None"                                         # 2
+        ([$env.PWD $env_name bin python] | path join)  # 3
+        ([$env.PWD $env_name] | path join)             # 4
+        $"(char lparen)($env_name)(char rparen)"       # 5
+        $orig_python_interpreter                       # 6
+        "None"                                         # 7
     ]
 
     virtualenv $env_name

--- a/scripts/test_virtualenv.nu
+++ b/scripts/test_virtualenv.nu
@@ -6,7 +6,7 @@ let test_lines = [
     $"overlay use '([$env.PWD $env_name bin activate.nu] | path join)'"
     "python -c 'import sys; print(sys.executable)'"                                  # 3
     "python -c 'import os; import sys; v = os.environ.get("VIRTUAL_ENV"); print(v)'" # 4
-    "print $env.VIRTUAL_PROMPT"                                                      # 5
+    "print $env.VIRTUAL_ENV_PROMPT"                                                  # 5
     # "pydoc -w pydoc_test"
     "deactivate"
     "python -c 'import sys; print(sys.executable)'"                                  # 6
@@ -21,7 +21,7 @@ def main [] {
         "None"                                         # 2
         ([$env.PWD $env_name bin python] | path join)  # 3
         ([$env.PWD $env_name] | path join)             # 4
-        $"(char lparen)($env_name)(char rparen)"       # 5
+        $env_name                                      # 5
         $orig_python_interpreter                       # 6
         "None"                                         # 7
     ]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

(Resurrect of https://github.com/nushell/nushell/pull/9521)

Instead of running virtualenv's test suite, run only Nushell's test script (not including pydoc test, not sure how to get it working without the virtualenv's test suite).

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
