### PR TITLE
from csv: stream input, fix memory consumption

### DIFF
--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -128,12 +128,13 @@ fn from_csv(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let name = call.head;
+    let span = call.head;
+
     if let PipelineData::Value(Value::List { .. }, _) = input {
         return Err(ShellError::TypeMismatch {
             err_message: "received list stream, did you forget to open file with --raw flag?"
                 .into(),
-            span: name,
+            span,
         });
     }
 
@@ -173,6 +174,7 @@ fn from_csv(
 
     let config = DelimitedReaderConfig {
         separator,
+        record_separator: '\n',
         comment,
         quote,
         escape,
@@ -182,7 +184,7 @@ fn from_csv(
         trim,
     };
 
-    from_delimited_data(config, input, name)
+    from_delimited_data(config, input, span, engine_state.ctrlc.clone())
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -1,9 +1,12 @@
-use csv::{ReaderBuilder, Trim};
-use nu_protocol::{IntoPipelineData, PipelineData, Record, ShellError, Span, Value};
+use std::sync::{atomic::AtomicBool, Arc};
 
-fn from_delimited_string_to_value(
+use csv::{ReaderBuilder, Trim};
+use nu_protocol::{IntoInterruptiblePipelineData, PipelineData, Record, ShellError, Span, Value};
+
+fn from_delimited_to_values<R>(
     DelimitedReaderConfig {
         separator,
+        record_separator: _,
         comment,
         quote,
         escape,
@@ -12,9 +15,12 @@ fn from_delimited_string_to_value(
         no_infer,
         trim,
     }: DelimitedReaderConfig,
-    s: String,
+    reader: R,
     span: Span,
-) -> Result<Value, csv::Error> {
+) -> csv::Result<impl Iterator<Item = Value> + Send + 'static>
+where
+    R: std::io::Read + Send + 'static,
+{
     let mut reader = ReaderBuilder::new()
         .has_headers(!noheaders)
         .flexible(flexible)
@@ -23,7 +29,7 @@ fn from_delimited_string_to_value(
         .quote(quote as u8)
         .escape(escape.map(|c| c as u8))
         .trim(trim)
-        .from_reader(s.as_bytes());
+        .from_reader(reader);
 
     let headers = if noheaders {
         (1..=reader.headers()?.len())
@@ -33,38 +39,50 @@ fn from_delimited_string_to_value(
         reader.headers()?.iter().map(String::from).collect()
     };
 
-    let mut rows = vec![];
-    for row in reader.records() {
-        let row = row?;
-        let output_row = (0..headers.len())
-            .map(|i| {
-                row.get(i)
-                    .map(|value| {
-                        if no_infer {
-                            Value::string(value.to_string(), span)
-                        } else if let Ok(i) = value.parse::<i64>() {
-                            Value::int(i, span)
-                        } else if let Ok(f) = value.parse::<f64>() {
-                            Value::float(f, span)
-                        } else {
-                            Value::string(value.to_string(), span)
-                        }
+    Ok(reader
+        .into_records()
+        .scan(
+            headers,
+            move |headers, row: csv::Result<csv::StringRecord>| {
+                // Is there a better way to bubble the error up?
+                let row = match row {
+                    Ok(row) => row,
+                    Err(err) => {
+                        eprintln!("Error: {}", err);
+                        return None;
+                    }
+                };
+
+                let output_row = (0..headers.len())
+                    .map(|i| {
+                        row.get(i)
+                            .map(|value| {
+                                if no_infer {
+                                    Value::string(value.to_string(), span)
+                                } else if let Ok(i) = value.parse::<i64>() {
+                                    Value::int(i, span)
+                                } else if let Ok(f) = value.parse::<f64>() {
+                                    Value::float(f, span)
+                                } else {
+                                    Value::string(value.to_string(), span)
+                                }
+                            })
+                            .unwrap_or(Value::nothing(span))
                     })
-                    .unwrap_or(Value::nothing(span))
-            })
-            .collect::<Vec<Value>>();
+                    .collect::<Vec<Value>>();
 
-        rows.push(Value::record(
-            Record::from_raw_cols_vals(headers.clone(), output_row),
-            span,
-        ));
-    }
-
-    Ok(Value::list(rows, span))
+                Some(Value::record(
+                    Record::from_raw_cols_vals(headers.clone(), output_row),
+                    span,
+                ))
+            },
+        )
+        .fuse())
 }
 
 pub(super) struct DelimitedReaderConfig {
     pub separator: char,
+    pub record_separator: char,
     pub comment: Option<char>,
     pub quote: char,
     pub escape: Option<char>,
@@ -77,16 +95,31 @@ pub(super) struct DelimitedReaderConfig {
 pub(super) fn from_delimited_data(
     config: DelimitedReaderConfig,
     input: PipelineData,
-    name: Span,
+    span: Span,
+    ctrlc: Option<Arc<AtomicBool>>,
 ) -> Result<PipelineData, ShellError> {
-    let (concat_string, _span, metadata) = input.collect_string_strict(name)?;
+    let (reader, span, metadata) = input.into_reader(
+        span,
+        Some(
+            u8::try_from(config.record_separator).map_err(|err| ShellError::IncorrectValue {
+                msg: format!("Invalid separator: {}", err),
+                val_span: span,
+                call_span: span,
+            })?,
+        ),
+    )?;
 
-    Ok(from_delimited_string_to_value(config, concat_string, name)
-        .map_err(|x| ShellError::DelimiterError {
-            msg: x.to_string(),
-            span: name,
-        })?
-        .into_pipeline_data_with_metadata(metadata))
+    let csv_err = |err: csv::Error| ShellError::GenericError {
+        error: "CSVError".into(),
+        msg: err.to_string(),
+        span: Some(span),
+        help: None,
+        inner: vec![],
+    };
+
+    Ok(from_delimited_to_values(config, reader, span)
+        .map_err(csv_err)?
+        .into_pipeline_data_with_metadata(metadata, ctrlc))
 }
 
 pub fn trim_from_str(trim: Option<Value>) -> Result<Trim, ShellError> {

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -139,6 +139,7 @@ fn from_tsv(
 
     let config = DelimitedReaderConfig {
         separator: '\t',
+        record_separator: '\n',
         comment,
         quote,
         escape,
@@ -148,7 +149,7 @@ fn from_tsv(
         trim,
     };
 
-    from_delimited_data(config, input, name)
+    from_delimited_data(config, input, name, engine_state.ctrlc.clone())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

Fixes memory consumption of `from csv` by changing it to steam its input and output, rather than soak up everything into memory.

This is accomplished with a new type `StreamReader` that implements `std::io::Read` to give direct access to the bytes of the underlying values, if the values are a type that can give back bytes in a semantically unambiguous way. Types that cannot yield an error in the reads.

This reader is used as the input source of the `csv::Reader` so that it can be properly steamed.


### User-Facing Changes

The main benefit is the ability to stream an arbitrarily large input without exhausting memory.

In addition, the allowed input types have been expanded to allow literal `Value`s as well, e.g. these now work:

```nu
open --raw data.csv | lines | str replace 'foo' 'bar' | from csv
["foo,bar,baz", "quux,blerp,blorp"] | from csv
```

# Tests + Formatting

To test the memory consumption, I used [this publicly available dataset of registered electric vehicles](https://catalog.data.gov/dataset/electric-vehicle-population-data), using the first 1,000, 10,000, and 100,000 entries, in that order. I ran the following script to benchmark the changes against the current stable release:

```nu
#!/usr/bin/nu

let new_shellbin = $"($env.HOME)/src/nushell/target/aarch64-linux-android/release/nu"
let current_shellbin = "nu"
const dbpath = 'Electric_Vehicle_Population_Data.csv'

[$current_shellbin, $new_shellbin]
  | each {|shellbin|
    [1000, 10000, 100000]
      | each {|rows|
          do {
            time -f '%M %e %U %S' $shellbin -c (
              $"cat ($dbpath) | head -n ($rows) | from csv"
            )
          }
          | complete
          | get stderr
          | str trim
          | parse '{rss_max} {real} {user} {kernel}'
          | update cells -c [rss_max] { $"($in)kb" | into filesize }
          | update cells -c [real, user, kernel] { $"($in)sec" | into duration }
          | insert rows $rows
          | roll right
          | insert bin { if ($shellbin == $new_shellbin) { "new" } else { "old" } }
          | roll right
        }
      | flatten
  }
  | flatten
  | to nuon
```

This yields the following results

|bin|rows|rss_max|real|user|kernel|
|-|-|-|-|-|-|
|old|1000|44.1 MiB|110ms|90ms|30ms|
|old|10000|76.3 MiB|680ms|610ms|80ms|
|old|100000|396.5 MiB|5sec 460ms|5sec 80ms|680ms|
|new|1000|40.1 MiB|130ms|100ms|40ms|
|new|10000|45.2 MiB|590ms|550ms|90ms|
|new|100000|45.5 MiB|4sec 950ms|4sec 850ms|970ms|
