### PR TITLE
add a few more columns to linux `ps -l` output

### DIFF
--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, IntoInterruptiblePipelineData, PipelineData, Record, ShellError, Signature,
-    Type, Value,
+    Span, Type, Value,
 };
 use std::time::Duration;
 
@@ -101,6 +101,43 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
 
         if long {
             record.push("command", Value::string(proc.command(), span));
+            #[cfg(all(
+                unix,
+                not(target_os = "macos"),
+                not(target_os = "windows"),
+                not(target_os = "android"),
+                not(target_os = "ios")
+            ))]
+            {
+                let proc_stat = proc.curr_proc.stat().map_err(|e| {
+                    ShellError::GenericError(
+                        "Error getting process stat".into(),
+                        e.to_string(),
+                        Some(Span::unknown()),
+                        None,
+                        Vec::new(),
+                    )
+                })?;
+                let proc_start = match proc_stat.starttime() {
+                    Ok(t) => t,
+                    Err(_) => {
+                        // If we can't get the start time, just use the current time
+                        chrono::Local::now()
+                    }
+                };
+                record.push("start_time", Value::date(proc_start.into(), span));
+                record.push("user_id", Value::int(proc.curr_proc.owner() as i64, span));
+                // These work and may be helpful, but it just seemed crowded
+                // record.push("group_id", Value::int(proc_stat.pgrp as i64, span));
+                // record.push("session_id", Value::int(proc_stat.session as i64, span));
+                // This may be helpful for ctrl+z type of checking, once we get there
+                // record.push("tpg_id", Value::int(proc_stat.tpgid as i64, span));
+                record.push("priority", Value::int(proc_stat.priority as i64, span));
+                record.push(
+                    "proc_threads",
+                    Value::int(proc_stat.num_threads as i64, span),
+                );
+            }
             #[cfg(windows)]
             {
                 //TODO: There's still more information we can cram in there if we want to

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -132,11 +132,8 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
                 // record.push("session_id", Value::int(proc_stat.session as i64, span));
                 // This may be helpful for ctrl+z type of checking, once we get there
                 // record.push("tpg_id", Value::int(proc_stat.tpgid as i64, span));
-                record.push("priority", Value::int(proc_stat.priority as i64, span));
-                record.push(
-                    "process_threads",
-                    Value::int(proc_stat.num_threads as i64, span),
-                );
+                record.push("priority", Value::int(proc_stat.priority, span));
+                record.push("process_threads", Value::int(proc_stat.num_threads, span));
             }
             #[cfg(windows)]
             {

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -1,11 +1,20 @@
 #[cfg(windows)]
 use itertools::Itertools;
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    not(target_os = "android"),
+    not(target_os = "ios")
+))]
+use nu_protocol::Span;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, IntoInterruptiblePipelineData, PipelineData, Record, ShellError, Signature,
-    Span, Type, Value,
+    Type, Value,
 };
+
 use std::time::Duration;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -134,7 +134,7 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
                 // record.push("tpg_id", Value::int(proc_stat.tpgid as i64, span));
                 record.push("priority", Value::int(proc_stat.priority as i64, span));
                 record.push(
-                    "proc_threads",
+                    "process_threads",
                     Value::int(proc_stat.num_threads as i64, span),
                 );
             }


### PR DESCRIPTION
# Description

This PR tried to add a few more columns to the Linux `ps -l` command. Those columns are:
* start_time
* user_id
* priority
* process_threads

There are a few that I left commented out that could be added but the screen was beginning to look crowded. So, I left out:
* group_id
* session_id
* tgp_id (which could be helpful for eventual job control)

And there's like 100 more things that could be added that didn't seem especially useful right now.

![image](https://github.com/nushell/nushell/assets/343840/065c0538-8f7d-4c9f-871f-a1bc98aff9d1)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
