### PR TITLE
differentiating between `--x` and `--x: bool`

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -180,3 +180,13 @@ fn def_default_value_should_restrict_implicit_type() {
     let actual2 = nu!("def foo2 [--x = 3] { $x }; foo2 --x 3.0");
     assert!(actual2.err.contains("expected int"));
 }
+
+#[test]
+fn def_boolean_flags() {
+    let actual = nu!("def foo [--x: bool] { $x }; foo --x");
+    assert!(actual.err.contains("flag missing bool argument"));
+    let actual = nu!("def foo [--x: bool = false] { $x }; foo");
+    assert_eq!(actual.out, "false");
+    let actual = nu!("def foo [--x: bool = false] { $x }; foo --x");
+    assert!(actual.err.contains("flag missing bool argument"));
+}

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -189,4 +189,7 @@ fn def_boolean_flags() {
     assert_eq!(actual.out, "false");
     let actual = nu!("def foo [--x: bool = false] { $x }; foo --x");
     assert!(actual.err.contains("flag missing bool argument"));
+    // boolean flags' default value should be null
+    let actual = nu!("def foo [--x: bool] { $x == null }; foo");
+    assert_eq!(actual.out, "true");
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -17,7 +17,7 @@ use nu_protocol::{
     engine::StateWorkingSet,
     eval_const::{eval_constant, value_as_string},
     span, BlockId, DidYouMean, Flag, ParseError, PositionalArg, Signature, Span, Spanned,
-    SyntaxShape, Type, Unit, Value, VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
+    SyntaxShape, Type, Unit, VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
 };
 
 use crate::parse_keywords::{
@@ -3704,19 +3704,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), Type::List(Box::new(syntax_shape.to_type())));
                                         *shape = syntax_shape;
                                     }
-                                    Arg::Flag(Flag {
-                                        arg,
-                                        var_id,
-                                        default_value,
-                                        ..
-                                    }) => {
-                                        if syntax_shape == SyntaxShape::Boolean {
-                                            // set up default value, this would allow something
-                                            // def a [--x: bool] { $x }; a
-                                            *default_value =
-                                                Some(Value::bool(false, Span::unknown()));
-                                        }
-
+                                    Arg::Flag(Flag { arg, var_id, .. }) => {
                                         working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), syntax_shape.to_type());
                                         *arg = Some(syntax_shape);
                                     }

--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -100,7 +100,7 @@ def "nu-complete list-externs" [] {
 
 def build-help-header [
     text: string
-    --no-newline (-n): bool
+    --no-newline (-n)
 ] {
     let header = $"(ansi green)($text)(ansi reset):"
 

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -68,7 +68,7 @@ fn do_rest_args() -> TestResult {
 #[test]
 fn custom_switch1() -> TestResult {
     run_test(
-        r#"def florb [ --dry-run: bool ] { if ($dry_run) { "foo" } else { "bar" } }; florb --dry-run"#,
+        r#"def florb [ --dry-run: bool ] { if ($dry_run) { "foo" } else { "bar" } }; florb --dry-run true"#,
         "foo",
     )
 }

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -68,29 +68,13 @@ fn do_rest_args() -> TestResult {
 #[test]
 fn custom_switch1() -> TestResult {
     run_test(
-        r#"def florb [ --dry-run: bool ] { if ($dry_run) { "foo" } else { "bar" } }; florb --dry-run true"#,
-        "foo",
-    )
-}
-
-#[test]
-fn custom_switch2() -> TestResult {
-    run_test(
-        r#"def florb [ --dry-run: bool ] { if ($dry_run) { "foo" } else { "bar" } }; florb"#,
-        "bar",
-    )
-}
-
-#[test]
-fn custom_switch3() -> TestResult {
-    run_test(
         r#"def florb [ --dry-run ] { if ($dry_run) { "foo" } else { "bar" } }; florb --dry-run"#,
         "foo",
     )
 }
 
 #[test]
-fn custom_switch4() -> TestResult {
+fn custom_switch2() -> TestResult {
     run_test(
         r#"def florb [ --dry-run ] { if ($dry_run) { "foo" } else { "bar" } }; florb"#,
         "bar",

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -440,7 +440,7 @@ fn string_escape_interpolation2() -> TestResult {
 #[test]
 fn proper_rest_types() -> TestResult {
     run_test(
-        r#"def foo [--verbose(-v): bool, # my test flag
+        r#"def foo [--verbose(-v), # my test flag
                    ...rest: int # my rest comment
                 ] { if $verbose { print "verbose!" } else { print "not verbose!" } }; foo"#,
         "not verbose!",

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -8,8 +8,8 @@
 
 # check standard code formatting and apply the changes
 export def fmt [
-    --check: bool  # do not apply the format changes, only check the syntax
-    --verbose: bool # print extra information about the command's progress
+    --check # do not apply the format changes, only check the syntax
+    --verbose  # print extra information about the command's progress
 ] {
     if $verbose {
         print $"running ('toolkit fmt' | pretty-format-command)"
@@ -32,9 +32,9 @@ export def fmt [
 #
 # > it is important to make `clippy` happy :relieved:
 export def clippy [
-    --verbose: bool # print extra information about the command's progress
+    --verbose # print extra information about the command's progress
     --features: list<string> # the list of features to run *Clippy* on
-    --workspace: bool # run the *Clippy* command on the whole workspace (overrides `--features`)
+    --workspace # run the *Clippy* command on the whole workspace (overrides `--features`)
 ] {
     if $verbose {
         print $"running ('toolkit clippy' | pretty-format-command)"
@@ -63,9 +63,9 @@ export def clippy [
 
 # check that all the tests pass
 export def test [
-    --fast: bool  # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
+    --fast # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
     --features: list<string> # the list of features to run the tests on
-    --workspace: bool # run the *Clippy* command on the whole workspace (overrides `--features`)
+    --workspace # run the *Clippy* command on the whole workspace (overrides `--features`)
 ] {
     if $fast {
         if $workspace {
@@ -104,11 +104,11 @@ def pretty-format-command [] {
 # otherwise, the truth values will be incremental, following
 # the order above.
 def report [
-    --fail-fmt: bool
-    --fail-clippy: bool
-    --fail-test: bool
-    --fail-test-stdlib: bool
-    --no-fail: bool
+    --fail-fmt
+    --fail-clippy
+    --fail-test
+    --fail-test-stdlib
+    --no-fail
 ] {
     [fmt clippy test "test stdlib"]
     | wrap stage
@@ -227,7 +227,7 @@ def report [
 #
 # now the whole `toolkit check pr` passes! :tada:
 export def "check pr" [
-    --fast: bool  # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
+    --fast # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
     --features: list<string> # the list of features to check the current PR on
 ] {
     $env.NU_TEST_LOCALE_OVERRIDE = 'en_US.utf8';
@@ -297,7 +297,7 @@ def build-plugin [] {
 # build Nushell and plugins with some features
 export def build [
     ...features: string@"nu-complete list features"  # a space-separated list of feature to install with Nushell
-    --all: bool  # build all plugins with Nushell
+    --all # build all plugins with Nushell
 ] {
     build-nushell ($features | str join ",")
 
@@ -335,7 +335,7 @@ def install-plugin [] {
 # install Nushell and features you want
 export def install [
     ...features: string@"nu-complete list features"  # a space-separated list of feature to install with Nushell
-    --all: bool  # install all plugins with Nushell
+    --all # install all plugins with Nushell
 ] {
     touch crates/nu-cmd-lang/build.rs # needed to make sure `version` has the correct `commit_hash`
     cargo install --path . --features ($features | str join ",") --locked --force


### PR DESCRIPTION
# Description
Fixes: #10450 

This pr differentiating between `--x: bool` and `--x`

Here are examples which demostrate difference between them:
```nushell
def a [--x: bool] { $x };
a --x    # not allowed, you need to parse a value to the flag.
a        # it's allowed, and the value of `$x` is false, which behaves the same to `def a [--x] { $x }; a`
```

For boolean flag with default value, it works a little bit different to #10450 mentioned:
```nushell
def foo [--option: bool = false] { $option }
foo                  # output false
foo --option         # not allowed, you need to parse a value to the flag.
foo --option true    # output true
```

# User-Facing Changes
After the pr, the following code is not allowed:
```nushell
def a [--x: bool] { $x }; a --x
```

Instead, you have to pass a value to flag `--x` like `a --x false`.  But bare flag works in the same way as before.  

## Update: one more breaking change to help on #7260 
```
def foo [--option: bool] { $option == null }
foo
```
After the pr, if we don't use a boolean flag, the value will be `null` instead of `true`.  Because here `--option: bool` is treated as a flag rather than a switch