### PR TITLE
Remove unused `SyntaxShape::Variable`

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2743,7 +2743,6 @@ pub fn parse_shape_name(
         b"signature" => SyntaxShape::Signature,
         b"string" => SyntaxShape::String,
         _ if bytes.starts_with(b"table") => parse_collection_shape(working_set, bytes, span),
-        b"variable" => SyntaxShape::Variable,
         b"var-with-opt-type" => SyntaxShape::VarWithOptType,
         _ => {
             if bytes.contains(&b'@') {

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -110,9 +110,6 @@ pub enum SyntaxShape {
     /// A table is allowed, eg `[[first, second]; [1, 2]]`
     Table(Vec<(String, SyntaxShape)>),
 
-    /// A variable name, eg `$foo`
-    Variable,
-
     /// A variable with optional type, `x` or `x: int`
     VarWithOptType,
 }
@@ -164,7 +161,6 @@ impl SyntaxShape {
             SyntaxShape::String => Type::String,
             SyntaxShape::Table(columns) => Type::Table(mk_ty(columns)),
             SyntaxShape::VarWithOptType => Type::Any,
-            SyntaxShape::Variable => Type::Any,
         }
     }
 }
@@ -226,7 +222,6 @@ impl Display for SyntaxShape {
             SyntaxShape::Operator => write!(f, "operator"),
             SyntaxShape::RowCondition => write!(f, "condition"),
             SyntaxShape::MathExpression => write!(f, "variable"),
-            SyntaxShape::Variable => write!(f, "var"),
             SyntaxShape::VarWithOptType => write!(f, "vardecl"),
             SyntaxShape::Signature => write!(f, "signature"),
             SyntaxShape::MatchPattern => write!(f, "match-pattern"),


### PR DESCRIPTION
# Description
We don't use this shape during parsing and never reference it in command
signatures. Thus it should be removed.

# User-Facing Changes
None functional.
Plugin authors that used it would never be provided with data that specifically matched `SyntaxShape::Variable`
Builds using it will now fail.

# Tests + Formatting
NA
