### PR TITLE
fix some new chrono warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.27"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -4115,9 +4115,9 @@ dependencies = [
 
 [[package]]
 name = "pure-rust-locales"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b856d7d028ebb0011d78eded5bc9185932412f36c12c67930f222d6b407526b"
+checksum = "ed02a829e62dc2715ceb8afb4f80e298148e1345749ceb369540fe0eb3368432"
 
 [[package]]
 name = "pwd"

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
@@ -269,7 +269,7 @@ pub fn from_parsed_columns(column_values: ColumnMap) -> Result<NuDataFrame, Shel
                 InputType::Date => {
                     let it = column.values.iter().map(|v| {
                         if let Value::Date { val, .. } = &v {
-                            Some(val.timestamp_nanos())
+                            Some(val.timestamp_nanos_opt().unwrap_or_default())
                         } else {
                             None
                         }
@@ -413,7 +413,7 @@ fn input_type_list_to_series(
 
                 let it = v.as_list()?.iter().map(|v| {
                     if let Value::Date { val, .. } = &v {
-                        Some(val.timestamp_nanos())
+                        Some(val.timestamp_nanos_opt().unwrap_or_default())
                     } else {
                         None
                     }

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -1,5 +1,4 @@
 use chrono::{FixedOffset, TimeZone};
-
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::CallExt;
 use nu_protocol::{
@@ -299,7 +298,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
                     span,
                 )
             } else {
-                Value::int(val.timestamp_nanos(), span)
+                Value::int(val.timestamp_nanos_opt().unwrap_or_default(), span)
             }
         }
         Value::Duration { val, .. } => Value::int(*val, span),

--- a/crates/nu-command/tests/commands/into_int.rs
+++ b/crates/nu-command/tests/commands/into_int.rs
@@ -49,7 +49,7 @@ fn into_int_datetime1() {
             .unwrap())
     );
 
-    let dt_nano = dt.expect("foo").timestamp_nanos();
+    let dt_nano = dt.expect("foo").timestamp_nanos_opt().unwrap_or_default();
     assert_eq!(dt_nano % 1_000_000_000, 123456789);
 }
 


### PR DESCRIPTION
# Description

This PR cleans up some warnings on the latest chrono dependency.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
