### PR TITLE
name hooks internally

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -390,7 +390,7 @@ pub fn evaluate_repl(
         // Right before we start our prompt and take input from the user,
         // fire the "pre_prompt" hook
         if let Some(hook) = config.hooks.pre_prompt.clone() {
-            if let Err(err) = eval_hook(engine_state, stack, None, vec![], &hook) {
+            if let Err(err) = eval_hook(engine_state, stack, None, vec![], &hook, "pre_prompt") {
                 report_error_new(engine_state, &err);
             }
         }
@@ -465,7 +465,9 @@ pub fn evaluate_repl(
                     repl.buffer = s.to_string();
                     drop(repl);
 
-                    if let Err(err) = eval_hook(engine_state, stack, None, vec![], &hook) {
+                    if let Err(err) =
+                        eval_hook(engine_state, stack, None, vec![], &hook, "pre_execution")
+                    {
                         report_error_new(engine_state, &err);
                     }
                 }

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -257,7 +257,14 @@ pub fn eval_source(
             {
                 result = print_if_stream(stream, stderr_stream, false, exit_code);
             } else if let Some(hook) = config.hooks.display_output.clone() {
-                match eval_hook(engine_state, stack, Some(pipeline_data), vec![], &hook) {
+                match eval_hook(
+                    engine_state,
+                    stack,
+                    Some(pipeline_data),
+                    vec![],
+                    &hook,
+                    "display_output",
+                ) {
                     Err(err) => {
                         result = Err(err);
                     }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -371,6 +371,7 @@ impl ExternalCommand {
                                             ),
                                         )],
                                         &hook,
+                                        "command_not_found",
                                     )
                                 {
                                     err_str = format!("{}\n{}", err_str, val);

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -213,7 +213,14 @@ pub fn nu_repl() {
         // Check for pre_prompt hook
         let config = engine_state.get_config();
         if let Some(hook) = config.hooks.pre_prompt.clone() {
-            if let Err(err) = eval_hook(&mut engine_state, &mut stack, None, vec![], &hook) {
+            if let Err(err) = eval_hook(
+                &mut engine_state,
+                &mut stack,
+                None,
+                vec![],
+                &hook,
+                "pre_prompt",
+            ) {
                 outcome_err(&engine_state, &err);
             }
         }
@@ -238,7 +245,14 @@ pub fn nu_repl() {
             .buffer = line.to_string();
 
         if let Some(hook) = config.hooks.pre_execution.clone() {
-            if let Err(err) = eval_hook(&mut engine_state, &mut stack, None, vec![], &hook) {
+            if let Err(err) = eval_hook(
+                &mut engine_state,
+                &mut stack,
+                None,
+                vec![],
+                &hook,
+                "pre_execution",
+            ) {
                 outcome_err(&engine_state, &err);
             }
         }


### PR DESCRIPTION
# Description

This PR names the hooks as they're executing so that you can see them with debug statements. So, at the beginning of `eval_hook()` you could put a dbg! or eprintln! to see what hook was executing. It also shows up in View files.

### Before - notice item 14 and 25
![image](https://github.com/nushell/nushell/assets/343840/22c19bbe-6bac-4132-9579-863922d91f22)

### After - The hooks are now named (14 & 25)
![image](https://github.com/nushell/nushell/assets/343840/a08abd11-4f03-4f09-bbac-e4b5180df078)


Curiosity, on my mac, the display_output hook fires 3 times before anything else. Also, curious is that the value if the display_output, is not what I have in my config but what is in the default_config. So, there may be a bug or some shenanigans going on somewhere with hooks.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
