### PR TITLE
Update internal use of `decimal` to `float`

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/between_values.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/between_values.rs
@@ -226,7 +226,7 @@ pub(super) fn compute_series_single_value(
                 compute_series_i64(&lhs, *val, <ChunkedArray<Int64Type>>::add, lhs_span)
             }
             Value::Float { val, .. } => {
-                compute_series_decimal(&lhs, *val, <ChunkedArray<Float64Type>>::add, lhs_span)
+                compute_series_float(&lhs, *val, <ChunkedArray<Float64Type>>::add, lhs_span)
             }
             Value::String { val, .. } => add_string_to_series(&lhs, val, lhs_span),
             _ => Err(ShellError::OperatorMismatch {
@@ -242,7 +242,7 @@ pub(super) fn compute_series_single_value(
                 compute_series_i64(&lhs, *val, <ChunkedArray<Int64Type>>::sub, lhs_span)
             }
             Value::Float { val, .. } => {
-                compute_series_decimal(&lhs, *val, <ChunkedArray<Float64Type>>::sub, lhs_span)
+                compute_series_float(&lhs, *val, <ChunkedArray<Float64Type>>::sub, lhs_span)
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
@@ -257,7 +257,7 @@ pub(super) fn compute_series_single_value(
                 compute_series_i64(&lhs, *val, <ChunkedArray<Int64Type>>::mul, lhs_span)
             }
             Value::Float { val, .. } => {
-                compute_series_decimal(&lhs, *val, <ChunkedArray<Float64Type>>::mul, lhs_span)
+                compute_series_float(&lhs, *val, <ChunkedArray<Float64Type>>::mul, lhs_span)
             }
             _ => Err(ShellError::OperatorMismatch {
                 op_span: operator.span,
@@ -281,7 +281,7 @@ pub(super) fn compute_series_single_value(
                     if val.is_zero() {
                         Err(ShellError::DivisionByZero { span })
                     } else {
-                        compute_series_decimal(
+                        compute_series_float(
                             &lhs,
                             *val,
                             <ChunkedArray<Float64Type>>::div,
@@ -301,7 +301,7 @@ pub(super) fn compute_series_single_value(
         Operator::Comparison(Comparison::Equal) => match &right {
             Value::Int { val, .. } => compare_series_i64(&lhs, *val, ChunkedArray::equal, lhs_span),
             Value::Float { val, .. } => {
-                compare_series_decimal(&lhs, *val, ChunkedArray::equal, lhs_span)
+                compare_series_float(&lhs, *val, ChunkedArray::equal, lhs_span)
             }
             Value::String { val, .. } => {
                 let equal_pattern = format!("^{}$", fancy_regex::escape(val));
@@ -323,7 +323,7 @@ pub(super) fn compute_series_single_value(
                 compare_series_i64(&lhs, *val, ChunkedArray::not_equal, lhs_span)
             }
             Value::Float { val, .. } => {
-                compare_series_decimal(&lhs, *val, ChunkedArray::not_equal, lhs_span)
+                compare_series_float(&lhs, *val, ChunkedArray::not_equal, lhs_span)
             }
             Value::Date { val, .. } => compare_series_i64(
                 &lhs,
@@ -342,7 +342,7 @@ pub(super) fn compute_series_single_value(
         Operator::Comparison(Comparison::LessThan) => match &right {
             Value::Int { val, .. } => compare_series_i64(&lhs, *val, ChunkedArray::lt, lhs_span),
             Value::Float { val, .. } => {
-                compare_series_decimal(&lhs, *val, ChunkedArray::lt, lhs_span)
+                compare_series_float(&lhs, *val, ChunkedArray::lt, lhs_span)
             }
             Value::Date { val, .. } => {
                 compare_series_i64(&lhs, val.timestamp_millis(), ChunkedArray::lt, lhs_span)
@@ -358,7 +358,7 @@ pub(super) fn compute_series_single_value(
         Operator::Comparison(Comparison::LessThanOrEqual) => match &right {
             Value::Int { val, .. } => compare_series_i64(&lhs, *val, ChunkedArray::lt_eq, lhs_span),
             Value::Float { val, .. } => {
-                compare_series_decimal(&lhs, *val, ChunkedArray::lt_eq, lhs_span)
+                compare_series_float(&lhs, *val, ChunkedArray::lt_eq, lhs_span)
             }
             Value::Date { val, .. } => {
                 compare_series_i64(&lhs, val.timestamp_millis(), ChunkedArray::lt_eq, lhs_span)
@@ -374,7 +374,7 @@ pub(super) fn compute_series_single_value(
         Operator::Comparison(Comparison::GreaterThan) => match &right {
             Value::Int { val, .. } => compare_series_i64(&lhs, *val, ChunkedArray::gt, lhs_span),
             Value::Float { val, .. } => {
-                compare_series_decimal(&lhs, *val, ChunkedArray::gt, lhs_span)
+                compare_series_float(&lhs, *val, ChunkedArray::gt, lhs_span)
             }
             Value::Date { val, .. } => {
                 compare_series_i64(&lhs, val.timestamp_millis(), ChunkedArray::gt, lhs_span)
@@ -390,7 +390,7 @@ pub(super) fn compute_series_single_value(
         Operator::Comparison(Comparison::GreaterThanOrEqual) => match &right {
             Value::Int { val, .. } => compare_series_i64(&lhs, *val, ChunkedArray::gt_eq, lhs_span),
             Value::Float { val, .. } => {
-                compare_series_decimal(&lhs, *val, ChunkedArray::gt_eq, lhs_span)
+                compare_series_float(&lhs, *val, ChunkedArray::gt_eq, lhs_span)
             }
             Value::Date { val, .. } => {
                 compare_series_i64(&lhs, val.timestamp_millis(), ChunkedArray::gt_eq, lhs_span)
@@ -514,7 +514,7 @@ where
     }
 }
 
-fn compute_series_decimal<F>(
+fn compute_series_float<F>(
     series: &Series,
     val: f64,
     f: F,
@@ -548,7 +548,7 @@ where
         _ => Err(ShellError::GenericError(
             "Incorrect type".into(),
             format!(
-                "Series of type {} can not be used for operations with a decimal value",
+                "Series of type {} can not be used for operations with a float value",
                 series.dtype()
             ),
             Some(span),
@@ -668,7 +668,7 @@ where
     }
 }
 
-fn compare_series_decimal<F>(
+fn compare_series_float<F>(
     series: &Series,
     val: f64,
     f: F,
@@ -702,7 +702,7 @@ where
         _ => Err(ShellError::GenericError(
             "Incorrect type".into(),
             format!(
-                "Series of type {} can not be used for operations with a decimal value",
+                "Series of type {} can not be used for operations with a float value",
                 series.dtype()
             ),
             Some(span),

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/between_values.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/between_values.rs
@@ -281,12 +281,7 @@ pub(super) fn compute_series_single_value(
                     if val.is_zero() {
                         Err(ShellError::DivisionByZero { span })
                     } else {
-                        compute_series_float(
-                            &lhs,
-                            *val,
-                            <ChunkedArray<Float64Type>>::div,
-                            lhs_span,
-                        )
+                        compute_series_float(&lhs, *val, <ChunkedArray<Float64Type>>::div, lhs_span)
                     }
                 }
                 _ => Err(ShellError::OperatorMismatch {
@@ -514,12 +509,7 @@ where
     }
 }
 
-fn compute_series_float<F>(
-    series: &Series,
-    val: f64,
-    f: F,
-    span: Span,
-) -> Result<Value, ShellError>
+fn compute_series_float<F>(series: &Series, val: f64, f: F, span: Span) -> Result<Value, ShellError>
 where
     F: Fn(ChunkedArray<Float64Type>, f64) -> ChunkedArray<Float64Type>,
 {
@@ -668,12 +658,7 @@ where
     }
 }
 
-fn compare_series_float<F>(
-    series: &Series,
-    val: f64,
-    f: F,
-    span: Span,
-) -> Result<Value, ShellError>
+fn compare_series_float<F>(series: &Series, val: f64, f: F, span: Span) -> Result<Value, ShellError>
 where
     F: Fn(&ChunkedArray<Float64Type>, f64) -> ChunkedArray<BooleanType>,
 {

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -107,7 +107,7 @@ impl Command for SubCommand {
                 result: None,
             },
             Example {
-                description: "convert a decimal to a nushell binary primitive",
+                description: "convert a float to a nushell binary primitive",
                 example: "1.234 | into binary",
                 result: Some(Value::binary(
                     1.234f64.to_ne_bytes().to_vec(),

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -95,12 +95,12 @@ impl Command for SubCommand {
                 result: Some(Value::bool(true, span)),
             },
             Example {
-                description: "convert decimal to boolean",
+                description: "convert float to boolean",
                 example: "0.3 | into bool",
                 result: Some(Value::bool(true, span)),
             },
             Example {
-                description: "convert decimal string to boolean",
+                description: "convert float string to boolean",
                 example: "'0.0' | into bool",
                 result: Some(Value::bool(false, span)),
             },

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -105,7 +105,7 @@ impl Command for SubCommand {
                 result: Some(Value::filesize(2, Span::test_data())),
             },
             Example {
-                description: "Convert decimal to filesize",
+                description: "Convert float to filesize",
                 example: "8.3 | into filesize",
                 result: Some(Value::filesize(8, Span::test_data())),
             },

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     #[allow(clippy::approx_constant)]
-    fn string_to_decimal() {
+    fn string_to_float() {
         let word = Value::test_string("3.1415");
         let expected = Value::test_float(3.1415);
 
@@ -154,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn communicates_parsing_error_given_an_invalid_decimallike_string() {
+    fn communicates_parsing_error_given_an_invalid_floatlike_string() {
         let invalid_str = Value::test_string("11.6anra");
 
         let actual = action(

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -169,7 +169,7 @@ impl Command for SubCommand {
                 result: Some(Value::test_int(2)),
             },
             Example {
-                description: "Convert decimal to integer",
+                description: "Convert float to integer",
                 example: "5.9 | into int",
                 result: Some(Value::test_int(5)),
             },

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -89,22 +89,22 @@ impl Command for SubCommand {
                 result: Some(Value::test_string("5.000")),
             },
             Example {
-                description: "convert decimal to string and round to nearest integer",
+                description: "convert float to string and round to nearest integer",
                 example: "1.7 | into string -d 0",
                 result: Some(Value::test_string("2")),
             },
             Example {
-                description: "convert decimal to string",
+                description: "convert float to string",
                 example: "1.7 | into string -d 1",
                 result: Some(Value::test_string("1.7")),
             },
             Example {
-                description: "convert decimal to string and limit to 2 decimals",
+                description: "convert float to string and limit to 2 decimals",
                 example: "1.734 | into string -d 2",
                 result: Some(Value::test_string("1.73")),
             },
             Example {
-                description: "try to convert decimal to string and provide negative decimal points",
+                description: "try to convert float to string and provide negative decimal points",
                 example: "1.734 | into string -d -2",
                 result: None,
                 // FIXME
@@ -116,7 +116,7 @@ impl Command for SubCommand {
                 // }),
             },
             Example {
-                description: "convert decimal to string",
+                description: "convert float to string",
                 example: "4.3 | into string",
                 result: Some(Value::test_string("4.3")),
             },

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -8,7 +8,7 @@ fn into_filesize_int() {
 }
 
 #[test]
-fn into_filesize_decimal() {
+fn into_filesize_float() {
     let actual = nu!("1.2 | into filesize");
 
     assert!(actual.out.contains("1 B"));

--- a/crates/nu-command/tests/commands/math/mod.rs
+++ b/crates/nu-command/tests/commands/math/mod.rs
@@ -117,7 +117,7 @@ fn error_zero_division_int_int() {
 }
 
 #[test]
-fn error_zero_division_decimal_int() {
+fn error_zero_division_float_int() {
     let actual = nu!(pipeline(
         r#"
             1.0 / 0
@@ -128,7 +128,7 @@ fn error_zero_division_decimal_int() {
 }
 
 #[test]
-fn error_zero_division_int_decimal() {
+fn error_zero_division_int_float() {
     let actual = nu!(pipeline(
         r#"
             1 / 0.0
@@ -139,7 +139,7 @@ fn error_zero_division_int_decimal() {
 }
 
 #[test]
-fn error_zero_division_decimal_decimal() {
+fn error_zero_division_float_float() {
     let actual = nu!(pipeline(
         r#"
             1.0 / 0.0
@@ -194,7 +194,7 @@ fn error_zero_floor_division_int_int() {
 }
 
 #[test]
-fn error_zero_floor_division_decimal_int() {
+fn error_zero_floor_division_float_int() {
     let actual = nu!(pipeline(
         r#"
             1.0 // 0
@@ -205,7 +205,7 @@ fn error_zero_floor_division_decimal_int() {
 }
 
 #[test]
-fn error_zero_floor_division_int_decimal() {
+fn error_zero_floor_division_int_float() {
     let actual = nu!(pipeline(
         r#"
             1 // 0.0
@@ -216,7 +216,7 @@ fn error_zero_floor_division_int_decimal() {
 }
 
 #[test]
-fn error_zero_floor_division_decimal_decimal() {
+fn error_zero_floor_division_float_float() {
     let actual = nu!(pipeline(
         r#"
             1.0 // 0.0

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -21,7 +21,7 @@ fn from_number() {
 }
 
 #[test]
-fn from_decimal() {
+fn from_float() {
     let actual = nu!(r#"
         echo 1.5 | into string
         "#);
@@ -90,7 +90,7 @@ fn from_filesize() {
 }
 
 #[test]
-fn from_decimal_correct_trailing_zeros() {
+fn from_float_correct_trailing_zeros() {
     let actual = nu!(r#"
         1.23000 | into string -d 3
         "#);
@@ -99,7 +99,7 @@ fn from_decimal_correct_trailing_zeros() {
 }
 
 #[test]
-fn from_int_decimal_correct_trailing_zeros() {
+fn from_int_float_correct_trailing_zeros() {
     let actual = nu!(r#"
         1.00000 | into string -d 3
         "#);
@@ -108,7 +108,7 @@ fn from_int_decimal_correct_trailing_zeros() {
 }
 
 #[test]
-fn from_int_decimal_trim_trailing_zeros() {
+fn from_int_float_trim_trailing_zeros() {
     let actual = nu!(r#"
         1.00000 | into string | $"($in) flat"
         "#);

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -135,7 +135,7 @@ fn converts_to_int() {
 }
 
 #[test]
-fn converts_to_decimal() {
+fn converts_to_float() {
     let actual = nu!(pipeline(
         r#"
             echo "3.1, 0.0415"

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2709,7 +2709,7 @@ pub fn parse_shape_name(
         b"duration" => SyntaxShape::Duration,
         b"error" => SyntaxShape::Error,
         b"expr" => SyntaxShape::Expression,
-        b"float" | b"decimal" => SyntaxShape::Decimal,
+        b"float" | b"decimal" => SyntaxShape::Float,
         b"filesize" => SyntaxShape::Filesize,
         b"full-cell-path" => SyntaxShape::FullCellPath,
         b"glob" => SyntaxShape::GlobPattern,
@@ -4654,7 +4654,7 @@ pub fn parse_value(
             expression
         }
         SyntaxShape::Number => parse_number(working_set, span),
-        SyntaxShape::Decimal => parse_float(working_set, span),
+        SyntaxShape::Float => parse_float(working_set, span),
         SyntaxShape::Int => parse_int(working_set, span),
         SyntaxShape::Duration => parse_duration(working_set, span),
         SyntaxShape::DateTime => parse_datetime(working_set, span),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2709,7 +2709,7 @@ pub fn parse_shape_name(
         b"duration" => SyntaxShape::Duration,
         b"error" => SyntaxShape::Error,
         b"expr" => SyntaxShape::Expression,
-        b"float" | b"decimal" => SyntaxShape::Float,
+        b"float" => SyntaxShape::Float,
         b"filesize" => SyntaxShape::Filesize,
         b"full-cell-path" => SyntaxShape::FullCellPath,
         b"glob" => SyntaxShape::GlobPattern,

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -189,7 +189,7 @@ impl Display for SyntaxShape {
             SyntaxShape::Number => write!(f, "number"),
             SyntaxShape::Range => write!(f, "range"),
             SyntaxShape::Int => write!(f, "int"),
-            SyntaxShape::Float => write!(f, "decimal"),
+            SyntaxShape::Float => write!(f, "float"),
             SyntaxShape::Filepath => write!(f, "path"),
             SyntaxShape::Directory => write!(f, "directory"),
             SyntaxShape::GlobPattern => write!(f, "glob"),

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -82,7 +82,7 @@ pub enum SyntaxShape {
     /// Nothing
     Nothing,
 
-    /// Only a numeric (integer or decimal) value is allowed
+    /// Only a numeric (integer or float) value is allowed
     Number,
 
     /// One of a list of possible items, checked in order

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -31,9 +31,6 @@ pub enum SyntaxShape {
     /// A datetime value, eg `2022-02-02` or `2019-10-12T07:20:50.52+00:00`
     DateTime,
 
-    /// A decimal value, eg `1.0`
-    Decimal,
-
     /// A directory is allowed
     Directory,
 
@@ -51,6 +48,9 @@ pub enum SyntaxShape {
 
     /// A filesize value is allowed, eg `10kb`
     Filesize,
+
+    /// A floating point value, eg `1.0`
+    Float,
 
     /// A dotted path to navigate the table (including variable)
     FullCellPath,
@@ -137,7 +137,7 @@ impl SyntaxShape {
             SyntaxShape::Expression => Type::Any,
             SyntaxShape::Filepath => Type::String,
             SyntaxShape::Directory => Type::String,
-            SyntaxShape::Decimal => Type::Float,
+            SyntaxShape::Float => Type::Float,
             SyntaxShape::Filesize => Type::Filesize,
             SyntaxShape::FullCellPath => Type::Any,
             SyntaxShape::GlobPattern => Type::String,
@@ -189,7 +189,7 @@ impl Display for SyntaxShape {
             SyntaxShape::Number => write!(f, "number"),
             SyntaxShape::Range => write!(f, "range"),
             SyntaxShape::Int => write!(f, "int"),
-            SyntaxShape::Decimal => write!(f, "decimal"),
+            SyntaxShape::Float => write!(f, "decimal"),
             SyntaxShape::Filepath => write!(f, "path"),
             SyntaxShape::Directory => write!(f, "directory"),
             SyntaxShape::GlobPattern => write!(f, "glob"),

--- a/crates/nu-std/std/dt.nu
+++ b/crates/nu-std/std/dt.nu
@@ -149,7 +149,7 @@ export def datetime-diff [from: datetime, to: datetime] {
         $result = (borrow-second $from_expanded $result)
     }
 
-    $result.millisecond = ($result.nanosecond / 1_000_000 | into int) # don't want a decimal
+    $result.millisecond = ($result.nanosecond / 1_000_000 | into int) # don't want a float
     $result.microsecond = (($result.nanosecond mod 1_000_000) / 1_000 | into int)
     $result.nanosecond = ($result.nanosecond mod 1_000 | into int)
 

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -561,7 +561,7 @@ fn index_out_of_bounds() {
 }
 
 #[test]
-fn negative_decimal_start() {
+fn negative_float_start() {
     let actual = nu!("
             -1.3 + 4
         ");


### PR DESCRIPTION
# Description
We made the decision that our floating point type should be referred to as `float` over `decimal`.
Commands were updated by #9979 and #10320

Now make the internal codebase consistent in referring to this data type as `float`.

Work for #10332

# User-Facing Changes

`decimal` has been removed as a type name/symbol. 

Instead of 
```nushell
def foo [bar: decimal] decimal -> decimal {}
```
use 
```nushell
def foo [bar: float] float -> float {}
```

Potential effect of `SyntaxShape`'s `Display` implementation now also referring to `float` instead of `decimal`

# Details
- Rename `SyntaxShape::Decimal` to `Float`
- Update `Display for SyntaxShape` to `float`
- Update error message + fn name in dataframe code
- Fix docs in command examples
- Rename tests that are float specific
- Update doccomment on `SyntaxShape`
- Update comment in script

# Tests + Formatting
Updates the names of some tests
