### PR TITLE
support tab completion cycling

### DIFF
--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -478,6 +478,7 @@ fn add_menu_keybindings(keybindings: &mut Keybindings) {
         KeyCode::Tab,
         ReedlineEvent::UntilFound(vec![
             ReedlineEvent::Menu("completion_menu".to_string()),
+            ReedlineEvent::MenuNext,
             ReedlineEvent::Edit(vec![EditCommand::Complete]),
         ]),
     );

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -320,6 +320,7 @@ $env.config = {
                 until: [
                     { send: menu name: completion_menu }
                     { send: menunext }
+                    { edit: complete }
                 ]
             }
         }


### PR DESCRIPTION
should close https://github.com/nushell/nushell/issues/7202

# Description
i have been annoyed enough by this missing feature, so let's add that to Nushell without requiring any user configuration :smirk: 

# User-Facing Changes
this PR should allow tab completion cycling everytime, without requiring the user to use the default config files or add the following keybindings to their config
```nushell
    {
        name: completion_menu
        modifier: none
        keycode: tab
        mode: [emacs vi_normal vi_insert]
        event: {
            until: [
                { send: menu name: completion_menu }
                { send: menunext }
                { edit: complete }
            ]
        }
    }
```

### :test_tube: try it out
from the root of the repo, one can try `<tab>` in each of the following cases:
- `cargo run -- -n` to load Nushell without any config
- `cargo run -- --config crates/nu-utils/src/sample_config/default_config.nu --env-config crates/nu-utils/src/sample_config/default_env.nu` to load the default configuration
- `cargo run` to load the user configuration

## before
- `<tab>`, `ls <tab>` and `str <tab>` only work with the second `cargo run`, i.e. when loading the default config files

## after
- `<tab>` should cycle through the available commands
- `ls <tab>` should cycle through the available files and directories
- `str <tab>` should cycle the subcommands of `str`

in all three cases

# Tests + Formatting

# After submitting