### PR TITLE
fix input --until-bytes: now stops at any of given bytes

### DIFF
--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -5,7 +5,6 @@ use crossterm::{
     style::Print,
     terminal::{self, ClearType},
 };
-use itertools::Itertools;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -116,7 +115,7 @@ impl Command for Input {
                                 }
 
                                 if let Some(bytes_until) = bytes_until.as_ref() {
-                                    if bytes_until.bytes().contains(&(c as u8)) {
+                                    if bytes_until.contains(c) {
                                         break;
                                     }
                                 }

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -64,7 +64,7 @@ impl Command for Input {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let prompt: Option<String> = call.opt(engine_state, stack, 0)?;
-        let bytes_until: Option<String> = call.get_flag(engine_state, stack, "bytes-until")?;
+        let bytes_until: Option<String> = call.get_flag(engine_state, stack, "bytes-until-any")?;
         let suppress_output = call.has_flag("suppress-output");
         let numchar: Option<Spanned<i64>> = call.get_flag(engine_state, stack, "numchar")?;
         let numchar: Spanned<i64> = numchar.unwrap_or(Spanned {

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -42,7 +42,7 @@ impl Command for Input {
             .named(
                 "bytes-until",
                 SyntaxShape::String,
-                "read bytes (not text) until a stop byte",
+                "read bytes (not text) until any of the given stop bytes is seen",
                 Some('u'),
             )
             .named(

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -5,6 +5,7 @@ use crossterm::{
     style::Print,
     terminal::{self, ClearType},
 };
+use itertools::Itertools;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -80,19 +81,6 @@ impl Command for Input {
             ));
         }
 
-        let byte_until = if let Some(bytes_until) = bytes_until {
-            if let Some(c) = bytes_until.bytes().next() {
-                Some(c)
-            } else {
-                let _ = crossterm::terminal::disable_raw_mode();
-                return Err(ShellError::IOError(
-                    "input can't stop on this byte".to_string(),
-                ));
-            }
-        } else {
-            None
-        };
-
         if let Some(prompt) = &prompt {
             print!("{prompt}");
             let _ = std::io::stdout().flush();
@@ -127,8 +115,8 @@ impl Command for Input {
                                     continue;
                                 }
 
-                                if let Some(byte_until) = byte_until {
-                                    if c == byte_until as char {
+                                if let Some(bytes_until) = bytes_until.as_ref() {
+                                    if bytes_until.bytes().contains(&(c as u8)) {
                                         break;
                                     }
                                 }

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -5,6 +5,7 @@ use crossterm::{
     style::Print,
     terminal::{self, ClearType},
 };
+use itertools::Itertools;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -115,7 +116,7 @@ impl Command for Input {
                                 }
 
                                 if let Some(bytes_until) = bytes_until.as_ref() {
-                                    if bytes_until.contains(c) {
+                                    if bytes_until.bytes().contains(&(c as u8)) {
                                         break;
                                     }
                                 }

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -41,7 +41,7 @@ impl Command for Input {
             .allow_variants_without_examples(true)
             .optional("prompt", SyntaxShape::String, "prompt to show the user")
             .named(
-                "bytes-until",
+                "bytes-until-any",
                 SyntaxShape::String,
                 "read bytes (not text) until any of the given stop bytes is seen",
                 Some('u'),


### PR DESCRIPTION
- this PR should close #10197

# Description
`input --bytes-until` takes a string but used to only terminate on the first byte of that string. Now it checks for each byte in the string.

# User-Facing Changes
all of the above. No change in documentation needed. New behavior arguably fits better.

# Tests + Formatting
don't know how to test input
