### PR TITLE
deprecate `echo`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -49,7 +49,7 @@ little reason to use this over just writing the values as-is."#
                 "Deprecated command".into(),
                 "`echo` is deprecated and will be removed in 0.85.".into(),
                 Some(call.head),
-                Some("Please use the `print` command to print the data to the terminal or directly the value if you want to use it in a pipeline.".into()),
+                Some("Please use the `print` command to print the data to the terminal or use the value directly to send it to the pipeline.".into()),
                 vec![],
             ),
         );

--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -2,8 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack, StateWorkingSet};
 use nu_protocol::{
-    Category, Example, ListStream, PipelineData, ShellError, Signature, Span, SyntaxShape, Type,
-    Value,
+    report_error_new, Category, Example, ListStream, PipelineData, ShellError, Signature, Span,
+    SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -43,6 +43,16 @@ little reason to use this over just writing the values as-is."#
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let args = call.rest(engine_state, stack, 0);
+        report_error_new(
+                engine_state,
+            &ShellError::GenericError(
+                "Deprecated command".into(),
+                "`echo` is deprecated and will be removed in 0.85.".into(),
+                Some(call.head),
+                Some("Please use the `print` command to print the data to the terminal or directly the value if you want to use it in a pipeline.".into()),
+                vec![],
+            ),
+        );
         run(engine_state, args, call)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -49,7 +49,13 @@ little reason to use this over just writing the values as-is."#
                 "Deprecated command".into(),
                 "`echo` is deprecated and will be removed in 0.85.".into(),
                 Some(call.head),
-                Some("Please use the `print` command to print the data to the terminal or use the value directly to send it to the pipeline.".into()),
+                Some(r#"Please use the `print` command to print the data to the terminal or use the value directly to send it to the pipeline.
+
+    To print to the screen:
+        print "hello world"
+
+    To send to the pipeline:
+        "hello world" | str length"#.into()),
                 vec![],
             ),
         );

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -57,7 +57,7 @@ fn ignore_program_errors_works_for_external_with_semicolon() {
 
 #[test]
 fn ignore_error_should_work_for_external_command() {
-    let actual = nu!(r#"do -i { nu --testbin fail asdf }; echo post"#);
+    let actual = nu!(r#"do -i { nu --testbin fail asdf }; print post"#);
 
     assert_eq!(actual.err, "");
     assert_eq!(actual.out, "post");

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -305,7 +305,7 @@ fn parse_string_as_script_success() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                echo $'two(char nl)lines' | nu-check
+                $'two(char nl)lines' | nu-check
             "#
         ));
 

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -241,7 +241,7 @@ fn open_wildcard() {
         "
     ));
 
-    assert_eq!(actual.out, "3")
+    assert_eq!(actual.out, "2")
 }
 
 #[test]

--- a/tests/fixtures/formats/early_return.nu
+++ b/tests/fixtures/formats/early_return.nu
@@ -1,3 +1,3 @@
-echo "a"
+print "a"
 return 1
 error make {msg: "this should not show"}

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -153,7 +153,7 @@ fn env_change_define_env_var() {
 #[test]
 fn env_change_define_alias() {
     let inp = &[
-        &env_change_hook_code("FOO", r#"'alias spam = print "spam"'"#),
+        &env_change_hook_code("FOO", r#"'alias spam = do { "spam" }'"#),
         "$env.FOO = 1",
         "spam",
     ];

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -153,7 +153,7 @@ fn env_change_define_env_var() {
 #[test]
 fn env_change_define_alias() {
     let inp = &[
-        &env_change_hook_code("FOO", r#"'alias spam = echo "spam"'"#),
+        &env_change_hook_code("FOO", r#"'alias spam = print "spam"'"#),
         "$env.FOO = 1",
         "spam",
     ];

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -25,7 +25,7 @@ fn plugins_are_declared_with_wix() {
                 | where Directory.attributes.Id == "$(var.PlatformProgramFilesFolder)"
                 | get Directory.children.Directory.children.0 | last
                 | get Directory.children.Component.children
-                | each { |it| echo $it | first }
+                | each { |it| $it | first }
                 | skip
                 | where File.attributes.Name =~ "nu_plugin"
                 | str substring [_, -4] File.attributes.Name
@@ -234,7 +234,7 @@ fn run_in_login_mode() {
     let child_output = std::process::Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "{:?} -l -c 'echo $nu.is-login'",
+            "{:?} -l -c '$nu.is-login'",
             nu_test_support::fs::executable_path()
         ))
         .output()
@@ -249,7 +249,7 @@ fn run_in_not_login_mode() {
     let child_output = std::process::Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "{:?} -c 'echo $nu.is-login'",
+            "{:?} -c '$nu.is-login'",
             nu_test_support::fs::executable_path()
         ))
         .output()
@@ -264,7 +264,7 @@ fn run_in_interactive_mode() {
     let child_output = std::process::Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "{:?} -i -c 'echo $nu.is-interactive'",
+            "{:?} -i -c '$nu.is-interactive'",
             nu_test_support::fs::executable_path()
         ))
         .output()
@@ -279,7 +279,7 @@ fn run_in_noninteractive_mode() {
     let child_output = std::process::Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "{:?} -c 'echo $nu.is-interactive'",
+            "{:?} -c '$nu.is-interactive'",
             nu_test_support::fs::executable_path()
         ))
         .output()

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -481,7 +481,7 @@ fn block_params_override() {
 
 #[test]
 fn alias_reuse() {
-    let actual = nu!("alias foo = echo bob; foo; foo");
+    let actual = nu!("alias foo = print bob; foo; foo");
 
     assert!(actual.out.contains("bob"));
     assert!(actual.err.is_empty());


### PR DESCRIPTION
## ⚠️ wait for before 0.85 on 2023-09-19 ⚠️

# Description
because the distinction between `echo` and `print` appears to be confusing and we do not really need `echo`, i propose after discussing with the @nushell/core-team to deprecate `echo` in favor of `print`.

in the tests, i either had to remove `echo` or replace it with `print` or `do { ... }`

# User-Facing Changes
the following error will be printed when using `echo` now
```nushell
> echo "foo" | describe
Error:   × Deprecated command
   ╭─[entry #3:1:1]
 1 │ echo "foo" | describe
   · ──┬─
   ·   ╰── `echo` is deprecated and will be removed in 0.85.
   ╰────
  help: Please use the `print` command to print the data
        to the terminal or directly the value if you want
        to use it in a pipeline.


string
```

> **Note**  
> please note that `echo` still works for now and `echo "foo" | describe` both gives the error and the expected result, i.e. that `"foo"` is a `string`

# Tests + Formatting

# After Submitting
do not forget to remove this command later