### PR TITLE
chore: Small refactor of `eval.rs`

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1015,9 +1015,7 @@ pub fn eval_block(
     let num_pipelines = block.len();
 
     for (pipeline_idx, pipeline) in block.pipelines.iter().enumerate() {
-        let mut i = 0;
-
-        while i < pipeline.elements.len() {
+        for i in 0..pipeline.elements.len() {
             let redirect_stderr = redirect_stderr
                 || ((i < pipeline.elements.len() - 1)
                     && (matches!(
@@ -1074,8 +1072,6 @@ pub fn eval_block(
                     }
                 }
             }
-
-            i += 1;
         }
 
         if pipeline_idx < (num_pipelines) - 1 {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1026,6 +1026,15 @@ pub fn eval_block(
                             | PipelineElement::Redirection(_, Redirection::StdoutAndStderr, _)
                             | PipelineElement::SeparateRedirection { .. }
                     )));
+            let redirect_stdout = redirect_stdout
+                || (i != pipeline.elements.len() - 1)
+                    && (matches!(
+                        pipeline.elements[i + 1],
+                        PipelineElement::Redirection(_, Redirection::Stdout, _)
+                            | PipelineElement::Redirection(_, Redirection::StdoutAndStderr, _)
+                            | PipelineElement::Expression(..)
+                            | PipelineElement::SeparateRedirection { .. }
+                    ));
 
             // if eval internal command failed, it can just make early return with `Err(ShellError)`.
             let eval_result = eval_element_with_input(
@@ -1033,15 +1042,7 @@ pub fn eval_block(
                 stack,
                 &pipeline.elements[i],
                 input,
-                redirect_stdout
-                    || (i != pipeline.elements.len() - 1)
-                        && (matches!(
-                            pipeline.elements[i + 1],
-                            PipelineElement::Redirection(_, Redirection::Stdout, _)
-                                | PipelineElement::Redirection(_, Redirection::StdoutAndStderr, _)
-                                | PipelineElement::Expression(..)
-                                | PipelineElement::SeparateRedirection { .. }
-                        )),
+                redirect_stdout,
                 redirect_stderr,
             );
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
- Extract long expression in `eval.rs` into variable
- Improve loop in eval.rs

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
None

# Tests + Formatting
✅
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
