### PR TITLE
fix public boolean switches in the standard library

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -138,10 +138,10 @@ def check-clipboard [
 #       │     but
 #       │     the xclip clipboard command was not found on your system.
 export def clip [
-    --silent: bool  # do not print the content of the clipboard to the standard output
-    --no-notify: bool  # do not throw a notification (only on linux)
-    --no-strip: bool  # do not strip ANSI escape sequences from a string
-    --expand (-e): bool  # auto-expand the data given as input
+    --silent # do not print the content of the clipboard to the standard output
+    --no-notify  # do not throw a notification (only on linux)
+    --no-strip # do not strip ANSI escape sequences from a string
+    --expand (-e) # auto-expand the data given as input
     --codepage (-c): int  # the id of the codepage to use (only on Windows), see https://en.wikipedia.org/wiki/Windows_code_page, e.g. 65001 is for UTF-8
 ] {
     let input = (
@@ -241,8 +241,8 @@ def "from ns" [] {
 export def bench [
     code: closure  # the piece of `nushell` code to measure the performance of
     --rounds (-n): int = 50  # the number of benchmark rounds (hopefully the more rounds the less variance)
-    --verbose (-v): bool  # be more verbose (namely prints the progress)
-    --pretty: bool  # shows the results in human-readable format: "<mean> +/- <stddev>"
+    --verbose (-v) # be more verbose (namely prints the progress)
+    --pretty # shows the results in human-readable format: "<mean> +/- <stddev>"
 ] {
     let times = (
         seq 1 $rounds | each {|i|


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/10456

# Description
this PR will fix the public API of the standard library by removing the type annotations from public boolean switches.

1. the signature before
```nushell
clip [--silent: bool, --no-notify: bool, --no-strip: bool, --expand (-e): bool, --codepage (-c): int]
```
2. the signature after
```nushell
clip [--silent, --no-notify, --no-strip, --expand (-e), --codepage (-c): int]
```

# User-Facing Changes
### before
```nushell
> "foo" | clip
Error: nu::shell::cant_convert

  × Can't convert to bool.
     ╭─[NU_STDLIB_VIRTUAL_DIR/std/mod.nu:148:1]
 148 │         $in
 149 │         | if $expand { table --expand } else { table }
     ·              ───┬───
     ·                 ╰── can't convert nothing to bool
 150 │         | into string
     ╰────
```

### after
```nushell
> "foo" | clip
foo
saved to clipboard
```

# Tests + Formatting

# After Submitting