### PR TITLE
Remove `exit_esc` and `show_banner` config from `explore`

### DIFF
--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -77,9 +77,6 @@ impl Command for Explore {
         update_config(&mut config, show_index, show_head);
         prepare_default_config(&mut config);
 
-        let show_banner = is_need_banner(&config).unwrap_or(true);
-        let exit_esc = is_need_esc_exit(&config).unwrap_or(true);
-
         let style = style_from_config(&config);
 
         let lscolors = create_lscolors(engine_state, stack);
@@ -89,8 +86,6 @@ impl Command for Explore {
         config.reverse = is_reverse;
         config.peek_value = peek_value;
         config.reverse = is_reverse;
-        config.exit_esc = exit_esc;
-        config.show_banner = show_banner;
 
         let result = run_pager(engine_state, &mut stack.clone(), ctrlc, input, config);
 
@@ -129,16 +124,6 @@ impl Command for Explore {
             },
         ]
     }
-}
-
-// For now, this doesn't use StyleComputer.
-// As such, closures can't be given as styles for Explore.
-fn is_need_banner(config: &HashMap<String, Value>) -> Option<bool> {
-    config.get("help_banner").and_then(|v| v.as_bool().ok())
-}
-
-fn is_need_esc_exit(config: &HashMap<String, Value>) -> Option<bool> {
-    config.get("exit_esc").and_then(|v| v.as_bool().ok())
 }
 
 fn update_config(config: &mut HashMap<String, Value>, show_index: bool, show_head: bool) {

--- a/crates/nu-explore/src/lib.rs
+++ b/crates/nu-explore/src/lib.rs
@@ -50,9 +50,7 @@ fn run_pager(
         return p.run(engine_state, stack, ctrlc, information_view(), commands);
     }
 
-    if config.show_banner {
-        p.show_message("For help type :help");
-    }
+    p.show_message("For help type :help");
 
     if let Some(value) = has_simple_value(&data) {
         let text = value.into_abbreviated_string(config.nu_config);
@@ -145,9 +143,6 @@ fn create_config_command(commands: &[Command]) -> ConfigCmd {
     config.register_group(ConfigOption::new(GROUP, "Command bar background", "command_bar_background", default_color_list()));
 
     config.register_group(ConfigOption::new(GROUP, "Highlight color in search", "highlight", default_color_list()));
-
-    config.register_group(ConfigOption::boolean(GROUP, "Show help banner on open", "help_banner"));
-    config.register_group(ConfigOption::boolean(GROUP, "Pressing ESC causes a program exit", "exit_esc"));
 
     config
 }

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -109,14 +109,6 @@ impl<'a> Pager<'a> {
         let path = path.iter().map(|s| s.as_str()).collect::<Vec<_>>();
 
         match &path[..] {
-            ["exit_esc"] => {
-                if matches!(value, Value::Bool { .. }) {
-                    self.config.exit_esc = value.is_true();
-                    true
-                } else {
-                    false
-                }
-            }
             ["status_bar_text"] => value_as_style(&mut self.config.style.status_bar_text, &value),
             ["status_bar_background"] => {
                 value_as_style(&mut self.config.style.status_bar_background, &value)
@@ -171,9 +163,7 @@ pub struct PagerConfig<'a> {
     pub config: ConfigMap,
     pub style: StyleConfig,
     pub peek_value: bool,
-    pub exit_esc: bool,
     pub reverse: bool,
-    pub show_banner: bool,
 }
 
 impl<'a> PagerConfig<'a> {
@@ -189,9 +179,7 @@ impl<'a> PagerConfig<'a> {
             config,
             lscolors,
             peek_value: false,
-            exit_esc: true,
             reverse: false,
-            show_banner: false,
             style: StyleConfig::default(),
         }
     }
@@ -359,7 +347,7 @@ fn react_to_event_result(
             String::default(),
         ),
         Transition::Ok => {
-            let exit = view_stack.stack.is_empty() && pager.config.exit_esc;
+            let exit = view_stack.stack.is_empty();
             if exit {
                 return (
                     Some(peak_value_from_view(&mut view_stack.view, pager)),


### PR DESCRIPTION
Removing 2 underused config options from `explore`.

`show_banner` controls whether `For help type :help"` is shown in the message area when `explore is first launched. I don't think there's any good reason not to show it, it's not a modal dialog or anything.

`exit_esc` controls whether to exit `explore` when `esc` is pressed and we can't "go up" any further (or at least that's what it's supposed to do, looking at the code I'm not so sure). IMO we don't need to make this kind of basic interaction configurable unless there's a really good reason.

## Context

`explore` is complicated and we want to overhaul its design. It will be easier to make meaningful changes if `explore` is a little slimmer first, so I'm trying to pare back unused/underused code and config as a starting point.

I'm gonna be making more PRs like this, I'll try to keep them small+self-contained.