### PR TITLE
add more information to `nu::shell::type_mismatch` errors

### DIFF
--- a/crates/nu-cmd-extra/src/extra/filters/roll/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/mod.rs
@@ -35,7 +35,7 @@ fn vertical_rotate_value(
             Ok(Value::list(values.to_owned(), span))
         }
         _ => Err(ShellError::TypeMismatch {
-            err_message: "list".to_string(),
+            err_message: format!("expected list, found {}", value.get_type()),
             span: value.span(),
         }),
     }
@@ -82,7 +82,7 @@ fn horizontal_rotate_value(
             Ok(Value::list(values, span))
         }
         _ => Err(ShellError::TypeMismatch {
-            err_message: "record".to_string(),
+            err_message: format!("expected record, found {}", value.get_type()),
             span: value.span(),
         }),
     }

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -192,7 +192,7 @@ fn extract_int_or_range(
     int_opt
         .or(range_opt)
         .ok_or_else(|| ShellError::TypeMismatch {
-            err_message: "int or range".into(),
+            err_message: format!("expected int or range, found {}", value.get_type()),
             span: value.span(),
         })
 }

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -121,7 +121,7 @@ fn replace_headers(
             Ok(Value::list(vals, span))
         }
         _ => Err(ShellError::TypeMismatch {
-            err_message: "record".to_string(),
+            err_message: format!("expected record, found {}", value.get_type()),
             span: value.span(),
         }),
     }
@@ -186,7 +186,7 @@ fn extract_headers(
                 )
             })?,
         _ => Err(ShellError::TypeMismatch {
-            err_message: "record".to_string(),
+            err_message: format!("expected record, found {}", value.get_type()),
             span: value.span(),
         }),
     }

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -86,7 +86,7 @@ impl Command for Skip {
                     }
                     _ => {
                         return Err(ShellError::TypeMismatch {
-                            err_message: "expected int".into(),
+                            err_message: format!("expected int, found {}", v.get_type()),
                             span,
                         })
                     }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -379,7 +379,7 @@ pub fn eval_constant(
             match lhs {
                 Value::Bool { val, .. } => Ok(Value::bool(!val, expr.span)),
                 _ => Err(ShellError::TypeMismatch {
-                    err_message: "bool".to_string(),
+                    err_message: format!("expected bool, found {}", lhs.get_type()),
                     span: expr.span,
                 }),
             }

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -359,11 +359,11 @@ impl PipelineData {
             PipelineData::Empty => Ok((String::new(), span, None)),
             PipelineData::Value(Value::String { val, .. }, metadata) => Ok((val, span, metadata)),
             PipelineData::Value(val, _) => Err(ShellError::TypeMismatch {
-                err_message: "string".into(),
+                err_message: format!("expected string, found {}", val.get_type()),
                 span: val.span(),
             }),
             PipelineData::ListStream(_, _) => Err(ShellError::TypeMismatch {
-                err_message: "string".into(),
+                err_message: "expected string, found a ListStream".into(),
                 span,
             }),
             PipelineData::ExternalStream {

--- a/src/command.rs
+++ b/src/command.rs
@@ -129,7 +129,7 @@ pub(crate) fn parse_commandline_args(
                         }))
                     } else {
                         Err(ShellError::TypeMismatch {
-                            err_message: "string".into(),
+                            err_message: "expected string, found empty expression".into(),
                             span: expr.span,
                         })
                     }


### PR DESCRIPTION
# Description 
i've received quite a few times files pretending to be CSVs where they are separated with other characters...

an example would be a `.csv` file which is in fact a `;`-separated file
```nushell
> open data.csv --raw
a;b
1;2
3;4
```
Nushell is still able to open it as a regular CSV with a single column called `a;b`
```nushell
> open data.csv
#┬a;b
0│1;2
1│3;4
─┴───
```

if i know before hand that this `.csv` file is in fact separated by `;` and forgot to `open --raw` before using `from csv --separator` i get a very unhelpful "type mismatch" error :eyes:
```nushell
> open data.csv | from csv --separator ";"
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[entry #64:1:1]
 1 │ open data.csv | from csv --separator ";"
   · ──┬─
   ·   ╰── string
   ╰────
```

this PR also fixes all the other `nu::shell::type_mismatch` errors of the source base by adding expected types for each one of them when it was missing :thumbsup:

# User-Facing Changes
with these changes, the error will now tell explicitely what the input type was, making it hopefully much more clear that the issue comes from `open` transforming the invalid data into a table where we really would like a string with `open --raw`
```nushell
> open ~/data.csv | from csv --separator ";"
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[entry #1:1:1]
 1 │ open ~/data.csv | from csv --separator ";"
   · ──┬─
   ·   ╰── expected string, found table<a;b: string>
   ╰────
```

# Tests + Formatting

# After Submitting