### PR TITLE
Document that `open` looks up `from` subcommands

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -245,6 +245,11 @@ impl Command for Open {
                 example: "open myfile.txt --raw | decode utf-8",
                 result: None,
             },
+            Example {
+                description: "Create a custom `from` parser to open newline-delimited JSON files with `open`",
+                example: r#"def "from ndjson" [] { from json -o }; open myfile.ndjson"#,
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -30,6 +30,10 @@ impl Command for Open {
         "Load a file into a cell, converting to table if possible (avoid by appending '--raw')."
     }
 
+    fn extra_usage(&self) -> &str {
+        "Support to automatically parse files with an extension `.xyz` can be provided by a `from xyz` command in scope."
+    }
+
     fn search_terms(&self) -> Vec<&str> {
         vec!["load", "read", "load_file", "read_file"]
     }


### PR DESCRIPTION
# Description
Related to https://github.com/nushell/nushell.github.io/pull/1048

Include this information in the command help.


# User-Facing Changes
As soon as this information is documented people are much more likely to
depend on it so we need to be careful in the future if this design
sparks joy or not.

