### PR TITLE
signpost 'input list --types [key]' from 'keybindings list'

### DIFF
--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -24,7 +24,6 @@ impl Command for KeybindingsListen {
         r#"This is an internal debugging tool. For better output, try `input listen` instead:
 
 ```
-use std input
 input listen --types [key]
 ```
 "#

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -20,6 +20,16 @@ impl Command for KeybindingsListen {
         "Get input from the user."
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This is an internal debugging tool. For better output, try `input listen` instead:
+
+```
+use std input
+input listen --types [key]
+```
+"#
+    }
+
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Platform)

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -21,12 +21,7 @@ impl Command for KeybindingsListen {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This is an internal debugging tool. For better output, try `input listen` instead:
-
-```
-input listen --types [key]
-```
-"#
+        "This is an internal debugging tool. For better output, try `input listen --types [key]`"
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -7,8 +7,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    record, Category, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
-    Type, Value,
+    record, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span,
+    SyntaxShape, Type, Value,
 };
 use num_traits::AsPrimitive;
 use std::io::stdout;
@@ -69,7 +69,18 @@ There are 4 `key_type` variants:
     media - dedicated media keys (play, pause, tracknext ...)
     other - keys not falling under previous categories (up, down, backspace, enter ...)"#
     }
-
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Listen for a keyboard shortcut and find out how nu receives it",
+            example: "use std input; input list --types [key]",
+            result: Some(Value::test_record(record! {
+                "type" => Value::test_string("key"),
+                "key_type" => Value::test_string("char"),
+                "code" => Value::test_string("c"),
+                "modifiers" => Value::test_list(vec![Value::test_string("keymodifiers(control)")]),
+            })),
+        }]
+    }
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -72,7 +72,7 @@ There are 4 `key_type` variants:
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Listen for a keyboard shortcut and find out how nu receives it",
-            example: "use std input; input list --types [key]",
+            example: "input list --types [key]",
             result: None,
         }]
     }

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -72,7 +72,7 @@ There are 4 `key_type` variants:
     fn examples(&self) -> Vec<Example> {
         vec![Example {
             description: "Listen for a keyboard shortcut and find out how nu receives it",
-            example: "input list --types [key]",
+            example: "input listen --types [key]",
             result: None,
         }]
     }

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -73,12 +73,7 @@ There are 4 `key_type` variants:
         vec![Example {
             description: "Listen for a keyboard shortcut and find out how nu receives it",
             example: "use std input; input list --types [key]",
-            result: Some(Value::test_record(record! {
-                "type" => Value::test_string("key"),
-                "key_type" => Value::test_string("char"),
-                "code" => Value::test_string("c"),
-                "modifiers" => Value::test_list(vec![Value::test_string("keymodifiers(control)")]),
-            })),
+            result: None,
         }]
     }
     fn run(


### PR DESCRIPTION
Supercedes https://github.com/nushell/nushell/pull/10196

# Description

After reading https://github.com/nushell/nushell/pull/10196#issuecomment-1703986359 I added a signpost from `keybindings listen` to `input listen`

When I initially tried `input listen` it always immediately returned with:
```
╭───────┬────────╮
│ type  │ focus  │
│ event │ gained │
╰───────┴────────╯
```

I added an example to `input listen --help` to suggest only listening to key events

Initially I also included a `result` but it prints as:

```
  ╭───────────┬───────────────╮
  │ type      │ key           │
  │ key_type  │ char          │
  │ code      │ c             │
  │ modifiers │ [list 1 item] │
  ╰───────────┴───────────────╯
```

rather than:

```
╭───────────┬───────────────────────────────╮
│ type      │ key                           │
│ key_type  │ char                          │
│ code      │ c                             │
│           │ ╭───┬───────────────────────╮ │
│ modifiers │ │ 0 │ keymodifiers(control) │ │
│           │ ╰───┴───────────────────────╯ │
╰───────────┴───────────────────────────────╯
```
so I removed it.

# User-Facing Changes

<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

* Example describing how to use `input list --types [key]` to listen for keybindings.
* Signpost pointing at `use std input; input list --types [key]` from `keybindings list`.

## After merging

It is probably worth:

a) signposting to the keybindings section of the book from both of these subcommands (like I did in https://github.com/nushell/nushell/pull/10193), 
b) giving an example in the book of how to take the output from `input listen --types [key]` and format it for including in `config nu`
c) there are not currently any examples in crates/nu-utils/src/sample_config/default_config.nu for keybindings with multiple modifiers. Should I add alt+backspace-in-macos-vscode as an example (gets translated to `{ modifier: control_alt keycode: char_h }` for historical reasons)?