### PR TITLE
don't overrite arg's type if it's annotated explicitly

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -164,3 +164,19 @@ fn extern_with_block() {
 
     assert_eq!(actual.out, "--bar,baz,--,-q,-u,-x");
 }
+
+#[test]
+fn def_default_value_shouldnt_restrict_explicit_type() {
+    let actual = nu!("def foo [x: any = null] { $x }; foo 1");
+    assert_eq!(actual.out, "1");
+    let actual2 = nu!("def foo [--x: any = null] { $x }; foo --x 1");
+    assert_eq!(actual2.out, "1");
+}
+
+#[test]
+fn def_defualt_value_should_restrict_implicit_type() {
+    let actual = nu!("def foo [x = 3] { $x }; foo 'a'");
+    assert!(actual.err.contains("expected int"));
+    let actual2 = nu!("def foo2 [--x = 'a'] { $x }; foo2 --x 3");
+    assert!(actual2.err.contains("expected string"));
+}


### PR DESCRIPTION
# Description
Fixes: #10410 

So the following script is possible:
```nushell
def a [b: any = null] { let b = ($b | default "default_b"); }
a "given_b"
```

## About the change
When parsing signature, and nushell meets something like `a: any`, it force the parser to treat `a` as `any` type.  This is what `arg_explicit_type` means, it's only set when we goes into `ParseMode::TypeMode`, and it will be reset to `false` if the token goes to next argument.

so, when we have something like this: `def a [b: any = null] { $b }`, the type of `$b` won't be overwritten.

But if we have something like this: `def a [b = null] { $b }`, the type of `$b` is not annotated, so we make it to be `nothing`(which is the type of null)


