### PR TITLE
`reject` multiple row args support

### DIFF
--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -73,6 +73,17 @@ impl Command for Reject {
                 }),
             },
             Example {
+                description: "Reject a row in a table",
+                example: "[[a, b]; [1, 2] [3, 4]] | reject 1",
+                result: Some(Value::List {
+                    vals: vec![Value::test_record(Record {
+                        cols: vec!["a".to_string(), "b".to_string()],
+                        vals: vec![Value::test_int(1), Value::test_int(2)],
+                    })],
+                    span: Span::test_data(),
+                }),
+            },
+            Example {
                 description: "Reject the specified field in a record",
                 example: "{a: 1, b: 2} | reject a",
                 result: Some(Value::test_record(Record {

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -129,7 +129,7 @@ fn reject(
                         Vec::new(),
                     ));
                 }
-                if unique_rows.contains_key(&val) {
+                if unique_rows.contains_key(val) {
                     return Err(ShellError::GenericError(
                         "Reject can't get the same row twice".into(),
                         "duplicated row index".into(),

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -130,19 +130,16 @@ fn reject(
                         Vec::new(),
                     ));
                 }
-                if unique_rows.contains(val) {
-                    return Err(ShellError::GenericError(
-                        "Reject can't get the same row twice".into(),
-                        "duplicated row index".into(),
-                        Some(*span),
-                        None,
-                        Vec::new(),
-                    ));
+                if !unique_rows.contains(val) {
+                    unique_rows.insert(*val);
+                    new_rows.push(column);
                 }
-                unique_rows.insert(*val);
-                new_rows.push(column);
             }
-            _ => new_columns.push(column),
+            _ => {
+                if !new_columns.contains(&column) {
+                    new_columns.push(column)
+                }
+            }
         };
     }
     new_rows.sort_unstable_by_key(|k| {

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -154,10 +154,8 @@ fn reject_multiple_rows_ascending() {
 
 #[test]
 fn reject_multiple_rows_descending() {
-    let actual = nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 2 1");
-
-    assert!(actual.out.contains("a"));
-    assert!(actual.out.contains("b"));
-    assert!(actual.out.contains("1"));
-    assert!(actual.out.contains("2"));
+    assert_eq!(
+        nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 2 1 | to nuon"),
+        "[[a, b]; [1, 2]]"
+    )
 }

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -80,6 +80,12 @@ fn ignores_duplicate_columns_rejected() {
 }
 
 #[test]
+fn ignores_duplicate_rows_rejected() {
+    let actual = nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 2 2 | to nuon");
+    assert_eq!(actual.out, "[[a, b]; [1, 2], [3, 4]]");
+}
+
+#[test]
 fn reject_record_from_raw_eval() {
     let actual = nu!(r#"{"a": 3} | reject a | describe"#);
 

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -146,16 +146,12 @@ fn reject_optional_row() {
 
 #[test]
 fn reject_multiple_rows_ascending() {
-    assert_eq!(
-        nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 1 2 | to nuon"),
-        "[[a, b]; [1, 2]]"
-    )
+    let actual = nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 1 2 | to nuon");
+    assert_eq!(actual.out, "[[a, b]; [1, 2]]");
 }
 
 #[test]
 fn reject_multiple_rows_descending() {
-    assert_eq!(
-        nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 2 1 | to nuon"),
-        "[[a, b]; [1, 2]]"
-    )
+    let actual = nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 2 1 | to nuon");
+    assert_eq!(actual.out, "[[a, b]; [1, 2]]");
 }

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -143,3 +143,23 @@ fn reject_optional_row() {
     let actual = nu!("[{foo: 'bar'}] | reject 3? | to nuon");
     assert_eq!(actual.out, "[[foo]; [bar]]");
 }
+
+#[test]
+fn reject_multiple_rows_ascending() {
+    let actual = nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 1 2");
+
+    assert!(actual.out.contains("a"));
+    assert!(actual.out.contains("b"));
+    assert!(actual.out.contains("1"));
+    assert!(actual.out.contains("2"));
+}
+
+#[test]
+fn reject_multiple_rows_descending() {
+    let actual = nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 2 1");
+
+    assert!(actual.out.contains("a"));
+    assert!(actual.out.contains("b"));
+    assert!(actual.out.contains("1"));
+    assert!(actual.out.contains("2"));
+}

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -146,12 +146,10 @@ fn reject_optional_row() {
 
 #[test]
 fn reject_multiple_rows_ascending() {
-    let actual = nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 1 2");
-
-    assert!(actual.out.contains("a"));
-    assert!(actual.out.contains("b"));
-    assert!(actual.out.contains("1"));
-    assert!(actual.out.contains("2"));
+    assert_eq!(
+        nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 1 2 | to nuon"),
+        "[[a, b]; [1, 2]]"
+    )
 }
 
 #[test]


### PR DESCRIPTION

# Description
This PR fixes `reject` failing when providing row items in ascending order.


# User-Facing Changes
users can now `reject` multiple rows independently of each other.
```nushell
let foo = [[a b]; [ 1 2] [3 4] [ 5 6]]
# this will work independant of the order
print ($foo | reject 2 1)
print ($foo | reject 1 2)
```