### PR TITLE
update the doc in toolchain.toml describing the update plan

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -9,8 +9,8 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-# The current plan is to be 1 release behind the latest stable release. So, if the
-# latest stable release is 1.62.0, the channel should be 1.61.0. We want to do this
+# The current plan is to be 2 releases behind the latest stable release. So, if the
+# latest stable release is 1.72.0, the channel should be 1.70.0. We want to do this
 # so that we give repo maintainers and package managers a chance to update to a more
 # recent version of rust. However, if there is a "cool new feature" that we want to
 # use in nushell, we may opt to use the bleeding edge stable version of rust.


### PR DESCRIPTION

The *toolchain.toml* doc incorrectly stated how many releases behind stable we will be...

It said we would be 1 release behind when actually we want to be 2 releases behind stable.

