### PR TITLE
Rename: change the SyntaxShape of `-c` flag from list to record

### DIFF
--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -134,7 +134,7 @@ fn rename(
             }
             if columns.is_empty() {
                 return Err(ShellError::TypeMismatch {
-                    err_message: "the column info cannot be empty".to_owned(),
+                    err_message: "The column info cannot be empty".to_owned(),
                     span: call.head,
                 });
             }

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -34,7 +34,7 @@ impl Command for Rename {
                 "A closure to apply changes on each column",
                 Some('b'),
             )
-            .rest("rest", SyntaxShape::String, "The new names for the columns")
+            .rest("rest", SyntaxShape::String, "the new names for the columns")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -132,6 +132,12 @@ fn rename(
                     }
                 }
             }
+            if columns.is_empty() {
+                return Err(ShellError::TypeMismatch {
+                    err_message: "the column info cannot be empty".to_owned(),
+                    span: call.head,
+                });
+            }
             Some(columns)
         }
         None => None,

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -34,7 +34,7 @@ impl Command for Rename {
                 "A closure to apply changes on each column",
                 Some('b'),
             )
-            .rest("rest", SyntaxShape::String, "the new names for the columns")
+            .rest("rest", SyntaxShape::String, "The new names for the columns")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -111,6 +111,6 @@ fn errors_if_columns_param_is_empty() {
                 "#
         ));
 
-        assert!(actual.err.contains("The column list cannot be empty"));
+        assert!(actual.err.contains("The column info cannot be empty"));
     })
 }

--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -107,7 +107,7 @@ fn errors_if_columns_param_is_empty() {
                 | lines
                 | wrap name
                 | default "arepa!" hit
-                | rename -c []
+                | rename -c {}
                 "#
         ));
 


### PR DESCRIPTION
# Description
Fixes: #7085 
Also closes: #7526 

# User-Facing Changes
After this change, we need to use `-c` flag like this:
```nushell
[[a, b, c]; [1, 2, 3]] | rename -c { a: ham }
```
But we can rename many columns easily, here is another example:
```nushell
[[a, b, c]; [1, 2, 3]] | rename -c { a: ham, b: ham2 }
```
