### PR TITLE
Allow escaping glob with `\` in `nu-glob`

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -98,9 +98,9 @@ impl Command for Ls {
         };
 
         let (path, p_tag, absolute_path) = match pattern_arg {
-            Some(p) => {
-                let p_tag = p.span;
-                let mut p = expand_to_real_path(p.item);
+            Some(pat) => {
+                let p_tag = pat.span;
+                let mut p = expand_to_real_path(&pat.item);
 
                 let expanded = nu_path::expand_path_with(&p, &cwd);
                 // Avoid checking and pushing "*" to the path when directory (do not show contents) flag is true
@@ -128,7 +128,7 @@ impl Command for Ls {
                             Vec::new(),
                         ));
                     }
-                    if is_empty_dir(&expanded) {
+                    if !nu_engine::has_glob_chars(&pat.item) && is_empty_dir(&expanded) {
                         return Ok(Value::list(vec![], call_span).into_pipeline_data());
                     }
                     p.push("*");

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -56,11 +56,14 @@ fn lists_regular_files_in_special_folder() {
             .mkdir("abcd")
             .mkdir("abcd/*")
             .mkdir("abcd/?")
+            .mkdir("\\abcd")
             .with_files(vec![EmptyFile("[abcd]/test.txt")])
             .with_files(vec![EmptyFile("abcd]/test.txt")])
             .with_files(vec![EmptyFile("abcd/*/test.txt")])
             .with_files(vec![EmptyFile("abcd/?/test.txt")])
             .with_files(vec![EmptyFile("abcd/?/test2.txt")]);
+            .with_files(vec![EmptyFile("\\abcd/test.txt")]);
+            .with_files(vec![EmptyFile("\\abcd/test2.txt")]);
 
         let actual = nu!(
             cwd: dirs.test().join("abcd]"), format!(r#"ls | length"#));
@@ -92,6 +95,9 @@ fn lists_regular_files_in_special_folder() {
         let actual = nu!(
             cwd: dirs.test().join("abcd/?"), format!(r#"ls ../* | length"#));
         assert_eq!(actual.out, "3");
+        let actual = nu!(
+            cwd: dirs.test().join("\\abcd"), format!(r#"ls ../* | length"#));
+        assert_eq!(actual.out, "2");
     })
 }
 
@@ -110,6 +116,8 @@ fn lists_regular_files_in_special_folder() {
 #[case("?bcd/[xy]y.t?t", 2)]
 #[case("[[]abcd[]].txt", 1)]
 #[case("[[]?bcd[]].txt", 2)]
+#[case("\\[abcd\\].txt", 1)]
+#[case("\\[?bcd\\].txt", 2)]
 #[case("??bcd[]].txt", 2)]
 #[case("??bcd].txt", 2)]
 #[case("[[]?bcd].txt", 2)]

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -96,7 +96,7 @@ fn lists_regular_files_in_special_folder() {
             cwd: dirs.test().join("abcd/?"), format!(r#"ls ../* | length"#));
         assert_eq!(actual.out, "3");
         let actual = nu!(
-            cwd: dirs.test().join("\\abcd"), format!(r#"ls ../* | length"#));
+            cwd: dirs.test().join("\\abcd"), format!(r#"ls | length"#));
         assert_eq!(actual.out, "2");
     })
 }

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -61,8 +61,8 @@ fn lists_regular_files_in_special_folder() {
             .with_files(vec![EmptyFile("abcd]/test.txt")])
             .with_files(vec![EmptyFile("abcd/*/test.txt")])
             .with_files(vec![EmptyFile("abcd/?/test.txt")])
-            .with_files(vec![EmptyFile("abcd/?/test2.txt")]);
-            .with_files(vec![EmptyFile("\\abcd/test.txt")]);
+            .with_files(vec![EmptyFile("abcd/?/test2.txt")])
+            .with_files(vec![EmptyFile("\\abcd/test.txt")])
             .with_files(vec![EmptyFile("\\abcd/test2.txt")]);
 
         let actual = nu!(

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -9,6 +9,10 @@ use nu_protocol::{ShellError, Span, Spanned};
 
 const GLOB_CHARS: &[char] = &['*', '?', '['];
 
+pub fn has_glob_chars(s: &str) -> bool {
+    s.contains(GLOB_CHARS)
+}
+
 /// This function is like `nu_glob::glob` from the `glob` crate, except it is relative to a given cwd.
 ///
 /// It returns a tuple of two values: the first is an optional prefix that the expanded filenames share.
@@ -29,7 +33,7 @@ pub fn glob_from(
     ),
     ShellError,
 > {
-    let (prefix, pattern) = if pattern.item.contains(GLOB_CHARS) {
+    let (prefix, pattern) = if has_glob_chars(&pattern.item) {
         // Pattern contains glob, split it
         let mut p = PathBuf::new();
         let path = PathBuf::from(&pattern.item);
@@ -38,7 +42,7 @@ pub fn glob_from(
 
         for c in components {
             if let Component::Normal(os) = c {
-                if os.to_string_lossy().contains(GLOB_CHARS) {
+                if has_glob_chars(&os.to_string_lossy()) {
                     break;
                 }
             }

--- a/crates/nu-engine/src/lib.rs
+++ b/crates/nu-engine/src/lib.rs
@@ -14,4 +14,4 @@ pub use eval::{
     eval_block, eval_block_with_early_return, eval_call, eval_expression,
     eval_expression_with_input, eval_subexpression, eval_variable, redirect_env,
 };
-pub use glob_from::glob_from;
+pub use glob_from::{glob_from, has_glob_chars};

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -562,7 +562,8 @@ const ERROR_WILDCARDS: &str = "wildcards are either regular `*` or recursive `**
 const ERROR_RECURSIVE_WILDCARDS: &str = "recursive wildcards must form a single path \
                                          component";
 const ERROR_INVALID_RANGE: &str = "invalid range pattern";
-const ERROR_INVALID_ESCAPE: &str = "invalid escapeo, '\\' can only be used to escape '\\', '*', '?', '[', ']'";
+const ERROR_INVALID_ESCAPE: &str =
+    "invalid escapeo, '\\' can only be used to escape '\\', '*', '?', '[', ']'";
 
 impl Pattern {
     /// This function compiles Unix shell style patterns.
@@ -669,12 +670,14 @@ impl Pattern {
                     });
                 }
                 '\\' => {
-                    match chars[i+1] {
+                    match chars[i + 1] {
                         '\\' | '*' | '?' | '[' | ']' => tokens.push(Char(chars[i + 1])),
-                        _ => return Err(PatternError {
-                            pos: i,
-                            msg: ERROR_INVALID_ESCAPE,
-                        }),
+                        _ => {
+                            return Err(PatternError {
+                                pos: i,
+                                msg: ERROR_INVALID_ESCAPE,
+                            })
+                        }
                     };
                     i += 2;
                 }
@@ -1340,7 +1343,9 @@ mod test {
         assert!(Pattern::new("\\n").is_err());
         assert!(Pattern::new("\\t").is_err());
         assert!(Pattern::new("\\\\test").unwrap().matches("\\test"));
-        assert!(Pattern::new("\\[test\\]\\*\\?").unwrap().matches("[test]*?"));
+        assert!(Pattern::new("\\[test\\]\\*\\?")
+            .unwrap()
+            .matches("[test]*?"));
     }
 
     #[test]

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -704,14 +704,10 @@ impl Pattern {
             match c {
                 // note that ! does not need escaping because it is only special
                 // inside brackets
-                '?' | '*' | '[' | ']' => {
+                '?' | '*' | '[' | ']' | '\\' => {
                     escaped.push('[');
                     escaped.push(c);
                     escaped.push(']');
-                }
-                '\\' => {
-                    escaped.push('\\');
-                    escaped.push('\\');
                 }
                 c => {
                     escaped.push(c);

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -1347,7 +1347,7 @@ mod test {
     #[test]
     fn test_pattern_escape() {
         let s = "_[_]_?_*_!_\\";
-        assert_eq!(Pattern::escape(s), "_[[]_[]]_[?]_[*]_!_\\\\".to_string());
+        assert_eq!(Pattern::escape(s), "_[[]_[]]_[?]_[*]_!_[\\]".to_string());
         assert!(Pattern::new(&Pattern::escape(s)).unwrap().matches(s));
     }
 

--- a/crates/nu-glob/src/lib.rs
+++ b/crates/nu-glob/src/lib.rs
@@ -704,10 +704,14 @@ impl Pattern {
             match c {
                 // note that ! does not need escaping because it is only special
                 // inside brackets
-                '?' | '*' | '[' | ']' | '\\' => {
+                '?' | '*' | '[' | ']' => {
                     escaped.push('[');
                     escaped.push(c);
                     escaped.push(']');
+                }
+                '\\' => {
+                    escaped.push('\\');
+                    escaped.push('\\');
                 }
                 c => {
                     escaped.push(c);
@@ -1347,7 +1351,7 @@ mod test {
     #[test]
     fn test_pattern_escape() {
         let s = "_[_]_?_*_!_\\";
-        assert_eq!(Pattern::escape(s), "_[[]_[]]_[?]_[*]_!_[\\]".to_string());
+        assert_eq!(Pattern::escape(s), "_[[]_[]]_[?]_[*]_!_\\\\".to_string());
         assert!(Pattern::new(&Pattern::escape(s)).unwrap().matches(s));
     }
 


### PR DESCRIPTION
Related: https://github.com/nushell/nushell/issues/10244

# Description

1. Current `nu-glob` only escape glob chars with `[]`, this pr also allows `\` to escape them. e.g.

    ```bash 
    ls \*   # list folder `*`
    ls \?  # list folder `?`
    ls \[test\]  # list folder `[test]`
    ```

    and user can still use `[[]`, `[*]` to escape glob chars.

2. `ls` is more consistent for folder with glob chars, e.g.

    ```bash
    mkdir *
    ls *  # now with list all files under current folder
    ls \* # only list fold `*`
    ```


# User-Facing Changes

User can use either to escape '[', '*', '?':

- `ls \[test\]`
- `ls [[]test[]]`

Notice: In current implementation, `\` need to be escaped ONLY when used with glob, for example

This is a glob, so it should be escaped:

<img width="470" alt="escape" src="https://github.com/nushell/nushell/assets/1991933/a447ea2f-6900-46c6-8ccb-abc49b45d013">

But this is not, it's just a raw path string, no `\` does not need to be escaped:

<img width="475" alt="raw path" src="https://github.com/nushell/nushell/assets/1991933/8c063542-b818-4e33-b461-dd5bf33bf235">

Should `\` always need to be escaped?

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

As mentioned in https://github.com/nushell/nushell/issues/10244, it'll be better to have some documentation about how to use nu-glob.