### PR TITLE
Exit early when encountering parsing errors

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -107,6 +107,11 @@ pub fn evaluate_file(
     trace!("parsing file: {}", file_path_str);
     let block = parse(&mut working_set, Some(file_path_str), &file, false);
 
+    if let Some(err) = working_set.parse_errors.first() {
+        report_error(&working_set, err);
+        std::process::exit(1);
+    }
+
     for block in &mut working_set.delta.blocks {
         if block.signature.name == "main" {
             block.signature.name = source_filename.to_string_lossy().to_string();

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -6,3 +6,12 @@ fn source_file_relative_to_file() {
 
     assert!(actual.err.contains("redefined"));
 }
+
+#[test]
+fn run_file_parse_error() {
+    let actual = nu!(
+        cwd: "tests/fixtures/eval",
+    "nu script.nu");
+
+    assert!(actual.err.contains("unknown type"));
+}

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -11,7 +11,8 @@ fn source_file_relative_to_file() {
 fn run_file_parse_error() {
     let actual = nu!(
         cwd: "tests/fixtures/eval",
-    "nu script.nu");
+        "nu script.nu"
+    );
 
     assert!(actual.err.contains("unknown type"));
 }

--- a/tests/fixtures/eval/script.nu
+++ b/tests/fixtures/eval/script.nu
@@ -1,0 +1,9 @@
+def main [] {
+  somefunc "foo"
+}
+
+def somefunc [
+  somearg: unknown_type
+] {
+  echo $somearg
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
This PR tries to fix #10184 and #10182.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
