### PR TITLE
Deref `&String` arguments to `&str` where appropriate

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -136,7 +136,7 @@ impl NuCompleter {
                         for (flat_idx, flat) in flattened.iter().enumerate() {
                             let is_passthrough_command = spans
                                 .first()
-                                .filter(|content| *content == &String::from("sudo"))
+                                .filter(|content| content.as_str() == "sudo")
                                 .is_some();
                             // Read the current spam to string
                             let current_span = working_set.get_span_contents(flat.0).to_vec();

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -116,9 +116,8 @@ pub fn evaluate_file(
         if block.signature.name == "main" {
             block.signature.name = source_filename.to_string_lossy().to_string();
         } else if block.signature.name.starts_with("main ") {
-            block.signature.name = source_filename.to_string_lossy().to_string()
-                + " "
-                + &String::from_utf8_lossy(&block.signature.name.as_bytes()[5..]);
+            block.signature.name =
+                source_filename.to_string_lossy().to_string() + " " + &block.signature.name[5..];
         }
     }
 

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -2,7 +2,7 @@ use nu_test_support::fs::{files_exist_at, Stub::EmptyFile};
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
 #[test]
 fn removes_a_file() {
@@ -376,10 +376,10 @@ fn removes_symlink() {
 }
 
 struct Cleanup<'a> {
-    dir_to_clean: &'a PathBuf,
+    dir_to_clean: &'a Path,
 }
 
-fn set_dir_read_only(directory: &PathBuf, read_only: bool) {
+fn set_dir_read_only(directory: &Path, read_only: bool) {
     let mut permissions = fs::metadata(directory).unwrap().permissions();
     permissions.set_readonly(read_only);
     fs::set_permissions(directory, permissions).expect("failed to set directory permissions");

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -418,8 +418,8 @@ impl Stack {
         engine_state.env_vars.contains_key(name)
     }
 
-    pub fn is_overlay_active(&self, name: &String) -> bool {
-        self.active_overlays.contains(name)
+    pub fn is_overlay_active(&self, name: &str) -> bool {
+        self.active_overlays.iter().any(|n| n == name)
     }
 
     pub fn add_overlay(&mut self, name: String) {

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -427,7 +427,7 @@ impl Stack {
         self.active_overlays.push(name);
     }
 
-    pub fn remove_overlay(&mut self, name: &String) {
+    pub fn remove_overlay(&mut self, name: &str) {
         self.active_overlays.retain(|o| o != name);
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -7,19 +7,19 @@ use crate::{
     record, HistoryFileFormat, PipelineData, Range, Record, ShellError, Span, Value,
 };
 use nu_system::os_info::{get_kernel_version, get_os_arch, get_os_family, get_os_name};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Value, ShellError> {
-    fn canonicalize_path(engine_state: &EngineState, path: &PathBuf) -> PathBuf {
+    fn canonicalize_path(engine_state: &EngineState, path: &Path) -> PathBuf {
         let cwd = engine_state.current_work_dir();
 
         if path.exists() {
             match nu_path::canonicalize_with(path, cwd) {
                 Ok(canon_path) => canon_path,
-                Err(_) => path.clone(),
+                Err(_) => path.to_owned(),
             }
         } else {
-            path.clone()
+            path.to_owned()
         }
     }
 

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -469,9 +469,9 @@ pub fn read_std(std: &[u8]) -> String {
     out.replace('\n', "")
 }
 
-use std::{path::PathBuf, process::Command};
+use std::{path::Path, process::Command};
 
-pub fn run_command(executable_path: &PathBuf, target_cwd: &str) -> Command {
+pub fn run_command(executable_path: &Path, target_cwd: &str) -> Command {
     let mut command = Command::new(executable_path);
 
     command

--- a/crates/nu-test-support/src/playground/matchers.rs
+++ b/crates/nu-test-support/src/playground/matchers.rs
@@ -30,7 +30,7 @@ pub fn says() -> Play {
 
 trait CheckerMatchers {
     fn output(&self, actual: &Outcome) -> MatchResult;
-    fn std(&self, actual: &[u8], expected: Option<&String>, description: &str) -> MatchResult;
+    fn std(&self, actual: &[u8], expected: Option<&str>, description: &str) -> MatchResult;
     fn stdout(&self, actual: &Outcome) -> MatchResult;
 }
 
@@ -40,10 +40,10 @@ impl CheckerMatchers for Play {
     }
 
     fn stdout(&self, actual: &Outcome) -> MatchResult {
-        self.std(&actual.out, self.stdout_expectation.as_ref(), "stdout")
+        self.std(&actual.out, self.stdout_expectation.as_deref(), "stdout")
     }
 
-    fn std(&self, actual: &[u8], expected: Option<&String>, description: &str) -> MatchResult {
+    fn std(&self, actual: &[u8], expected: Option<&str>, description: &str) -> MatchResult {
         let out = match expected {
             Some(out) => out,
             None => return Ok(()),
@@ -51,7 +51,7 @@ impl CheckerMatchers for Play {
         let actual =
             str::from_utf8(actual).map_err(|_| format!("{description} was not utf8 encoded"))?;
 
-        if actual != *out {
+        if actual != out {
             return Err(format!(
                 "not equal:\n    actual: {actual}\n  expected: {out}\n\n"
             ));

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -46,12 +46,12 @@ impl Dirs {
         self.fixtures.join("playground/config")
     }
 
-    pub fn root(&self) -> &PathBuf {
-        &self.root
+    pub fn root(&self) -> &Path {
+        self.root.as_path()
     }
 
-    pub fn test(&self) -> &PathBuf {
-        &self.test
+    pub fn test(&self) -> &Path {
+        self.test.as_path()
     }
 }
 

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -51,7 +51,7 @@ fn find_id(
 
 fn read_in_file<'a>(
     engine_state: &'a mut EngineState,
-    file_path: &String,
+    file_path: &str,
 ) -> (Vec<u8>, StateWorkingSet<'a>) {
     let file = std::fs::read(file_path)
         .into_diagnostic()
@@ -74,7 +74,7 @@ fn read_in_file<'a>(
     (file, working_set)
 }
 
-pub fn check(engine_state: &mut EngineState, file_path: &String, max_errors: &Value) {
+pub fn check(engine_state: &mut EngineState, file_path: &str, max_errors: &Value) {
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
     engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
@@ -137,7 +137,7 @@ pub fn check(engine_state: &mut EngineState, file_path: &String, max_errors: &Va
     }
 }
 
-pub fn goto_def(engine_state: &mut EngineState, file_path: &String, location: &Value) {
+pub fn goto_def(engine_state: &mut EngineState, file_path: &str, location: &Value) {
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
     engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
@@ -191,7 +191,7 @@ pub fn goto_def(engine_state: &mut EngineState, file_path: &String, location: &V
     println!("{{}}");
 }
 
-pub fn hover(engine_state: &mut EngineState, file_path: &String, location: &Value) {
+pub fn hover(engine_state: &mut EngineState, file_path: &str, location: &Value) {
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
     engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
@@ -577,7 +577,7 @@ pub fn hover(engine_state: &mut EngineState, file_path: &String, location: &Valu
     }
 }
 
-pub fn complete(engine_reference: Arc<EngineState>, file_path: &String, location: &Value) {
+pub fn complete(engine_reference: Arc<EngineState>, file_path: &str, location: &Value) {
     let stack = Stack::new();
     let mut completer = NuCompleter::new(engine_reference, stack);
 
@@ -603,7 +603,7 @@ pub fn complete(engine_reference: Arc<EngineState>, file_path: &String, location
     }
 }
 
-pub fn ast(engine_state: &mut EngineState, file_path: &String) {
+pub fn ast(engine_state: &mut EngineState, file_path: &str) {
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
     engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 

--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -9,7 +9,7 @@ fn canonicalize_path() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![EmptyFile("spam.txt")]);
 
-        let mut spam = dirs.test().clone();
+        let mut spam = dirs.test().to_owned();
         spam.push("spam.txt");
 
         let cwd = std::env::current_dir().expect("Could not get current directory");
@@ -24,7 +24,7 @@ fn canonicalize_unicode_path() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![EmptyFile("🚒.txt")]);
 
-        let mut spam = dirs.test().clone();
+        let mut spam = dirs.test().to_owned();
         spam.push("🚒.txt");
 
         let cwd = std::env::current_dir().expect("Could not get current directory");
@@ -47,7 +47,7 @@ fn canonicalize_path_relative_to() {
         sandbox.with_files(vec![EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with("spam.txt", dirs.test()).expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -60,11 +60,11 @@ fn canonicalize_unicode_path_relative_to_unicode_path_with_spaces() {
         sandbox.mkdir("e-$ èрт🚒♞中片-j");
         sandbox.with_files(vec![EmptyFile("e-$ èрт🚒♞中片-j/🚒.txt")]);
 
-        let mut relative_to = dirs.test().clone();
+        let mut relative_to = dirs.test().to_owned();
         relative_to.push("e-$ èрт🚒♞中片-j");
 
         let actual = canonicalize_with("🚒.txt", relative_to).expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("e-$ èрт🚒♞中片-j/🚒.txt");
 
         assert_eq!(actual, expected);
@@ -82,7 +82,7 @@ fn canonicalize_absolute_path_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.with_files(vec![EmptyFile("spam.txt")]);
 
-        let mut absolute_path = dirs.test().clone();
+        let mut absolute_path = dirs.test().to_owned();
         absolute_path.push("spam.txt");
 
         let actual = canonicalize_with(&absolute_path, "non/existent/directory")
@@ -118,7 +118,7 @@ fn canonicalize_path_with_dot_relative_to() {
         sandbox.with_files(vec![EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with("./spam.txt", dirs.test()).expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -132,7 +132,7 @@ fn canonicalize_path_with_many_dots_relative_to() {
 
         let actual = canonicalize_with("././/.//////./././//.////spam.txt", dirs.test())
             .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -158,7 +158,7 @@ fn canonicalize_path_with_double_dot_relative_to() {
 
         let actual =
             canonicalize_with("foo/../spam.txt", dirs.test()).expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -173,7 +173,7 @@ fn canonicalize_path_with_many_double_dots_relative_to() {
 
         let actual = canonicalize_with("foo/bar/baz/../../../spam.txt", dirs.test())
             .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -201,7 +201,7 @@ fn canonicalize_path_with_3_ndots_relative_to() {
 
         let actual =
             canonicalize_with("foo/bar/.../spam.txt", dirs.test()).expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -219,7 +219,7 @@ fn canonicalize_path_with_many_3_ndots_relative_to() {
             dirs.test(),
         )
         .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -234,7 +234,7 @@ fn canonicalize_path_with_4_ndots_relative_to() {
 
         let actual = canonicalize_with("foo/bar/baz/..../spam.txt", dirs.test())
             .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -252,7 +252,7 @@ fn canonicalize_path_with_many_4_ndots_relative_to() {
             dirs.test(),
         )
         .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -265,12 +265,12 @@ fn canonicalize_path_with_way_too_many_dots_relative_to() {
         sandbox.mkdir("foo/bar/baz/eggs/sausage/bacon/vikings");
         sandbox.with_files(vec![EmptyFile("spam.txt")]);
 
-        let mut relative_to = dirs.test().clone();
+        let mut relative_to = dirs.test().to_owned();
         relative_to.push("foo/bar/baz/eggs/sausage/bacon/vikings");
 
         let actual = canonicalize_with("././..////././...///././.....///spam.txt", relative_to)
             .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -283,12 +283,12 @@ fn canonicalize_unicode_path_with_way_too_many_dots_relative_to_unicode_path_wit
         sandbox.mkdir("foo/áčěéí  +šř=é/baz/eggs/e-$ èрт🚒♞中片-j/bacon/öäöä öäöä");
         sandbox.with_files(vec![EmptyFile("🚒.txt")]);
 
-        let mut relative_to = dirs.test().clone();
+        let mut relative_to = dirs.test().to_owned();
         relative_to.push("foo/áčěéí  +šř=é/baz/eggs/e-$ èрт🚒♞中片-j/bacon/öäöä öäöä");
 
         let actual = canonicalize_with("././..////././...///././.....///🚒.txt", relative_to)
             .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("🚒.txt");
 
         assert_eq!(actual, expected);
@@ -324,12 +324,12 @@ fn canonicalize_symlink() {
         sandbox.with_files(vec![EmptyFile("spam.txt")]);
         sandbox.symlink("spam.txt", "link_to_spam.txt");
 
-        let mut symlink_path = dirs.test().clone();
+        let mut symlink_path = dirs.test().to_owned();
         symlink_path.push("link_to_spam.txt");
 
         let cwd = std::env::current_dir().expect("Could not get current directory");
         let actual = canonicalize_with(symlink_path, cwd).expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -345,7 +345,7 @@ fn canonicalize_symlink_relative_to() {
 
         let actual =
             canonicalize_with("link_to_spam.txt", dirs.test()).expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -377,7 +377,7 @@ fn canonicalize_nested_symlink_relative_to() {
 
         let actual = canonicalize_with("link_to_link_to_spam.txt", dirs.test())
             .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -396,7 +396,7 @@ fn canonicalize_nested_symlink_within_symlink_dir_relative_to() {
 
         let actual = canonicalize_with("link_to_foo/link_to_link_to_spam.txt", dirs.test())
             .expect("Failed to canonicalize");
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("foo/bar/baz/spam.txt");
 
         assert_eq!(actual, expected);

--- a/tests/path/expand_path.rs
+++ b/tests/path/expand_path.rs
@@ -39,12 +39,12 @@ fn expand_path_no_change() {
 #[test]
 fn expand_unicode_path_no_change() {
     Playground::setup("nu_path_test_1", |dirs, _| {
-        let mut spam = dirs.test().clone();
+        let mut spam = dirs.test().to_owned();
         spam.push("🚒.txt");
 
         let cwd = std::env::current_dir().expect("Could not get current directory");
         let actual = expand_path_with(spam, cwd);
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("🚒.txt");
 
         assert_eq!(actual, expected);
@@ -61,7 +61,7 @@ fn expand_non_utf8_path() {
 fn expand_path_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
         let actual = expand_path_with("spam.txt", dirs.test());
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -71,11 +71,11 @@ fn expand_path_relative_to() {
 #[test]
 fn expand_unicode_path_relative_to_unicode_path_with_spaces() {
     Playground::setup("nu_path_test_1", |dirs, _| {
-        let mut relative_to = dirs.test().clone();
+        let mut relative_to = dirs.test().to_owned();
         relative_to.push("e-$ èрт🚒♞中片-j");
 
         let actual = expand_path_with("🚒.txt", relative_to);
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("e-$ èрт🚒♞中片-j/🚒.txt");
 
         assert_eq!(actual, expected);
@@ -91,7 +91,7 @@ fn expand_non_utf8_path_relative_to_non_utf8_path_with_spaces() {
 #[test]
 fn expand_absolute_path_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
-        let mut absolute_path = dirs.test().clone();
+        let mut absolute_path = dirs.test().to_owned();
         absolute_path.push("spam.txt");
 
         let actual = expand_path_with(&absolute_path, "non/existent/directory");
@@ -105,7 +105,7 @@ fn expand_absolute_path_relative_to() {
 fn expand_path_with_dot_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
         let actual = expand_path_with("./spam.txt", dirs.test());
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -116,7 +116,7 @@ fn expand_path_with_dot_relative_to() {
 fn expand_path_with_many_dots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
         let actual = expand_path_with("././/.//////./././//.////spam.txt", dirs.test());
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -127,7 +127,7 @@ fn expand_path_with_many_dots_relative_to() {
 fn expand_path_with_double_dot_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
         let actual = expand_path_with("foo/../spam.txt", dirs.test());
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -138,7 +138,7 @@ fn expand_path_with_double_dot_relative_to() {
 fn expand_path_with_many_double_dots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
         let actual = expand_path_with("foo/bar/baz/../../../spam.txt", dirs.test());
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -149,7 +149,7 @@ fn expand_path_with_many_double_dots_relative_to() {
 fn expand_path_with_3_ndots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
         let actual = expand_path_with("foo/bar/.../spam.txt", dirs.test());
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -163,7 +163,7 @@ fn expand_path_with_many_3_ndots_relative_to() {
             "foo/bar/baz/eggs/sausage/bacon/.../.../.../spam.txt",
             dirs.test(),
         );
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -174,7 +174,7 @@ fn expand_path_with_many_3_ndots_relative_to() {
 fn expand_path_with_4_ndots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
         let actual = expand_path_with("foo/bar/baz/..../spam.txt", dirs.test());
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -188,7 +188,7 @@ fn expand_path_with_many_4_ndots_relative_to() {
             "foo/bar/baz/eggs/sausage/bacon/..../..../spam.txt",
             dirs.test(),
         );
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -198,11 +198,11 @@ fn expand_path_with_many_4_ndots_relative_to() {
 #[test]
 fn expand_path_with_way_too_many_dots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, _| {
-        let mut relative_to = dirs.test().clone();
+        let mut relative_to = dirs.test().to_owned();
         relative_to.push("foo/bar/baz/eggs/sausage/bacon/vikings");
 
         let actual = expand_path_with("././..////././...///././.....///spam.txt", relative_to);
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("spam.txt");
 
         assert_eq!(actual, expected);
@@ -212,11 +212,11 @@ fn expand_path_with_way_too_many_dots_relative_to() {
 #[test]
 fn expand_unicode_path_with_way_too_many_dots_relative_to_unicode_path_with_spaces() {
     Playground::setup("nu_path_test_1", |dirs, _| {
-        let mut relative_to = dirs.test().clone();
+        let mut relative_to = dirs.test().to_owned();
         relative_to.push("foo/áčěéí  +šř=é/baz/eggs/e-$ èрт🚒♞中片-j/bacon/öäöä öäöä");
 
         let actual = expand_path_with("././..////././...///././.....///🚒.txt", relative_to);
-        let mut expected = dirs.test().clone();
+        let mut expected = dirs.test().to_owned();
         expected.push("🚒.txt");
 
         assert_eq!(actual, expected);


### PR DESCRIPTION
# Description
This generally makes for nicer APIs, as you are not forced to use an existing allocation covering the full `String`.

Some exceptions remain where the underlying type requirements favor it.

# User-Facing Changes
None
