### PR TITLE
Change `with_buffer_editor` to `with_buffer_editor_command`

### DIFF
--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -38,6 +38,7 @@ once_cell = "1.18"
 percent-encoding = "2"
 sysinfo = "0.29"
 unicode-segmentation = "1.10"
+uuid = { version = "1.4.1", features = ["v4"] }
 
 [features]
 plugin = []

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -5,7 +5,7 @@ use crate::{
     util::eval_source,
     NuHighlighter, NuValidator, NushellPrompt,
 };
-use crossterm::{cursor::SetCursorStyle};
+use crossterm::cursor::SetCursorStyle;
 use log::{trace, warn};
 use miette::{ErrReport, IntoDiagnostic, Result};
 use nu_cmd_base::hook::eval_hook;
@@ -26,10 +26,11 @@ use reedline::{
     SqliteBackedHistory, Vi,
 };
 use std::{
+    env::temp_dir,
     io::{self, IsTerminal, Write},
     path::Path,
     sync::atomic::Ordering,
-    time::Instant, env::temp_dir,
+    time::Instant,
 };
 use sysinfo::SystemExt;
 
@@ -334,8 +335,12 @@ pub fn evaluate_repl(
         line_editor = if let Some(buffer_editor) = buffer_editor {
             let mut command = std::process::Command::new(&buffer_editor);
             let temp_file = temp_dir().join(format!("{}.nu", uuid::Uuid::new_v4().to_string()));
-            command.arg(&temp_file)
-            .envs(engine_state.render_env_vars().into_iter().filter_map(|(k,v)| v.as_string().ok().map(|v| (k,v))));
+            command.arg(&temp_file).envs(
+                engine_state
+                    .render_env_vars()
+                    .into_iter()
+                    .filter_map(|(k, v)| v.as_string().ok().map(|v| (k, v))),
+            );
             line_editor.with_buffer_editor_command(command, temp_file)
         } else {
             line_editor

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -5,7 +5,7 @@ use crate::{
     util::eval_source,
     NuHighlighter, NuValidator, NushellPrompt,
 };
-use crossterm::cursor::SetCursorStyle;
+use crossterm::{cursor::SetCursorStyle};
 use log::{trace, warn};
 use miette::{ErrReport, IntoDiagnostic, Result};
 use nu_cmd_base::hook::eval_hook;
@@ -29,7 +29,7 @@ use std::{
     io::{self, IsTerminal, Write},
     path::Path,
     sync::atomic::Ordering,
-    time::Instant,
+    time::Instant, env::temp_dir,
 };
 use sysinfo::SystemExt;
 
@@ -332,7 +332,11 @@ pub fn evaluate_repl(
         };
 
         line_editor = if let Some(buffer_editor) = buffer_editor {
-            line_editor.with_buffer_editor(buffer_editor, "nu".into())
+            let mut command = std::process::Command::new(&buffer_editor);
+            let temp_file = temp_dir().join(format!("{}.nu", uuid::Uuid::new_v4().to_string()));
+            command.arg(&temp_file)
+            .envs(engine_state.render_env_vars().into_iter().filter_map(|(k,v)| v.as_string().ok().map(|v| (k,v))));
+            line_editor.with_buffer_editor_command(command, temp_file)
         } else {
             line_editor
         };

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -341,7 +341,7 @@ pub fn evaluate_repl(
                     .into_iter()
                     .filter_map(|(k, v)| v.as_string().ok().map(|v| (k, v))),
             );
-            line_editor.with_buffer_editor_command(command, temp_file)
+            line_editor.with_buffer_editor_command(command, temp_file.clone())
         } else {
             line_editor
         };

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -95,6 +95,7 @@ pub fn evaluate_repl(
 
     let mut start_time = std::time::Instant::now();
     let mut line_editor = Reedline::create();
+    let temp_file = temp_dir().join(format!("{}.nu", uuid::Uuid::new_v4()));
 
     // Now that reedline is created, get the history session id and store it in engine_state
     store_history_id_in_engine(engine_state, &line_editor);
@@ -334,7 +335,6 @@ pub fn evaluate_repl(
 
         line_editor = if let Some(buffer_editor) = buffer_editor {
             let mut command = std::process::Command::new(&buffer_editor);
-            let temp_file = temp_dir().join(format!("{}.nu", uuid::Uuid::new_v4().to_string()));
             command.arg(&temp_file).envs(
                 engine_state
                     .render_env_vars()


### PR DESCRIPTION
This pr should only be merged  after https://github.com/nushell/reedline/pull/630

This pr needs a rebase after https://github.com/nushell/nushell/pull/10210

# Description

This pr change BufferEditor setup to pass a `Command` to `reedline`. this change:

* Allow user use buffer editor with arguments by setting `$nu.EDITOR` or `$nu.VISUAL` to `list<string>`, just like https://github.com/nushell/nushell/pull/10210
* Now nushell will pass all its environment variables to Buffer Editor.
* Generate path of temp file for each instance and so now user can use buffer editor from different instance at the sametime
    - (before this pr, buffer editor may open the same temp file when user press Ctrl-O while another buffer is still under editing)


# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

None
