### PR TITLE
Use `heck` for string casing (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,9 +2730,9 @@ dependencies = [
 name = "nu-cmd-extra"
 version = "0.85.1"
 dependencies = [
- "Inflector",
  "ahash",
  "fancy-regex",
+ "heck",
  "htmlescape",
  "nu-ansi-term",
  "nu-cmd-base",

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -20,7 +20,7 @@ nu-cmd-base = { path = "../nu-cmd-base", version = "0.85.1" }
 nu-utils = { path = "../nu-utils", version = "0.85.1" }
 
 # Potential dependencies for extras
-Inflector = "0.11"
+heck = "0.4.1"
 num-traits = "0.2"
 ahash = "0.8.3"
 nu-ansi-term = "0.49.0"

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/camel_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/camel_case.rs
@@ -50,7 +50,13 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &ToLowerCamelCase::to_lower_camel_case)
+        operate(
+            engine_state,
+            stack,
+            call,
+            input,
+            &ToLowerCamelCase::to_lower_camel_case,
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/camel_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/camel_case.rs
@@ -1,4 +1,4 @@
-use inflector::cases::camelcase::to_camel_case;
+use heck::ToLowerCamelCase;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -50,7 +50,7 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &to_camel_case)
+        operate(engine_state, stack, call, input, &ToLowerCamelCase::to_lower_camel_case)
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/kebab_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/kebab_case.rs
@@ -1,4 +1,4 @@
-use inflector::cases::kebabcase::to_kebab_case;
+use heck::ToKebabCase;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -50,7 +50,7 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &to_kebab_case)
+        operate(engine_state, stack, call, input, &ToKebabCase::to_kebab_case)
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/kebab_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/kebab_case.rs
@@ -50,7 +50,13 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &ToKebabCase::to_kebab_case)
+        operate(
+            engine_state,
+            stack,
+            call,
+            input,
+            &ToKebabCase::to_kebab_case,
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/pascal_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/pascal_case.rs
@@ -50,7 +50,13 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &ToUpperCamelCase::to_upper_camel_case)
+        operate(
+            engine_state,
+            stack,
+            call,
+            input,
+            &ToUpperCamelCase::to_upper_camel_case,
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/pascal_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/pascal_case.rs
@@ -1,4 +1,4 @@
-use inflector::cases::pascalcase::to_pascal_case;
+use heck::ToUpperCamelCase;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -50,7 +50,7 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &to_pascal_case)
+        operate(engine_state, stack, call, input, &ToUpperCamelCase::to_upper_camel_case)
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/screaming_snake_case.rs
@@ -1,4 +1,4 @@
-use inflector::cases::screamingsnakecase::to_screaming_snake_case;
+use heck::ToShoutySnakeCase;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -50,7 +50,7 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &to_screaming_snake_case)
+        operate(engine_state, stack, call, input, &ToShoutySnakeCase::to_shouty_snake_case)
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/screaming_snake_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/screaming_snake_case.rs
@@ -50,7 +50,13 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &ToShoutySnakeCase::to_shouty_snake_case)
+        operate(
+            engine_state,
+            stack,
+            call,
+            input,
+            &ToShoutySnakeCase::to_shouty_snake_case,
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/snake_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/snake_case.rs
@@ -1,4 +1,4 @@
-use inflector::cases::snakecase::to_snake_case;
+use heck::ToSnakeCase;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -49,7 +49,7 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &to_snake_case)
+        operate(engine_state, stack, call, input, &ToSnakeCase::to_snake_case)
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/snake_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/snake_case.rs
@@ -49,7 +49,13 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &ToSnakeCase::to_snake_case)
+        operate(
+            engine_state,
+            stack,
+            call,
+            input,
+            &ToSnakeCase::to_snake_case,
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/title_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/title_case.rs
@@ -1,4 +1,4 @@
-use inflector::cases::titlecase::to_title_case;
+use heck::ToTitleCase;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -50,7 +50,7 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &to_title_case)
+        operate(engine_state, stack, call, input, &ToTitleCase::to_title_case)
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/title_case.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/title_case.rs
@@ -50,7 +50,13 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input, &ToTitleCase::to_title_case)
+        operate(
+            engine_state,
+            stack,
+            call,
+            input,
+            &ToTitleCase::to_title_case,
+        )
     }
 
     fn examples(&self) -> Vec<Example> {


### PR DESCRIPTION
Re-fixes #3674, if that is seen as desirable to do.

# Description
This PR changes the implementation of the `--features=extra` string casing commands from Inflector to `heck`, as in PR #4081. This PR landed a long time ago, but somewhere along the way (i can't find it) the implementation ended up being switched back to Inflector.

# User-Facing Changes
Inflector and `heck` implement casing differently, so all of the commands have different behavior around edge cases (consecutive capitals, interspersed numbers and letters, etc)

### Before
```nu
G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str camel-case
╭───┬───────────╮
│ 0 │ userID    │
│ 1 │ abcdefGHI │
│ 2 │ foo123Bar │
╰───┴───────────╯
G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str snake-case
╭───┬─────────────╮
│ 0 │ user_id     │
│ 1 │ ab_cdef_ghi │
│ 2 │ foo_12_3bar │
╰───┴─────────────╯
```

### After
```nu
G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str camel-case
╭───┬───────────╮
│ 0 │ userId    │
│ 1 │ abCdefGhi │
│ 2 │ foo123bar │
╰───┴───────────╯
G:/Dev/nu-itself/nushell> [UserID ABCdefGHI foo123bar] | str snake-case
╭───┬─────────────╮
│ 0 │ user_id     │
│ 1 │ ab_cdef_ghi │
│ 2 │ foo123bar   │
╰───┴─────────────╯
```

# Tests + Formatting

The existing string casing tests pass... because none of them relied on any of these edge cases 🤔

# Alternatives

Adding `--no-default-features` to Inflector seems to remove most of the stuff other than case conversions, which might make the crate smaller or quicker to compile.
