### PR TITLE
return error when user break sleep by ctrl-c

### DIFF
--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -62,7 +62,7 @@ impl Command for Sleep {
             }
 
             if nu_utils::ctrl_c::was_pressed(ctrlc_ref) {
-                break;
+                return Err(ShellError::SleepBreaked);
             }
         }
 

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -62,7 +62,9 @@ impl Command for Sleep {
             }
 
             if nu_utils::ctrl_c::was_pressed(ctrlc_ref) {
-                return Err(ShellError::SleepBreaked);
+                return Err(ShellError::InterruptedByUser {
+                    span: Some(call.head),
+                });
             }
         }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1006,6 +1006,11 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::non_unicode_input))]
     NonUnicodeInput,
 
+    /// Sleep is breaked.
+    #[error("Sleep is breaked.")]
+    #[diagnostic(code(nu::shell::sleep_breaked))]
+    SleepBreaked,
+
     /// Unexpected abbr component.
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1006,11 +1006,6 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::non_unicode_input))]
     NonUnicodeInput,
 
-    /// Sleep is breaked.
-    #[error("Sleep is breaked.")]
-    #[diagnostic(code(nu::shell::sleep_breaked))]
-    SleepBreaked,
-
     /// Unexpected abbr component.
     ///
     /// ## Resolution


### PR DESCRIPTION
# Description

Closes: #10218
I think this is `sleep`'s specific issue, it's because it always return a `Value::nothing` where it's interrupted by `ctrl-c`.

To fix the issue, I'd propose to make it returns Err(ShellError)

This is how it behaves:
```nushell
❯ sleep 5sec; echo "hello!"
^CError: nu::shell::sleep_breaked

  × Sleep is breaked.

❯ sleep 5sec; ^echo "hello!"
^CError: nu::shell::sleep_breaked

  × Sleep is breaked.
```
# User-Facing Changes
None

# Tests + Formatting


# After Submitting
