### PR TITLE
Keep order for `par-each`

### DIFF
--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -69,6 +69,13 @@ impl Command for ParEach {
                 ])),
             },
             Example {
+                example: r#"1..3 | enumerate | par-each {|p| update item ($p.item * 2)} | sort-by item | get item"#,
+                description: "Enumerate and sort-by can be used to reconstruct the original order",
+                result: Some(Value::test_list(
+                    vec![Value::test_int(2), Value::test_int(4), Value::test_int(6)]
+                )),
+            },
+            Example {
                 example: r#"[foo bar baz] | par-each {|e| $e + '!' } | sort"#,
                 description: "Output can still be sorted afterward",
                 result: Some(Value::test_list(vec![

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -71,9 +71,11 @@ impl Command for ParEach {
             Example {
                 example: r#"1..3 | enumerate | par-each {|p| update item ($p.item * 2)} | sort-by item | get item"#,
                 description: "Enumerate and sort-by can be used to reconstruct the original order",
-                result: Some(Value::test_list(
-                    vec![Value::test_int(2), Value::test_int(4), Value::test_int(6)]
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(2),
+                    Value::test_int(4),
+                    Value::test_int(6),
+                ])),
             },
             Example {
                 example: r#"[foo bar baz] | par-each {|e| $e + '!' } | sort"#,

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -54,10 +54,19 @@ impl Command for ParEach {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "[1 2 3] | par-each {|| 2 * $in }",
+                example: "[1 2 3] | par-each {|e| $e * 2 }",
                 description:
                     "Multiplies each number. Note that the list will become arbitrarily disordered.",
                 result: None,
+            },
+            Example {
+                example: r#"[1 2 3] | par-each -k {|e| $e * 2 }"#,
+                description: "Multiplies each number, keeping an original order",
+                result: Some(Value::test_list(vec![
+                    Value::test_int(2),
+                    Value::test_int(4),
+                    Value::test_int(6),
+                ])),
             },
             Example {
                 example: r#"[foo bar baz] | par-each {|e| $e + '!' } | sort"#,
@@ -66,18 +75,6 @@ impl Command for ParEach {
                     Value::test_string("bar!"),
                     Value::test_string("baz!"),
                     Value::test_string("foo!"),
-                ])),
-            },
-            Example {
-                example: r#"1..6 | par-each -k {|| 2 * $in }"#,
-                description: "Multiplies each number, keeping an original order",
-                result: Some(Value::test_list(vec![
-                    Value::test_int(2),
-                    Value::test_int(4),
-                    Value::test_int(6),
-                    Value::test_int(8),
-                    Value::test_int(10),
-                    Value::test_int(12),
                 ])),
             },
             Example {

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -60,7 +60,7 @@ impl Command for ParEach {
                 result: None,
             },
             Example {
-                example: r#"[1 2 3] | par-each -k {|e| $e * 2 }"#,
+                example: r#"[1 2 3] | par-each --keep-order {|e| $e * 2 }"#,
                 description: "Multiplies each number, keeping an original order",
                 result: Some(Value::test_list(vec![
                     Value::test_int(2),


### PR DESCRIPTION
# Description
This PR adds new flag `--keep-order/-k` for the `par_each` filter. This flag keeps sequence of output same as the order of input.

Output without the flag:
```nu
> 1..6 | par-each {|n| $n * 2 }
╭────╮
│  4 │
│ 10 │
│  2 │
│  8 │
│ 12 │
│  6 │
╰────╯
```

Output with the `--keep-order` flag:
```nu
> 1..6 | par-each --keep-order {|n| $n * 2 }
╭────╮
│  2 │
│  4 │
│  6 │
│  8 │
│ 10 │
│ 12 │
╰────╯
```

I think the presence of this flag is justified, since:
- Much easier to use than `.. | enumerate | par-each {|p| update item ..} | sort-by index | get item`
- Faster, as it uses internally parallel sorting in the same thread pool

A note about naming: it may conflict with `--keep-empty/-k` flag of the `each` filter if the same feature will be used in `par-each`, so maybe it needs some other name.