### PR TITLE
Add --env and --wrapped flags to def

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -19,11 +19,11 @@ impl Command for Def {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("def")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .switch("env", "keep the environment defined inside the command", None)
-            .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
             .required("def_name", SyntaxShape::String, "command name")
             .required("params", SyntaxShape::Signature, "parameters")
-            .required("body", SyntaxShape::Closure(None), "body of the definition")
+            .required("block", SyntaxShape::Closure(None), "body of the definition")
+            .switch("env", "keep the environment defined inside the command", None)
+            .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -19,7 +19,9 @@ impl Command for Def {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("def")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "definition name")
+            .switch("env", "keep the environment defined inside the command", None)
+            .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
+            .required("def_name", SyntaxShape::String, "command name")
             .required("params", SyntaxShape::Signature, "parameters")
             .required("body", SyntaxShape::Closure(None), "body of the definition")
             .category(Category::Core)
@@ -55,6 +57,16 @@ impl Command for Def {
                 description: "Define a command and run it with parameter(s)",
                 example: r#"def say-sth [sth: string] { echo $sth }; say-sth hi"#,
                 result: Some(Value::test_string("hi")),
+            },
+            Example {
+                description: "Set environment variable by call a custom command",
+                example: r#"def --env foo [] { $env.BAR = "BAZ" }; foo; $env.BAR"#,
+                result: Some(Value::test_string("BAZ")),
+            },
+            Example {
+                description: "Define a custom wrapper for an external command",
+                example: r#"def --wrapped my-echo [...rest] { echo $rest }; my-echo spam"#,
+                result: Some(Value::test_list(vec![Value::test_string("spam")])),
             },
         ]
     }

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -19,11 +19,11 @@ impl Command for ExportDef {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export def")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .switch("env", "keep the environment defined inside the command", None)
-            .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
             .required("def_name", SyntaxShape::String, "command name")
             .required("params", SyntaxShape::Signature, "parameters")
             .required("block", SyntaxShape::Block, "body of the definition")
+            .switch("env", "keep the environment defined inside the command", None)
+            .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -19,7 +19,9 @@ impl Command for ExportDef {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export def")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("name", SyntaxShape::String, "definition name")
+            .switch("env", "keep the environment defined inside the command", None)
+            .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
+            .required("def_name", SyntaxShape::String, "command name")
             .required("params", SyntaxShape::Signature, "parameters")
             .required("block", SyntaxShape::Block, "body of the definition")
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/module.rs
@@ -62,7 +62,7 @@ impl Command for Module {
             },
             Example {
                 description: "Define a custom command that participates in the environment in a module and call it",
-                example: r#"module foo { export def-env bar [] { $env.FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
+                example: r#"module foo { export def --env bar [] { $env.FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
                 result: Some(Value::test_string("BAZ")),
             },
         ]

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -155,7 +155,7 @@ This command is a parser keyword. For details, check:
             },
             Example {
                 description: "Define a custom command that participates in the environment in a module and call it",
-                example: r#"module foo { export def-env bar [] { $env.FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
+                example: r#"module foo { export def --env bar [] { $env.FOO_BAR = "BAZ" } }; use foo bar; bar; $env.FOO_BAR"#,
                 result: Some(Value::test_string("BAZ")),
             },
             Example {

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -163,7 +163,7 @@ impl Command for ViewSource {
             },
             Example {
                 description: "View the source of a custom command, which participates in the caller environment",
-                example: r#"def-env foo [] { $env.BAR = 'BAZ' }; view source foo"#,
+                example: r#"def --env foo [] { $env.BAR = 'BAZ' }; view source foo"#,
                 result: Some(Value::test_string("def foo [] { $env.BAR = 'BAZ' }")),
             },
             Example {

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -291,3 +291,11 @@ fn def_wrapped_wrong_rest_type_error() {
     assert!(actual.err.contains("type_mismatch_help"));
     assert!(actual.err.contains("of ...eggs to 'string'"));
 }
+
+#[test]
+fn def_env_wrapped() {
+    let actual = nu!(
+        "def --env --wrapped spam [...eggs: string] { $env.SPAM = $eggs.0 }; spam bacon; $env.SPAM"
+    );
+    assert_eq!(actual.out, "bacon");
+}

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -46,7 +46,7 @@ fn def_errors_with_no_space_between_params_and_name_1() {
 
 #[test]
 fn def_errors_with_no_space_between_params_and_name_2() {
-    let actual = nu!("def-env test-command() {}");
+    let actual = nu!("def --env test-command() {}");
 
     assert!(actual.err.contains("expected space"));
 }

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -208,3 +208,73 @@ fn def_wrapped_from_module() {
         .out
         .contains("foo -b -as -9 --abc -- -Dxmy=AKOO - bar"));
 }
+
+#[test]
+fn def_cursed_env_flag_positions() {
+    let actual = nu!("def spam --env [] { $env.SPAM = 'spam' }; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+
+    let actual =
+        nu!("def spam --env []: nothing -> nothing { $env.SPAM = 'spam' }; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+#[ignore = "TODO: Investigate why it's not working, it might be the signature parsing"]
+fn def_cursed_env_flag_positions_2() {
+    let actual = nu!("def spam [] --env { $env.SPAM = 'spam' }; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+
+    let actual = nu!("def spam [] { $env.SPAM = 'spam' } --env; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+
+    let actual =
+        nu!("def spam []: nothing -> nothing { $env.SPAM = 'spam' } --env; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn export_def_cursed_env_flag_positions() {
+    let actual = nu!("export def spam --env [] { $env.SPAM = 'spam' }; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+
+    let actual =
+        nu!("export def spam --env []: nothing -> nothing { $env.SPAM = 'spam' }; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+#[ignore = "TODO: Investigate why it's not working, it might be the signature parsing"]
+fn export_def_cursed_env_flag_positions_2() {
+    let actual = nu!("export def spam [] --env { $env.SPAM = 'spam' }; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+
+    let actual = nu!("export def spam [] { $env.SPAM = 'spam' } --env; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+
+    let actual =
+        nu!("export def spam []: nothing -> nothing { $env.SPAM = 'spam' } --env; spam; $env.SPAM");
+    assert_eq!(actual.out, "spam");
+}
+
+#[test]
+fn def_cursed_wrapped_flag_positions() {
+    let actual = nu!("def spam --wrapped [...rest] { $rest.0 }; spam --foo");
+    assert_eq!(actual.out, "--foo");
+
+    let actual = nu!("def spam --wrapped [...rest]: nothing -> nothing { $rest.0 }; spam --foo");
+    assert_eq!(actual.out, "--foo");
+}
+
+#[test]
+#[ignore = "TODO: Investigate why it's not working, it might be the signature parsing"]
+fn def_cursed_wrapped_flag_positions_2() {
+    let actual = nu!("def spam [...rest] --wrapped { $rest.0 }; spam --foo");
+    assert_eq!(actual.out, "--foo");
+
+    let actual = nu!("def spam [...rest] { $rest.0 } --wrapped; spam --foo");
+    assert_eq!(actual.out, "--foo");
+
+    let actual = nu!("def spam [...rest]: nothing -> nothing { $rest.0 } --wrapped; spam --foo");
+    assert_eq!(actual.out, "--foo");
+}

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -278,3 +278,16 @@ fn def_cursed_wrapped_flag_positions_2() {
     let actual = nu!("def spam [...rest]: nothing -> nothing { $rest.0 } --wrapped; spam --foo");
     assert_eq!(actual.out, "--foo");
 }
+
+#[test]
+fn def_wrapped_missing_rest_error() {
+    let actual = nu!("def --wrapped spam [] {}");
+    assert!(actual.err.contains("missing_positional"))
+}
+
+#[test]
+fn def_wrapped_wrong_rest_type_error() {
+    let actual = nu!("def --wrapped spam [...eggs: list<string>] { $eggs }");
+    assert!(actual.err.contains("type_mismatch_help"));
+    assert!(actual.err.contains("of ...eggs to 'string'"));
+}

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -157,15 +157,6 @@ fn def_with_paren_params() {
 }
 
 #[test]
-fn extern_with_block() {
-    let actual = nu!(
-        "extern-wrapped foo [...rest] { print ($rest | str join ',' ) }; foo --bar baz -- -q -u -x"
-    );
-
-    assert_eq!(actual.out, "--bar,baz,--,-q,-u,-x");
-}
-
-#[test]
 fn def_default_value_shouldnt_restrict_explicit_type() {
     let actual = nu!("def foo [x: any = null] { $x }; foo 1");
     assert_eq!(actual.out, "1");
@@ -192,4 +183,28 @@ fn def_boolean_flags() {
     // boolean flags' default value should be null
     let actual = nu!("def foo [--x: bool] { $x == null }; foo");
     assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn def_wrapped_with_block() {
+    let actual = nu!(
+        "def --wrapped foo [...rest] { print ($rest | str join ',' ) }; foo --bar baz -- -q -u -x"
+    );
+
+    assert_eq!(actual.out, "--bar,baz,--,-q,-u,-x");
+}
+
+#[test]
+fn def_wrapped_from_module() {
+    let actual = nu!(r#"module spam {
+            export def --wrapped my-echo [...rest] { ^echo $rest }
+        }
+
+        use spam
+        spam my-echo foo -b -as -9 --abc -- -Dxmy=AKOO - bar
+        "#);
+
+    assert!(actual
+        .out
+        .contains("foo -b -as -9 --abc -- -Dxmy=AKOO - bar"));
 }

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -259,7 +259,7 @@ fn use_main_4() {
 #[test]
 fn use_main_def_env() {
     let inp = &[
-        r#"module spam { export def-env main [] { $env.SPAM = "spam" } }"#,
+        r#"module spam { export def --env main [] { $env.SPAM = "spam" } }"#,
         r#"use spam"#,
         r#"spam"#,
         r#"$env.SPAM"#,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5340,7 +5340,7 @@ pub fn parse_builtin_commands(
     let name = working_set.get_span_contents(lite_command.parts[0]);
 
     match name {
-        b"def" | b"def-env" => parse_def(working_set, lite_command, None),
+        b"def" | b"def-env" => parse_def(working_set, lite_command, None).0,
         b"extern" | b"extern-wrapped" => parse_extern(working_set, lite_command, None),
         b"let" => parse_let(working_set, &lite_command.parts),
         b"const" => parse_const(working_set, &lite_command.parts),

--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -358,6 +358,10 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::type_mismatch))]
     TypeMismatch(Type, Type, #[label("expected {0}, found {1}")] Span), // expected, found, span
 
+    #[error("Type mismatch.")]
+    #[diagnostic(code(nu::parser::type_mismatch_help), help("{3}"))]
+    TypeMismatchHelp(Type, Type, #[label("expected {0}, found {1}")] Span, String), // expected, found, span, help
+
     #[error("Missing required flag.")]
     #[diagnostic(code(nu::parser::missing_required_flag))]
     MissingRequiredFlag(String, #[label("missing required flag {0}")] Span),
@@ -532,6 +536,7 @@ impl ParseError {
             ParseError::KeywordMissingArgument(_, _, s) => *s,
             ParseError::MissingType(s) => *s,
             ParseError::TypeMismatch(_, _, s) => *s,
+            ParseError::TypeMismatchHelp(_, _, s, _) => *s,
             ParseError::InputMismatch(_, s) => *s,
             ParseError::OutputMismatch(_, s) => *s,
             ParseError::MissingRequiredFlag(_, s) => *s,

--- a/crates/nu-std/CONTRIBUTING.md
+++ b/crates/nu-std/CONTRIBUTING.md
@@ -117,7 +117,7 @@ is described below:
       a main command as well.  
       Use `export def` to make these names public to your users.
     * If your command is updating environment variables, you must use
-      `export def-env` (instead of `export def`) to define the subcommand,
+      `export def --env` (instead of `export def`) to define the subcommand,
       `export-env {}` to initialize the environment variables and `let-env` to
       update them. For an example of a custom command which modifies
       environment variables, see: `./crates/nu-std/lib/dirs.nu`.  

--- a/crates/nu-std/std/dirs.nu
+++ b/crates/nu-std/std/dirs.nu
@@ -23,7 +23,7 @@ export-env {
 
 # Add one or more directories to the list.
 # PWD becomes first of the newly added directories.
-export def-env add [
+export def --env add [
     ...paths: string    # directory or directories to add to working list
     ] {
         mut abspaths = []
@@ -45,7 +45,7 @@ export def-env add [
 export alias enter = add
 
 # Advance to the next directory in the list or wrap to beginning.
-export def-env next [
+export def --env next [
     N:int = 1   # number of positions to move.
 ] {
     _fetch $N
@@ -54,7 +54,7 @@ export def-env next [
 export alias n = next
 
 # Back up to the previous directory or wrap to the end.
-export def-env prev [
+export def --env prev [
     N:int = 1   # number of positions to move.
 ] {
     _fetch (-1 * $N)
@@ -64,7 +64,7 @@ export alias p = prev
 
 # Drop the current directory from the list, if it's not the only one.
 # PWD becomes the next working directory
-export def-env drop [] {
+export def --env drop [] {
     if ($env.DIRS_LIST | length) > 1 {
         $env.DIRS_LIST = ($env.DIRS_LIST | reject $env.DIRS_POSITION)
         if ($env.DIRS_POSITION >= ($env.DIRS_LIST | length)) {$env.DIRS_POSITION = 0}
@@ -78,7 +78,7 @@ export def-env drop [] {
 export alias dexit = drop
 
 # Display current working directories.
-export def-env show [] {
+export def --env show [] {
     mut out = []
     for $p in ($env.DIRS_LIST | enumerate) {
         let is_act_slot = $p.index == $env.DIRS_POSITION
@@ -95,7 +95,7 @@ export def-env show [] {
 
 export alias shells = show
 
-export def-env goto [shell?: int] {
+export def --env goto [shell?: int] {
     if $shell == null {
         return (show)
     }
@@ -119,7 +119,7 @@ export def-env goto [shell?: int] {
 export alias g = goto
 
 # fetch item helper
-def-env _fetch [
+def --env _fetch [
     offset: int,        # signed change to position
     --forget_current    # true to skip saving PWD
     --always_cd         # true to always cd

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -34,7 +34,7 @@ use log.nu
 # ```nushell
 # >_ std path add {linux: "foo", windows: "bar", darwin: "baz"}
 # ```
-export def-env "path add" [
+export def --env "path add" [
     --ret (-r)  # return $env.PATH, useful in pipelines to avoid scoping.
     --append (-a)  # append to $env.PATH instead of prepending to.
     ...paths  # the paths to add to $env.PATH.

--- a/crates/nu-std/tests/test_dirs.nu
+++ b/crates/nu-std/tests/test_dirs.nu
@@ -3,8 +3,8 @@ use std assert
 use std log
 
 # A couple of nuances to understand when testing module that exports environment:
-# Each 'use' for that module in the test script will execute the def-env block.
-# PWD at the time of the `use` will be what the export def-env block will see.
+# Each 'use' for that module in the test script will execute the def --env block.
+# PWD at the time of the `use` will be what the export def --env block will see.
 
 #[before-each]
 def before-each [] {
@@ -43,11 +43,11 @@ def dirs_command [] {
     # must capture value of $in before executing `use`s
     let $c = $in
 
-    # must set PWD *before* doing `use` that will run the def-env block in dirs module.
+    # must set PWD *before* doing `use` that will run the def --env block in dirs module.
     cd $c.base_path
 
     # must execute these uses for the UOT commands *after* the test and *not* just put them at top of test module.
-    # the def-env gets messed up
+    # the def --env gets messed up
     use std dirs
 
     # Stack: [BASE]
@@ -92,7 +92,7 @@ def dirs_command [] {
 def dirs_next [] {
     # must capture value of $in before executing `use`s
     let $c = $in
-    # must set PWD *before* doing `use` that will run the def-env block in dirs module.
+    # must set PWD *before* doing `use` that will run the def --env block in dirs module.
     cd $c.base_path
     assert equal $env.PWD $c.base_path "test setup"
 
@@ -114,7 +114,7 @@ def dirs_next [] {
 def dirs_cd [] {
     # must capture value of $in before executing `use`s
     let $c = $in
-    # must set PWD *before* doing `use` that will run the def-env block in dirs module.
+    # must set PWD *before* doing `use` that will run the def --env block in dirs module.
     cd $c.base_path
 
     use std dirs

--- a/src/tests/test_engine.rs
+++ b/src/tests/test_engine.rs
@@ -189,7 +189,7 @@ fn let_sees_in_variable2() -> TestResult {
 #[test]
 fn def_env() -> TestResult {
     run_test(
-        r#"def-env bob [] { $env.BAR = "BAZ" }; bob; $env.BAR"#,
+        r#"def --env bob [] { $env.BAR = "BAZ" }; bob; $env.BAR"#,
         "BAZ",
     )
 }
@@ -202,7 +202,7 @@ fn not_def_env() -> TestResult {
 #[test]
 fn def_env_hiding_something() -> TestResult {
     fail_test(
-        r#"$env.FOO = "foo"; def-env bob [] { hide-env FOO }; bob; $env.FOO"#,
+        r#"$env.FOO = "foo"; def --env bob [] { hide-env FOO }; bob; $env.FOO"#,
         "",
     )
 }
@@ -210,7 +210,7 @@ fn def_env_hiding_something() -> TestResult {
 #[test]
 fn def_env_then_hide() -> TestResult {
     fail_test(
-        r#"def-env bob [] { $env.BOB = "bob" }; def-env un-bob [] { hide-env BOB }; bob; un-bob; $env.BOB"#,
+        r#"def --env bob [] { $env.BOB = "bob" }; def --env un-bob [] { hide-env BOB }; bob; un-bob; $env.BOB"#,
         "",
     )
 }
@@ -218,7 +218,7 @@ fn def_env_then_hide() -> TestResult {
 #[test]
 fn export_def_env() -> TestResult {
     run_test(
-        r#"module foo { export def-env bob [] { $env.BAR = "BAZ" } }; use foo bob; bob; $env.BAR"#,
+        r#"module foo { export def --env bob [] { $env.BAR = "BAZ" } }; use foo bob; bob; $env.BAR"#,
         "BAZ",
     )
 }

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -54,20 +54,6 @@ fn known_external_from_module() -> TestResult {
 }
 
 #[test]
-fn known_external_wrapped_from_module() -> TestResult {
-    run_test_contains(
-        r#"module spam {
-            export extern-wrapped my-echo [...rest] { ^echo $rest }
-        }
-
-        use spam
-        spam my-echo foo -b -as -9 --abc -- -Dxmy=AKOO - bar
-        "#,
-        "foo -b -as -9 --abc -- -Dxmy=AKOO - bar",
-    )
-}
-
-#[test]
 fn known_external_short_flag_batch_arg_allowed() -> TestResult {
     run_test_contains("extern echo [-a, -b: int]; echo -ab 10", "-b 10")
 }

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1215,7 +1215,7 @@ fn overlay_use_main_prefix() {
 #[test]
 fn overlay_use_main_def_env() {
     let inp = &[
-        r#"module spam { export def-env main [] { $env.SPAM = "spam" } }"#,
+        r#"module spam { export def --env main [] { $env.SPAM = "spam" } }"#,
         "overlay use spam",
         "spam",
         "$env.SPAM",

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -207,7 +207,7 @@ fn run_script_that_looks_like_module() {
             "export use spam eggs",
             "export def foo [] { eggs }",
             "export alias bar = foo",
-            "export def-env baz [] { bar }",
+            "export def --env baz [] { bar }",
             "baz",
         ];
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -130,15 +130,6 @@ fn command_not_found_error_shows_not_found_1() {
 }
 
 #[test]
-fn command_not_found_error_shows_not_found_2() {
-    let actual = nu!(r#"
-            export extern-wrapped my-foo [...rest] { foo };
-            my-foo
-        "#);
-    assert!(actual.err.contains("did you mean"));
-}
-
-#[test]
 fn command_substitution_wont_output_extra_newline() {
     let actual = nu!(r#"
         with-env [FOO "bar"] { echo $"prefix (nu --testbin echo_env FOO) suffix" }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1118,3 +1118,12 @@ fn pipe_input_to_print() {
     assert_eq!(actual.out, "foo");
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn command_not_found_error_shows_not_found_2() {
+    let actual = nu!(r#"
+            export def --wrapped my-foo [...rest] { foo };
+            my-foo
+        "#);
+    assert!(actual.err.contains("did you mean"));
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds `--env` and `--wrapped` flags to `def` to be used instead of `def-env` and `extern-wrapped`. This allows `def --env --wrapped` to be used together, which was not possible before. In addition, it reduces the number of keywords we have and avoids the confusion of `extern-wrapped` being, in fact, a normal command, not a known external.

## Deprecation strategy

Because `def-env` is used everywhere, including virtualenv, I propose the following steps:
* 0.86: Add this PR, keep `def-env` and `extern-wrapped` unchanged.
* 0.87: Add deprecation warning to `def-env` and `extern-wrapped` but keep them working.
* 0.88 (or later): Remove `def-env` and `extern-wrapped`.

## Possible caveat

There is a silent failure if you put the flag between the signature and the block, e.g., `def spam [] --env {}`. I suspect it's because of some signature parsing weirdness. Because signatures are not first-class values, I noticed some weird behavior when I tried to parse them in value situations, such as `let x: signature = ...`. Not 100% but it might be related. Given the new parser is underway, I didn't investigate further, as this code will be replaced anyway.

Doing `def spam [] {} --env` fails with a missing positional error which is also quite unhelpful, but at least it fails

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Apart from the added flags, no changes. There should be no breakages (yet...).

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
