### PR TITLE
Screen reader-friendly errors

### DIFF
--- a/crates/nu-protocol/src/cli_error.rs
+++ b/crates/nu-protocol/src/cli_error.rs
@@ -53,7 +53,7 @@ impl std::fmt::Debug for CliError<'_> {
         let errors_style = *error_style;
 
         let miette_handler: Box<dyn ReportHandler> = match errors_style {
-            "narratable" => Box::new(NarratableReportHandler::new()),
+            "simple" => Box::new(NarratableReportHandler::new()),
             _ => Box::new(
                 MietteHandlerOpts::new()
                     // For better support of terminal themes use the ANSI coloring

--- a/crates/nu-protocol/src/cli_error.rs
+++ b/crates/nu-protocol/src/cli_error.rs
@@ -49,8 +49,8 @@ impl std::fmt::Debug for CliError<'_> {
         let ansi_support = &config.use_ansi_coloring;
         let ansi_support = *ansi_support;
 
-        let errors_style = &config.errors_style.as_str();
-        let errors_style = *errors_style;
+        let error_style = &config.error_style.as_str();
+        let errors_style = *error_style;
 
         let miette_handler: Box<dyn ReportHandler> = match errors_style {
             "narratable" => Box::new(NarratableReportHandler::new()),

--- a/crates/nu-protocol/src/cli_error.rs
+++ b/crates/nu-protocol/src/cli_error.rs
@@ -1,5 +1,8 @@
 use crate::engine::{EngineState, StateWorkingSet};
-use miette::{LabeledSpan, MietteHandlerOpts, ReportHandler, RgbColors, Severity, SourceCode};
+use miette::{
+    LabeledSpan, MietteHandlerOpts, NarratableReportHandler, ReportHandler, RgbColors, Severity,
+    SourceCode,
+};
 use thiserror::Error;
 
 /// This error exists so that we can defer SourceCode handling. It simply
@@ -41,16 +44,27 @@ pub fn report_error_new(
 
 impl std::fmt::Debug for CliError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let ansi_support = self.1.get_config().use_ansi_coloring;
+        let config = self.1.get_config();
 
-        let miette_handler = MietteHandlerOpts::new()
-            // For better support of terminal themes use the ANSI coloring
-            .rgb_colors(RgbColors::Never)
-            // If ansi support is disabled in the config disable the eye-candy
-            .color(ansi_support)
-            .unicode(ansi_support)
-            .terminal_links(ansi_support)
-            .build();
+        let ansi_support = &config.use_ansi_coloring;
+        let ansi_support = *ansi_support;
+
+        let errors_style = &config.errors_style.as_str();
+        let errors_style = *errors_style;
+
+        let miette_handler: Box<dyn ReportHandler> = match errors_style {
+            "narratable" => Box::new(NarratableReportHandler::new()),
+            _ => Box::new(
+                MietteHandlerOpts::new()
+                    // For better support of terminal themes use the ANSI coloring
+                    .rgb_colors(RgbColors::Never)
+                    // If ansi support is disabled in the config disable the eye-candy
+                    .color(ansi_support)
+                    .unicode(ansi_support)
+                    .terminal_links(ansi_support)
+                    .build(),
+            ),
+        };
 
         // Ignore error to prevent format! panics. This can happen if span points at some
         // inaccessible location, for example by calling `report_error()` with wrong working set.

--- a/crates/nu-protocol/src/cli_error.rs
+++ b/crates/nu-protocol/src/cli_error.rs
@@ -53,7 +53,7 @@ impl std::fmt::Debug for CliError<'_> {
         let errors_style = *error_style;
 
         let miette_handler: Box<dyn ReportHandler> = match errors_style {
-            "simple" => Box::new(NarratableReportHandler::new()),
+            "plain" => Box::new(NarratableReportHandler::new()),
             _ => Box::new(
                 MietteHandlerOpts::new()
                     // For better support of terminal themes use the ANSI coloring

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -113,7 +113,7 @@ pub struct Config {
     pub cursor_shape_emacs: NuCursorShape,
     pub datetime_normal_format: Option<String>,
     pub datetime_table_format: Option<String>,
-    pub errors_style: String,
+    pub error_style: String,
 }
 
 impl Default for Config {
@@ -177,7 +177,7 @@ impl Default for Config {
 
             keybindings: Vec::new(),
 
-            errors_style: "fancy".into(),
+            error_style: "fancy".into(),
         }
     }
 }
@@ -1325,48 +1325,12 @@ impl Value {
                             );
                         }
                     }
-                    "errors" => {
-                        if let Value::Record { val, span } = &mut vals[index] {
-                            let Record { cols, vals } = val;
-                            let span = *span;
-                            for index in (0..cols.len()).rev() {
-                                let value = &vals[index];
-                                let key2 = cols[index].as_str();
-                                match key2 {
-                                    "style" => match value.as_string() {
-                                        Ok(style) => {
-                                            config.errors_style = style;
-                                        }
-                                        _ => {
-                                            invalid!(Some(span), "Should be a string");
-                                            vals[index] = Value::record(
-                                                record! {
-                                                    "style" => Value::string(config.errors_style.clone(), span),
-                                                },
-                                                span,
-                                            );
-                                        }
-                                    },
-                                    x => {
-                                        invalid_key!(
-                                            cols,
-                                            vals,
-                                            index,
-                                            Some(value.span()),
-                                            "$env.config.{key}.{x} is an unknown config setting"
-                                        );
-                                    }
-                                }
-                            }
+                    "error_style" => {
+                        if let Ok(style) = value.as_string() {
+                            config.error_style = style;
                         } else {
-                            invalid!(Some(vals[index].span()), "should be a record");
-                            // Reconstruct
-                            vals[index] = Value::record(
-                                record! {
-                                    "style" => Value::string(config.errors_style.clone(), span),
-                                },
-                                span,
-                            );
+                            invalid!(Some(span), "should be a string");
+                            vals[index] = Value::string(config.error_style.clone(), span);
                         }
                     }
                     // Catch all

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -26,7 +26,7 @@ pub struct ParsedMenu {
     pub source: Value,
 }
 
-/// Definition of a parsed menu from the config object
+/// Definition of a parsed hook from the config object
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Hooks {
     pub pre_prompt: Option<Value>,

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -76,7 +76,7 @@ fn fancy_default_errors() {
 #[test]
 fn narratable_errors() {
     let actual = nu!(nu_repl_code(&[
-        r#"$env.config = { error_style: "simple" }"#,
+        r#"$env.config = { error_style: "plain" }"#,
         r#"def force_error [x] {
         let span = (metadata $x).span;
         error make {

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -76,7 +76,7 @@ fn fancy_default_errors() {
 #[test]
 fn narratable_errors() {
     let actual = nu!(nu_repl_code(&[
-        r#"$env.config = { error_style: "narratable" }"#,
+        r#"$env.config = { error_style: "simple" }"#,
         r#"def force_error [x] {
         let span = (metadata $x).span;
         error make {

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -49,3 +49,58 @@ fn filesize_format_auto_metric_false() {
     let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, r#"["1.9 MiB", "1.9 GiB", "1.8 TiB"]"#);
 }
+
+#[test]
+fn fancy_default_errors() {
+    let actual = nu!(nu_repl_code(&[
+        r#"def force_error [x] {
+        let span = (metadata $x).span;
+        error make {
+            msg: "oh no!"
+            label: {
+                text: "here's the error"
+                start: $span.start
+                end: $span.end
+            }
+        }
+    }"#,
+        r#"force_error "My error""#
+    ]));
+
+    assert_eq!(
+        actual.err,
+        "Error:   \u{1b}[31m×\u{1b}[0m oh no!\n   ╭─[\u{1b}[36;1;4mline1\u{1b}[0m:1:1]\n \u{1b}[2m1\u{1b}[0m │ force_error \"My error\"\n   · \u{1b}[35;1m            ─────┬────\u{1b}[0m\n   ·                  \u{1b}[35;1m╰── \u{1b}[35;1mhere's the error\u{1b}[0m\u{1b}[0m\n   ╰────\n\n\n"
+    );
+}
+
+#[test]
+fn narratable_errors() {
+    let actual = nu!(nu_repl_code(&[
+        r#"$env.config = { errors: { style: "narratable" } }"#,
+        r#"def force_error [x] {
+        let span = (metadata $x).span;
+        error make {
+            msg: "oh no!"
+            label: {
+                text: "here's the error"
+                start: $span.start
+                end: $span.end
+            }
+        }
+    }"#,
+        r#"force_error "my error""#,
+    ]));
+
+    assert_eq!(
+        actual.err,
+        r#"Error: oh no!
+    Diagnostic severity: error
+Begin snippet for line2 starting at line 1, column 1
+
+snippet line 1: force_error "my error"
+    label at line 1, columns 13 to 22: here's the error
+
+
+"#,
+    );
+}

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -76,7 +76,7 @@ fn fancy_default_errors() {
 #[test]
 fn narratable_errors() {
     let actual = nu!(nu_repl_code(&[
-        r#"$env.config = { errors: { style: "narratable" } }"#,
+        r#"$env.config = { error_style: "narratable" }"#,
         r#"def force_error [x] {
         let span = (metadata $x).span;
         error make {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -167,6 +167,10 @@ $env.config = {
         header_on_separator: false # show header text on separator/border line
     }
 
+    errors: {
+        style: "fancy" # "fancy" or "narratable" for screen reader-friendly error messages
+    }
+
     # datetime_format determines what a datetime rendered in the shell would look like.
     # Behavior without this configuration point will be to "humanize" the datetime display,
     # showing something like "a day ago."

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -167,7 +167,7 @@ $env.config = {
         header_on_separator: false # show header text on separator/border line
     }
 
-    error_style: "fancy" # "fancy" or "simple" for screen reader-friendly error messages
+    error_style: "fancy" # "fancy" or "plain" for screen reader-friendly error messages
 
     # datetime_format determines what a datetime rendered in the shell would look like.
     # Behavior without this configuration point will be to "humanize" the datetime display,

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -167,7 +167,7 @@ $env.config = {
         header_on_separator: false # show header text on separator/border line
     }
 
-    error_style: "fancy"
+    error_style: "fancy" # "fancy" or "narratable" for screen reader-friendly error messages
 
     # datetime_format determines what a datetime rendered in the shell would look like.
     # Behavior without this configuration point will be to "humanize" the datetime display,

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -167,7 +167,7 @@ $env.config = {
         header_on_separator: false # show header text on separator/border line
     }
 
-    error_style: "fancy" # "fancy" or "narratable" for screen reader-friendly error messages
+    error_style: "fancy" # "fancy" or "simple" for screen reader-friendly error messages
 
     # datetime_format determines what a datetime rendered in the shell would look like.
     # Behavior without this configuration point will be to "humanize" the datetime display,

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -167,9 +167,7 @@ $env.config = {
         header_on_separator: false # show header text on separator/border line
     }
 
-    errors: {
-        style: "fancy" # "fancy" or "narratable" for screen reader-friendly error messages
-    }
+    error_style: "fancy"
 
     # datetime_format determines what a datetime rendered in the shell would look like.
     # Behavior without this configuration point will be to "humanize" the datetime display,


### PR DESCRIPTION
- Hopefully closes #10120  

# Description

This PR adds a new config item, `error_style`. It will render errors in a screen reader friendly mode when set to `"simple"`. This is done using `miette`'s own `NarratableReportHandler`, which seamlessly replaces the default one when needed.

Before:
```
Error: nu::shell::external_command

  × External command failed
   ╭─[entry #2:1:1]
 1 │ doesnt exist
   · ───┬──
   ·    ╰── executable was not found
   ╰────
  help: No such file or directory (os error 2)
```

After:
```
Error: External command failed
    Diagnostic severity: error
Begin snippet for entry #4 starting at line 1, column 1

snippet line 1: doesnt exist
    label at line 1, columns 1 to 6: executable was not found
diagnostic help: No such file or directory (os error 2)
diagnostic code: nu::shell::external_command

```

## Things to be determined

- ~Review naming. `errors.style` is not _that_ consistent with the rest of the code. Menus use a `style` record, but table rendering mode is set via `mode`.~ As it's a single config, we're using `error_style` for now.
- Should this kind of setting be toggable with one single parameter? `accessibility.no_decorations` or similar, which would adjust the style of both errors and tables accordingly.

# User-Facing Changes

No changes by default, errors will be rendered differently if `error_style` is set to `simple`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting

There's a PR updating the docs over here https://github.com/nushell/nushell.github.io/pull/1026
