### PR TITLE
Update removed "MDI" icons to current MD icons

### DIFF
--- a/crates/nu-command/src/viewers/icons.rs
+++ b/crates/nu-command/src/viewers/icons.rs
@@ -205,13 +205,13 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "conf" => '\u{e615}',           // 
             "cp" => '\u{e61d}',             // 
             "cpp" => '\u{e61d}',            // 
-            "cs" => '\u{f031b}',             // 󰌛
+            "cs" => '\u{f031b}',            // 󰌛
             "csh" => '\u{f489}',            // 
             "cshtml" => '\u{f1fa}',         // 
-            "csproj" => '\u{f031b}',         // 󰌛
+            "csproj" => '\u{f031b}',        // 󰌛
             "css" => '\u{e749}',            // 
             "csv" => '\u{f1c3}',            // 
-            "csx" => '\u{f031b}',            // 󰌛
+            "csx" => '\u{f031b}',           // 󰌛
             "cxx" => '\u{e61d}',            // 
             "d" => '\u{e7af}',              // 
             "dart" => '\u{e798}',           // 
@@ -283,7 +283,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "latex" => '\u{e600}',          // 
             "less" => '\u{e758}',           // 
             "lhs" => '\u{e777}',            // 
-            "license" => '\u{f0fc3}',        // 󰿃
+            "license" => '\u{f0fc3}',       // 󰿃
             "localized" => '\u{f179}',      // 
             "lock" => '\u{f023}',           // 
             "log" => '\u{f18d}',            // 
@@ -307,7 +307,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "msi" => '\u{e70f}',            // 
             "mustache" => '\u{e60f}',       // 
             "nix" => '\u{f313}',            // 
-            "node" => '\u{f0399}',           // 󰎙
+            "node" => '\u{f0399}',          // 󰎙
             "npmignore" => '\u{e71e}',      // 
             "odp" => '\u{f1c4}',            // 
             "ods" => '\u{f1c3}',            // 
@@ -347,7 +347,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "rspec_parallel" => '\u{e21e}', // 
             "rspec_status" => '\u{e21e}',   // 
             "rss" => '\u{f09e}',            // 
-            "rtf" => '\u{f0219}',            // 󰈙
+            "rtf" => '\u{f0219}',           // 󰈙
             "ru" => '\u{e21e}',             // 
             "rubydoc" => '\u{e73b}',        // 
             "sass" => '\u{e603}',           // 
@@ -381,7 +381,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "tzo" => '\u{f410}',            // 
             "video" => '\u{f03d}',          // 
             "vim" => '\u{e62b}',            // 
-            "vue" => '\u{f0844}',            // 󰡄
+            "vue" => '\u{f0844}',           // 󰡄
             "war" => '\u{e256}',            // 
             "wav" => '\u{f001}',            // 
             "webm" => '\u{f03d}',           // 
@@ -392,8 +392,8 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "xhtml" => '\u{f13b}',          // 
             "xls" => '\u{f1c3}',            // 
             "xlsx" => '\u{f1c3}',           // 
-            "xml" => '\u{f05c0}',            // 󰗀
-            "xul" => '\u{f05c0}',            // 󰗀
+            "xml" => '\u{f05c0}',           // 󰗀
+            "xul" => '\u{f05c0}',           // 󰗀
             "xz" => '\u{f410}',             // 
             "yaml" => '\u{f481}',           // 
             "yml" => '\u{f481}',            // 

--- a/crates/nu-command/src/viewers/icons.rs
+++ b/crates/nu-command/src/viewers/icons.rs
@@ -205,13 +205,13 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "conf" => '\u{e615}',           // 
             "cp" => '\u{e61d}',             // 
             "cpp" => '\u{e61d}',            // 
-            "cs" => '\u{f81a}',             // 
+            "cs" => '\u{f031b}',             // 󰌛
             "csh" => '\u{f489}',            // 
             "cshtml" => '\u{f1fa}',         // 
-            "csproj" => '\u{f81a}',         // 
+            "csproj" => '\u{f031b}',         // 󰌛
             "css" => '\u{e749}',            // 
             "csv" => '\u{f1c3}',            // 
-            "csx" => '\u{f81a}',            // 
+            "csx" => '\u{f031b}',            // 󰌛
             "cxx" => '\u{e61d}',            // 
             "d" => '\u{e7af}',              // 
             "dart" => '\u{e798}',           // 
@@ -283,7 +283,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "latex" => '\u{e600}',          // 
             "less" => '\u{e758}',           // 
             "lhs" => '\u{e777}',            // 
-            "license" => '\u{f718}',        // 
+            "license" => '\u{f0fc3}',        // 󰿃
             "localized" => '\u{f179}',      // 
             "lock" => '\u{f023}',           // 
             "log" => '\u{f18d}',            // 
@@ -307,7 +307,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "msi" => '\u{e70f}',            // 
             "mustache" => '\u{e60f}',       // 
             "nix" => '\u{f313}',            // 
-            "node" => '\u{f898}',           // 
+            "node" => '\u{f0399}',           // 󰎙
             "npmignore" => '\u{e71e}',      // 
             "odp" => '\u{f1c4}',            // 
             "ods" => '\u{f1c3}',            // 
@@ -347,7 +347,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "rspec_parallel" => '\u{e21e}', // 
             "rspec_status" => '\u{e21e}',   // 
             "rss" => '\u{f09e}',            // 
-            "rtf" => '\u{f718}',            // 
+            "rtf" => '\u{f0219}',            // 󰈙
             "ru" => '\u{e21e}',             // 
             "rubydoc" => '\u{e73b}',        // 
             "sass" => '\u{e603}',           // 
@@ -381,7 +381,7 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "tzo" => '\u{f410}',            // 
             "video" => '\u{f03d}',          // 
             "vim" => '\u{e62b}',            // 
-            "vue" => '\u{fd42}',            // ﵂
+            "vue" => '\u{f0844}',            // 󰡄
             "war" => '\u{e256}',            // 
             "wav" => '\u{f001}',            // 
             "webm" => '\u{f03d}',           // 
@@ -392,8 +392,8 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
             "xhtml" => '\u{f13b}',          // 
             "xls" => '\u{f1c3}',            // 
             "xlsx" => '\u{f1c3}',           // 
-            "xml" => '\u{fabf}',            // 謹
-            "xul" => '\u{fabf}',            // 謹
+            "xml" => '\u{f05c0}',            // 󰗀
+            "xul" => '\u{f05c0}',            // 󰗀
             "xz" => '\u{f410}',             // 
             "yaml" => '\u{f481}',           // 
             "yml" => '\u{f481}',            // 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR updates now-removed (since NF 3.0.0) file icons shown in e.g. `grid` to their updated codepoints.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
File icons changed were for:
`cs`, `csproj`, `csx`, `license`, `node`, `rtf`, `vue`, `xml`, and `xul`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
