### PR TITLE
`explore`: remove unused colour config code

### DIFF
--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -209,8 +209,6 @@ fn prepare_default_config(config: &mut HashMap<String, Value>) {
 
     const TABLE_SELECT_COLUMN: Style = color(None, None);
 
-    const CONFIG_CURSOR_COLOR: Style = color(Some(Color::Black), Some(Color::LightYellow));
-
     insert_style(config, "status_bar_background", STATUS_BAR);
     insert_style(config, "command_bar_text", INPUT_BAR);
     insert_style(config, "highlight", HIGHLIGHT);
@@ -243,17 +241,6 @@ fn prepare_default_config(config: &mut HashMap<String, Value>) {
         insert_style(&mut hm, "selected_column", TABLE_SELECT_COLUMN);
 
         config.insert(String::from("table"), map_into_value(hm));
-    }
-
-    {
-        let mut hm = config
-            .get("config")
-            .and_then(parse_hash_map)
-            .unwrap_or_default();
-
-        insert_style(&mut hm, "cursor_color", CONFIG_CURSOR_COLOR);
-
-        config.insert(String::from("config"), map_into_value(hm));
     }
 }
 
@@ -307,25 +294,12 @@ fn insert_bool(map: &mut HashMap<String, Value>, key: &str, value: bool) {
 fn include_nu_config(config: &mut HashMap<String, Value>, style_computer: &StyleComputer) {
     let line_color = lookup_color(style_computer, "separator");
     if line_color != nu_ansi_term::Style::default() {
-        {
-            let mut map = config
-                .get("table")
-                .and_then(parse_hash_map)
-                .unwrap_or_default();
-            insert_style(&mut map, "split_line", line_color);
-            config.insert(String::from("table"), map_into_value(map));
-        }
-
-        {
-            let mut map = config
-                .get("config")
-                .and_then(parse_hash_map)
-                .unwrap_or_default();
-
-            insert_style(&mut map, "border_color", line_color);
-
-            config.insert(String::from("config"), map_into_value(map));
-        }
+        let mut map = config
+            .get("table")
+            .and_then(parse_hash_map)
+            .unwrap_or_default();
+        insert_style(&mut map, "split_line", line_color);
+        config.insert(String::from("table"), map_into_value(map));
     }
 }
 


### PR DESCRIPTION
Remove code for 2 no-longer-used configuration options in `explore`: `explore.config.cursor_color` and `explore.config.border_color`.

Think I made these unnecessary in https://github.com/nushell/nushell/pull/10533 and https://github.com/nushell/nushell/pull/10270 but missed this code, my bad. The `explore` config code is a little hard to follow because it does so many key lookups in hashmaps.