### PR TITLE
enable/update some example tests so they work again

### DIFF
--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -130,12 +130,11 @@ impl Command for SubCommand {
                 example: "true | into string",
                 result: Some(Value::test_string("true")),
             },
-            // TODO: This should work but does not; see https://github.com/nushell/nushell/issues/7032
-            // Example {
-            //     description: "convert date to string",
-            //     example: "'2020-10-10 10:00:00 +02:00' | into datetime | into string",
-            //     result: Some(Value::test_string("Sat Oct 10 10:00:00 2020")),
-            // },
+            Example {
+                description: "convert date to string",
+                example: "'2020-10-10 10:00:00 +02:00' | into datetime | into string",
+                result: Some(Value::test_string("Sat Oct 10 10:00:00 2020")),
+            },
             Example {
                 description: "convert filepath to string",
                 example: "ls Cargo.toml | get name | into string",

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -81,6 +81,34 @@ impl Command for SubCommand {
             Some(Value::Record { cols, vals, span })
         };
 
+        let example_result_2 = || {
+            let span = Span::test_data();
+            let cols = vec![
+                "year".into(),
+                "month".into(),
+                "day".into(),
+                "hour".into(),
+                "minute".into(),
+                "second".into(),
+                "nanosecond".into(),
+                "timezone".into(),
+            ];
+            let vals = vec![
+                Value::Int { val: 2020, span },
+                Value::Int { val: 4, span },
+                Value::Int { val: 12, span },
+                Value::Int { val: 22, span },
+                Value::Int { val: 10, span },
+                Value::Int { val: 57, span },
+                Value::Int { val: 0, span },
+                Value::String {
+                    val: "+02:00".to_string(),
+                    span,
+                },
+            ];
+            Some(Value::Record { cols, vals, span })
+        };
+
         vec![
             Example {
                 description: "Convert the current date into a record.",
@@ -97,12 +125,11 @@ impl Command for SubCommand {
                 example: "'2020-04-12T22:10:57.123+02:00' | date to-record",
                 result: example_result_1(),
             },
-            // TODO: This should work but does not; see https://github.com/nushell/nushell/issues/7032
-            // Example {
-            //     description: "Convert a date into a record.",
-            //     example: "'2020-04-12 22:10:57 +0200' | into datetime | date to-record",
-            //     result: example_result_1(),
-            // },
+            Example {
+                description: "Convert a date into a record.",
+                example: "'2020-04-12 22:10:57 +0200' | into datetime | date to-record",
+                result: example_result_2(),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -81,6 +81,37 @@ impl Command for SubCommand {
             })
         };
 
+        let example_result_2 = || {
+            let span = Span::test_data();
+            let cols = vec![
+                "year".into(),
+                "month".into(),
+                "day".into(),
+                "hour".into(),
+                "minute".into(),
+                "second".into(),
+                "nanosecond".into(),
+                "timezone".into(),
+            ];
+            let vals = vec![
+                Value::Int { val: 2020, span },
+                Value::Int { val: 4, span },
+                Value::Int { val: 12, span },
+                Value::Int { val: 22, span },
+                Value::Int { val: 10, span },
+                Value::Int { val: 57, span },
+                Value::Int { val: 0, span },
+                Value::String {
+                    val: "+02:00".to_string(),
+                    span,
+                },
+            ];
+            Some(Value::List {
+                vals: vec![Value::Record { cols, vals, span }],
+                span,
+            })
+        };
+
         vec![
             Example {
                 description: "Convert the current date into a table.",
@@ -94,17 +125,14 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert a given date into a table.",
-                //todo: resolve https://github.com/bspeice/dtparse/issues/40, which truncates nanosec bits
-                // for now, change the example to use date literal rather than string conversion, as workaround
                 example: "2020-04-12T22:10:57.000000789+02:00 | date to-table",
                 result: example_result_1(),
             },
-            // TODO: This should work but does not; see https://github.com/nushell/nushell/issues/7032
-            // Example {
-            //     description: "Convert a given date into a table.",
-            //     example: "'2020-04-12 22:10:57 +0200' | into datetime | date to-table",
-            //     result: example_result_1(),
-            // },
+            Example {
+                description: "Convert a given date into a table.",
+                example: "'2020-04-12 22:10:57 +0200' | into datetime | date to-table",
+                result: example_result_2(),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -99,12 +99,11 @@ impl Command for SubCommand {
                 example: r#""2020-10-10 10:00:00 +02:00" | date to-timezone "+0500""#,
                 result: example_result_1(),
             },
-            // TODO: This should work but does not; see https://github.com/nushell/nushell/issues/7032
-            // Example {
-            //     description: "Get the current date in Hawaii, from a datetime object",
-            //     example: r#""2020-10-10 10:00:00 +02:00" | into datetime | date to-timezone "+0500""#,
-            //     result: example_result_1(),
-            // },
+            Example {
+                description: "Get the current date in Hawaii, from a datetime object",
+                example: r#""2020-10-10 10:00:00 +02:00" | into datetime | date to-timezone "+0500""#,
+                result: example_result_1(),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -9,9 +9,9 @@ pub fn test_examples(cmd: impl Command + 'static) {
 #[cfg(test)]
 mod test_examples {
     use super::super::{
-        Ansi, Date, Enumerate, Flatten, From, Get, Into, IntoString, Math, MathRound, ParEach,
-        Path, PathParse, Random, Sort, SortBy, Split, SplitColumn, SplitRow, Str, StrJoin,
-        StrLength, StrReplace, Update, Url, Values, Wrap,
+        Ansi, Date, Enumerate, Filter, Flatten, From, Get, Into, IntoDatetime, IntoString, Math,
+        MathRound, ParEach, Path, PathParse, Random, Sort, SortBy, Split, SplitColumn, SplitRow,
+        Str, StrJoin, StrLength, StrReplace, Update, Url, Values, Wrap,
     };
     use crate::{Each, To};
     use nu_cmd_lang::example_support::{
@@ -70,12 +70,14 @@ mod test_examples {
             working_set.add_decl(Box::new(Each));
             working_set.add_decl(Box::new(Echo));
             working_set.add_decl(Box::new(Enumerate));
+            working_set.add_decl(Box::new(Filter));
             working_set.add_decl(Box::new(Flatten));
             working_set.add_decl(Box::new(From));
             working_set.add_decl(Box::new(Get));
             working_set.add_decl(Box::new(If));
             working_set.add_decl(Box::new(Into));
             working_set.add_decl(Box::new(IntoString));
+            working_set.add_decl(Box::new(IntoDatetime));
             working_set.add_decl(Box::new(Let));
             working_set.add_decl(Box::new(Math));
             working_set.add_decl(Box::new(MathRound));

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -233,25 +233,24 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                     span: Span::test_data(),
                 }),
             },
-            // TODO: This should work but does not. (Note that `Let` must be present in the working_set in `example_test.rs`).
-            // See https://github.com/nushell/nushell/issues/7034
-            // Example {
-            //     description: "List all numbers above 3, using an existing closure condition",
-            //     example: "let a = {$in > 3}; [1, 2, 5, 6] | filter $a",
-            //     result: Some(Value::List {
-            //         vals: vec![
-            //             Value::Int {
-            //                 val: 5,
-            //                 span: Span::test_data(),
-            //             },
-            //             Value::Int {
-            //                 val: 6,
-            //                 span: Span::test_data(),
-            //             },
-            //         ],
-            //         span: Span::test_data(),
-            //     }),
-            // },
+            Example {
+                description: "List all numbers above 3, using an existing closure condition",
+                example: "let a = {$in > 3}; [1, 2, 5, 6] | filter $a",
+                result: None, // TODO: This should work
+                              // result: Some(Value::List {
+                              //     vals: vec![
+                              //         Value::Int {
+                              //             val: 5,
+                              //             span: Span::test_data(),
+                              //         },
+                              //         Value::Int {
+                              //             val: 6,
+                              //             span: Span::test_data(),
+                              //         },
+                              //     ],
+                              //     span: Span::test_data(),
+                              // }),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -78,16 +78,16 @@ impl Command for Sleep {
                     span: Span::test_data(),
                 }),
             },
-            // Example {
-            //     description: "Sleep for 3sec",
-            //     example: "sleep 1sec 1sec 1sec",
-            //     result: None,
-            // },
-            // Example {
-            //     description: "Send output after 1sec",
-            //     example: "sleep 1sec; echo done",
-            //     result: None,
-            // },
+            Example {
+                description: "Sleep for 3sec",
+                example: "sleep 1sec 1sec 1sec",
+                result: None,
+            },
+            Example {
+                description: "Send output after 1sec",
+                example: "sleep 1sec; echo done",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -76,15 +76,14 @@ impl Command for FormatDate {
 
     fn examples(&self) -> Vec<Example> {
         vec![
-            // TODO: This should work but does not; see https://github.com/nushell/nushell/issues/7032
-            // Example {
-            //     description: "Format a given date-time using the default format (RFC 2822).",
-            //     example: r#"'2021-10-22 20:00:12 +01:00' | into datetime | format date"#,
-            //     result: Some(Value::String {
-            //         val: "Fri, 22 Oct 2021 20:00:12 +0100".to_string(),
-            //         span: Span::test_data(),
-            //     }),
-            // },
+            Example {
+                description: "Format a given date-time using the default format (RFC 2822).",
+                example: r#"'2021-10-22 20:00:12 +01:00' | into datetime | format date"#,
+                result: Some(Value::String {
+                    val: "Fri, 22 Oct 2021 20:00:12 +0100".to_string(),
+                    span: Span::test_data(),
+                }),
+            },
             Example {
                 description:
                     "Format a given date-time as a string using the default format (RFC 2822).",


### PR DESCRIPTION
# Description

This PR updates some `Example` tests so that they work again. The only one I couldn't figure out is the one in the `filter` command. It should work but does not. However, I left the test in because it's valuable, it just has a `None` result. I'd like to fix this but I'm not sure how.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
