### PR TITLE
fix default after an empty where

### DIFF
--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -2,7 +2,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned,
+    SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
@@ -114,6 +115,8 @@ fn default(
             },
             ctrlc,
         )
+    } else if input.is_nothing() {
+        Ok(value.into_pipeline_data())
     } else {
         input.map(
             move |item| match item {

--- a/crates/nu-command/tests/commands/default.rs
+++ b/crates/nu-command/tests/commands/default.rs
@@ -33,3 +33,10 @@ fn adds_row_data_if_column_missing() {
         assert_eq!(actual.out, "2");
     });
 }
+
+#[test]
+fn default_after_empty_filter() {
+    let actual = nu!("[a b] | where $it == 'c' | last | default 'd'");
+
+    assert_eq!(actual.out, "d");
+}


### PR DESCRIPTION
should close https://github.com/nushell/nushell/issues/10237

# Description
this is @fdncred's findings :yum: 
i just made the PR :relieved: 

# User-Facing Changes
```nushell
[a b] | where $it == 'c' | last | default 'd'
```
now works and gives `d`


# Tests + Formatting
adds a new `default_after_empty_filter` test.

# After Submitting