### PR TITLE
make the charpage optional for `std clip`

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -142,7 +142,7 @@ export def clip [
     --no-notify: bool  # do not throw a notification (only on linux)
     --no-strip: bool  # do not strip ANSI escape sequences from a string
     --expand (-e): bool  # auto-expand the data given as input
-    --charpage (-c): int  # the id of the charpage to use (only on Windows), see https://en.wikipedia.org/wiki/Windows_code_page, e.g. 65001 is for UTF-8
+    --codepage (-c): int  # the id of the codepage to use (only on Windows), see https://en.wikipedia.org/wiki/Windows_code_page, e.g. 65001 is for UTF-8
 ] {
     let input = (
         $in
@@ -162,8 +162,8 @@ export def clip [
             }
         },
         "windows" => {
-            if $charpage != null {
-                chcp $charpage
+            if $codepage != null {
+                chcp $codepage
             }
             check-clipboard clip.exe --system "Windows"
             $input | clip.exe

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -142,6 +142,7 @@ export def clip [
     --no-notify: bool  # do not throw a notification (only on linux)
     --no-strip: bool  # do not strip ANSI escape sequences from a string
     --expand (-e): bool  # auto-expand the data given as input
+    --charpage (-c): int  # the id of the charpage to use (only on Windows), see https://en.wikipedia.org/wiki/Windows_code_page, e.g. 65001 is for UTF-8
 ] {
     let input = (
         $in
@@ -161,7 +162,9 @@ export def clip [
             }
         },
         "windows" => {
-            chcp 65001  # see https://discord.com/channels/601130461678272522/601130461678272524/1085535756237426778
+            if $charpage != null {
+                chcp $charpage
+            }
             check-clipboard clip.exe --system $"('xorg' | pretty-command) on linux"
             $input | clip.exe
         },

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -165,15 +165,15 @@ export def clip [
             if $charpage != null {
                 chcp $charpage
             }
-            check-clipboard clip.exe --system $"('xorg' | pretty-command) on linux"
+            check-clipboard clip.exe --system "Windows"
             $input | clip.exe
         },
         "macos" => {
-            check-clipboard pbcopy --system macOS
+            check-clipboard pbcopy --system "MacOS"
             $input | pbcopy
         },
         "android" => {
-            check-clipboard termux-clipboard-set --system Termux
+            check-clipboard termux-clipboard-set --system "Termux"
             $input | termux-clipboard-set
         },
         _ => {


### PR DESCRIPTION
related to
- https://discord.com/channels/601130461678272522/615253963645911060/1142060647358668841

# Description
in order to make the charpage for Windows as general as possible, `chcp` will only run on Windows when `--charpage` is given an integer.

while i was at it, i fixed the system messages given to `check-clipboard` because some of the were incorrect => see the second commit 6865ec9a5

# User-Facing Changes
this is a breaking change as users relying on the fact that `std clip` changed the page to `65001` by itself is not true anymore => they will have to add `--charpage 65001`.

# Tests + Formatting

# After Submitting