### PR TITLE
handle empty pipeline while parsing let (fix Issue10083)

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5476,10 +5476,14 @@ pub fn parse_pipeline(
                                         {
                                             let block = working_set.get_block(*block_id);
 
-                                            let element = block.pipelines[0].elements[0].clone();
-
-                                            if let PipelineElement::Expression(prepend, expr) =
-                                                element
+                                            if let Some(PipelineElement::Expression(
+                                                prepend,
+                                                expr,
+                                            )) = block
+                                                .pipelines
+                                                .first()
+                                                .and_then(|p| p.elements.first())
+                                                .cloned()
                                             {
                                                 if expr.has_in_variable(working_set) {
                                                     let new_expr = PipelineElement::Expression(
@@ -5608,9 +5612,12 @@ pub fn parse_pipeline(
                                 {
                                     let block = working_set.get_block(*block_id);
 
-                                    let element = block.pipelines[0].elements[0].clone();
-
-                                    if let PipelineElement::Expression(prepend, expr) = element {
+                                    if let Some(PipelineElement::Expression(prepend, expr)) = block
+                                        .pipelines
+                                        .first()
+                                        .and_then(|p| p.elements.first())
+                                        .cloned()
+                                    {
                                         if expr.has_in_variable(working_set) {
                                             let new_expr = PipelineElement::Expression(
                                                 prepend,

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1012,15 +1012,12 @@ mod string {
 #[case(b"mut a = }")]
 #[case(b"let a = | }")]
 #[case(b"mut a = | }")]
-fn test_semi_open_brace(
-        #[case] phrase: &[u8],
-    ) {
+fn test_semi_open_brace(#[case] phrase: &[u8]) {
     let engine_state = EngineState::new();
     let mut working_set = StateWorkingSet::new(&engine_state);
     // this should not panic
     let _block = parse(&mut working_set, None, phrase, true);
 }
-
 
 mod range {
     use super::*;

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -1007,6 +1007,21 @@ mod string {
     }
 }
 
+#[rstest]
+#[case(b"let a = }")]
+#[case(b"mut a = }")]
+#[case(b"let a = | }")]
+#[case(b"mut a = | }")]
+fn test_semi_open_brace(
+        #[case] phrase: &[u8],
+    ) {
+    let engine_state = EngineState::new();
+    let mut working_set = StateWorkingSet::new(&engine_state);
+    // this should not panic
+    let _block = parse(&mut working_set, None, phrase, true);
+}
+
+
 mod range {
     use super::*;
     use nu_protocol::ast::{RangeInclusion, RangeOperator};


### PR DESCRIPTION
- fixes #10083 

# Description

nushell crashes in the following 2 condition:

- `let a = {}` , then delete `{`
- `let a = | {}`, then delete `{`

When delete `{` the pipeline becomes empty but current `nu-parser` assume they are non-empty. This pr adds extra empty check to avoid crash.

# User-Facing Changes

None

# Tests + Formatting

- `cargo fmt --all -- --check`: OK
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used`: OK
- `cargo test --workspace` : OK
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"`: OK

# After Submitting

None