### PR TITLE
allow `return` to return any nushell value

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -19,7 +19,10 @@ impl Command for Return {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("return")
-            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .input_output_types(vec![
+                (Type::Nothing, Type::Nothing),
+                (Type::Nothing, Type::Any),
+            ])
             .optional("return_value", SyntaxShape::Any, "optional value to return")
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -19,10 +19,7 @@ impl Command for Return {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("return")
-            .input_output_types(vec![
-                (Type::Nothing, Type::Nothing),
-                (Type::Nothing, Type::Any),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .optional("return_value", SyntaxShape::Any, "optional value to return")
             .category(Category::Core)
     }


### PR DESCRIPTION
# Description

This PR allows the `return` command to return any nushell value.

### Before
![image](https://github.com/nushell/nushell/assets/343840/2c0a70d7-86e4-4c7f-bd3a-d7c7d74b1c1a)

### After
![image](https://github.com/nushell/nushell/assets/343840/f428d486-4a4f-4058-a29f-7d7a845e08f7)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
