### PR TITLE
run Nushell with the default config files in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
       - name: Install Nushell
         run: cargo install --path . --locked --no-default-features
 
+      - name: Test default config files
+        run: nu --config-file crates/nu-utils/src/sample_config/default_config.nu --env-config crates/nu-utils/src/sample_config/default_env.nu
+
       - name: Standard library tests
         run: nu -c 'use std testing; testing run-tests --path crates/nu-std'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   fmt-clippy:
+    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -51,6 +52,7 @@ jobs:
         run: cargo clippy --workspace ${{ matrix.flags }} --exclude nu_plugin_* -- $CLIPPY_OPTIONS
 
   tests:
+    if: false
     strategy:
       fail-fast: true
       matrix:
@@ -136,6 +138,7 @@ jobs:
         shell: bash
 
   plugins:
+    if: false
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: cargo install --path . --locked --no-default-features
 
       - name: Test default config files
-        run: nu --config crates/nu-utils/src/sample_config/default_config.nu --env-config crates/nu-utils/src/sample_config/default_env.nu
+        run: nu --config crates/nu-utils/src/sample_config/default_config.nu --env-config crates/nu-utils/src/sample_config/default_env.nu --commands ""
 
       - name: Standard library tests
         run: nu -c 'use std testing; testing run-tests --path crates/nu-std'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         run: cargo install --path . --locked --no-default-features
 
       - name: Test default config files
-        run: nu --config-file crates/nu-utils/src/sample_config/default_config.nu --env-config crates/nu-utils/src/sample_config/default_env.nu
+        run: nu --config crates/nu-utils/src/sample_config/default_config.nu --env-config crates/nu-utils/src/sample_config/default_env.nu
 
       - name: Standard library tests
         run: nu -c 'use std testing; testing run-tests --path crates/nu-std'

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -80,3 +80,6 @@ $env.NU_PLUGIN_DIRS = [
 
 # To add entries to PATH (on Windows you might use Path), you can use the following pattern:
 # $env.PATH = ($env.PATH | split row (char esep) | prepend '/some/path')
+
+"" | str replace --string "" ""
+print "env.nu done"

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -80,6 +80,3 @@ $env.NU_PLUGIN_DIRS = [
 
 # To add entries to PATH (on Windows you might use Path), you can use the following pattern:
 # $env.PATH = ($env.PATH | split row (char esep) | prepend '/some/path')
-
-"" | str replace --string "" ""
-print "env.nu done"


### PR DESCRIPTION
# :warning: WIP => this PR will be rebased when done

related to
- https://github.com/nushell/nushell/pull/10038
- https://github.com/nushell/nushell/pull/10052

# Description
the CI did not catch the breaking change from https://github.com/nushell/nushell/pull/10038, which is a problem.

this PR aims at adding the default config files to the CI to catch issues with it.

## :warning: WIP
for now i just want to run the CI and see if it fails.
because this PR is based on a commit **before** the fix of https://github.com/nushell/nushell/pull/10052, it should fail.

# User-Facing Changes

# Tests + Formatting
for now, the test is running in the `std-lib-and-python-virtualenv` job, to reuse the `cargo install`.

# After Submitting