### PR TITLE
allow int as a cellpath for `select`

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -112,6 +112,16 @@ produce a table, a list will produce a list, and a record will produce a record.
                     };
                     new_columns.push(cv.clone());
                 }
+                Value::Int { val, .. } => {
+                    let cv = CellPath {
+                        members: vec![PathMember::Int {
+                            val: val as usize,
+                            span: Span::unknown(),
+                            optional: false,
+                        }],
+                    };
+                    new_columns.push(cv.clone());
+                }
                 x => {
                     return Err(ShellError::CantConvert {
                         to_type: "cell path".into(),

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -64,18 +64,20 @@ produce a table, a list will produce a list, and a record will produce a record.
         let columns: Vec<Value> = call.rest(engine_state, stack, 0)?;
         let mut new_columns: Vec<CellPath> = vec![];
         for col_val in columns {
+            let col_span = &col_val.span()?;
             match col_val {
                 Value::CellPath { val, .. } => {
                     new_columns.push(val);
                 }
                 Value::List { vals, .. } => {
-                    for val in vals {
-                        match val {
+                    for value in vals {
+                        let val_span = &value.span()?;
+                        match value {
                             Value::String { val, .. } => {
                                 let cv = CellPath {
                                     members: vec![PathMember::String {
                                         val: val.clone(),
-                                        span: Span::unknown(),
+                                        span: *val_span,
                                         optional: false,
                                     }],
                                 };
@@ -85,7 +87,7 @@ produce a table, a list will produce a list, and a record will produce a record.
                                 let cv = CellPath {
                                     members: vec![PathMember::Int {
                                         val: val as usize,
-                                        span: Span::unknown(),
+                                        span: *val_span,
                                         optional: false,
                                     }],
                                 };
@@ -106,7 +108,7 @@ produce a table, a list will produce a list, and a record will produce a record.
                     let cv = CellPath {
                         members: vec![PathMember::String {
                             val: val.clone(),
-                            span: Span::unknown(),
+                            span: *col_span,
                             optional: false,
                         }],
                     };
@@ -116,7 +118,7 @@ produce a table, a list will produce a list, and a record will produce a record.
                     let cv = CellPath {
                         members: vec![PathMember::Int {
                             val: val as usize,
-                            span: Span::unknown(),
+                            span: *col_span,
                             optional: false,
                         }],
                     };

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -264,3 +264,11 @@ fn select_rows_with_variable_list() {
 
     assert_eq!(actual.out, "[[a, b, c]; [1, 2, 3], [7, 8, 9]]");
 }
+
+#[test]
+fn select_single_row_with_variable() {
+    let actual = nu!("let idx = 2;[{a: 1, b: 2} {a: 3, b: 5} {a: 3}] | select $idx | to nuon");
+
+    assert_eq!(actual.out, "[[a]; [3]]".to_string());
+    assert!(actual.err.is_empty());
+}


### PR DESCRIPTION
 Description

This PR allows ints to be used as cell paths.

### Before
```nushell
❯ let index = 0
❯ locations | select $index
Error: nu::shell::cant_convert

  × Can't convert to cell path.
   ╭─[entry #26:1:1]
 1 │ locations | select $index
   ·                    ───┬──
   ·                       ╰── can't convert int to cell path
   ╰────
```

### After
```nushell
❯ let index = 0
❯ locations | select $index
╭#┬───────location────────┬city_column┬state_column┬country_column┬lat_column┬lon_column╮
│0│http://ip-api.com/json/│city       │region      │countryCode   │lat       │lon       │
╰─┴───────────────────────┴───────────┴────────────┴──────────────┴──────────┴──────────╯
```
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
