### PR TITLE
show_banner is true, false, or a nu line.

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -169,11 +169,16 @@ pub fn evaluate_repl(
     let nu_const = create_nu_constant(engine_state, Span::unknown())?;
     engine_state.set_variable_const_val(NU_VARIABLE_ID, nu_const);
 
-    if load_std_lib.is_none() && engine_state.get_config().show_banner {
+    let show_banner = match engine_state.get_config().show_banner.as_str() {
+        "true" => "use std banner; banner".to_owned(),
+        cmd => cmd.to_owned(),
+    };
+
+    if load_std_lib.is_none() && show_banner != "false" {
         eval_source(
             engine_state,
             stack,
-            r#"use std banner; banner"#.as_bytes(),
+            show_banner.as_bytes(),
             "show_banner",
             PipelineData::empty(),
             false,

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -104,7 +104,7 @@ pub struct Config {
     pub case_sensitive_completions: bool,
     pub enable_external_completion: bool,
     pub trim_strategy: TrimStrategy,
-    pub show_banner: bool,
+    pub show_banner: String,
     pub bracketed_paste: bool,
     pub show_clickable_links_in_ls: bool,
     pub render_right_prompt_on_last_line: bool,
@@ -120,7 +120,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            show_banner: true,
+            show_banner: "true".to_string(),
 
             use_ls_colors: true,
             show_clickable_links_in_ls: true,
@@ -1192,7 +1192,15 @@ impl Value {
                         }
                     }
                     "show_banner" => {
-                        try_bool!(cols, vals, index, span, show_banner);
+                        if let Ok(v) = value.as_string() {
+                            config.show_banner = v;
+                        } else {
+                            if let Ok(v) = value.as_bool() {
+                                config.show_banner = v.to_string();
+                            } else {
+                                invalid!(Some(span), "should be true, false, or a nu string");
+                            }
+                        }
                     }
                     "render_right_prompt_on_last_line" => {
                         try_bool!(cols, vals, index, span, render_right_prompt_on_last_line);


### PR DESCRIPTION
First thing the shell made me want to change is the show_banner variable.  I found the chuck norris one liner and added it to my login.nu but I still am not sure how to go about making that run from cmd.exe/windows.

Figured it would be cool if the banner was tri-state, true, false, or a nu command. 
```
$env.config = {
    show_banner: "(http get https://api.chucknorris.io/jokes/random).value",
```

now I get a joke when I start my shell.

This works changing the show_banner to be a string.  The code parses a boolean value and a string value correctly so this does not break existing configs.  

I'd like something that gets run when the shell is interactive and not there when exec'd from non-interactive process.  I'm not sure if that is login.nu or this mechanism; but this works for me now.  maybe others would like a chuck norris joke as their banner.... or some other command.  cheers.