### PR TITLE
engine eval.rs remove pub from fn eval_element_with_input

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -718,7 +718,7 @@ fn might_consume_external_result(input: PipelineData) -> (PipelineData, bool) {
     input.is_external_failed()
 }
 
-pub fn eval_element_with_input(
+fn eval_element_with_input(
     engine_state: &EngineState,
     stack: &mut Stack,
     element: &PipelineElement,


### PR DESCRIPTION

code cleanup of *eval.rs*

I was reviewing the engine code and noticed this...

The *eval_element_with_input* method in eval.rs does not need to be public at the moment
because no one is calling it...

@jntrnr is making this method not public going to block someone in the future who might need it ?

Right now its not being used so I decided to tighten up the API a bit... 
