### PR TITLE
Revert "Port command examples to long option"

### DIFF
--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -359,12 +359,12 @@ impl Command for Cp {
             },
             Example {
                 description: "Recursively copy dir_a to dir_b",
-                example: "cp --recursive dir_a dir_b",
+                example: "cp -r dir_a dir_b",
                 result: None,
             },
             Example {
                 description: "Recursively copy dir_a to dir_b, and print the feedbacks",
-                example: "cp --recursive --verbose dir_a dir_b",
+                example: "cp -r -v dir_a dir_b",
                 result: None,
             },
             Example {
@@ -374,7 +374,7 @@ impl Command for Cp {
             },
             Example {
                 description: "Copy only if source file is newer than target file",
-                example: "cp --update a b",
+                example: "cp -u a b",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -68,12 +68,12 @@ impl Command for UCp {
             },
             Example {
                 description: "Recursively copy dir_a to dir_b",
-                example: "ucp --recursive dir_a dir_b",
+                example: "ucp -r dir_a dir_b",
                 result: None,
             },
             Example {
                 description: "Recursively copy dir_a to dir_b, and print the feedbacks",
-                example: "ucp --recursive --verbose dir_a dir_b",
+                example: "ucp -r -v dir_a dir_b",
                 result: None,
             },
             Example {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -134,7 +134,7 @@ impl Command for Table {
         vec![
             Example {
                 description: "List the files in current directory, with indexes starting from 1.",
-                example: r#"ls | table --start-number 1"#,
+                example: r#"ls | table -n 1"#,
                 result: None,
             },
             Example {

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -113,13 +113,13 @@ impl Command for Explore {
             },
             Example {
                 description: "Explore a list of Markdown files' contents, with row indexes",
-                example: r#"glob *.md | each {|| open } | explore --index"#,
+                example: r#"glob *.md | each {|| open } | explore -i"#,
                 result: None,
             },
             Example {
                 description:
                     "Explore a JSON file, then save the last visited sub-structure to a file",
-                example: r#"open file.json | explore --peek | to json | save part.json"#,
+                example: r#"open file.json | explore -p | to json | save part.json"#,
                 result: None,
             },
         ]


### PR DESCRIPTION
Reverts nushell/nushell#10596

Using the long option in examples is going to be confusing as it makes the reader think the long option is required. It also isn't idiomatic Nushell.

The examples should be copy-paste-able as idiomatic Nushell, so as such we shouldn't expand them to the long flag name.