### PR TITLE
remove profiling from nushell's hot loop

### DIFF
--- a/crates/nu-command/src/debug/profile.rs
+++ b/crates/nu-command/src/debug/profile.rs
@@ -1,6 +1,6 @@
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{Closure, Command, EngineState, ProfilingConfig, Stack};
+use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
     Category, DataSource, Example, IntoPipelineData, PipelineData, PipelineMetadata, Signature,
     Spanned, SyntaxShape, Type, Value,
@@ -70,24 +70,13 @@ Current known limitations are:
             }
         }
 
-        stack.profiling_config = ProfilingConfig::new(
-            call.get_flag::<i64>(engine_state, &mut stack, "max-depth")?
-                .unwrap_or(1),
-            call.has_flag("source"),
-            call.has_flag("values"),
-        );
-
-        let profiling_metadata = Box::new(PipelineMetadata {
-            data_source: DataSource::Profiling(vec![]),
-        });
-
         let result = if let Some(PipelineMetadata {
             data_source: DataSource::Profiling(values),
         }) = eval_block(
             engine_state,
             &mut stack,
             block,
-            input_val.into_pipeline_data_with_metadata(profiling_metadata),
+            input_val.into_pipeline_data(),
             redirect_stdout,
             redirect_stderr,
         )?

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -7,44 +7,6 @@ use crate::{ShellError, Span, Value, VarId};
 /// Environment variables per overlay
 pub type EnvVars = HashMap<String, HashMap<String, Value>>;
 
-#[derive(Debug, Clone)]
-pub struct ProfilingConfig {
-    pub max_depth: i64,
-    pub depth: i64,
-    pub collect_source: bool,
-    pub collect_values: bool,
-}
-
-impl ProfilingConfig {
-    pub fn new(max_depth: i64, collect_source: bool, collect_values: bool) -> Self {
-        ProfilingConfig {
-            max_depth,
-            depth: 0,
-            collect_source,
-            collect_values,
-        }
-    }
-
-    pub fn enter_block(&mut self) {
-        self.depth += 1;
-    }
-
-    pub fn leave_block(&mut self) {
-        self.depth -= 1;
-    }
-
-    pub fn should_debug(&self) -> bool {
-        self.depth <= self.max_depth
-    }
-
-    pub fn reset(&mut self) {
-        self.max_depth = 0;
-        self.depth = 0;
-        self.collect_source = false;
-        self.collect_values = false;
-    }
-}
-
 /// A runtime value stack used during evaluation
 ///
 /// A note on implementation:
@@ -73,7 +35,6 @@ pub struct Stack {
     /// List of active overlays
     pub active_overlays: Vec<String>,
     pub recursion_count: Box<u64>,
-    pub profiling_config: ProfilingConfig,
 }
 
 impl Stack {
@@ -84,7 +45,6 @@ impl Stack {
             env_hidden: HashMap::new(),
             active_overlays: vec![DEFAULT_OVERLAY_NAME.to_string()],
             recursion_count: Box::new(0),
-            profiling_config: ProfilingConfig::new(0, false, false),
         }
     }
 
@@ -195,7 +155,6 @@ impl Stack {
             env_hidden: self.env_hidden.clone(),
             active_overlays: self.active_overlays.clone(),
             recursion_count: self.recursion_count.to_owned(),
-            profiling_config: self.profiling_config.clone(),
         }
     }
 
@@ -223,7 +182,6 @@ impl Stack {
             env_hidden: self.env_hidden.clone(),
             active_overlays: self.active_overlays.clone(),
             recursion_count: self.recursion_count.to_owned(),
-            profiling_config: self.profiling_config.clone(),
         }
     }
 


### PR DESCRIPTION
# Description

This removes pipeline element profiling. This could be a useful feature, but pipeline elements are going to be the most sensitive to in terms of performance, as `eval_block` and how pipelines are built is one of the hot loops inside of the eval engine.

# User-Facing Changes

Removes pipeline element profiling.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
