### PR TITLE
Tweak contributor image to include more users

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Please submit an issue or PR to be added to this list.
 See [Contributing](CONTRIBUTING.md) for details. Thanks to all the people who already contributed!
 
 <a href="https://github.com/nushell/nushell/graphs/contributors">
-  <img src="https://contributors-img.web.app/image?repo=nushell/nushell&max=500" />
+  <img src="https://contributors-img.web.app/image?repo=nushell/nushell&max=600" />
 </a>
 
 ## License


### PR DESCRIPTION
We previously had a limit of 500 users but we are well past that