### PR TITLE
fix the pretty printing of failing tests in std

### DIFF
--- a/crates/nu-std/std/testing.nu
+++ b/crates/nu-std/std/testing.nu
@@ -134,7 +134,7 @@ def show-pretty-test [indent: int = 4] {
     let test = $in
 
     [
-        (1..$indent | map {" "} | str join)
+        (1..$indent | each {" "} | str join)
         (match $test.result {
             "pass" => { ansi green },
             "skip" => { ansi yellow },


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/10293/files#diff-371ea1a6b13ef0f2f10ddd0b23b86c54eb8221892e45c2e4c1913a233c585ae7R137

# Description
looks to me like https://github.com/nushell/nushell/pull/10293 introduced the use of `map` command in `std testing`, but it's not a valid Nushell command, right?

this PR uses `each` as a replacement, that's what the error even says :yum: 
```nushell
> map
Error: nu::shell::external_command

  × External command failed
   ╭─[entry #1:1:1]
 1 │ map
   · ─┬─
   ·  ╰── did you mean 'each'?
   ╰────
  help: No such file or directory (os error 2)
```

## example
because this call to `map` only occurs when there is a failing test, let's say i introduce a bug in one of the tests by applying
```diff
diff --git a/crates/nu-std/tests/test_std.nu b/crates/nu-std/tests/test_std.nu
index 6e82335ae..b246f0152 100644
--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -51,7 +51,7 @@ def repeat_things [] {
 
     for x in ["foo", [1 2], {a: 1}] {
         std assert equal ($x | std repeat 0) []
-        std assert equal ($x | std repeat 1) [$x]
+        std assert equal ($x | std repeat 1) []
         std assert equal ($x | std repeat 2) [$x $x]
     }
 }
```

### `toolkit test stdlib` before the change
`repeat_things` fails but the report also fails to be printed...
```
...
2023-09-14T19:41:26.638|INF|Running debug in module test_basic_commands
2023-09-14T19:41:26.724|INF|Running assert_length in module test_asserts
Error:   × Assertion failed.
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nushell/crates/nu-std/tests/Q8cIDxGutb.nu:53:1]
 53 │         std assert equal ($x | std repeat 0) []
 54 │         std assert equal ($x | std repeat 1) []
    ·                          ───────────┬──────────
    ·                                     ╰── They are not equal. Left = '[foo]'. Right = '[]'.
 55 │         std assert equal ($x | std repeat 2) [$x $x]
    ╰────


2023-09-14T19:41:28.717|INF|Running debug_short in module test_basic_commands
Error: nu::shell::eval_block_with_input

  × Eval block failed with pipeline input
     ╭─[NU_STDLIB_VIRTUAL_DIR/std/testing.nu:275:1]
 275 │         | append $skipped_tests
 276 │         | select file name test result
     ·           ───┬──
     ·              ╰── source value
 277 │     )
     ╰────

Error: nu::shell::external_command

  × External command failed
     ╭─[NU_STDLIB_VIRTUAL_DIR/std/testing.nu:136:1]
 136 │     [
 137 │         (1..$indent | map {" "} | str join)
     ·                       ─┬─
     ·                        ╰── did you mean 'each'?
 138 │         (match $test.result {
     ╰────
  help: No such file or directory (os error 2)
```

### `toolkit test stdlib` before the change
gives the report of failing tests as expected
```
2023-09-14T19:47:50.412|INF|Running assert_greater_or_equal in module test_asserts
2023-09-14T19:47:50.881|INF|Running assert_length in module test_asserts
Error:   × Assertion failed.
    ╭─[/home/amtoine/documents/repos/github.com/amtoine/nushell/crates/nu-std/tests/Kwjs6w4zm9.nu:53:1]
 53 │         std assert equal ($x | std repeat 0) []
 54 │         std assert equal ($x | std repeat 1) []
    ·                          ───────────┬──────────
    ·                                     ╰── They are not equal. Left = '[foo]'. Right = '[]'.
 55 │         std assert equal ($x | std repeat 2) [$x $x]
    ╰────


Error:   × some tests did not pass (see complete errors below):
  │
  │       test_iter iter_find_index
  │       test_iter iter_find
  │       test_iter iter_zip_with
  │       test_iter iter_filter_map
  │       test_iter iter_scan
  │       test_iter iter_intersperse
  │       test_iter iter_zip_into_record
  │       test_iter iter_flat_map
  │       test_dirs dirs_command
  │       test_dirs dirs_cd
  │       test_dirs dirs_next
  │       test_asserts assert_not_equal
  │       test_asserts assert_basic
  │       test_asserts assert_greater
  │       test_asserts assert_equal
  │       test_asserts assert_less
  │       test_asserts assert_length
  │       test_asserts assert_error
  │       test_asserts assert_not
  │       test_asserts assert_greater_or_equal
  │       test_asserts assert_less_or_equal
  │     s test_asserts assert_skip
  │       test_formats from_jsonl_invalid_object
  │       test_formats from_ndjson_single_object
  │       test_formats from_jsonl_single_object
  │       test_formats from_ndjson_invalid_object
  │       test_formats from_jsonl_multiple_objects
  │       test_formats from_ndjson_multiple_objects
  │       test_setup_teardown assert_pass
  │     s test_setup_teardown assert_skip
  │     s test_setup_teardown assert_fail_skipped_by_default
  │       test_logger_env env_log_format
  │       test_logger_env env_log_ansi
  │       test_logger_env env_log_short_prefix
  │       test_logger_env env_log_level
  │       test_logger_env env_log_prefix
  │       test_log_format_flag format_flag
  │       test_log_custom errors_during_deduction
  │       test_log_custom valid_calls
  │       test_log_custom log_level_handling
  │       test_xml xml_xupdate
  │       test_xml xml_xaccess
  │       test_xml xml_xinsert
  │       test_basic_commands error_short
  │       test_basic_commands debug_short
  │       test_basic_commands warning
  │       test_basic_commands critical
  │       test_basic_commands critical_short
  │       test_basic_commands debug
  │       test_basic_commands warning_short
  │       test_basic_commands info_short
  │       test_basic_commands info
  │       test_basic_commands error
  │     ⨯ test_std repeat_things
  │       test_std path_add
  │       test_std banner
  │
```

# User-Facing Changes

# Tests + Formatting

# After Submitting
