### PR TITLE
refactor: move the `partial_from` function to the single place it is invoked

### DIFF
--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -1,12 +1,10 @@
-use crate::completions::{
-    completion_common::complete_item, Completer, CompletionOptions, SortBy, SEP,
-};
+use crate::completions::{completion_common::complete_item, Completer, CompletionOptions, SortBy};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     levenshtein_distance, Span,
 };
 use reedline::Suggestion;
-use std::path::Path;
+use std::path::{Path, MAIN_SEPARATOR as SEP};
 use std::sync::Arc;
 
 #[derive(Clone)]

--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -1,4 +1,6 @@
-use crate::completions::{completion_common::complete_item, Completer, CompletionOptions};
+use crate::completions::{
+    completion_common::complete_item, Completer, CompletionOptions, SortBy, SEP,
+};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     levenshtein_distance, Span,
@@ -6,10 +8,6 @@ use nu_protocol::{
 use reedline::Suggestion;
 use std::path::Path;
 use std::sync::Arc;
-
-use super::SortBy;
-
-const SEP: char = std::path::MAIN_SEPARATOR;
 
 #[derive(Clone)]
 pub struct DirectoryCompletion {

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -1,11 +1,11 @@
-use crate::completions::{file_path_completion, Completer, CompletionOptions, SortBy, SEP};
+use crate::completions::{file_path_completion, Completer, CompletionOptions, SortBy};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     Span,
 };
 use reedline::Suggestion;
 use std::{
-    path::{is_separator, MAIN_SEPARATOR_STR},
+    path::{is_separator, MAIN_SEPARATOR as SEP, MAIN_SEPARATOR_STR},
     sync::Arc,
 };
 

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -1,13 +1,13 @@
-use crate::completions::{
-    file_path_completion, partial_from, Completer, CompletionOptions, SortBy,
-};
+use crate::completions::{file_path_completion, Completer, CompletionOptions, SortBy, SEP};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     Span,
 };
 use reedline::Suggestion;
-use std::sync::Arc;
-const SEP: char = std::path::MAIN_SEPARATOR;
+use std::{
+    path::{is_separator, MAIN_SEPARATOR_STR},
+    sync::Arc,
+};
 
 #[derive(Clone)]
 pub struct DotNuCompletion {
@@ -30,9 +30,16 @@ impl Completer for DotNuCompletion {
         _: usize,
         options: &CompletionOptions,
     ) -> Vec<Suggestion> {
-        let prefix_str = String::from_utf8_lossy(&prefix).to_string();
+        let prefix_str = String::from_utf8_lossy(&prefix).replace('`', "");
         let mut search_dirs: Vec<String> = vec![];
-        let (base_dir, mut partial) = partial_from(&prefix_str);
+
+        // If prefix_str is only a word we want to search in the current dir
+        let (base, partial) = prefix_str
+            .rsplit_once(is_separator)
+            .unwrap_or((".", &prefix_str));
+        let base_dir = base.replace(is_separator, MAIN_SEPARATOR_STR);
+        let mut partial = partial.to_string();
+        // On windows, this standardizes paths to use \
         let mut is_current_folder = false;
 
         // Fetch the lib dirs
@@ -58,7 +65,8 @@ impl Completer for DotNuCompletion {
             };
 
         // Check if the base_dir is a folder
-        if base_dir != format!(".{SEP}") {
+        // rsplit_once removes the separator
+        if base_dir != "." {
             // Add the base dir into the directories to be searched
             search_dirs.push(base_dir.clone());
 

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -1,15 +1,13 @@
-use crate::completions::{completion_common::complete_item, Completer, CompletionOptions};
+use crate::completions::{
+    completion_common::complete_item, Completer, CompletionOptions, SortBy, SEP,
+};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     levenshtein_distance, Span,
 };
 use reedline::Suggestion;
-use std::path::{is_separator, Path};
+use std::path::Path;
 use std::sync::Arc;
-
-use super::SortBy;
-
-const SEP: char = std::path::MAIN_SEPARATOR;
 
 #[derive(Clone)]
 pub struct FileCompletion {
@@ -104,20 +102,6 @@ impl Completer for FileCompletion {
 
         non_hidden
     }
-}
-
-pub fn partial_from(input: &str) -> (String, String) {
-    let partial = input.replace('`', "");
-
-    // If partial is only a word we want to search in the current dir
-    let (base, rest) = partial.rsplit_once(is_separator).unwrap_or((".", &partial));
-    // On windows, this standardizes paths to use \
-    let mut base = base.replace(is_separator, &SEP.to_string());
-
-    // rsplit_once removes the separator
-    base.push(SEP);
-
-    (base.to_string(), rest.to_string())
 }
 
 pub fn file_path_completion(

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -1,12 +1,10 @@
-use crate::completions::{
-    completion_common::complete_item, Completer, CompletionOptions, SortBy, SEP,
-};
+use crate::completions::{completion_common::complete_item, Completer, CompletionOptions, SortBy};
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
     levenshtein_distance, Span,
 };
 use reedline::Suggestion;
-use std::path::Path;
+use std::path::{Path, MAIN_SEPARATOR as SEP};
 use std::sync::Arc;
 
 #[derive(Clone)]

--- a/crates/nu-cli/src/completions/mod.rs
+++ b/crates/nu-cli/src/completions/mod.rs
@@ -17,6 +17,7 @@ pub use completion_options::{CompletionOptions, MatchAlgorithm, SortBy};
 pub use custom_completions::CustomCompletion;
 pub use directory_completions::DirectoryCompletion;
 pub use dotnu_completions::DotNuCompletion;
-pub use file_completions::{file_path_completion, matches, partial_from, FileCompletion};
+pub use file_completions::{file_path_completion, matches, FileCompletion};
 pub use flag_completions::FlagCompletion;
+pub use std::path::MAIN_SEPARATOR as SEP;
 pub use variable_completions::VariableCompletion;

--- a/crates/nu-cli/src/completions/mod.rs
+++ b/crates/nu-cli/src/completions/mod.rs
@@ -19,5 +19,4 @@ pub use directory_completions::DirectoryCompletion;
 pub use dotnu_completions::DotNuCompletion;
 pub use file_completions::{file_path_completion, matches, FileCompletion};
 pub use flag_completions::FlagCompletion;
-pub use std::path::MAIN_SEPARATOR as SEP;
 pub use variable_completions::VariableCompletion;


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

After the addition of the prefix tab completion support, the older `partial_from` function is left with a single invocation. This PR moves the code inside the function to the point of invocation.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No user facing changes.

# Tests + Formatting
Tests are passing.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
