### PR TITLE
Preserve relative paths for local files

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -94,7 +94,6 @@ pub fn complete_item(
     let cwd_pathbuf = Path::new(cwd).to_path_buf();
     let mut original_cwd = OriginalCwd::None;
     let mut components = Path::new(&partial).components().peekable();
-    let n_components = Path::new(&partial).components().count();
     let mut cwd = match components.peek().cloned() {
         Some(c @ Component::Prefix(..)) => {
             // windows only by definition
@@ -113,8 +112,7 @@ pub fn complete_item(
             original_cwd = OriginalCwd::Home(home_dir().unwrap_or(cwd_pathbuf.clone()));
             home_dir().unwrap_or(cwd_pathbuf)
         }
-        // Either we have a bare `.` or a `.` followed by the name of a local file
-        Some(Component::CurDir) if n_components < 3 => {
+        Some(Component::CurDir) => {
             components.next();
             original_cwd = match components.peek().cloned() {
                 Some(Component::Normal(_)) | None => OriginalCwd::Local(cwd_pathbuf.clone()),


### PR DESCRIPTION
- fixes #10649

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
Tab completions for paths starting with `./` shall have the prefix preserved. 
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
