### PR TITLE
fix #10319: allow json request of value type list

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -223,6 +223,10 @@ pub fn send_request(
             };
             send_cancellable_request(&request_url, Box::new(request_fn), ctrl_c)
         }
+        Value::List { .. } if body_type == BodyType::Json => {
+            let data = value_to_json_value(&body)?;
+            send_cancellable_request(&request_url, Box::new(|| request.send_json(data)), ctrl_c)
+        }
         _ => Err(ShellErrorOrRequestError::ShellError(ShellError::IOError(
             "unsupported body input".into(),
         ))),

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -94,3 +94,21 @@ fn http_post_json_is_success() {
     mock.assert();
     assert!(actual.out.is_empty())
 }
+
+#[test]
+fn http_post_json_list_is_success() {
+    let mut server = Server::new();
+
+    let mock = server
+        .mock("POST", "/")
+        .match_body(r#"[{"foo":"bar"}]"#)
+        .create();
+
+    let actual = nu!(format!(
+        r#"http post -t 'application/json' {url} [{{foo: "bar"}}]"#,
+        url = server.url()
+    ));
+
+    mock.assert();
+    assert!(actual.out.is_empty())
+}


### PR DESCRIPTION
# Description

this commit adds the handling of Value::List when BodyType is Json
it also adds the corresponding test (trying to send a list)

Fixes #10319

# User-Facing Changes

Added the ability to send a json list in the POST message

# Tests + Formatting
- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

Also ran `nc -l -p 8080` in other terminal and `http post -fe -t application/json http://localhost:8080 [{ field: true }]` I see the following appear in the output of nc:
```
POST / HTTP/1.1
Host: localhost:8080
User-Agent: nushell
Accept: */*
Content-Type: application/json
accept-encoding: gzip
Content-Length: 16

[{"field":true}]%
```
