### PR TITLE
remove underline from std NU_LOG_FORMAT

### DIFF
--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -31,7 +31,7 @@ export-env {
         "DEBUG": "D"
     }
 
-    $env.NU_LOG_FORMAT = $"%ANSI_START%%DATE%|%LEVEL%|(ansi u)%MSG%%ANSI_STOP%"
+    $env.NU_LOG_FORMAT = $"%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
 }
 
 def log-types [] {


### PR DESCRIPTION
# Description

This PR removes the underline from the log format. It's been messing things up for me since there is no ansi reset in the log format and therefore everything after it is underlined.

This PR should end things like this.
![image](https://github.com/nushell/nushell/assets/343840/17e6dc87-11ba-4395-aac3-f70872b9182a)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
