### PR TITLE
Make `mkdir -v` output PipelineData rather than printing string; update `print_created_paths` test; completes #10411

### DIFF
--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -5,7 +5,7 @@ use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
     SyntaxShape, Type, Value,
 };
 
@@ -25,7 +25,7 @@ impl Command for Mkdir {
                 SyntaxShape::Directory,
                 "the name(s) of the path(s) to create",
             )
-            .switch("verbose", "print created path(s).", Some('v'))
+            .switch("verbose", "output created path(s) to pipeline", Some('v'))
             .category(Category::FileSystem)
     }
 
@@ -102,7 +102,13 @@ impl Command for Mkdir {
             Example {
                 description: "Make multiple directories and show the paths created",
                 example: "mkdir -v foo/bar foo2",
-                result: None,
+                result: Some(Value::list(
+                    vec![
+                        Value::test_string("$env.PWD/foo/bar"),
+                        Value::test_string("$env.PWD/foo2"),
+                    ],
+                    Span::test_data(),
+                )),
             },
         ]
     }

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -83,11 +83,13 @@ impl Command for Mkdir {
             }
         }
 
-        stream
-            .into_iter()
-            .into_pipeline_data(engine_state.ctrlc.clone())
-            .print_not_formatted(engine_state, false, true)?;
-        Ok(PipelineData::empty())
+        if !stream.is_empty() {
+            Ok(stream
+                .into_iter()
+                .into_pipeline_data(engine_state.ctrlc.clone()))
+        } else {
+            Ok(PipelineData::Empty)
+        }
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/tests/commands/mkdir.rs
+++ b/crates/nu-command/tests/commands/mkdir.rs
@@ -68,7 +68,7 @@ fn print_created_paths() {
         let actual = nu!(
          cwd: dirs.test(),
          pipeline(
-             "mkdir -v dir_1 dir_2 dir_3"
+             "mkdir -v dir_1 dir_2 dir_3 | to json --raw"
         ));
 
         assert!(files_exist_at(
@@ -76,9 +76,21 @@ fn print_created_paths() {
             dirs.test()
         ));
 
-        assert!(actual.err.contains("dir_1"));
-        assert!(actual.err.contains("dir_2"));
-        assert!(actual.err.contains("dir_3"));
+        assert_eq!(
+            actual.out,
+            format!(
+                "[\"{}\",\"{}\",\"{}\"]",
+                Path::new(dirs.test())
+                    .join(Path::new("dir_1"))
+                    .to_string_lossy(),
+                Path::new(dirs.test())
+                    .join(Path::new("dir_2"))
+                    .to_string_lossy(),
+                Path::new(dirs.test())
+                    .join(Path::new("dir_3"))
+                    .to_string_lossy(),
+            )
+        );
     })
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Currently mkdir -v prints a string containing the created directories which is a nice feature. In the spirit of nushell, however, it seems like this would be better suited as PipelineData, making functions like the following possible (which is the simple function I was writing when I noticed this):
```nu
def-env mkcd [dirname: string] {
    mkdir -v $dirname | cd $in.0
}
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Example of new `mkdir -v` output:
```nu
➜ mkdir --verbose testing testing2 hello
╭───┬───────────────────────────────────────────╮
│ 0 │ /home/marchall/documents/nushell/testing  │
│ 1 │ /home/marchall/documents/nushell/testing2 │
│ 2 │ /home/marchall/documents/nushell/hello    │
╰───┴───────────────────────────────────────────╯
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
No issues.
