### PR TITLE
add more `ps` columns in Windows

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -1,11 +1,11 @@
-use std::time::Duration;
-
+use itertools::Itertools;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, IntoInterruptiblePipelineData, PipelineData, Record, ShellError, Signature,
     Type, Value,
 };
+use std::time::Duration;
 
 #[derive(Clone)]
 pub struct Ps;
@@ -102,6 +102,32 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
             record.push("command", Value::string(proc.command(), span));
             #[cfg(windows)]
             {
+                //TODO: There's still more information we can cram in there if we want to
+                // see the ProcessInfo struct for more information
+                record.push(
+                    "start_time",
+                    Value::date(proc.start_time.fixed_offset(), span),
+                );
+                record.push(
+                    "user",
+                    Value::string(
+                        proc.user.clone().name.unwrap_or("unknown".to_string()),
+                        span,
+                    ),
+                );
+                record.push(
+                    "user_sid",
+                    Value::string(
+                        proc.user
+                            .clone()
+                            .sid
+                            .iter()
+                            .map(|r| r.to_string())
+                            .join("-"),
+                        span,
+                    ),
+                );
+                record.push("priority", Value::int(proc.priority as i64, span));
                 record.push("cwd", Value::string(proc.cwd(), span));
                 record.push(
                     "environment",

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -1,3 +1,4 @@
+#[cfg(windows)]
 use itertools::Itertools;
 use nu_protocol::{
     ast::Call,

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -135,9 +135,11 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
             let io = get_io(handle);
 
             let start_time = if let Some((start, _, _, _)) = times {
+                // 11_644_473_600 is the number of seconds between the Windows epoch (1601-01-01) and
+                // the Linux epoch (1970-01-01).
                 let time = chrono::Duration::seconds(start as i64 / 10_000_000);
                 let base =
-                    NaiveDate::from_ymd_opt(1600, 1, 1).and_then(|nd| nd.and_hms_opt(0, 0, 0));
+                    NaiveDate::from_ymd_opt(1601, 1, 1).and_then(|nd| nd.and_hms_opt(0, 0, 0));
                 if let Some(base) = base {
                     let time = base + time;
                     Local.from_utc_datetime(&time)
@@ -146,7 +148,7 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
                 }
             } else {
                 let time =
-                    NaiveDate::from_ymd_opt(1600, 1, 1).and_then(|nt| nt.and_hms_opt(0, 0, 0));
+                    NaiveDate::from_ymd_opt(1601, 1, 1).and_then(|nt| nt.and_hms_opt(0, 0, 0));
                 if let Some(time) = time {
                     Local.from_utc_datetime(&time)
                 } else {
@@ -775,6 +777,7 @@ fn get_io(handle: HANDLE) -> Option<(u64, u64)> {
     }
 }
 
+#[derive(Clone)]
 pub struct SidName {
     pub sid: Vec<u64>,
     pub name: Option<String>,


### PR DESCRIPTION
# Description

This PR adds a few more columns to `ps -l` on Windows. It would be good to add these changes cross-platform in separate PRs. This PR also fixes a bug where start time was calculated wrong.

I've added:
start_time
user
user_sid
priority

![image](https://github.com/nushell/nushell/assets/343840/cba16a17-ee70-46b5-9e6d-ef06641b264e)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
