### PR TITLE
Fix wrong parsing of signatures in predecl scan

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -31,7 +31,7 @@ use crate::{
     lite_parser::{lite_parse, LiteCommand, LiteElement},
     parser::{
         check_call, check_name, garbage, garbage_pipeline, parse, parse_call, parse_expression,
-        parse_import_pattern, parse_internal_call, parse_multispan_value, parse_signature,
+        parse_full_signature, parse_import_pattern, parse_internal_call, parse_multispan_value,
         parse_string, parse_value, parse_var_with_opt_type, trim_quotes, ParsedInternalCall,
     },
     unescape_unquote_string, Token, TokenContents,
@@ -228,7 +228,7 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
     // The second time is when we actually parse the body itworking_set.
     // We can't reuse the first time because the variables that are created during parse_signature
     // are lost when we exit the scope below.
-    let sig = parse_signature(working_set, spans[signature_pos]);
+    let sig = parse_full_signature(working_set, &spans[signature_pos..]);
     working_set.parse_errors.truncate(starting_error_count);
     working_set.exit_scope();
 

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -102,6 +102,23 @@ fn parse_file_relative_to_parsed_file_simple() {
     })
 }
 
+#[test]
+fn predecl_signature_parse() {
+    Playground::setup("predecl_signature_parse", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "spam.nu",
+            "
+                def main [] { foo }
+
+                def foo []: nothing -> nothing { print 'foo' }
+            ",
+        )]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu spam.nu"));
+
+        assert_eq!(actual.out, "foo");
+    })
+}
 #[ignore]
 #[test]
 fn parse_file_relative_to_parsed_file() {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes https://github.com/nushell/nushell/issues/10605

Seems like when we introduced input/output types, we didn't update signature parsing in the predecl scan. I'm surprised it hasn't caused any issues until recently.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Fixed a bug

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
