### PR TITLE
Fix wrong path expansion in `save`

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -1,4 +1,6 @@
+use nu_engine::current_dir;
 use nu_engine::CallExt;
+use nu_path::expand_path_with;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -7,7 +9,7 @@ use nu_protocol::{
 };
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::thread;
 
 use crate::progress_bar;
@@ -67,9 +69,20 @@ impl Command for Save {
         let progress = call.has_flag("progress");
 
         let span = call.head;
+        let cwd = current_dir(engine_state, stack)?;
 
-        let path = call.req::<Spanned<String>>(engine_state, stack, 0)?;
-        let stderr_path = call.get_flag::<Spanned<String>>(engine_state, stack, "stderr")?;
+        let path_arg = call.req::<Spanned<PathBuf>>(engine_state, stack, 0)?;
+        let path = Spanned {
+            item: expand_path_with(path_arg.item, &cwd),
+            span: path_arg.span,
+        };
+
+        let stderr_path = call
+            .get_flag::<Spanned<PathBuf>>(engine_state, stack, "stderr")?
+            .map(|arg| Spanned {
+                item: expand_path_with(arg.item, cwd),
+                span: arg.span,
+            });
 
         match input {
             PipelineData::ExternalStream { stdout: None, .. } => {
@@ -258,12 +271,12 @@ fn value_to_bytes(value: Value) -> Result<Vec<u8>, ShellError> {
 /// Convert string path to [`Path`] and [`Span`] and check if this path
 /// can be used with given flags
 fn prepare_path(
-    path: &Spanned<String>,
+    path: &Spanned<PathBuf>,
     append: bool,
     force: bool,
 ) -> Result<(&Path, Span), ShellError> {
     let span = path.span;
-    let path = Path::new(&path.item);
+    let path = &path.item;
 
     if !(force || append) && path.exists() {
         Err(ShellError::GenericError(
@@ -303,8 +316,8 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
 
 /// Get output file and optional stderr file
 fn get_files(
-    path: &Spanned<String>,
-    stderr_path: &Option<Spanned<String>>,
+    path: &Spanned<PathBuf>,
+    stderr_path: &Option<Spanned<PathBuf>>,
     append: bool,
     force: bool,
 ) -> Result<(File, Option<File>), ShellError> {

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -297,3 +297,31 @@ fn writes_out_range() {
         assert_eq!(actual, "[\n  1,\n  2,\n  3\n]")
     })
 }
+
+// https://github.com/nushell/nushell/issues/10044
+#[test]
+fn save_file_correct_relative_path() {
+    Playground::setup("save_test_15", |dirs, sandbox| {
+        sandbox.with_files(vec![Stub::FileWithContent(
+            "test.nu",
+            r#"
+                export def main [] {
+                    let foo = "foo"
+                    mkdir bar
+                    cd bar
+                    'foo!' | save $foo
+                }
+            "#,
+        )]);
+
+        let expected_file = dirs.test().join("bar/foo");
+
+        nu!(
+            cwd: dirs.test(),
+            r#"use test.nu; test"#
+        );
+
+        let actual = file_contents(expected_file);
+        assert_eq!(actual, "foo!");
+    })
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR fixes wrong path expansion of the `save` command.

Fixes https://github.com/nushell/nushell/issues/10044

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
