### PR TITLE
Tests: clean up unnecessary use of pipeline()

### DIFF
--- a/crates/nu-command/tests/commands/glob.rs
+++ b/crates/nu-command/tests/commands/glob.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::EmptyFile;
+use nu_test_support::nu;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu};
 
 #[test]
 fn empty_glob_pattern_triggers_error() {

--- a/crates/nu-command/tests/commands/glob.rs
+++ b/crates/nu-command/tests/commands/glob.rs
@@ -1,6 +1,6 @@
 use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::playground::Playground;
-use nu_test_support::{nu, pipeline};
+use nu_test_support::{nu};
 
 #[test]
 fn empty_glob_pattern_triggers_error() {
@@ -31,7 +31,7 @@ fn nonempty_glob_lists_matching_paths() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            pipeline("glob '*' | length"),
+            "glob '*' | length",
         );
 
         assert_eq!(actual.out, "3");
@@ -55,7 +55,7 @@ fn glob_subdirs() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            pipeline("glob '**/*' | length"),
+            "glob '**/*' | length",
         );
 
         assert_eq!(
@@ -82,7 +82,7 @@ fn glob_subdirs_ignore_dirs() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            pipeline("glob '**/*' -D | length"),
+            "glob '**/*' -D | length",
         );
 
         assert_eq!(
@@ -109,7 +109,7 @@ fn glob_ignore_files() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            pipeline("glob '*' -F | length"),
+            ("glob '*' -F | length",
         );
 
         assert_eq!(

--- a/crates/nu-command/tests/commands/glob.rs
+++ b/crates/nu-command/tests/commands/glob.rs
@@ -109,7 +109,7 @@ fn glob_ignore_files() {
 
         let actual = nu!(
             cwd: dirs.test(),
-            ("glob '*' -F | length",
+            "glob '*' -F | length",
         );
 
         assert_eq!(

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -313,21 +313,21 @@ fn help_usage_extra_usage_alias() {
             "#,
         )]);
 
-        let actual = nu!(cwd: dirs.test(), pipeline("use spam.nu *; help modules spam"));
+        let actual = nu!(cwd: dirs.test(), "use spam.nu *; help modules spam");
         assert!(actual.out.contains("module_line1"));
         assert!(actual.out.contains("module_line2"));
 
         let actual = nu!(cwd: dirs.test(),
-            pipeline("use spam.nu *; help modules | where name == spam | get 0.usage"));
+            "use spam.nu *; help modules | where name == spam | get 0.usage");
         assert!(actual.out.contains("module_line1"));
         assert!(!actual.out.contains("module_line2"));
 
-        let actual = nu!(cwd: dirs.test(), pipeline("use spam.nu *; help aliases bar"));
+        let actual = nu!(cwd: dirs.test(), "use spam.nu *; help aliases bar");
         assert!(actual.out.contains("alias_line1"));
         assert!(actual.out.contains("alias_line2"));
 
         let actual = nu!(cwd: dirs.test(),
-            pipeline("use spam.nu *; help aliases | where name == bar | get 0.usage"));
+            "use spam.nu *; help aliases | where name == bar | get 0.usage");
         assert!(actual.out.contains("alias_line1"));
         assert!(!actual.out.contains("alias_line2"));
     })
@@ -356,7 +356,7 @@ fn help_modules_main_2() {
         "help modules | where name == spam | get 0.commands.0.name",
     ];
 
-    let actual = nu!(pipeline(&inp.join("; ")));
+    let actual = nu!(&inp.join("; "));
 
     assert_eq!(actual.out, "spam");
 }

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -1,7 +1,7 @@
 use nu_test_support::fs::AbsolutePath;
 use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::nu;
-use nu_test_support::pipeline;
+use nu_test_support::;
 use nu_test_support::playground::Playground;
 
 #[should_panic]
@@ -169,7 +169,7 @@ fn source_env_eval_export_env() {
 
         let inp = &[r#"source-env spam.nu"#, r#"$env.FOO"#];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })
@@ -191,7 +191,7 @@ fn source_env_eval_export_env_hide() {
             r#"$env.FOO"#,
         ];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert!(actual.err.contains("not_found"));
     })
@@ -214,7 +214,7 @@ fn source_env_do_cd() {
             r#"$env.PWD | path basename"#,
         ];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "test2");
     })
@@ -237,7 +237,7 @@ fn source_env_do_cd_file_relative() {
             r#"$env.PWD | path basename"#,
         ];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "test1");
     })
@@ -262,7 +262,7 @@ fn source_env_dont_cd_overlay() {
             r#"$env.PWD | path basename"#,
         ];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "source_env_dont_cd_overlay");
     })
@@ -281,13 +281,13 @@ fn source_env_is_scoped() {
 
         let inp = &[r#"source-env spam.nu"#, r#"no-name-similar-to-this"#];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert!(actual.err.contains("executable was not found"));
 
         let inp = &[r#"source-env spam.nu"#, r#"nor-similar-to-this"#];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert!(actual.err.contains("executable was not found"));
     })
@@ -309,7 +309,7 @@ fn source_env_const_file() {
             r#"$env.FOO"#,
         ];
 
-        let actual = nu!(cwd: dirs.test(), pipeline(&inp.join("; ")));
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
         assert_eq!(actual.out, "foo");
     })

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -1,7 +1,7 @@
 use nu_test_support::fs::AbsolutePath;
 use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::nu;
-use nu_test_support::;
+use nu_test_support::pipeline;
 use nu_test_support::playground::Playground;
 
 #[should_panic]


### PR DESCRIPTION
As described in Issue #8670, removed `pipeline()` wherever its argument contained no line breaks.