### PR TITLE
Pin reedline to `0.24` for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4291,8 +4291,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.23.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#f9939396905a81841645da30b411f3a255c7a037"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971ac45071721aae18927f3feb7e4c2b95cce387d96af185c5103166d332e55c"
 dependencies = [
  "chrono",
  "crossterm 0.27.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.84.1" }
 nu-std = { path = "./crates/nu-std", version = "0.84.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.84.1" }
 nu-ansi-term = "0.49.0"
-reedline = { version = "0.23.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.24.0", features = ["bashisms", "sqlite"] }
 
 crossterm = "0.27"
 ctrlc = "3.4"
@@ -164,7 +164,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
+# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main"}
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Criterion benchmarking setup

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -25,7 +25,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.84.1" }
 nu-utils = { path = "../nu-utils", version = "0.84.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.84.1" }
 nu-ansi-term = "0.49.0"
-reedline = { version = "0.23.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.24.0", features = ["bashisms", "sqlite"] }
 
 chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.27"


### PR DESCRIPTION
See release notes:
https://github.com/nushell/reedline/releases/tag/v0.24.0
