### PR TITLE
Update winget submission workflow include only default msi files

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -20,8 +20,9 @@ jobs:
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: Nushell.Nushell
-          # Exclude *-msvc-full.msi Full release files
-          installers-regex: 'msvc\.msi$' # Only standard .msi files
+          # Exclude all `*-msvc-full.msi` full release files,
+          # and only the default `*msvc.msi` files will be included
+          installers-regex: 'msvc\.msi$'
           version: ${{ inputs.tag_name || github.event.release.tag_name }}
           release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
           token: ${{ secrets.NUSHELL_PAT }}

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -7,7 +7,7 @@ on:
     inputs:
       tag_name:
         description: 'Specific tag name'
-        required: true 
+        required: true
         type: string
 
 jobs:
@@ -20,6 +20,8 @@ jobs:
         uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: Nushell.Nushell
+          # Exclude *-msvc-full.msi Full release files
+          installers-regex: 'msvc\.msi$' # Only standard .msi files
           version: ${{ inputs.tag_name || github.event.release.tag_name }}
           release-tag: ${{ inputs.tag_name || github.event.release.tag_name }}
           token: ${{ secrets.NUSHELL_PAT }}


### PR DESCRIPTION
### Update winget submission workflow include only default msi files:
---
The new release workflow after https://github.com/nushell/nushell/pull/10457 will add full featured packages like: `nu-*-x86_64-windows-msvc-full.msi` and `nu-*-aarch64-windows-msvc-full.msi` (A release preview could be found here: https://github.com/nushell/nightly/releases/tag/nightly-6a2fd91 ) and this change will make sure only the default packages will be included just the same as before to make sure that nothing will be broken.

BTW: Due to lots of changes made recently about the release workflow, I will stand-by for the next release.
