### PR TITLE
Only use list to specify editor's arguments (issue 10205)

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -8,8 +8,8 @@ use crate::{
 use crossterm::cursor::SetCursorStyle;
 use log::{trace, warn};
 use miette::{ErrReport, IntoDiagnostic, Result};
-use nu_cmd_base::hook::eval_hook;
 use nu_cmd_base::util::get_guaranteed_cwd;
+use nu_cmd_base::{hook::eval_hook, util::get_editor};
 use nu_color_config::StyleComputer;
 use nu_engine::convert_env_values;
 use nu_parser::{lex, parse, trim_quotes_str};
@@ -316,23 +316,10 @@ pub fn evaluate_repl(
         );
 
         start_time = std::time::Instant::now();
-        let buffer_editor = if !config.buffer_editor.is_empty() {
-            Some(config.buffer_editor.clone())
-        } else {
-            stack
-                .get_env_var(engine_state, "EDITOR")
-                .map(|v| v.as_string().unwrap_or_default())
-                .filter(|v| !v.is_empty())
-                .or_else(|| {
-                    stack
-                        .get_env_var(engine_state, "VISUAL")
-                        .map(|v| v.as_string().unwrap_or_default())
-                        .filter(|v| !v.is_empty())
-                })
-        };
+        let buffer_editor = get_editor(engine_state, stack, Span::unknown());
 
-        line_editor = if let Some(buffer_editor) = buffer_editor {
-            line_editor.with_buffer_editor(buffer_editor, "nu".into())
+        line_editor = if let Ok((buffer_editor, arguments)) = buffer_editor {
+            line_editor.with_argumented_buffer_editor(buffer_editor, arguments, "nu".into())
         } else {
             line_editor
         };

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -8,8 +8,8 @@ use crate::{
 use crossterm::cursor::SetCursorStyle;
 use log::{trace, warn};
 use miette::{ErrReport, IntoDiagnostic, Result};
+use nu_cmd_base::hook::eval_hook;
 use nu_cmd_base::util::get_guaranteed_cwd;
-use nu_cmd_base::{hook::eval_hook, util::get_editor};
 use nu_color_config::StyleComputer;
 use nu_engine::convert_env_values;
 use nu_parser::{lex, parse, trim_quotes_str};
@@ -316,10 +316,23 @@ pub fn evaluate_repl(
         );
 
         start_time = std::time::Instant::now();
-        let buffer_editor = get_editor(engine_state, stack, Span::unknown());
+        let buffer_editor = if !config.buffer_editor.is_empty() {
+            Some(config.buffer_editor.clone())
+        } else {
+            stack
+                .get_env_var(engine_state, "EDITOR")
+                .map(|v| v.as_string().unwrap_or_default())
+                .filter(|v| !v.is_empty())
+                .or_else(|| {
+                    stack
+                        .get_env_var(engine_state, "VISUAL")
+                        .map(|v| v.as_string().unwrap_or_default())
+                        .filter(|v| !v.is_empty())
+                })
+        };
 
-        line_editor = if let Ok((buffer_editor, arguments)) = buffer_editor {
-            line_editor.with_argumented_buffer_editor(buffer_editor, arguments, "nu".into())
+        line_editor = if let Some(buffer_editor) = buffer_editor {
+            line_editor.with_buffer_editor(buffer_editor, "nu".into())
         } else {
             line_editor
         };

--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -55,3 +55,63 @@ pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
 
     Ok((start, end))
 }
+
+const HELP_MSG: &str = "Nushell's config file can be found with the command: $nu.config-path. \
+For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)";
+
+fn get_editor_commandline(value: &Value) -> Result<(String, Vec<String>), ShellError> {
+    match value {
+        Value::String { val, .. } if !val.is_empty() => Ok((val.to_string(), Vec::new())),
+        Value::List { vals, .. } if !vals.is_empty() => {
+            let mut editor_cmd = vals.iter().map(|l| l.as_string());
+            match editor_cmd.next().transpose()? {
+                Some(editor) if !editor.is_empty() => {
+                    let params = editor_cmd.collect::<Result<_, ShellError>>()?;
+                    Ok((editor, params))
+                }
+                _ => Err(ShellError::GenericError(
+                    "Editor's executable is missing".into(),
+                    "Set the first element to an executable".into(),
+                    Some(value.span()),
+                    Some(HELP_MSG.into()),
+                    vec![],
+                )),
+            }
+        }
+        Value::String { .. } | Value::List { .. } => Err(ShellError::GenericError(
+            "$EDITOR or $VISUAL should be a non-empty string or list<String>".into(),
+            "Specify an executable here".into(),
+            Some(value.span()),
+            Some(HELP_MSG.into()),
+            vec![],
+        )),
+        x => Err(ShellError::CantConvert {
+            to_type: "string or list<string>".into(),
+            from_type: x.get_type().to_string(),
+            span: value.span(),
+            help: None,
+        }),
+    }
+}
+
+pub fn get_editor(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    span: Span,
+) -> Result<(String, Vec<String>), ShellError> {
+    let config = engine_state.get_config();
+    let env_vars = stack.get_env_vars(engine_state);
+    if !config.buffer_editor.is_empty() {
+        Ok((config.buffer_editor.clone(), Vec::new()))
+    } else if let Some(value) = env_vars.get("EDITOR").or_else(|| env_vars.get("VISUAL")) {
+        get_editor_commandline(value)
+    } else {
+        Err(ShellError::GenericError(
+            "No editor configured".into(),
+            "Please specify one via environment variables $EDITOR or $VISUAL".into(),
+            Some(span),
+            Some(HELP_MSG.into()),
+            vec![],
+        ))
+    }
+}

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -5,7 +5,8 @@ use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Type,
 };
 
-use super::utils::{gen_command, get_editor};
+use super::utils::gen_command;
+use nu_cmd_base::util::get_editor;
 
 #[derive(Clone)]
 pub struct ConfigEnv;

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -5,7 +5,8 @@ use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Type,
 };
 
-use super::utils::{gen_command, get_editor};
+use super::utils::gen_command;
+use nu_cmd_base::util::get_editor;
 
 #[derive(Clone)]
 pub struct ConfigNu;

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -8,6 +8,44 @@ use nu_protocol::{
 
 use crate::ExternalCommand;
 
+const HELP_MSG: &str = "Nushell's config file can be found with the command: $nu.config-path. \
+For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)";
+
+fn get_editor_commandline(value: &Value) -> Result<(String, Vec<String>), ShellError> {
+    match value {
+        Value::String { val, .. } if !val.is_empty() => Ok((val.to_string(), Vec::new())),
+        Value::List { vals, .. } if !vals.is_empty() => {
+            let mut editor_cmd = vals.iter().map(|l| l.as_string());
+            match editor_cmd.next().transpose()? {
+                Some(editor) if !editor.is_empty() => {
+                    let params = editor_cmd.collect::<Result<_, ShellError>>()?;
+                    Ok((editor, params))
+                }
+                _ => Err(ShellError::GenericError(
+                    "Editor's executable is missing".into(),
+                    "Set the first element to an executable".into(),
+                    Some(value.span()),
+                    Some(HELP_MSG.into()),
+                    vec![],
+                )),
+            }
+        }
+        Value::String { .. } | Value::List { .. } => Err(ShellError::GenericError(
+            "Editor can not be empty".into(),
+            "Specify one in $EDITOR or $VISUAL".into(),
+            Some(value.span()),
+            Some(HELP_MSG.into()),
+            vec![],
+        )),
+        x => Err(ShellError::CantConvert {
+            to_type: "string or list<string>".into(),
+            from_type: x.get_type().to_string(),
+            span: value.span(),
+            help: None,
+        }),
+    }
+}
+
 pub(crate) fn get_editor(
     engine_state: &EngineState,
     stack: &mut Stack,
@@ -18,45 +56,13 @@ pub(crate) fn get_editor(
     if !config.buffer_editor.is_empty() {
         Ok((config.buffer_editor.clone(), Vec::new()))
     } else if let Some(value) = env_vars.get("EDITOR").or_else(|| env_vars.get("VISUAL")) {
-        match value {
-            Value::String { val, .. } if !val.is_empty() => Ok((val.to_string(), Vec::new())),
-            Value::List { vals, .. } if !vals.is_empty() => {
-                let mut editor_cmd = vals.iter().map(|l| l.as_string());
-                match editor_cmd.next().transpose()? {
-                    Some(editor) if !editor.is_empty() => {
-                        let params = editor_cmd.collect::<Result<_, ShellError>>()?;
-                        Ok((editor, params))
-                    },
-                    _ => {
-                        Err(ShellError::GenericError(
-                                    "Empty editor configured".into(),
-                                    "$EDITOR or $VISUAL should be an non-empty String or List<String>".into(),
-                                    Some(span),
-                                    Some(
-                                        "Nushell's config file can be found with the command: $nu.config-path. For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)"
-                                            .into(),
-                                    ),
-                                    vec![],
-                                ))
-                    }
-                }
-            }
-            x => Err(ShellError::CantConvert {
-                to_type: "string or list<string>".into(),
-                from_type: x.get_type().to_string(),
-                span: value.span(),
-                help: None,
-            }),
-        }
+        get_editor_commandline(value)
     } else {
         Err(ShellError::GenericError(
             "No editor configured".into(),
             "Please specify one via environment variables $EDITOR or $VISUAL".into(),
             Some(span),
-            Some(
-                "Nushell's config file can be found with the command: $nu.config-path. For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)"
-                    .into(),
-            ),
+            Some(HELP_MSG.into()),
             vec![],
         ))
     }

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -31,7 +31,7 @@ fn get_editor_commandline(value: &Value) -> Result<(String, Vec<String>), ShellE
             }
         }
         Value::String { .. } | Value::List { .. } => Err(ShellError::GenericError(
-            "Editor can not be empty".into(),
+            "$EDITOR or $VISUAL should be an non-empty string or list<String>".into(),
             "Specify one in $EDITOR or $VISUAL".into(),
             Some(value.span()),
             Some(HELP_MSG.into()),

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -31,8 +31,8 @@ fn get_editor_commandline(value: &Value) -> Result<(String, Vec<String>), ShellE
             }
         }
         Value::String { .. } | Value::List { .. } => Err(ShellError::GenericError(
-            "$EDITOR or $VISUAL should be an non-empty string or list<String>".into(),
-            "Specify one in $EDITOR or $VISUAL".into(),
+            "$EDITOR or $VISUAL should be a non-empty string or list<String>".into(),
+            "Specify an executable here".into(),
             Some(value.span()),
             Some(HELP_MSG.into()),
             vec![],

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -1,72 +1,9 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use nu_protocol::{
-    engine::{EngineState, Stack},
-    ShellError, Span, Spanned, Value,
-};
+use nu_protocol::{Span, Spanned};
 
 use crate::ExternalCommand;
-
-const HELP_MSG: &str = "Nushell's config file can be found with the command: $nu.config-path. \
-For more help: (https://nushell.sh/book/configuration.html#configurations-with-built-in-commands)";
-
-fn get_editor_commandline(value: &Value) -> Result<(String, Vec<String>), ShellError> {
-    match value {
-        Value::String { val, .. } if !val.is_empty() => Ok((val.to_string(), Vec::new())),
-        Value::List { vals, .. } if !vals.is_empty() => {
-            let mut editor_cmd = vals.iter().map(|l| l.as_string());
-            match editor_cmd.next().transpose()? {
-                Some(editor) if !editor.is_empty() => {
-                    let params = editor_cmd.collect::<Result<_, ShellError>>()?;
-                    Ok((editor, params))
-                }
-                _ => Err(ShellError::GenericError(
-                    "Editor's executable is missing".into(),
-                    "Set the first element to an executable".into(),
-                    Some(value.span()),
-                    Some(HELP_MSG.into()),
-                    vec![],
-                )),
-            }
-        }
-        Value::String { .. } | Value::List { .. } => Err(ShellError::GenericError(
-            "$EDITOR or $VISUAL should be a non-empty string or list<String>".into(),
-            "Specify an executable here".into(),
-            Some(value.span()),
-            Some(HELP_MSG.into()),
-            vec![],
-        )),
-        x => Err(ShellError::CantConvert {
-            to_type: "string or list<string>".into(),
-            from_type: x.get_type().to_string(),
-            span: value.span(),
-            help: None,
-        }),
-    }
-}
-
-pub(crate) fn get_editor(
-    engine_state: &EngineState,
-    stack: &mut Stack,
-    span: Span,
-) -> Result<(String, Vec<String>), ShellError> {
-    let config = engine_state.get_config();
-    let env_vars = stack.get_env_vars(engine_state);
-    if !config.buffer_editor.is_empty() {
-        Ok((config.buffer_editor.clone(), Vec::new()))
-    } else if let Some(value) = env_vars.get("EDITOR").or_else(|| env_vars.get("VISUAL")) {
-        get_editor_commandline(value)
-    } else {
-        Err(ShellError::GenericError(
-            "No editor configured".into(),
-            "Please specify one via environment variables $EDITOR or $VISUAL".into(),
-            Some(span),
-            Some(HELP_MSG.into()),
-            vec![],
-        ))
-    }
-}
 
 pub(crate) fn gen_command(
     span: Span,


### PR DESCRIPTION
fixes https://github.com/nushell/nushell/issues/10205 without  break https://github.com/nushell/nushell/issues/8051 as possible

# Description

While dealing with #8051 , the function for using arguments in `editor` variable is introduced but it still only receive  `string` for `$env.VISUAL` and `$env.EDITOR`  so the input is just splitted by `' '` to find arguments, and this finally causes https://github.com/nushell/nushell/issues/10205.

As nushell provides `list<string>`, it's more natural to use a `list` rather than `string` for list of arguments. 

# User-Facing Changes

* `$env.EDITOR = "string"` is only considered as an executable
*  User should use `$env.EDITOR = ["editor", "-argument"]` to specify arguments

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Add what is allowed for these variables in https://nushell.sh/book/configuration.html#configurations-with-built-in-commands
