### PR TITLE
Add themes to help command when available #10318

### DIFF
--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -57,7 +57,7 @@ impl NuHelpCompleter {
                 let _ = write!(long_desc, "Usage:\r\n  > {}\r\n", sig.call_signature());
 
                 if !sig.named.is_empty() {
-                    long_desc.push_str(&get_flags_section(sig, |v| {
+                    long_desc.push_str(&get_flags_section(Some(&*self.0.clone()), sig, |v| {
                         v.into_string_parsable(", ", &self.0.config)
                     }))
                 }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -73,7 +73,7 @@ fn get_documentation(
     let g: String = get_ansi_color_for_component_or_default(engine_state, "header", "\x1b[32m"); // default: green
 
     let c: String = get_ansi_color_for_component_or_default(engine_state, "row_index", "\x1b[36m"); // default: cyan
-                                                                                                     // was const bb: &str = "\x1b[1;34m"; // bold blue
+                                                                                                    // was const bb: &str = "\x1b[1;34m"; // bold blue
     let bb: String =
         get_ansi_color_for_component_or_default(engine_state, "foreground", "\x1b[94m"); // default: light blue (nobold, should be bolding the *names*)
 
@@ -440,7 +440,7 @@ where
     if let Some(engine_state) = engine_state_opt {
         g = get_ansi_color_for_component_or_default(engine_state, "header", "\x1b[32m"); // default: green
         c = get_ansi_color_for_component_or_default(engine_state, "row_index", "\x1b[36m"); // default: cyan
-                                                                                             // was const bb: &str = "\x1b[1;34m"; // bold blue
+                                                                                            // was const bb: &str = "\x1b[1;34m"; // bold blue
         bb = get_ansi_color_for_component_or_default(engine_state, "foreground", "\x1b[94m");
     // default: light blue (nobold, should be bolding the *names*)
     } else {

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -350,10 +350,7 @@ fn get_ansi_color_for_component_or_default(
                 PipelineData::Empty,
             ) {
                 if let Ok((str, ..)) = result.collect_string_strict(span) {
-                    if let Some(index) = str.find('[') {
-                        let res = &str[index..];
-                        return "\x1b".to_owned() + res.trim();
-                    }
+                    return str;
                 }
             }
         }

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -385,7 +385,7 @@ fn print_help(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
                 }
             })
             .and_then(|_| {
-                let flags = get_flags_section(&signature.sig, |v| format!("{:#?}", v));
+                let flags = get_flags_section(None, &signature.sig, |v| format!("{:#?}", v));
                 write!(help, "{flags}")
             })
             .and_then(|_| writeln!(help, "\nParameters:"))

--- a/crates/nu_plugin_query/src/query.rs
+++ b/crates/nu_plugin_query/src/query.rs
@@ -71,6 +71,6 @@ pub fn get_brief_subcommand_help(sigs: &[PluginSignature]) -> String {
         let _ = writeln!(help, "  {} - {}", x.1.sig.name, x.1.sig.usage);
     }
 
-    help.push_str(&get_flags_section(&sigs[0].sig, |v| format!("{:#?}", v)));
+    help.push_str(&get_flags_section(None,&sigs[0].sig, |v| format!("{:#?}", v)));
     help
 }

--- a/crates/nu_plugin_query/src/query.rs
+++ b/crates/nu_plugin_query/src/query.rs
@@ -71,6 +71,8 @@ pub fn get_brief_subcommand_help(sigs: &[PluginSignature]) -> String {
         let _ = writeln!(help, "  {} - {}", x.1.sig.name, x.1.sig.usage);
     }
 
-    help.push_str(&get_flags_section(None,&sigs[0].sig, |v| format!("{:#?}", v)));
+    help.push_str(&get_flags_section(None, &sigs[0].sig, |v| {
+        format!("{:#?}", v)
+    }));
     help
 }


### PR DESCRIPTION
# Description
The issue #10318 is resolved by introducing helper methods within the existing `get_documentation` function in the nu-engine crate. Initially, I considered using nu-color-config crate to convert HEX config color to ANSI color and employing the following method [https://github.com/nushell/nushell/blob/main/crates/nu-color-config/src/color_config.rs#L9C1-L20C2](https://github.com/nushell/nushell/blob/main/crates/nu-color-config/src/color_config.rs#L9C1-L20C2). However, this approach was deemed impractical due to circular dependencies. Consequently, in a manner akin to how we invoke the `table` command from the nu-command crate in `get_documentation` function  to create a themed-colored table, we invoke the `ansi` command from nu-command to obtain the ANSI theme color code.

# User-Facing Changes
Visual Changes Only: the help command now uses configured theme, else it falls back on default hard coded values.


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
