### PR TITLE
fix 'let' to properly redirect

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -61,14 +61,7 @@ impl Command for Let {
             .expect("internal error: missing right hand side");
 
         let block = engine_state.get_block(block_id);
-        let pipeline_data = eval_block(
-            engine_state,
-            stack,
-            block,
-            input,
-            call.redirect_stdout,
-            call.redirect_stderr,
-        )?;
+        let pipeline_data = eval_block(engine_state, stack, block, input, true, false)?;
         stack.add_var(var_id, pipeline_data.into_value(call.head));
         Ok(PipelineData::empty())
     }

--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -47,8 +47,15 @@ fn mut_pipeline_allows_in() {
 }
 
 #[test]
-fn let_pipeline_redirects() {
+fn let_pipeline_redirects_internals() {
     let actual = nu!(r#"let x = echo 'bar'; $x | str length"#);
+
+    assert_eq!(actual.out, "3");
+}
+
+#[test]
+fn let_pipeline_redirects_externals() {
+    let actual = nu!(r#"let x = nu --testbin cococo 'bar'; $x | str length"#);
 
     assert_eq!(actual.out, "3");
 }

--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -46,6 +46,13 @@ fn mut_pipeline_allows_in() {
     assert_eq!(actual.out, "21");
 }
 
+#[test]
+fn let_pipeline_redirects() {
+    let actual = nu!(r#"let x = echo 'bar'; $x | str length"#);
+
+    assert_eq!(actual.out, "3");
+}
+
 #[ignore]
 #[test]
 fn let_with_external_failed() {


### PR DESCRIPTION
# Description

Fixes a bug in `let` where the pipeline wasn't being properly redirected.

fixes #9767

# User-Facing Changes

Shouldn't have any breaking changes, as this should be better for expected use cases.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
