### PR TITLE
Add 'help escapes' command for quick reference of nushell string escapes

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -1,7 +1,7 @@
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
 use crate::{
-    help::{HelpAliases, HelpCommands, HelpExterns, HelpModules, HelpOperators, HelpEscapes},
+    help::{HelpAliases, HelpCommands, HelpEscapes, HelpExterns, HelpModules, HelpOperators},
     *,
 };
 pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -1,7 +1,7 @@
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
 use crate::{
-    help::{HelpAliases, HelpCommands, HelpExterns, HelpModules, HelpOperators},
+    help::{HelpAliases, HelpCommands, HelpExterns, HelpModules, HelpOperators, HelpEscapes},
     *,
 };
 pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
@@ -127,6 +127,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             HelpCommands,
             HelpModules,
             HelpOperators,
+            HelpEscapes,
         };
 
         // Debug

--- a/crates/nu-command/src/help/help_escapes.rs
+++ b/crates/nu-command/src/help/help_escapes.rs
@@ -1,7 +1,8 @@
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    record, Category, PipelineData, IntoInterruptiblePipelineData, ShellError, Signature, Type, Value,
+    record, Category, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Type,
+    Value,
 };
 
 #[derive(Clone)]

--- a/crates/nu-command/src/help/help_escapes.rs
+++ b/crates/nu-command/src/help/help_escapes.rs
@@ -1,8 +1,7 @@
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    record, Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type,
-    Value, IntoInterruptiblePipelineData,
+    record, Category, PipelineData, IntoInterruptiblePipelineData, ShellError, Signature, Type, Value,
 };
 
 #[derive(Clone)]
@@ -20,28 +19,8 @@ impl Command for HelpEscapes {
     fn signature(&self) -> Signature {
         Signature::build("help escapes")
             .category(Category::Core)
-            .rest(
-                "rest",
-                SyntaxShape::String,
-                "the escape pattern to get help on",
-            )
             .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
-    }
-
-    fn examples(&self) -> Vec<Example> {
-        vec![
-            Example {
-                description: "show all escape sequences",
-                example: "help escapes",
-                result: None,
-            },
-            Example {
-                description: "show help for a single escape sequence",
-                example: "help escapes \\n",
-                result: None,
-            }
-        ]
     }
 
     fn run(
@@ -140,4 +119,14 @@ fn generate_escape_info() -> Vec<EscapeInfo> {
             character: "u".into(),
         },
     ]
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_examples() {
+        use super::HelpEscapes;
+        use crate::test_examples;
+        test_examples(HelpEscapes {})
+    }
 }

--- a/crates/nu-command/src/help/help_escapes.rs
+++ b/crates/nu-command/src/help/help_escapes.rs
@@ -13,7 +13,7 @@ impl Command for HelpEscapes {
     }
 
     fn usage(&self) -> &str {
-        "Show help on nushell escapes."
+        "Show help on nushell string escapes."
     }
 
     fn signature(&self) -> Signature {
@@ -38,6 +38,7 @@ impl Command for HelpEscapes {
             recs.push(Value::record(
                 record! {
                     "sequence" => Value::string(escape.sequence, head),
+                    "output" => Value::string(escape.output, head),
                 },
                 head,
             ));
@@ -51,72 +52,94 @@ impl Command for HelpEscapes {
 
 struct EscapeInfo {
     sequence: String,
+    output: String,
 }
 
 fn generate_escape_info() -> Vec<EscapeInfo> {
     vec![
         EscapeInfo {
             sequence: "\\\"".into(),
+            output: "\"".into(),
         },
         EscapeInfo {
             sequence: "\\\'".into(),
+            output: "\'".into(),
         },
         EscapeInfo {
             sequence: "\\\\".into(),
+            output: "\\".into(),
         },
         EscapeInfo {
             sequence: "\\/".into(),
+            output: "/".into(),
         },
         EscapeInfo {
             sequence: "\\(".into(),
+            output: "(".into(),
         },
         EscapeInfo {
             sequence: "\\)".into(),
+            output: ")".into(),
         },
         EscapeInfo {
             sequence: "\\{".into(),
+            output: "{".into(),
         },
         EscapeInfo {
             sequence: "\\}".into(),
+            output: "}".into(),
         },
         EscapeInfo {
             sequence: "\\$".into(),
+            output: "$".into(),
         },
         EscapeInfo {
             sequence: "\\^".into(),
+            output: "^".into(),
         },
         EscapeInfo {
             sequence: "\\#".into(),
+            output: "#".into(),
         },
         EscapeInfo {
             sequence: "\\|".into(),
+            output: "|".into(),
         },
         EscapeInfo {
             sequence: "\\~".into(),
+            output: "~".into(),
         },
         EscapeInfo {
             sequence: "\\a".into(),
+            output: "alert bell".into(),
         },
         EscapeInfo {
             sequence: "\\b".into(),
+            output: "backspace".into(),
         },
         EscapeInfo {
             sequence: "\\e".into(),
+            output: "escape".into(),
         },
         EscapeInfo {
             sequence: "\\f".into(),
+            output: "form feed".into(),
         },
         EscapeInfo {
             sequence: "\\n".into(),
+            output: "newline (line feed)".into(),
         },
         EscapeInfo {
             sequence: "\\r".into(),
+            output: "carriage return".into(),
         },
         EscapeInfo {
             sequence: "\\t".into(),
+            output: "tab".into(),
         },
         EscapeInfo {
-            sequence: "\\u".into(),
+            sequence: "\\u{X...}".into(),
+            output: "a single unicode character, where X... is 1-6 digits (0-9, A-F)".into(),
         },
     ]
 }

--- a/crates/nu-command/src/help/help_escapes.rs
+++ b/crates/nu-command/src/help/help_escapes.rs
@@ -1,11 +1,8 @@
-use crate::help::highlight_search_in_table;
-use nu_color_config::StyleComputer;
-use nu_engine::{scope::ScopeData, CallExt};
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    span, Category, DeclId, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
-    ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
+    record, Category, Example, PipelineData, ShellError, Signature, SyntaxShape, Type,
+    Value, IntoInterruptiblePipelineData,
 };
 
 #[derive(Clone)]
@@ -18,10 +15,6 @@ impl Command for HelpEscapes {
 
     fn usage(&self) -> &str {
         "Show help on nushell escapes."
-    }
-
-    fn extra_usage(&self) -> &str {
-        todo!()
     }
 
     fn signature(&self) -> Signature {
@@ -37,24 +30,114 @@ impl Command for HelpEscapes {
     }
 
     fn examples(&self) -> Vec<Example> {
-        todo!()
+        vec![
+            Example {
+                description: "show all escape sequences",
+                example: "help escapes",
+                result: None,
+            },
+            Example {
+                description: "show help for a single escape sequence",
+                example: "help escapes \\n",
+                result: None,
+            }
+        ]
     }
 
     fn run(
         &self,
         engine_state: &EngineState,
-        stack: &mut Stack,
+        _stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        help_escapes(engine_state, stack, call)
+        let head = call.head;
+        let escape_info = generate_escape_info();
+        let mut recs = vec![];
+
+        for escape in escape_info {
+            recs.push(Value::record(
+                record! {
+                    "character" => Value::string(escape.character, head),
+                },
+                head,
+            ));
+        }
+
+        Ok(recs
+            .into_iter()
+            .into_pipeline_data(engine_state.ctrlc.clone()))
     }
 }
 
-fn help_escapes(
-    engine_state: &EngineState,
-    stack: &mut Stack,
-    call: &Call,
-) -> Result<PipelineData, ShellError> {
-    todo!()
+struct EscapeInfo {
+    character: String,
+}
+
+fn generate_escape_info() -> Vec<EscapeInfo> {
+    vec![
+        EscapeInfo {
+            character: "\"".into(),
+        },
+        EscapeInfo {
+            character: "\'".into(),
+        },
+        EscapeInfo {
+            character: "\\".into(),
+        },
+        EscapeInfo {
+            character: "/".into(),
+        },
+        EscapeInfo {
+            character: "(".into(),
+        },
+        EscapeInfo {
+            character: ")".into(),
+        },
+        EscapeInfo {
+            character: "{".into(),
+        },
+        EscapeInfo {
+            character: "}".into(),
+        },
+        EscapeInfo {
+            character: "$".into(),
+        },
+        EscapeInfo {
+            character: "^".into(),
+        },
+        EscapeInfo {
+            character: "#".into(),
+        },
+        EscapeInfo {
+            character: "|".into(),
+        },
+        EscapeInfo {
+            character: "~".into(),
+        },
+        EscapeInfo {
+            character: "a".into(),
+        },
+        EscapeInfo {
+            character: "b".into(),
+        },
+        EscapeInfo {
+            character: "e".into(),
+        },
+        EscapeInfo {
+            character: "f".into(),
+        },
+        EscapeInfo {
+            character: "n".into(),
+        },
+        EscapeInfo {
+            character: "r".into(),
+        },
+        EscapeInfo {
+            character: "t".into(),
+        },
+        EscapeInfo {
+            character: "u".into(),
+        },
+    ]
 }

--- a/crates/nu-command/src/help/help_escapes.rs
+++ b/crates/nu-command/src/help/help_escapes.rs
@@ -37,7 +37,7 @@ impl Command for HelpEscapes {
         for escape in escape_info {
             recs.push(Value::record(
                 record! {
-                    "character" => Value::string(escape.character, head),
+                    "sequence" => Value::string(escape.sequence, head),
                 },
                 head,
             ));
@@ -50,73 +50,73 @@ impl Command for HelpEscapes {
 }
 
 struct EscapeInfo {
-    character: String,
+    sequence: String,
 }
 
 fn generate_escape_info() -> Vec<EscapeInfo> {
     vec![
         EscapeInfo {
-            character: "\"".into(),
+            sequence: "\\\"".into(),
         },
         EscapeInfo {
-            character: "\'".into(),
+            sequence: "\\\'".into(),
         },
         EscapeInfo {
-            character: "\\".into(),
+            sequence: "\\\\".into(),
         },
         EscapeInfo {
-            character: "/".into(),
+            sequence: "\\/".into(),
         },
         EscapeInfo {
-            character: "(".into(),
+            sequence: "\\(".into(),
         },
         EscapeInfo {
-            character: ")".into(),
+            sequence: "\\)".into(),
         },
         EscapeInfo {
-            character: "{".into(),
+            sequence: "\\{".into(),
         },
         EscapeInfo {
-            character: "}".into(),
+            sequence: "\\}".into(),
         },
         EscapeInfo {
-            character: "$".into(),
+            sequence: "\\$".into(),
         },
         EscapeInfo {
-            character: "^".into(),
+            sequence: "\\^".into(),
         },
         EscapeInfo {
-            character: "#".into(),
+            sequence: "\\#".into(),
         },
         EscapeInfo {
-            character: "|".into(),
+            sequence: "\\|".into(),
         },
         EscapeInfo {
-            character: "~".into(),
+            sequence: "\\~".into(),
         },
         EscapeInfo {
-            character: "a".into(),
+            sequence: "\\a".into(),
         },
         EscapeInfo {
-            character: "b".into(),
+            sequence: "\\b".into(),
         },
         EscapeInfo {
-            character: "e".into(),
+            sequence: "\\e".into(),
         },
         EscapeInfo {
-            character: "f".into(),
+            sequence: "\\f".into(),
         },
         EscapeInfo {
-            character: "n".into(),
+            sequence: "\\n".into(),
         },
         EscapeInfo {
-            character: "r".into(),
+            sequence: "\\r".into(),
         },
         EscapeInfo {
-            character: "t".into(),
+            sequence: "\\t".into(),
         },
         EscapeInfo {
-            character: "u".into(),
+            sequence: "\\u".into(),
         },
     ]
 }

--- a/crates/nu-command/src/help/help_escapes.rs
+++ b/crates/nu-command/src/help/help_escapes.rs
@@ -1,0 +1,60 @@
+use crate::help::highlight_search_in_table;
+use nu_color_config::StyleComputer;
+use nu_engine::{scope::ScopeData, CallExt};
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    span, Category, DeclId, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
+    ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct HelpEscapes;
+
+impl Command for HelpEscapes {
+    fn name(&self) -> &str {
+        "help escapes"
+    }
+
+    fn usage(&self) -> &str {
+        "Show help on nushell escapes."
+    }
+
+    fn extra_usage(&self) -> &str {
+        todo!()
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("help escapes")
+            .category(Category::Core)
+            .rest(
+                "rest",
+                SyntaxShape::String,
+                "the escape pattern to get help on",
+            )
+            .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
+            .allow_variants_without_examples(true)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        todo!()
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        help_escapes(engine_state, stack, call)
+    }
+}
+
+fn help_escapes(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+) -> Result<PipelineData, ShellError> {
+    todo!()
+}

--- a/crates/nu-command/src/help/mod.rs
+++ b/crates/nu-command/src/help/mod.rs
@@ -1,18 +1,18 @@
 mod help_;
 mod help_aliases;
 mod help_commands;
+mod help_escapes;
 mod help_externs;
 mod help_modules;
 mod help_operators;
-mod help_escapes;
 
 pub use help_::Help;
 pub use help_aliases::HelpAliases;
 pub use help_commands::HelpCommands;
+pub use help_escapes::HelpEscapes;
 pub use help_externs::HelpExterns;
 pub use help_modules::HelpModules;
 pub use help_operators::HelpOperators;
-pub use help_escapes::HelpEscapes;
 
 pub(crate) use help_::{highlight_search_in_table, highlight_search_string};
 pub(crate) use help_aliases::help_aliases;

--- a/crates/nu-command/src/help/mod.rs
+++ b/crates/nu-command/src/help/mod.rs
@@ -4,6 +4,7 @@ mod help_commands;
 mod help_externs;
 mod help_modules;
 mod help_operators;
+mod help_escapes;
 
 pub use help_::Help;
 pub use help_aliases::HelpAliases;
@@ -11,6 +12,7 @@ pub use help_commands::HelpCommands;
 pub use help_externs::HelpExterns;
 pub use help_modules::HelpModules;
 pub use help_operators::HelpOperators;
+pub use help_escapes::HelpEscapes;
 
 pub(crate) use help_::{highlight_search_in_table, highlight_search_string};
 pub(crate) use help_aliases::help_aliases;


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

resolves #4869 

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Adds a `help escape` command that can be used to display a table of string escape sequences and their outputs.
```nu
help escapes
```
```nu
help escapes -h
```

The command should also appear in the list displayed when tab autocompleting on `help`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Users can now use a new `help escapes` command to output a table of string escape sequences and their outputs.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
Need to update docs to reflect existence of the new `help escapes` command.
