### PR TITLE
Remove "let config" warning

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -4,7 +4,7 @@ use nu_cli::read_plugin_file;
 use nu_cli::{eval_config_contents, eval_source};
 use nu_path::canonicalize_with;
 use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
-use nu_protocol::{report_error, Span};
+use nu_protocol::report_error;
 use nu_protocol::{ParseError, PipelineData, Spanned};
 use nu_utils::{get_default_config, get_default_env};
 use std::fs::File;

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -203,19 +203,6 @@ pub(crate) fn setup_config(
     if is_login_shell {
         read_loginshell_file(engine_state, stack);
     }
-
-    // Give a warning if we see `$config` for a few releases
-    {
-        let working_set = StateWorkingSet::new(engine_state);
-        if let Some(var) = working_set
-            .find_variable(b"$config")
-            .and_then(|id| stack.get_var(id, Span::unknown()).ok())
-        {
-            if var.as_record().is_ok() {
-                println!("warning: use `$env.config = ...` instead of `let config = ...`");
-            }
-        }
-    }
 }
 
 pub(crate) fn set_config_path(


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

If you have a `config` variable defined at some point after reading config files, Nushell would print
```
warning: use `$env.config = ...` instead of `let config = ...`
```

I think it's long enough since we've used `$env.config` that we can remove this. Furthermore, it should be printed during `let` parsing because you can end up with a `config` constant after importing a `config` module (that was my case). The warning thus can be misleading.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
