### PR TITLE
Fix tab completion order of directories to consistent with order of files

### DIFF
--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -63,7 +63,12 @@ impl Completer for DirectoryCompletion {
 
         match self.get_sort_by() {
             SortBy::Ascending => {
-                sorted_items.sort_by(|a, b| a.value.cmp(&b.value));
+                sorted_items.sort_by(|a, b| {
+                    // Ignore trailing slashes in folder names when sorting
+                    a.value
+                        .trim_end_matches(SEP)
+                        .cmp(b.value.trim_end_matches(SEP))
+                });
             }
             SortBy::LevenshteinDistance => {
                 sorted_items.sort_by(|a, b| {

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -60,7 +60,12 @@ impl Completer for FileCompletion {
 
         match self.get_sort_by() {
             SortBy::Ascending => {
-                sorted_items.sort_by(|a, b| a.value.cmp(&b.value));
+                sorted_items.sort_by(|a, b| {
+                    // Ignore trailing slashes in folder names when sorting
+                    a.value
+                        .trim_end_matches(SEP)
+                        .cmp(b.value.trim_end_matches(SEP))
+                });
             }
             SortBy::LevenshteinDistance => {
                 sorted_items.sort_by(|a, b| {


### PR DESCRIPTION
# Description

fixed #10020

Tab completion order of directories is inconsistent with order of files.
This problem is caused by sorting folder names containing a trailing slash.
This PR fixes the problem.

# User-Facing Changes

Users get the same order of suggestions in the tab completion for both file and directory.

![image](https://github.com/nushell/nushell/assets/37319612/208e5a01-01a2-489c-b41a-36ece999f971)


# Tests + Formatting

```
$ toolkit check pr

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
```

# After Submitting

nothing