### PR TITLE
remove the `$nothing` variable

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -151,6 +151,6 @@ fn capture_error_with_both_stdout_stderr_messages_not_hang_nushell() {
 
 #[test]
 fn ignore_error_works_with_list_stream() {
-    let actual = nu!(r#"do -i { ["a", $nothing, "b"] | ansi strip }"#);
+    let actual = nu!(r#"do -i { ["a", null, "b"] | ansi strip }"#);
     assert!(actual.err.is_empty());
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -6,8 +6,8 @@ use nu_protocol::{
         Expression, Math, Operator, PathMember, PipelineElement, Redirection,
     },
     engine::{EngineState, Stack},
-    IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Range, Record, ShellError, Span,
-    Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
+    report_error_new, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Range, Record,
+    ShellError, Span, Spanned, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
 use std::collections::HashMap;
 
@@ -1127,6 +1127,20 @@ pub fn eval_variable(
     span: Span,
 ) -> Result<Value, ShellError> {
     match var_id {
+        // $nothing
+        nu_protocol::NOTHING_VARIABLE_ID => {
+            report_error_new(
+                engine_state,
+                &ShellError::GenericError(
+                    "Deprecated variable".into(),
+                    "`$nothing` is deprecated and will be removed in 0.87.".into(),
+                    Some(span),
+                    Some("Use `null` instead".into()),
+                    vec![],
+                ),
+            );
+            Ok(Value::nothing(span))
+        }
         // $nu
         nu_protocol::NU_VARIABLE_ID => {
             if let Some(val) = engine_state.get_constant(var_id) {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1810,7 +1810,7 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
 
     if contents == b"$nothing" {
         return Expression {
-            expr: Expr::Nothing,
+            expr: Expr::Var(nu_protocol::NOTHING_VARIABLE_ID),
             span,
             ty: Type::Nothing,
             custom_completion: None,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -17,7 +17,7 @@ use nu_protocol::{
     engine::StateWorkingSet,
     eval_const::{eval_constant, value_as_string},
     span, BlockId, DidYouMean, Flag, ParseError, PositionalArg, Signature, Span, Spanned,
-    SyntaxShape, Type, Unit, VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
+    SyntaxShape, Type, Unit, VarId, IN_VARIABLE_ID, NOTHING_VARIABLE_ID,
 };
 
 use crate::parse_keywords::{
@@ -6106,7 +6106,9 @@ pub fn discover_captures_in_expr(
             discover_captures_in_expr(working_set, expr, seen, seen_blocks, output)?;
         }
         Expr::Var(var_id) => {
-            if (*var_id > ENV_VARIABLE_ID || *var_id == IN_VARIABLE_ID) && !seen.contains(var_id) {
+            if (*var_id > NOTHING_VARIABLE_ID || *var_id == IN_VARIABLE_ID)
+                && !seen.contains(var_id)
+            {
                 output.push((*var_id, expr.span));
             }
         }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -113,6 +113,7 @@ const REGEX_CACHE_SIZE: usize = 100; // must be nonzero, otherwise will panic
 pub const NU_VARIABLE_ID: usize = 0;
 pub const IN_VARIABLE_ID: usize = 1;
 pub const ENV_VARIABLE_ID: usize = 2;
+pub const NOTHING_VARIABLE_ID: usize = 3;
 // NOTE: If you add more to this list, make sure to update the > checks based on the last in the list
 
 impl EngineState {

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -27,7 +27,7 @@ pub use alias::*;
 pub use cli_error::*;
 pub use config::*;
 pub use did_you_mean::did_you_mean;
-pub use engine::{ENV_VARIABLE_ID, IN_VARIABLE_ID, NU_VARIABLE_ID};
+pub use engine::{ENV_VARIABLE_ID, IN_VARIABLE_ID, NOTHING_VARIABLE_ID, NU_VARIABLE_ID};
 pub use example::*;
 pub use exportable::*;
 pub use id::*;

--- a/src/tests/test_cell_path.rs
+++ b/src/tests/test_cell_path.rs
@@ -3,12 +3,12 @@ use crate::tests::{fail_test, run_test, TestResult};
 // Tests for null / null / Value::Nothing
 #[test]
 fn nothing_fails_string() -> TestResult {
-    fail_test("let nil = null; nil.foo", "doesn't support cell paths")
+    fail_test("let nil = null; $nil.foo", "doesn't support cell paths")
 }
 
 #[test]
 fn nothing_fails_int() -> TestResult {
-    fail_test("let nil = null; nil.3", "doesn't support cell paths")
+    fail_test("let nil = null; $nil.3", "doesn't support cell paths")
 }
 
 // Tests for records

--- a/src/tests/test_cell_path.rs
+++ b/src/tests/test_cell_path.rs
@@ -1,14 +1,14 @@
 use crate::tests::{fail_test, run_test, TestResult};
 
-// Tests for $nothing / null / Value::Nothing
+// Tests for null / null / Value::Nothing
 #[test]
 fn nothing_fails_string() -> TestResult {
-    fail_test("$nothing.foo", "doesn't support cell paths")
+    fail_test("let nil = null; nil.foo", "doesn't support cell paths")
 }
 
 #[test]
 fn nothing_fails_int() -> TestResult {
-    fail_test("$nothing.3", "doesn't support cell paths")
+    fail_test("let nil = null; nil.3", "doesn't support cell paths")
 }
 
 // Tests for records

--- a/src/tests/test_table_operations.rs
+++ b/src/tests/test_table_operations.rs
@@ -181,9 +181,9 @@ fn missing_column_errors() -> TestResult {
 
 #[test]
 fn missing_optional_column_fills_in_nothing() -> TestResult {
-    // The empty value will be replaced with $nothing because of the ?
+    // The empty value will be replaced with null because of the ?
     run_test(
-        r#"[ { name: ABC, size: 20 }, { name: HIJ } ].size?.1 == $nothing"#,
+        r#"[ { name: ABC, size: 20 }, { name: HIJ } ].size?.1 == null"#,
         "true",
     )
 }
@@ -199,9 +199,9 @@ fn missing_required_row_fails() -> TestResult {
 
 #[test]
 fn missing_optional_row_fills_in_nothing() -> TestResult {
-    // ?.3 will return $nothing if there is no 3rd row
+    // ?.3 will return null if there is no 3rd row
     run_test(
-        r#"[ { name: ABC, size: 20 }, { name: HIJ } ].3? == $nothing"#,
+        r#"[ { name: ABC, size: 20 }, { name: HIJ } ].3? == null"#,
         "true",
     )
 }

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -101,7 +101,7 @@ fn const_string() {
 
 #[test]
 fn const_nothing() {
-    let inp = &["const x = $nothing", "$x | describe"];
+    let inp = &["const x = null", "$x | describe"];
 
     let actual = nu!(&inp.join("; "));
 

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -114,15 +114,15 @@ def report [
     | wrap stage
     | merge (
         if $no_fail               { [true     true     true     true] }
-        else if $fail_fmt         { [false    $nothing $nothing $nothing] }
-        else if $fail_clippy      { [true     false    $nothing $nothing] }
-        else if $fail_test        { [true     true     false    $nothing] }
+        else if $fail_fmt         { [false    null null null] }
+        else if $fail_clippy      { [true     false    null null] }
+        else if $fail_test        { [true     true     false    null] }
         else if $fail_test_stdlib { [true     true     true     false] }
-        else                      { [$nothing $nothing $nothing $nothing] }
+        else                      { [null null null null] }
         | wrap success
     )
     | upsert emoji {|it|
-        if ($it.success == $nothing) {
+        if ($it.success == null) {
             ":black_circle:"
         } else if $it.success {
             ":green_circle:"


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell/pull/9973
- https://github.com/nushell/nushell/pull/9918

thanks to @jntrnr and their super useful tips on this PR, i learned about the parser + evaluation, so :pray: 

# Description
because we already have `null` as the value of the type `nothing` and as a followup to the two other attempts of mine, i propose to remove the redundant `$nothing` built-in variable :yum: 

this PR is the first step, deprecating `$nothing`.
a followup PR will remove it altogether and wait for 0.87 :+1: 

:gear: **details**: a new `NOTHING_VARIABLE_ID = 3` has been added, parsing `$nothing` will create it, finally a `Value::Nothing` will be produced and a warning will be reported.

this PR already fixes the `toolkit.nu` module so that it does not throw a bunch of warnings each time :ok_hand: 

# User-Facing Changes
`$nothing` is now deprecated and will be removed in 0.87
```nushell
> $nothing
Error:   × Deprecated variable
   ╭─[entry #1:1:1]
 1 │ $nothing
   · ────┬───
   ·     ╰── `$nothing` is deprecated and will be removed in 0.87.
   ╰────
  help: Use `null` instead
```

# Tests + Formatting
tests have been updated, especially
- `nothing_fails_string`
- `nothing_fails_int`
which use a variable called `nil` now to make sure `nothing` does not support cell paths :+1: 

# After Submitting
classic deprecation mention :+1: 
