### PR TITLE
Improve error label for `MissingPositional`

### DIFF
--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -337,7 +337,7 @@ pub enum ParseError {
 
     #[error("Missing required positional argument.")]
     #[diagnostic(code(nu::parser::missing_positional), help("Usage: {2}"))]
-    MissingPositional(String, #[label("missing {0}")] Span, String),
+    MissingPositional(String, #[label("missing argument: {0}")] Span, String),
 
     #[error("Missing argument to `{1}`.")]
     #[diagnostic(code(nu::parser::keyword_missing_arg))]

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -410,7 +410,7 @@ fn ends_with_operator_succeeds() -> TestResult {
 
 #[test]
 fn proper_missing_param() -> TestResult {
-    fail_test(r#"def foo [x y z w] { }; foo a b c"#, "missing w")
+    fail_test(r#"def foo [x y z w] { }; foo a b c"#, "missing argument: w")
 }
 
 #[test]


### PR DESCRIPTION
# Description
The previous label could be confusing depending on the name of the
missing positional, as it just annotated the code with `missing <name>`

Now label with `missing argument: <name>`

## before

![image](https://github.com/nushell/nushell/assets/15833959/a132153e-11e5-43f2-a354-f72e0596435e)

h/t @AucaCoyan

# User-Facing Changes
Changed error message when missing a positional argument

# Tests + Formatting
1 updated test
