### PR TITLE
Remove dead tests depending on `inc`

### DIFF
--- a/crates/nu-command/tests/commands/update.rs
+++ b/crates/nu-command/tests/commands/update.rs
@@ -21,21 +21,6 @@ fn doesnt_convert_record_to_table() {
     assert_eq!(actual.out, "{a: 2}");
 }
 
-#[cfg(features = "inc")]
-#[test]
-fn sets_the_column_from_a_block_run_output() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        "
-            open cargo_sample.toml
-            | update dev-dependencies.pretty_assertions { open cargo_sample.toml | get dev-dependencies.pretty_assertions | inc --minor }
-            | get dev-dependencies.pretty_assertions
-        "
-    ));
-
-    assert_eq!(actual.out, "0.7.0");
-}
-
 #[test]
 fn sets_the_column_from_a_block_full_stream_output() {
     let actual = nu!(

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -20,21 +20,6 @@ fn doesnt_convert_record_to_table() {
     assert_eq!(actual.out, "{a: 2}");
 }
 
-#[cfg(features = "inc")]
-#[test]
-fn sets_the_column_from_a_block_run_output() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        "
-            open cargo_sample.toml
-            | upsert dev-dependencies.pretty_assertions { open cargo_sample.toml | get dev-dependencies.pretty_assertions | inc --minor }
-            | get dev-dependencies.pretty_assertions
-        "
-    ));
-
-    assert_eq!(actual.out, "0.7.0");
-}
-
 #[test]
 fn sets_the_column_from_a_block_full_stream_output() {
     let actual = nu!(


### PR DESCRIPTION
They relied on the `nu_plugin_inc` but where behind a feature flag that
isn't actually defined anywhere. These tests of `update` or `upsert`
shouldn't really depend on `inc` so I decided to remove them outright as
they haven't been used to exercise the commands under test.
