### PR TITLE
Keep `arrow2` out of basic `--workspace` build

### DIFF
--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = { version = "2.0" }
 num = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "0.36.1", optional = true }
-polars-io = { version = "0.32", features = ["avro"] }
+polars-io = { version = "0.32", features = ["avro"], optional = true }
 
 [dependencies.polars]
 features = [
@@ -57,7 +57,7 @@ optional = true
 version = "0.32"
 
 [features]
-dataframe = ["num", "polars", "sqlparser"]
+dataframe = ["num", "polars", "polars-io", "sqlparser"]
 default = []
 
 [dev-dependencies]


### PR DESCRIPTION
Same logic as in #9971

Prevents building the heavy polars and arrow dependencies when just
running `cargo test --workspace` or `rust-analyzer`

`polars-io` dependency was introduced in #10019
