### PR TITLE
pin serde to avoid https://github.com/serde-rs/serde/issues/2538

### DIFF
--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -22,7 +22,8 @@ chrono = { version = "0.4", features = ["std", "unstable-locales"], default-feat
 fancy-regex = "0.11"
 indexmap = { version = "2.0" }
 num = { version = "0.4", optional = true }
-serde = { version = "1.0", features = ["derive"] }
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172", features = ["derive"] }
 sqlparser = { version = "0.34", features = ["serde"], optional = true }
 polars-io = { version = "0.30.0", features = ["avro"] }
 

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -26,7 +26,8 @@ ahash = "0.8.3"
 nu-ansi-term = "0.49.0"
 fancy-regex = "0.11.0"
 rust-embed = "6.7.0"
-serde = "1.0.164"
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172" }
 nu-pretty-hex = { version = "0.83.2", path = "../nu-pretty-hex" }
 nu-json = { version = "0.83.2", path = "../nu-json" }
 serde_urlencoded = "0.7.1"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -17,7 +17,8 @@ nu-utils = { path = "../nu-utils", version = "0.83.2" }
 nu-engine = { path = "../nu-engine", version = "0.83.2" }
 nu-json = { path="../nu-json", version = "0.83.2"  }
 
-serde = { version="1.0", features=["derive"] }
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172", features = ["derive"] }
 
 [dev-dependencies]
 nu-test-support = { path="../nu-test-support", version = "0.83.2"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -76,7 +76,8 @@ regex = "1.7"
 roxmltree = "0.18"
 rusqlite = { version = "0.29", features = ["bundled"], optional = true }
 same-file = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 serde_yaml = "0.9"

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -19,7 +19,8 @@ default = ["preserve_order"]
 [dependencies]
 linked-hash-map = { version="0.5", optional=true }
 num-traits = "0.2"
-serde = "1.0"
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172" }
 
 [dev-dependencies]
 # nu-path = { path="../nu-path", version = "0.83.2" }

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -16,5 +16,6 @@ nu-protocol = { path = "../nu-protocol", version = "0.83.2"  }
 
 bincode = "1.3"
 rmp-serde = "1.1"
-serde = { version = "1.0" }
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172" }
 serde_json = { version = "1.0"}

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -23,7 +23,8 @@ indexmap = "2.0"
 lru = "0.11"
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }
 num-format = "0.4"
-serde = { version = "1.0", default-features = false }
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172", default-features = false }
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
 typetag = "0.2"

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -12,5 +12,6 @@ bench = false
 [dependencies]
 nu-plugin = { path = "../nu-plugin", version = "0.83.2" }
 nu-protocol = { path = "../nu-protocol", version = "0.83.2", features = ["plugin"] }
-serde = { version = "1.0", default-features = false }
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172", default-features = false }
 typetag = "0.2"

--- a/tests/fixtures/formats/cargo_sample.toml
+++ b/tests/fixtures/formats/cargo_sample.toml
@@ -36,7 +36,8 @@ log = "0.4.6"
 pretty_env_logger = "0.3.0"
 lalrpop-util = "0.17.0"
 regex = "1.1.6"
-serde = "1.0.91"
+# Due to https://github.com/serde-rs/serde/issues/2538
+serde = { version = "1.0, < 1.0.172" }
 serde_json = "1.0"
 serde_derive = "1.0.91"
 getset = "0.0.7"


### PR DESCRIPTION
Context: https://github.com/serde-rs/serde/issues/2538

As other projects are investigating, this should pin serde to the last stable release before binary requirements were introduced.

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
