### PR TITLE
fixed usages of deprecated chrono DateTime::from_utc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,16 +565,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "pure-rust-locales",
  "serde",
- "winapi",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -3998,9 +3998,9 @@ dependencies = [
 
 [[package]]
 name = "pure-rust-locales"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45c49fc4f91f35bae654f85ebb3a44d60ac64f11b3166ffa609def390c732d8"
+checksum = "4b856d7d028ebb0011d78eded5bc9185932412f36c12c67930f222d6b407526b"
 
 [[package]]
 name = "pwd"

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
@@ -912,7 +912,8 @@ fn series_to_values(
                             }
                         }
                     };
-                    let datetime = DateTime::<FixedOffset>::from_utc(naive_datetime, offset);
+                    let datetime =
+                        DateTime::<FixedOffset>::from_naive_utc_and_offset(naive_datetime, offset);
 
                     Value::Date {
                         val: datetime,
@@ -982,7 +983,8 @@ fn series_to_values(
                             }
                         }
                     };
-                    let datetime = DateTime::<FixedOffset>::from_utc(naive_datetime, offset);
+                    let datetime =
+                        DateTime::<FixedOffset>::from_naive_utc_and_offset(naive_datetime, offset);
 
                     Value::Date {
                         val: datetime,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3993,7 +3993,7 @@ mod tests {
         #[test]
         fn test_datetime() {
             let string = Value::Date {
-                val: DateTime::from_utc(
+                val: DateTime::from_naive_utc_and_offset(
                     NaiveDateTime::from_timestamp_millis(-123456789).unwrap(),
                     FixedOffset::east_opt(0).unwrap(),
                 ),
@@ -4010,7 +4010,7 @@ mod tests {
         #[test]
         fn test_negative_year_datetime() {
             let string = Value::Date {
-                val: DateTime::from_utc(
+                val: DateTime::from_naive_utc_and_offset(
                     NaiveDateTime::from_timestamp_millis(-72135596800000).unwrap(),
                     FixedOffset::east_opt(0).unwrap(),
                 ),


### PR DESCRIPTION
This addresses the warnings generated from using DateTime::from_utc. DateTime::from_utc was deprecated as of chrono 0.4.27