### PR TITLE
Revert "pin serde to avoid https://github.com/serde-rs/serde/issues/2538"

### DIFF
--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -22,8 +22,7 @@ chrono = { version = "0.4", features = ["std", "unstable-locales"], default-feat
 fancy-regex = "0.11"
 indexmap = { version = "2.0" }
 num = { version = "0.4", optional = true }
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "0.34", features = ["serde"], optional = true }
 polars-io = { version = "0.30.0", features = ["avro"] }
 

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -26,8 +26,7 @@ ahash = "0.8.3"
 nu-ansi-term = "0.49.0"
 fancy-regex = "0.11.0"
 rust-embed = "6.7.0"
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172" }
+serde = "1.0.164"
 nu-pretty-hex = { version = "0.83.2", path = "../nu-pretty-hex" }
 nu-json = { version = "0.83.2", path = "../nu-json" }
 serde_urlencoded = "0.7.1"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -17,8 +17,7 @@ nu-utils = { path = "../nu-utils", version = "0.83.2" }
 nu-engine = { path = "../nu-engine", version = "0.83.2" }
 nu-json = { path="../nu-json", version = "0.83.2"  }
 
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172", features = ["derive"] }
+serde = { version="1.0", features=["derive"] }
 
 [dev-dependencies]
 nu-test-support = { path="../nu-test-support", version = "0.83.2"  }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -76,8 +76,7 @@ regex = "1.7"
 roxmltree = "0.18"
 rusqlite = { version = "0.29", features = ["bundled"], optional = true }
 same-file = "1.0"
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_urlencoded = "0.7"
 serde_yaml = "0.9"

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -19,8 +19,7 @@ default = ["preserve_order"]
 [dependencies]
 linked-hash-map = { version="0.5", optional=true }
 num-traits = "0.2"
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172" }
+serde = "1.0"
 
 [dev-dependencies]
 # nu-path = { path="../nu-path", version = "0.83.2" }

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -16,6 +16,5 @@ nu-protocol = { path = "../nu-protocol", version = "0.83.2"  }
 
 bincode = "1.3"
 rmp-serde = "1.1"
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172" }
+serde = { version = "1.0" }
 serde_json = { version = "1.0"}

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -23,8 +23,7 @@ indexmap = "2.0"
 lru = "0.11"
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }
 num-format = "0.4"
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172", default-features = false }
+serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
 typetag = "0.2"

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -12,6 +12,5 @@ bench = false
 [dependencies]
 nu-plugin = { path = "../nu-plugin", version = "0.83.2" }
 nu-protocol = { path = "../nu-protocol", version = "0.83.2", features = ["plugin"] }
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172", default-features = false }
+serde = { version = "1.0", default-features = false }
 typetag = "0.2"

--- a/tests/fixtures/formats/cargo_sample.toml
+++ b/tests/fixtures/formats/cargo_sample.toml
@@ -36,8 +36,7 @@ log = "0.4.6"
 pretty_env_logger = "0.3.0"
 lalrpop-util = "0.17.0"
 regex = "1.1.6"
-# Due to https://github.com/serde-rs/serde/issues/2538
-serde = { version = "1.0, < 1.0.172" }
+serde = "1.0.91"
 serde_json = "1.0"
 serde_derive = "1.0.91"
 getset = "0.0.7"


### PR DESCRIPTION
Reverts nushell/nushell#10061

The latest serde (1.0.184) reverts the binary requirement.