### PR TITLE
Allow auto-cd on trailing slash

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -826,11 +826,11 @@ fn looks_like_path(orig: &str) -> bool {
 #[cfg(windows)]
 #[test]
 fn looks_like_path_windows_drive_path_works() {
-    assert_eq!(looks_like_path("C:"), true);
-    assert_eq!(looks_like_path("D:\\"), true);
-    assert_eq!(looks_like_path("E:/"), true);
-    assert_eq!(looks_like_path("F:\\some_dir"), true);
-    assert_eq!(looks_like_path("G:/some_dir"), true);
+    assert!(looks_like_path("C:"));
+    assert!(looks_like_path("D:\\"));
+    assert!(looks_like_path("E:/"));
+    assert!(looks_like_path("F:\\some_dir"));
+    assert!(looks_like_path("G:/some_dir"));
 }
 
 #[cfg(windows)]

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -823,14 +823,26 @@ fn looks_like_path(orig: &str) -> bool {
         || orig.ends_with(std::path::MAIN_SEPARATOR)
 }
 
+#[cfg(windows)]
 #[test]
 fn looks_like_path_windows_drive_path_works() {
-    let on_windows = cfg!(windows);
-    assert_eq!(looks_like_path("C:"), on_windows);
-    assert_eq!(looks_like_path("D:\\"), on_windows);
-    assert_eq!(looks_like_path("E:/"), on_windows);
-    assert_eq!(looks_like_path("F:\\some_dir"), on_windows);
-    assert_eq!(looks_like_path("G:/some_dir"), on_windows);
+    assert_eq!(looks_like_path("C:"), true);
+    assert_eq!(looks_like_path("D:\\"), true);
+    assert_eq!(looks_like_path("E:/"), true);
+    assert_eq!(looks_like_path("F:\\some_dir"), true);
+    assert_eq!(looks_like_path("G:/some_dir"), true);
+}
+
+#[cfg(windows)]
+#[test]
+fn trailing_slash_looks_like_path() {
+    assert!(looks_like_path("foo\\"))
+}
+
+#[cfg(not(windows))]
+#[test]
+fn trailing_slash_looks_like_path() {
+    assert!(looks_like_path("foo/"))
 }
 
 #[test]

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -820,6 +820,7 @@ fn looks_like_path(orig: &str) -> bool {
         || orig.starts_with('~')
         || orig.starts_with('/')
         || orig.starts_with('\\')
+        || orig.ends_with(std::path::MAIN_SEPARATOR)
 }
 
 #[test]


### PR DESCRIPTION
# Description

This allows auto-cd (cd'ing by just typing the directory name with `cd`) to work if there's a trailing slash in the path.

# User-Facing Changes

This should be an improvement over previous behaviour. I don't think this clashes with any existing assumptions.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
