### PR TITLE
fix(nu-command): fix catching and ignoring fs related errors

### DIFF
--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -615,7 +615,10 @@ fn copy_file_with_update_flag_impl(progress: bool) {
 }
 
 #[test]
+#[cfg(not(windows))] // windows requires too much effort to replicate permission errors
 fn copy_shows_multiple_errors() {
+    use nu_test_support::{fs::Stub::EmptyFile, playground::Playground};
+
     Playground::setup("copy_shows_multiple_errors", |dirs, playground| {
         let files = ["test/test1.txt", "test/test2.txt"];
         playground

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -1,9 +1,4 @@
 use nu_test_support::nu;
-use nu_test_support::{
-    fs::{files_exist_at, Stub::EmptyFile},
-    pipeline,
-    playground::Playground,
-};
 
 #[test]
 fn capture_errors_works() {
@@ -120,7 +115,9 @@ fn capture_error_with_too_much_stdout_not_hang_nushell() {
 #[cfg(not(windows))]
 fn capture_error_with_both_stdout_stderr_messages_not_hang_nushell() {
     use nu_test_support::fs::Stub::FileWithContent;
+    use nu_test_support::pipeline;
     use nu_test_support::playground::Playground;
+
     Playground::setup(
         "external with many stdout and stderr messages",
         |dirs, sandbox| {
@@ -159,7 +156,13 @@ fn ignore_error_works_with_list_stream() {
 }
 
 #[test]
+#[cfg(not(windows))] // windows requires too much effort to replicate permission errors
 fn ignore_fs_related_errors() {
+    use nu_test_support::{
+        fs::{files_exist_at, Stub::EmptyFile},
+        playground::Playground,
+    };
+
     Playground::setup("ignore_fs_related_errors", |dirs, playground| {
         let file_names = vec!["test1.txt", "test2.txt", "test3.txt"];
 

--- a/crates/nu-command/tests/commands/mkdir.rs
+++ b/crates/nu-command/tests/commands/mkdir.rs
@@ -123,3 +123,71 @@ fn creates_directory_three_dots_quotation_marks() {
         assert!(expected.exists());
     })
 }
+
+#[test]
+fn mkdir_shows_multiple_errors() {
+    Playground::setup("mkdir_shows_multiple_errors", |dirs, playground| {
+        playground.mkdir("test");
+
+        let test_root = dirs.test();
+        let test_dir = test_root.join("test");
+
+        let mut test_dir_permissions = playground.permissions(&test_dir);
+
+        test_dir_permissions.set_readonly(true);
+        test_dir_permissions.apply().unwrap();
+
+        let actual = nu!(cwd: test_root, "mkdir test/test1 test/test2 test3");
+
+        assert!(
+            actual.err.contains("Could not create some directories"),
+            "should show generic error message"
+        );
+
+        assert!(
+            actual.err.contains(&format!(
+                "failed to create directory {}: Permission denied",
+                test_dir.join("test1").to_string_lossy()
+            )),
+            "permissions error"
+        );
+        assert!(
+            actual.err.contains(&format!(
+                "failed to create directory {}: Permission denied",
+                test_dir.join("test2").to_string_lossy()
+            )),
+            "permissions error"
+        );
+
+        // despite errors for some entries directories that is allowed should be created
+        assert!(
+            test_root.join("test3").exists(),
+            "directory should be created"
+        );
+    });
+}
+
+#[test]
+fn mkdir_verbose() {
+    Playground::setup("mkdir_verbose", |dirs, _playground| {
+        let test_root = dirs.test();
+
+        let actual = nu!(cwd: test_root, "mkdir --verbose test1 test2");
+
+        assert!(
+            actual.err.contains(&format!(
+                "Created dir {}",
+                test_root.join("test1").to_string_lossy()
+            )),
+            "should show verbose info on creating directory"
+        );
+
+        assert!(
+            actual.err.contains(&format!(
+                "Created dir {}",
+                test_root.join("test2").to_string_lossy()
+            )),
+            "should show verbose info on creating directory"
+        );
+    });
+}

--- a/crates/nu-command/tests/commands/mkdir.rs
+++ b/crates/nu-command/tests/commands/mkdir.rs
@@ -125,7 +125,10 @@ fn creates_directory_three_dots_quotation_marks() {
 }
 
 #[test]
+#[cfg(not(windows))] // windows requires too much effort to replicate permission errors
 fn mkdir_shows_multiple_errors() {
+    use nu_test_support::playground::Playground;
+
     Playground::setup("mkdir_shows_multiple_errors", |dirs, playground| {
         playground.mkdir("test");
 

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -493,7 +493,10 @@ fn mv_with_update_flag() {
 }
 
 #[test]
+#[cfg(not(windows))] // windows requires too much effort to replicate permission errors
 fn move_shows_multiple_errors() {
+    use nu_test_support::{fs::Stub::EmptyFile, playground::Playground};
+
     Playground::setup("move_shows_multiple_errors", |dirs, playground| {
         let files = ["test1.txt", "test2.txt"];
         playground

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -491,3 +491,79 @@ fn mv_with_update_flag() {
         assert_eq!(actual.out, "newest_body");
     });
 }
+
+#[test]
+fn move_shows_multiple_errors() {
+    Playground::setup("move_shows_multiple_errors", |dirs, playground| {
+        let files = ["test1.txt", "test2.txt"];
+        playground
+            .mkdir("test")
+            .mkdir("target")
+            .with_files(files.into_iter().map(EmptyFile).collect());
+
+        let test_root = dirs.test();
+        let target_dir = test_root.join("target");
+
+        let mut target_dir_permissions = playground.permissions(&target_dir);
+
+        target_dir_permissions.set_readonly(true);
+        target_dir_permissions.apply().unwrap();
+
+        let actual = nu!(cwd: test_root, "mv test*.txt target");
+
+        assert!(
+            actual
+                .err
+                .contains("Could not move some files or directories"),
+            "should show generic error message"
+        );
+        assert!(
+            actual.err.contains(&format!(
+                "Could not move \"{}\"",
+                test_root.join("test1.txt").to_string_lossy()
+            )),
+            "permissions error"
+        );
+        assert!(
+            actual.err.contains(&format!(
+                "Could not move \"{}\"",
+                test_root.join("test2.txt").to_string_lossy()
+            )),
+            "permissions error"
+        );
+    });
+}
+
+#[test]
+fn move_verbose() {
+    Playground::setup("move_verbose", |dirs, playground| {
+        let files = ["test1.txt", "test2.txt"];
+
+        playground
+            .mkdir("target")
+            .with_files(files.into_iter().map(EmptyFile).collect());
+
+        let test_root = dirs.test();
+        let target_dir = test_root.join("target");
+
+        let actual = nu!(cwd: test_root, "mv --verbose test*.txt target");
+
+        assert!(
+            actual.err.contains(&format!(
+                "moved {} to {}",
+                test_root.join("test1.txt").to_string_lossy(),
+                target_dir.to_string_lossy()
+            )),
+            "should show verbose info on copying file"
+        );
+
+        assert!(
+            actual.err.contains(&format!(
+                "moved {} to {}",
+                test_root.join("test2.txt").to_string_lossy(),
+                target_dir.to_string_lossy()
+            )),
+            "should show verbose info on copying file"
+        );
+    });
+}

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -413,7 +413,10 @@ fn rm_prints_filenames_on_error() {
 }
 
 #[test]
+#[cfg(not(windows))] // windows requires too much effort to replicate permission errors
 fn rm_shows_multiple_errors() {
+    use nu_test_support::{fs::Stub::EmptyFile, playground::Playground};
+
     Playground::setup("rm_shows_multiple_errors", |dirs, playground| {
         let files = [
             "test.txt",

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -1,8 +1,4 @@
 use nu_test_support::nu;
-use nu_test_support::{
-    fs::{files_exist_at, Stub::EmptyFile},
-    playground::Playground,
-};
 
 #[test]
 fn try_succeed() {
@@ -87,7 +83,13 @@ fn catch_block_can_use_error_object() {
 }
 
 #[test]
+#[cfg(not(windows))] // windows requires too much effort to replicate permission errors
 fn catch_fs_related_errors() {
+    use nu_test_support::{
+        fs::{files_exist_at, Stub::EmptyFile},
+        playground::Playground,
+    };
+
     Playground::setup("ignore_fs_related_errors", |dirs, playground| {
         let file_names = vec!["test1.txt", "test2.txt", "test3.txt"];
 

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -742,32 +742,6 @@ impl PipelineData {
         Ok(0)
     }
 
-    /// Consume and print self data immediately.
-    ///
-    /// Unlike [print] does not call `table` to format data and just prints it
-    /// one element on a line
-    /// * `no_newline` controls if we need to attach newline character to output.
-    /// * `to_stderr` controls if data is output to stderr, when the value is false, the data is output to stdout.
-    pub fn print_not_formatted(
-        self,
-        engine_state: &EngineState,
-        no_newline: bool,
-        to_stderr: bool,
-    ) -> Result<i64, ShellError> {
-        if let PipelineData::ExternalStream {
-            stdout: stream,
-            stderr: stderr_stream,
-            exit_code,
-            ..
-        } = self
-        {
-            print_if_stream(stream, stderr_stream, to_stderr, exit_code)
-        } else {
-            let config = engine_state.get_config();
-            self.write_all_and_flush(engine_state, config, no_newline, to_stderr)
-        }
-    }
-
     fn write_all_and_flush(
         self,
         engine_state: &EngineState,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
fixes https://github.com/nushell/nushell/issues/9462

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Fixes issues with `do -i` and `try-catch` that couldn't catch fs related errors. The issue were introduced by the pr https://github.com/nushell/nushell/pull/8014 that changed the way how verbose output is generated for fs commands.

This pr changes the way the problem pr is implemented - instead of filtering out unnecessary values from the pipeline_data fs commands now outputting verbose info by themselves and returning generic error in case of any errors.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Changes slightly how errors are generated for fs commands but it is more about visual comprehensions of commands
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
no action is required
