### PR TITLE
Various Android fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 name: continuous-integration
 
 env:
-  NUSHELL_CARGO_TARGET: ci
+  NUSHELL_CARGO_PROFILE: ci
   NU_LOG_LEVEL: DEBUG
   CLIPPY_OPTIONS: "-D warnings -D clippy::unwrap_used"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
 dependencies = [
- "nix",
+ "nix 0.26.2",
  "windows-sys 0.48.0",
 ]
 
@@ -2486,6 +2486,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "896d4664b919f48478f3ce02c502adfe9bffeb61563d2a12ddf1aad8f6cd926f"
+dependencies = [
+ "bitflags 2.3.3",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,7 +2578,7 @@ dependencies = [
  "log",
  "miette",
  "mimalloc",
- "nix",
+ "nix 0.27.0",
  "nu-ansi-term",
  "nu-cli",
  "nu-cmd-base",
@@ -2761,7 +2772,7 @@ dependencies = [
  "mime_guess",
  "mockito",
  "native-tls",
- "nix",
+ "nix 0.27.0",
  "notify-debouncer-full",
  "nu-ansi-term",
  "nu-cmd-base",
@@ -2957,7 +2968,7 @@ dependencies = [
  "libproc",
  "log",
  "mach2",
- "nix",
+ "nix 0.27.0",
  "ntapi",
  "once_cell",
  "procfs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ signal-hook = { version = "0.3", default-features = false }
 winresource = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.26", default-features = false, features = [
+nix = { version = "0.27", default-features = false, features = [
 	"signal",
 	"process",
 	"fs",

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+fn main() {
+    // convenience alias for trash support
+    if cfg!(all(
+        feature = "trash-support",
+        not(any(target_os = "android", target_os = "ios"))
+    )) {
+        println!("cargo:rustc-cfg=trash");
+    }
+
+    if cfg!(all(
+        feature = "trash-support",
+        any(target_os = "android", target_os = "ios")
+    )) {
+        println!("cargo:warning=\"trash-support\" feature enabled on unsupported platform ");
+    }
+}

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -101,7 +101,7 @@ winreg = "0.50"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 umask = "2.1"
-nix = { version = "0.26", default-features = false, features = ["user"] }
+nix = { version = "0.27", default-features = false, features = ["user"] }
 
 [target.'cfg(trash)'.dependencies.trash]
 optional = true

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -103,7 +103,7 @@ libc = "0.2"
 umask = "2.1"
 nix = { version = "0.26", default-features = false, features = ["user"] }
 
-[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
+[target.'cfg(trash)'.dependencies.trash]
 optional = true
 version = "3.0"
 

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -27,7 +27,13 @@ def path_add [] {
         assert equal (get_path) ["fooooo", "foo", "bar", "baz"]
 
         load-env {$path_name: []}
-        let target_paths = {linux: "foo", windows: "bar", macos: "baz"}
+
+        let target_paths = {
+            linux: "foo",
+            windows: "bar",
+            macos: "baz",
+            android: "quux",
+        }
 
         std path add $target_paths
         assert equal (get_path) [($target_paths | get $nu.os-info.name)]

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2"
 log = "0.4"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.26", default-features = false, features = ["fs", "term", "process", "signal"] }
+nix = { version = "0.27", default-features = false, features = ["fs", "term", "process", "signal"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs = "0.15"

--- a/crates/nu-test-support/src/commands.rs
+++ b/crates/nu-test-support/src/commands.rs
@@ -23,7 +23,7 @@ pub fn ensure_plugins_built() {
     let cargo_path = env!("CARGO");
     let mut arguments = vec!["build", "--package", "nu_plugin_*", "--quiet"];
 
-    let profile = std::env::var("NUSHELL_CARGO_TARGET");
+    let profile = std::env::var("NUSHELL_CARGO_PROFILE");
     if let Ok(profile) = &profile {
         arguments.push("--profile");
         arguments.push(profile);

--- a/crates/nu-test-support/src/fs.rs
+++ b/crates/nu-test-support/src/fs.rs
@@ -233,18 +233,21 @@ pub fn root() -> PathBuf {
 }
 
 pub fn binaries() -> PathBuf {
-    let mut build_type = "debug".to_string();
-    if !cfg!(debug_assertions) {
-        build_type = "release".to_string()
-    }
-    if let Ok(target) = std::env::var("NUSHELL_CARGO_TARGET") {
-        build_type = target;
-    }
+    let build_target = std::env::var("CARGO_BUILD_TARGET").unwrap_or(String::new());
+
+    let profile = if let Ok(env_profile) = std::env::var("NUSHELL_CARGO_PROFILE") {
+        env_profile
+    } else if cfg!(debug_assertions) {
+        "debug".into()
+    } else {
+        "release".into()
+    };
 
     std::env::var("CARGO_TARGET_DIR")
-        .ok()
-        .map(|target_dir| PathBuf::from(target_dir).join(&build_type))
-        .unwrap_or_else(|| root().join(format!("target/{}", &build_type)))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| root().join("target"))
+        .join(build_target)
+        .join(profile)
 }
 
 pub fn fixtures() -> PathBuf {

--- a/scripts/coverage-local.nu
+++ b/scripts/coverage-local.nu
@@ -45,7 +45,7 @@ let start = (date now)
 # Some of the internal tests rely on the exact cargo profile
 # (This is somewhat criminal itself)
 # but we have to signal to the tests that we use the `ci` `--profile`
-$env.NUSHELL_CARGO_TARGET = "ci"
+$env.NUSHELL_CARGO_PROFILE = "ci"
 
 # Manual gathering of coverage to catch invocation of the `nu` binary.
 # This is relevant for tests using the `nu!` macro from `nu-test-support`

--- a/scripts/coverage-local.sh
+++ b/scripts/coverage-local.sh
@@ -17,7 +17,7 @@ REPO_ROOT=$(dirname $DIR)
 # Some of the internal tests rely on the exact cargo profile
 # (This is somewhat criminal itself)
 # but we have to signal to the tests that we use the `ci` `--profile`
-export NUSHELL_CARGO_TARGET=ci
+export NUSHELL_CARGO_PROFILE=ci
 
 # Manual gathering of coverage to catch invocation of the `nu` binary.
 # This is relevant for tests using the `nu!` macro from `nu-test-support`

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -436,7 +436,7 @@ def compute-coverage [] {
 # - https://github.com/andythigpen/nvim-coverage (probably needs some additional config)
 export def cov [] {
     let start = (date now)
-    $env.NUSHELL_CARGO_TARGET = "ci"
+    $env.NUSHELL_CARGO_PROFILE = "ci"
 
     compute-coverage
 


### PR DESCRIPTION
# Description

#10013 got Android compiling successfully, but there are a few remaining issues that this PR fixes.

* Trash
  * Fix unused variable warnings on Android
  * Add a convenience configuration option called `trash` to signal when the `trash-support` feature is enabled and the build machine is one of the platforms which has trash
* Some unit tests fail
  * The path to the binaries for tests is slightly incorrect. It is missing the build target when it is set with the `CARGO_BUILD_TARGET` environment variable. It is common on Termux to set `CARGO_BUILD_TARGET` explicitly since the default target that rustc detects can cause problems on some projects, such as python's `cryptography` package.
  * Additionally, the existing variable named `NUSHELL_CARGO_TARGET` is in fact the profile, not the build target, so this was corrected.
  * `std path add` tests were missing `android` test
* upgrade nix to 0.27
  * This fixes a segfault on Android when fetching the user group. See: https://github.com/nix-rust/nix/issues/2084

# User-Facing Changes

None

# Tests + Formatting

All tests now pass on Android on Termux
