### PR TITLE
Improve assertions in `src/tests.rs`

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -118,7 +118,7 @@ pub fn run_test_contains(input: &str, expected: &str) -> TestResult {
 
     assert!(output.status.success());
 
-    assert!(stdout.contains(expected));
+    assert!(stdout.contains(expected), "Expected output to contain: {expected}");
 
     Ok(())
 }
@@ -147,7 +147,7 @@ pub fn test_ide_contains(input: &str, ide_commands: &[&str], expected: &str) -> 
 
     assert!(output.status.success());
 
-    assert!(stdout.contains(expected));
+    assert!(stdout.contains(expected), "Expected output to contain: {expected}");
 
     Ok(())
 }
@@ -175,7 +175,7 @@ pub fn fail_test(input: &str, expected: &str) -> TestResult {
     println!("stdout: {stdout}");
     println!("stderr: {stderr}");
 
-    assert!(!stderr.is_empty() && stderr.contains(expected));
+    assert!(!stderr.is_empty() && stderr.contains(expected), "Expected error to contain: {expected}");
 
     Ok(())
 }


### PR DESCRIPTION
# Description
Mention the expected substring in:
- `fn run_test_contains()`
- `fn test_ide_contains()`
- `fn fail_test()`


# Developer-Facing Changes
You can read the test failure to figure out what is going on, don't necessarily have to look up the test

# Tests + Formatting
This is an assetion used in several tests in the workspace root
