### PR TITLE
Fix watch not detecting modifications on Windows

### DIFF
--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -252,7 +252,8 @@ impl Command for Watch {
                                 .map(|path| event_handler("Remove", path, None))
                                 .unwrap_or(Ok(())),
                             EventKind::Modify(ModifyKind::Data(DataChange::Content))
-                            | EventKind::Modify(ModifyKind::Data(DataChange::Any)) => one_event
+                            | EventKind::Modify(ModifyKind::Data(DataChange::Any))
+                            | EventKind::Modify(ModifyKind::Any) => one_event
                                 .paths
                                 .pop()
                                 .map(|path| event_handler("Write", path, None))


### PR DESCRIPTION
Closes #9910 FOR REAL this time.

I had fixed the issue on Linux but not Windows. Context: https://github.com/nushell/nushell/issues/9910#issuecomment-1689308886

I've tested this PR successfully on Windows, Linux, and macOS by running `watch . {|a,b| print $a; print $b}` and confirming that it prints once when I change a file in the current directory.