### PR TITLE
Start removing colour config from `explore`

### DIFF
--- a/crates/nu-explore/src/commands/try.rs
+++ b/crates/nu-explore/src/commands/try.rs
@@ -47,7 +47,6 @@ impl ViewCommand for TryCmd {
         #[rustfmt::skip]
         let config_options = vec![
             ConfigOption::boolean(":try options", "In the `:try` REPL, attempt to run the command on every keypress", "try.reactive"),
-            ConfigOption::new(":try options", "Change a border color of the menus", "try.border_color", default_color_list()),
             ConfigOption::new(":try options", "Change a highlighted menu color", "try.highlighted_color", default_color_list()),
         ];
 

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -219,8 +219,6 @@ fn prepare_default_config(config: &mut HashMap<String, Value>) {
 
     const TABLE_SELECT_COLUMN: Style = color(None, None);
 
-    const TRY_BORDER_COLOR: Style = color(None, None);
-
     const CONFIG_CURSOR_COLOR: Style = color(Some(Color::Black), Some(Color::LightYellow));
 
     insert_style(config, "status_bar_background", STATUS_BAR);
@@ -260,17 +258,6 @@ fn prepare_default_config(config: &mut HashMap<String, Value>) {
         insert_bool(&mut hm, "line_index", TABLE_LINE_INDEX);
 
         config.insert(String::from("table"), map_into_value(hm));
-    }
-
-    {
-        let mut hm = config
-            .get("try")
-            .and_then(parse_hash_map)
-            .unwrap_or_default();
-
-        insert_style(&mut hm, "border_color", TRY_BORDER_COLOR);
-
-        config.insert(String::from("try"), map_into_value(hm));
     }
 
     {
@@ -342,15 +329,6 @@ fn include_nu_config(config: &mut HashMap<String, Value>, style_computer: &Style
                 .unwrap_or_default();
             insert_style(&mut map, "split_line", line_color);
             config.insert(String::from("table"), map_into_value(map));
-        }
-
-        {
-            let mut map = config
-                .get("try")
-                .and_then(parse_hash_map)
-                .unwrap_or_default();
-            insert_style(&mut map, "border_color", line_color);
-            config.insert(String::from("try"), map_into_value(map));
         }
 
         {

--- a/crates/nu-explore/src/views/interactive.rs
+++ b/crates/nu-explore/src/views/interactive.rs
@@ -20,7 +20,7 @@ use crate::{
 
 use super::{
     record::{RecordView, TableTheme},
-    util::nu_style_to_tui,
+    util::{lookup_tui_color, nu_style_to_tui},
     Layout, Orientation, View, ViewConfig,
 };
 
@@ -248,12 +248,10 @@ impl View for InteractiveView<'_> {
     }
 
     fn setup(&mut self, config: ViewConfig<'_>) {
+        self.border_color = lookup_tui_color(config.style_computer, "separator");
+
         if let Some(hm) = config.config.get("try").and_then(create_map) {
             let colors = get_color_map(&hm);
-
-            if let Some(color) = colors.get("border_color").copied() {
-                self.border_color = nu_style_to_tui(color);
-            }
 
             if let Some(color) = colors.get("highlighted_color").copied() {
                 self.highlighted_color = nu_style_to_tui(color);

--- a/crates/nu-explore/src/views/util.rs
+++ b/crates/nu-explore/src/views/util.rs
@@ -33,6 +33,11 @@ pub fn set_span(
     text_width as u16
 }
 
+pub fn lookup_tui_color(style_computer: &StyleComputer, key: &str) -> Style {
+    let nu_style = style_computer.compute(key, &Value::nothing(nu_protocol::Span::unknown()));
+    nu_style_to_tui(nu_style)
+}
+
 pub fn nu_style_to_tui(style: NuStyle) -> ratatui::style::Style {
     let mut out = ratatui::style::Style::default();
     if let Some(clr) = style.background {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -197,10 +197,6 @@ $env.config = {
             line_shift: true,
             line_index: true,
         },
-        config: {
-            border_color: {fg: "white"}
-            cursor_color: {fg: "black", bg: "light_yellow"}
-        },
     }
 
     history: {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -178,9 +178,6 @@ $env.config = {
     }
 
     explore: {
-        try: {
-            border_color: {fg: "white"}
-        },
         status_bar_background: {fg: "#1D1F21", bg: "#C4C9C6"},
         command_bar_text: {fg: "#C4C9C6"},
         highlight: {fg: "black", bg: "yellow"},


### PR DESCRIPTION
This PR removes the `explore.try.border_color` config item, and instead always uses the `separator` colour (the one used for regular table borders) from the current theme.

The PR also removes some unused `explore.config` bits from the default config (I missed this in https://github.com/nushell/nushell/pull/10259).

### Future Work

This PR is intentionally small, I want to confirm that I'm on the right track before I rip out more colour config from `explore`. If all goes well, expect more PRs like this soon.

### Testing

I confirmed that this works by changing my `separator` colour in `config.nu`, and also confirmed that nothing breaks if a user still has `explore.try.border_color` in their config.