### PR TITLE
relax the plugin name requirements

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3576,20 +3576,8 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
     let current_envs =
         nu_engine::env::env_to_strings(working_set.permanent_state, &stack).unwrap_or_default();
 
-    let error = arguments.and_then(|(path, path_span)| {
+    let error = arguments.and_then(|(path, _)| {
         let path = path.path_buf();
-        // restrict plugin file name starts with `nu_plugin_`
-        let valid_plugin_name = path
-            .file_name()
-            .map(|s| s.to_string_lossy().starts_with("nu_plugin_"));
-
-        let Some(true) = valid_plugin_name else {
-            return Err(ParseError::LabeledError(
-                "Register plugin failed".into(),
-                "plugin name must start with nu_plugin_".into(),
-                path_span,
-            ));
-        };
 
         let signatures = signature.map_or_else(
             || {


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell/pull/9726

# Description
in this PR, i propose to relax the requirement to have plugin binaries starting with `nu_plugin_`

a bit like file extensions, i think plugin could start with `nu_plugin_` as a convention, which they do follow :ok_hand: 
but having that as a hardcoded requirement sounds a bit too strict :relieved: 

for instance, one could call their plugin `nu-plugin-foo` or `nu-foo`.

# User-Facing Changes
it's now possible to register a plugin that does not start with `nu_plugin_`

# Tests + Formatting
# After Submitting