### PR TITLE
Exit explore on ctrl+c/d/q

### DIFF
--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -793,14 +793,13 @@ fn handle_event<V: View>(
 }
 
 fn handle_exit_key_event(key: &KeyEvent) -> bool {
-    matches!(
-        key,
-        KeyEvent {
-            code: KeyCode::Char('z'),
-            modifiers: KeyModifiers::CONTROL,
-            ..
+    if key.modifiers == KeyModifiers::CONTROL {
+        // these are all common things people might try, might as well handle them all
+        if let KeyCode::Char('c') | KeyCode::Char('d') | KeyCode::Char('q') = key.code {
+            return true;
         }
-    )
+    }
+    false
 }
 
 fn handle_general_key_events1<V>(


### PR DESCRIPTION
Currently, `ctrl+z` is the command to exit `explore` no matter where you are in the UI. IMO this is a bit unintuitive since that's usually used to suspend a process.

After this change, `ctrl+c`, `ctrl+d`, and `ctrl+q` all work to exit `explore`.

I think these are all shortcuts that users might try when attempting to exit `explore`, and I think we might as well handle them all.