### PR TITLE
Refactor `CellPath` to support negative `rowPaths`

### DIFF
--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -14,7 +14,40 @@ pub enum PathMember {
         val: usize,
         span: Span,
         optional: bool,
+        reverse: bool,
     },
+}
+
+impl PathMember {
+    /**
+    Generates a new `Pathmember::Int`, given a `i64`, `Span` and an `optional`.
+    */
+    pub fn new_int(int: i64, span: Span, optional: bool) -> PathMember {
+        if int < 0 {
+            return PathMember::Int {
+                val: (int.abs() as usize),
+                span,
+                optional,
+                reverse: true,
+            };
+        }
+        PathMember::Int {
+            val: int as usize,
+            span,
+            optional,
+            reverse: false,
+        }
+    }
+    /**
+    Generates a new `Pathmember::String` given a `String`, `Span` an an `optional`.
+    */
+    pub fn new_string(string: String, span: Span, optional: bool) -> PathMember {
+        PathMember::String {
+            val: string,
+            span,
+            optional,
+        }
+    }
 }
 
 impl PartialEq for PathMember {
@@ -36,14 +69,16 @@ impl PartialEq for PathMember {
                 Self::Int {
                     val: l_val,
                     optional: l_opt,
+                    reverse: l_rev,
                     ..
                 },
                 Self::Int {
                     val: r_val,
                     optional: r_opt,
+                    reverse: r_rev,
                     ..
                 },
-            ) => l_val == r_val && l_opt == r_opt,
+            ) => l_val == r_val && l_opt == r_opt && l_rev == r_rev,
             _ => false,
         }
     }


### PR DESCRIPTION
This PR is in relation #10392, and enables easier integration of ranges for PR #10363

# User-Facing Changes
commands like `select` and `reject` will be able to pass negative numbers without hanging like in the #10392 
while functionality of said negative ranges will be implemented on a later PR

---
The initial idea is to add a reverse bool to `PathMember::Int` to support passing negative ranges. Any suggestions welcome.
