### PR TITLE
Remove pythonic `int * list` behavior

### DIFF
--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -506,11 +506,3 @@ fn int_multiple_string() {
     let actual = nu!(pipeline(r#""ab" * 3"#));
     assert_eq!(actual.out, "ababab");
 }
-
-#[test]
-fn int_multiple_list() {
-    let actual = nu!(pipeline(r#"3 * [1 2] | to nuon"#));
-    assert_eq!(actual.out, "[1, 2, 1, 2, 1, 2]");
-    let actual = nu!(pipeline(r#"[1 2] * 3 | to nuon"#));
-    assert_eq!(actual.out, "[1, 2, 1, 2, 1, 2]");
-}

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -241,8 +241,6 @@ pub fn math_result_type(
                 (Type::Float, Type::Duration) => (Type::Duration, None),
                 (Type::Int, Type::String) => (Type::String, None),
                 (Type::String, Type::Int) => (Type::String, None),
-                (Type::Int, Type::List(a)) => (Type::List(a.clone()), None),
-                (Type::List(a), Type::Int) => (Type::List(a.clone()), None),
 
                 (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.to_string()), None),
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2663,20 +2663,6 @@ impl Value {
                 }
                 Ok(Value::string(res, span))
             }
-            (Value::Int { val: lhs, .. }, Value::List { vals: rhs, .. }) => {
-                let mut res = vec![];
-                for _ in 0..*lhs {
-                    res.append(&mut rhs.clone())
-                }
-                Ok(Value::list(res, span))
-            }
-            (Value::List { vals: lhs, .. }, Value::Int { val: rhs, .. }) => {
-                let mut res = vec![];
-                for _ in 0..*rhs {
-                    res.append(&mut lhs.clone())
-                }
-                Ok(Value::list(res, span))
-            }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: op,
                 lhs_ty: self.get_type().to_string(),


### PR DESCRIPTION
# Description
The pythonism that multiplying a scalar integer with a list results in a
repeated concatenation of the list, is ambiguous with other possible
interpretations and thus actively harmful to clear semantics in nushell.

Another possible reading of this scalar/vector product would be trying
to perform elementwise multiplication with the scalar.

Before we bless this alternative as a more reasonable design the best
course of action is to remove this pythonism.

Work related to #10233


# User-Facing Changes
Breaking change as this turns `int * list` or `list * int` into hard
errors.

# Tests + Formatting
Remove the associated test
