### PR TITLE
Add a stub `dfr` command

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/mod.rs
@@ -2,6 +2,7 @@ mod eager;
 mod expressions;
 mod lazy;
 mod series;
+mod stub;
 mod utils;
 mod values;
 
@@ -15,6 +16,7 @@ use nu_protocol::engine::{EngineState, StateWorkingSet};
 pub fn add_dataframe_context(mut engine_state: EngineState) -> EngineState {
     let delta = {
         let mut working_set = StateWorkingSet::new(&engine_state);
+        working_set.add_decl(Box::new(stub::Dfr));
         add_series_decls(&mut working_set);
         add_eager_decls(&mut working_set);
         add_expressions(&mut working_set);

--- a/crates/nu-cmd-dataframe/src/dataframe/stub.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/stub.rs
@@ -1,0 +1,47 @@
+use nu_engine::get_full_help;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{Category, IntoPipelineData, PipelineData, ShellError, Signature, Type, Value};
+
+#[derive(Clone)]
+pub struct Dfr;
+
+impl Command for Dfr {
+    fn name(&self) -> &str {
+        "dfr"
+    }
+
+    fn usage(&self) -> &str {
+        "Operate with data in a dataframe format."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("dfr")
+            .category(Category::Custom("dataframe".into()))
+            .input_output_types(vec![(Type::Nothing, Type::String)])
+    }
+
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(Value::string(
+            get_full_help(
+                &Dfr.signature(),
+                &Dfr.examples(),
+                engine_state,
+                stack,
+                self.is_parser_keyword(),
+            ),
+            call.head,
+        )
+        .into_pipeline_data())
+    }
+}


### PR DESCRIPTION
# Description
This will only display the list of subcommands.

Prompted by a question on Discord why completions may be missing.
With standard completion settings getting the subcommands doesn't seem
to be a problem but we could add this command for good measure.

# User-Facing Changes
New command `dfr` that does nothing apart from displaying the subcommands and hogging a space in the completions

# Tests + Formatting
(-)
