### PR TITLE
AnyTable and AnyRecord types

### DIFF
--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -16,7 +16,7 @@ impl Command for DropColumn {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Table(vec![]), Type::AnyTable)])
             .optional(
                 "columns",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -18,7 +18,7 @@ impl Command for Drop {
     fn signature(&self) -> Signature {
         Signature::build("drop")
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/enumerate.rs
+++ b/crates/nu-command/src/filters/enumerate.rs
@@ -23,7 +23,7 @@ impl Command for Enumerate {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("enumerate")
-            .input_output_types(vec![(Type::Any, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Any, Type::AnyTable)])
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -31,7 +31,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (Type::Range, Type::List(Box::new(Type::Any))),
             ])
             .required(

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -33,7 +33,7 @@ impl Command for Find {
                 (
                     // For find -p
                     Type::Table(vec![]),
-                    Type::Table(vec![]),
+                    Type::AnyTable,
                 ),
             ])
             .named(

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -22,7 +22,7 @@ impl Command for Flatten {
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
-                (Type::Record(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyTable),
             ])
             .rest(
                 "rest",

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -22,10 +22,7 @@ impl Command for GroupBy {
             // example. Perhaps Table should be a subtype of List, in which case
             // the current signature would suffice even when a Table example
             // exists.
-            .input_output_types(vec![(
-                Type::List(Box::new(Type::Any)),
-                Type::AnyRecord,
-            )])
+            .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::AnyRecord)])
             .optional(
                 "grouper",
                 SyntaxShape::OneOf(vec![

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -24,7 +24,7 @@ impl Command for GroupBy {
             // exists.
             .input_output_types(vec![(
                 Type::List(Box::new(Type::Any)),
-                Type::Record(vec![]),
+                Type::AnyRecord,
             )])
             .optional(
                 "grouper",

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -16,11 +16,11 @@ impl Command for Headers {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     // Tables with missing values are List<Any>
                     Type::List(Box::new(Type::Any)),
-                    Type::Table(vec![]),
+                    Type::AnyTable,
                 ),
             ])
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -49,7 +49,7 @@ impl Command for Join {
             .switch("left", "Left-outer join", Some('l'))
             .switch("right", "Right-outer join", Some('r'))
             .switch("outer", "Outer join", Some('o'))
-            .input_output_types(vec![(Type::Table(vec![]), Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Table(vec![]), Type::AnyTable)])
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -29,8 +29,8 @@ repeating this process with row 1, and so on."#
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("merge")
             .input_output_types(vec![
-                (Type::Record(vec![]), Type::Record(vec![])),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyRecord),
+                (Type::Table(vec![]), Type::AnyTable),
             ])
             .required(
                 "value",

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -27,8 +27,8 @@ impl Command for Move {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("move")
             .input_output_types(vec![
-                (Type::Record(vec![]), Type::Record(vec![])),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyRecord),
+                (Type::Table(vec![]), Type::AnyTable),
             ])
             .rest("columns", SyntaxShape::String, "the columns to move")
             .named(

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -19,8 +19,8 @@ impl Command for Reject {
     fn signature(&self) -> Signature {
         Signature::build("reject")
             .input_output_types(vec![
-                (Type::Record(vec![]), Type::Record(vec![])),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyRecord),
+                (Type::Table(vec![]), Type::AnyTable),
             ])
             .rest(
                 "rest",

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -19,8 +19,8 @@ impl Command for Rename {
     fn signature(&self) -> Signature {
         Signature::build("rename")
             .input_output_types(vec![
-                (Type::Record(vec![]), Type::Record(vec![])),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyRecord),
+                (Type::Table(vec![]), Type::AnyTable),
             ])
             .named(
                 "column",

--- a/crates/nu-command/src/filters/reverse.rs
+++ b/crates/nu-command/src/filters/reverse.rs
@@ -20,7 +20,7 @@ impl Command for Reverse {
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
             ])
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -19,8 +19,8 @@ impl Command for Select {
     fn signature(&self) -> Signature {
         Signature::build("select")
             .input_output_types(vec![
-                (Type::Record(vec![]), Type::Record(vec![])),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyRecord),
+                (Type::Table(vec![]), Type::AnyTable),
                 (Type::List(Box::new(Type::Any)), Type::Any),
             ])
             .switch(

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -19,7 +19,7 @@ impl Command for Skip {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -17,7 +17,7 @@ impl Command for SkipUntil {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -17,7 +17,7 @@ impl Command for SkipWhile {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -20,7 +20,7 @@ impl Command for Sort {
         .input_output_types(vec![(
             Type::List(Box::new(Type::Any)),
             Type::List(Box::new(Type::Any)),
-        ), (Type::Record(vec![]), Type::Record(vec![])),])
+        ), (Type::Record(vec![]), Type::AnyRecord),])
     .switch("reverse", "Sort in reverse order", Some('r'))
             .switch(
                 "ignore-case",

--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -17,7 +17,7 @@ impl Command for SortBy {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("sort-by")
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -17,7 +17,7 @@ impl Command for SplitBy {
 
     fn signature(&self) -> Signature {
         Signature::build("split-by")
-            .input_output_types(vec![(Type::Record(vec![]), Type::Record(vec![]))])
+            .input_output_types(vec![(Type::Record(vec![]), Type::AnyRecord)])
             .optional("splitter", SyntaxShape::Any, "the splitter value to use")
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -17,7 +17,7 @@ impl Command for Take {
     fn signature(&self) -> Signature {
         Signature::build("take")
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -17,7 +17,7 @@ impl Command for TakeUntil {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -17,7 +17,7 @@ impl Command for TakeWhile {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -28,7 +28,7 @@ impl Command for Transpose {
         Signature::build("transpose")
             .input_output_types(vec![
                 (Type::Table(vec![]), Type::Any),
-                (Type::Record(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyTable),
             ])
             .switch(
                 "header-row",

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -27,7 +27,7 @@ impl Command for Uniq {
                 (
                     // -c
                     Type::List(Box::new(Type::Any)),
-                    Type::Table(vec![]),
+                    Type::AnyTable,
                 ),
             ])
             .switch(

--- a/crates/nu-command/src/filters/uniq_by.rs
+++ b/crates/nu-command/src/filters/uniq_by.rs
@@ -18,7 +18,7 @@ impl Command for UniqBy {
     fn signature(&self) -> Signature {
         Signature::build("uniq-by")
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -17,8 +17,8 @@ impl Command for Update {
     fn signature(&self) -> Signature {
         Signature::build("update")
             .input_output_types(vec![
-                (Type::Record(vec![]), Type::Record(vec![])),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyRecord),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -17,8 +17,8 @@ impl Command for Upsert {
     fn signature(&self) -> Signature {
         Signature::build("upsert")
             .input_output_types(vec![
-                (Type::Record(vec![]), Type::Record(vec![])),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Record(vec![]), Type::AnyRecord),
+                (Type::Table(vec![]), Type::AnyTable),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -31,7 +31,7 @@ not supported."#
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::AnyTable),
                 (Type::Range, Type::Any),
             ])
             .required(

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -21,9 +21,9 @@ impl Command for Wrap {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("wrap")
             .input_output_types(vec![
-                (Type::List(Box::new(Type::Any)), Type::Table(vec![])),
-                (Type::Range, Type::Table(vec![])),
-                (Type::Any, Type::Record(vec![])),
+                (Type::List(Box::new(Type::Any)), Type::AnyTable),
+                (Type::Range, Type::AnyTable),
+                (Type::Any, Type::AnyRecord),
             ])
             .required("name", SyntaxShape::String, "the name of the column")
             .allow_variants_without_examples(true)

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2795,16 +2795,16 @@ fn parse_collection_shape(
     };
 
     if bytes == name.as_bytes() {
-        mk_shape(vec![])
+        return if is_table {
+            SyntaxShape::AnyTable
+        } else {
+            SyntaxShape::AnyRecord
+        };
     } else if bytes.starts_with(prefix) {
         let Some(inner_span) = prepare_inner_span(working_set, bytes, span, prefix_len) else {
             return SyntaxShape::Any;
         };
 
-        // record<> or table<>
-        if inner_span.end - inner_span.start == 0 {
-            return mk_shape(vec![]);
-        }
         let source = working_set.get_span_contents(inner_span);
         let (tokens, err) = lex_signature(
             source,

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -58,6 +58,11 @@ pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
         (Type::Closure, Type::Block) => true,
         (Type::Any, _) => true,
         (_, Type::Any) => true,
+        (Type::Table(_), Type::AnyTable) => true,
+        (Type::Record(_), Type::AnyRecord) => true,
+        (Type::List(_), Type::AnyTable) => true,
+        (Type::AnyTable, Type::Table(_)) => true,
+        (Type::AnyRecord, Type::Record(_)) => true,
         (Type::Record(lhs), Type::Record(rhs)) | (Type::Table(lhs), Type::Table(rhs)) => {
             is_compatible(lhs, rhs)
         }

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -103,6 +103,9 @@ pub enum SyntaxShape {
     /// A record value, eg `{x: 1, y: 2}`
     Record(Vec<(String, SyntaxShape)>),
 
+    /// A record that is subtype of any other record
+    AnyRecord,
+
     /// A math expression which expands shorthand forms on the lefthand side, eg `foo > 1`
     /// The shorthand allows us to more easily reach columns inside of the row being passed in
     RowCondition,
@@ -115,6 +118,9 @@ pub enum SyntaxShape {
 
     /// A table is allowed, eg `[[first, second]; [1, 2]]`
     Table(Vec<(String, SyntaxShape)>),
+
+    /// A table that is subtype of any other record
+    AnyTable,
 
     /// A variable with optional type, `x` or `x: int`
     VarWithOptType,
@@ -171,11 +177,13 @@ impl SyntaxShape {
             SyntaxShape::Operator => Type::Any,
             SyntaxShape::Range => Type::Range,
             SyntaxShape::Record(entries) => Type::Record(mk_ty(entries)),
+            SyntaxShape::AnyRecord => Type::AnyRecord,
             SyntaxShape::RowCondition => Type::Bool,
             SyntaxShape::Boolean => Type::Bool,
             SyntaxShape::Signature => Type::Signature,
             SyntaxShape::String => Type::String,
             SyntaxShape::Table(columns) => Type::Table(mk_ty(columns)),
+            SyntaxShape::AnyTable => Type::AnyTable,
             SyntaxShape::VarWithOptType => Type::Any,
         }
     }
@@ -220,18 +228,20 @@ impl Display for SyntaxShape {
             SyntaxShape::List(x) => write!(f, "list<{x}>"),
             SyntaxShape::Table(columns) => {
                 if columns.is_empty() {
-                    write!(f, "table")
+                    write!(f, "table<>")
                 } else {
                     write!(f, "table<{}>", mk_fmt(columns))
                 }
             }
+            SyntaxShape::AnyTable => write!(f, "table"),
             SyntaxShape::Record(entries) => {
                 if entries.is_empty() {
-                    write!(f, "record")
+                    write!(f, "record<>")
                 } else {
                     write!(f, "record<{}>", mk_fmt(entries))
                 }
             }
+            SyntaxShape::AnyRecord => write!(f, "record"),
             SyntaxShape::Filesize => write!(f, "filesize"),
             SyntaxShape::Duration => write!(f, "duration"),
             SyntaxShape::DateTime => write!(f, "datetime"),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -108,8 +108,8 @@ impl Type {
             Type::Nothing => SyntaxShape::Nothing,
             Type::Record(entries) => SyntaxShape::Record(mk_shape(entries)),
             Type::Table(columns) => SyntaxShape::Table(mk_shape(columns)),
-            Type::AnyRecord => SyntaxShape::Record(vec![]),
-            Type::AnyTable => SyntaxShape::Table(vec![]),
+            Type::AnyRecord => SyntaxShape::AnyRecord,
+            Type::AnyTable => SyntaxShape::AnyTable,
             Type::ListStream => SyntaxShape::List(Box::new(SyntaxShape::Any)),
             Type::Any => SyntaxShape::Any,
             Type::Error => SyntaxShape::Any,
@@ -166,7 +166,7 @@ impl Display for Type {
             Type::Range => write!(f, "range"),
             Type::Record(fields) => {
                 if fields.is_empty() {
-                    write!(f, "record")
+                    write!(f, "record<>")
                 } else {
                     write!(
                         f,
@@ -179,10 +179,10 @@ impl Display for Type {
                     )
                 }
             }
-            Type::AnyRecord => write!(f, "record<any>"),
+            Type::AnyRecord => write!(f, "record"),
             Type::Table(columns) => {
                 if columns.is_empty() {
-                    write!(f, "table")
+                    write!(f, "table<>")
                 } else {
                     write!(
                         f,
@@ -195,7 +195,7 @@ impl Display for Type {
                     )
                 }
             }
-            Type::AnyTable => write!(f, "table<any>"),
+            Type::AnyTable => write!(f, "table"),
             Type::List(l) => write!(f, "list<{l}>"),
             Type::Nothing => write!(f, "nothing"),
             Type::Number => write!(f, "number"),

--- a/src/tests/test_signatures.rs
+++ b/src/tests/test_signatures.rs
@@ -136,7 +136,7 @@ fn list_annotations_with_extra_characters() -> TestResult {
 #[test]
 fn record_annotations_none() -> TestResult {
     let input = "def run [rec: record] { $rec }; run {} | describe";
-    let expected = "record";
+    let expected = "record<>";
     run_test(input, expected)
 }
 
@@ -266,7 +266,7 @@ fn record_annotations_with_extra_characters() -> TestResult {
 #[test]
 fn table_annotations_none() -> TestResult {
     let input = "def run [t: table] { $t }; run [[]; []] | describe";
-    let expected = "table";
+    let expected = "table<>";
     run_test(input, expected)
 }
 


### PR DESCRIPTION
This PR adresses remaining problems in #9702

# Description
This PR adds two new types (and syntax shapes) `AnyTable` and `AnyRecord` that are a narrower version of `Any` types that work similarly to it but only with tables and records respectively.
To be more precies any table is a subtype of `AnyTable` and likewise with `AnyRecord`. This differs from behavior of type denoted as `table<>` and `record<>`.  While any record can be assigned to a variable of type `record<>`, that variable itself could only be assigned to another variable of type `record<>`, but not of any other type (e.g. `record<>` can't be assigned to `record<a: int>`). This presents a problem when dealing with commands like `merge` which accept arbitrary records/tables and return another table which has some other arbitrary fields. In the following example it is clear that all the types are correctly defined, but is impossible to encode this information in signature of `merge`:
```nu
def merge_records [other: record<bar: int>]: record<foo: string> -> record<foo: string, bar: int> {
    merge $other
}
```
Currently output type of `merge` is `record<>` which is not a subtype of `record<foo: string bar: int>` and thus parsing fails. Introducing `AnyRecord` type allows to change signature of `merge` in a way that will delegate type checking to user writing code in such situation.

Additionally there are changes to how parser treats `table` and `record` types. Previously they were equivalent to `table<>` and `record<>` types. This PR makes them parse to `AnyTable` and `AnyRecord` types instead. This does not break any existing scripts because `AnyTable` and `AnyRecord` are supertypes of any respective structure, the same as `table<>` and `record<>` types. Yet this does neatly give a distinct meaning to two different notations and does not create any new special syntax like `record<any>`. In my opinion this is the most intuitive way of writing this special types.

# User-Facing Changes
- Changed semantics of `table` and `record` types. Unlike `table<>` and `record<>` they can now be assigned from and also TO any kind of table/record
- `describe` now prints `table<>` instead of `table` and likewise `record<>` instead of `record`
- Updated output types of all commands from filter category to use new types where appropriate

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
