### PR TITLE
Add notice to enable develop mode on Windows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Make sure you've run and fixed any issues with these commands:
 
 - `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
 - `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
-- `cargo test --workspace` to check that all tests pass
+- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
 - `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library
 
 > **Note**


### PR DESCRIPTION
Developer mode needs to be enabled to create symlinks on Windows. Since creating symlinks is part of the testbench, this needs to be enabled.

(I always wondered why two tests fail on my Windows machine, but not on the CI)