### PR TITLE
Add long options for conversions

### DIFF
--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -85,18 +85,18 @@ impl Command for Fill {
             Example {
                 description:
                     "Fill a string on the left side to a width of 15 with the character '─'",
-                example: "'nushell' | fill -a l -c '─' -w 15",
+                example: "'nushell' | fill --alignment l --character '─' --width 15",
                 result: Some(Value::string("nushell────────", Span::test_data())),
             },
             Example {
                 description:
                     "Fill a string on the right side to a width of 15 with the character '─'",
-                example: "'nushell' | fill -a r -c '─' -w 15",
+                example: "'nushell' | fill --alignment r --character '─' --width 15",
                 result: Some(Value::string("────────nushell", Span::test_data())),
             },
             Example {
                 description: "Fill a string on both sides to a width of 15 with the character '─'",
-                example: "'nushell' | fill -a m -c '─' -w 15",
+                example: "'nushell' | fill --alignment m --character '─' --width 15",
                 result: Some(Value::string("────nushell────", Span::test_data())),
             },
             Example {

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -175,7 +175,7 @@ impl Command for SubCommand {
             Example {
                 description:
                     "Convert non-standard timestamp string to datetime using a custom format",
-                example: "'20210227_135540+0000' | into datetime -f '%Y%m%d_%H%M%S%z'",
+                example: "'20210227_135540+0000' | into datetime --format '%Y%m%d_%H%M%S%z'",
                 #[allow(clippy::inconsistent_digit_grouping)]
                 result: example_result_1(1614434140_000000000),
             },

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -197,12 +197,12 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert to int from binary data (radix: 2)",
-                example: "'1101' | into int -r 2",
+                example: "'1101' | into int --radix 2",
                 result: Some(Value::test_int(13)),
             },
             Example {
                 description: "Convert to int from hex",
-                example: "'FF' |  into int -r 16",
+                example: "'FF' |  into int --radix 16",
                 result: Some(Value::test_int(255)),
             },
             Example {
@@ -217,7 +217,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert 0 padded string to int with radix 8",
-                example: "'0010132' | into int -r 8",
+                example: "'0010132' | into int --radix 8",
                 result: Some(Value::test_int(4186)),
             },
         ]

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -85,35 +85,23 @@ impl Command for SubCommand {
         vec![
             Example {
                 description: "convert int to string and append three decimal places",
-                example: "5 | into string -d 3",
+                example: "5 | into string --decimals 3",
                 result: Some(Value::test_string("5.000")),
             },
             Example {
                 description: "convert float to string and round to nearest integer",
-                example: "1.7 | into string -d 0",
+                example: "1.7 | into string --decimals 0",
                 result: Some(Value::test_string("2")),
             },
             Example {
                 description: "convert float to string",
-                example: "1.7 | into string -d 1",
+                example: "1.7 | into string --decimals 1",
                 result: Some(Value::test_string("1.7")),
             },
             Example {
                 description: "convert float to string and limit to 2 decimals",
-                example: "1.734 | into string -d 2",
+                example: "1.734 | into string --decimals 2",
                 result: Some(Value::test_string("1.73")),
-            },
-            Example {
-                description: "try to convert float to string and provide negative decimal points",
-                example: "1.734 | into string -d -2",
-                result: None,
-                // FIXME
-                // result: Some(Value::Error {
-                //     error: ShellError::UnsupportedInput(
-                //         String::from("Cannot accept negative integers for decimals arguments"),
-                //         Span::test_data(),
-                //     ),
-                // }),
             },
             Example {
                 description: "convert float to string",


### PR DESCRIPTION
As discussed in https://github.com/nushell/nushell/pull/10597#issuecomment-1745692687

I've also removed one failing example for `into string`. It was simply printed in the docs without context, and the expected result was commented out.