### PR TITLE
add helper switch to move cursor to end of buffer

### DIFF
--- a/crates/nu-cli/src/commands/commandline.rs
+++ b/crates/nu-cli/src/commands/commandline.rs
@@ -1,9 +1,9 @@
 use nu_engine::CallExt;
-use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::Category;
-use nu_protocol::IntoPipelineData;
-use nu_protocol::{PipelineData, ShellError, Signature, SyntaxShape, Type, Value};
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type, Value,
+};
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Clone)]
@@ -24,6 +24,11 @@ impl Command for Commandline {
                 "cursor",
                 "Set or get the current cursor position",
                 Some('c'),
+            )
+            .switch(
+                "cursor-end",
+                "Set the current cursor position to the end of the buffer",
+                Some('e'),
             )
             .switch(
                 "append",
@@ -104,8 +109,11 @@ impl Command for Commandline {
             }
             Ok(Value::nothing(call.head).into_pipeline_data())
         } else {
-            let repl = engine_state.repl_state.lock().expect("repl state mutex");
-            if call.has_flag("cursor") {
+            let mut repl = engine_state.repl_state.lock().expect("repl state mutex");
+            if call.has_flag("cursor-end") {
+                repl.cursor_pos = repl.buffer.graphemes(true).count();
+                Ok(Value::nothing(call.head).into_pipeline_data())
+            } else if call.has_flag("cursor") {
                 let char_pos = repl
                     .buffer
                     .grapheme_indices(true)


### PR DESCRIPTION
# Description

This PR adds a helper flag named `--cursor-end`/`-e` that allows you to set the cursor to the end of the buffer. Before this, you'd have to do something like `--cursor 100` where you're guessing that 100 would be longer than the buffer and just put it at the end.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
