### PR TITLE
Use `int` type name consistently

### DIFF
--- a/crates/nu-cli/src/commands/commandline.rs
+++ b/crates/nu-cli/src/commands/commandline.rs
@@ -91,7 +91,7 @@ impl Command for Commandline {
                             from_type: "string".to_string(),
                             span: cmd.span(),
                             help: Some(format!(
-                                r#"string "{cmd_str}" does not represent a valid integer"#
+                                r#"string "{cmd_str}" does not represent a valid int"#
                             )),
                         })
                     }

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -25,13 +25,13 @@ impl Command for BitsAnd {
             .required(
                 "target",
                 SyntaxShape::Int,
-                "target integer to perform bit and",
+                "target int to perform bit and",
             )
             .category(Category::Bits)
     }
 
     fn usage(&self) -> &str {
-        "Performs bitwise and for integers."
+        "Performs bitwise and for ints."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -85,7 +85,7 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "int".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/into.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/into.rs
@@ -219,7 +219,7 @@ pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer, filesize, string, date, duration, binary or bool".into(),
+                exp_input_type: "int, filesize, string, date, duration, binary, or bool".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -158,7 +158,7 @@ fn operate(value: Value, head: Span, signed: bool, number_size: NumberBytes) -> 
             Value::Error { .. } => other,
             _ => Value::error(
                 ShellError::OnlySupportsThisInputType {
-                    exp_input_type: "integer".into(),
+                    exp_input_type: "int".into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/or.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/or.rs
@@ -25,13 +25,13 @@ impl Command for BitsOr {
             .required(
                 "target",
                 SyntaxShape::Int,
-                "target integer to perform bit or",
+                "target int to perform bit or",
             )
             .category(Category::Bits)
     }
 
     fn usage(&self) -> &str {
-        "Performs bitwise or for integers."
+        "Performs bitwise or for ints."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -85,7 +85,7 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "int".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -41,7 +41,7 @@ impl Command for BitsRol {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise rotate left for integers."
+        "Bitwise rotate left for ints."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -145,7 +145,7 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "int".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -41,7 +41,7 @@ impl Command for BitsRor {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise rotate right for integers."
+        "Bitwise rotate right for ints."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -149,7 +149,7 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "int".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -41,7 +41,7 @@ impl Command for BitsShl {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise shift left for integers."
+        "Bitwise shift left for ints."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -169,7 +169,7 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "int".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -41,7 +41,7 @@ impl Command for BitsShr {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise shift right for integers."
+        "Bitwise shift right for ints."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -159,7 +159,7 @@ fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: Num
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "int".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/xor.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/xor.rs
@@ -25,13 +25,13 @@ impl Command for BitsXor {
             .required(
                 "target",
                 SyntaxShape::Int,
-                "target integer to perform bit xor",
+                "target int to perform bit xor",
             )
             .category(Category::Bits)
     }
 
     fn usage(&self) -> &str {
-        "Performs bitwise xor for integers."
+        "Performs bitwise xor for ints."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -84,7 +84,7 @@ fn operate(value: Value, target: i64, head: Span) -> Value {
         Value::Error { .. } => value,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer".into(),
+                exp_input_type: "int".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/conversions/fmt.rs
+++ b/crates/nu-cmd-extra/src/extra/conversions/fmt.rs
@@ -88,7 +88,7 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "float , integer or filesize".into(),
+                exp_input_type: "float, int, or filesize".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -199,7 +199,7 @@ impl Command for For {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Echo the square of each integer",
+                description: "Print the square of each integer",
                 example: "for x in [1 2 3] { print ($x * $x) }",
                 result: None,
             },
@@ -209,7 +209,7 @@ impl Command for For {
                 result: None,
             },
             Example {
-                description: "Number each item and echo a message",
+                description: "Number each item and print a message",
                 example:
                     "for $it in ['bob' 'fred'] --numbered { print $\"($it.index) is ($it.item)\" }",
                 result: None,

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -116,7 +116,7 @@ impl Command for SubCommand {
             },
             Example {
                 description:
-                    "convert an integer to a nushell binary primitive with compact enabled",
+                    "convert an int to a nushell binary primitive with compact enabled",
                 example: "10 | into binary --compact",
                 result: Some(Value::binary(vec![10], Span::test_data())),
             },
@@ -172,7 +172,7 @@ pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer, float, filesize, string, date, duration, binary or bool"
+                exp_input_type: "int, float, filesize, string, date, duration, binary, or bool"
                     .into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -90,7 +90,7 @@ impl Command for SubCommand {
                 result: Some(Value::bool(true, span)),
             },
             Example {
-                description: "convert integer to boolean",
+                description: "convert int to boolean",
                 example: "1 | into bool",
                 result: Some(Value::bool(true, span)),
             },
@@ -159,7 +159,7 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "bool, integer, float or string".into(),
+                exp_input_type: "bool, int, float or string".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: other.span(),

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -256,7 +256,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         other => {
             return Value::error(
                 ShellError::OnlySupportsThisInputType {
-                    exp_input_type: "string and integer".into(),
+                    exp_input_type: "string and int".into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),

--- a/crates/nu-command/src/conversions/into/decimal.rs
+++ b/crates/nu-command/src/conversions/into/decimal.rs
@@ -138,7 +138,7 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "string, integer or bool".into(),
+                exp_input_type: "string, int, or bool".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -136,7 +136,7 @@ pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         Value::Nothing { .. } => Value::filesize(0, value_span),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "string and integer".into(),
+                exp_input_type: "string and int".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
                 src_span: value_span,

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -121,7 +121,7 @@ fn action(input: &Value, _args: &CellPathOnlyArgs, head: Span) -> Value {
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "string, integer or bool".into(),
+                exp_input_type: "string, int or bool".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -158,32 +158,32 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Convert string to integer in table",
+                description: "Convert string to int in table",
                 example: "[[num]; ['-5'] [4] [1.5]] | into int num",
                 result: None,
             },
             Example {
-                description: "Convert string to integer",
+                description: "Convert string to int",
                 example: "'2' | into int",
                 result: Some(Value::test_int(2)),
             },
             Example {
-                description: "Convert float to integer",
+                description: "Convert float to int",
                 example: "5.9 | into int",
                 result: Some(Value::test_int(5)),
             },
             Example {
-                description: "Convert decimal string to integer",
+                description: "Convert decimal string to int",
                 example: "'5.9' | into int",
                 result: Some(Value::test_int(5)),
             },
             Example {
-                description: "Convert file size to integer",
+                description: "Convert file size to int",
                 example: "4KB | into int",
                 result: Some(Value::test_int(4000)),
             },
             Example {
-                description: "Convert bool to integer",
+                description: "Convert bool to int",
                 example: "[false, true] | into int",
                 result: Some(Value::list(
                     vec![Value::test_int(0), Value::test_int(1)],
@@ -191,32 +191,32 @@ impl Command for SubCommand {
                 )),
             },
             Example {
-                description: "Convert date to integer (Unix nanosecond timestamp)",
+                description: "Convert date to int (Unix nanosecond timestamp)",
                 example: "1983-04-13T12:09:14.123456789-05:00 | into int",
                 result: Some(Value::test_int(419101754123456789)),
             },
             Example {
-                description: "Convert to integer from binary",
+                description: "Convert to int from binary data (radix: 2)",
                 example: "'1101' | into int -r 2",
                 result: Some(Value::test_int(13)),
             },
             Example {
-                description: "Convert to integer from hex",
+                description: "Convert to int from hex",
                 example: "'FF' |  into int -r 16",
                 result: Some(Value::test_int(255)),
             },
             Example {
-                description: "Convert octal string to integer",
+                description: "Convert octal string to int",
                 example: "'0o10132' | into int",
                 result: Some(Value::test_int(4186)),
             },
             Example {
-                description: "Convert 0 padded string to integer",
+                description: "Convert 0 padded string to int",
                 example: "'0010132' | into int",
                 result: Some(Value::test_int(10132)),
             },
             Example {
-                description: "Convert 0 padded string to integer with radix",
+                description: "Convert 0 padded string to int with radix 8",
                 example: "'0010132' | into int -r 8",
                 result: Some(Value::test_int(4186)),
             },
@@ -248,7 +248,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
                             return Value::error(
                                 ShellError::CantConvert {
                                     to_type: "float".to_string(),
-                                    from_type: "integer".to_string(),
+                                    from_type: "int".to_string(),
                                     span,
                                     help: None,
                                 },
@@ -327,7 +327,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
         Value::Error { .. } => input.clone(),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "integer, float, filesize, date, string, binary, duration or bool"
+                exp_input_type: "int, float, filesize, date, string, binary, duration, or bool"
                     .into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: span,
@@ -376,7 +376,7 @@ fn convert_int(input: &Value, head: Span, radix: u32) -> Value {
         other => {
             return Value::error(
                 ShellError::OnlySupportsThisInputType {
-                    exp_input_type: "string and integer".into(),
+                    exp_input_type: "string and int".into(),
                     wrong_type: other.get_type().to_string(),
                     dst_span: head,
                     src_span: other.span(),

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -84,7 +84,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "convert integer to string and append three decimal places",
+                description: "convert int to string and append three decimal places",
                 example: "5 | into string -d 3",
                 result: Some(Value::test_string("5.000")),
             },

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -41,7 +41,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
         vec![
             Example {
                 example: "[0 1 2 3] | append 4",
-                description: "Append one integer to a list",
+                description: "Append one int to a list",
                 result: Some(Value::test_list(vec![
                     Value::test_int(0),
                     Value::test_int(1),
@@ -70,7 +70,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[0 1] | append [2 3 4]",
-                description: "Append three integer items",
+                description: "Append three int items",
                 result: Some(Value::test_list(vec![
                     Value::test_int(0),
                     Value::test_int(1),
@@ -81,7 +81,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[0 1] | append [2 nu 4 shell]",
-                description: "Append integers and strings",
+                description: "Append ints and strings",
                 result: Some(Value::test_list(vec![
                     Value::test_int(0),
                     Value::test_int(1),
@@ -93,7 +93,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[0 1] | append 2..4",
-                description: "Append a range of integers to a list",
+                description: "Append a range of ints to a list",
                 result: Some(Value::test_list(vec![
                     Value::test_int(0),
                     Value::test_int(1),

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -122,7 +122,7 @@ impl Command for DropNth {
                 if from.is_negative() || to.is_negative() {
                     let span: Spanned<Range> = call.req(engine_state, stack, 0)?;
                     return Err(ShellError::TypeMismatch {
-                        err_message: "drop nth accepts only positive integers".to_string(),
+                        err_message: "drop nth accepts only positive ints".to_string(),
                         span: span.span,
                     });
                 }

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -62,7 +62,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[1 2 3 4] | prepend 0",
-                description: "Prepend one integer item",
+                description: "Prepend one int item",
                 result: Some(Value::test_list(vec![
                     Value::test_int(0),
                     Value::test_int(1),
@@ -73,7 +73,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[2 3 4] | prepend [0 1]",
-                description: "Prepend two integer items",
+                description: "Prepend two int items",
                 result: Some(Value::test_list(vec![
                     Value::test_int(0),
                     Value::test_int(1),
@@ -84,7 +84,7 @@ only unwrap the outer list, and leave the variable's contents untouched."#
             },
             Example {
                 example: "[2 nu 4 shell] | prepend [0 1 rocks]",
-                description: "Prepend integers and strings",
+                description: "Prepend ints and strings",
                 result: Some(Value::test_list(vec![
                     Value::test_int(0),
                     Value::test_int(1),

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -81,14 +81,14 @@ impl Command for Skip {
                     Value::Int { val, .. } => {
                         val.try_into().map_err(|err| ShellError::TypeMismatch {
                             err_message: format!(
-                                "Could not convert {val} to unsigned integer: {err}"
+                                "Could not convert {val} to unsigned int: {err}"
                             ),
                             span,
                         })?
                     }
                     _ => {
                         return Err(ShellError::TypeMismatch {
-                            err_message: "expected integer".into(),
+                            err_message: "expected int".into(),
                             span,
                         })
                     }

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -97,7 +97,7 @@ impl Command for ToNuon {
                 result: Some(Value::test_string("[1, 2, 3]"))
             },
             Example {
-                description: "Outputs a NUON array of integers, with pretty indentation",
+                description: "Outputs a NUON array of ints, with pretty indentation",
                 example: "[1 2 3] | to nuon --indent 2",
                 result: Some(Value::test_string("[\n  1,\n  2,\n  3\n]")),
             },

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -108,7 +108,7 @@ pub fn calculate(
         PipelineData::Value(val, ..) => mf(&[val], span, name),
         PipelineData::Empty { .. } => Err(ShellError::PipelineEmpty { dst_span: name }),
         val => Err(ShellError::UnsupportedInput(
-            "Only integers, floats, lists, records or ranges are supported".into(),
+            "Only ints, floats, lists, records, or ranges are supported".into(),
             "value originates from here".into(),
             name,
             // This requires both the ListStream and Empty match arms to be above it.

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -66,7 +66,7 @@ fn sum_of_squares(values: &[Value], span: Span) -> Result<Value, ShellError> {
             Value::Int { .. } | Value::Float { .. } => Ok(value),
             Value::Error { error, .. } => Err(*error.clone()),
             _ => Err(ShellError::UnsupportedInput(
-                "Attempted to compute the sum of squares of a non-integer, non-float value"
+                "Attempted to compute the sum of squares of a non-int, non-float value"
                     .to_string(),
                 "value originates from here".into(),
                 span,

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -288,7 +288,7 @@ pub fn request_set_timeout(
         let val = timeout.as_i64()?;
         if val.is_negative() || val < 1 {
             return Err(ShellError::TypeMismatch {
-                err_message: "Timeout value must be an integer and larger than 0".to_string(),
+                err_message: "Timeout value must be an int and larger than 0".to_string(),
                 span: timeout.span(),
             });
         }

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -152,7 +152,7 @@ impl UrlComponents {
                             }),
                             Err(_) => Err(ShellError::IncompatibleParametersSingle {
                                 msg: String::from(
-                                    "Port parameter should represent an unsigned integer",
+                                    "Port parameter should represent an unsigned int",
                                 ),
                                 span,
                             }),
@@ -166,7 +166,7 @@ impl UrlComponents {
                 Value::Error { error, .. } => Err(*error),
                 other => Err(ShellError::IncompatibleParametersSingle {
                     msg: String::from(
-                        "Port parameter should be an unsigned integer or a string representing it",
+                        "Port parameter should be an unsigned int or a string representing it",
                     ),
                     span: other.span(),
                 }),

--- a/crates/nu-command/tests/commands/random/int.rs
+++ b/crates/nu-command/tests/commands/random/int.rs
@@ -2,21 +2,21 @@ use nu_test_support::nu;
 
 #[test]
 fn generates_an_integer() {
-    let actual = nu!("random integer 42..43");
+    let actual = nu!("random int 42..43");
 
     assert!(actual.out.contains("42") || actual.out.contains("43"));
 }
 
 #[test]
 fn generates_55() {
-    let actual = nu!("random integer 55..55");
+    let actual = nu!("random int 55..55");
 
     assert!(actual.out.contains("55"));
 }
 
 #[test]
 fn generates_0() {
-    let actual = nu!("random integer ..<1");
+    let actual = nu!("random int ..<1");
 
     assert!(actual.out.contains('0'));
 }

--- a/crates/nu-command/tests/commands/random/mod.rs
+++ b/crates/nu-command/tests/commands/random/mod.rs
@@ -2,6 +2,6 @@ mod bool;
 mod chars;
 mod dice;
 mod float;
-mod integer;
+mod int;
 #[cfg(feature = "uuid_crate")]
 mod uuid;

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -26,7 +26,7 @@ impl FromValue for Spanned<i64> {
             Value::Duration { val, .. } => Ok(Spanned { item: *val, span }),
 
             v => Err(ShellError::CantConvert {
-                to_type: "integer".into(),
+                to_type: "int".into(),
                 from_type: v.get_type().to_string(),
                 span: v.span(),
                 help: None,
@@ -43,7 +43,7 @@ impl FromValue for i64 {
             Value::Duration { val, .. } => Ok(*val),
 
             v => Err(ShellError::CantConvert {
-                to_type: "integer".into(),
+                to_type: "int".into(),
                 from_type: v.get_type().to_string(),
                 span: v.span(),
                 help: None,
@@ -123,7 +123,7 @@ impl FromValue for Spanned<usize> {
             }
 
             v => Err(ShellError::CantConvert {
-                to_type: "non-negative integer".into(),
+                to_type: "non-negative int".into(),
                 from_type: v.get_type().to_string(),
                 span: v.span(),
                 help: None,
@@ -159,7 +159,7 @@ impl FromValue for usize {
             }
 
             v => Err(ShellError::CantConvert {
-                to_type: "non-negative integer".into(),
+                to_type: "non-negative int".into(),
                 from_type: v.get_type().to_string(),
                 span: v.span(),
                 help: None,

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -255,7 +255,7 @@ impl Value {
         match self {
             Value::Int { val, .. } => Ok(*val),
             x => Err(ShellError::CantConvert {
-                to_type: "integer".into(),
+                to_type: "int".into(),
                 from_type: x.get_type().to_string(),
                 span: self.span(),
                 help: None,

--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -124,6 +124,6 @@ fn commandline_test_cursor_invalid() -> TestResult {
     fail_test(
         "commandline --replace '123456'\n\
         commandline --cursor 'abc'",
-        r#"string "abc" does not represent a valid integer"#,
+        r#"string "abc" does not represent a valid int"#,
     )
 }


### PR DESCRIPTION
# Description
When referring to the type use `int` consistently. Only when referring to the concept of integer numbers use `integer`.

- Fix `random integer` to `random int` tests
  - Forgot in #10520
- Use int instead of integer in error messages
- Use int type name in bits commands
- Fix messages in `for` examples
- Use int typename in `into` commands
- Use int typename in rest of commands
- Report errors in `nu-protocol` with int typename

# User-Facing Changes
User errorrs should now use `int` so you can easily find the necessary commands or type annotations.

# Tests + Formatting
Only one test found that needed updating
