### PR TITLE
Fix unit tests on Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 name: continuous-integration
 
 env:
-  NUSHELL_CARGO_TARGET: ci
+  NUSHELL_CARGO_PROFILE: ci
   NU_LOG_LEVEL: DEBUG
   CLIPPY_OPTIONS: "-D warnings -D clippy::unwrap_used"
 

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -27,7 +27,13 @@ def path_add [] {
         assert equal (get_path) ["fooooo", "foo", "bar", "baz"]
 
         load-env {$path_name: []}
-        let target_paths = {linux: "foo", windows: "bar", macos: "baz"}
+
+        let target_paths = {
+            linux: "foo",
+            windows: "bar",
+            macos: "baz",
+            android: "quux",
+        }
 
         std path add $target_paths
         assert equal (get_path) [($target_paths | get $nu.os-info.name)]

--- a/crates/nu-test-support/src/commands.rs
+++ b/crates/nu-test-support/src/commands.rs
@@ -23,7 +23,7 @@ pub fn ensure_plugins_built() {
     let cargo_path = env!("CARGO");
     let mut arguments = vec!["build", "--package", "nu_plugin_*", "--quiet"];
 
-    let profile = std::env::var("NUSHELL_CARGO_TARGET");
+    let profile = std::env::var("NUSHELL_CARGO_PROFILE");
     if let Ok(profile) = &profile {
         arguments.push("--profile");
         arguments.push(profile);

--- a/crates/nu-test-support/src/fs.rs
+++ b/crates/nu-test-support/src/fs.rs
@@ -233,18 +233,21 @@ pub fn root() -> PathBuf {
 }
 
 pub fn binaries() -> PathBuf {
-    let mut build_type = "debug".to_string();
-    if !cfg!(debug_assertions) {
-        build_type = "release".to_string()
-    }
-    if let Ok(target) = std::env::var("NUSHELL_CARGO_TARGET") {
-        build_type = target;
-    }
+    let build_target = std::env::var("CARGO_BUILD_TARGET").unwrap_or(String::new());
+
+    let profile = if let Ok(env_profile) = std::env::var("NUSHELL_CARGO_PROFILE") {
+        env_profile
+    } else if cfg!(debug_assertions) {
+        "debug".into()
+    } else {
+        "release".into()
+    };
 
     std::env::var("CARGO_TARGET_DIR")
-        .ok()
-        .map(|target_dir| PathBuf::from(target_dir).join(&build_type))
-        .unwrap_or_else(|| root().join(format!("target/{}", &build_type)))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| root().join("target"))
+        .join(build_target)
+        .join(profile)
 }
 
 pub fn fixtures() -> PathBuf {

--- a/scripts/coverage-local.nu
+++ b/scripts/coverage-local.nu
@@ -45,7 +45,7 @@ let start = (date now)
 # Some of the internal tests rely on the exact cargo profile
 # (This is somewhat criminal itself)
 # but we have to signal to the tests that we use the `ci` `--profile`
-$env.NUSHELL_CARGO_TARGET = "ci"
+$env.NUSHELL_CARGO_PROFILE = "ci"
 
 # Manual gathering of coverage to catch invocation of the `nu` binary.
 # This is relevant for tests using the `nu!` macro from `nu-test-support`

--- a/scripts/coverage-local.sh
+++ b/scripts/coverage-local.sh
@@ -17,7 +17,7 @@ REPO_ROOT=$(dirname $DIR)
 # Some of the internal tests rely on the exact cargo profile
 # (This is somewhat criminal itself)
 # but we have to signal to the tests that we use the `ci` `--profile`
-export NUSHELL_CARGO_TARGET=ci
+export NUSHELL_CARGO_PROFILE=ci
 
 # Manual gathering of coverage to catch invocation of the `nu` binary.
 # This is relevant for tests using the `nu!` macro from `nu-test-support`

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -436,7 +436,7 @@ def compute-coverage [] {
 # - https://github.com/andythigpen/nvim-coverage (probably needs some additional config)
 export def cov [] {
     let start = (date now)
-    $env.NUSHELL_CARGO_TARGET = "ci"
+    $env.NUSHELL_CARGO_PROFILE = "ci"
 
     compute-coverage
 


### PR DESCRIPTION
# Description

* The path to the binaries for tests is slightly incorrect. It is missing the build target when it is set with the `CARGO_BUILD_TARGET` environment variable. For example, when `CARGO_BUILD_TARGET` is set to `aarch64-linux-android`, the path to the `nu` binary is:

  `./target/aarch64-linux-android/debug/nu`

  rather than

  `./target/debug/nu`

  This is common on Termux since the default target that rustc detects can cause problems on some projects, such as [python's `cryptography` package](https://github.com/pyca/cryptography/issues/7248).
  
  This technically isn't a problem specific to Android, but is more likely to happen on Android due to the latter.
* Additionally, the existing variable named `NUSHELL_CARGO_TARGET` is in fact the profile, not the build target, so this was renamed to `NUSHELL_CARGO_PROFILE`. This change is included because without the rename, the build system would be using `CARGO_BUILD_TARGET` for the build target and `NUSHELL_CARGO_TARGET` for the build profile, which is confusing.
* `std path add` tests were missing `android` test

# User-Facing Changes

For those who would like to build nushell on Termux, the unit tests will pass now.
