### PR TITLE
update format date when using %x %X %r

### DIFF
--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -118,7 +118,7 @@ where
 {
     let mut formatter_buf = String::new();
     // These are already in locale format, so we don't need to localize them
-    let format = if ["%x", "%X", "%r", "%c"]
+    let format = if ["%x", "%X", "%r"]
         .iter()
         .any(|item| formatter.contains(item))
     {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -803,7 +803,7 @@ impl Value {
     {
         let mut formatter_buf = String::new();
         // These are already in locale format, so we don't need to localize them
-        let format = if ["%x", "%X", "%r", "%c"]
+        let format = if ["%x", "%X", "%r"]
             .iter()
             .any(|item| formatter.contains(item))
         {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -802,13 +802,21 @@ impl Value {
         Tz::Offset: Display,
     {
         let mut formatter_buf = String::new();
-        let locale: Locale = get_system_locale_string()
-            .map(|l| l.replace('-', "_")) // `chrono::Locale` needs something like `xx_xx`, rather than `xx-xx`
-            .unwrap_or_else(|| String::from("en_US"))
-            .as_str()
-            .try_into()
-            .unwrap_or(Locale::en_US);
-        let format = date_time.format_localized(formatter, locale);
+        // These are already in locale format, so we don't need to localize them
+        let format = if ["%x", "%X", "%r", "%c"]
+            .iter()
+            .any(|item| formatter.contains(item))
+        {
+            date_time.format(formatter)
+        } else {
+            let locale: Locale = get_system_locale_string()
+                .map(|l| l.replace('-', "_")) // `chrono::Locale` needs something like `xx_xx`, rather than `xx-xx`
+                .unwrap_or_else(|| String::from("en_US"))
+                .as_str()
+                .try_into()
+                .unwrap_or(Locale::en_US);
+            date_time.format_localized(formatter, locale)
+        };
 
         match formatter_buf.write_fmt(format_args!("{format}")) {
             Ok(_) => (),


### PR DESCRIPTION
# Description

Apparently some strftime formats are already localized and when you "double localize" them, they don't work. This PR fixes that so that %x %X %r %c don't go through the localization step.

Example: %x %X
### Before
```nushell
❯ date now | format date "%x %X %p"
09/08/2023 08 AM
```
### After
```nushell
❯ date now | format date "%x %X %p"
09/08/23 08:09:14 AM
```

I started to make one format_datetime to rule them all but one returns a string and one returns a value. If we convert to the string, we lose the nice error messages. If we change to value, more code has to be changed elsewhere. So, I decided to just leave two functions.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
