### PR TITLE
Fix parsing of signature inp/out types in predecls

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -202,6 +202,7 @@ pub fn parse_def_predecl(working_set: &mut StateWorkingSet, spans: &[Span]) {
                 .starts_with(&[b'('])
         {
             signature_pos = Some(pos);
+            break;
         }
 
         pos += 1;

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -103,10 +103,10 @@ fn parse_file_relative_to_parsed_file_simple() {
 }
 
 #[test]
-fn predecl_signature_parse() {
-    Playground::setup("predecl_signature_parse", |dirs, sandbox| {
+fn predecl_signature_single_inp_out_type() {
+    Playground::setup("predecl_signature_single_inp_out_type", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "spam.nu",
+            "spam1.nu",
             "
                 def main [] { foo }
 
@@ -114,11 +114,33 @@ fn predecl_signature_parse() {
             ",
         )]);
 
-        let actual = nu!(cwd: dirs.test(), pipeline("nu spam.nu"));
+        let actual = nu!(cwd: dirs.test(), pipeline("nu spam1.nu"));
 
         assert_eq!(actual.out, "foo");
     })
 }
+
+#[test]
+fn predecl_signature_multiple_inp_out_types() {
+    Playground::setup(
+        "predecl_signature_multiple_inp_out_types",
+        |dirs, sandbox| {
+            sandbox.with_files(vec![FileWithContentToBeTrimmed(
+                "spam2.nu",
+                "
+                def main [] { foo }
+
+                def foo []: [nothing -> string, string -> string] { 'foo' }
+            ",
+            )]);
+
+            let actual = nu!(cwd: dirs.test(), pipeline("nu spam2.nu"));
+
+            assert_eq!(actual.out, "foo");
+        },
+    )
+}
+
 #[ignore]
 #[test]
 fn parse_file_relative_to_parsed_file() {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes https://github.com/nushell/nushell/issues/10605 (again).

The loop looking for `[` to determine signature position didn't stop early enough, so it thought the second `[` denoting the inp/out types marks the beginning of the signature.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
