### PR TITLE
make better error message for `not` operator

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -331,8 +331,8 @@ pub fn eval_expression(
             let lhs = eval_expression(engine_state, stack, expr)?;
             match lhs {
                 Value::Bool { val, .. } => Ok(Value::bool(!val, expr.span)),
-                _ => Err(ShellError::TypeMismatch {
-                    err_message: "bool".to_string(),
+                other => Err(ShellError::TypeMismatch {
+                    err_message: format!("expected bool, found {}", other.get_type()),
                     span: expr.span,
                 }),
             }


### PR DESCRIPTION
Fixes: #10476

After the change, the error message will be something like this:
```nushell
❯ not null
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[entry #11:1:1]
 1 │ not null
   ·     ──┬─
   ·       ╰── expected bool, found nothing
   ╰────
```