### PR TITLE
Simplify `nu!` test macros.

### DIFF
--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -346,11 +346,7 @@ pub fn nu_inner(opts: NuOpts, path: impl AsRef<str>, with_std: bool) -> Outcome 
 
     let process = match command.spawn() {
         Ok(child) => child,
-        Err(why) => panic!(
-            "Can't run test {:?} {}",
-            crate::fs::executable_path(),
-            why
-        ),
+        Err(why) => panic!("Can't run test {:?} {}", crate::fs::executable_path(), why),
     };
 
     let output = process

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -281,12 +281,7 @@ pub fn nu_run_test(opts: NuOpts, commands: impl AsRef<str>, with_std: bool) -> O
     Outcome::new(out, err.into_owned())
 }
 
-pub fn nu_with_plugin_run_test(
-    cwd: impl AsRef<Path>,
-    plugins: &[&str],
-    command: &str,
-) -> Outcome {
-
+pub fn nu_with_plugin_run_test(cwd: impl AsRef<Path>, plugins: &[&str], command: &str) -> Outcome {
     let test_bins = crate::fs::binaries();
     let test_bins = nu_path::canonicalize_with(&test_bins, ".").unwrap_or_else(|e| {
         panic!(

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -349,7 +349,7 @@ pub fn nu_inner(opts: NuOpts, path: impl AsRef<str>, with_std: bool) -> Outcome 
         Err(why) => panic!(
             "Can't run test {:?} {}",
             crate::fs::executable_path(),
-            why.to_string()
+            why
         ),
     };
 


### PR DESCRIPTION
# Description
Unify the logic between `nu!` and `nu_with_std!`.
The inner code actually does not contain any variadic components. So it can safely be abstracted into a function.

This also seems to simplify the codegen for tests.

Comparing the size of the `/target/debug` folder after running:

```sh
cargo clean --profile dev
cargo build --workspace --tests
```

With this branch a reduction from `8.9GB` to `8.7GB`

# User-Facing Changes
None

# Tests + Formatting
No changes necessary
