### PR TITLE
Point from keybindings help to the book's reedline chapter

### DIFF
--- a/crates/nu-cli/src/commands/keybindings.rs
+++ b/crates/nu-cli/src/commands/keybindings.rs
@@ -24,7 +24,10 @@ impl Command for Keybindings {
     }
 
     fn extra_usage(&self) -> &str {
-        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+        r#"You must use one of the following subcommands. Using this command as-is will only produce this help message.
+
+For more information on input and keybindings, check:
+  https://www.nushell.sh/book/line_editor.html"#
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

I am just starting to play around with nushell, and I wanted to map option+backspace to cut-small-word or something, to match my muscle memory from bash/macos GUI apps (this muscle memory is what currently keeps me using bash even on macos).

I initially tried typing `key<tab>` and this gave me the "keybindings" family of commands, but the help messages for these commands are quite sparse. Web searches also brought me preferentially to the unhelpful `keybindings` command help page rather than the page in the book.

Hopefully this will signal people in the right direction.

<details><summary>context</summary>
Next step on my journey will be working out the mapping between `char: h, code: 0x000068, modifier: CONTROL | ALT, flags: 0b000110, kind: Press, state: NONE` (as generated by vscode on macos) and the format used by `config nu`. Would you be interested in a  `keybindings generate` command (similar to `keybindings listen` but with a different output format) if I write one?

Once I have worked out the mapping, I expect I will stumble across https://github.com/nushell/reedline/issues/570 and need to fix that. It is going to be an adventure ;-) 
</details>


```
~/src/nushell> keybindings -h
Keybindings related commands.

You must use one of the following subcommands. Using this command as-is will only produce this help message.

For more information on input and keybindings, check:
  https://www.nushell.sh/book/line_editor.html
```
See https://github.com/nushell/nushell.github.io/pull/1040 for details and rationale.

I copied the style of crates/nu-cmd-lang/src/core_commands/hide.rs here.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Documentation of keybindings command now points to the appropriate section of the book.

