### PR TITLE
Deny wildcard dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
+[build]
+# Don't allow locally; can't publish to crates.io 
+rustflags = ["-Dclippy::wildcard_dependencies"]
+
 [target.x86_64-pc-windows-msvc]
 # increase the default windows stack size
 # statically link the CRT so users don't have to install it

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,9 @@ nu-utils = { path = "./crates/nu-utils", version = "0.84.1" }
 nu-ansi-term = "0.49.0"
 reedline = { version = "0.23.0", features = ["bashisms", "sqlite"] }
 
+# swap these lines to try linting wildcard dependencies
 crossterm = "0.26"
+#crossterm = "*"
 ctrlc = "3.4"
 log = "0.4"
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -29,7 +29,9 @@ reedline = { version = "0.23.0", features = ["bashisms", "sqlite"] }
 
 chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.26"
+# swap these 2 lines to test linting wildcard dependencies
 fancy-regex = "0.11"
+#fancy-regex = "*"
 fuzzy-matcher = "0.3"
 is_executable = "1.0"
 is-terminal = "0.4.8"


### PR DESCRIPTION
General fix to prevent pure wildcard dependencies (e.g `dependencies.rstest = "*"`).  
These are acceptable to  cargo but cannot be published to https://crates.io.
See #10095 for a case where this broke a release.

# Description
There is a `clippy::wildcard_dependencies` lint, but it is "allowed" by default (it's part of the `clippy::cargo` group, which are all allowed by default).

This PR activates the lint by passing a "-Dclippy::wildcard_dependencies" to each invocation of `rustc`, configured in `./cargo/config.toml`.  This will be used in builds at the root of the project but also in the build of child crates, like `./crates/nu-cli`.   Thus, `> cargo clippy` will flag the offending dependencies and catch the error before the PR is even posted.

Here's an example of the lint detecting a problem:
```
> cargo clippy
    Checking nu-utils v0.84.1 (/home/bobhy/src/rust/nushell/crates/nu-utils)
    Checking nu-path v0.84.1 (/home/bobhy/src/rust/nushell/crates/nu-path)
    Checking nu-glob v0.84.1 (/home/bobhy/src/rust/nushell/crates/nu-glob)
    Checking nu-json v0.84.1 (/home/bobhy/src/rust/nushell/crates/nu-json)
    Checking nu-system v0.84.1 (/home/bobhy/src/rust/nushell/crates/nu-system)
   Compiling nu-cmd-lang v0.84.1 (/home/bobhy/src/rust/nushell/crates/nu-cmd-lang)
    Checking nu-pretty-hex v0.84.1 (/home/bobhy/src/rust/nushell/crates/nu-pretty-hex)
   Compiling nu v0.84.1 (/home/bobhy/src/rust/nushell)
error: wildcard dependency for `fancy-regex`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wildcard_dependencies
  = note: requested on the command line with `-D clippy::wildcard-dependencies`

error: could not compile `nu` (build script) due to previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `nu-cmd-lang` (build script) due to previous error
error: could not compile `nu-utils` (lib) due to previous error
error: could not compile `nu-path` (lib) due to previous error
```
# User-Facing Changes
none

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
