### PR TITLE
Let `run_in_login_mode` succeed even with broken local config

### DIFF
--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -234,7 +234,7 @@ fn run_in_login_mode() {
     let child_output = std::process::Command::new("sh")
         .arg("-c")
         .arg(format!(
-            "{:?} -l -c 'echo $nu.is-login'",
+            "{:?} --no-config-file --login --commands 'echo $nu.is-login'",
             nu_test_support::fs::executable_path()
         ))
         .output()


### PR DESCRIPTION
I wondered why this test failed for me.
Turns out my config file is not compatible with current main, but the error message was useless. I've added `--no-config-file` and improved the surrounding tests a bit while I was at it.