### PR TITLE
update install/build scripts to include `--locked`

### DIFF
--- a/scripts/build-all-maclin.sh
+++ b/scripts/build-all-maclin.sh
@@ -21,7 +21,7 @@ NU_PLUGINS=(
 echo "Building nushell"
 (
     cd $REPO_ROOT
-    cargo build --features=dataframe
+    cargo build --features=dataframe,extra --locked
 )
 
 for plugin in "${NU_PLUGINS[@]}"

--- a/scripts/build-all-windows.cmd
+++ b/scripts/build-all-windows.cmd
@@ -5,7 +5,7 @@ echo -------------------------------------------------------------------
 echo.
 
 echo Building nushell.exe
-cargo build --features=dataframe
+cargo build --features=dataframe,extra --locked
 echo.
 
 call :build crates\nu_plugin_example nu_plugin_example.exe

--- a/scripts/build-all.nu
+++ b/scripts/build-all.nu
@@ -13,7 +13,7 @@ def build-nushell [] {
     print '----------------------------'
 
     cd $repo_root
-    cargo build --features=dataframe
+    cargo build --features=dataframe,extra --locked
 }
 
 def build-plugin [] {

--- a/scripts/install-all.ps1
+++ b/scripts/install-all.ps1
@@ -8,7 +8,7 @@ Write-Output ""
 
 Write-Output "Install nushell from local..."
 Write-Output "----------------------------------------------"
-cargo install --force --path . --features=dataframe
+cargo install --force --path . --features=dataframe,extra --locked
 
 $NU_PLUGINS = @(
     'nu_plugin_example',

--- a/scripts/install-all.sh
+++ b/scripts/install-all.sh
@@ -12,7 +12,7 @@ echo ""
 
 echo "Install nushell from local..."
 echo "----------------------------------------------"
-cargo install --force --path "$REPO_ROOT" --features=dataframe
+cargo install --force --path "$REPO_ROOT" --features=dataframe,extra --locked
 
 NU_PLUGINS=(
     'nu_plugin_inc'

--- a/scripts/uninstall-all.sh
+++ b/scripts/uninstall-all.sh
@@ -13,6 +13,7 @@ NU_PLUGINS=(
     'nu_plugin_query'
     'nu_plugin_example'
     'nu_plugin_formats'
+    'nu_plugin_custom_values'
 )
 
 cargo uninstall nu

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -338,7 +338,7 @@ export def install [
     --all: bool  # install all plugins with Nushell
 ] {
     touch crates/nu-cmd-lang/build.rs # needed to make sure `version` has the correct `commit_hash`
-    cargo install --path . --features ($features | str join ",") --locked
+    cargo install --path . --features ($features | str join ",") --locked --force
     if not $all {
         return
     }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -281,7 +281,7 @@ def build-nushell [features: string] {
     print $'(char nl)Building nushell'
     print '----------------------------'
 
-    cargo build --features $features
+    cargo build --features $features --locked
 }
 
 def build-plugin [] {
@@ -338,7 +338,7 @@ export def install [
     --all: bool  # install all plugins with Nushell
 ] {
     touch crates/nu-cmd-lang/build.rs # needed to make sure `version` has the correct `commit_hash`
-    cargo install --path . --features ($features | str join ",")
+    cargo install --path . --features ($features | str join ",") --locked
     if not $all {
         return
     }
@@ -351,6 +351,7 @@ export def install [
         nu_plugin_custom_values,
         nu_plugin_formats,
     ]
+
     for plugin in $plugins {
         $plugin | install-plugin
     }


### PR DESCRIPTION
# Description

This PR updates the toolkit and the build/install scripts to include `--locked`, also added `extra` feature to the _all_ scripts, and `--force` to the install scripts.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used -A clippy::needless_collect -A clippy::result_large_err` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
