### PR TITLE
Optimize use of range in `std repeat`

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -322,5 +322,5 @@ export def repeat [
         return []
     }
 
-    ..($n - 1) | each { $item }
+    1..$n | each { $item }
 }


### PR DESCRIPTION
# Description
By using a `from: 1` the additional subexpression for `to` becomes
unnecessary.

Saves additional evaluation steps if `std repeat` is frequently used
with low `n`

# User-Facing Changes
None

# Tests + Formatting
(-)
