### PR TITLE
show the whole path in "missing mod.nu" errors

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1943,7 +1943,10 @@ pub fn parse_module_file_or_dir(
         let mod_nu_path = module_path.clone().join("mod.nu");
 
         if !(mod_nu_path.exists() && mod_nu_path.is_file()) {
-            working_set.error(ParseError::ModuleMissingModNuFile(path_span));
+            working_set.error(ParseError::ModuleMissingModNuFile(
+                module_path.path().to_string_lossy().to_string(),
+                path_span,
+            ));
             return None;
         }
 

--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -212,7 +212,7 @@ pub enum ParseError {
     #[error("Missing mod.nu file.")]
     #[diagnostic(
         code(nu::parser::module_missing_mod_nu_file),
-        help("When importing a directory as a Nushell module, it needs to contain a mod.nu file (can be empty). Alternatively, you can use .nu files in the directory as modules individually.\n\ntarget directory: {0}")
+        help("Directory {0} is missing a mod.nu file.\n\nWhen importing a directory as a Nushell module, it needs to contain a mod.nu file (can be empty). Alternatively, you can use .nu files in the directory as modules individually.")
     )]
     ModuleMissingModNuFile(
         String,

--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -212,11 +212,11 @@ pub enum ParseError {
     #[error("Missing mod.nu file.")]
     #[diagnostic(
         code(nu::parser::module_missing_mod_nu_file),
-        help("When importing a directory as a Nushell module, it needs to contain a mod.nu file (can be empty). Alternatively, you can use .nu files in the directory as modules individually.")
+        help("When importing a directory as a Nushell module, it needs to contain a mod.nu file (can be empty). Alternatively, you can use .nu files in the directory as modules individually.\n\ntarget directory: {0}")
     )]
     ModuleMissingModNuFile(
         String,
-        #[label = "module directory {0} is missing a mod.nu file"] Span,
+        #[label = "module directory is missing a mod.nu file"] Span,
     ),
 
     #[error("Cyclical module import.")]

--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -214,7 +214,10 @@ pub enum ParseError {
         code(nu::parser::module_missing_mod_nu_file),
         help("When importing a directory as a Nushell module, it needs to contain a mod.nu file (can be empty). Alternatively, you can use .nu files in the directory as modules individually.")
     )]
-    ModuleMissingModNuFile(#[label = "module directory is missing a mod.nu file"] Span),
+    ModuleMissingModNuFile(
+        String,
+        #[label = "module directory {0} is missing a mod.nu file"] Span,
+    ),
 
     #[error("Cyclical module import.")]
     #[diagnostic(code(nu::parser::cyclical_module_import), help("{0}"))]
@@ -504,7 +507,7 @@ impl ParseError {
             ParseError::AliasNotValid(s) => *s,
             ParseError::CommandDefNotValid(s) => *s,
             ParseError::ModuleNotFound(s) => *s,
-            ParseError::ModuleMissingModNuFile(s) => *s,
+            ParseError::ModuleMissingModNuFile(_, s) => *s,
             ParseError::NamedAsModule(_, _, _, s) => *s,
             ParseError::ModuleDoubleMain(_, s) => *s,
             ParseError::InvalidModuleFileName(_, _, s) => *s,


### PR DESCRIPTION
related to
- https://discord.com/channels/601130461678272522/614593951969574961/1153261556411408384

## description
when it comes to the `use` command, the directories and files in the current directory take precedence over the ones in the paths defined in `$env.NU_LIB_DIRS`.
because the "missing mod.nu" error does not mention the path to the directory module trying to be `use`d, it can be quite confusing: see the Discord discussion above, quite a hard to debug thing :thinking: 

this PR adds the full path to the module to the "missing mod.nu" error, making it hopefully easier to debug.

## reproduce the unhelpful error
1. write `export def main [] { echo "this is scripts" }` inside `$nu.default-config-dir | path join "scripts/mod.nu"` 
2. add `$nu.default-config-dir` to `$env.NU_LIB_DIRS` in `env.nu`
3. add `use scripts/` in `config.nu`
4. open Nushell => it should work
5. go to the Nushell repo, or any directory with a `scripts/` directory missing a `mod.nu` file
6. run `nu` => it will give an error

### before
the error is quite hard to debug :sweat_smile: 
```
Error: nu::parser::module_missing_mod_nu_file

  × Missing mod.nu file.
   ╭─[entry #1:1:1]
 1 │ use scripts
   ·     ───┬───
   ·        ╰── module directory is missing a mod.nu file
   ╰────
  help: When importing a directory as a Nushell module,
        it needs to contain a mod.nu file (can be empty).
        Alternatively, you can use .nu files in the
        directory as modules individually.
```

### after
the error mentions the full path to the directory module, so that the user can see that it's not the one from `NU_LIB_DIRS` that is being `use`d :fingers_crossed: 
```
Error: nu::parser::module_missing_mod_nu_file

  × Missing mod.nu file.
   ╭─[entry #1:1:1]
 1 │ use scripts
   ·     ───┬───
   ·        ╰── module directory /home/disc/a.stevan/documents/repos/github.com/nushell/nushell/scripts is missing a mod.nu file
   ╰────
  help: When importing a directory as a Nushell module,
        it needs to contain a mod.nu file (can be empty).
        Alternatively, you can use .nu files in the
        directory as modules individually.
```
