### PR TITLE
clean up control-w in default config and make it behave like bash

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -582,8 +582,15 @@ $env.config = {
             name: delete_one_word_backward
             modifier: control
             keycode: char_w
-            mode: [emacs, vi_insert]
+            mode: vi_insert
             event: {edit: backspaceword}
+        }
+        {
+            name: cut_big_word_left
+            modifier: control
+            keycode: char_w
+            mode: emacs
+            event: {edit: cutbigwordleft}
         }
         {
             name: move_left
@@ -644,13 +651,6 @@ $env.config = {
             keycode: char_y
             mode: emacs
             event: {edit: pastecutbufferbefore}
-        }
-        {
-            name: cut_word_left
-            modifier: control
-            keycode: char_w
-            mode: emacs
-            event: {edit: cutwordleft}
         }
         {
             name: cut_line_to_end

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -593,6 +593,13 @@ $env.config = {
             event: {edit: cutbigwordleft}
         }
         {
+            name: alt_backspace_from_vscode
+            modifier: control_alt
+            keycode: char_h
+            mode: emacs
+            event: { edit: cutwordleft }
+        }
+        {
             name: move_left
             modifier: none
             keycode: backspace


### PR DESCRIPTION
relates to:

> c) there are not currently any examples in crates/nu-utils/src/sample_config/default_config.nu for keybindings with multiple modifiers. Should I add alt+backspace-in-macos-vscode as an example (gets translated to { modifier: control_alt keycode: char_h } for historical reasons)?

-- https://github.com/nushell/nushell/pull/10287

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This is two separate but related changes. I could have put them as separate PRs but they would conflict with each other.

#### First commit:

```
clean up control-w in default config and make it behave like bash

'man bash' documents this as:

       unix-word-rubout (C-w)
              Kill the word behind point, using white space as a word boundary.  The killed text
              is saved on the kill-ring.

zsh does not have a concept of small/big words, but its 'word' is slightly bigger nushell's big word, because it includes -./_ and a few other punctuation marks.

fish's control-w is slightly larger than nushell's small word in that it seems to delete up to the next / (and doesn't need an extra control-w to delete the '/' 'thing/'.

I've not tested powershell.
```

I noticed that control-w was defined twice for emacs mode, so I cleaned that up. If there are objections to the rest of this PR then I will make a separate change that *just* does that instead.

I didn't change the vi_insert mode bindings, because I don't have any experience of what they do in bash, and they seem to line up with what control-w does in actual vim.

#### Second commit
```
make alt+backspace work in vscode by default
    
On MacOS, vscode generates control-alt-h in response to alt+backspace.
This is handled in bash as cut-smallword-left and in zsh as cut-word-left
(zsh doesn't seem to have a concept of small/big words). Fish treats this
as cut small word left (fish bigwords include anything up to /, and its
small words stop on any punctuation).
```

Note that fish's smallword is about the same size as bash's smallword. nushell's smallword is about a big as fish's bigword (goes up to the next /). See https://github.com/nushell/reedline/issues/570 for previous discussion on this topic. 

This is a quality of life thing for me. I'm happy to drop it if it's not something that people want.

For bonus points, this change adds an example of a keybinding with multiple modifier keys pressed, which serves as documentation for how to write this in the config file (as I mentioned at the bottom of https://github.com/nushell/nushell/pull/10287)

I realise that keybindings are the kind of thing that can cause holy wars, so I'm happy to back out any changes that people dislike.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Changes to the default configuration:
* control-w now deletes a big word (up to the next space), like bash
* alt+backspace in vscode now deletes a small word (up to the next /)

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

I noticed that ctrl+y only yanks the last word that you cut. If you cut a bunch of consecutive words with control+w or alt+backspace in bash, it restores all of them. I will write a reedline ticket for this next, if there is not one already.