### PR TITLE
Change `str replace` to match substring by default

### DIFF
--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -4,8 +4,8 @@ use nu_engine::CallExt;
 use nu_protocol::{
     ast::{Call, CellPath},
     engine::{Command, EngineState, Stack},
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Type,
-    Value,
+    report_error_new, Category, Example, PipelineData, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type, Value,
 };
 
 struct Arguments {
@@ -59,12 +59,17 @@ impl Command for SubCommand {
             )
             .switch(
                 "string",
-                "match the pattern as a substring of the input, instead of a regular expression",
+                "DEPRECATED option, will be removed in 0.85. Substring matching is now the default.",
                 Some('s'),
             )
             .switch(
+                "regex",
+                "match the pattern as a regular expression in the input, instead of a substring",
+                Some('r'),
+            )
+            .switch(
                 "multiline",
-                "multi-line regex mode: ^ and $ match begin/end of line; equivalent to (?m)",
+                "multi-line regex mode (implies --regex): ^ and $ match begin/end of line; equivalent to (?m)",
                 Some('m'),
             )
             .allow_variants_without_examples(true)
@@ -91,7 +96,19 @@ impl Command for SubCommand {
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 2)?;
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
         let literal_replace = call.has_flag("no-expand");
-        let no_regex = call.has_flag("string");
+        if call.has_flag("string") {
+            report_error_new(
+                engine_state,
+                &ShellError::GenericError(
+                    "Deprecated option".into(),
+                    "`str replace --string` is deprecated and will be removed in 0.85.".into(),
+                    Some(call.head),
+                    Some("Substring matching is now the default. Use `--regex` or `--multiline` for matching regular expressions.".into()),
+                    vec![],
+                ),
+            );
+        }
+        let no_regex = !call.has_flag("regex") && !call.has_flag("multiline");
         let multiline = call.has_flag("multiline");
 
         let args = Arguments {
@@ -109,19 +126,29 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Find and replace contents with capture group",
-                example: "'my_library.rb' | str replace '(.+).rb' '$1.nu'",
-                result: Some(Value::test_string("my_library.nu")),
+                description: "Find and replace the first occurrence of a substring",
+                example: r"'c:\some\cool\path' | str replace 'c:\some\cool' '~'",
+                result: Some(Value::test_string("~\\path")),
             },
             Example {
-                description: "Find and replace all occurrences of find string",
-                example: "'abc abc abc' | str replace -a 'b' 'z'",
+                description: "Find and replace all occurrences of a substring",
+                example: r#"'abc abc abc' | str replace -a 'b' 'z'"#,
                 result: Some(Value::test_string("azc azc azc")),
             },
             Example {
-                description: "Find and replace all occurrences of find string in table",
+                description: "Find and replace contents with capture group using regular expression",
+                example: "'my_library.rb' | str replace -r '(.+).rb' '$1.nu'",
+                result: Some(Value::test_string("my_library.nu")),
+            },
+            Example {
+                description: "Find and replace all occurrences of find string using regular expression",
+                example: "'abc abc abc' | str replace -ar 'b' 'z'",
+                result: Some(Value::test_string("azc azc azc")),
+            },
+            Example {
+                description: "Find and replace all occurrences of find string in table using regular expression",
                 example:
-                    "[[ColA ColB ColC]; [abc abc ads]] | str replace -a 'b' 'z' ColA ColC",
+                    "[[ColA ColB ColC]; [abc abc ads]] | str replace -ar 'b' 'z' ColA ColC",
                 result: Some(Value::List {
                     vals: vec![Value::Record {
                         cols: vec!["ColA".to_string(), "ColB".to_string(), "ColC".to_string()],
@@ -136,9 +163,9 @@ impl Command for SubCommand {
                 }),
             },
             Example {
-                description: "Find and replace all occurrences of find string in record",
+                description: "Find and replace all occurrences of find string in record using regular expression",
                 example:
-                    "{ KeyA: abc, KeyB: abc, KeyC: ads } | str replace -a 'b' 'z' KeyA KeyC",
+                    "{ KeyA: abc, KeyB: abc, KeyC: ads } | str replace -ar 'b' 'z' KeyA KeyC",
                 result: Some(Value::Record {
                         cols: vec!["KeyA".to_string(), "KeyB".to_string(), "KeyC".to_string()],
                         vals: vec![
@@ -151,36 +178,26 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Find and replace contents without using the replace parameter as a regular expression",
-                example: r"'dogs_$1_cats' | str replace '\$1' '$2' -n",
+                example: r"'dogs_$1_cats' | str replace -r '\$1' '$2' -n",
                 result: Some(Value::test_string("dogs_$2_cats")),
             },
             Example {
-                description: "Find and replace the first occurrence using string replacement *not* regular expressions",
-                example: r"'c:\some\cool\path' | str replace 'c:\some\cool' '~' -s",
-                result: Some(Value::test_string("~\\path")),
-            },
-            Example {
-                description: "Find and replace all occurrences using string replacement *not* regular expressions",
-                example: r#"'abc abc abc' | str replace -a 'b' 'z' -s"#,
-                result: Some(Value::test_string("azc azc azc")),
-            },
-            Example {
-                description: "Use captures to manipulate the input text",
-                example: r#""abc-def" | str replace "(.+)-(.+)" "${2}_${1}""#,
+                description: "Use captures to manipulate the input text using regular expression",
+                example: r#""abc-def" | str replace -r "(.+)-(.+)" "${2}_${1}""#,
                 result: Some(Value::test_string("def_abc")),
             },
             Example {
-                description: "Find and replace with fancy-regex",
-                example: r"'a successful b' | str replace '\b([sS])uc(?:cs|s?)e(ed(?:ed|ing|s?)|ss(?:es|ful(?:ly)?|i(?:ons?|ve(?:ly)?)|ors?)?)\b' '${1}ucce$2'",
+                description: "Find and replace with fancy-regex using regular expression",
+                example: r"'a successful b' | str replace -r '\b([sS])uc(?:cs|s?)e(ed(?:ed|ing|s?)|ss(?:es|ful(?:ly)?|i(?:ons?|ve(?:ly)?)|ors?)?)\b' '${1}ucce$2'",
                 result: Some(Value::test_string("a successful b")),
             },
             Example {
-                description: "Find and replace with fancy-regex",
-                example: r#"'GHIKK-9+*' | str replace '[*[:xdigit:]+]' 'z'"#,
+                description: "Find and replace with fancy-regex using regular expression",
+                example: r#"'GHIKK-9+*' | str replace -r '[*[:xdigit:]+]' 'z'"#,
                 result: Some(Value::test_string("GHIKK-z+*")),
             },
             Example {
-                description: "Find and replace on individual lines (multiline)",
+                description: "Find and replace on individual lines using multiline regular expression",
                 example: r#""non-matching line\n123. one line\n124. another line\n" | str replace -am '^[0-9]+\. ' ''"#,
                 result: Some(Value::test_string("non-matching line\none line\nanother line\n")),
             },

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -203,7 +203,7 @@ fn regex_error_in_pattern() {
             cwd: dirs.test(), pipeline(
             r#"
                  'source string'
-                 | str replace 'source \Ufoo' "destination"
+                 | str replace -r 'source \Ufoo' "destination"
              "#
         ));
 

--- a/src/tests/test_help.rs
+++ b/src/tests/test_help.rs
@@ -20,7 +20,7 @@ fn can_get_help(#[case] exp_result: &str) -> TestResult {
             --f2:string, # f2 named no default
             --f3:int=33 # f3 named default 3
             ] {{ true }};
-            help t | ansi strip | find `{exp_result}` | get 0 | str replace -a '^(.*({exp_result}).*)$' '$2'"#,
+            help t | ansi strip | find `{exp_result}` | get 0 | str replace -ar '^(.*({exp_result}).*)$' '$2'"#,
         ),
         exp_result,
     )


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR makes `str replace` to match substring by default instead of regular expression. I was constantly getting tripped over this when using `str replace` on Windows paths which got interpreted as escape characters.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* Deprecates `str replace --string` (this is now the default behavior)
* Puts regex matching behind `--regex` flag. (`--multiline` flag implies `--regex`)

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
