### PR TITLE
add plugin path when there are no signatures

### DIFF
--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -113,6 +113,11 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
             if let Some(path) = &engine_state.plugin_signatures {
                 let canon_plugin_path = canonicalize_path(engine_state, path);
                 Value::string(canon_plugin_path.to_string_lossy(), span)
+            } else if let Some(mut plugin_path) = nu_path::config_dir() {
+                // If there are no signatures, we should still populate the plugin path
+                plugin_path.push("nushell");
+                plugin_path.push("plugin.nu");
+                Value::string(plugin_path.to_string_lossy(), span)
             } else {
                 Value::error(
                     ShellError::IOError("Could not get plugin signature location".into()),


### PR DESCRIPTION
# Description

This PR adds the ability to have a `$nu.plugin-path` even when you plugins are registered and it also should work with `nu -n --no-stdlib`.

### Before
It would give an error
```
│ plugin-path        │ IOError("Could not get plugin signature location")             │
```

### After
It returns the proper path, like this for me
```
│ plugin-path        │ /Users/fdncred/Library/Application Support/nushell/plugin.nu   │
```

Closed #10198 
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
