### PR TITLE
Remove illegal star dependency

### DIFF
--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -36,4 +36,4 @@ serde_json = "1.0"
 strum = "0.25"
 strum_macros = "0.25"
 nu-test-support = { path = "../nu-test-support", version = "0.83.2" }
-rstest = "*"
+rstest = "0.18"


### PR DESCRIPTION
The wildcard dev-dependency added in #9632 blocked us from publishing
the crate
