### PR TITLE
Simplify rawstrings in tests

### DIFF
--- a/crates/nu-command/tests/commands/platform/ansi_.rs
+++ b/crates/nu-command/tests/commands/platform/ansi_.rs
@@ -1,23 +1,15 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
 fn test_ansi_shows_error_on_escape() {
-    let actual = nu!(pipeline(
-        r#"
-            ansi -e \
-        "#
-    ));
+    let actual = nu!(r"ansi -e \");
 
     assert!(actual.err.contains("no need for escape characters"))
 }
 
 #[test]
 fn test_ansi_list_outputs_table() {
-    let actual = nu!(pipeline(
-        r#"
-            ansi --list | length
-        "#
-    ));
+    let actual = nu!("ansi --list | length");
 
     assert_eq!(actual.out, "424");
 }

--- a/crates/nu-command/tests/commands/split_column.rs
+++ b/crates/nu-command/tests/commands/split_column.rs
@@ -35,13 +35,13 @@ fn to_column() {
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            r"
                 open sample2.txt
                 | lines
                 | str trim
                 | split column -r '\s*,\s*'
                 | get column2
-            "#
+            "
         ));
 
         assert!(actual.out.contains("shipper"));

--- a/crates/nu-command/tests/commands/split_row.rs
+++ b/crates/nu-command/tests/commands/split_row.rs
@@ -35,13 +35,13 @@ fn to_row() {
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            r"
                 open sample2.txt
                 | lines
                 | str trim
                 | split row -r '\s*,\s*'
                 | length
-            "#
+            "
         ));
 
         assert!(actual.out.contains('5'));

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -254,12 +254,12 @@ fn from_csv_text_with_custom_escapes_to_table() {
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            r"
                 open los_tres_caballeros.txt
                 | from csv --escape '\'
                 | first
                 | get first_name
-            "#
+            "
         ));
 
         assert_eq!(actual.out, "And\"rés");

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -177,12 +177,12 @@ fn from_tsv_text_with_custom_escapes_to_table() {
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
-            r#"
+            r"
                 open los_tres_caballeros.txt
                 | from tsv --escape '\'
                 | first
                 | get first_name
-            "#
+            "
         ));
 
         assert_eq!(actual.out, "And\"rés");


### PR DESCRIPTION
Inspired by https://rust-lang.github.io/rust-clippy/master/index.html#/needless_raw_string_hashes

Ran `cargo +stable clippy --workspace --all-targets`

Fixed manually as I ran into a false positive along the lines of:
https://github.com/rust-lang/rust-clippy/issues/11068

Also collapse one set of single line tests.

Work for #8670
