### PR TITLE
evaluate `$nu` during `--ide-check`

### DIFF
--- a/src/ide.rs
+++ b/src/ide.rs
@@ -1,10 +1,10 @@
 use miette::IntoDiagnostic;
 use nu_cli::NuCompleter;
 use nu_parser::{flatten_block, parse, FlatShape};
-use nu_protocol::report_error;
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
-    DeclId, ShellError, Span, Value, VarId,
+    eval_const::create_nu_constant,
+    report_error, DeclId, ShellError, Span, Value, VarId, NU_VARIABLE_ID,
 };
 use reedline::Completer;
 use serde_json::{json, Value as JsonValue};
@@ -77,6 +77,17 @@ fn read_in_file<'a>(
 pub fn check(engine_state: &mut EngineState, file_path: &str, max_errors: &Value) {
     let cwd = std::env::current_dir().expect("Could not get current working directory.");
     engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
+    let working_set = StateWorkingSet::new(engine_state);
+
+    // Regenerate the $nu constant to contain the startup time and any other potential updates
+    let nu_const = match create_nu_constant(engine_state, Span::unknown()) {
+        Ok(nu_const) => nu_const,
+        Err(err) => {
+            report_error(&working_set, &err);
+            std::process::exit(1);
+        }
+    };
+    engine_state.set_variable_const_val(NU_VARIABLE_ID, nu_const);
 
     let mut working_set = StateWorkingSet::new(engine_state);
     let file = std::fs::read(file_path);

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -79,7 +79,6 @@ pub fn check(engine_state: &mut EngineState, file_path: &str, max_errors: &Value
     engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
     let working_set = StateWorkingSet::new(engine_state);
 
-    // Regenerate the $nu constant to contain the startup time and any other potential updates
     let nu_const = match create_nu_constant(engine_state, Span::unknown()) {
         Ok(nu_const) => nu_const,
         Err(err) => {


### PR DESCRIPTION
# Description

This PR fixes a bug found by @kubouch where `$nu` is not evaluated as a constant when the `--ide-check` parameter is passed to nushell for the LSP-like functionality. Not quite sure my changes are proper but it seems to work!

### Before
![image](https://github.com/nushell/nushell/assets/343840/72ba28fe-74a1-450a-8a75-8d152c3a15b1)


### After
![image](https://github.com/nushell/nushell/assets/343840/1f70985b-4350-4e3f-8708-0aead3f5a505)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
