### PR TITLE
WIP: Support creating records from IndexMap to keep key order

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1822,6 +1822,16 @@ impl Value {
         }
     }
 
+    pub fn record_from_indexmap(map: &IndexMap<String, Value>, span: Span) -> Value {
+        let mut cols = vec![];
+        let mut vals = vec![];
+        for (key, val) in map.iter() {
+            cols.push(key.clone());
+            vals.push(val.clone());
+        }
+        Value::record(cols, vals, span)
+    }
+
     pub fn list(vals: Vec<Value>, span: Span) -> Value {
         Value::List {
             vals,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
If I use HashMap to create records, the key order is not guaranteed.
I have added a function to support IndexMap, which helps keep the key order in some cases, for example, when it is necessary to prioritize displaying some important columns before other columns.
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
Users can quickly find the preferred columns in a large table, and the columns are kept in order when changing the code, helping users avoid surprises.
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
Ok
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
