### PR TITLE
Revert "Restore initial foreground process group on exit"

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,60 +1,22 @@
 #[cfg(unix)]
-use std::{
-    io::IsTerminal,
-    sync::atomic::{AtomicI32, Ordering},
-};
-
-#[cfg(unix)]
-use nix::{
-    errno::Errno,
-    libc,
-    sys::signal::{self, raise, signal, SaFlags, SigAction, SigHandler, SigSet, Signal},
-    unistd::{self, Pid},
-};
-
-#[cfg(unix)]
-static INITIAL_PGID: AtomicI32 = AtomicI32::new(-1);
-
-#[cfg(unix)]
 pub(crate) fn acquire_terminal(interactive: bool) {
+    use nix::{
+        errno::Errno,
+        sys::signal::{signal, SigHandler, Signal},
+        unistd,
+    };
+    use std::io::IsTerminal;
+
     if interactive && std::io::stdin().is_terminal() {
         // see also: https://www.gnu.org/software/libc/manual/html_node/Initializing-the-Shell.html
 
-        let initial_pgid = take_control();
-
-        INITIAL_PGID.store(initial_pgid.into(), Ordering::Relaxed);
+        take_control();
 
         unsafe {
-            if libc::atexit(restore_terminal) != 0 {
-                eprintln!("ERROR: failed to set exit function");
-                std::process::exit(1);
-            };
-
-            // SIGINT and SIGQUIT have special handling
+            // SIGINT and SIGQUIT have special handling above
             signal(Signal::SIGTSTP, SigHandler::SigIgn).expect("signal ignore");
             signal(Signal::SIGTTIN, SigHandler::SigIgn).expect("signal ignore");
             signal(Signal::SIGTTOU, SigHandler::SigIgn).expect("signal ignore");
-            signal(Signal::SIGCHLD, SigHandler::SigIgn).expect("signal ignore");
-
-            signal_hook::low_level::register(signal_hook::consts::SIGTERM, || {
-                // Safety: can only call async-signal-safe functions here
-                // restore_terminal, signal, and raise are all async-signal-safe
-
-                restore_terminal();
-
-                if signal(Signal::SIGTERM, SigHandler::SigDfl).is_err() {
-                    // Failed to set signal handler to default.
-                    // This should not be possible, but if it does happen,
-                    // then this could result in an infitite loop due to the raise below.
-                    // So, we'll just exit immediately if this happens.
-                    std::process::exit(1);
-                };
-
-                if raise(Signal::SIGTERM).is_err() {
-                    std::process::exit(1);
-                };
-            })
-            .expect("signal hook");
         }
 
         // Put ourselves in our own process group, if not already
@@ -71,7 +33,7 @@ pub(crate) fn acquire_terminal(interactive: bool) {
             }
         }
         // Set our possibly new pgid to be in control of terminal
-        let _ = unistd::tcsetpgrp(libc::STDIN_FILENO, shell_pgid);
+        let _ = unistd::tcsetpgrp(nix::libc::STDIN_FILENO, shell_pgid);
     }
 }
 
@@ -79,20 +41,25 @@ pub(crate) fn acquire_terminal(interactive: bool) {
 pub(crate) fn acquire_terminal(_: bool) {}
 
 // Inspired by fish's acquire_tty_or_exit
-// Returns our original pgid
 #[cfg(unix)]
-fn take_control() -> Pid {
+fn take_control() {
+    use nix::{
+        errno::Errno,
+        sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet, Signal},
+        unistd::{self, Pid},
+    };
+
     let shell_pgid = unistd::getpgrp();
 
     match unistd::tcgetpgrp(nix::libc::STDIN_FILENO) {
         Ok(owner_pgid) if owner_pgid == shell_pgid => {
             // Common case, nothing to do
-            return owner_pgid;
+            return;
         }
         Ok(owner_pgid) if owner_pgid == unistd::getpid() => {
             // This can apparently happen with sudo: https://github.com/fish-shell/fish-shell/issues/7388
             let _ = unistd::setpgid(owner_pgid, owner_pgid);
-            return owner_pgid;
+            return;
         }
         _ => (),
     }
@@ -113,14 +80,14 @@ fn take_control() -> Pid {
     }
 
     for _ in 0..4096 {
-        match unistd::tcgetpgrp(libc::STDIN_FILENO) {
+        match unistd::tcgetpgrp(nix::libc::STDIN_FILENO) {
             Ok(owner_pgid) if owner_pgid == shell_pgid => {
                 // success
-                return owner_pgid;
+                return;
             }
             Ok(owner_pgid) if owner_pgid == Pid::from_raw(0) => {
                 // Zero basically means something like "not owned" and we can just take it
-                let _ = unistd::tcsetpgrp(libc::STDIN_FILENO, shell_pgid);
+                let _ = unistd::tcsetpgrp(nix::libc::STDIN_FILENO, shell_pgid);
             }
             Err(Errno::ENOTTY) => {
                 eprintln!("ERROR: no TTY for interactive shell");
@@ -136,16 +103,6 @@ fn take_control() -> Pid {
         }
     }
 
-    eprintln!("ERROR: failed to take control of the terminal, we might be orphaned");
+    eprintln!("ERROR: failed take control of the terminal, we might be orphaned");
     std::process::exit(1);
-}
-
-#[cfg(unix)]
-extern "C" fn restore_terminal() {
-    // Safety: can only call async-signal-safe functions here
-    // tcsetpgrp and getpgrp are async-signal-safe
-    let initial_pgid = Pid::from_raw(INITIAL_PGID.load(Ordering::Relaxed));
-    if initial_pgid.as_raw() > 0 && initial_pgid != unistd::getpgrp() {
-        let _ = unistd::tcsetpgrp(libc::STDIN_FILENO, initial_pgid);
-    }
 }


### PR DESCRIPTION
Reverts nushell/nushell#10021

Preparing a revert due to this issue on MacOS.
```
❯ rm foo --trash
Error: nu::shell::remove_not_possible

  × Remove not possible
   ╭─[entry #2:1:1]
 1 │ rm foo --trash
   ·    ─┬─
   ·     ╰── Could not delete /Users/fdncred/src/nushell/foo: Unknown { description: "No child processes (os error 10)" }
Try '--trash' flag
   ╰────
```