### PR TITLE
allow update to use metadata

### DIFF
--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -172,7 +172,7 @@ fn update(
                 },
                 ctrlc,
             )?
-            .set_metadata(mdclone.clone()))
+            .set_metadata(mdclone))
     } else {
         if let Some(PathMember::Int { val, span, .. }) = cell_path.members.get(0) {
             let mut input = input.into_iter();
@@ -198,7 +198,7 @@ fn update(
                 .into_iter()
                 .chain(vec![replacement])
                 .chain(input)
-                .into_pipeline_data_with_metadata(metadata.clone(), ctrlc));
+                .into_pipeline_data_with_metadata(metadata, ctrlc));
         }
         Ok(input
             .map(
@@ -214,7 +214,7 @@ fn update(
                 },
                 ctrlc,
             )?
-            .set_metadata(metadata.clone()))
+            .set_metadata(metadata))
     }
 }
 


### PR DESCRIPTION
# Description

This PR is an attempt to fix the `update` command so that it passes along metadata. I'm not really sure I did this right, so please feel free to point out where it's wrong.

The point is to be able to do something like this and have it respect your LS_COLORS.
```
ls | update modified { format date }
```
### Before
![image](https://github.com/nushell/nushell/assets/343840/fc3eb207-4f6f-42b1-b5a4-87a1fe194399)

### After
![image](https://github.com/nushell/nushell/assets/343840/19d58443-7c88-4dd6-9532-1f45f615ac7b)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
