### PR TITLE
Fix example history command pipeline

### DIFF
--- a/crates/nu-cli/src/commands/history.rs
+++ b/crates/nu-cli/src/commands/history.rs
@@ -139,7 +139,7 @@ impl Command for History {
                 result: None,
             },
             Example {
-                example: "history | wrap cmd | where cmd =~ cargo",
+                example: "history | where command =~ cargo | get command",
                 description: "Search all the commands from history that contains 'cargo'",
                 result: None,
             },


### PR DESCRIPTION
```
❯ history | wrap cmd | where cmd =~ cargo
Error: nu::shell::type_mismatch

  × Type mismatch during operation.
   ╭─[entry #23:1:1]
 1 │ history | wrap cmd | where cmd =~ cargo
   · ───┬───                        ─┬ ──┬──
   ·    │                            │   ╰── string
   ·    │                            ╰── type mismatch for operator
   ·    ╰── record<start_timestamp: string, command: string, cwd: string, duration: duration, exit_status: int>
   ╰────
```