### PR TITLE
Improve `select` row perf for large N

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -342,19 +342,19 @@ impl Iterator for NthIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-                if let Some(row) = self.rows.first() {
-                    if self.current == *row {
-                        self.rows.pop_first();
-                        self.current += 1;
-                        return self.input.next();
-                    } else {
-                        self.current += 1;
-                        let _ = self.input.next();
-                        continue;
-                    }
+            if let Some(row) = self.rows.first() {
+                if self.current == *row {
+                    self.rows.pop_first();
+                    self.current += 1;
+                    return self.input.next();
                 } else {
-                    return None;
+                    self.current += 1;
+                    let _ = self.input.next();
+                    continue;
                 }
+            } else {
+                return None;
+            }
         }
     }
 }

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
     PipelineIterator, Record, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 #[derive(Clone)]
 pub struct Select;
@@ -197,7 +197,7 @@ fn select(
     columns: Vec<CellPath>,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let mut unique_rows: HashSet<usize> = HashSet::new();
+    let mut unique_rows: BTreeSet<usize> = BTreeSet::new();
 
     let mut new_columns = vec![];
 
@@ -227,7 +227,6 @@ fn select(
     let mut unique_rows: Vec<usize> = unique_rows.into_iter().collect();
 
     let input = if !unique_rows.is_empty() {
-        unique_rows.sort_unstable();
         // let skip = call.has_flag("skip");
         let metadata = input.metadata();
         let pipeline_iter: PipelineIterator = input.into_iter();

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -224,7 +224,6 @@ fn select(
         };
     }
     let columns = new_columns;
-    let mut unique_rows: Vec<usize> = unique_rows.into_iter().collect();
 
     let input = if !unique_rows.is_empty() {
         // let skip = call.has_flag("skip");
@@ -334,7 +333,7 @@ fn select(
 
 struct NthIterator {
     input: PipelineIterator,
-    rows: Vec<usize>,
+    rows: BTreeSet<usize>,
     current: usize,
 }
 
@@ -345,7 +344,7 @@ impl Iterator for NthIterator {
         loop {
                 if let Some(row) = self.rows.first() {
                     if self.current == *row {
-                        self.rows.remove(0);
+                        self.rows.pop_first();
                         self.current += 1;
                         return self.input.next();
                     } else {

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -234,7 +234,6 @@ fn select(
         NthIterator {
             input: pipeline_iter,
             rows: unique_rows,
-            skip: false,
             current: 0,
         }
         .into_pipeline_data(engine_state.ctrlc.clone())
@@ -336,7 +335,6 @@ fn select(
 struct NthIterator {
     input: PipelineIterator,
     rows: Vec<usize>,
-    skip: bool,
     current: usize,
 }
 
@@ -345,7 +343,6 @@ impl Iterator for NthIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if !self.skip {
                 if let Some(row) = self.rows.first() {
                     if self.current == *row {
                         self.rows.remove(0);
@@ -359,19 +356,6 @@ impl Iterator for NthIterator {
                 } else {
                     return None;
                 }
-            } else if let Some(row) = self.rows.first() {
-                if self.current == *row {
-                    self.rows.remove(0);
-                    self.current += 1;
-                    let _ = self.input.next();
-                    continue;
-                } else {
-                    self.current += 1;
-                    return self.input.next();
-                }
-            } else {
-                return self.input.next();
-            }
         }
     }
 }

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -232,7 +232,7 @@ fn select(
 
         NthIterator {
             input: pipeline_iter,
-            rows: unique_rows,
+            rows: unique_rows.into_iter().peekable(),
             current: 0,
         }
         .into_pipeline_data(engine_state.ctrlc.clone())
@@ -333,7 +333,7 @@ fn select(
 
 struct NthIterator {
     input: PipelineIterator,
-    rows: BTreeSet<usize>,
+    rows: std::iter::Peekable<std::collections::btree_set::IntoIter<usize>>,
     current: usize,
 }
 
@@ -342,9 +342,9 @@ impl Iterator for NthIterator {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if let Some(row) = self.rows.first() {
+            if let Some(row) = self.rows.peek() {
                 if self.current == *row {
-                    self.rows.pop_first();
+                    self.rows.next();
                     self.current += 1;
                     return self.input.next();
                 } else {


### PR DESCRIPTION
# Description
While reviewing #10350 I noticed that a `HashSet<usize>` was used to deduplicate the incoming rows, which are then sorted after cloning to a separate `Vec`. This sounds like a candidate for a `BTreeSet` which guarantees the ordering.

In the process I removed some dead code.

- Use `BTreeSet` instead of `HashSet`
- Remove dead `skip` logic
- Use `BTreeSet` directly in `NthIterator`
# User-Facing Changes
None

# Benchmarking

Data was cached and test script run for `cargo build --release`

Random data was chosen to create some duplication and create a worst case amount of work.
No significant impact was observed for small data with predictable input.

```
use std repeat

# let data = ls | repeat 1000 | flatten
# let index = random dice -d 10000 -s 20000
let data = open data.nuon
let index = open index.nuon

1..1000 | each { timeit { $data | select $index } } | math avg
```

```
=== bbea7da66 ===
17ms 96µs 202ns
=== 8b5d50968 ===
17ms 906µs 870ns
=== 94d651f21 ===
17ms 70µs 277ns
=== c085d27fa ===
14ms 429µs 701ns
=== ddcb22e22 ===
14ms 349µs 939ns
```
