### PR TITLE
make "can't follow stream paths" error a bit better

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{Call, PathMember},
+    ast::{Call, CellPath, PathMember},
     engine::{EngineState, Stack, StateWorkingSet},
     format_error, Config, ListStream, RawStream, ShellError, Span, Value,
 };
@@ -394,11 +394,20 @@ impl PipelineData {
             }
             PipelineData::Value(v, ..) => v.follow_cell_path(cell_path, insensitive),
             PipelineData::Empty => Err(ShellError::IOError(format!(
-                "can't follow path '{:?}' in empty stream",
-                cell_path
+                "can't follow path '{}' in empty stream",
+                CellPath {
+                    members: cell_path.to_vec()
+                }
+                .into_string()
             ))),
             PipelineData::ExternalStream { span, .. } => Err(ShellError::IOErrorSpanned(
-                format!("can't follow path '{:?}' in external stream", cell_path,),
+                format!(
+                    "can't follow path '{}' in external stream",
+                    CellPath {
+                        members: cell_path.to_vec()
+                    }
+                    .into_string()
+                ),
                 span,
             )),
         }

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ast::{Call, CellPath, PathMember},
+    ast::{Call, PathMember},
     engine::{EngineState, Stack, StateWorkingSet},
     format_error, Config, ListStream, RawStream, ShellError, Span, Value,
 };

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -393,7 +393,14 @@ impl PipelineData {
                 Value::list(stream.collect(), head).follow_cell_path(cell_path, insensitive)
             }
             PipelineData::Value(v, ..) => v.follow_cell_path(cell_path, insensitive),
-            _ => Err(ShellError::IOError("can't follow stream paths".into())),
+            PipelineData::Empty => Err(ShellError::IOError(format!(
+                "can't follow path '{:?}' in empty stream",
+                cell_path
+            ))),
+            PipelineData::ExternalStream { span, .. } => Err(ShellError::IOErrorSpanned(
+                format!("can't follow path '{:?}' in external stream", cell_path,),
+                span,
+            )),
         }
     }
 

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -393,23 +393,14 @@ impl PipelineData {
                 Value::list(stream.collect(), head).follow_cell_path(cell_path, insensitive)
             }
             PipelineData::Value(v, ..) => v.follow_cell_path(cell_path, insensitive),
-            PipelineData::Empty => Err(ShellError::IOError(format!(
-                "can't follow path '{}' in empty stream",
-                CellPath {
-                    members: cell_path.to_vec()
-                }
-                .into_string()
-            ))),
-            PipelineData::ExternalStream { span, .. } => Err(ShellError::IOErrorSpanned(
-                format!(
-                    "can't follow path '{}' in external stream",
-                    CellPath {
-                        members: cell_path.to_vec()
-                    }
-                    .into_string()
-                ),
+            PipelineData::Empty => Err(ShellError::IncompatiblePathAccess {
+                type_name: "empty pipeline".to_string(),
+                span: head,
+            }),
+            PipelineData::ExternalStream { span, .. } => Err(ShellError::IncompatiblePathAccess {
+                type_name: "external stream".to_string(),
                 span,
-            )),
+            }),
         }
     }
 


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/issues/9373
- https://github.com/nushell/nushell/issues/8639

might be able to close https://github.com/nushell/nushell/issues/8639? 

# Description
"can't follow stream paths" errors have always been a bit scary and obnoxious because they give no information about what happens...

in this PR i try to slightly improve the error message by telling if the stream was empty or not and give span information when available.

# User-Facing Changes
```nushell
> update value (get value)
Error: nu::shell::incompatible_path_access

  × Data cannot be accessed with a cell path
   ╭─[entry #1:1:1]
 1 │ update value (get value)
   ·               ─┬─
   ·                ╰── empty pipeline doesn't support cell paths
   ╰────
```
```nushell
> ^echo "foo" | get 0
Error: nu::shell::incompatible_path_access

  × Data cannot be accessed with a cell path
   ╭─[entry #2:1:1]
 1 │ ^echo "foo" | get 0
   ·  ──┬─
   ·    ╰── external stream doesn't support cell paths
   ╰────
```

# Tests + Formatting

# After Submitting