### PR TITLE
add case-insensitive example to `where`

### DIFF
--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -152,6 +152,11 @@ not supported."#
                 example: "ls | where type == file | sort-by name -n | enumerate | where {|e| $e.item.name !~ $'^($e.index + 1)' } | each {|| get item }",
                 result: None,
             },
+            Example {
+                description: r#"Find case-insensitively files called "readme", without an explicit closure"#,
+                example: "ls | where ($it.name | str downcase) =~ readme",
+                result: None,
+            }
         ]
     }
 }

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -156,7 +156,14 @@ not supported."#
                 description: r#"Find case-insensitively files called "readme", without an explicit closure"#,
                 example: "ls | where ($it.name | str downcase) =~ readme",
                 result: None,
+            },
+            Example {
+                description: "same as above but with regex only",
+                example: "ls | where name =~ '(?i)readme'",
+                result: None,
             }
+
+
         ]
     }
 }


### PR DESCRIPTION
related to
- https://discord.com/channels/601130461678272522/614593951969574961/1150395064292495400

# Description
two cool things about the `where` command
- it's versatile enough to allow creating a case-insensitive version of itself
- it does not require the explicit use of a closure

this PR adds an example showing how to filter with `where` but case-insensitively and without an explicite closure.

# User-Facing Changes
new example to `where`:
```nushell
  Find case-insensitively files called "readme", without an explicit closure
  > ls | where ($it.name | str downcase) =~ readme
```

# Tests + Formatting
the new example test above.

# After Submitting