### PR TITLE
update rust-toolchain doc to 4 weeks from 3

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -14,6 +14,6 @@ profile = "default"
 # so that we give repo maintainers and package managers a chance to update to a more
 # recent version of rust. However, if there is a "cool new feature" that we want to
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
-# I believe rust is on a 6 week release cycle and nushell is on a 3 week release cycle.
+# I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
 channel = "1.70.0"


### PR DESCRIPTION
When we updated our release schedule from 3 weeks to 4 weeks the doc on the toolchain
file was never updated so I went ahead and did that...

