### PR TITLE
Added a comment that perl is required for feature static-link-openssl…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,8 @@ stable = ["default"]
 wasi = ["nu-cmd-lang/wasi"]
 # NOTE: individual features are also passed to `nu-cmd-lang` that uses them to generate the feature matrix in the `version` command
 
-# Enable to statically link OpenSSL; otherwise the system version will be used. Not enabled by default because it takes a while to build
+# Enable to statically link OpenSSL (perl is required, to build OpenSSL https://docs.rs/openssl/latest/openssl/); 
+# otherwise the system version will be used. Not enabled by default because it takes a while to build
 static-link-openssl = ["dep:openssl", "nu-cmd-lang/static-link-openssl"]
 
 mimalloc = ["nu-cmd-lang/mimalloc", "dep:mimalloc"]


### PR DESCRIPTION
this PR should close https://github.com/nushell/nushell/issues/10290

it is a simple comment in Cargo.toml, which explains that perl is required for feature static-link-openssl to work.