### PR TITLE
Make cursor_shape optional

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -235,13 +235,15 @@ pub fn evaluate_repl(
 
         // Find the configured cursor shapes for each mode
         let cursor_config = CursorConfig {
-            vi_insert: Some(map_nucursorshape_to_cursorshape(
-                config.cursor_shape_vi_insert,
-            )),
-            vi_normal: Some(map_nucursorshape_to_cursorshape(
-                config.cursor_shape_vi_normal,
-            )),
-            emacs: Some(map_nucursorshape_to_cursorshape(config.cursor_shape_emacs)),
+            vi_insert: config
+                .cursor_shape_vi_insert
+                .map(map_nucursorshape_to_cursorshape),
+            vi_normal: config
+                .cursor_shape_vi_normal
+                .map(map_nucursorshape_to_cursorshape),
+            emacs: config
+                .cursor_shape_emacs
+                .map(map_nucursorshape_to_cursorshape),
         };
         perf(
             "get config/cursor config",

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -108,9 +108,9 @@ pub struct Config {
     pub show_clickable_links_in_ls: bool,
     pub render_right_prompt_on_last_line: bool,
     pub explore: HashMap<String, Value>,
-    pub cursor_shape_vi_insert: NuCursorShape,
-    pub cursor_shape_vi_normal: NuCursorShape,
-    pub cursor_shape_emacs: NuCursorShape,
+    pub cursor_shape_vi_insert: Option<NuCursorShape>,
+    pub cursor_shape_vi_normal: Option<NuCursorShape>,
+    pub cursor_shape_emacs: Option<NuCursorShape>,
     pub datetime_normal_format: Option<String>,
     pub datetime_table_format: Option<String>,
     pub error_style: String,
@@ -156,9 +156,9 @@ impl Default for Config {
             filesize_metric: false,
             filesize_format: "auto".into(),
 
-            cursor_shape_emacs: NuCursorShape::Line,
-            cursor_shape_vi_insert: NuCursorShape::Block,
-            cursor_shape_vi_normal: NuCursorShape::UnderScore,
+            cursor_shape_emacs: None,
+            cursor_shape_vi_insert: None,
+            cursor_shape_vi_normal: None,
 
             color_config: HashMap::new(),
             use_grid_icons: true,
@@ -683,12 +683,13 @@ impl Value {
                             ($name:expr, $span:expr) => {
                                 Value::string(
                                     match $name {
-                                        NuCursorShape::Line => "line",
-                                        NuCursorShape::Block => "block",
-                                        NuCursorShape::UnderScore => "underscore",
-                                        NuCursorShape::BlinkLine => "blink_line",
-                                        NuCursorShape::BlinkBlock => "blink_block",
-                                        NuCursorShape::BlinkUnderScore => "blink_underscore",
+                                        Some(NuCursorShape::Line) => "line",
+                                        Some(NuCursorShape::Block) => "block",
+                                        Some(NuCursorShape::UnderScore) => "underscore",
+                                        Some(NuCursorShape::BlinkLine) => "blink_line",
+                                        Some(NuCursorShape::BlinkBlock) => "blink_block",
+                                        Some(NuCursorShape::BlinkUnderScore) => "blink_underscore",
+                                        _ => "",
                                     },
                                     $span,
                                 )
@@ -706,27 +707,27 @@ impl Value {
                                             match val_str.as_ref() {
                                                 "line" => {
                                                     config.cursor_shape_vi_insert =
-                                                        NuCursorShape::Line;
+                                                        Some(NuCursorShape::Line);
                                                 }
                                                 "block" => {
                                                     config.cursor_shape_vi_insert =
-                                                        NuCursorShape::Block;
+                                                        Some(NuCursorShape::Block);
                                                 }
                                                 "underscore" => {
                                                     config.cursor_shape_vi_insert =
-                                                        NuCursorShape::UnderScore;
+                                                        Some(NuCursorShape::UnderScore);
                                                 }
                                                 "blink_line" => {
                                                     config.cursor_shape_vi_insert =
-                                                        NuCursorShape::BlinkLine;
+                                                        Some(NuCursorShape::BlinkLine);
                                                 }
                                                 "blink_block" => {
                                                     config.cursor_shape_vi_insert =
-                                                        NuCursorShape::BlinkBlock;
+                                                        Some(NuCursorShape::BlinkBlock);
                                                 }
                                                 "blink_underscore" => {
                                                     config.cursor_shape_vi_insert =
-                                                        NuCursorShape::BlinkUnderScore;
+                                                        Some(NuCursorShape::BlinkUnderScore);
                                                 }
                                                 _ => {
                                                     invalid!(Some(span),
@@ -754,27 +755,27 @@ impl Value {
                                             match val_str.as_ref() {
                                                 "line" => {
                                                     config.cursor_shape_vi_normal =
-                                                        NuCursorShape::Line;
+                                                        Some(NuCursorShape::Line);
                                                 }
                                                 "block" => {
                                                     config.cursor_shape_vi_normal =
-                                                        NuCursorShape::Block;
+                                                        Some(NuCursorShape::Block);
                                                 }
                                                 "underscore" => {
                                                     config.cursor_shape_vi_normal =
-                                                        NuCursorShape::UnderScore;
+                                                        Some(NuCursorShape::UnderScore);
                                                 }
                                                 "blink_line" => {
                                                     config.cursor_shape_vi_normal =
-                                                        NuCursorShape::BlinkLine;
+                                                        Some(NuCursorShape::BlinkLine);
                                                 }
                                                 "blink_block" => {
                                                     config.cursor_shape_vi_normal =
-                                                        NuCursorShape::BlinkBlock;
+                                                        Some(NuCursorShape::BlinkBlock);
                                                 }
                                                 "blink_underscore" => {
                                                     config.cursor_shape_vi_normal =
-                                                        NuCursorShape::BlinkUnderScore;
+                                                        Some(NuCursorShape::BlinkUnderScore);
                                                 }
                                                 _ => {
                                                     invalid!(Some(span),
@@ -801,27 +802,28 @@ impl Value {
                                             let val_str = v.to_lowercase();
                                             match val_str.as_ref() {
                                                 "line" => {
-                                                    config.cursor_shape_emacs = NuCursorShape::Line;
+                                                    config.cursor_shape_emacs =
+                                                        Some(NuCursorShape::Line);
                                                 }
                                                 "block" => {
                                                     config.cursor_shape_emacs =
-                                                        NuCursorShape::Block;
+                                                        Some(NuCursorShape::Block);
                                                 }
                                                 "underscore" => {
                                                     config.cursor_shape_emacs =
-                                                        NuCursorShape::UnderScore;
+                                                        Some(NuCursorShape::UnderScore);
                                                 }
                                                 "blink_line" => {
                                                     config.cursor_shape_emacs =
-                                                        NuCursorShape::BlinkLine;
+                                                        Some(NuCursorShape::BlinkLine);
                                                 }
                                                 "blink_block" => {
                                                     config.cursor_shape_emacs =
-                                                        NuCursorShape::BlinkBlock;
+                                                        Some(NuCursorShape::BlinkBlock);
                                                 }
                                                 "blink_underscore" => {
                                                     config.cursor_shape_emacs =
-                                                        NuCursorShape::BlinkUnderScore;
+                                                        Some(NuCursorShape::BlinkUnderScore);
                                                 }
                                                 _ => {
                                                     invalid!(Some(span),

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -689,7 +689,7 @@ impl Value {
                                         Some(NuCursorShape::BlinkLine) => "blink_line",
                                         Some(NuCursorShape::BlinkBlock) => "blink_block",
                                         Some(NuCursorShape::BlinkUnderScore) => "blink_underscore",
-                                        _ => "",
+                                        None => "inherit",
                                     },
                                     $span,
                                 )
@@ -729,9 +729,12 @@ impl Value {
                                                     config.cursor_shape_vi_insert =
                                                         Some(NuCursorShape::BlinkUnderScore);
                                                 }
+                                                "inherit" => {
+                                                    config.cursor_shape_vi_insert = None;
+                                                }
                                                 _ => {
                                                     invalid!(Some(span),
-                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
+                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', 'blink_underscore' or 'inherit'"
                                                     );
                                                     // Reconstruct
                                                     vals[index] = reconstruct_cursor_shape!(
@@ -777,9 +780,12 @@ impl Value {
                                                     config.cursor_shape_vi_normal =
                                                         Some(NuCursorShape::BlinkUnderScore);
                                                 }
+                                                "inherit" => {
+                                                    config.cursor_shape_vi_normal = None;
+                                                }
                                                 _ => {
                                                     invalid!(Some(span),
-                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
+                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', 'blink_underscore' or 'inherit'"
                                                     );
                                                     // Reconstruct
                                                     vals[index] = reconstruct_cursor_shape!(
@@ -825,9 +831,12 @@ impl Value {
                                                     config.cursor_shape_emacs =
                                                         Some(NuCursorShape::BlinkUnderScore);
                                                 }
+                                                "inherit" => {
+                                                    config.cursor_shape_emacs = None;
+                                                }
                                                 _ => {
                                                     invalid!(Some(span),
-                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', or 'blink_underscore'"
+                                                        "unrecognized $env.config.{key}.{key2} '{val_str}'; expected either 'line', 'block', 'underscore', 'blink_line', 'blink_block', 'blink_underscore' or 'inherit'"
                                                     );
                                                     // Reconstruct
                                                     vals[index] = reconstruct_cursor_shape!(

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -224,9 +224,9 @@ $env.config = {
     }
 
     cursor_shape: {
-        emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line (line is the default)
-        vi_insert: block # block, underscore, line , blink_block, blink_underscore, blink_line (block is the default)
-        vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line (underscore is the default)
+        emacs: line # block, underscore, line, blink_block, blink_underscore, blink_line, inherit to skip setting cursor shape (line is the default)
+        vi_insert: block # block, underscore, line, blink_block, blink_underscore, blink_line, inherit to skip setting cursor shape (block is the default)
+        vi_normal: underscore # block, underscore, line, blink_block, blink_underscore, blink_line, inherit to skip setting cursor shape (underscore is the default)
     }
 
     color_config: $dark_theme # if you want a more interesting theme, you can replace the empty record with `$dark_theme`, `$light_theme` or another custom record


### PR DESCRIPTION
# Description
There are several cursor shape related issues #7151 #9243 #7271 #8452 #10169, you can't disable the cursor shape feature even if you comment out the entire `cursor_shape` block in the config.nu, and even worse, when nushell exits with an error, the cursor shape can't be restored, that is annoying. 

This PR provides an opportunity to disable setting the cursor shape.

# User-Facing Changes
If you use the default config.nu, nothing changes, but if you comment out `cursor_shape`  block or set them to `inherit`, related cursor shape will not be set.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
