### PR TITLE
Testing support tweaks: exit status in `Outcome`

### DIFF
--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -3,12 +3,15 @@ pub mod fs;
 pub mod locale_override;
 pub mod macros;
 pub mod playground;
+use std::process::ExitStatus;
+
 // Needs to be reexported for `nu!` macro
 pub use nu_path;
 
 pub struct Outcome {
     pub out: String,
     pub err: String,
+    pub status: ExitStatus,
 }
 
 #[cfg(windows)]
@@ -22,8 +25,8 @@ pub const NATIVE_PATH_ENV_SEPARATOR: char = ';';
 pub const NATIVE_PATH_ENV_SEPARATOR: char = ':';
 
 impl Outcome {
-    pub fn new(out: String, err: String) -> Outcome {
-        Outcome { out, err }
+    pub fn new(out: String, err: String, status: ExitStatus) -> Outcome {
+        Outcome { out, err, status }
     }
 }
 

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -279,7 +279,7 @@ pub fn nu_run_test(opts: NuOpts, commands: impl AsRef<str>, with_std: bool) -> O
 
     println!("=== stderr\n{}", err);
 
-    Outcome::new(out, err.into_owned())
+    Outcome::new(out, err.into_owned(), output.status)
 }
 
 pub fn nu_with_plugin_run_test(cwd: impl AsRef<Path>, plugins: &[&str], command: &str) -> Outcome {
@@ -339,7 +339,7 @@ pub fn nu_with_plugin_run_test(cwd: impl AsRef<Path>, plugins: &[&str], command:
 
     println!("=== stderr\n{}", err);
 
-    Outcome::new(out, err.into_owned())
+    Outcome::new(out, err.into_owned(), output.status)
 }
 
 fn escape_quote_string(input: String) -> String {


### PR DESCRIPTION
This PR makes a couple of tweaks to the testing support crate:

1. Add the `nu` invocation's exit status to the test output so that one can assert that nu exited with a successful code.
2. ~~Currently, the `nu!` macro will add semicolons to every line of the input script, which breaks any test with a multi-line expression, such as a table literal. A new `join` option is added to the `nu!` macro to allow turning this behavior off to just run the input script as it is.~~

This PR was split off of #10232.
