### PR TITLE
expand record! macro

### DIFF
--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -2,7 +2,7 @@ use crate::Value;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Record {
     pub cols: Vec<String>,
     pub vals: Vec<Value>,
@@ -87,13 +87,168 @@ impl<'a> IntoIterator for &'a mut Record {
 
 #[macro_export]
 macro_rules! record {
-    {$($col:expr => $val:expr),+ $(,)?} => {
-        $crate::Record {
-            cols: vec![$($col.into(),)+],
-            vals: vec![$($val,)+]
+    {$col:expr => $val:expr, $($tail:tt)*} => {
+        record!(@top $col => $val, $($tail)*)
+    };
+
+    {$val:ident, $($tail:tt)*} => {
+        record!(@top $val, $($tail)*)
+    };
+
+    {$col:expr => $val:expr} => {
+        record!($col => $val,)
+    };
+
+    {$val:ident} => {
+        record!($val,)
+    };
+
+    {@top $($tokens:tt)+} => {
+        {
+            let mut cols = Vec::new();
+
+            #[allow(clippy::vec_init_then_push)]
+            {
+                record!(@col cols, $($tokens)+);
+            }
+
+            let mut vals = Vec::new();
+
+            #[allow(clippy::vec_init_then_push)]
+            {
+                record!(@val vals, $($tokens)+);
+            }
+
+            $crate::Record {
+                cols,
+                vals,
+            }
         }
     };
-    {} => {
-        $crate::Record::new()
+
+    {@col $cols:ident, $col:expr => $val:expr, $($tail:tt)*} => {
+        $cols.push($col.into());
+        record!(@col $cols, $($tail)*)
     };
+    {@col $cols:ident, $col:expr => $val:expr} => {
+        record!(@col $cols, $col => $val,)
+    };
+    {@col $cols:ident, $val:ident, $($tail:tt)* } => {
+        $cols.push(stringify!($val).into());
+        record!(@col $cols, $($tail)*)
+    };
+    {@col $cols:ident, $val:ident } => {
+        record!(@col $cols, $val,)
+    };
+    {@col $cols:ident, $(,)?} => {};
+
+    {@val $vals:ident, $col:expr => $val:expr, $($tail:tt)* } => {
+        $vals.push($val);
+        record!(@val $vals, $($tail)*)
+    };
+    {@val $vals:ident, $col:expr => $val:expr} => {
+        record!(@val $vals, $col => $val,)
+    };
+    {@val $vals:ident, $val:ident, $($tail:tt)* } => {
+        $vals.push($val);
+        record!(@val $vals, $($tail)*)
+    };
+    {@val $cols:ident, $val:ident } => {
+        record!(@val $cols, $val,)
+    };
+    {@val $vals:ident, $(,)?} => {};
+
+    {} => {};
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Record, Span, Value};
+
+    #[test]
+    fn record_macro_arrows() {
+        assert_eq!(
+            Record::from_iter([(
+                "foo".into(),
+                Value::string("bar".to_owned(), Span::unknown())
+            ),]),
+            record!("foo" => Value::string("bar".to_owned(), Span::unknown())) // no trailing comma
+        );
+
+        assert_eq!(
+            Record::from_iter([
+                (
+                    "foo".into(),
+                    Value::string("bar".to_owned(), Span::unknown())
+                ),
+                (
+                    "baz".into(),
+                    Value::string("quux".to_owned(), Span::unknown())
+                ),
+            ]),
+            record!(
+                "foo" => Value::string("bar".to_owned(), Span::unknown()),
+                "baz" => Value::string("quux".to_owned(), Span::unknown()) // no trailing comma
+            )
+        );
+
+        assert_eq!(
+            Record::from_iter([
+                ("foo".into(), Value::int(0, Span::unknown())),
+                ("baz".into(), Value::int(1, Span::unknown())),
+            ]),
+            record!(
+                "foo" => Value::int(0, Span::unknown()),
+                "baz" => Value::int(1, Span::unknown()), // with trailing comma
+            )
+        );
+    }
+
+    #[test]
+    fn record_macro_identifier() {
+        let foo = Value::bool(false, Span::unknown());
+        let bar = Value::int(1, Span::unknown());
+
+        assert_eq!(
+            Record::from_iter([
+                ("foo".into(), Value::bool(false, Span::unknown())),
+                ("bar".into(), Value::int(1, Span::unknown())),
+            ]),
+            record!(foo, bar)
+        );
+
+        let foo = Value::bool(true, Span::unknown());
+        let bar = Value::int(2, Span::unknown());
+
+        assert_eq!(
+            Record::from_iter([
+                ("foo".into(), Value::bool(true, Span::unknown())),
+                ("bar".into(), Value::int(2, Span::unknown())) // no trailing comma
+            ]),
+            record!(foo, bar)
+        );
+    }
+
+    #[test]
+    fn record_macro_identifier_arrow_mix() {
+        let foo = Value::bool(false, Span::unknown());
+
+        assert_eq!(
+            Record::from_iter([
+                ("foo".into(), Value::bool(false, Span::unknown())),
+                ("bar".into(), Value::int(1, Span::unknown()))
+            ]),
+            record!(foo, "bar".to_owned() => Value::int(1, Span::unknown()))
+        );
+
+        let bar = Value::int(2, Span::unknown());
+
+        assert_eq!(
+            Record::from_iter([
+                ("foo".into(), Value::bool(false, Span::unknown())),
+                ("bar".into(), Value::int(2, Span::unknown())) // no trailing comma
+            ]),
+            record!("foo".to_owned() => Value::bool(false, Span::unknown()), bar)
+        );
+    }
 }


### PR DESCRIPTION
# Description

This expands the syntax of the `record!` macro. In addition to the `key => value` syntax, one can now also put a simple identifier for a column. This creates a column with the same name as that of the identifier, and a value of the identifier's value.

This makes it easier to make a record when you already have a variable with the value you want and want to give you column the same name as
that of the variable. e.g.

```rust
let foo = Value::int(1, Span::unknown());
let bar = Value::int(2, Span::unknown());
let rec = record!(foo, bar);
```

This will create a record like:

```nu
{ foo: 1, bar: 2 }
```

# User-Facing Changes

This won't affect the user, but it's a nice QOL improvement for plug-in authors and core contributors.

# Tests + Formatting

I added some unit tests to verify the macro is doing what it should.