### PR TITLE
changed default env file to use $nu.home_path to find home

### DIFF
--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -3,14 +3,7 @@
 # version = "0.84.1"
 
 def create_left_prompt [] {
-    mut home = ""
-    try {
-        if $nu.os-info.name == "windows" {
-            $home = $env.USERPROFILE
-        } else {
-            $home = $env.HOME
-        }
-    }
+    let home =  $nu.home-path
 
     let dir = ([
         ($env.PWD | str substring 0..($home | str length) | str replace $home "~"),


### PR DESCRIPTION


# Description
Changed the default env file so that home is found using `$nu.home-path` instead to using an if-else statement to find the os then find the specific environment variable
