### PR TITLE
remove commas for into float/int

### DIFF
--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -96,6 +96,10 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
         Value::String { val: s, .. } => {
             let other = s.trim();
 
+            // NOTE: this assumes US style commas in values
+            // and needs to be updated to respect locale
+            let other = other.replace(',', "");
+
             match other.parse::<f64>() {
                 Ok(x) => Value::float(x, head),
                 Err(reason) => Value::error(

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -262,7 +262,11 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         ),
         Value::String { val, .. } => {
             if radix == 10 {
-                match int_from_string(val, span) {
+                // NOTE: this assumes US style commas in values
+                // and needs to be updated to respect locale
+                let val = val.replace(',', "");
+
+                match int_from_string(&val, span) {
                     Ok(val) => Value::int(val, span),
                     Err(error) => Value::error(error, span),
                 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

This removes the commas in strings before doing `into int` and `into float`


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
