### PR TITLE
Make `append`/`prepend` consistent for ranges

### DIFF
--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -3,7 +3,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, Span, SyntaxShape, Type, Value,
+    Signature, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -42,80 +42,65 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             Example {
                 example: "[0 1 2 3] | append 4",
                 description: "Append one integer to a list",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                        Value::test_int(4),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(4),
+                ])),
             },
             Example {
                 example: "0 | append [1 2 3]",
                 description: "Append a list to an item",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                ])),
             },
             Example {
                 example: r#""a" | append ["b"] "#,
                 description: "Append a list of string to a string",
-                result: Some(Value::list(
-                    vec![Value::test_string("a"), Value::test_string("b")],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_string("a"),
+                    Value::test_string("b"),
+                ])),
             },
             Example {
                 example: "[0 1] | append [2 3 4]",
                 description: "Append three integer items",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                        Value::test_int(4),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(4),
+                ])),
             },
             Example {
                 example: "[0 1] | append [2 nu 4 shell]",
                 description: "Append integers and strings",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_string("nu"),
-                        Value::test_int(4),
-                        Value::test_string("shell"),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_string("nu"),
+                    Value::test_int(4),
+                    Value::test_string("shell"),
+                ])),
             },
             Example {
                 example: "[0 1] | append 2..4",
                 description: "Append a range of integers to a list",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                        Value::test_int(4),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(4),
+                ])),
             },
         ]
     }

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -2,8 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
-    SyntaxShape, Type, Value,
+    Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
+    Signature, Span, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -40,7 +40,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[0,1,2,3] | append 4",
+                example: "[0 1 2 3] | append 4",
                 description: "Append one integer to a list",
                 result: Some(Value::list(
                     vec![
@@ -75,7 +75,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
                 )),
             },
             Example {
-                example: "[0,1] | append [2,3,4]",
+                example: "[0 1] | append [2 3 4]",
                 description: "Append three integer items",
                 result: Some(Value::list(
                     vec![
@@ -89,7 +89,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
                 )),
             },
             Example {
-                example: "[0,1] | append [2,nu,4,shell]",
+                example: "[0 1] | append [2 nu 4 shell]",
                 description: "Append integers and strings",
                 result: Some(Value::list(
                     vec![
@@ -99,6 +99,20 @@ only unwrap the outer list, and leave the variable's contents untouched."#
                         Value::test_string("nu"),
                         Value::test_int(4),
                         Value::test_string("shell"),
+                    ],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                example: "[0 1] | append 2..4",
+                description: "Append a range of integers to a list",
+                result: Some(Value::list(
+                    vec![
+                        Value::test_int(0),
+                        Value::test_int(1),
+                        Value::test_int(2),
+                        Value::test_int(3),
+                        Value::test_int(4),
                     ],
                     Span::test_data(),
                 )),
@@ -113,32 +127,14 @@ only unwrap the outer list, and leave the variable's contents untouched."#
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let val: Value = call.req(engine_state, stack, 0)?;
-        let vec: Vec<Value> = process_value(val);
+        let other: Value = call.req(engine_state, stack, 0)?;
         let metadata = input.metadata();
 
         Ok(input
             .into_iter()
-            .chain(vec)
+            .chain(other.into_pipeline_data())
             .into_pipeline_data(engine_state.ctrlc.clone())
             .set_metadata(metadata))
-    }
-}
-
-fn process_value(val: Value) -> Vec<Value> {
-    match val {
-        Value::List {
-            vals: input_vals, ..
-        } => {
-            let mut output = vec![];
-            for input_val in input_vals {
-                output.push(input_val);
-            }
-            output
-        }
-        _ => {
-            vec![val]
-        }
     }
 }
 

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -3,7 +3,7 @@ use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
-    Signature, Span, SyntaxShape, Type, Value,
+    Signature, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -45,81 +45,66 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             Example {
                 example: "0 | prepend [1 2 3]",
                 description: "prepend a list to an item",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                        Value::test_int(0),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(0),
+                ])),
             },
             Example {
                 example: r#""a" | prepend ["b"] "#,
                 description: "Prepend a list of strings to a string",
-                result: Some(Value::list(
-                    vec![Value::test_string("b"), Value::test_string("a")],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_string("b"),
+                    Value::test_string("a"),
+                ])),
             },
             Example {
                 example: "[1 2 3 4] | prepend 0",
                 description: "Prepend one integer item",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                        Value::test_int(4),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(4),
+                ])),
             },
             Example {
                 example: "[2 3 4] | prepend [0 1]",
                 description: "Prepend two integer items",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                        Value::test_int(4),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(4),
+                ])),
             },
             Example {
                 example: "[2 nu 4 shell] | prepend [0 1 rocks]",
                 description: "Prepend integers and strings",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_string("rocks"),
-                        Value::test_int(2),
-                        Value::test_string("nu"),
-                        Value::test_int(4),
-                        Value::test_string("shell"),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_string("rocks"),
+                    Value::test_int(2),
+                    Value::test_string("nu"),
+                    Value::test_int(4),
+                    Value::test_string("shell"),
+                ])),
             },
             Example {
                 example: "[3 4] | prepend 0..2",
                 description: "Prepend a range",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                        Value::test_int(4),
-                    ],
-                    Span::test_data(),
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
+                    Value::test_int(4),
+                ])),
             },
         ]
     }


### PR DESCRIPTION
# Description
This PR makes `append` more consistent, in particular, it allows you to work with ranges. Previously, you couldn't append a list by range:
```nu
> 0..1 | append 2..4
╭──────╮
│    0 │
│    1 │
│ 2..4 │
╰──────╯
```

Now it works:
```nu
> 0..1 | append 2..4
╭───╮
│ 0 │
│ 1 │
│ 2 │
│ 3 │
│ 4 │
╰───╯
```

# User-Facing Changes
If someone needs the old behavior, then it can be obtained like this:
```nu
> 0..1 | append [2..4]
╭──────╮
│    0 │
│    1 │
│ 2..4 │
╰──────╯
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
