### PR TITLE
Upgrade softprops/action-gh-release to v0.1.15 for release and nightly build workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -13,7 +13,7 @@ on:
       - nightly   # Just for test purpose only with the nightly repo
   # This schedule will run only from the default branch
   schedule:
-    - cron: '15 1 * * *' # run at 01:15 AM UTC
+    - cron: '15 0 * * *' # run at 01:15 AM UTC
 
 defaults:
   run:
@@ -53,14 +53,13 @@ jobs:
           # We can't push if no user name and email are configured
           git config user.name 'hustcer'
           git config user.email 'hustcer@outlook.com'
-          git fetch origin main
+          git pull origin main
           git remote add src https://github.com/nushell/nushell.git
           git fetch src main
-          # git pull --rebase src main
           # All the changes will be overwritten by the upstream main branch
           git reset --hard src/main
           git push origin main -f
-          let sha_short = (git rev-parse --short src/main | str trim | str substring 0..7)
+          let sha_short = (git rev-parse --short origin/main | str trim | str substring 0..7)
           let tag_name = $'nightly-($sha_short)'
           if (git ls-remote --tags origin $tag_name | is-empty) {
             git tag -a $tag_name -m $'Nightly build from ($sha_short)'
@@ -176,7 +175,7 @@ jobs:
     # REF: https://github.com/marketplace/actions/gh-release
     # Create a release only in nushell/nightly repo
     - name: Publish Archive
-      uses: softprops/action-gh-release@v0.1.13
+      uses: softprops/action-gh-release@v0.1.15
       if: ${{ startsWith(github.repository, 'nushell/nightly') }}
       with:
         draft: false

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -13,7 +13,7 @@ on:
       - nightly   # Just for test purpose only with the nightly repo
   # This schedule will run only from the default branch
   schedule:
-    - cron: '15 0 * * *' # run at 01:15 AM UTC
+    - cron: '15 0 * * *' # run at 00:15 AM UTC
 
 defaults:
   run:

--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -172,18 +172,22 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
         cp -r $'($dist)/*' target/release/
         cargo install cargo-wix --version 0.3.4
         cargo wix --no-build --nocapture --package nu --output $wixRelease
-        print $'archive: ---> ($wixRelease)';
-        echo $"archive=($wixRelease)" | save --append $env.GITHUB_OUTPUT
+        # Workaround for https://github.com/softprops/action-gh-release/issues/280
+        let archive = ($wixRelease | str replace -a '\' '/')
+        print $'archive: ---> ($archive)';
+        echo $"archive=($archive)" | save --append $env.GITHUB_OUTPUT
 
     } else {
 
         print $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls
         let archive = $'($dist)/($releaseStem).zip'
         7z a $archive *
-        print $'archive: ---> ($archive)';
         let pkg = (ls -f $archive | get name)
         if not ($pkg | is-empty) {
-            echo $"archive=($pkg | get 0)" | save --append $env.GITHUB_OUTPUT
+            # Workaround for https://github.com/softprops/action-gh-release/issues/280
+            let archive = ($pkg | get 0 | str replace -a '\' '/')
+            print $'archive: ---> ($archive)'
+            echo $"archive=($archive)" | save --append $env.GITHUB_OUTPUT
         }
     }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
 
     # REF: https://github.com/marketplace/actions/gh-release
     - name: Publish Archive
-      uses: softprops/action-gh-release@v0.1.13
+      uses: softprops/action-gh-release@v0.1.15
       if: ${{ startsWith(github.ref, 'refs/tags/') }}
       with:
         draft: true


### PR DESCRIPTION

# Description

Upgrade `softprops/action-gh-release` to v0.1.15 for release and nightly build workflow

softprops/action-gh-release@v0.1.13 uses `node12` and there are lots of warnings here: https://github.com/nushell/nushell/actions/runs/5944081632

We make it stay at v0.1.13 due to [this issue](https://github.com/softprops/action-gh-release/issues/280), but we can try to update it with [this workaround](https://github.com/softprops/action-gh-release/issues/280#issuecomment-1322187892) and test it in our nightly release repo: https://github.com/nushell/nightly to make sure that it works for the next release.



