### PR TITLE
add `to ndjson` and `to jsonl` to the standard library

### DIFF
--- a/crates/nu-std/std/formats.nu
+++ b/crates/nu-std/std/formats.nu
@@ -9,22 +9,22 @@
 # These functions help `open` the files with unsupported extensions such as ndjson.
 #
 
-# Convert from NDJSON to structured data.
+# Convert from [NDJSON](http://ndjson.org/) to structured data.
 export def "from ndjson" []: string -> any {
     from json --objects
 }
 
-# Convert from JSONL to structured data.
+# Convert from [JSONL](https://jsonlines.org/) to structured data.
 export def "from jsonl" []: string -> any {
     from json --objects
 }
 
-# Convert structured data to NDJSON.
+# Convert structured data to [NDJSON](http://ndjson.org/).
 export def "to ndjson" []: any -> string {
     each { to json --raw } | to text
 }
 
-# Convert structured data to JSONL.
+# Convert structured data to [JSONL](https://jsonlines.org/).
 export def "to jsonl" []: any -> string {
     each { to json --raw } | to text
 }

--- a/crates/nu-std/std/formats.nu
+++ b/crates/nu-std/std/formats.nu
@@ -20,11 +20,11 @@ export def "from jsonl" []: string -> any {
 }
 
 # Convert structured data to NDJSON.
-def "to ndjson" []: any -> string {
+export def "to ndjson" []: any -> string {
     each { to json --raw } | to text
 }
 
 # Convert structured data to JSONL.
-def "to jsonl" []: any -> string {
+export def "to jsonl" []: any -> string {
     each { to json --raw } | to text
 }

--- a/crates/nu-std/std/formats.nu
+++ b/crates/nu-std/std/formats.nu
@@ -18,3 +18,13 @@ export def "from ndjson" []: string -> any {
 export def "from jsonl" []: string -> any {
     from json --objects
 }
+
+# Convert structured data to ndjson.
+def "to ndjson" []: any -> string {
+    each { to json --raw } | to text
+}
+
+# Convert structured data to jsonl.
+def "to jsonl" []: any -> string {
+    each { to json --raw } | to text
+}

--- a/crates/nu-std/std/formats.nu
+++ b/crates/nu-std/std/formats.nu
@@ -9,22 +9,22 @@
 # These functions help `open` the files with unsupported extensions such as ndjson.
 #
 
-# Convert from ndjson to structured data.
+# Convert from NDJSON to structured data.
 export def "from ndjson" []: string -> any {
     from json --objects
 }
 
-# Convert from jsonl to structured data.
+# Convert from JSONL to structured data.
 export def "from jsonl" []: string -> any {
     from json --objects
 }
 
-# Convert structured data to ndjson.
+# Convert structured data to NDJSON.
 def "to ndjson" []: any -> string {
     each { to json --raw } | to text
 }
 
-# Convert structured data to jsonl.
+# Convert structured data to JSONL.
 def "to jsonl" []: any -> string {
     each { to json --raw } | to text
 }

--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -52,3 +52,35 @@ def from_jsonl_invalid_object [] {
   use std formats *
   assert error { '{"a":1' | from jsonl }
 }
+
+#[test]
+def to_ndjson_multiple_objects [] {
+  use std formats *
+  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to ndjson
+  let expect = ndjson_test_data1
+  assert equal $result $expect "could not convert to NDJSON"
+}
+
+#[test]
+def to_ndjson_single_object [] {
+  use std formats *
+  let result = [{a:1}] | to ndjson
+  let expect = '{"a":1}'
+  assert equal $result $expect "could not convert to NDJSON"
+}
+
+#[test]
+def to_jsonl_multiple_objects [] {
+  use std formats *
+  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to jsonl
+  let expect = ndjson_test_data1
+  assert equal $result $expect "could not convert to JSONL"
+}
+
+#[test]
+def to_jsonl_single_object [] {
+  use std formats *
+  let result = [{a:1}] | to jsonl
+  let expect = '{"a":1}'
+  assert equal $result $expect "could not convert to JSONL"
+}

--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -1,12 +1,12 @@
 use std assert
 
 def ndjson_test_data1 [] {
-  '{"a":1}
-{"a":2}
-{"a":3}
-{"a":4}
-{"a":5}
-{"a":6}'
+  "{\"a\": 1}
+{\"a\": 2}
+{\"a\": 3}
+{\"a\": 4}
+{\"a\": 5}
+{\"a\": 6}\n"
 }
 
 #[test]
@@ -20,7 +20,7 @@ def from_ndjson_multiple_objects [] {
 #[test]
 def from_ndjson_single_object [] {
   use std formats *
-  let result = '{"a":1}' | from ndjson
+  let result = '{"a": 1}' | from ndjson
   let expect = [{a:1}]
   assert equal $result $expect "could not convert from NDJSON"
 }
@@ -42,7 +42,7 @@ def from_jsonl_multiple_objects [] {
 #[test]
 def from_jsonl_single_object [] {
   use std formats *
-  let result = '{"a":1}' | from jsonl
+  let result = '{"a": 1}' | from jsonl
   let expect = [{a:1}]
   assert equal $result $expect "could not convert from JSONL"
 }
@@ -65,7 +65,7 @@ def to_ndjson_multiple_objects [] {
 def to_ndjson_single_object [] {
   use std formats *
   let result = [{a:1}] | to ndjson
-  let expect = '{"a":1}'
+  let expect = "{\"a\": 1}\n"
   assert equal $result $expect "could not convert to NDJSON"
 }
 
@@ -81,6 +81,6 @@ def to_jsonl_multiple_objects [] {
 def to_jsonl_single_object [] {
   use std formats *
   let result = [{a:1}] | to jsonl
-  let expect = '{"a":1}'
+  let expect = "{\"a\": 1}\n"
   assert equal $result $expect "could not convert to JSONL"
 }

--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -1,6 +1,6 @@
 use std assert
 
-def ndjson_test_data1 [] {
+def test_data_multiline [] {
   let lines = [
     "{\"a\": 1}",
     "{\"a\": 2}",
@@ -20,7 +20,7 @@ def ndjson_test_data1 [] {
 #[test]
 def from_ndjson_multiple_objects [] {
   use std formats *
-  let result = ndjson_test_data1 | from ndjson
+  let result = test_data_multiline | from ndjson
   let expect = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}]
   assert equal $result $expect "could not convert from NDJSON"
 }
@@ -42,7 +42,7 @@ def from_ndjson_invalid_object [] {
 #[test]
 def from_jsonl_multiple_objects [] {
   use std formats *
-  let result = ndjson_test_data1 | from jsonl
+  let result = test_data_multiline | from jsonl
   let expect = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}]
   assert equal $result $expect "could not convert from JSONL"
 }
@@ -65,7 +65,7 @@ def from_jsonl_invalid_object [] {
 def to_ndjson_multiple_objects [] {
   use std formats *
   let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to ndjson | str trim
-  let expect = ndjson_test_data1
+  let expect = test_data_multiline
   assert equal $result $expect "could not convert to NDJSON"
 }
 
@@ -81,7 +81,7 @@ def to_ndjson_single_object [] {
 def to_jsonl_multiple_objects [] {
   use std formats *
   let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to jsonl | str trim
-  let expect = ndjson_test_data1
+  let expect = test_data_multiline
   assert equal $result $expect "could not convert to JSONL"
 }
 

--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -1,12 +1,20 @@
 use std assert
 
 def ndjson_test_data1 [] {
-  "{\"a\": 1}
-{\"a\": 2}
-{\"a\": 3}
-{\"a\": 4}
-{\"a\": 5}
-{\"a\": 6}"
+  let lines = [
+    "{\"a\": 1}",
+    "{\"a\": 2}",
+    "{\"a\": 3}",
+    "{\"a\": 4}",
+    "{\"a\": 5}",
+    "{\"a\": 6}",
+  ]
+
+  if $nu.os-info.name == "windows" {
+    $lines | str join "\r\n"
+  } else {
+    $lines | str join "\n"
+  }
 }
 
 #[test]

--- a/crates/nu-std/tests/test_formats.nu
+++ b/crates/nu-std/tests/test_formats.nu
@@ -6,7 +6,7 @@ def ndjson_test_data1 [] {
 {\"a\": 3}
 {\"a\": 4}
 {\"a\": 5}
-{\"a\": 6}\n"
+{\"a\": 6}"
 }
 
 #[test]
@@ -56,7 +56,7 @@ def from_jsonl_invalid_object [] {
 #[test]
 def to_ndjson_multiple_objects [] {
   use std formats *
-  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to ndjson
+  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to ndjson | str trim
   let expect = ndjson_test_data1
   assert equal $result $expect "could not convert to NDJSON"
 }
@@ -64,15 +64,15 @@ def to_ndjson_multiple_objects [] {
 #[test]
 def to_ndjson_single_object [] {
   use std formats *
-  let result = [{a:1}] | to ndjson
-  let expect = "{\"a\": 1}\n"
+  let result = [{a:1}] | to ndjson | str trim
+  let expect = "{\"a\": 1}"
   assert equal $result $expect "could not convert to NDJSON"
 }
 
 #[test]
 def to_jsonl_multiple_objects [] {
   use std formats *
-  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to jsonl
+  let result = [{a:1},{a:2},{a:3},{a:4},{a:5},{a:6}] | to jsonl | str trim
   let expect = ndjson_test_data1
   assert equal $result $expect "could not convert to JSONL"
 }
@@ -80,7 +80,7 @@ def to_jsonl_multiple_objects [] {
 #[test]
 def to_jsonl_single_object [] {
   use std formats *
-  let result = [{a:1}] | to jsonl
-  let expect = "{\"a\": 1}\n"
+  let result = [{a:1}] | to jsonl | str trim
+  let expect = "{\"a\": 1}"
   assert equal $result $expect "could not convert to JSONL"
 }


### PR DESCRIPTION
follow up to
- #10283

# Description
even though it appears defining `to foo` does not allow to do `save x.foo` for free (see https://github.com/nushell/nushell/issues/10429), because #10283 did add `from ndjson` and `from jsonl` to the standard library, i thought adding their `to ...` counterpart would make sense :yum: 

# User-Facing Changes
users can now convert structured data back to NDJSON and JSONL :ok_hand: 

# Tests + Formatting
this PR adds the exact same tests as for the `from ...` commands
- structured data is in `result` and the string is now the expected
- the two invalid `from ...` tests cannot be reproduced for `to ...` afaik

# After Submitting