### PR TITLE
remove warnings in nu_command tests

### DIFF
--- a/crates/nu-command/tests/commands/path/mod.rs
+++ b/crates/nu-command/tests/commands/path/mod.rs
@@ -7,7 +7,7 @@ mod parse;
 mod split;
 mod type_;
 
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 use std::path::MAIN_SEPARATOR;
 
 /// Helper function that joins string literals with '/' or '\', based on host OS

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -1,5 +1,4 @@
 use nu_test_support::nu;
-use nu_test_support::pipeline;
 
 #[test]
 fn filters_by_unit_size_comparison() {

--- a/crates/nu-command/tests/commands/where_.rs
+++ b/crates/nu-command/tests/commands/where_.rs
@@ -1,4 +1,6 @@
 use nu_test_support::nu;
+#[allow(unused_imports)]
+use nu_test_support::pipeline;
 
 #[test]
 fn filters_by_unit_size_comparison() {


### PR DESCRIPTION

several warnings were appearing in nu_command tests when running just the tests
in nu_command so I went ahead and removed the warnings...

