### PR TITLE
WIP: `keybindings listen --generate-config` to generate `config nu`-compatible output

### DIFF
--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -3,8 +3,8 @@ use crossterm::{event::Event, event::KeyCode, event::KeyEvent, terminal};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    record, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Type,
-    Value,
+    record, Category, Example, IntoPipelineData, PipelineData, Record, ShellError, Signature, Span,
+    Type, Value,
 };
 use std::io::{stdout, Write};
 
@@ -76,17 +76,13 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
         // stdout.queue(crossterm::style::Print("\r\n"))?;
 
         // Get a record
-        let v = print_events_helper(event)?;
+        let val = print_events_helper(event)?;
         // Print out the record
-        let o = match v {
-            Value::Record { val, .. } => val
-                .iter()
-                .map(|(x, y)| format!("{}: {}", x, y.into_string("", config)))
-                .collect::<Vec<String>>()
-                .join(", "),
-
-            _ => "".to_string(),
-        };
+        let o = val
+            .iter()
+            .map(|(x, y)| format!("{}: {}", x, y.into_string("", config)))
+            .collect::<Vec<String>>()
+            .join(" ");
         stdout.queue(crossterm::style::Print(o))?;
         stdout.queue(crossterm::style::Print("\r\n"))?;
         stdout.flush()?;
@@ -101,7 +97,7 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
 // even seeing the events. if you press a key and no events
 // are printed, it's a good chance your terminal is eating
 // those events.
-fn print_events_helper(event: Event) -> Result<Value, ShellError> {
+fn print_events_helper(event: Event) -> Result<Record, ShellError> {
     if let Event::Key(KeyEvent {
         code,
         modifiers,
@@ -119,7 +115,7 @@ fn print_events_helper(event: Event) -> Result<Value, ShellError> {
                     "kind" => Value::string(format!("{kind:?}"), Span::unknown()),
                     "state" => Value::string(format!("{state:?}"), Span::unknown()),
                 };
-                Ok(Value::record(record, Span::unknown()))
+                Ok(record)
             }
             _ => {
                 let record = record! {
@@ -129,11 +125,11 @@ fn print_events_helper(event: Event) -> Result<Value, ShellError> {
                     "kind" => Value::string(format!("{kind:?}"), Span::unknown()),
                     "state" => Value::string(format!("{state:?}"), Span::unknown()),
                 };
-                Ok(Value::record(record, Span::unknown()))
+                Ok(record)
             }
         }
     } else {
         let record = record! { "event" => Value::string(format!("{event:?}"), Span::unknown()) };
-        Ok(Value::record(record, Span::unknown()))
+        Ok(record)
     }
 }

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -130,7 +130,7 @@ fn print_events(engine_state: &EngineState, style: OutputStyle) -> Result<Value,
                         // FIXME: this outputs a string like:
                         // {modifier: 'control' keycode: 'char_a' mode: 'emacs' event: {edit: 'InsertString', value: 'Add your action here'}}
                         // This works, but is a bit ugly. Is there a nushell autoformatter that we can pipe this through to remove the quotes etc?
-                        .into_string_parsable(" ", &config)
+                        .into_string_parsable(" ", config)
                     },
                 )
                 .unwrap_or_default()

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -3,13 +3,20 @@ use crossterm::{event::Event, event::KeyCode, event::KeyEvent, terminal};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    record, Category, Example, IntoPipelineData, PipelineData, Record, ShellError, Signature, Span,
-    Type, Value,
+    record, Category, Example, IntoPipelineData, ParsedKeybinding, PipelineData, Record,
+    ShellError, Signature, Span, Type, Value,
 };
 use std::io::{stdout, Write};
 
+use crate::reedline_config::key_combination_to_parsed_keybinding;
+
 #[derive(Clone)]
 pub struct KeybindingsListen;
+
+enum OutputStyle {
+    Raw,
+    Config,
+}
 
 impl Command for KeybindingsListen {
     fn name(&self) -> &str {
@@ -24,19 +31,27 @@ impl Command for KeybindingsListen {
         Signature::build(self.name())
             .category(Category::Platform)
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .allow_variants_without_examples(true)
+            .switch(
+                "generate-config",
+                "generate output capable of being pasted into `config nu` keybindings section",
+                Some('g'),
+            )
     }
 
     fn run(
         &self,
         engine_state: &EngineState,
         _stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         println!("Type any key combination to see key details. Press ESC to abort.");
+        let style = match call.has_flag("generate-config") {
+            true => OutputStyle::Config,
+            false => OutputStyle::Raw,
+        };
 
-        match print_events(engine_state) {
+        match print_events(engine_state, style) {
             Ok(v) => Ok(v.into_pipeline_data()),
             Err(e) => {
                 terminal::disable_raw_mode()?;
@@ -52,15 +67,22 @@ impl Command for KeybindingsListen {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Type and see key event codes",
-            example: "keybindings listen",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "Type and see key event codes",
+                example: "keybindings listen",
+                result: None,
+            },
+            Example {
+                description: "Generate code for putting into `config nu`",
+                example: "keybindings listen -g; config nu",
+                result: None,
+            },
+        ]
     }
 }
 
-pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
+fn print_events(engine_state: &EngineState, style: OutputStyle) -> Result<Value, ShellError> {
     let config = engine_state.get_config();
 
     stdout().flush()?;
@@ -75,14 +97,45 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
         // stdout.queue(crossterm::style::Print(format!("event: {:?}", &event)))?;
         // stdout.queue(crossterm::style::Print("\r\n"))?;
 
-        // Get a record
-        let val = print_events_helper(event)?;
-        // Print out the record
-        let o = val
-            .iter()
-            .map(|(x, y)| format!("{}: {}", x, y.into_string("", config)))
-            .collect::<Vec<String>>()
-            .join(" ");
+        let o = match style {
+            OutputStyle::Raw => {
+                // Get a record
+                let val = print_events_raw_helper(event)?;
+                // Print out the record
+                val.iter()
+                    .map(|(x, y)| format!("{}: {}", x, y.into_string("", config)))
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            }
+            OutputStyle::Config => {
+                let val = print_events_config_helper(event)?;
+                val.map(
+                    |ParsedKeybinding {
+                         modifier,
+                         keycode,
+                         ..
+                     }| {
+                        Value::record(
+                            record! {
+                                "modifier" => modifier.clone(),
+                                "keycode" => keycode.clone(),
+                                "mode" => Value::string(config.edit_mode.clone(), Span::unknown()),
+                                "event" => Value::record(record!{
+                                    "edit" => Value::string("InsertString", Span::unknown()),
+                                    "value" => Value::string("Add your action here", Span::unknown()),
+                                }, Span::unknown()),
+                            },
+                            Span::unknown(),
+                        )
+                        // FIXME: this outputs a string like:
+                        // {modifier: 'control' keycode: 'char_a' mode: 'emacs' event: {edit: 'InsertString', value: 'Add your action here'}}
+                        // This works, but is a bit ugly. Is there a nushell autoformatter that we can pipe this through to remove the quotes etc?
+                        .into_string_parsable(" ", &config)
+                    },
+                )
+                .unwrap_or_default()
+            }
+        };
         stdout.queue(crossterm::style::Print(o))?;
         stdout.queue(crossterm::style::Print("\r\n"))?;
         stdout.flush()?;
@@ -97,7 +150,7 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
 // even seeing the events. if you press a key and no events
 // are printed, it's a good chance your terminal is eating
 // those events.
-fn print_events_helper(event: Event) -> Result<Record, ShellError> {
+fn print_events_raw_helper(event: Event) -> Result<Record, ShellError> {
     if let Event::Key(KeyEvent {
         code,
         modifiers,
@@ -131,5 +184,16 @@ fn print_events_helper(event: Event) -> Result<Record, ShellError> {
     } else {
         let record = record! { "event" => Value::string(format!("{event:?}"), Span::unknown()) };
         Ok(record)
+    }
+}
+
+fn print_events_config_helper(event: Event) -> Result<Option<ParsedKeybinding>, ShellError> {
+    if let Event::Key(KeyEvent {
+        code, modifiers, ..
+    }) = event
+    {
+        Ok(Some(key_combination_to_parsed_keybinding(modifiers, code)?))
+    } else {
+        Ok(None)
     }
 }

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -717,7 +717,7 @@ fn parsed_keybinding_to_key_combination(
     Ok((modifier, keycode))
 }
 
-fn key_combination_to_parsed_keybinding(
+pub fn key_combination_to_parsed_keybinding(
     modifier: KeyModifiers,
     keycode: KeyCode,
 ) -> Result<ParsedKeybinding, ShellError> {

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -613,6 +613,22 @@ fn add_parsed_keybinding(
     keybinding: &ParsedKeybinding,
     config: &Config,
 ) -> Result<(), ShellError> {
+    let (modifier, keycode) = parsed_keybinding_to_key_combination(keybinding, config)?;
+
+    if let Some(event) = parse_event(&keybinding.event, config)? {
+        keybindings.add_binding(modifier, keycode, event);
+    } else {
+        keybindings.remove_binding(modifier, keycode);
+    }
+
+    Ok(())
+}
+
+// FIXME: return type should be reedline::edit_mode::keybindings::KeyCombination, but it doesn't seem to be exported.
+fn parsed_keybinding_to_key_combination(
+    keybinding: &ParsedKeybinding,
+    config: &Config,
+) -> Result<(KeyModifiers, KeyCode), ShellError> {
     let modifier = match keybinding
         .modifier
         .into_string("", config)
@@ -698,13 +714,7 @@ fn add_parsed_keybinding(
             ))
         }
     };
-    if let Some(event) = parse_event(&keybinding.event, config)? {
-        keybindings.add_binding(modifier, keycode, event);
-    } else {
-        keybindings.remove_binding(modifier, keycode);
-    }
-
-    Ok(())
+    Ok((modifier, keycode))
 }
 
 enum EventType<'config> {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

As hinted in the context of https://github.com/nushell/nushell/pull/10193 , I really struggled to get the keybindings system to work, because there was no documented mapping between the output of `keybindings listen` and the format of `config nu`. This is an attempt to fix that.

Current output looks like this (which works, but could be improved if you have any pointers):
```
~/src/nushell> keybindings listen --generate-config                                                                                                                     09/03/2023 01:50:59 AM
Type any key combination to see key details. Press ESC to abort.
{modifier: 'control' keycode: 'char_a' mode: 'emacs' event: {edit: 'InsertString', value: 'Add your action here'}}
{modifier: 'control' keycode: 'char_c' mode: 'emacs' event: {edit: 'InsertString', value: 'Add your action here'}}
~/src/nushell>   
```


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

`--generate-config` option to `keybindings listen`

- [ ] personally, I think that this should be the default format, and we should add a --raw flag to switch to the old format. I've coded it up in a very risk-averse way, but I'm happy to change it.


# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

- [ ] rewrite the book's section on keybindings to suggest a copy-paste based workflow

# Before Merging

- [ ] I have a *bunch* of FIXMEs lying around in the code. Pointers on how to fix these would be nice.
- [ ] I got quite attached to the ability to have a bidirectional mapping between ParsedKeyBindings and reedline::edit_mode::keybindings::KeyCombination so that I could write a nice round-trip test. It's kind-of wonky though, because it ignores `event` and `mode`. Maybe splitting it into separate functions for modifier and keycode would be better.
- [ ] it's currently 2am. I should go to bed.