### PR TITLE
show the full directory / file path in "directory not found" error

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -509,9 +509,8 @@ pub fn evaluate_repl(
                             report_error(
                                 &working_set,
                                 &ShellError::DirectoryNotFound(
-                                    path.to_string_lossy().to_string(),
                                     tokens.0[0].span,
-                                    None,
+                                    path.to_string_lossy().to_string(),
                                 ),
                             );
                         }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -508,7 +508,11 @@ pub fn evaluate_repl(
 
                             report_error(
                                 &working_set,
-                                &ShellError::DirectoryNotFound(tokens.0[0].span, None),
+                                &ShellError::DirectoryNotFound(
+                                    path.to_string_lossy().to_string(),
+                                    tokens.0[0].span,
+                                    None,
+                                ),
                             );
                         }
                         let path = nu_path::canonicalize_with(path, &cwd)

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -91,6 +91,7 @@ impl Command for Cd {
                                         Ok(p) => p,
                                         Err(e) => {
                                             return Err(ShellError::DirectoryNotFound(
+                                                path.to_string_lossy().to_string(),
                                                 v.span,
                                                 Some(format!("IO Error: {e:?}")),
                                             ))
@@ -98,6 +99,7 @@ impl Command for Cd {
                                     }
                                 } else {
                                     return Err(ShellError::DirectoryNotFound(
+                                        path.to_string_lossy().to_string(),
                                         v.span,
                                         Some(format!("IO Error: {e1:?}")),
                                     ));
@@ -121,6 +123,7 @@ impl Command for Cd {
                                         Ok(path) => path,
                                         Err(e) => {
                                             return Err(ShellError::DirectoryNotFound(
+                                                p.to_string_lossy().to_string(),
                                                 v.span,
                                                 Some(format!("IO Error: {e:?}")),
                                             ))
@@ -140,13 +143,18 @@ impl Command for Cd {
                                     Ok(path) => path,
                                     Err(e) => {
                                         return Err(ShellError::DirectoryNotFound(
+                                            path_no_whitespace.to_string(),
                                             v.span,
                                             Some(format!("IO Error: {e:?}")),
                                         ))
                                     }
                                 }
                             } else {
-                                return Err(ShellError::DirectoryNotFound(v.span, None));
+                                return Err(ShellError::DirectoryNotFound(
+                                    path_no_whitespace.to_string(),
+                                    v.span,
+                                    None,
+                                ));
                             }
                         }
                     };

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -85,23 +85,21 @@ impl Command for Cd {
                         let path = oldpwd.as_path()?;
                         let path = match nu_path::canonicalize_with(path.clone(), &cwd) {
                             Ok(p) => p,
-                            Err(e1) => {
+                            Err(_) => {
                                 if use_abbrev {
                                     match query(&path, None, v.span) {
                                         Ok(p) => p,
-                                        Err(e) => {
+                                        Err(_) => {
                                             return Err(ShellError::DirectoryNotFound(
-                                                path.to_string_lossy().to_string(),
                                                 v.span,
-                                                Some(format!("IO Error: {e:?}")),
+                                                path.to_string_lossy().to_string(),
                                             ))
                                         }
                                     }
                                 } else {
                                     return Err(ShellError::DirectoryNotFound(
-                                        path.to_string_lossy().to_string(),
                                         v.span,
-                                        Some(format!("IO Error: {e1:?}")),
+                                        path.to_string_lossy().to_string(),
                                     ));
                                 }
                             }
@@ -121,11 +119,10 @@ impl Command for Cd {
                                     // if it's not a dir, let's check to see if it's something abbreviated
                                     match query(&p, None, v.span) {
                                         Ok(path) => path,
-                                        Err(e) => {
+                                        Err(_) => {
                                             return Err(ShellError::DirectoryNotFound(
-                                                p.to_string_lossy().to_string(),
                                                 v.span,
-                                                Some(format!("IO Error: {e:?}")),
+                                                p.to_string_lossy().to_string(),
                                             ))
                                         }
                                     };
@@ -141,19 +138,17 @@ impl Command for Cd {
                             if use_abbrev {
                                 match query(&path_no_whitespace, None, v.span) {
                                     Ok(path) => path,
-                                    Err(e) => {
+                                    Err(_) => {
                                         return Err(ShellError::DirectoryNotFound(
-                                            path_no_whitespace.to_string(),
                                             v.span,
-                                            Some(format!("IO Error: {e:?}")),
+                                            path_no_whitespace.to_string(),
                                         ))
                                     }
                                 }
                             } else {
                                 return Err(ShellError::DirectoryNotFound(
-                                    path_no_whitespace.to_string(),
                                     v.span,
-                                    None,
+                                    path_no_whitespace.to_string(),
                                 ));
                             }
                         }

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -102,6 +102,7 @@ impl Command for Cp {
         let is_directory = path_last_char == Some('/') || path_last_char == Some('\\');
         if is_directory && !destination.exists() {
             return Err(ShellError::DirectoryNotFound(
+                destination.to_string_lossy().to_string(),
                 dst.span,
                 Some("destination directory does not exist".to_string()),
             ));

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -102,9 +102,8 @@ impl Command for Cp {
         let is_directory = path_last_char == Some('/') || path_last_char == Some('\\');
         if is_directory && !destination.exists() {
             return Err(ShellError::DirectoryNotFound(
-                destination.to_string_lossy().to_string(),
                 dst.span,
-                Some("destination directory does not exist".to_string()),
+                destination.to_string_lossy().to_string(),
             ));
         }
         let ctrlc = engine_state.ctrlc.clone();

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -276,7 +276,11 @@ fn move_file(
     };
 
     if !destination_dir_exists {
-        return Err(ShellError::DirectoryNotFound(to_span, None));
+        return Err(ShellError::DirectoryNotFound(
+            to.to_string_lossy().to_string(),
+            to_span,
+            None,
+        ));
     }
 
     // This can happen when changing case on a case-insensitive filesystem (ex: changing foo to Foo on Windows)
@@ -287,7 +291,13 @@ fn move_file(
     if !from_to_are_same_file && to.is_dir() {
         let from_file_name = match from.file_name() {
             Some(name) => name,
-            None => return Err(ShellError::DirectoryNotFound(to_span, None)),
+            None => {
+                return Err(ShellError::DirectoryNotFound(
+                    from.to_string_lossy().to_string(),
+                    to_span,
+                    None,
+                ))
+            }
         };
 
         to.push(from_file_name);

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -277,9 +277,8 @@ fn move_file(
 
     if !destination_dir_exists {
         return Err(ShellError::DirectoryNotFound(
-            to.to_string_lossy().to_string(),
             to_span,
-            None,
+            to.to_string_lossy().to_string(),
         ));
     }
 
@@ -293,9 +292,8 @@ fn move_file(
             Some(name) => name,
             None => {
                 return Err(ShellError::DirectoryNotFound(
-                    from.to_string_lossy().to_string(),
                     to_span,
-                    None,
+                    from.to_string_lossy().to_string(),
                 ))
             }
         };

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -82,11 +82,10 @@ impl Command for Watch {
 
         let path = match nu_path::canonicalize_with(path_no_whitespace, cwd) {
             Ok(p) => p,
-            Err(e) => {
+            Err(_) => {
                 return Err(ShellError::DirectoryNotFound(
-                    path_no_whitespace.to_string(),
                     path_arg.span,
-                    Some(format!("IO Error: {e:?}")),
+                    path_no_whitespace.to_string(),
                 ))
             }
         };

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -84,6 +84,7 @@ impl Command for Watch {
             Ok(p) => p,
             Err(e) => {
                 return Err(ShellError::DirectoryNotFound(
+                    path_no_whitespace.to_string(),
                     path_arg.span,
                     Some(format!("IO Error: {e:?}")),
                 ))

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -391,7 +391,7 @@ fn copy_to_non_existing_dir_impl(progress: bool) {
             progress_flag
         );
         assert!(actual.err.contains("directory not found"));
-        assert!(actual.err.contains("/not_a_dir/ not found"));
+        assert!(actual.err.contains("does not exist"));
     });
 }
 

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -391,7 +391,7 @@ fn copy_to_non_existing_dir_impl(progress: bool) {
             progress_flag
         );
         assert!(actual.err.contains("directory not found"));
-        assert!(actual.err.contains("destination directory does not exist"));
+        assert!(actual.err.contains("/not_a_dir/ not found"));
     });
 }
 

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -73,9 +73,8 @@ pub fn glob_from(
                 p
             } else {
                 return Err(ShellError::DirectoryNotFound(
-                    path.to_string_lossy().to_string(),
                     pattern.span,
-                    None,
+                    path.to_string_lossy().to_string(),
                 ));
             };
             (path.parent().map(|parent| parent.to_path_buf()), path)

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -69,10 +69,14 @@ pub fn glob_from(
         if is_symlink {
             (path.parent().map(|parent| parent.to_path_buf()), path)
         } else {
-            let path = if let Ok(p) = canonicalize_with(path, cwd) {
+            let path = if let Ok(p) = canonicalize_with(path.clone(), cwd) {
                 p
             } else {
-                return Err(ShellError::DirectoryNotFound(pattern.span, None));
+                return Err(ShellError::DirectoryNotFound(
+                    path.to_string_lossy().to_string(),
+                    pattern.span,
+                    None,
+                ));
             };
             (path.parent().map(|parent| parent.to_path_buf()), path)
         }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -801,8 +801,8 @@ pub enum ShellError {
     ///
     /// Make sure the directory in the error message actually exists before trying again.
     #[error("Directory not found")]
-    #[diagnostic(code(nu::shell::directory_not_found))]
-    DirectoryNotFound(#[label("directory not found")] Span, #[help] Option<String>),
+    #[diagnostic(code(nu::shell::directory_not_found), help("{0}"))]
+    DirectoryNotFound(String, #[label("directory not found")] Span, Option<String>),
 
     /// Attempted to perform an operation on a directory that doesn't exist.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -801,7 +801,10 @@ pub enum ShellError {
     ///
     /// Make sure the directory in the error message actually exists before trying again.
     #[error("Directory not found")]
-    #[diagnostic(code(nu::shell::directory_not_found), help("{0}"))]
+    #[diagnostic(
+        code(nu::shell::directory_not_found),
+        help("the target directory was {0}")
+    )]
     DirectoryNotFound(String, #[label("directory not found")] Span, Option<String>),
 
     /// Attempted to perform an operation on a directory that doesn't exist.

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -801,7 +801,7 @@ pub enum ShellError {
     ///
     /// Make sure the directory in the error message actually exists before trying again.
     #[error("Directory not found")]
-    #[diagnostic(code(nu::shell::directory_not_found), help("{1} not found"))]
+    #[diagnostic(code(nu::shell::directory_not_found), help("{1} does not exist"))]
     DirectoryNotFound(#[label("directory not found")] Span, String),
 
     /// Attempted to perform an operation on a directory that doesn't exist.

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -801,11 +801,8 @@ pub enum ShellError {
     ///
     /// Make sure the directory in the error message actually exists before trying again.
     #[error("Directory not found")]
-    #[diagnostic(
-        code(nu::shell::directory_not_found),
-        help("the target directory was {0}")
-    )]
-    DirectoryNotFound(String, #[label("directory not found")] Span, Option<String>),
+    #[diagnostic(code(nu::shell::directory_not_found), help("{1} not found"))]
+    DirectoryNotFound(#[label("directory not found")] Span, String),
 
     /// Attempted to perform an operation on a directory that doesn't exist.
     ///


### PR DESCRIPTION
should close https://github.com/nushell/nushell/issues/10406

# Description
when writing a script, with variables you try to `ls` or `open`, you will get a "directory not found" error but the variable won't be expanded and you won't be able to see which one of the variable was the issue...

this PR adds this information to the error.

# User-Facing Changes
let's define a variable
```nushell
let does_not_exist = "i_do_not_exist_in_the_current_directory"
```
### before
```nushell
> open $does_not_exist
Error: nu::shell::directory_not_found

  × Directory not found
   ╭─[entry #7:1:1]
 1 │ open $does_not_exist
   ·      ───────┬───────
   ·             ╰── directory not found
   ╰────
```
```nushell
> ls $does_not_exist
Error: nu::shell::directory_not_found

  × Directory not found
   ╭─[entry #8:1:1]
 1 │ ls $does_not_exist
   ·    ───────┬───────
   ·           ╰── directory not found
   ╰────
```

### after
```nushell
> open $does_not_exist
Error: nu::shell::directory_not_found

  × Directory not found
   ╭─[entry #3:1:1]
 1 │ open $does_not_exist
   ·      ───────┬───────
   ·             ╰── directory not found
   ╰────
  help: /home/amtoine/documents/repos/github.com/amtoine/nushell/i_do_not_exist_in_the_current_directory does not exist
```
```nushell
> ls $does_not_exist
Error: nu::shell::directory_not_found

  × Directory not found
   ╭─[entry #4:1:1]
 1 │ ls $does_not_exist
   ·    ───────┬───────
   ·           ╰── directory not found
   ╰────
  help: /home/amtoine/documents/repos/github.com/amtoine/nushell/i_do_not_exist_in_the_current_directory does not exist
```

# Tests + Formatting
shouldn't harm anything :crossed_fingers: 

# After Submitting