### PR TITLE
Added range type to be passable to `select`

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -129,7 +129,6 @@ produce a table, a list will produce a list, and a record will produce a record.
                     let valiter = val.into_range_iter(engine_state.ctrlc.clone())?;
 
                     for value in valiter {
-                        dbg!(&value);
                         match value {
                             Value::Int { val, .. } => {
                                 let cv = CellPath {
@@ -143,9 +142,12 @@ produce a table, a list will produce a list, and a record will produce a record.
                             }
                             x => {
                                 let span = x.span();
+                                let msg = format!(
+                                    "The value expected was Int, but got: {}",
+                                    x.get_type()
+                                );
                                 return Err(ShellError::TypeMismatch {
-                                    err_message: "The value expected was Int, but got: {}"
-                                        .to_string(),
+                                    err_message: msg,
                                     span,
                                 });
                             }

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -279,3 +279,10 @@ fn select_single_row_with_variable() {
     assert_eq!(actual.out, "[[a]; [3]]".to_string());
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn select_range() {
+    let actual = nu!("[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select 1..2 | to nuon");
+
+    assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+}

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -280,9 +280,89 @@ fn select_single_row_with_variable() {
     assert!(actual.err.is_empty());
 }
 
-#[test]
-fn select_range() {
-    let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select 1..2 | to nuon");
+#[cfg(test)]
+mod range {
+    use nu_test_support::nu;
 
-    assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+    #[test]
+    fn positive_positive() {
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select 1..2 | to nuon");
+
+        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+    }
+
+    // Should these two tests work? if negative vals would work this would translate to rows 1 0 4 3
+    #[test]
+    #[ignore]
+    fn positive_negative() {
+        let actual = nu!(
+            "[[a b c]; [1 2 3] [4 5 6] [7 8 9] [10 11 12] [13 14 15]] | select 1..(-2) | to nuon"
+        );
+
+        assert_eq!(
+            actual.out,
+            "[[a, b, c]; [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]]"
+        );
+    }
+
+    // TODO `select` could maybe take values from the end of the list.
+    #[test]
+    #[ignore]
+    fn negative_negative() {
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select (-1)..(-2) | to nuon");
+
+        assert!(actual.err.is_empty());
+    }
+
+    // Should these two tests work?
+    #[test]
+    #[ignore]
+    fn negative_positive() {
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select (-1)..2 | to nuon");
+
+        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+    }
+
+    #[test]
+    #[ignore]
+    fn infinity_positive() {
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select 1.. | to nuon");
+
+        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+    }
+
+    #[test]
+    #[ignore]
+    fn infinity_negative() {
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select (-2).. | to nuon");
+
+        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+    }
+
+    #[test]
+    #[ignore]
+    fn ninfinity_positive() {
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select ..2 | to nuon");
+
+        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+    }
+
+    #[test]
+    #[ignore]
+    fn ninfinity_negative() {
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select ..(-2) | to nuon");
+
+        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+    }
+
+    #[test]
+    #[ignore]
+    fn positive_step_positive() {
+        let actual = nu!("[a b c]; [1 2 3] [4 5 6] [7 8 9] [10 11 12] [13 14 15] [16 17 18] [19 20 21]] | select 0..2..6 | to nuon");
+
+        assert_eq!(
+            actual.out,
+            "[[a, b, c]; [1, 2, 3], [7, 8, 9], [13, 14, 15], [19, 20, 21]]"
+        );
+    }
 }

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -291,7 +291,7 @@ mod range {
         assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
     }
 
-    // Should these two tests work? if negative vals would work this would translate to rows 1 0 4 3
+    // Should these two tests work? It would select 1 till the 2nd from last (-2, -1,0*) * for 0 you just leave blank
     #[test]
     #[ignore]
     fn positive_negative() {
@@ -299,28 +299,28 @@ mod range {
             "[[a b c]; [1 2 3] [4 5 6] [7 8 9] [10 11 12] [13 14 15]] | select 1..(-2) | to nuon"
         );
 
-        assert_eq!(
-            actual.out,
-            "[[a, b, c]; [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]]"
-        );
+        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
     }
 
-    // TODO `select` could maybe take values from the end of the list.
     #[test]
     #[ignore]
     fn negative_negative() {
-        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select (-1)..(-2) | to nuon");
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9] [10 11 12] [13 14 15]] | select (-1)..(-2) | to nuon");
 
-        assert!(actual.err.is_empty());
+        assert_eq!(actual.out, "[[a, b, c]; [7, 8, 9], [10, 11, 12]]");
     }
 
-    // Should these two tests work?
     #[test]
     #[ignore]
     fn negative_positive() {
-        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select (-1)..2 | to nuon");
+        let actual = nu!(
+            "[[a b c]; [1 2 3] [4 5 6] [7 8 9] [10 11 12] [13 14 15]] | select (-1)..1 | to nuon"
+        );
 
-        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+        assert_eq!(
+            actual.out,
+            "[[a, b, c]; [4, 5, 6], [10, 11, 12], [13, 14, 15]]"
+        );
     }
 
     #[test]
@@ -334,7 +334,7 @@ mod range {
     #[test]
     #[ignore]
     fn infinity_negative() {
-        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select (-2).. | to nuon");
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select (-1).. | to nuon");
 
         assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
     }
@@ -342,17 +342,17 @@ mod range {
     #[test]
     #[ignore]
     fn ninfinity_positive() {
-        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select ..2 | to nuon");
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select ..1 | to nuon");
 
-        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+        assert_eq!(actual.out, "[[a, b, c]; [1, 2, 3], [4, 5, 6]]");
     }
 
     #[test]
     #[ignore]
     fn ninfinity_negative() {
-        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select ..(-2) | to nuon");
+        let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select ..(-1) | to nuon");
 
-        assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
+        assert_eq!(actual.out, "[[a, b, c]; [1, 2, 3], [4, 5, 6]]");
     }
 
     #[test]

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -282,7 +282,7 @@ fn select_single_row_with_variable() {
 
 #[test]
 fn select_range() {
-    let actual = nu!("[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select 1..2 | to nuon");
+    let actual = nu!("[[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select 1..2 | to nuon");
 
     assert_eq!(actual.out, "[[a, b, c]; [4, 5, 6], [7, 8, 9]]");
 }


### PR DESCRIPTION
This PR adds `range` type to `select` command args for row filtering.
This is a reopend PR after #10362 
# User-Facing Changes

The user is now able to pass `range` to `select`:
```nushell
[[a b c]; [ 1 2 3] [4 5 6]  [7 8 9] [10 11 12]] | select 1..2
```

# The operation of ranges

- `n..` selects from `n` till the end
- `(-n)..` selects the `n` from back till the end
- `..n` selects from start till the `n`
- `..(-n)` selects from start till `n` from the back
- `n..m` selects everything between `n` and `m` 
- `(-n)..m` selects `n` from the back till the end and from start till `m` (think of it as reverse n..m)
- `n..(-m)` selects from `n` till `m` from the back
- `(-n)..(-m)` selects from `n` from the back till `m` from the back

# After Submitting
- [ ] add range example to select in docs?