### PR TITLE
fix(#7760): Make sure that the latest config is used in core places

### DIFF
--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -27,7 +27,7 @@ pub fn evaluate_commands(
     // Parse the source code
     let (block, delta) = {
         if let Some(ref t_mode) = table_mode {
-            let mut config = engine_state.get_config().clone();
+            let mut config = nu_engine::get_config(engine_state, stack);
             config.table_mode = t_mode.as_string()?;
             engine_state.set_config(&config);
         }
@@ -53,7 +53,7 @@ pub fn evaluate_commands(
     // Run the block
     let exit_code = match eval_block(engine_state, stack, &block, input, false, false) {
         Ok(pipeline_data) => {
-            let mut config = engine_state.get_config().clone();
+            let mut config = nu_engine::get_config(engine_state, stack);
             if let Some(t_mode) = table_mode {
                 config.table_mode = t_mode.as_string()?;
             }

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -243,7 +243,7 @@ pub fn eval_source(
 
     match b {
         Ok(pipeline_data) => {
-            let config = engine_state.get_config();
+            let config = nu_engine::env::get_config(engine_state, stack);
             let result;
             if let PipelineData::ExternalStream {
                 stdout: stream,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -591,6 +591,7 @@ pub fn eval_expression(
                 parts.push(eval_expression(engine_state, stack, expr)?);
             }
 
+            // TODO: Should this move to nu_engine::env::get_config?
             let config = engine_state.get_config();
 
             parts

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -211,7 +211,7 @@ pub fn nu_repl() {
         }
 
         // Check for pre_prompt hook
-        let config = engine_state.get_config();
+        let config = nu_engine::env::get_config(&engine_state, &stack);
         if let Some(hook) = config.hooks.pre_prompt.clone() {
             if let Err(err) = eval_hook(
                 &mut engine_state,
@@ -226,7 +226,7 @@ pub fn nu_repl() {
         }
 
         // Check for env change hook
-        let config = engine_state.get_config();
+        let config = nu_engine::env::get_config(&engine_state, &stack);
         if let Err(err) = eval_env_change_hook(
             config.hooks.env_change.clone(),
             &mut engine_state,
@@ -236,7 +236,7 @@ pub fn nu_repl() {
         }
 
         // Check for pre_execution hook
-        let config = engine_state.get_config();
+        let config = nu_engine::env::get_config(&engine_state, &stack);
 
         engine_state
             .repl_state
@@ -278,10 +278,10 @@ pub fn nu_repl() {
         }
 
         let input = PipelineData::empty();
-        let config = engine_state.get_config();
+        let config = nu_engine::env::get_config(&engine_state, &stack);
 
         match eval_block(&engine_state, &mut stack, &block, input, false, false) {
-            Ok(pipeline_data) => match pipeline_data.collect_string("", config) {
+            Ok(pipeline_data) => match pipeline_data.collect_string("", &config) {
                 Ok(s) => last_output = s,
                 Err(err) => outcome_err(&engine_state, &err),
             },


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR fixes #7760 and updates the usage of `EngineState::get_config` to `nu_engine::get_config` in some core places in nu. There are still many many more places that use `get_config` 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
