### PR TITLE
feat!: use ~/.config/nushell as the primary config directory (ammended)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,27 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dlv-list"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1350,7 +1340,7 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "windows-sys 0.48.0",
 ]
 
@@ -2849,13 +2839,13 @@ dependencies = [
  "csv",
  "dialoguer",
  "digest",
- "dirs-next",
  "dtparse",
  "encoding_rs",
  "fancy-regex",
  "filesize",
  "filetime",
  "fs_extra",
+ "home",
  "htmlescape",
  "indexmap 2.0.0",
  "indicatif",
@@ -2996,8 +2986,9 @@ dependencies = [
 name = "nu-path"
 version = "0.85.1"
 dependencies = [
- "dirs-next",
+ "etcetera",
  "omnipath",
+ "once_cell",
  "pwd",
 ]
 
@@ -3508,7 +3499,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.1",
 ]
@@ -4261,31 +4252,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
 ]
 
 [[package]]
@@ -5171,7 +5142,7 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix 0.38.3",
  "windows-sys 0.48.0",
 ]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -127,7 +127,7 @@ which-support = ["which"]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.85.1" }
 nu-test-support = { path = "../nu-test-support", version = "0.85.1" }
 
-dirs-next = "2.0"
+home = "0.5"
 mockito = { version = "1.2", default-features = false }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -124,7 +124,7 @@ fn filesystem_change_to_home_directory() {
             "
         );
 
-        assert_eq!(Some(PathBuf::from(actual.out)), dirs_next::home_dir());
+        assert_eq!(Some(PathBuf::from(actual.out)), home::home_dir());
     })
 }
 

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -12,7 +12,8 @@ exclude = ["/fuzz"]
 bench = false
 
 [dependencies]
-dirs-next = "2.0"
+etcetera = "0.8"
+once_cell = "1.18"
 
 [target.'cfg(windows)'.dependencies]
 omnipath = "0.1"

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -9,10 +9,13 @@ static CONFIG_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
     let default = if let Some(mut config_dir) = home_dir() {
         config_dir.push(".config");
         if config_dir.join("nushell").is_dir() {
+            // `~/.config/nushell` exists, so we'll use that
             return Some(config_dir);
         }
+        // `~/.config/nushell` doesn't exist, but we'll use it if the "native" folder doesn't exist either
         Some(config_dir)
     } else {
+        // `~` not found, so we'll return `None` if the "native" folder doesn't exist either
         None
     };
 
@@ -23,17 +26,32 @@ static CONFIG_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
             basedirs.config_dir()
         };
         if config_home.join("nushell").is_dir() {
+            // "native" config folder exists, so we'll use that
             return Some(config_home);
         }
     }
 
+    // fresh install, so we'll use the default defined above
     default
 });
 
+/// Returns the home directory of the current user.
+///
+/// Uses the `HOME` environment variable on Linux and macOS, if set, otherwise `getpwuid_r`.
+/// Uses the `USERPROFILE` environment variable on Windows, if set, otherwise `SHGetKnownFolderPath` with `CSIDL_PROFILE`.
 pub fn home_dir() -> Option<PathBuf> {
     HOME_DIR.clone()
 }
 
+/// Returns the path where the `nushell` folder should be located.
+///
+/// If `~/.config/nushell` exists, returns `~/.config`.
+/// Checks the following path based on the OS:
+///   - Linux: `~/.config/`
+///   - macOS: `~/Library/Application Support/`
+///   - Windows: `{FOLDERID_RoamingAppData}`
+/// If the `nushell` folder exists in the path, returns the path.
+/// Otherwise, returns `~/.config'.
 pub fn config_dir() -> Option<PathBuf> {
     CONFIG_DIR.clone()
 }

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -1,13 +1,41 @@
+use etcetera::BaseStrategy;
 #[cfg(windows)]
 use omnipath::WinPathExt;
+use once_cell::sync::Lazy;
 use std::path::PathBuf;
 
+static HOME_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| etcetera::home_dir().ok());
+static CONFIG_DIR: Lazy<Option<PathBuf>> = Lazy::new(|| {
+    let default = if let Some(mut config_dir) = home_dir() {
+        config_dir.push(".config");
+        if config_dir.join("nushell").is_dir() {
+            return Some(config_dir);
+        }
+        Some(config_dir)
+    } else {
+        None
+    };
+
+    if let Ok(basedirs) = etcetera::base_strategy::choose_native_strategy() {
+        let config_home = if cfg!(target_os = "macos") {
+            basedirs.data_dir()
+        } else {
+            basedirs.config_dir()
+        };
+        if config_home.join("nushell").is_dir() {
+            return Some(config_home);
+        }
+    }
+
+    default
+});
+
 pub fn home_dir() -> Option<PathBuf> {
-    dirs_next::home_dir()
+    HOME_DIR.clone()
 }
 
 pub fn config_dir() -> Option<PathBuf> {
-    dirs_next::config_dir()
+    CONFIG_DIR.clone()
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
This PR implements the config location logic proposed in https://github.com/nushell/nushell/pull/8682#issuecomment-1718276590. I've made these changes on top of the changes in https://github.com/nushell/nushell/pull/8682 and have tried to keep them as minimal as possible. Feel free to copy these changes into the original PR (or throw them away entirely).

While this PR implements the suggestion in the comment linked above, it's worth noting that it deviates in two ways from the default behaviour of the [etcetera crate](https://docs.rs/etcetera/latest/etcetera/):

1. The etcetera crate (IMO, correctly) follows the XDG standard for macOS whereas this PR does not; and
2. On macOS, it considers `~/Library/Application Support/nushell` to be the native config directory whereas etcetera considers that to be the native data directory and `~/Library/Preferences/nushell` to be the config directory. I left this logic in as it was in the original PR.