### PR TITLE
fix(cd): on android/termux fails to cd into /sdcard

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -229,7 +229,16 @@ fn have_permission(dir: impl AsRef<Path>) -> PermissionResult<'static> {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn any_group(_current_user_gid: gid_t, owner_group: u32) -> bool {
+    use crate::filesystem::util::users;
+    let Some(user_groups) = users::current_user_groups() else {
+        return false;
+    };
+    user_groups.iter().any(|gid| gid.as_raw() == owner_group)
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
 fn any_group(current_user_gid: gid_t, owner_group: u32) -> bool {
     use crate::filesystem::util::users;
 


### PR DESCRIPTION
fix on android/termux fails to cd into /sdcard or any directory that user has access via group

fixes #8095

I am not aware how this works on other platform so feel free to modify this pr or even close it if it is not correct

# Description
on android or on linux to check if the user belongs to given directory group, use `libc::getgroups` function

# User-Facing Changes
NA

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting

