### PR TITLE
[Proposal] Allow `from xx` to accept file paths with `open`

### DIFF
--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -181,15 +181,13 @@ impl Command for Open {
                             .map(|_| extract_extensions(path_str.as_str()))
                     };
 
-                    let converter = exts_opt
-                        .map(|exts| {
-                            exts.iter().find_map(|ext| {
-                                engine_state
-                                    .find_decl(format!("from {}", ext).as_bytes(), &[])
-                                    .map(|id| (id, ext.to_string()))
-                            })
+                    let converter = exts_opt.and_then(|exts| {
+                        exts.iter().find_map(|ext| {
+                            engine_state
+                                .find_decl(format!("from {}", ext).as_bytes(), &[])
+                                .map(|id| (id, ext.to_string()))
                         })
-                        .flatten();
+                    });
 
                     match converter {
                         Some((converter_id, ext)) => {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -193,11 +193,11 @@ impl Command for Open {
                     match converter {
                         Some((converter_id, ext)) => {
                             let decl = engine_state.get_decl(converter_id);
-                            let file_contents = if decl
+                            let input = if decl
                                 .signature()
                                 .usage
                                 .lines()
-                                .any(|line| line.trim() == "nu::AcceptsPath")
+                                .any(|line| line.trim() == "@nu::open::accepts_filepaths")
                             {
                                 PipelineData::Value(
                                     Value::string(path.to_string_lossy().to_string(), call_span),
@@ -208,9 +208,9 @@ impl Command for Open {
                             };
                             let command_output = if let Some(block_id) = decl.get_block_id() {
                                 let block = engine_state.get_block(block_id);
-                                eval_block(engine_state, stack, block, file_contents, false, false)
+                                eval_block(engine_state, stack, block, input, false, false)
                             } else {
-                                decl.run(engine_state, stack, &Call::new(call_span), file_contents)
+                                decl.run(engine_state, stack, &Call::new(call_span), input)
                             };
                             output.push(command_output.map_err(|inner| {
                                     ShellError::GenericError(

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -174,11 +174,12 @@ impl Command for Open {
                     let exts_opt: Option<Vec<String>> = if raw {
                         None
                     } else {
-                        // path.extension()
-                        //     .map(|name| name.to_string_lossy().to_string().to_lowercase())
-                        let path_str = path.to_string_lossy().to_string().to_lowercase();
-                        path.extension()
-                            .map(|_| extract_extensions(path_str.as_str()))
+                        let path_str = path
+                            .file_name()
+                            .unwrap_or(std::ffi::OsStr::new(path))
+                            .to_string_lossy()
+                            .to_lowercase();
+                        Some(extract_extensions(path_str.as_str()))
                     };
 
                     let converter = exts_opt.and_then(|exts| {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -171,36 +171,36 @@ impl Command for Open {
                         metadata: None,
                         trim_end_newline: false,
                     };
-                    let ext = if raw {
+                    let exts_opt: Option<Vec<String>> = if raw {
                         None
                     } else {
+                        // path.extension()
+                        //     .map(|name| name.to_string_lossy().to_string().to_lowercase())
+                        let path_str = path.to_string_lossy().to_string().to_lowercase();
                         path.extension()
-                            .map(|name| name.to_string_lossy().to_string().to_lowercase())
+                            .map(|_| extract_extensions(path_str.as_str()))
                     };
 
-                    if let Some(ext) = ext {
-                        match engine_state.find_decl(format!("from {ext}").as_bytes(), &[]) {
-                            Some(converter_id) => {
-                                let decl = engine_state.get_decl(converter_id);
-                                let command_output = if let Some(block_id) = decl.get_block_id() {
-                                    let block = engine_state.get_block(block_id);
-                                    eval_block(
-                                        engine_state,
-                                        stack,
-                                        block,
-                                        file_contents,
-                                        false,
-                                        false,
-                                    )
-                                } else {
-                                    decl.run(
-                                        engine_state,
-                                        stack,
-                                        &Call::new(call_span),
-                                        file_contents,
-                                    )
-                                };
-                                output.push(command_output.map_err(|inner| {
+                    let converter = exts_opt
+                        .map(|exts| {
+                            exts.iter().find_map(|ext| {
+                                engine_state
+                                    .find_decl(format!("from {}", ext).as_bytes(), &[])
+                                    .map(|id| (id, ext.to_string()))
+                            })
+                        })
+                        .flatten();
+
+                    match converter {
+                        Some((converter_id, ext)) => {
+                            let decl = engine_state.get_decl(converter_id);
+                            let command_output = if let Some(block_id) = decl.get_block_id() {
+                                let block = engine_state.get_block(block_id);
+                                eval_block(engine_state, stack, block, file_contents, false, false)
+                            } else {
+                                decl.run(engine_state, stack, &Call::new(call_span), file_contents)
+                            };
+                            output.push(command_output.map_err(|inner| {
                                     ShellError::GenericError(
                                         format!("Error while parsing as {ext}"),
                                         format!("Could not parse '{}' with `from {}`", path.display(), ext),
@@ -209,11 +209,8 @@ impl Command for Open {
                                         vec![inner],
                                     )
                                 })?);
-                            }
-                            None => output.push(file_contents),
                         }
-                    } else {
-                        output.push(file_contents)
+                        None => output.push(file_contents),
                     }
                 }
             }
@@ -264,4 +261,24 @@ fn permission_denied(dir: impl AsRef<Path>) -> bool {
         Err(e) => matches!(e.kind(), std::io::ErrorKind::PermissionDenied),
         Ok(_) => false,
     }
+}
+
+fn extract_extensions(filename: &str) -> Vec<String> {
+    let parts: Vec<&str> = filename.split('.').collect();
+    let mut extensions: Vec<String> = Vec::new();
+    let mut current_extension = String::new();
+
+    for part in parts.iter().rev() {
+        if current_extension.is_empty() {
+            current_extension.push_str(part);
+        } else {
+            current_extension = format!("{}.{}", part, current_extension);
+        }
+        extensions.push(current_extension.clone());
+    }
+
+    extensions.pop();
+    extensions.reverse();
+
+    extensions
 }

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -193,6 +193,19 @@ impl Command for Open {
                     match converter {
                         Some((converter_id, ext)) => {
                             let decl = engine_state.get_decl(converter_id);
+                            let file_contents = if decl
+                                .signature()
+                                .usage
+                                .lines()
+                                .any(|line| line.trim() == "nu::AcceptsPath")
+                            {
+                                PipelineData::Value(
+                                    Value::string(path.to_string_lossy().to_string(), call_span),
+                                    None,
+                                )
+                            } else {
+                                file_contents
+                            };
                             let command_output = if let Some(block_id) = decl.get_block_id() {
                                 let block = engine_state.get_block(block_id);
                                 eval_block(engine_state, stack, block, file_contents, false, false)

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -33,6 +33,36 @@ fn parses_file_with_uppercase_extension() {
         assert_eq!(actual.out, "SGML");
     })
 }
+#[test]
+fn parses_file_with_multiple_extensions() {
+    Playground::setup("open_test_multiple_extensions", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            FileWithContent("file.tar.gz", "this is a tar.gz file"),
+            FileWithContent("file.tar.xz", "this is a tar.xz file"),
+        ]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                def "from tar.gz" [] { 'opened tar.gz' } ;
+                open file.tar.gz
+            "#
+        ));
+
+        assert_eq!(actual.out, "opened tar.gz");
+
+        let actual2 = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                def "from tar.gz" [] { 'opened tar.gz' } ;
+                def "from xz" [] { 'opened xz' } ;
+                open file.tar.xz
+            "#
+        ));
+
+        assert_eq!(actual2.out, "opened xz");
+    })
+}
 
 #[test]
 fn parses_csv() {

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -33,6 +33,7 @@ fn parses_file_with_uppercase_extension() {
         assert_eq!(actual.out, "SGML");
     })
 }
+
 #[test]
 fn parses_file_with_multiple_extensions() {
     Playground::setup("open_test_multiple_extensions", |dirs, sandbox| {
@@ -44,7 +45,11 @@ fn parses_file_with_multiple_extensions() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
+                hide "from tar.gz" ;
+                hide "from gz" ;
+
                 def "from tar.gz" [] { 'opened tar.gz' } ;
+                def "from gz" [] { 'opened gz' } ;
                 open file.tar.gz
             "#
         ));
@@ -54,13 +59,41 @@ fn parses_file_with_multiple_extensions() {
         let actual2 = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                def "from tar.gz" [] { 'opened tar.gz' } ;
+                hide "from tar.xz" ;
+                hide "from xz" ;
+                hide "from tar" ;
+
+                def "from tar" [] { 'opened tar' } ;
                 def "from xz" [] { 'opened xz' } ;
                 open file.tar.xz
             "#
         ));
 
         assert_eq!(actual2.out, "opened xz");
+    })
+}
+
+#[test]
+fn parses_dotfile() {
+    Playground::setup("open_test_dotfile", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent(
+            ".gitignore",
+            r#"
+              /target/
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                hide "from gitignore" ;
+
+                def "from gitignore" [] { 'opened gitignore' } ;
+                open .gitignore
+            "#
+        ));
+
+        assert_eq!(actual.out, "opened gitignore");
     })
 }
 


### PR DESCRIPTION
## Issue

For now, plugins cannot receive data streams, so any plugin trying to implement `from xx` to be able for it to be used with `open` has to suffer the huge performance overhead of copying through the pipeline the whole file.

## Proposed solution

|                     | Accepted type                                                                      |  Equivalent |
| ------------- | ----------------------------------------------------------------|---| 
| Current        | `unstructured data`                                                               | `[u8]` |
| Proposed     |  `unstructured data` **OR**  `pointer to unstructured data`  |  `[u8] \| &[u8]` |

Add **an optional** level of indirection without changing the contract of `from xx` methods or `open`.

## Current implementation

For now this PR allows `from xxx` to use a *somewhat hacky* attribute syntax by specifiying `@nu::open::accepts_filepaths` in the said function's usage. When `open` finds such an attribute, it passes the file path as pipeline input instead of the traditional byte stream. 

```nu
# @nu::open::accepts_filepaths
def "from xx" [] { print $"received ($in)" }
open file.xx
# prints "received C:/Users/user/Desktop/file.xx"
``` 

## Pros

1. This allows to avoid passing the whole binary data through the pipeline when the `from xx` function only needs to access a smaller part of the file.
2. This PR is somewhat of a workaround for #4308

## Cons 

1. New attribute syntax; do we want to generalize it, parse it properly etc
2. Adds for 'magic' to `open`. 

## Alternatives

* `open` checks for `from file xx` or something similar (`from xx-file`, `from-file xx`)

## After-thoughts

To me, it raises the general question on how `open file.xx` should do its *magic*. I would personally argue that all `from xxx` functions that want to be able to be called using `open` should use some kind of attribute or way of discerning themselves from 'unaware' users who might define such a function.

```nu
# user-defined function that isn't supposed to be called by `open`
def "from text" [] {
	# ...
}
# user wants to open a .text file and everything breaks
open mytext.text
```