### PR TITLE
Fix #10506 by adding `ExpectedNonNull` `ShellError` if required field is entered as `$nothing`, `null`, "", etc.

### DIFF
--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -286,7 +286,7 @@ impl UrlComponents {
                                 engine_state,
                                 &ShellError::GenericError(
                                     format!("'{key}' is not a valid URL field"),
-                                    format!("Remove '{key}' col from input record"),
+                                    format!("remove '{key}' col from input record"),
                                     Some(span),
                                     None,
                                     vec![],

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -227,7 +227,7 @@ impl UrlComponents {
         match value.as_string() {
             Ok(s) => {
                 if s.trim().is_empty() {
-                    Ok(self)
+                    self.check_required(key, value_span)
                 } else {
                     match key.as_str() {
                         "host" => Ok(Self {
@@ -297,6 +297,20 @@ impl UrlComponents {
                     }
                 }
             }
+            _ => self.check_required(key, value_span),
+        }
+    }
+
+    fn check_required(self, key: String, value_span: Span) -> Result<Self, ShellError> {
+        match key.as_str() {
+            "host" => Err(ShellError::ExpectedNonNull {
+                exp_type: "string".into(),
+                span: value_span,
+            }),
+            "scheme" => Err(ShellError::ExpectedNonNull {
+                exp_type: "string".into(),
+                span: value_span,
+            }),
             _ => Ok(self),
         }
     }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -170,6 +170,19 @@ pub enum ShellError {
         span: Span,
     },
 
+    /// A command parameter is expected to be non-null.
+    ///
+    /// ## Resolution
+    ///
+    /// Pass a non-null value.
+    #[error("Expected {exp_type} found null.")]
+    #[diagnostic(code(nu::shell::expected_non_null))]
+    ExpectedNonNull {
+        exp_type: String,
+        #[label = "expected {exp_type}, found null"]
+        span: Span,
+    },
+
     /// An expected command parameter is missing.
     ///
     /// ## Resolution


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Fix #10506 by adding `ExpectedNonNull` `ShellError` if required field is entered as `$nothing`, `null`, " ", etc.

This adds a new `ShellError`, `ExpectedNonNull`, taking the expected type and span.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Will get a more helpful error in the case described by #10506. Examples:
```nushell
➜ {scheme: "", host: "github.com"} | url join
Error: nu::shell::expected_non_null

  × Expected string found null.
   ╭─[entry #16:1:1]
 1 │ {scheme: "", host: "github.com"} | url join
   ·          ─┬
   ·           ╰── expected string, found null
   ╰────
```

```nushell
❯ {scheme: "https", host: null} | url join
Error: nu::shell::expected_non_null

  × Expected string found null.
   ╭─[entry #19:1:1]
 1 │ {scheme: "https", host: null} | url join
   ·                         ──┬─
   ·                           ╰── expected string, found null
   ╰────
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
All pass.

