### PR TITLE
Add warning to `url join` when input key is not supported (#10506)

### DIFF
--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -285,8 +285,8 @@ impl UrlComponents {
                             nu_protocol::report_error_new(
                                 engine_state,
                                 &ShellError::GenericError(
-                                    format!("'{key}' is not a valid URL field").into(),
-                                    format!("Remove '{key}' col from input record").into(),
+                                    format!("'{key}' is not a valid URL field"),
+                                    format!("Remove '{key}' col from input record"),
                                     Some(span),
                                     None,
                                     vec![],

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -275,7 +275,10 @@ impl UrlComponents {
                             }),
                             ..self
                         }),
-                        _ => Ok(self),
+                        _ => {
+                            println!("warning: '{key}' not a valid URL key");
+                            Ok(self)
+                        }
                     }
                 }
             }

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -82,7 +82,7 @@ impl Command for SubCommand {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         _stack: &mut Stack,
         call: &Call,
         input: PipelineData,
@@ -98,7 +98,7 @@ impl Command for SubCommand {
                         let url_components = val
                             .into_iter()
                             .try_fold(UrlComponents::new(), |url, (k, v)| {
-                                url.add_component(k, v, span)
+                                url.add_component(k, v, span, engine_state)
                             });
 
                         url_components?.to_url(span)
@@ -137,8 +137,14 @@ impl UrlComponents {
         Default::default()
     }
 
-    pub fn add_component(self, key: String, value: Value, _span: Span) -> Result<Self, ShellError> {
-        let span = value.span();
+    pub fn add_component(
+        self,
+        key: String,
+        value: Value,
+        span: Span,
+        engine_state: &EngineState,
+    ) -> Result<Self, ShellError> {
+        let value_span = value.span();
         if key == "port" {
             return match value {
                 Value::String { val, .. } => {
@@ -154,7 +160,7 @@ impl UrlComponents {
                                 msg: String::from(
                                     "Port parameter should represent an unsigned integer",
                                 ),
-                                span,
+                                span: value_span,
                             }),
                         }
                     }
@@ -205,7 +211,7 @@ impl UrlComponents {
 
                     Ok(Self {
                         query: Some(qs),
-                        params_span: Some(span),
+                        params_span: Some(value_span),
                         ..self
                     })
                 }
@@ -276,7 +282,16 @@ impl UrlComponents {
                             ..self
                         }),
                         _ => {
-                            println!("warning: '{key}' not a valid URL key");
+                            nu_protocol::report_error_new(
+                                engine_state,
+                                &ShellError::GenericError(
+                                    format!("'{key}' is not a valid URL field").into(),
+                                    format!("Remove '{key}' col from input record").into(),
+                                    Some(span),
+                                    None,
+                                    vec![],
+                                ),
+                            );
                             Ok(self)
                         }
                     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Adds warning to `url join` when input key is not supported as suggested by @amtoine in #10506.

It just adds a `println!` statement but it seems like that is all that is done for other warnings, e.g., https://github.com/nushell/nushell/blob/20aaaaf90c24ea5495cba3396d3977ab10923488/crates/nu-glob/src/lib.rs#L434

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
All pass.
