### PR TITLE
improve assertion error messages in `std assert`

### DIFF
--- a/crates/nu-std/std/assert.nu
+++ b/crates/nu-std/std/assert.nu
@@ -116,7 +116,7 @@ export def error [
     main ($error_raised) $message --error-label {
         start: (metadata $code).span.start
         end: (metadata $code).span.end
-        text: $"There were no error during code execution: (view source $code)"
+        text: $"There were no error during code execution:\n(view source $code)"
     }
 }
 
@@ -133,7 +133,7 @@ export def equal [left: any, right: any, message?: string] {
     main ($left == $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"They are not equal. Left = '($left)'. Right = '($right)'."
+        text: $"These are not equal.\nLeft = '($left | to nuon --raw)'\nRight = '($right | to nuon --raw)'"
     }
 }
 
@@ -150,7 +150,7 @@ export def "not equal" [left: any, right: any, message?: string] {
     main ($left != $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"They both are '($left)'."
+        text: $"These are both '($left | to nuon --raw)'."
     }
 }
 
@@ -167,7 +167,7 @@ export def "less or equal" [left: any, right: any, message?: string] {
     main ($left <= $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"Left: '($left)', Right: '($right)'"
+        text: $"The condition *left <= right* is not satisfied.\nLeft: '($left)'\nRight: '($right)'"
     }
 }
 
@@ -183,7 +183,7 @@ export def less [left: any, right: any, message?: string] {
     main ($left < $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"Left: '($left)', Right: '($right)'"
+        text: $"The condition *left < right* is not satisfied.\nLeft: '($left)'\nRight: '($right)'"
     }
 }
 
@@ -199,7 +199,7 @@ export def greater [left: any, right: any, message?: string] {
     main ($left > $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"Left: '($left)', Right: '($right)'"
+        text: $"The condition *left > right* is not satisfied.\nLeft: '($left)'\nRight: '($right)'"
     }
 }
 
@@ -216,7 +216,7 @@ export def "greater or equal" [left: any, right: any, message?: string] {
     main ($left >= $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"Left: '($left)', Right: '($right)'"
+        text: $"The condition *left >= right* is not satisfied.\nLeft: '($left)'\nRight: '($right)'"
     }
 }
 
@@ -233,7 +233,7 @@ export def length [left: list, right: int, message?: string] {
     main (($left | core length) == $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"Length of ($left) is ($left | core length), not ($right)"
+        text: $"This does not have the correct length:\nvalue: ($left | to nuon --raw)\nlength: ($left | core length)\nexpected: ($right)"
     }
 }
 
@@ -250,6 +250,6 @@ export def "str contains" [left: string, right: string, message?: string] {
     main ($left | core str contains $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"'($left)' does not contain '($right)'."
+        text: $"This does not contain '($right)'.\nvalue: ($left | to nuon --raw)"
     }
 }

--- a/crates/nu-std/std/assert.nu
+++ b/crates/nu-std/std/assert.nu
@@ -138,8 +138,8 @@ export def equal [left: any, right: any, message?: string] {
         end: (metadata $right).span.end
         text: (
             "These are not equal.\n"
-         + $"        Left = '($left | to nuon --raw)'\n"
-         + $"        Right = '($right | to nuon --raw)'"
+         + $"        Left  : '($left | to nuon --raw)'\n"
+         + $"        Right : '($right | to nuon --raw)'"
         )
     }
 }
@@ -176,8 +176,8 @@ export def "less or equal" [left: any, right: any, message?: string] {
         end: (metadata $right).span.end
         text: (
             "The condition *left <= right* is not satisfied.\n"
-         + $"        Left: '($left)'\n"
-         + $"        Right: '($right)'"
+         + $"        Left  : '($left)'\n"
+         + $"        Right : '($right)'"
         )
     }
 }
@@ -196,8 +196,8 @@ export def less [left: any, right: any, message?: string] {
         end: (metadata $right).span.end
         text: (
             "The condition *left < right* is not satisfied.\n"
-         + $"        Left: '($left)'\n"
-         + $"        Right: '($right)'"
+         + $"        Left  : '($left)'\n"
+         + $"        Right : '($right)'"
         )
     }
 }
@@ -216,8 +216,8 @@ export def greater [left: any, right: any, message?: string] {
         end: (metadata $right).span.end
         text: (
             "The condition *left > right* is not satisfied.\n"
-         + $"        Left: '($left)'\n"
-         + $"        Right: '($right)'"
+         + $"        Left  : '($left)'\n"
+         + $"        Right : '($right)'"
         )
     }
 }
@@ -237,8 +237,8 @@ export def "greater or equal" [left: any, right: any, message?: string] {
         end: (metadata $right).span.end
         text: (
             "The condition *left < right* is not satisfied.\n"
-         + $"        Left: '($left)'\n"
-         + $"        Right: '($right)'"
+         + $"        Left  : '($left)'\n"
+         + $"        Right : '($right)'"
         )
     }
 }
@@ -258,9 +258,9 @@ export def length [left: list, right: int, message?: string] {
         end: (metadata $right).span.end
         text: (
             "This does not have the correct length:\n"
-         + $"        value: ($left | to nuon --raw)\n"
-         + $"        length: ($left | core length)\n"
-         + $"        expected: ($right)"
+         + $"        value    : ($left | to nuon --raw)\n"
+         + $"        length   : ($left | core length)\n"
+         + $"        expected : ($right)"
         )
     }
 }

--- a/crates/nu-std/std/assert.nu
+++ b/crates/nu-std/std/assert.nu
@@ -116,7 +116,10 @@ export def error [
     main ($error_raised) $message --error-label {
         start: (metadata $code).span.start
         end: (metadata $code).span.end
-        text: $"There were no error during code execution:\n(view source $code)"
+        text: (
+            "There were no error during code execution:\n"
+         + $"        (view source $code)"
+        )
     }
 }
 
@@ -133,7 +136,11 @@ export def equal [left: any, right: any, message?: string] {
     main ($left == $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"These are not equal.\nLeft = '($left | to nuon --raw)'\nRight = '($right | to nuon --raw)'"
+        text: (
+            "These are not equal.\n"
+         + $"        Left = '($left | to nuon --raw)'\n"
+         + $"        Right = '($right | to nuon --raw)'"
+        )
     }
 }
 
@@ -167,7 +174,11 @@ export def "less or equal" [left: any, right: any, message?: string] {
     main ($left <= $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"The condition *left <= right* is not satisfied.\nLeft: '($left)'\nRight: '($right)'"
+        text: (
+            "The condition *left <= right* is not satisfied.\n"
+         + $"        Left: '($left)'\n"
+         + $"        Right: '($right)'"
+        )
     }
 }
 
@@ -183,7 +194,11 @@ export def less [left: any, right: any, message?: string] {
     main ($left < $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"The condition *left < right* is not satisfied.\nLeft: '($left)'\nRight: '($right)'"
+        text: (
+            "The condition *left < right* is not satisfied.\n"
+         + $"        Left: '($left)'\n"
+         + $"        Right: '($right)'"
+        )
     }
 }
 
@@ -199,7 +214,11 @@ export def greater [left: any, right: any, message?: string] {
     main ($left > $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"The condition *left > right* is not satisfied.\nLeft: '($left)'\nRight: '($right)'"
+        text: (
+            "The condition *left > right* is not satisfied.\n"
+         + $"        Left: '($left)'\n"
+         + $"        Right: '($right)'"
+        )
     }
 }
 
@@ -216,7 +235,11 @@ export def "greater or equal" [left: any, right: any, message?: string] {
     main ($left >= $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"The condition *left >= right* is not satisfied.\nLeft: '($left)'\nRight: '($right)'"
+        text: (
+            "The condition *left < right* is not satisfied.\n"
+         + $"        Left: '($left)'\n"
+         + $"        Right: '($right)'"
+        )
     }
 }
 
@@ -233,7 +256,12 @@ export def length [left: list, right: int, message?: string] {
     main (($left | core length) == $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"This does not have the correct length:\nvalue: ($left | to nuon --raw)\nlength: ($left | core length)\nexpected: ($right)"
+        text: (
+            "This does not have the correct length:\n"
+         + $"        value: ($left | to nuon --raw)\n"
+         + $"        length: ($left | core length)\n"
+         + $"        expected: ($right)"
+        )
     }
 }
 
@@ -250,6 +278,9 @@ export def "str contains" [left: string, right: string, message?: string] {
     main ($left | core str contains $right) $message --error-label {
         start: (metadata $left).span.start
         end: (metadata $right).span.end
-        text: $"This does not contain '($right)'.\nvalue: ($left | to nuon --raw)"
+        text: (
+            $"This does not contain '($right)'.\n"
+          + $"        value: ($left | to nuon --raw)"
+        )
     }
 }


### PR DESCRIPTION
should close #10549 

# Description
this PR is twofold
- uses `to nuon --raw` in the error messages to make sure #10549 is solved and makes a difference between `"1"` and `1`
- tries to introduce slightly better errors, i.e. by putting left / right on new lines => this should hopefully help when the values become a bit big :yum: 

# User-Facing Changes
the original issue:
```nushell
> assert equal {one:1 two:2} {one:"1" two:"2"}
Error:   × Assertion failed.
   ╭─[entry #3:1:1]
 1 │ assert equal {one:1 two:2} {one:"1" two:"2"}
   ·              ───────────────┬───────────────
   ·                             ╰── These are not equal.
        Left  : '{one: 1, two: 2}'
        Right : '{one: "1", two: "2"}'
   ╰────
```

a sample for all the assertions and their new messages
```nushell
> assert equal {one:1 two:2} {one:"1" two:"2"}
Error:   × Assertion failed.
   ╭─[entry #3:1:1]
 1 │ assert equal {one:1 two:2} {one:"1" two:"2"}
   ·              ───────────────┬───────────────
   ·                             ╰── These are not equal.
        Left  : '{one: 1, two: 2}'
        Right : '{one: "1", two: "2"}'
   ╰────
```
```nushell
> assert equal 1 2
Error:   × Assertion failed.
   ╭─[entry #4:1:1]
 1 │ assert equal 1 2
   ·              ─┬─
   ·               ╰── These are not equal.
        Left  : '1'
        Right : '2'
   ╰────
```
```nushell
> assert less 3 1
Error:   × Assertion failed.
   ╭─[entry #6:1:1]
 1 │ assert less 3 1
   ·             ─┬─
   ·              ╰── The condition *left < right* is not satisfied.
        Left  : '3'
        Right : '1'
   ╰────
```
```nushell
> assert less or equal 3 1
Error:   × Assertion failed.
   ╭─[entry #7:1:1]
 1 │ assert less or equal 3 1
   ·                      ─┬─
   ·                       ╰── The condition *left <= right* is not satisfied.
        Left  : '3'
        Right : '1'
   ╰────
```
```nushell
> assert greater 1 3
Error:   × Assertion failed.
   ╭─[entry #8:1:1]
 1 │ assert greater 1 3
   ·                ─┬─
   ·                 ╰── The condition *left > right* is not satisfied.
        Left  : '1'
        Right : '3'
   ╰────
```
```nushell
> assert greater or equal 1 3
Error:   × Assertion failed.
   ╭─[entry #9:1:1]
 1 │ assert greater or equal 1 3
   ·                         ─┬─
   ·                          ╰── The condition *left < right* is not satisfied.
        Left  : '1'
        Right : '3'
   ╰────
```
```nushell
> assert length [1 2 3] 2
Error:   × Assertion failed.
   ╭─[entry #10:1:1]
 1 │ assert length [1 2 3] 2
   ·               ────┬────
   ·                   ╰── This does not have the correct length:
        value    : [1, 2, 3]
        length   : 3
        expected : 2
   ╰────
```
```nushell
> assert length [1 "2" 3] 2
Error:   × Assertion failed.
   ╭─[entry #11:1:1]
 1 │ assert length [1 "2" 3] 2
   ·               ─────┬─────
   ·                    ╰── This does not have the correct length:
        value    : [1, "2", 3]
        length   : 3
        expected : 2
   ╰────
```
```nushell
> assert str contains "foo" "bar"
Error:   × Assertion failed.
   ╭─[entry #13:1:1]
 1 │ assert str contains "foo" "bar"
   ·                     ─────┬─────
   ·                          ╰── This does not contain '($right)'.
        value: "foo"
   ╰────
```

# Tests + Formatting

# After Submitting
