### PR TITLE
Bump `calamine` and fix clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,15 +546,15 @@ checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "calamine"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f023f9ae2c2f017564b7eca85660c3c09477bb037f2fbfbaaba732b5642a32"
+checksum = "8c2f67a25b1a04dfc4caf081d98bc758489a6e9b637cf566c3bc96b3cfe07aef"
 dependencies = [
  "byteorder",
  "codepage",
  "encoding_rs",
  "log",
- "quick-xml 0.28.2",
+ "quick-xml",
  "serde",
  "zip",
 ]
@@ -2897,7 +2897,7 @@ dependencies = [
  "percent-encoding",
  "powierza-coefficient",
  "print-positions",
- "quick-xml 0.30.0",
+ "quick-xml",
  "quickcheck",
  "quickcheck_macros",
  "rand",
@@ -4141,20 +4141,11 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
-dependencies = [
- "encoding_rs",
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
 dependencies = [
+ "encoding_rs",
  "memchr",
 ]
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -32,7 +32,7 @@ alphanumeric-sort = "1.5"
 base64 = "0.21"
 byteorder = "1.4"
 bytesize = "1.3"
-calamine = "0.21"
+calamine = "0.22"
 chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
 chrono-humanize = "0.2.3"
 chrono-tz = "0.8"

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -128,7 +128,7 @@ fn from_ods(
 
     let mut dict = IndexMap::new();
 
-    let mut sheet_names = ods.sheet_names().to_owned();
+    let mut sheet_names = ods.sheet_names();
     if !sel_sheets.is_empty() {
         sheet_names.retain(|e| sel_sheets.contains(e));
     }

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -127,7 +127,7 @@ fn from_xlsx(
 
     let mut dict = IndexMap::new();
 
-    let mut sheet_names = xlsx.sheet_names().to_owned();
+    let mut sheet_names = xlsx.sheet_names();
     if !sel_sheets.is_empty() {
         sheet_names.retain(|e| sel_sheets.contains(e));
     }


### PR DESCRIPTION
Upgrade calamine to 0.22
Reduces one potential dependency duplication

Supersedes #10305

Includes fixes for clippy lints as API changed to return owned data.
