### PR TITLE
Sort entries in `scope` commands; Fix usage of externs

### DIFF
--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -11,6 +11,7 @@ pub struct KnownExternal {
     pub name: String,
     pub signature: Box<Signature>,
     pub usage: String,
+    pub extra_usage: String,
 }
 
 impl Command for KnownExternal {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -215,6 +215,7 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
             let decl = KnownExternal {
                 name,
                 usage: "run external command".into(),
+                extra_usage: "".into(),
                 signature,
             };
 
@@ -650,7 +651,8 @@ pub fn parse_extern(
                 } else {
                     let decl = KnownExternal {
                         name: external_name,
-                        usage: [usage, extra_usage].join("\n"),
+                        usage,
+                        extra_usage,
                         signature,
                     };
 

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -253,3 +253,22 @@ fn correct_scope_externs_fields() {
         assert_eq!(actual.out, "false");
     })
 }
+
+#[test]
+fn scope_externs_sorted() {
+    let module_setup = r#"
+        export extern a []
+        export extern b []
+        export extern c []
+    "#;
+
+    let inp = &[
+        "extern a []",
+        "extern b []",
+        "extern c []",
+        "scope externs | get name | str join ''",
+    ];
+
+    let actual = nu!(&inp.join("; "));
+    assert_eq!(actual.out, "abc");
+}

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -240,6 +240,13 @@ fn correct_scope_externs_fields() {
 
         let inp = &[
             "use spam.nu",
+            "scope externs | where name == 'spam git' | get 0.usage | str contains (char nl)",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "false");
+
+        let inp = &[
+            "use spam.nu",
             "scope externs | where name == 'spam git' | get 0.decl_id | is-empty",
         ];
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

* All output of `scope` commands is sorted by the "name" column. (`scope externs` and some other commands had entries in a weird/random order)
* The output of `scope externs` does not have extra newlines (that was due to wrong usage creation of known externals)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
