### PR TITLE
Added range implementation to `select` 

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -218,7 +218,11 @@ fn select(
                     unique_rows.insert(*val);
                 }
             }
-            _ => new_columns.push(column),
+            _ => {
+                if !new_columns.contains(&column) {
+                    new_columns.push(column)
+                }
+            }
         };
     }
     let columns = new_columns;

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -214,9 +214,7 @@ fn select(
                         Vec::new(),
                     ));
                 }
-                if !unique_rows.contains(val) {
-                    unique_rows.insert(*val);
-                }
+                unique_rows.insert(*val);
             }
             _ => {
                 if !new_columns.contains(&column) {

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -214,16 +214,9 @@ fn select(
                         Vec::new(),
                     ));
                 }
-                if unique_rows.contains(val) {
-                    return Err(ShellError::GenericError(
-                        "Select can't get the same row twice".into(),
-                        "duplicated row index".into(),
-                        Some(*span),
-                        None,
-                        Vec::new(),
-                    ));
+                if !unique_rows.contains(val) {
+                    unique_rows.insert(*val);
                 }
-                unique_rows.insert(*val);
             }
             _ => new_columns.push(column),
         };

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -218,10 +218,17 @@ fn select_failed3() {
 }
 
 #[test]
-fn select_failed4() {
-    let actual = nu!("[{a: 1 b: 10}, {a:2, b:11}] | select 0 0");
+fn select_repeated_rows() {
+    let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select 0 0 | to nuon");
 
-    assert!(actual.err.contains("Select can't get the same row twice"));
+    assert_eq!(actual.out, "[[a, b, c]; [1, 2, 3]]");
+}
+
+#[test]
+fn select_repeated_column() {
+    let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select a a | to nuon");
+
+    assert_eq!(actual.out, "[[a]; [1], [4], [7]]");
 }
 
 #[test]


### PR DESCRIPTION
In reference to #10215 

Added `range` type to `select`

# User-Facing Changes
The user can now call range to select rows:
```nushell
[[a b c]; [ 1 2 3] [4 5 6]  [7 8 9]  [10 11 12] ] | select 1..2
```

# After Submitting
- [ ] add range example to docs?