### PR TITLE
allow `values` command to support `LazyRecord`s

### DIFF
--- a/crates/nu-command/src/filters/values.rs
+++ b/crates/nu-command/src/filters/values.rs
@@ -166,6 +166,13 @@ fn values(
                 Value::Record { val, .. } => {
                     Ok(val.vals.into_pipeline_data(ctrlc).set_metadata(metadata))
                 }
+                Value::LazyRecord { val, .. } => Ok(val
+                    .collect()?
+                    .as_record()?
+                    .vals
+                    .clone()
+                    .into_pipeline_data(ctrlc)
+                    .set_metadata(metadata)),
                 // Propagate errors
                 Value::Error { error, .. } => Err(*error),
                 other => Err(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -79,3 +79,11 @@ fn insert_support_lazy_record() {
         nu!(r#"let x = (lazy make -c ["h"] -g {|a| $a | str upcase}); $x | insert a 10 | get a"#);
     assert_eq!(actual.out, "10");
 }
+
+#[test]
+fn lazy_record_test_values() {
+    let actual = nu!(
+        r#"lazy make --columns ["haskell", "futures", "nushell"] --get-value { |lazything| $lazything + "!" } | values | length"#
+    );
+    assert_eq!(actual.out, "3");
+}


### PR DESCRIPTION
# Description

This PR allows the `values` command to support lazy records.

closes https://github.com/nushell/nushell/issues/10417

### Before
```nushell
sys | values
Error: nu::shell::only_supports_this_input_type

  × Input type not supported.
   ╭─[entry #1:1:1]
 1 │ sys | values
   · ─┬─   ───┬──
   ·  │       ╰── only record or table input data is supported
   ·  ╰── input type: record<host: record<name: string, os_version: string, long_os_version: string, kernel_version: string, hostname: string, uptime: duration, boot_time: string, sessions: list<any>>, cpu: table<name: string, brand: string, freq: int, cpu_usage: float, load_average: string, vendor_id: string>, disks: table<device: string, type: string, mount: string, total: filesize, free: filesize, removable: bool, kind: string>, mem: record<total: filesize, free: filesize, used: filesize, available: filesize, swap total: filesize, swap free: filesize, swap used: filesize>, temp: list<any>, net: table<name: string, sent: filesize, recv: filesize>>
   ╰────
```

### After
```nushell
❯ sys | values
╭─┬─────────────────╮
│0│{record 8 fields}│
│1│[table 16 rows]  │
│2│[table 1 row]    │
│3│{record 7 fields}│
│4│[list 0 items]   │
│5│[table 5 rows]   │
╰─┴─────────────────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
