### PR TITLE
add examples with `..` and `/` to `path join`

### DIFF
--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -90,6 +90,8 @@ the output of 'path parse' and 'path split' subcommands."#
                 example: r"'C:\Users\viking' | path join spams this_spam.txt",
                 result: Some(Value::test_string(r"C:\Users\viking\spams\this_spam.txt")),
             },
+            // TODO: an example with '..'
+            // TODO: an example with '/'
             Example {
                 description: "Join a list of parts into a path",
                 example: r"[ 'C:' '\' 'Users' 'viking' 'spam.txt' ] | path join",

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -90,8 +90,17 @@ the output of 'path parse' and 'path split' subcommands."#
                 example: r"'C:\Users\viking' | path join spams this_spam.txt",
                 result: Some(Value::test_string(r"C:\Users\viking\spams\this_spam.txt")),
             },
-            // TODO: an example with '..'
-            // TODO: an example with '/'
+            Example {
+                description: "Use relative paths, e.g. '..' will go up one directory",
+                example: r"'C:\Users\viking' | path join .. folder",
+                result: Some(Value::test_string(r"C:\Users\viking\..\folder")),
+            },
+            Example {
+                description:
+                    "Use absolute paths, e.g. '/' will bring you to the top level directory",
+                example: r"'C:\Users\viking' | path join / folder",
+                result: Some(Value::test_string(r"C:/folder")),
+            },
             Example {
                 description: "Join a list of parts into a path",
                 example: r"[ 'C:' '\' 'Users' 'viking' 'spam.txt' ] | path join",
@@ -128,14 +137,14 @@ the output of 'path parse' and 'path split' subcommands."#
             },
             Example {
                 description: "Use relative paths, e.g. '..' will go up one directory",
-                example: r"'/home/foo' | path join .. bar",
-                result: Some(Value::test_string(r"/home/foo/../bar")),
+                example: r"'/home/viking' | path join .. folder",
+                result: Some(Value::test_string(r"/home/viking/../folder")),
             },
             Example {
                 description:
                     "Use absolute paths, e.g. '/' will bring you to the top level directory",
-                example: r"'/home/foo' | path join / bar",
-                result: Some(Value::test_string(r"/bar")),
+                example: r"'/home/viking' | path join / folder",
+                result: Some(Value::test_string(r"/folder")),
             },
             Example {
                 description: "Join a list of parts into a path",

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -125,6 +125,17 @@ the output of 'path parse' and 'path split' subcommands."#
                 result: Some(Value::test_string(r"/home/viking/spams/this_spam.txt")),
             },
             Example {
+                description: "Use relative paths, e.g. '..' will go up one directory",
+                example: r"'/home/foo' | path join .. bar | path expand",
+                result: Some(Value::test_string(r"/home/bar")),
+            },
+            Example {
+                description:
+                    "Use absolute paths, e.g. '/' will bring you to the top level directory",
+                example: r"'/home/foo' | path join / bar",
+                result: Some(Value::test_string(r"/bar")),
+            },
+            Example {
                 description: "Join a list of parts into a path",
                 example: r"[ '/' 'home' 'viking' 'spam.txt' ] | path join",
                 result: Some(Value::test_string(r"/home/viking/spam.txt")),

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -128,8 +128,8 @@ the output of 'path parse' and 'path split' subcommands."#
             },
             Example {
                 description: "Use relative paths, e.g. '..' will go up one directory",
-                example: r"'/home/foo' | path join .. bar | path expand",
-                result: Some(Value::test_string(r"/home/bar")),
+                example: r"'/home/foo' | path join .. bar",
+                result: Some(Value::test_string(r"/home/foo/../bar")),
             },
             Example {
                 description:


### PR DESCRIPTION
related to
- https://discord.com/channels/601130461678272522/615329862395101194/1159484770468773990

# Description
because the following might not be trivial
```nushell
> "/foo/bar" | path join "/" "baz"
/baz
```
i thought adding a few examples to the `path join` command might help :innocent: 

# User-Facing Changes
two new examples in `help path join` one with `..` and the other with `/` :+1: 

# Tests + Formatting
the examples have `result`s so that they are checked.

# After Submitting