### PR TITLE
Proof of concept for command/utility separation in ls

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -2,6 +2,10 @@
 #
 # version = "0.85.1"
 
+def new-ls [pattern] {
+    glob $pattern | ls | sort-by name | sort-by type
+}
+
 # For more information on defining custom themes, see
 # https://www.nushell.sh/book/coloring_and_theming.html
 # And here is the theme collection


### PR DESCRIPTION
# Description
This PR demonstrates a proof-of-concept for the feature request in #10650. Note that this is a crude proof-of-concept, and you will see several TODO notes (which are not comprehensive).

With this proof-of-concept, `ls` is redefined to accept a list of strings as input instead of a command-line argument. This means that it must be called differently, and in a final version this would be renamed to `fetch-file-metadata` instead of `ls` to avoid confusion (note: the copy/paste did something funky with the table borders, they are still rendered as smooth lines on my terminal):

```
> ls # if there are no inputs, behavior is unchanged
╭────┬──────────────────────────────────────────────────────────┬──────┬──────────┬─────────────╮
│  # │                           name                           │ type │   size   │  modified   │
├────┼──────────────────────────────────────────────────────────┼──────┼──────────┼─────────────┤
│  0 │ /home/user/Projects/nushell/checkout/src                 │ dir  │   4.1 KB │ a week ago  │
│  1 │ /home/user/Projects/nushell/checkout/.gitattributes      │ file │    111 B │ a week ago  │
│  2 │ /home/user/Projects/nushell/checkout/rust-toolchain.toml │ file │   1.1 KB │ 3 hours ago │
│  3 │ /home/user/Projects/nushell/checkout/CODE_OF_CONDUCT.md  │ file │   3.4 KB │ 2 weeks ago │
│  4 │ /home/user/Projects/nushell/checkout/target              │ dir  │   4.1 KB │ an hour ago │
│  5 │ /home/user/Projects/nushell/checkout/docker              │ dir  │   4.1 KB │ a week ago  │
│  6 │ /home/user/Projects/nushell/checkout/README.md           │ file │  12.0 KB │ a week ago  │
│  7 │ /home/user/Projects/nushell/checkout/Cargo.lock          │ file │ 148.8 KB │ 3 hours ago │
│  8 │ /home/user/Projects/nushell/checkout/scripts             │ dir  │   4.1 KB │ a week ago  │
│  9 │ /home/user/Projects/nushell/checkout/.cargo              │ dir  │   4.1 KB │ a week ago  │
│ 10 │ /home/user/Projects/nushell/checkout/.github             │ dir  │   4.1 KB │ a week ago  │
│ 11 │ /home/user/Projects/nushell/checkout/tests               │ dir  │   4.1 KB │ 2 weeks ago │
│ 12 │ /home/user/Projects/nushell/checkout/.git                │ dir  │   4.1 KB │ an hour ago │
│ 13 │ /home/user/Projects/nushell/checkout/Cargo.toml          │ file │   5.8 KB │ a week ago  │
│ 14 │ /home/user/Projects/nushell/checkout/benches             │ dir  │   4.1 KB │ a week ago  │
│ 15 │ /home/user/Projects/nushell/checkout/LICENSE             │ file │   1.1 KB │ 2 weeks ago │
│ 16 │ /home/user/Projects/nushell/checkout/.gitignore          │ file │    660 B │ a week ago  │
│ 17 │ /home/user/Projects/nushell/checkout/assets              │ dir  │   4.1 KB │ a week ago  │
│ 18 │ /home/user/Projects/nushell/checkout/wix                 │ dir  │   4.1 KB │ a week ago  │
│ 19 │ /home/user/Projects/nushell/checkout/.githooks           │ dir  │   4.1 KB │ 2 weeks ago │
│ 20 │ /home/user/Projects/nushell/checkout/toolkit.nu          │ file │  14.5 KB │ 3 hours ago │
│ 21 │ /home/user/Projects/nushell/checkout/crates              │ dir  │   4.1 KB │ a week ago  │
│ 22 │ /home/user/Projects/nushell/checkout/Cross.toml          │ file │    666 B │ a week ago  │
│ 23 │ /home/user/Projects/nushell/checkout/CONTRIBUTING.md     │ file │  18.8 KB │ a week ago  │
╰────┴──────────────────────────────────────────────────────────┴──────┴──────────┴─────────────╯
> [/home] | ls # if given a single directory, the contents are still listed 
╭───┬────────────┬──────┬────────┬─────────────╮
│ # │    name    │ type │  size  │  modified   │
├───┼────────────┼──────┼────────┼─────────────┤
│ 0 │ /home/user │ dir  │ 4.1 KB │ an hour ago │
╰───┴────────────┴──────┴────────┴─────────────╯
> [/home /opt] | ls # if given multiple directories, still list the directories themselves                                                                                                    10/08/23 15:12:05 PM
╭───┬───────┬──────┬────────┬──────────────╮
│ # │ name  │ type │  size  │   modified   │
├───┼───────┼──────┼────────┼──────────────┤
│ 0 │ /home │ dir  │ 4.1 KB │ 2 weeks ago  │
│ 1 │ /opt  │ dir  │ 4.1 KB │ 2 months ago │
╰───┴───────┴──────┴────────┴──────────────╯
```

The default config file has been updated to provide a function named `new-ls`, which would be renamed to just `ls` in a final version:

```
> new-ls /home                                                                                                                                                                                10/08/23 15:13:40 PM
╭───┬────────────┬──────┬────────┬─────────────╮
│ # │    name    │ type │  size  │  modified   │
├───┼────────────┼──────┼────────┼─────────────┤
│ 0 │ /home/user │ dir  │ 4.1 KB │ an hour ago │
╰───┴────────────┴──────┴────────┴─────────────╯
> new-ls "/{home,opt}"                                                                                                                                                                      1 10/08/23 15:14:29 PM
╭───┬───────┬──────┬────────┬──────────────╮
│ # │ name  │ type │  size  │   modified   │
├───┼───────┼──────┼────────┼──────────────┤
│ 0 │ /home │ dir  │ 4.1 KB │ 2 weeks ago  │
│ 1 │ /opt  │ dir  │ 4.1 KB │ 2 months ago │
╰───┴───────┴──────┴────────┴──────────────╯
```

Note that I am sometimes experiencing notable delays when using `new-ls`. I assume that this is due to performance differences between `nu_glob` and `wax`. However, it is theoretically possible that it has to do with the nu-level function. I would expect that a final version of this PR would also provide a user-facing command which performs globbing as in `nu_glob`, and this would be used in the nu-level function be default.

One unresolved issue is that `new-ls` has no way to pass flags like `--directory` or `--short-names` to the underlying `ls` command. It is not clear whether these things are best handled within the Rust-level command, as separate commands in the pipeline, or in a more complicated implementation of `new-ls` (I would prefer to avoid any code beyond a simple pipeline in at least the default implementations of the nu-level functions).

# User-Facing Changes
A final version of this PR would not create any user-facing changes when invoking `ls`. However, it would give users the additional option of invoking `fetch-file-metadata` directly.

# Tests + Formatting
TODO
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
TODO
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
