### PR TITLE
Remove `select` error if same row/column is provided

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -218,7 +218,11 @@ fn select(
                     unique_rows.insert(*val);
                 }
             }
-            _ => new_columns.push(column),
+            _ => {
+                if !new_columns.contains(&column) {
+                    new_columns.push(column)
+                }
+            }
         };
     }
     let columns = new_columns;

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -214,9 +214,7 @@ fn select(
                         Vec::new(),
                     ));
                 }
-                if !unique_rows.contains(val) {
-                    unique_rows.insert(*val);
-                }
+                unique_rows.insert(*val);
             }
             _ => {
                 if !new_columns.contains(&column) {

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -214,16 +214,9 @@ fn select(
                         Vec::new(),
                     ));
                 }
-                if unique_rows.contains(val) {
-                    return Err(ShellError::GenericError(
-                        "Select can't get the same row twice".into(),
-                        "duplicated row index".into(),
-                        Some(*span),
-                        None,
-                        Vec::new(),
-                    ));
+                if !unique_rows.contains(val) {
+                    unique_rows.insert(*val);
                 }
-                unique_rows.insert(*val);
             }
             _ => new_columns.push(column),
         };

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -218,10 +218,17 @@ fn select_failed3() {
 }
 
 #[test]
-fn select_failed4() {
-    let actual = nu!("[{a: 1 b: 10}, {a:2, b:11}] | select 0 0");
+fn select_repeated_rows() {
+    let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select 0 0 | to nuon");
 
-    assert!(actual.err.contains("Select can't get the same row twice"));
+    assert_eq!(actual.out, "[[a, b, c]; [1, 2, 3]]");
+}
+
+#[test]
+fn select_repeated_column() {
+    let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select a a | to nuon");
+
+    assert_eq!(actual.out, "[[a]; [1], [4], [7]]");
 }
 
 #[test]


### PR DESCRIPTION
This PR is in reference to #10215.

This PR changes `select` to work even if multiple equal items were provided.
This would previously error, but now works
```nushell
let arg = [ 1 a ]
[[a b c]; [1 2 3] [4 5 6] [7 8 9]] 
| select $arg

```
# User-Facing Changes

Nothing too radical, just experience improvements. Users won't need to pass the values through `unique` beforehand.

