### PR TITLE
Update build flags for riscv64gc and armv7 targets

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -117,10 +117,10 @@ jobs:
           target_rustflags: ''
         - target: armv7-unknown-linux-gnueabihf
           os: ubuntu-20.04
-          target_rustflags: '--exclude=nu-cmd-dataframe'
+          target_rustflags: ''
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-20.04
-          target_rustflags: '--exclude=nu-cmd-dataframe'
+          target_rustflags: ''
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,10 @@ jobs:
           target_rustflags: ''
         - target: armv7-unknown-linux-gnueabihf
           os: ubuntu-20.04
-          target_rustflags: '--exclude=nu-cmd-dataframe'
+          target_rustflags: ''
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-20.04
-          target_rustflags: '--exclude=nu-cmd-dataframe'
+          target_rustflags: ''
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Update build flags for riscv64gc and armv7 targets， as they are not required any more, let's give it a try in nightly release