### PR TITLE
Reduce use of unchecked indexing in parser code

### DIFF
--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -7,6 +7,7 @@ mod parse_keywords;
 mod parse_patterns;
 mod parser;
 mod parser_path;
+mod span_array;
 mod type_check;
 
 pub use deparse::{escape_for_script_arg, escape_quote_string};

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2947,8 +2947,9 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         custom_completion: None,
                     };
 
+                    let mut idx = 0;
                     let Some(mut opt_type_spans) =
-                      PointedSpanArray::new_from_range(spans, 1..(span.0),0) else {
+                      PointedSpanArray::new_from_range(spans, 1..(span.0),& mut idx) else {
                        continue; // This checks span.0 > 1
                     } ;
                     let (lvalue, explicit_type) =
@@ -3046,7 +3047,8 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                 if !(item == b"=" && spans.len() > (span.0 + 1) && span.0 > 1) {
                     continue;
                 }
-                let Some(mut inner_spans) = PointedSpanArray::new(spans,0) else {
+                let mut idx = 0;
+                let Some(mut inner_spans) = PointedSpanArray::new(spans,& mut idx) else {
                      continue; // Only checks spans.len() > span.0
                     } ;
                 let rvalue = parse_multispan_value(
@@ -3062,8 +3064,9 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                     ));
                 }
 
+                let mut idx = 0;
                 let Some(mut opt_type_spans) =
-                     PointedSpanArray::new_from_range(spans, 1..(span.0),0) else {
+                     PointedSpanArray::new_from_range(spans, 1..(span.0),& mut idx) else {
                        continue; // This checks span.0 > 1
                 } ;
 
@@ -3205,8 +3208,9 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         custom_completion: None,
                     };
 
+                    let mut idx = 0;
                     let Some(mut opt_type_spans) =
-                      PointedSpanArray::new_from_range(spans, 1..(span.0),0) else {
+                      PointedSpanArray::new_from_range(spans, 1..(span.0),& mut idx) else {
                        continue; // This checks span.0 > 1
                     } ;
                     let (lvalue, explicit_type) =

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3046,7 +3046,7 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                 if !(item == b"=" && spans.len() > (span.0 + 1) && span.0 > 1) {
                     continue;
                 }
-                let Some(mut inner_spans) = PointedSpanArray::new(spans,0) else {
+                let Some(mut inner_spans) = PointedSpanArray::new(spans,span.0) else {
                      continue; // Only checks spans.len() > span.0
                     } ;
                 let rvalue = parse_multispan_value(

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2947,9 +2947,8 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         custom_completion: None,
                     };
 
-                    let mut idx = 0;
                     let Some(mut opt_type_spans) =
-                      PointedSpanArray::new_from_range(spans, 1..(span.0),& mut idx) else {
+                      PointedSpanArray::new_from_range(spans, 1..(span.0),0) else {
                        continue; // This checks span.0 > 1
                     } ;
                     let (lvalue, explicit_type) =
@@ -3047,8 +3046,7 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                 if !(item == b"=" && spans.len() > (span.0 + 1) && span.0 > 1) {
                     continue;
                 }
-                let mut idx = 0;
-                let Some(mut inner_spans) = PointedSpanArray::new(spans,& mut idx) else {
+                let Some(mut inner_spans) = PointedSpanArray::new(spans,0) else {
                      continue; // Only checks spans.len() > span.0
                     } ;
                 let rvalue = parse_multispan_value(
@@ -3064,9 +3062,8 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                     ));
                 }
 
-                let mut idx = 0;
                 let Some(mut opt_type_spans) =
-                     PointedSpanArray::new_from_range(spans, 1..(span.0),& mut idx) else {
+                     PointedSpanArray::new_from_range(spans, 1..(span.0),0) else {
                        continue; // This checks span.0 > 1
                 } ;
 
@@ -3208,9 +3205,8 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         custom_completion: None,
                     };
 
-                    let mut idx = 0;
                     let Some(mut opt_type_spans) =
-                      PointedSpanArray::new_from_range(spans, 1..(span.0),& mut idx) else {
+                      PointedSpanArray::new_from_range(spans, 1..(span.0),0) else {
                        continue; // This checks span.0 > 1
                     } ;
                     let (lvalue, explicit_type) =

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -981,6 +981,7 @@ pub fn parse_internal_call(
 
                 let Some(mut spans_til_end) =
                 spans.sub_span(..end) else {
+                    debug_assert!(end == 0 || spans.get_idx() == end);
                     working_set.error(ParseError::MissingPositional(
                         positional.name.clone(),
                         Span::new(current_span.end, current_span.end),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -594,7 +594,7 @@ where
             if signature.num_positionals_after(positional_idx) == 0 {
                 spans.len()
             } else if positional_idx < signature.required_positional.len()
-                && spans.len() > (signature.required_positional.len() - positional_idx)
+                && spans.len() - spans_idx > (signature.required_positional.len() - positional_idx)
             {
                 spans.len() - (signature.required_positional.len() - positional_idx - 1)
             } else {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -981,7 +981,7 @@ pub fn parse_internal_call(
                 let current_span = spans.current();
 
                 let Some(mut spans_til_end) =
-                spans.sub_span(..end) else {
+                spans.prefix_span(end) else {
                     debug_assert!(end == 0 || spans.get_idx() == end);
                     working_set.error(ParseError::MissingPositional(
                         positional.name.clone(),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -586,12 +586,11 @@ where
         } else {
             let spans_remaining = spans.len() - spans_idx;
             let positional_remaining = signature.required_positional.len() - positional_idx;
-            let non_positional_spans_remaining = spans_remaining - positional_remaining;
             // Make space for the remaining require positionals, if we can
             if signature.num_positionals_after(positional_idx) == 0 {
                 spans.len()
-            } else if positional_remaining > 0 && non_positional_spans_remaining > 0 {
-                spans_idx + 1 + non_positional_spans_remaining
+            } else if positional_remaining > 0 && spans_remaining > positional_remaining {
+                spans_idx + 1 + spans_remaining - positional_remaining
             } else {
                 spans_idx + 1
             }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -30,10 +30,7 @@ use crate::parse_keywords::{
 
 use itertools::Itertools;
 use log::trace;
-use std::{
-    collections::{HashMap, HashSet},
-    ops::DerefMut,
-};
+use std::collections::{HashMap, HashSet};
 use std::{num::ParseIntError, str};
 
 #[cfg(feature = "plugin")]
@@ -342,13 +339,12 @@ pub fn parse_external_call(
     }
 }
 
-fn parse_long_flag<I>(
+fn parse_long_flag(
     working_set: &mut StateWorkingSet,
-    spans: &mut PointedSpanArray<I>,
+    spans: &mut PointedSpanArray,
     sig: &Signature,
 ) -> (Option<Spanned<String>>, Option<Expression>)
 where
-    I: DerefMut<Target = usize>,
 {
     let arg_span = spans.current();
     let arg_contents = working_set.get_span_contents(arg_span);
@@ -439,14 +435,13 @@ where
     }
 }
 
-fn parse_short_flags<I>(
+fn parse_short_flags(
     working_set: &mut StateWorkingSet,
-    spans: &mut PointedSpanArray<I>,
+    spans: &mut PointedSpanArray,
     positional_idx: usize,
     sig: &Signature,
 ) -> Option<Vec<Flag>>
 where
-    I: DerefMut<Target = usize>,
 {
     let arg_span = spans.current();
 
@@ -561,14 +556,13 @@ fn first_kw_idx(
     (None, spans.len())
 }
 
-fn calculate_end_span<I>(
+fn calculate_end_span(
     working_set: &StateWorkingSet,
     signature: &Signature,
-    spans_both: &PointedSpanArray<I>,
+    spans_both: &PointedSpanArray,
     positional_idx: usize,
 ) -> usize
 where
-    I: DerefMut<Target = usize>,
 {
     let spans = spans_both.get_slice();
     let spans_idx = spans_both.get_idx();
@@ -605,13 +599,12 @@ where
     }
 }
 
-pub fn parse_multispan_value<I>(
+pub fn parse_multispan_value(
     working_set: &mut StateWorkingSet,
-    spans: &mut PointedSpanArray<I>,
+    spans: &mut PointedSpanArray,
     shape: &SyntaxShape,
 ) -> Expression
 where
-    I: DerefMut<Target = usize>,
 {
     match shape {
         SyntaxShape::VarWithOptType => {
@@ -3078,13 +3071,12 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
     }
 }
 
-pub fn parse_var_with_opt_type<I>(
+pub fn parse_var_with_opt_type(
     working_set: &mut StateWorkingSet,
-    spans: &mut PointedSpanArray<I>,
+    spans: &mut PointedSpanArray,
     mutable: bool,
 ) -> (Expression, Option<Type>)
 where
-    I: DerefMut<Target = usize>,
 {
     let bytes = working_set.get_span_contents(spans.current()).to_vec();
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -737,7 +737,6 @@ pub fn parse_multispan_value(
         }
         _ => {
             // All other cases are single-span values
-            // TODO
             let arg_span = spans.current();
 
             parse_value(working_set, arg_span, shape)
@@ -962,9 +961,7 @@ pub fn parse_internal_call(
             };
 
             let Some(mut spans_til_end) =
-                spans.get(..end).and_then(|new_span|
-                PointedSpanArray::new(new_span, &mut spans_idx)
-                )
+                PointedSpanArray::new_from_range(spans, ..end, &mut spans_idx)
             else {
                 working_set.error(ParseError::MissingPositional(
                     positional.name.clone(),
@@ -3934,8 +3931,6 @@ pub fn parse_list_expression(
             let LiteElement::Command(_, command) = arg else {
                 continue;
             };
-            // TODO: Error below?
-            // Should need continue
             let Some(mut parts_with_idx) = PointedSpanArray::new(&command.parts, &mut spans_idx) else {
                 continue;
             };
@@ -4398,10 +4393,9 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
             break;
         };
 
-        // TODO: This cannot fail, but still feels ugly
         let mut idx = 0;
         let single_span = [out_at_pos.span];
-        let Some(mut out_spans) = PointedSpanArray::new(&single_span, &mut idx) else { todo!()};
+        let Some(mut out_spans) = PointedSpanArray::new(&single_span, &mut idx) else { unreachable!()};
         let result = parse_multispan_value(
             working_set,
             &mut out_spans,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -963,7 +963,7 @@ pub fn parse_internal_call(
                 let end = calculate_end_span(working_set, &signature, &spans, positional_idx);
 
                 let end = if end == spans.get_idx() {
-                    // I belive this should be impossible, unless there's another bug in calculate_end_span
+                    // I believe this should be impossible, unless there's another bug in calculate_end_span
                     trace!("end is at span_idx, advancing one more");
                     end + 1
                 } else {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -738,6 +738,7 @@ where
                     custom_completion: None,
                 };
             }
+            // Possibly off-by-one here
             let expr = parse_multispan_value(working_set, spans, arg);
             let ty = expr.ty.clone();
 
@@ -3956,7 +3957,7 @@ pub fn parse_list_expression(
             let Some(mut parts_with_idx) = PointedSpanArray::new(&command.parts, 0) else {
                 continue;
             };
-            while parts_with_idx.try_advance() {
+            loop {
                 let arg = parse_multispan_value(working_set, &mut parts_with_idx, element_shape);
 
                 if let Some(ref ctype) = contained_type {
@@ -3968,6 +3969,9 @@ pub fn parse_list_expression(
                 }
 
                 args.push(arg);
+                if !parts_with_idx.try_advance() {
+                    break;
+                }
             }
         }
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -737,6 +737,7 @@ pub fn parse_multispan_value(
         }
         _ => {
             // All other cases are single-span values
+            // TODO
             let arg_span = spans.current();
 
             parse_value(working_set, arg_span, shape)
@@ -962,7 +963,7 @@ pub fn parse_internal_call(
 
             let Some(mut spans_til_end) =
                 spans.get(..end).and_then(|new_span|
-                PointedSpanArray::new(new_span, spans_idx)
+                PointedSpanArray::new(new_span, &mut spans_idx)
                 )
             else {
                 working_set.error(ParseError::MissingPositional(
@@ -975,8 +976,6 @@ pub fn parse_internal_call(
             };
 
             let arg = parse_multispan_value(working_set, &mut spans_til_end, &positional.shape);
-            // TODO: This is error-prone
-            spans_idx = spans_til_end.get_idx();
 
             let arg = if !type_compatible(&positional.shape.to_type(), &arg.ty) {
                 working_set.error(ParseError::TypeMismatch(
@@ -3930,12 +3929,14 @@ pub fn parse_list_expression(
 
     if !output.block.is_empty() {
         for arg in &output.block[0].commands {
+            let mut spans_idx = 0;
+
             let LiteElement::Command(_, command) = arg else {
                 continue;
             };
             // TODO: Error below?
             // Should need continue
-            let Some(mut parts_with_idx) = PointedSpanArray::new(&command.parts, 0) else {
+            let Some(mut parts_with_idx) = PointedSpanArray::new(&command.parts, &mut spans_idx) else {
                 continue;
             };
             while parts_with_idx.try_advance() {
@@ -4358,9 +4359,12 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
                 (&output[position..], false)
             };
 
+            let mut start = 0;
             let guard_span_vec = tokens.iter().map(|tok| tok.span).collect_vec();
             let Some(mut guard_spans) =
-                PointedSpanArray::new( &guard_span_vec, 0)  else {
+                PointedSpanArray::new(
+                    &guard_span_vec,
+                 &mut start)  else {
                     // When might this be empty?
                     todo!();
                 } ;
@@ -4395,8 +4399,9 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
         };
 
         // TODO: This cannot fail, but still feels ugly
+        let mut idx = 0;
         let single_span = [out_at_pos.span];
-        let Some(mut out_spans) = PointedSpanArray::new(&single_span, 0) else { todo!()};
+        let Some(mut out_spans) = PointedSpanArray::new(&single_span, &mut idx) else { todo!()};
         let result = parse_multispan_value(
             working_set,
             &mut out_spans,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -584,13 +584,13 @@ where
                 kw_idx - positionals_between
             }
         } else {
-            let spans_remaining = spans.len() - spans_idx;
-            let positional_remaining = signature.required_positional.len() - positional_idx;
             // Make space for the remaining require positionals, if we can
             if signature.num_positionals_after(positional_idx) == 0 {
                 spans.len()
-            } else if positional_remaining > 0 && spans_remaining > positional_remaining {
-                spans_idx + 1 + spans_remaining - positional_remaining
+            } else if signature.required_positional.len() > positional_idx
+                && spans.len() - spans_idx > signature.required_positional.len() - positional_idx
+            {
+                1 + spans.len() - (signature.required_positional.len() - positional_idx)
             } else {
                 spans_idx + 1
             }
@@ -963,6 +963,7 @@ pub fn parse_internal_call(
                 let end = calculate_end_span(working_set, &signature, &spans, positional_idx);
 
                 let end = if end == spans.get_idx() {
+                    // I belive this should be impossible, unless there's another bug in calculate_end_span
                     trace!("end is at span_idx, advancing one more");
                     end + 1
                 } else {

--- a/crates/nu-parser/src/span_array.rs
+++ b/crates/nu-parser/src/span_array.rs
@@ -3,9 +3,6 @@ use std::{
     slice::SliceIndex,
 };
 
-// use miette::SourceSpan;
-// use serde::{Deserialize, Serialize};
-
 use nu_protocol::Span;
 
 /// Arrays of spans that are guaranteed to be non-empty by construction
@@ -113,10 +110,6 @@ where
         }
     }
 
-    // pub fn get_last(self) -> Span {
-    //     self.inner[self.inner.len() - 1]
-    // }
-
     /// Get the value at an index
     #[inline]
     #[must_use]
@@ -129,13 +122,6 @@ where
     pub fn peek_next(&self) -> Option<Span> {
         self.get_at(*self.idx + 1)
     }
-
-    // /// Get the next n spans after the index
-    // #[inline]
-    // #[must_use]
-    // pub fn peek_n(self, number: usize) -> Option<Span> {
-    //     self.slice_arr(*self.idx..*self.idx + n)
-    // }
 }
 
 impl<'a, 'b, Idx: 'b> PointedSpanArray<'a, Idx>
@@ -166,22 +152,7 @@ where
     pub fn jump_to_end(&mut self) {
         *self.idx = self.inner.len() - 1;
     }
-
-    // pub fn is_at_end(&self) -> bool {
-    //     *self.idx == self.inner.len() - 1
-    // }
-
-    // #[inline]
-    // #[must_use]
-    // pub fn slice<I>(self, index: I) -> Option<Self>
-    // where
-    //     I: SliceIndex<[Span], Output = [Span]>,
-    // {
-    //     self.inner.get(index).and_then(|x| Self::new(x))
-    // }
 }
-
-// pub trait SpanIdx = DerefMut<Target = usize>;
 
 pub struct NestedUsize(usize);
 impl Deref for NestedUsize {

--- a/crates/nu-parser/src/span_array.rs
+++ b/crates/nu-parser/src/span_array.rs
@@ -19,6 +19,12 @@ impl<'a> TryFrom<&'a [Span]> for SpanArray<'a> {
     }
 }
 
+impl<'a> From<SpanArray<'a>> for &'a [Span] {
+    fn from(value: SpanArray<'a>) -> Self {
+        value.inner
+    }
+}
+
 impl<'a> SpanArray<'a> {
     #[inline]
     #[must_use]
@@ -57,30 +63,79 @@ impl<'a, 'b> PointedSpanArray<'a, 'b> {
     #[inline]
     #[must_use]
     pub fn new(value: &'a [Span], idx: &'b mut usize) -> Option<Self> {
-        value
-            .get(*idx)
-            .map(|_| PointedSpanArray { inner: value, idx })
+        // check valid index, otherwise return none
+        _ = value.get(*idx)?;
+        Some(PointedSpanArray { inner: value, idx })
     }
-    pub fn get(self) -> Span {
+
+    #[inline]
+    #[must_use]
+    pub fn new_from_range<I>(span: &'a [Span], range: I, idx: &'b mut usize) -> Option<Self>
+    where
+        I: SliceIndex<[Span], Output = [Span]>,
+    {
+        // Check valid index, otherwise return None
+        let new_span = span.get(range)?;
+        Self::new(new_span, idx)
+    }
+
+    /// Get the span at the current index
+    pub fn current(&self) -> Span {
+        // debug_assert!(self.inner.len() > *self.idx, "expect spans > 0");
+        // Safe, since the index is checked on construction
         self.inner[*self.idx]
     }
+
+    /// Get the spans starting at the current index
+    pub fn tail_inclusive(&self) -> SpanArray<'a> {
+        // Safe, since the index is checked on construction
+        SpanArray {
+            inner: &self.inner[*self.idx..],
+        }
+    }
+
     // pub fn get_last(self) -> Span {
     //     self.inner[self.inner.len() - 1]
     // }
+
+    /// Get the value at an index
     #[inline]
     #[must_use]
-    pub fn get_at(self, index: usize) -> Option<Span> {
-        self.inner.get(index).map(|&x| x)
+    pub fn get_at(&self, index: usize) -> Option<Span> {
+        Some(*self.inner.get(index)?)
     }
+
+    // /// Get the next n spans after the index
+    // #[inline]
+    // #[must_use]
+    // pub fn peek_n(self, number: usize) -> Option<Span> {
+    //     self.slice_arr(*self.idx..*self.idx + n)
+    // }
+
+    // TODO: Maybe return next value here
     #[inline]
     #[must_use]
-    pub fn try_advance(self) -> bool {
+    pub fn try_advance(&mut self) -> bool {
         if *self.idx + 1 < self.inner.len() {
             *self.idx += 1;
             true
         } else {
             false
         }
+    }
+
+    pub fn jump_to_end(&mut self) {
+        *self.idx = self.inner.len() - 1;
+    }
+
+    pub fn is_at_end(&self) -> bool {
+        *self.idx == self.inner.len() - 1
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn peek_next(&self) -> Option<Span> {
+        self.get_at(*self.idx + 1)
     }
 
     // #[inline]

--- a/crates/nu-parser/src/span_array.rs
+++ b/crates/nu-parser/src/span_array.rs
@@ -129,14 +129,23 @@ where
     Idx: Deref<Target = usize>,
     Idx: DerefMut<Target = usize>,
 {
+    /// Make a new span array of a prefix, sharing the index with the original
     #[inline]
     #[must_use]
-    pub fn sub_span<I>(&mut self, range: I) -> Option<PointedSpanArray<'a, NestedRef<Idx>>>
-    where
-        I: SliceIndex<[Span], Output = [Span]>,
-    {
-        PointedSpanArray::new_inner(self.inner.get(range)?, NestedRef(&mut self.idx))
+    pub fn prefix_span(&mut self, end: usize) -> Option<PointedSpanArray<'a, NestedRef<Idx>>> {
+        PointedSpanArray::new_inner(self.inner.get(..end)?, NestedRef(&mut self.idx))
     }
+
+    // // Note: Illegal for non-prefix ranges, since they can't share an index
+    // #[inline]
+    // #[must_use]
+    // pub fn sub_span<I>(&mut self, range: I) -> Option<PointedSpanArray<'a, NestedRef<Idx>>>
+    // where
+    //     I: SliceIndex<[Span], Output = [Span]>,
+    // {
+    //     PointedSpanArray::new_inner(self.inner.get(range)?, NestedRef(&mut self.idx))
+    // }
+
     // TODO: Maybe return next value here
     #[inline]
     #[must_use]

--- a/crates/nu-parser/src/span_array.rs
+++ b/crates/nu-parser/src/span_array.rs
@@ -1,0 +1,94 @@
+use std::slice::SliceIndex;
+
+// use miette::SourceSpan;
+// use serde::{Deserialize, Serialize};
+
+use nu_protocol::Span;
+
+/// Arrays of spans that are guaranteed to be non-empty by construction
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SpanArray<'a> {
+    inner: &'a [Span],
+}
+
+impl<'a> TryFrom<&'a [Span]> for SpanArray<'a> {
+    type Error = &'static str;
+
+    fn try_from(value: &'a [Span]) -> Result<Self, Self::Error> {
+        Self::new(value).ok_or("Got empty array")
+    }
+}
+
+impl<'a> SpanArray<'a> {
+    #[inline]
+    #[must_use]
+    pub fn new(value: &'a [Span]) -> Option<Self> {
+        if value.is_empty() {
+            None
+        } else {
+            Some(SpanArray { inner: value })
+        }
+    }
+    #[inline]
+    #[must_use]
+    pub fn get(self, index: usize) -> Option<Span> {
+        self.inner.get(index).map(|&x| x)
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn slice<I>(self, index: I) -> Option<Self>
+    where
+        I: SliceIndex<[Span], Output = [Span]>,
+    {
+        self.inner.get(index).and_then(|x| Self::new(x))
+    }
+}
+
+// This is almost an iterator, can it actually be one?
+/// An array of spans and an index into that array
+#[derive(Debug)]
+pub struct PointedSpanArray<'a, 'b> {
+    inner: &'a [Span],
+    idx: &'b mut usize,
+}
+
+impl<'a, 'b> PointedSpanArray<'a, 'b> {
+    #[inline]
+    #[must_use]
+    pub fn new(value: &'a [Span], idx: &'b mut usize) -> Option<Self> {
+        value
+            .get(*idx)
+            .map(|_| PointedSpanArray { inner: value, idx })
+    }
+    pub fn get(self) -> Span {
+        self.inner[*self.idx]
+    }
+    // pub fn get_last(self) -> Span {
+    //     self.inner[self.inner.len() - 1]
+    // }
+    #[inline]
+    #[must_use]
+    pub fn get_at(self, index: usize) -> Option<Span> {
+        self.inner.get(index).map(|&x| x)
+    }
+    #[inline]
+    #[must_use]
+    pub fn try_advance(self) -> bool {
+        if *self.idx + 1 < self.inner.len() {
+            *self.idx += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    // #[inline]
+    // #[must_use]
+    // pub fn slice<I>(self, index: I) -> Option<Self>
+    // where
+    //     I: SliceIndex<[Span], Output = [Span]>,
+    // {
+    //     self.inner.get(index).and_then(|x| Self::new(x))
+    // }
+}

--- a/crates/nu-parser/src/span_array.rs
+++ b/crates/nu-parser/src/span_array.rs
@@ -54,23 +54,23 @@ impl<'a> SpanArray<'a> {
 // This is almost an iterator, can it actually be one?
 /// An array of spans and an index into that array
 #[derive(Debug)]
-pub struct PointedSpanArray<'a, 'b> {
+pub struct PointedSpanArray<'a> {
     inner: &'a [Span],
-    idx: &'b mut usize,
+    idx: usize,
 }
 
-impl<'a, 'b> PointedSpanArray<'a, 'b> {
+impl<'a, 'b> PointedSpanArray<'a> {
     #[inline]
     #[must_use]
-    pub fn new(value: &'a [Span], idx: &'b mut usize) -> Option<Self> {
+    pub fn new(value: &'a [Span], idx: usize) -> Option<Self> {
         // check valid index, otherwise return none
-        _ = value.get(*idx)?;
+        _ = value.get(idx)?;
         Some(PointedSpanArray { inner: value, idx })
     }
 
     #[inline]
     #[must_use]
-    pub fn new_from_range<I>(span: &'a [Span], range: I, idx: &'b mut usize) -> Option<Self>
+    pub fn new_from_range<I>(span: &'a [Span], range: I, idx: usize) -> Option<Self>
     where
         I: SliceIndex<[Span], Output = [Span]>,
     {
@@ -78,19 +78,22 @@ impl<'a, 'b> PointedSpanArray<'a, 'b> {
         let new_span = span.get(range)?;
         Self::new(new_span, idx)
     }
+    pub fn get_idx(&self) -> usize {
+        self.idx
+    }
 
     /// Get the span at the current index
     pub fn current(&self) -> Span {
         // debug_assert!(self.inner.len() > *self.idx, "expect spans > 0");
         // Safe, since the index is checked on construction
-        self.inner[*self.idx]
+        self.inner[self.idx]
     }
 
     /// Get the spans starting at the current index
     pub fn tail_inclusive(&self) -> SpanArray<'a> {
         // Safe, since the index is checked on construction
         SpanArray {
-            inner: &self.inner[*self.idx..],
+            inner: &self.inner[self.idx..],
         }
     }
 
@@ -116,8 +119,8 @@ impl<'a, 'b> PointedSpanArray<'a, 'b> {
     #[inline]
     #[must_use]
     pub fn try_advance(&mut self) -> bool {
-        if *self.idx + 1 < self.inner.len() {
-            *self.idx += 1;
+        if self.idx + 1 < self.inner.len() {
+            self.idx += 1;
             true
         } else {
             false
@@ -125,17 +128,17 @@ impl<'a, 'b> PointedSpanArray<'a, 'b> {
     }
 
     pub fn jump_to_end(&mut self) {
-        *self.idx = self.inner.len() - 1;
+        self.idx = self.inner.len() - 1;
     }
 
-    pub fn is_at_end(&self) -> bool {
-        *self.idx == self.inner.len() - 1
-    }
+    // pub fn is_at_end(&self) -> bool {
+    //     *self.idx == self.inner.len() - 1
+    // }
 
     #[inline]
     #[must_use]
     pub fn peek_next(&self) -> Option<Span> {
-        self.get_at(*self.idx + 1)
+        self.get_at(self.idx + 1)
     }
 
     // #[inline]

--- a/crates/nu-parser/src/span_array.rs
+++ b/crates/nu-parser/src/span_array.rs
@@ -41,7 +41,7 @@ impl<'a> SpanArray<'a> {
     #[inline]
     #[must_use]
     pub fn get(self, index: usize) -> Option<Span> {
-        self.inner.get(index).map(|&x| x)
+        self.inner.get(index).copied()
     }
 
     #[inline]
@@ -50,7 +50,7 @@ impl<'a> SpanArray<'a> {
     where
         I: SliceIndex<[Span], Output = [Span]>,
     {
-        self.inner.get(index).and_then(|x| Self::new(x))
+        self.inner.get(index).and_then(Self::new)
     }
 }
 
@@ -145,7 +145,7 @@ where
 {
     #[inline]
     #[must_use]
-    pub fn sub_span<'d, I>(&mut self, range: I) -> Option<PointedSpanArray<'a, NestedRef<Idx>>>
+    pub fn sub_span<I>(&mut self, range: I) -> Option<PointedSpanArray<'a, NestedRef<Idx>>>
     where
         I: SliceIndex<[Span], Output = [Span]>,
     {

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -28,8 +28,9 @@ impl From<Span> for SourceSpan {
 }
 
 impl Span {
+    #[must_use]
     pub fn new_safe(start: usize, end: usize) -> Option<Span> {
-        if start < end {
+        if start <= end {
             Some(Span { start, end })
         } else {
             None

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -28,6 +28,14 @@ impl From<Span> for SourceSpan {
 }
 
 impl Span {
+    pub fn new_safe(start: usize, end: usize) -> Option<Span> {
+        if start < end {
+            Some(Span { start, end })
+        } else {
+            None
+        }
+    }
+
     pub fn new(start: usize, end: usize) -> Span {
         debug_assert!(
             end >= start,

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -205,6 +205,7 @@ fn too_few_arguments() -> TestResult {
     let cases = [
         "def a [b: bool, c: bool, d: float, e: float, f: float] {}; a true true 1 1",
         "def a [b: bool, c: bool, d: float, e: float, f: float, g: float] {}; a true true 1 1",
+        "def a [b: bool, c: bool, d: float, e: float, f: float, g: float, h: float] {}; a true true 1 1",
     ];
 
     let expected = "Missing required positional argument.";

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -200,6 +200,23 @@ fn assignment_with_no_var() -> TestResult {
 }
 
 #[test]
+fn too_few_arguments() -> TestResult {
+    // Test for https://github.com/nushell/nushell/issues/9072
+    let cases = [
+        "def a [b: bool, c: bool, d: float, e: float, f: float] {}; a true true 1 1",
+        "def a [b: bool, c: bool, d: float, e: float, f: float, g: float] {}; a true true 1 1",
+    ];
+
+    let expected = "Missing required positional argument.";
+
+    for case in cases {
+        fail_test(case, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
 fn long_flag() -> TestResult {
     run_test(
         r#"([a, b, c] | enumerate | each --keep-empty { |e| if $e.index != 1 { 100 }}).1 | to nuon"#,

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -208,7 +208,7 @@ fn too_few_arguments() -> TestResult {
         "def a [b: bool, c: bool, d: float, e: float, f: float, g: float, h: float] {}; a true true 1 1",
     ];
 
-    let expected = "Missing required positional argument.";
+    let expected = "missing f";
 
     for case in cases {
         fail_test(case, expected)?;

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -205,7 +205,6 @@ fn too_few_arguments() -> TestResult {
     let cases = [
         "def a [b: bool, c: bool, d: float, e: float, f: float] {}; a true true 1 1",
         "def a [b: bool, c: bool, d: float, e: float, f: float, g: float] {}; a true true 1 1",
-        "def a [b: bool, c: bool, d: float, e: float, f: float, g: float, h: float] {}; a true true 1 1",
     ];
 
     let expected = "Missing required positional argument.";


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
This draft is currently just an example of the kind of changes that would be done to the rest of the parser.

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
By replacing `spans[idx]` with `spans.get(idx)` calls, we can guarantee that we won't get any Index Out of Bounds panics, since we get back `Option<Span>` where we'll need to actually check that it was valid.

Some of the ones I replaced are very obviously checked, but that means that I can replace a check by a pattern match. And the goal is to remove all unchecked indexing in the parser.

- [x] Fixes #9072 and adds test for it
- Should prevent more errors like #10380 from appearing

## Further ideas:
- Make a new type for non-empty arrays of spans that guarantees that they are non-empty on construction.

# User-Facing Changes
None. Just refactoring and preventing crashes.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:
-->
- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library
<!--
> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
No user-facing changes

# More info
The approach is inspired by the [parse don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/) idea, where instead of first having a validation step where we check that the data is valid and then later construct data with implicit assumptions about the data, we combine these two into a single step, where we try to construct the data and if the data was invalid, we get a `None` back.