### PR TITLE
Allow filesystem commands to access files with glob metachars in name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,9 +2723,13 @@ dependencies = [
  "indexmap 2.0.2",
  "miette",
  "nu-engine",
+ "nu-glob",
  "nu-parser",
  "nu-path",
  "nu-protocol",
+ "nu-test-support",
+ "nu-utils",
+ "rstest",
 ]
 
 [[package]]

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -11,8 +11,14 @@ version = "0.85.1"
 
 [dependencies]
 nu-engine = { path = "../nu-engine", version = "0.85.1" }
+nu-glob = { path = "../nu-glob", version = "0.85.1" }
 nu-parser = { path = "../nu-parser", version = "0.85.1" }
 nu-path = { path = "../nu-path", version = "0.85.1" }
 nu-protocol = { version = "0.85.1", path = "../nu-protocol" }
+nu-utils = { path = "../nu-utils", version = "0.85.1" }
 indexmap = { version = "2.0" }
-miette = { version = "5.10", features = ["fancy-no-backtrace"] }
+miette = "5.10.0"
+
+[dev-dependencies]
+nu-test-support = { version = "0.85.1", path = "../nu-test-support" }
+rstest = "0.18.2"

--- a/crates/nu-cmd-base/src/arg_glob.rs
+++ b/crates/nu-cmd-base/src/arg_glob.rs
@@ -1,0 +1,207 @@
+// utilities for expanding globs in command arguments
+
+use nu_glob::{glob_with_parent, MatchOptions, Paths};
+use nu_protocol::{ShellError, Spanned};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// standard glob options to use for filesystem command arguments
+
+const GLOB_PARAMS: MatchOptions = MatchOptions {
+    case_sensitive: true,
+    require_literal_separator: false,
+    require_literal_leading_dot: false,
+    recursive_match_hidden_dir: true,
+};
+
+// handle an argument that could be a literal path or a glob.
+// if literal path, return just that (whether user can access it or not).
+// if glob, expand into matching paths, using GLOB_PARAMS options.
+pub fn arg_glob(
+    pattern: &Spanned<String>, // alleged path or glob
+    cwd: &Path,                // current working directory
+) -> Result<Paths, ShellError> {
+    arg_glob_opt(pattern, cwd, GLOB_PARAMS)
+}
+
+// variant of [arg_glob] that requires literal dot prefix in pattern to match dot-prefixed path.
+pub fn arg_glob_leading_dot(pattern: &Spanned<String>, cwd: &Path) -> Result<Paths, ShellError> {
+    arg_glob_opt(
+        pattern,
+        cwd,
+        MatchOptions {
+            require_literal_leading_dot: true,
+            ..GLOB_PARAMS
+        },
+    )
+}
+
+fn arg_glob_opt(
+    pattern: &Spanned<String>,
+    cwd: &Path,
+    options: MatchOptions,
+) -> Result<Paths, ShellError> {
+    // remove ansi coloring (?)
+    let pattern = {
+        Spanned {
+            item: nu_utils::strip_ansi_string_unlikely(pattern.item.clone()),
+            span: pattern.span,
+        }
+    };
+
+    // if there's a file with same path as the pattern, just return that.
+    let pp = cwd.join(&pattern.item);
+    let md = fs::metadata(pp);
+    #[allow(clippy::single_match)]
+    match md {
+        Ok(_metadata) => {
+            return Ok(Paths::single(&PathBuf::from(pattern.item), cwd));
+        }
+        // file not found, but also "invalid chars in file" (e.g * on Windows).  Fall through and glob
+        Err(_) => {}
+    }
+
+    // user wasn't referring to a specific thing in filesystem, try to glob it.
+    match glob_with_parent(&pattern.item, options, cwd) {
+        Ok(p) => Ok(p),
+        Err(pat_err) => {
+            Err(ShellError::InvalidGlobPattern(
+                pat_err.msg.into(),
+                pattern.span, // improve specificity
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use nu_glob::GlobResult;
+    use nu_protocol::{Span, Spanned};
+    use nu_test_support::fs::Stub::EmptyFile;
+    use nu_test_support::playground::Playground;
+    use rstest::rstest;
+
+    fn spanned_string(str: &str) -> Spanned<String> {
+        Spanned {
+            item: str.to_string(),
+            span: Span::test_data(),
+        }
+    }
+
+    #[test]
+    fn does_something() {
+        let act = arg_glob(&spanned_string("*"), &PathBuf::from("."));
+        assert!(act.is_ok());
+        for f in act.expect("checked ok") {
+            match f {
+                Ok(p) => {
+                    assert!(!p.to_str().unwrap().is_empty());
+                }
+                Err(e) => panic!("unexpected error {:?}", e),
+            };
+        }
+    }
+
+    #[test]
+    fn glob_format_error() {
+        let act = arg_glob(&spanned_string(r#"ab]c[def"#), &PathBuf::from("."));
+        assert!(act.is_err());
+    }
+
+    #[rstest]
+    #[case("*", 4, "no dirs")]
+    #[case("**/*", 7, "incl dirs")]
+    fn glob_subdirs(#[case] pat: &str, #[case] exp_count: usize, #[case] case: &str) {
+        Playground::setup("glob_subdirs", |dirs, sandbox| {
+            sandbox.with_files(vec![
+                EmptyFile("yehuda.txt"),
+                EmptyFile("jttxt"),
+                EmptyFile("andres.txt"),
+            ]);
+            sandbox.mkdir(".children");
+            sandbox.within(".children").with_files(vec![
+                EmptyFile("timothy.txt"),
+                EmptyFile("tiffany.txt"),
+                EmptyFile("trish.txt"),
+            ]);
+
+            let p: Vec<GlobResult> = arg_glob(&spanned_string(pat), &dirs.test)
+                .expect("no error")
+                .collect();
+            assert_eq!(
+                exp_count,
+                p.iter().filter(|i| i.is_ok()).count(),
+                " case: {case} ",
+            );
+
+            // expected behavior -- that directories are included in results (if name matches pattern)
+            let t = p
+                .iter()
+                .any(|i| i.as_ref().unwrap().to_string_lossy().contains(".children"));
+            assert!(t, "check for dir, case {case}");
+        })
+    }
+
+    #[rstest]
+    #[case("yehuda.txt", true, 1, "matches literal path")]
+    #[case("*", false, 3, "matches glob")]
+    #[case(r#"bad[glob.foo"#, true, 1, "matches literal, would be bad glob pat")]
+    fn exact_vs_glob(
+        #[case] pat: &str,
+        #[case] exp_matches_input: bool,
+        #[case] exp_count: usize,
+        #[case] case: &str,
+    ) {
+        Playground::setup("exact_vs_glob", |dirs, sandbox| {
+            sandbox.with_files(vec![
+                EmptyFile("yehuda.txt"),
+                EmptyFile("jttxt"),
+                EmptyFile("bad[glob.foo"),
+            ]);
+
+            let res = arg_glob(&spanned_string(pat), &dirs.test)
+                .expect("no error")
+                .collect::<Vec<GlobResult>>();
+
+            eprintln!("res: {:?}", res);
+            if exp_matches_input {
+                assert_eq!(
+                    exp_count,
+                    res.len(),
+                    " case {case}: matches input, but count not 1? "
+                );
+                assert_eq!(
+                    &res[0].as_ref().unwrap().to_string_lossy(),
+                    pat, // todo: is it OK for glob to return relative paths (not to current cwd, but to arg cwd of arg_glob)?
+                );
+            } else {
+                assert_eq!(exp_count, res.len(), " case: {}: matched glob", case);
+            }
+        })
+    }
+
+    #[rstest]
+    #[case(r#"realbad[glob.foo"#, true, 1, "error, bad glob")]
+    fn exact_vs_bad_glob(
+        // if path doesn't exist but pattern is not valid glob, should get error.
+        #[case] pat: &str,
+        #[case] _exp_matches_input: bool,
+        #[case] _exp_count: usize,
+        #[case] _tag: &str,
+    ) {
+        Playground::setup("exact_vs_bad_glob", |dirs, sandbox| {
+            sandbox.with_files(vec![
+                EmptyFile("yehuda.txt"),
+                EmptyFile("jttxt"),
+                EmptyFile("bad[glob.foo"),
+            ]);
+
+            let res = arg_glob(&spanned_string(pat), &dirs.test);
+            assert!(res
+                .expect_err("expected error")
+                .to_string()
+                .contains("Invalid glob pattern"));
+        })
+    }
+}

--- a/crates/nu-cmd-base/src/lib.rs
+++ b/crates/nu-cmd-base/src/lib.rs
@@ -1,4 +1,7 @@
+mod arg_glob;
 pub mod formats;
 pub mod hook;
 pub mod input_handler;
 pub mod util;
+pub use arg_glob::arg_glob;
+pub use arg_glob::arg_glob_leading_dot;

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use nu_cmd_base::arg_glob;
 use nu_engine::env::current_dir;
 use nu_engine::CallExt;
 use nu_path::{canonicalize_with, expand_path_with};
@@ -18,13 +19,6 @@ use super::util::try_interaction;
 
 use crate::filesystem::util::FileStructure;
 use crate::progress_bar;
-
-const GLOB_PARAMS: nu_glob::MatchOptions = nu_glob::MatchOptions {
-    case_sensitive: true,
-    require_literal_separator: false,
-    require_literal_leading_dot: false,
-    recursive_match_hidden_dir: true,
-};
 
 #[derive(Clone)]
 pub struct Cp;
@@ -81,12 +75,6 @@ impl Command for Cp {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let src: Spanned<String> = call.req(engine_state, stack, 0)?;
-        let src = {
-            Spanned {
-                item: nu_utils::strip_ansi_string_unlikely(src.item),
-                span: src.span,
-            }
-        };
         let dst: Spanned<String> = call.req(engine_state, stack, 1)?;
         let recursive = call.has_flag("recursive");
         let verbose = call.has_flag("verbose");
@@ -95,7 +83,6 @@ impl Command for Cp {
         let update_mode = call.has_flag("update");
 
         let current_dir_path = current_dir(engine_state, stack)?;
-        let source = current_dir_path.join(src.item.as_str());
         let destination = current_dir_path.join(dst.item.as_str());
 
         let path_last_char = destination.as_os_str().to_string_lossy().chars().last();
@@ -110,7 +97,7 @@ impl Command for Cp {
         let span = call.head;
 
         // Get an iterator with all the source files.
-        let sources: Vec<_> = match nu_glob::glob_with(&source.to_string_lossy(), GLOB_PARAMS) {
+        let sources: Vec<_> = match arg_glob(&src, &current_dir_path) {
             Ok(files) => files.collect(),
             Err(e) => {
                 return Err(ShellError::GenericError(
@@ -124,13 +111,7 @@ impl Command for Cp {
         };
 
         if sources.is_empty() {
-            return Err(ShellError::GenericError(
-                "No matches found".into(),
-                "no matches found".into(),
-                Some(src.span),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::FileNotFound(src.span));
         }
 
         if sources.len() > 1 && !destination.is_dir() {
@@ -189,9 +170,7 @@ impl Command for Cp {
                         }
 
                         let res = if src == dst {
-                            let message = format!(
-                                "src {source:?} and dst {destination:?} are identical(not copied)"
-                            );
+                            let message = format!("src and dst identical: {:?} (not copied)", src);
 
                             return Err(ShellError::GenericError(
                                 "Copy aborted".into(),

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -1,5 +1,6 @@
-use nu_engine::CallExt;
-use nu_path::expand_to_real_path;
+use nu_cmd_base::arg_glob;
+use nu_engine::{current_dir, CallExt};
+use nu_glob::GlobResult;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
@@ -10,12 +11,6 @@ use uu_cp::{BackupMode, UpdateMode};
 
 // TODO: related to uucore::error::set_exit_code(EXIT_ERR)
 // const EXIT_ERR: i32 = 1;
-const GLOB_PARAMS: nu_glob::MatchOptions = nu_glob::MatchOptions {
-    case_sensitive: true,
-    require_literal_separator: false,
-    require_literal_leading_dot: false,
-    recursive_match_hidden_dir: true,
-};
 
 #[cfg(not(target_os = "windows"))]
 const PATH_SEPARATOR: &str = "/";
@@ -154,20 +149,22 @@ impl Command for UCp {
                 Vec::new(),
             ));
         };
+
         // paths now contains the sources
-        let sources: Vec<Vec<PathBuf>> = paths
-            .iter()
-            .map(|p| {
-                // Need to expand too make it work with globbing
-                let expanded_src = expand_to_real_path(&p.item);
-                match nu_glob::glob_with(&expanded_src.to_string_lossy(), GLOB_PARAMS) {
-                    Ok(files) => {
-                        let f = files.filter_map(Result::ok).collect::<Vec<PathBuf>>();
-                        if f.is_empty() {
-                            return Err(ShellError::FileNotFound(p.span));
-                        }
-                        let any_source_is_dir = f.iter().any(|f| matches!(f, f if f.is_dir()));
-                        if any_source_is_dir && !recursive {
+
+        let cwd = current_dir(engine_state, stack)?;
+        let mut sources: Vec<PathBuf> = Vec::new();
+
+        for p in paths {
+            let exp_files = arg_glob(&p, &cwd)?.collect::<Vec<GlobResult>>();
+            if exp_files.is_empty() {
+                return Err(ShellError::FileNotFound(p.span));
+            };
+            let mut app_vals: Vec<PathBuf> = Vec::new();
+            for v in exp_files {
+                match v {
+                    Ok(path) => {
+                        if !recursive && path.is_dir() {
                             return Err(ShellError::GenericError(
                                 "could_not_copy_directory".into(),
                                 "resolves to a directory (not copied)".into(),
@@ -175,22 +172,20 @@ impl Command for UCp {
                                 Some("Directories must be copied using \"--recursive\"".into()),
                                 Vec::new(),
                             ));
-                        }
-
-                        Ok(f)
+                        };
+                        app_vals.push(path)
                     }
-                    Err(e) => Err(ShellError::GenericError(
-                        e.to_string(),
-                        "invalid pattern".to_string(),
-                        Some(p.span),
-                        None,
-                        Vec::new(),
-                    )),
+                    Err(e) => {
+                        return Err(ShellError::ErrorExpandingGlob(
+                            format!("error {} in path {}", e.error(), e.path().display()),
+                            p.span,
+                        ));
+                    }
                 }
-            })
-            .collect::<Result<Vec<Vec<PathBuf>>, ShellError>>()?;
+            }
+            sources.append(&mut app_vals);
+        }
 
-        let sources = sources.into_iter().flatten().collect::<Vec<PathBuf>>();
         let options = uu_cp::Options {
             overwrite,
             reflink_mode,

--- a/crates/nu-command/src/platform/du.rs
+++ b/crates/nu-command/src/platform/du.rs
@@ -1,28 +1,21 @@
 use crate::{DirBuilder, DirInfo, FileInfo};
-use nu_engine::CallExt;
-use nu_glob::{GlobError, MatchOptions, Pattern};
+use nu_cmd_base::arg_glob;
+use nu_engine::{current_dir, CallExt};
+use nu_glob::{GlobError, Pattern};
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Spanned,
-    SyntaxShape, Type, Value,
+    Category, Example, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Span,
+    Spanned, SyntaxShape, Type, Value,
 };
 use serde::Deserialize;
-use std::path::PathBuf;
-
-const GLOB_PARAMS: MatchOptions = MatchOptions {
-    case_sensitive: true,
-    require_literal_separator: true,
-    require_literal_leading_dot: false,
-    recursive_match_hidden_dir: true,
-};
 
 #[derive(Clone)]
 pub struct Du;
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct DuArgs {
-    path: Option<Spanned<PathBuf>>,
+    path: Option<Spanned<String>>,
     all: bool,
     deref: bool,
     exclude: Option<Spanned<String>>,
@@ -97,6 +90,8 @@ impl Command for Du {
                 return Err(ShellError::NeedsPositiveValue(min_size.span));
             }
         }
+        let current_dir = current_dir(engine_state, stack)?;
+
         let args = DuArgs {
             path: call.opt(engine_state, stack, 0)?,
             all: call.has_flag("all"),
@@ -107,38 +102,22 @@ impl Command for Du {
         };
 
         let exclude = args.exclude.map_or(Ok(None), move |x| {
-            Pattern::new(&x.item).map(Some).map_err(|e| {
-                ShellError::GenericError(
-                    "glob error".to_string(),
-                    e.msg.to_string(),
-                    Some(x.span),
-                    None,
-                    Vec::new(),
-                )
-            })
+            Pattern::new(&x.item)
+                .map(Some)
+                .map_err(|e| ShellError::InvalidGlobPattern(e.msg.to_string(), x.span))
         })?;
 
         let include_files = args.all;
         let mut paths = match args.path {
-            Some(p) => {
-                let item = p.item.to_str().expect("Why isn't this encoded properly?");
-                match nu_glob::glob_with(item, GLOB_PARAMS) {
-                    // Convert the PatternError to a ShellError, preserving the span
-                    // of the inputted glob.
-                    Err(e) => {
-                        return Err(ShellError::GenericError(
-                            "glob error".to_string(),
-                            e.msg.to_string(),
-                            Some(p.span),
-                            None,
-                            Vec::new(),
-                        ))
-                    }
-                    Ok(path) => path,
-                }
-            }
+            Some(p) => arg_glob(&p, &current_dir)?,
             // The * pattern should never fail.
-            None => nu_glob::glob_with("*", GLOB_PARAMS).expect("du: * pattern failed to glob"),
+            None => arg_glob(
+                &Spanned {
+                    item: "*".into(),
+                    span: Span::unknown(),
+                },
+                &current_dir,
+            )?,
         }
         .filter(move |p| {
             if include_files {

--- a/crates/nu-command/tests/commands/move_/mv.rs
+++ b/crates/nu-command/tests/commands/move_/mv.rs
@@ -203,7 +203,7 @@ fn errors_if_source_doesnt_exist() {
             cwd: dirs.test(),
             "mv non-existing-file test_folder/"
         );
-        assert!(actual.err.contains("File(s) not found"));
+        assert!(actual.err.contains("file not found"));
     })
 }
 

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -1005,6 +1005,7 @@ fn copies_files_with_glob_metachars(#[case] src_name: &str) {
 }
 
 #[cfg(not(windows))]
+#[rstest]
 #[case(r#"'a]?c'"#)]
 #[case(r#"'a*.?c'"#)]
 // windows doesn't allow filename with `*`.

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -975,8 +975,6 @@ fn test_cp_with_vars() {
 #[case(r#"'a[c'"#)]
 #[case(r#"'a[bc]d'"#)]
 #[case(r#"'a][c'"#)]
-#[case(r#"'a]?c'"#)]
-// windows doesn't allow filename with `*`.
 fn copies_files_with_glob_metachars(#[case] src_name: &str) {
     Playground::setup("ucp_test_34", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContent(
@@ -1004,4 +1002,12 @@ fn copies_files_with_glob_metachars(#[case] src_name: &str) {
         //let after_cp_hash = get_file_hash(dirs.test().join(TEST_HELLO_WORLD_DEST).display());
         //assert_eq!(src_hash, after_cp_hash);
     });
+}
+
+#[cfg(not(windows))]
+#[case(r#"'a]?c'"#)]
+#[case(r#"'a*.?c'"#)]
+// windows doesn't allow filename with `*`.
+fn copies_files_with_glob_metachars_nw(#[case] src_name: &str) {
+    copies_files_with_glob_metachars(src_name);
 }

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -6,6 +6,7 @@ use nu_test_support::fs::{
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 
+use rstest::rstest;
 use std::path::Path;
 
 #[cfg(not(target_os = "windows"))]
@@ -966,5 +967,41 @@ fn test_cp_with_vars() {
         "let src = 'input'; let dst = 'target'; cp $src $dst",
         );
         assert!(dirs.test().join("target").exists());
+    });
+}
+
+#[rstest]
+#[case(r#"'a]c'"#)]
+#[case(r#"'a[c'"#)]
+#[case(r#"'a[bc]d'"#)]
+#[case(r#"'a][c'"#)]
+#[case(r#"'a]?c'"#)]
+// windows doesn't allow filename with `*`.
+fn copies_files_with_glob_metachars(#[case] src_name: &str) {
+    Playground::setup("ucp_test_34", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContent(
+            src_name,
+            "What is the sound of one hand clapping?",
+        )]);
+
+        let src = dirs.test().join(src_name);
+
+        // -- open command doesn't like file name
+        //// Get the hash of the file content to check integrity after copy.
+        //let src_hash = get_file_hash(src.display());
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "cp {} {}",
+            src.display(),
+            TEST_HELLO_WORLD_DEST
+        );
+
+        assert!(actual.err.is_empty());
+        assert!(dirs.test().join(TEST_HELLO_WORLD_DEST).exists());
+
+        //// Get the hash of the copied file content to check against first_hash.
+        //let after_cp_hash = get_file_hash(dirs.test().join(TEST_HELLO_WORLD_DEST).display());
+        //assert_eq!(src_hash, after_cp_hash);
     });
 }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1128,6 +1128,31 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         help("Help messages are currently not supported to be constants.")
     )]
     NotAConstHelp(#[label = "Cannot get help message at parse time."] Span),
+
+    /// Invalid glob pattern
+    ///
+    /// ## Resolution
+    ///
+    /// Correct glob pattern
+    #[error("Invalid glob pattern")]
+    #[diagnostic(
+        code(nu::shell::invalid_glob_pattern),
+        help("Refer to xxx for help on nushell glob patterns.")
+    )]
+    InvalidGlobPattern(String, #[label = "{0}"] Span),
+
+    /// Error expanding glob pattern
+    ///
+    /// ## Resolution
+    ///
+    /// Correct glob pattern or file access issue
+    #[error("Error expanding glob pattern")]
+    #[diagnostic(
+        code(nu::shell::error_expanding_glob),
+        help("Correct glob pattern or file access issue")
+    )]
+    //todo: add error detail
+    ErrorExpandingGlob(String, #[label = "{0}"] Span),
 }
 
 // TODO: Implement as From trait


### PR DESCRIPTION
(squashed version of #10557, clean commit history and review thread)

Fixes #10571, also potentially: #10364, #10211, #9558, #9310,


# Description
Changes processing of arguments to filesystem commands that are source paths or globs.
Applies to `cp, cp-old, mv, rm, du` but not `ls` (because it uses a different globbing interface) or `glob` (because it uses a different globbing library).

The core of the change is to lookup the argument first as a file and only glob if it is not.  That way,
a path containing glob metacharacters can be referenced without glob quoting, though it will have to be single quoted to avoid nushell parsing.

Before: A file path that looks like a glob is not matched by the glob specified as a (source) argument and takes some thinking about to access. You might say the glob pattern shadows a file with the same spelling.
```
> ls a*
╭───┬────────┬──────┬──────┬────────────────╮
│ # │  name  │ type │ size │    modified    │
├───┼────────┼──────┼──────┼────────────────┤
│ 0 │ a[bc]d │ file │  0 B │ 34 seconds ago │
│ 1 │ abd    │ file │  0 B │ now            │
│ 2 │ acd    │ file │  0 B │ now            │
╰───┴────────┴──────┴──────┴────────────────╯

> cp --verbose 'a[bc]d' dest
copied /home/bobhy/src/rust/work/r4/abd to /home/bobhy/src/rust/work/r4/dest/abd
copied /home/bobhy/src/rust/work/r4/acd to /home/bobhy/src/rust/work/r4/dest/acd

> ## Note -- a[bc]d *not* copied, and seemingly hard to access.
> cp --verbose 'a\[bc\]d' dest
Error:   × No matches found
   ╭─[entry #33:1:1]
 1 │ cp --verbose 'a\[bc\]d' dest
   ·              ─────┬────
   ·                   ╰── no matches found
   ╰────

> #.. but is accessible with enough glob quoting.
> cp --verbose 'a[[]bc[]]d' dest
copied /home/bobhy/src/rust/work/r4/a[bc]d to /home/bobhy/src/rust/work/r4/dest/a[bc]d
```
Before_2: if file has glob metachars but isn't a valid pattern, user gets a confusing error:

```
> touch 'a[b'
> cp 'a[b' dest
Error:   × Pattern syntax error near position 30: invalid range pattern
   ╭─[entry #13:1:1]
 1 │ cp 'a[b' dest
   ·    ──┬──
   ·      ╰── invalid pattern
   ╰────
```

After: Args to cp, mv, etc. are tried first as literal files, and only as globs if not found to be files.

```
> cp --verbose 'a[bc]d' dest
copied /home/bobhy/src/rust/work/r4/a[bc]d to /home/bobhy/src/rust/work/r4/dest/a[bc]d
> cp --verbose '[a][bc]d' dest
copied /home/bobhy/src/rust/work/r4/abd to /home/bobhy/src/rust/work/r4/dest/abd
copied /home/bobhy/src/rust/work/r4/acd to /home/bobhy/src/rust/work/r4/dest/acd
```
After_2: file with glob metachars but invalid pattern just works. (though Windows does not allow file name to contain `*`.).

```
> cp --verbose 'a[b' dest
copied /home/bobhy/src/rust/work/r4/a[b to /home/bobhy/src/rust/work/r4/dest/a[b
```

So, with this fix, a file shadows a glob pattern with the same spelling. If you have such a file and really want to use the glob pattern, you will have to glob quote some of the characters in the pattern.  I think that's less confusing to the user: if ls shows a file with a weird name, s/he'll still be able to copy, rename or delete it.

# User-Facing Changes
Could break some existing scripts.  If user happened to have a file with a globbish name but was using a glob pattern with the same spelling, the new version will process the file and not expand the glob.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
