### PR TITLE
change LOG_FORMAT to NU_LOG_FORMAT in nu-std library

### DIFF
--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -31,7 +31,7 @@ export-env {
         "DEBUG": "D"
     }
 
-    $env.LOG_FORMAT = $"%ANSI_START%%DATE%|%LEVEL%|(ansi u)%MSG%%ANSI_STOP%"
+    $env.NU_LOG_FORMAT = $"%ANSI_START%%DATE%|%LEVEL%|(ansi u)%MSG%%ANSI_STOP%"
 }
 
 def log-types [] {
@@ -149,7 +149,7 @@ def handle-log [
     short: bool
 ] {
     let log_format = if ($format_string | is-empty) {
-        $env.LOG_FORMAT
+        $env.NU_LOG_FORMAT
     } else {
         $format_string
     }

--- a/crates/nu-std/tests/logger_tests/test_logger_env.nu
+++ b/crates/nu-std/tests/logger_tests/test_logger_env.nu
@@ -38,5 +38,5 @@ def env_log_short_prefix [] {
 
 #[test]
 def env_log_format [] {
-    assert equal $env.LOG_FORMAT $"%ANSI_START%%DATE%|%LEVEL%|(ansi u)%MSG%%ANSI_STOP%"
+    assert equal $env.NU_LOG_FORMAT $"%ANSI_START%%DATE%|%LEVEL%|(ansi u)%MSG%%ANSI_STOP%"
 }


### PR DESCRIPTION
this closes #10248 

@fdncred pointed out the problem and he was correct 😄 

I went ahead and made the simple change and the
https://github.com/influxdata/influxdb_iox binary
works like a charm...

@amtoine hopefully there are no issues with this change

I believe its a good one as other rust binaries might take advantage of this common
environment variable as well...
