### PR TITLE
allow `--login` to be used with nu's `--commands` parameter

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -35,6 +35,7 @@ pub(crate) fn run_commands(
             parsed_nu_cli_args.plugin_file,
             NUSHELL_FOLDER,
         );
+
         perf(
             "read plugins",
             start_time,
@@ -45,8 +46,8 @@ pub(crate) fn run_commands(
         );
 
         let start_time = std::time::Instant::now();
-        // only want to load config and env if relative argument is provided.
-        if parsed_nu_cli_args.env_file.is_some() {
+        // If we have a env file parameter *OR* we have a login shell parameter, read the env file
+        if parsed_nu_cli_args.env_file.is_some() || parsed_nu_cli_args.login_shell.is_some() {
             config_files::read_config_file(
                 engine_state,
                 &mut stack,
@@ -56,6 +57,7 @@ pub(crate) fn run_commands(
         } else {
             config_files::read_default_env_file(engine_state, &mut stack)
         }
+
         perf(
             "read env.nu",
             start_time,
@@ -66,7 +68,8 @@ pub(crate) fn run_commands(
         );
 
         let start_time = std::time::Instant::now();
-        if parsed_nu_cli_args.config_file.is_some() {
+        // If we have a config file parameter *OR* we have a login shell parameter, read the config file
+        if parsed_nu_cli_args.config_file.is_some() || parsed_nu_cli_args.login_shell.is_some() {
             config_files::read_config_file(
                 engine_state,
                 &mut stack,
@@ -74,8 +77,24 @@ pub(crate) fn run_commands(
                 false,
             );
         }
+
         perf(
             "read config.nu",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
+
+        // If we have a login shell parameter, read the login file
+        let start_time = std::time::Instant::now();
+        if parsed_nu_cli_args.login_shell.is_some() {
+            config_files::read_loginshell_file(engine_state, &mut stack);
+        }
+
+        perf(
+            "read login.nu",
             start_time,
             file!(),
             line!(),


### PR DESCRIPTION
# Description

This PR allows the `--login`/`-l` parameter to be used with nushell's `--commands`/`-c` parameter. When you do this, since you're invoking it with the `-l` flag, nushell will load your env.nu, config.nu, and login.nu, in that order. Then it will proceed to run your commands. I think this provides a better quality of life when you want to run scripts with your personal config files as a login shell.


### Before (these entries are from the default_env.nu)
![image](https://github.com/nushell/nushell/assets/343840/ce7adcd0-419e-485c-b7d1-f11f162e8e9e)


### After (these entries are from my personal env.nu)
![image](https://github.com/nushell/nushell/assets/343840/33bbc06b-983c-4461-8274-290e4c712506)


closes https://github.com/nushell/nushell/issues/9833

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
