### PR TITLE
add `toolkit run` to run a Nushell revision

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -256,6 +256,13 @@ export def "check pr" [
     report --no-fail
 }
 
+# run Nushell from source with a right indicator
+export def run [] {
+    cargo run -- [
+        -e "$env.PROMPT_COMMAND_RIGHT = $'(ansi magenta_reverse)trying Nushell inside Cargo(ansi reset)'"
+    ]
+}
+
 # set up git hooks to run:
 # - `toolkit fmt --check --verbose` on `git commit`
 # - `toolkit fmt --check --verbose` and `toolkit clippy --verbose` on `git push`


### PR DESCRIPTION
# Description
when i try out a PR, i always end up running `cargo run` but then i never know if i'm inside my install of Nushell or a PR :eyes: 

in this PR i propose to add a `run` command to the `toolkit.nu` which
- runs the current revision inside `cargo run`
- adds a clear right prompt to make sure one knows they are in `cargo run`

# User-Facing Changes
an example after running `toolkit run`
![tk-run](https://github.com/nushell/nushell/assets/44101798/1039f406-e413-495a-8e31-5aea99700aa4)


# Tests + Formatting

# After Submitting