### PR TITLE
Change `echo` to print when not redirected

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -1,6 +1,6 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack, StateWorkingSet};
+use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, ListStream, PipelineData, ShellError, Signature, Span, SyntaxShape, Type,
     Value,
@@ -43,17 +43,7 @@ little reason to use this over just writing the values as-is."#
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let args = call.rest(engine_state, stack, 0);
-        run(engine_state, args, call)
-    }
-
-    fn run_const(
-        &self,
-        working_set: &StateWorkingSet,
-        call: &Call,
-        _input: PipelineData,
-    ) -> Result<PipelineData, ShellError> {
-        let args = call.rest_const(working_set, 0);
-        run(working_set.permanent(), args, call)
+        run(engine_state, args, stack, call)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -79,9 +69,10 @@ little reason to use this over just writing the values as-is."#
 fn run(
     engine_state: &EngineState,
     args: Result<Vec<Value>, ShellError>,
+    stack: &mut Stack,
     call: &Call,
 ) -> Result<PipelineData, ShellError> {
-    args.map(|to_be_echoed| {
+    let result = args.map(|to_be_echoed| {
         let n = to_be_echoed.len();
         match n.cmp(&1usize) {
             //  More than one value is converted in a stream of values
@@ -96,7 +87,20 @@ fn run(
             //  When there are no elements, we echo the empty string
             std::cmp::Ordering::Less => PipelineData::Value(Value::string("", call.head), None),
         }
-    })
+    });
+
+    // If echo is not redirected, then print to the screen (to behave in a similar way to other shells)
+    if !call.redirect_stdout {
+        match result {
+            Ok(pipeline) => {
+                pipeline.print(engine_state, stack, false, false)?;
+                Ok(PipelineData::Empty)
+            }
+            Err(err) => Err(err),
+        }
+    } else {
+        result
+    }
 }
 
 #[cfg(test)]

--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -31,10 +31,6 @@ it returns it. Otherwise, it returns a list of the arguments. There is usually
 little reason to use this over just writing the values as-is."#
     }
 
-    fn is_const(&self) -> bool {
-        true
-    }
-
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -86,7 +86,7 @@ impl Command for Try {
             },
             Example {
                 description: "Try to run a missing command",
-                example: "try { asdfasdf } catch { echo 'missing' } ",
+                example: "try { asdfasdf } catch { 'missing' } ",
                 result: Some(Value::test_string("missing")),
             },
         ]

--- a/crates/nu-command/tests/commands/echo.rs
+++ b/crates/nu-command/tests/commands/echo.rs
@@ -34,9 +34,3 @@ fn echo_range_handles_exclusive_down() {
 
     assert_eq!(actual.out, "[3,2]");
 }
-
-#[test]
-fn echo_const() {
-    let actual = nu!("const x = (echo spam); $x");
-    assert_eq!(actual.out, "spam");
-}

--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -4,7 +4,7 @@ use nu_test_support::nu;
 fn for_doesnt_auto_print_in_each_iteration() {
     let actual = nu!("
         for i in 1..2 {
-            echo 1
+            $i
         }");
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore

--- a/crates/nu-command/tests/commands/loop_.rs
+++ b/crates/nu-command/tests/commands/loop_.rs
@@ -10,7 +10,7 @@ fn loop_doesnt_auto_print_in_each_iteration() {
             } else {
                 $total += 1;
             }
-            echo 1
+            1
         }");
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore

--- a/crates/nu-command/tests/commands/while_.rs
+++ b/crates/nu-command/tests/commands/while_.rs
@@ -11,7 +11,7 @@ fn while_sum() {
 
 #[test]
 fn while_doesnt_auto_print_in_each_iteration() {
-    let actual = nu!("mut total = 0; while $total < 2 { $total = $total + 1; echo 1 }");
+    let actual = nu!("mut total = 0; while $total < 2 { $total = $total + 1; 1 }");
     // Make sure we don't see any of these values in the output
     // As we do not auto-print loops anymore
     assert!(!actual.out.contains('1'));

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -333,7 +333,7 @@ fn describe_const() {
 
 #[test]
 fn ignore_const() {
-    let actual = nu!("const x = (echo spam | ignore); $x == null");
+    let actual = nu!(r#"const x = ("spam" | ignore); $x == null"#);
     assert_eq!(actual.out, "true");
 }
 


### PR DESCRIPTION
# Description

This changes `echo` to work more closely to what users of other shells would expect:

* when redirected, `echo` works as before and sends values through the pipeline
* when not redirected, `echo` will print values to the screen/terminal

# User-Facing Changes

A standalone `echo` now will print to the terminal, if not redirected.

The `echo` command is no longer const eval-able, as it will now print to the terminal in some cases.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
