### PR TITLE
add a multi-set cartesian product to the standard library

### DIFF
--- a/crates/nu-std/std/iter.nu
+++ b/crates/nu-std/std/iter.nu
@@ -220,3 +220,50 @@ export def zip-into-record [ # -> table<any>
     | append ($other | into record)
     | headers
 }
+
+# compute the cartesian product of any number of lists
+#
+# basically, if you give `iter cartesian product` *n* lists, from *i_1* to *i_n*,
+# it will compute recursively the cartesian product of the first one with the
+# `iter cartesian product` of the rest, i.e. if we call CP the two-set cartesian
+# product and ICP the multi cartesian product here, we have
+#
+#     *ICP(i_1, i_2, ..., i_n) == CP(i_1, ICP(i_2, ..., i_n))*
+#
+# # Example
+#```nushell
+# use std ["assert equal" "iter iter cartesian product"]
+#
+# let res = (
+#     iter cartesian product [1, 2] [3, 4]
+# )
+#
+# assert equal $res [
+#     [1, 3],
+#     [1, 4],
+#     [2, 3],
+#     [2, 4],
+# ]
+# ```
+export def "cartesian product" [
+    ...iters: list<any>  # the iterables you want the cartesian product of
+]: nothing -> list<list<any>> {
+    def aux [a: list<list<any>>]: nothing -> list<list<any>> {
+        if ($a | is-empty) {
+            return []
+        }
+
+        let head = $a | first
+        let tail = aux ($a | skip 1)
+
+        if ($head | is-empty) {
+            return $tail
+        } else if ($tail | is-empty) {
+            return $head
+        }
+
+        $head | each {|h| $tail | each {|t| [$h, $t]}} | flatten | each { flatten }
+    }
+
+    aux $iters
+}

--- a/crates/nu-std/tests/test_iter.nu
+++ b/crates/nu-std/tests/test_iter.nu
@@ -132,3 +132,33 @@ def iter_zip_into_record [] {
         [rust    github  1]
     ]
 }
+
+#[test]
+def iter_cartesian_product [] {
+    # emptyness
+    assert equal (iter cartesian product [] []) []
+    assert equal (iter cartesian product []) []
+    assert equal (iter cartesian product) []
+
+    # symmetry
+    assert equal (iter cartesian product [1, 2] []) [1, 2]
+    assert equal (iter cartesian product [] [1, 2]) [1, 2]
+    # NOTE: iter cartesian product might not preserve the order of the elements produced
+    assert equal (
+        iter cartesian product [1, 2] [3, 4] | each { sort } | sort
+    ) (
+        iter cartesian product [3, 4] [1, 2] | each { sort } | sort
+    )
+
+    assert equal (
+        iter cartesian product [1, 2] [3, 4]
+    ) [
+        [1, 3], [1, 4], [2, 3], [2, 4]
+    ]
+
+    assert equal (
+        iter cartesian product [1, 2] [3, 4] [5, 6]
+    ) [
+        [1, 3, 5], [1, 3, 6], [1, 4, 5], [1, 4, 6], [2, 3, 5], [2, 3, 6], [2, 4, 5], [2, 4, 6]
+    ]
+}


### PR DESCRIPTION
# Description
i wrote this for my job and thought it could be a nice fit in `std iter` :yum: 

# User-Facing Changes
adds the `std iter cartesian product` command which takes a *rest* number of lists as arguments and produces the list of lists of all the possible element combinations of the input lists.

# Tests + Formatting
adds a new `iter_cartesian_product` test to `test_iter.nu`

# After Submitting