### PR TITLE
bump nushell to dev version 0.84.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "assert_cmd",
  "criterion",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "chrono",
  "crossterm",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-base"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "indexmap 2.0.0",
  "nu-engine",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-dataframe"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "chrono",
  "fancy-regex",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-extra"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "Inflector",
  "ahash",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "fancy-regex",
  "itertools",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "alphanumeric-sort",
  "base64",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "nu-explore"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "ansi-str",
  "crossterm",
@@ -2849,14 +2849,14 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "doc-comment",
 ]
 
 [[package]]
 name = "nu-json"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "linked-hash-map",
  "num-traits",
@@ -2865,7 +2865,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "bincode",
  "nu-engine",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "heapless",
  "nu-ansi-term",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "nu-std"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "miette",
  "nu-engine",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "chrono",
  "is-terminal",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "nu-ansi-term",
  "nu-color-config",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "nu-utils",
  "unicode-width",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "hamcrest2",
  "nu-glob",
@@ -2994,7 +2994,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3024,7 +3024,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_formats"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "eml-parser",
  "ical",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "git2",
  "nu-plugin",
@@ -3045,7 +3045,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.84.0"
+version = "0.84.1"
 dependencies = [
  "gjson",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.60"
-version = "0.84.0"
+version = "0.84.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -46,34 +46,34 @@ members = [
 ]
 
 [dependencies]
-nu-cli = { path = "./crates/nu-cli", version = "0.84.0" }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.84.0" }
-nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.84.0" }
-nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.84.0" }
-nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.84.0", features = ["dataframe"], optional = true }
-nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.84.0", optional = true }
-nu-command = { path = "./crates/nu-command", version = "0.84.0" }
-nu-engine = { path = "./crates/nu-engine", version = "0.84.0" }
-nu-explore = { path = "./crates/nu-explore", version = "0.84.0" }
-nu-json = { path = "./crates/nu-json", version = "0.84.0" }
-nu-parser = { path = "./crates/nu-parser", version = "0.84.0" }
-nu-path = { path = "./crates/nu-path", version = "0.84.0" }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.84.0" }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.84.0" }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.84.0" }
-nu-system = { path = "./crates/nu-system", version = "0.84.0" }
-nu-table = { path = "./crates/nu-table", version = "0.84.0" }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.84.0" }
-nu-std = { path = "./crates/nu-std", version = "0.84.0" }
-nu-utils = { path = "./crates/nu-utils", version = "0.84.0" }
+nu-cli = { path = "./crates/nu-cli", version = "0.84.1" }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.84.1" }
+nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.84.1" }
+nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.84.1" }
+nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.84.1", features = ["dataframe"], optional = true }
+nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.84.1", optional = true }
+nu-command = { path = "./crates/nu-command", version = "0.84.1" }
+nu-engine = { path = "./crates/nu-engine", version = "0.84.1" }
+nu-explore = { path = "./crates/nu-explore", version = "0.84.1" }
+nu-json = { path = "./crates/nu-json", version = "0.84.1" }
+nu-parser = { path = "./crates/nu-parser", version = "0.84.1" }
+nu-path = { path = "./crates/nu-path", version = "0.84.1" }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.84.1" }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.84.1" }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.84.1" }
+nu-system = { path = "./crates/nu-system", version = "0.84.1" }
+nu-table = { path = "./crates/nu-table", version = "0.84.1" }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.84.1" }
+nu-std = { path = "./crates/nu-std", version = "0.84.1" }
+nu-utils = { path = "./crates/nu-utils", version = "0.84.1" }
 nu-ansi-term = "0.49.0"
-reedline = { version = "0.23.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.23.0", features = ["bashisms", "sqlite"] }
 
 crossterm = "0.26"
 ctrlc = "3.4"
 log = "0.4"
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }
-mimalloc = { version = "0.1.37", default-features = false, optional = true}
+mimalloc = { version = "0.1.37", default-features = false, optional = true }
 serde_json = "1.0"
 simplelog = "0.12"
 time = "0.3"
@@ -96,7 +96,7 @@ nix = { version = "0.26", default-features = false, features = [
 is-terminal = "0.4.8"
 
 [dev-dependencies]
-nu-test-support = { path = "./crates/nu-test-support", version = "0.84.0" }
+nu-test-support = { path = "./crates/nu-test-support", version = "0.84.1" }
 assert_cmd = "2.0"
 criterion = "0.5"
 pretty_assertions = "1.4"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -5,27 +5,27 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.84.0" }
-nu-test-support = { path = "../nu-test-support", version = "0.84.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.84.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.84.1" }
 rstest = { version = "0.18.1", default-features = false }
 
 [dependencies]
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.84.0" }
-nu-command = { path = "../nu-command", version = "0.84.0" }
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-path = { path = "../nu-path", version = "0.84.0" }
-nu-parser = { path = "../nu-parser", version = "0.84.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0" }
-nu-utils = { path = "../nu-utils", version = "0.84.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.84.0" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.84.1" }
+nu-command = { path = "../nu-command", version = "0.84.1" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-path = { path = "../nu-path", version = "0.84.1" }
+nu-parser = { path = "../nu-parser", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.84.1" }
 nu-ansi-term = "0.49.0"
-reedline = { version = "0.23.0", features = ["bashisms", "sqlite"]}
+reedline = { version = "0.23.0", features = ["bashisms", "sqlite"] }
 
 chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.26"

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-base"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-base"
-version = "0.84.0"
+version = "0.84.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-path = { path = "../nu-path", version = "0.84.0" }
-nu-protocol = { version = "0.84.0", path = "../nu-protocol" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-path = { path = "../nu-path", version = "0.84.1" }
+nu-protocol = { version = "0.84.1", path = "../nu-protocol" }
 indexmap = { version = "2.0" }

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-dataframe"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-dataframe"
-version = "0.84.0"
+version = "0.84.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,9 +13,9 @@ version = "0.84.0"
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-parser = { path = "../nu-parser", version = "0.84.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-parser = { path = "../nu-parser", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
 
 # Potential dependencies for extras
 chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
@@ -51,7 +51,7 @@ features = [
 	"serde",
 	"serde-lazy",
 	"strings",
-	"to_dummies"
+	"to_dummies",
 ]
 optional = true
 version = "0.30.0"
@@ -61,5 +61,5 @@ dataframe = ["num", "polars", "sqlparser"]
 default = []
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.84.0" }
-nu-test-support = { path = "../nu-test-support", version = "0.84.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.84.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.84.1" }

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-extra"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-extra"
-version = "0.84.0"
+version = "0.84.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,11 +13,11 @@ version = "0.84.0"
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-parser = { path = "../nu-parser", version = "0.84.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0" }
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.84.0" }
-nu-utils = { path = "../nu-utils", version = "0.84.0" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-parser = { path = "../nu-parser", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.84.1" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
 
 # Potential dependencies for extras
 Inflector = "0.11"
@@ -27,8 +27,8 @@ nu-ansi-term = "0.49.0"
 fancy-regex = "0.11.0"
 rust-embed = "6.7.0"
 serde = "1.0.164"
-nu-pretty-hex = { version = "0.84.0", path = "../nu-pretty-hex" }
-nu-json = { version = "0.84.0", path = "../nu-json" }
+nu-pretty-hex = { version = "0.84.1", path = "../nu-pretty-hex" }
+nu-json = { version = "0.84.1", path = "../nu-json" }
 serde_urlencoded = "0.7.1"
 htmlescape = "0.3.1"
 
@@ -37,6 +37,6 @@ extra = ["default"]
 default = []
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.84.0" }
-nu-command = { path = "../nu-command", version = "0.84.0" }
-nu-test-support = { path = "../nu-test-support", version = "0.84.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.84.1" }
+nu-command = { path = "../nu-command", version = "0.84.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.84.1" }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -6,16 +6,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-lang"
 edition = "2021"
 license = "MIT"
 name = "nu-cmd-lang"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-parser = { path = "../nu-parser", version = "0.84.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0"  }
-nu-utils = { path = "../nu-utils", version = "0.84.0" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-parser = { path = "../nu-parser", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
 nu-ansi-term = "0.49.0"
 
 fancy-regex = "0.11"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -5,19 +5,19 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-confi
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.84.0"  }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
 nu-ansi-term = "0.49.0"
-nu-utils = { path = "../nu-utils", version = "0.84.0" }
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-json = { path="../nu-json", version = "0.84.0"  }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-json = { path = "../nu-json", version = "0.84.1" }
 
-serde = { version="1.0", features=["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
-nu-test-support = { path="../nu-test-support", version = "0.84.0"  }
+nu-test-support = { path = "../nu-test-support", version = "0.84.1" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-command"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
-version = "0.84.0"
+version = "0.84.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,19 +14,19 @@ bench = false
 
 [dependencies]
 nu-ansi-term = "0.49.0"
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.84.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.84.0" }
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-glob = { path = "../nu-glob", version = "0.84.0" }
-nu-json = { path = "../nu-json", version = "0.84.0" }
-nu-parser = { path = "../nu-parser", version = "0.84.0" }
-nu-path = { path = "../nu-path", version = "0.84.0" }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.84.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0" }
-nu-system = { path = "../nu-system", version = "0.84.0" }
-nu-table = { path = "../nu-table", version = "0.84.0" }
-nu-term-grid = { path = "../nu-term-grid", version = "0.84.0" }
-nu-utils = { path = "../nu-utils", version = "0.84.0" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.84.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.84.1" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-glob = { path = "../nu-glob", version = "0.84.1" }
+nu-json = { path = "../nu-json", version = "0.84.1" }
+nu-parser = { path = "../nu-parser", version = "0.84.1" }
+nu-path = { path = "../nu-path", version = "0.84.1" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
+nu-system = { path = "../nu-system", version = "0.84.1" }
+nu-table = { path = "../nu-table", version = "0.84.1" }
+nu-term-grid = { path = "../nu-term-grid", version = "0.84.1" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
 
 alphanumeric-sort = "1.5"
 base64 = "0.21"
@@ -113,7 +113,7 @@ features = [
 	"Win32_Storage_FileSystem",
 	"Win32_System_SystemServices",
 	"Win32_Security",
-	"Win32_System_Threading"
+	"Win32_System_Threading",
 ]
 version = "0.48"
 
@@ -124,8 +124,8 @@ trash-support = ["trash"]
 which-support = ["which"]
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.84.0" }
-nu-test-support = { path = "../nu-test-support", version = "0.84.0" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.84.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.84.1" }
 
 dirs-next = "2.0"
 mockito = { version = "1.1", default-features = false }

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -5,18 +5,18 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.84.0"  }
-nu-path = { path = "../nu-path", version = "0.84.0"  }
-nu-glob = { path = "../nu-glob", version = "0.84.0" }
-nu-utils = { path = "../nu-utils", version = "0.84.0"  }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.84.1" }
+nu-path = { path = "../nu-path", version = "0.84.1" }
+nu-glob = { path = "../nu-glob", version = "0.84.1" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
 
-sysinfo ="0.29"
+sysinfo = "0.29"
 
 [features]
 plugin = []

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -5,20 +5,20 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-explore"
 edition = "2021"
 license = "MIT"
 name = "nu-explore"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dependencies]
 nu-ansi-term = "0.49.0"
-nu-protocol = { path = "../nu-protocol", version = "0.84.0" }
-nu-parser = { path = "../nu-parser", version = "0.84.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.84.0" }
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-table = { path = "../nu-table", version = "0.84.0" }
-nu-json = { path = "../nu-json", version = "0.84.0" }
-nu-utils = { path = "../nu-utils", version = "0.84.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
+nu-parser = { path = "../nu-parser", version = "0.84.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.84.1" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-table = { path = "../nu-table", version = "0.84.1" }
+nu-json = { path = "../nu-json", version = "0.84.1" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
 
 terminal_size = "0.2"
 strip-ansi-escapes = "0.2.0"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.84.0"
+version = "0.84.1"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.84.0"
+version = "0.84.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,10 +17,10 @@ preserve_order = ["linked-hash-map", "linked-hash-map/serde_impl"]
 default = ["preserve_order"]
 
 [dependencies]
-linked-hash-map = { version="0.5", optional=true }
+linked-hash-map = { version = "0.5", optional = true }
 num-traits = "0.2"
 serde = "1.0"
 
 [dev-dependencies]
-# nu-path = { path="../nu-path", version = "0.84.0" }
+# nu-path = { path="../nu-path", version = "0.84.1" }
 # serde_json = "1.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-path = {path = "../nu-path", version = "0.84.0" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.84.0"  }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-path = { path = "../nu-path", version = "0.84.1" }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
 
 bytesize = "1.2"
 chrono = { default-features = false, features = ['std'], version = "0.4" }

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.84.0"  }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0"  }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
 
 bincode = "1.3"
 rmp-serde = "1.1"
 serde = { version = "1.0" }
-serde_json = { version = "1.0"}
+serde_json = { version = "1.0" }

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 doctest = false
@@ -19,4 +19,3 @@ nu-ansi-term = "0.49.0"
 [dev-dependencies]
 heapless = { version = "0.7", default-features = false }
 rand = "0.8"
-

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.84.0"
+version = "0.84.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,7 +13,7 @@ version = "0.84.0"
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.84.0" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
 
 byte-unit = "4.0"
 chrono = { version = "0.4", features = [ "serde", "std", "unstable-locales" ], default-features = false }
@@ -35,5 +35,5 @@ plugin = ["serde_json"]
 serde_json = "1.0"
 strum = "0.25"
 strum_macros = "0.25"
-nu-test-support = { path = "../nu-test-support", version = "0.84.0" }
+nu-test-support = { path = "../nu-test-support", version = "0.84.1" }
 rstest = "0.18"

--- a/crates/nu-std/Cargo.toml
+++ b/crates/nu-std/Cargo.toml
@@ -5,10 +5,10 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-std"
 edition = "2021"
 license = "MIT"
 name = "nu-std"
-version = "0.84.0"
+version = "0.84.1"
 
 [dependencies]
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }
-nu-parser = { version = "0.84.0", path = "../nu-parser" }
-nu-protocol = { version = "0.84.0", path = "../nu-protocol" }
-nu-engine = { version = "0.84.0", path = "../nu-engine" }
+nu-parser = { version = "0.84.1", path = "../nu-parser" }
+nu-protocol = { version = "0.84.1", path = "../nu-protocol" }
+nu-engine = { version = "0.84.1", path = "../nu-engine" }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.84.0"
+version = "0.84.1"
 edition = "2021"
 license = "MIT"
 
@@ -17,11 +17,11 @@ libc = "0.2"
 log = "0.4"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.26", default-features = false, features = ["fs", "term", "process", "signal"]}
+nix = { version = "0.26", default-features = false, features = ["fs", "term", "process", "signal"] }
 is-terminal = "0.4.8"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-procfs  = "0.15"
+procfs = "0.15"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14"
@@ -31,4 +31,33 @@ mach2 = "0.4"
 chrono = "0.4"
 ntapi = "0.4"
 once_cell = "1.18"
-winapi = { version = "0.3", features = ["tlhelp32", "fileapi", "handleapi", "ifdef", "ioapiset", "minwindef", "pdh", "psapi", "synchapi", "sysinfoapi", "winbase", "winerror", "winioctl", "winnt", "oleauto", "wbemcli", "rpcdce", "combaseapi", "objidl", "powerbase", "netioapi", "lmcons", "lmaccess", "lmapibuf", "memoryapi", "shellapi", "std", "securitybaseapi"] }
+winapi = { version = "0.3", features = [
+    "tlhelp32",
+    "fileapi",
+    "handleapi",
+    "ifdef",
+    "ioapiset",
+    "minwindef",
+    "pdh",
+    "psapi",
+    "synchapi",
+    "sysinfoapi",
+    "winbase",
+    "winerror",
+    "winioctl",
+    "winnt",
+    "oleauto",
+    "wbemcli",
+    "rpcdce",
+    "combaseapi",
+    "objidl",
+    "powerbase",
+    "netioapi",
+    "lmcons",
+    "lmaccess",
+    "lmapibuf",
+    "memoryapi",
+    "shellapi",
+    "std",
+    "securitybaseapi",
+] }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -5,18 +5,18 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.84.0" }
-nu-utils = { path = "../nu-utils", version = "0.84.0" }
-nu-engine = { path = "../nu-engine", version = "0.84.0" }
-nu-color-config = { path = "../nu-color-config", version = "0.84.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
+nu-color-config = { path = "../nu-color-config", version = "0.84.1" }
 nu-ansi-term = "0.49.0"
 tabled = { version = "0.14.0", features = ["color"], default-features = false }
 
 [dev-dependencies]
-# nu-test-support = { path="../nu-test-support", version = "0.84.0"  }
+# nu-test-support = { path="../nu-test-support", version = "0.84.1"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.84.0"  }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
 
 unicode-width = "0.1"

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-suppor
 edition = "2021"
 license = "MIT"
 name = "nu-test-support"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 doctest = false
 bench = false
 
 [dependencies]
-nu-path = { path="../nu-path", version = "0.84.0"  }
-nu-glob = { path = "../nu-glob", version = "0.84.0" }
-nu-utils = { path="../nu-utils", version = "0.84.0"  }
+nu-path = { path = "../nu-path", version = "0.84.1" }
+nu-glob = { path = "../nu-glob", version = "0.84.1" }
+nu-utils = { path = "../nu-utils", version = "0.84.1" }
 
 num-format = "0.4"
 which = "4.3"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-utils"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
-version = "0.84.0"
+version = "0.84.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -1,6 +1,6 @@
 # Nushell Config File
 #
-# version = "0.84.0"
+# version = "0.84.1"
 
 # For more information on defining custom themes, see
 # https://www.nushell.sh/book/coloring_and_theming.html
@@ -31,7 +31,7 @@ let dark_theme = {
     list: white
     block: white
     hints: dark_gray
-    search_result: {bg: red fg: white}    
+    search_result: {bg: red fg: white}
     shape_and: purple_bold
     shape_binary: purple_bold
     shape_block: blue_bold
@@ -94,7 +94,7 @@ let light_theme = {
     list: white
     block: white
     hints: dark_gray
-    search_result: {fg: white bg: red}    
+    search_result: {fg: white bg: red}
     shape_and: purple_bold
     shape_binary: purple_bold
     shape_block: blue_bold

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -1,6 +1,6 @@
 # Nushell Environment Config File
 #
-# version = "0.84.0"
+# version = "0.84.1"
 
 def create_left_prompt [] {
     mut home = ""

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -10,7 +10,7 @@ name = "nu_plugin_custom_values"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.84.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1", features = ["plugin"] }
 serde = { version = "1.0", default-features = false }
 typetag = "0.2"

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_exam
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.84.0"
+version = "0.84.1"
 
 [[bin]]
 name = "nu_plugin_example"
@@ -15,5 +15,5 @@ bench = false
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.84.0" }
-nu-protocol = { path="../nu-protocol", version = "0.84.0", features = ["plugin"]}
+nu-plugin = { path = "../nu-plugin", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1", features = ["plugin"] }

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_form
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_formats"
-version = "0.84.0"
+version = "0.84.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.84.0" }
-nu-protocol = { path = "../nu-protocol", version = "0.84.0", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1", features = ["plugin"] }
 
 indexmap = "2.0"
 eml-parser = "0.1"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gsta
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_gstat"
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.84.0" }
-nu-protocol = { path="../nu-protocol", version = "0.84.0" }
+nu-plugin = { path = "../nu-plugin", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
 
 git2 = "0.17"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_inc"
 bench = false
 
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.84.0" }
-nu-protocol = { path="../nu-protocol", version = "0.84.0", features = ["plugin"]}
+nu-plugin = { path = "../nu-plugin", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1", features = ["plugin"] }
 
 semver = "1.0"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_quer
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.84.0"
+version = "0.84.1"
 
 [lib]
 doctest = false
@@ -15,11 +15,10 @@ bench = false
 name = "nu_plugin_query"
 bench = false
 
-
 [dependencies]
-nu-plugin = { path="../nu-plugin", version = "0.84.0" }
-nu-protocol = { path="../nu-protocol", version = "0.84.0" }
-nu-engine = { path="../nu-engine", version = "0.84.0" }
+nu-plugin = { path = "../nu-plugin", version = "0.84.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
+nu-engine = { path = "../nu-engine", version = "0.84.1" }
 
 gjson = "0.8"
 scraper = { default-features = false, version = "0.17" }


### PR DESCRIPTION
# Description

This PR bumps nushell from release version 0.84.0 to dev version 0.84.1.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
