### PR TITLE
Add kitty protocol config to nushell

### DIFF
--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -73,7 +73,7 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
 
     if config.use_kitty_protocol {
         if let Ok(false) = crossterm::terminal::supports_keyboard_enhancement() {
-            println!("WARN: The terminal doesn't support use_kitty_protocol config.");
+            println!("WARN: The terminal doesn't support use_kitty_protocol config.\r");
         }
 
         // enable kitty protocol

--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -1,6 +1,6 @@
+use crossterm::execute;
 use crossterm::QueueableCommand;
 use crossterm::{event::Event, event::KeyCode, event::KeyEvent, terminal};
-use crossterm::execute;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -90,7 +90,9 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
         // Refer to https://sw.kovidgoyal.net/kitty/keyboard-protocol/ if you're curious.
         let _ = execute!(
             stdout(),
-            crossterm::event::PushKeyboardEnhancementFlags(crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+            crossterm::event::PushKeyboardEnhancementFlags(
+                crossterm::event::KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+            )
         );
     }
 
@@ -122,7 +124,10 @@ pub fn print_events(engine_state: &EngineState) -> Result<Value, ShellError> {
     }
 
     if config.use_kitty_protocol {
-        let _ = execute!(std::io::stdout(), crossterm::event::PopKeyboardEnhancementFlags);
+        let _ = execute!(
+            std::io::stdout(),
+            crossterm::event::PopKeyboardEnhancementFlags
+        );
     }
 
     terminal::disable_raw_mode()?;

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -182,7 +182,7 @@ pub fn evaluate_repl(
 
     if engine_state.get_config().use_kitty_protocol {
         if line_editor.can_use_kitty_protocol() {
-            let _ = line_editor.enable_kitty_protocol();
+            line_editor.enable_kitty_protocol();
         } else {
             warn!("Terminal doesn't support use_kitty_protocol config");
         }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -180,6 +180,14 @@ pub fn evaluate_repl(
         );
     }
 
+    if engine_state.get_config().use_kitty_protocol {
+        if line_editor.can_use_kitty_protocol() {
+            let _ = line_editor.enable_kitty_protocol();
+        } else {
+            warn!("Terminal doesn't support use_kitty_protocol config");
+        }
+    }
+
     loop {
         let loop_start_time = std::time::Instant::now();
 

--- a/crates/nu-protocol/src/config.rs
+++ b/crates/nu-protocol/src/config.rs
@@ -115,6 +115,7 @@ pub struct Config {
     pub datetime_normal_format: Option<String>,
     pub datetime_table_format: Option<String>,
     pub error_style: String,
+    pub use_kitty_protocol: bool,
 }
 
 impl Default for Config {
@@ -180,6 +181,8 @@ impl Default for Config {
             keybindings: Vec::new(),
 
             error_style: "fancy".into(),
+
+            use_kitty_protocol: false,
         }
     }
 }
@@ -1199,6 +1202,9 @@ impl Value {
                     }
                     "bracketed_paste" => {
                         try_bool!(cols, vals, index, span, bracketed_paste);
+                    }
+                    "use_kitty_protocol" => {
+                        try_bool!(cols, vals, index, span, use_kitty_protocol);
                     }
                     // Menus
                     "menus" => match create_menus(value) {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -240,6 +240,7 @@ $env.config = {
     edit_mode: emacs # emacs, vi
     shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.
     render_right_prompt_on_last_line: false # true or false to enable or disable right prompt to be rendered on last line of the prompt.
+    use_kitty_protocol: false # enables keyboard enhancement protocol implemented by kitty console, only if your terminal support this
 
     hooks: {
         pre_prompt: [{ null }] # run before the prompt is shown


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
This PR should close https://github.com/nushell/nushell/issues/9733.

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Support keyboard enhancement protocol as implemented by Kitty console, hence Kitty protocol.

This PR enables Nushell to use keybinding that is not available before, such as Ctrl+i (that alias to Tab) or Ctrl+e (that alias to Esc, likely I mistaken). After this PR merged and you set `use_kitty_protocol` enabled, if your console app support Kitty protocol (WezTerm, Kitty, etc.) you will be able to set more fine-grained keybinding.

For Colemak users, this feature is a blessing, because some Ctrl+[hjkl] that previously unmap-able to Ctlr+[hnei] now it is.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
This adds `use_kitty_protocol` config which defaults to false. When set to `true`, it enables kitty protocol on the line editor when supported, or else it warns.

# Tests + Formatting

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
  It produces an error. I don't think this is my doing since the current main also suffers this error in my local.
  ```
  failures:

  ---- shell::run_in_login_mode stdout ----
  thread 'shell::run_in_login_mode' panicked at 'assertion failed: child_output.stderr.is_empty()', tests/shell/mod.rs:243:5


  failures:
      shell::run_in_login_mode

  test result: FAILED. 485 passed; 1 failed; 20 ignored; 0 measured; 0 filtered out; finished in 49.96s
  ```
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
