### PR TITLE
add 'from ndjson' into standard library

### DIFF
--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -28,6 +28,7 @@ pub fn load_standard_library(
             ("xml.nu", include_str!("../std/xml.nu")),
             ("input.nu", include_str!("../std/input.nu")),
             ("math.nu", include_str!("../std/math.nu")),
+            ("formats.nu", include_str!("../std/formats.nu")),
         ];
 
         let mut working_set = StateWorkingSet::new(engine_state);

--- a/crates/nu-std/std/formats.nu
+++ b/crates/nu-std/std/formats.nu
@@ -1,0 +1,18 @@
+# formats.nu
+#
+# This file contains functions for formatting data in various ways.
+#
+# Usage:
+#   use std format *
+#   use std format <function name>
+#
+# These functions help `open` the files with unsupported extensions such as ndjson.
+#
+
+export def "from ndjson" []: string -> any {
+    from json --objects
+}
+
+export def "from jsonl" []: string -> any {
+    from json --objects
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

close #8574
related #10276 

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

added below into standard library
```
def "from ndjson" []: string -> any {
    from json --objects
}
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Users can use functions like "from ndjson" in standard library, and can open ndjson files with `open` command.
```
use std formats *
# `from ndjson` is available now
open sample.ndjson
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

`toolkit check pr`

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`


# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
