### PR TITLE
Remove clippy global `-A` from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: continuous-integration
 env:
   NUSHELL_CARGO_TARGET: ci
   NU_LOG_LEVEL: DEBUG
-  CLIPPY_OPTIONS: "-D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err"
+  CLIPPY_OPTIONS: "-D warnings -D clippy::unwrap_used"
 
 jobs:
   fmt-clippy:


### PR DESCRIPTION
# Description
We allowed two default lints due to false positives. This should be locally addressed with explicit information what causes either a false positive or why a particular design choice in the code is made.


# User-Facing Changes
None

# Tests + Formatting
We should detect a few more things with clippy out of the box. If you encounter a false positive you will need to address it on a case by case basis.