### PR TITLE
Allow for `.parq` file ending as alternative to `.parquet`

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/eager/open.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/open.rs
@@ -116,7 +116,7 @@ fn command(
     match type_id {
         Some((e, msg, blamed)) => match e.as_str() {
             "csv" | "tsv" => from_csv(engine_state, stack, call),
-            "parquet" => from_parquet(engine_state, stack, call),
+            "parquet" | "parq" => from_parquet(engine_state, stack, call),
             "ipc" | "arrow" => from_ipc(engine_state, stack, call),
             "json" => from_json(engine_state, stack, call),
             "jsonl" => from_jsonl(engine_state, stack, call),


### PR DESCRIPTION
# Description

Many systems like Hadoops HDFS store parquet files with the short variant `.parq`. It is quite annoying to rename these file before opening them with nushell. This PR lets nushell accept .parq alongside .parquet file endings.


# User-Facing Changes
Not sure if this is applicable here.

# Tests + Formatting

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)  - :heavy_check_mark: 
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style - :heavy_check_mark: 
- `cargo test --workspace` to check that all tests pass - :x: (fails on none related test)
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library - :heavy_check_mark: 

