### PR TITLE
change canonicalize test use a more deeply rooted folder

### DIFF
--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -1,5 +1,6 @@
 use nu_path::canonicalize_with;
 use nu_test_support::fs::Stub::EmptyFile;
+use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use pretty_assertions::assert_eq;
 use std::path::Path;
@@ -181,16 +182,23 @@ fn canonicalize_path_with_many_double_dots_relative_to() {
 }
 
 #[test]
-fn canonicalize_ndots() {
-    let cwd = std::env::current_dir().expect("Could not get current directory");
-    let actual = canonicalize_with("...", &cwd).expect("Failed to canonicalize");
-    let expected = cwd
-        .parent()
-        .expect("Could not get parent of current directory")
-        .parent()
-        .expect("Could not get parent of a parent of current directory");
+fn canonicalize_ndots2() {
+    // This test will fail if you have the nushell repo on the root partition
+    // So, let's start in a nested folder before trying to canonicalize_with "..."
+    Playground::setup("nu_path_test_1", |dirs, sandbox| {
+        sandbox.mkdir("aaa/bbb/ccc");
+        let output = nu!( cwd: dirs.root(), "cd nu_path_test_1/aaa/bbb/ccc; $env.PWD");
+        let cwd = Path::new(&output.out);
 
-    assert_eq!(actual, expected);
+        let actual = canonicalize_with("...", cwd).expect("Failed to canonicalize");
+        let expected = cwd
+            .parent()
+            .expect("Could not get parent of current directory")
+            .parent()
+            .expect("Could not get parent of a parent of current directory");
+
+        assert_eq!(actual, expected);
+    });
 }
 
 #[test]


### PR DESCRIPTION
# Description

This PR changes the `canonicalize_ndots` tests (renames to canonicalize_ndots2) so that when it's checking for `canonicalize_with("...", cwd)` it guarantees it begins in a more deeply nested folder. I was having problems because my new DevDrive is on D:\nushell and it can't do `cd ...` from that folder.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
