### PR TITLE
 `toolkit check pr` does same clippy checks as  github CI

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -34,27 +34,19 @@ export def fmt [
 export def clippy [
     --verbose # print extra information about the command's progress
     --features: list<string> # the list of features to run *Clippy* on
-    --workspace # run the *Clippy* command on the whole workspace (overrides `--features`)
 ] {
     if $verbose {
         print $"running ('toolkit clippy' | pretty-format-command)"
     }
 
-    try {
-        if $workspace {(
+    try {(
             cargo clippy
                 --workspace
-            --
-                -D warnings
-                -D clippy::unwrap_used
-        )} else {(
-            cargo clippy
+                --tests
                 --features ($features | str join ",")
             --
                 -D warnings
-                -D clippy::unwrap_used
-        )}
-    } catch {
+    )} catch {
         error make --unspanned {
             msg: $"\nplease fix the above ('clippy' | pretty-format-command) errors before continuing!"
         }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -40,12 +40,12 @@ export def clippy [
     }
 
     try {(
-            cargo clippy
-                --workspace
-                --tests
-                --features ($features | str join ",")
-            --
-                -D warnings
+        cargo clippy
+            --workspace
+            --tests
+            --features ($features | str join ",")
+        --
+            -D warnings
     )} catch {
         error make --unspanned {
             msg: $"\nplease fix the above ('clippy' | pretty-format-command) errors before continuing!"


### PR DESCRIPTION
Align the clippy checks done by `toolkit check pr` with the ones done by github CI when you post a PR. 
Motivated in no small part by my frustration at having the third PR in one day fail due to a lint that `toolkit check pr` didn't find!

# Description
Change definition of `toolkit clippy` 
* always run checks on all crates in the workspace
* always run checks on tests as well as non-test code
* don't check for `unwrap_used`.  There are many (legit) uses of `.unwrap()` in tests,
* 
# User-Facing Changes
Changes to `toolkit clippy`:
* remove `--workspace` switch
* `--features` is no longer mutually exclusive with `--workspace`

# Tests + Formatting
n/a

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
