### PR TITLE
dirs goto: update current ring slot before leaving it.

### DIFF
--- a/crates/nu-std/std/dirs.nu
+++ b/crates/nu-std/std/dirs.nu
@@ -111,9 +111,8 @@ export def --env goto [shell?: int] {
             }
         }
     }
-    $env.DIRS_POSITION = $shell
 
-    cd ($env.DIRS_LIST | get $env.DIRS_POSITION)
+    _fetch ($shell - $env.DIRS_POSITION)
 }
 
 export alias g = goto

--- a/crates/nu-std/tests/test_dirs.nu
+++ b/crates/nu-std/tests/test_dirs.nu
@@ -134,3 +134,44 @@ def dirs_cd [] {
     cur_ring_check $c.path_b 0 "cd updates current position in non-empty ring"
     assert equal [$c.path_b $c.path_b] $env.DIRS_LIST "cd updated both positions in ring"
 }
+
+#[test]
+def dirs_goto_bug10696 [] {
+    let $c = $in
+    cd $c.base_path
+    use std dirs
+
+    dirs add $c.path_a
+    cd $c.path_b
+    dirs goto 0
+    dirs goto 1
+
+    assert equal $env.PWD $c.path_b "goto other, then goto to come back returns to same directory"
+}
+
+#[test]
+def dirs_goto [] {
+    let $c = $in
+    cd $c.base_path
+    use std dirs
+
+    # check that goto can move *from* any position in the ring *to* any other position (correctly)
+
+    assert equal $env.PWD $c.base_path
+    dirs add $c.path_a
+    dirs add $c.path_b
+    assert equal ($env.DIRS_LIST | length) 3 "start with 3 elements in ring"
+    
+    let exp_dir = [$c.base_path $c.path_a $c.path_b]
+    
+    for $cur_pos in 0..<($env.DIRS_LIST | length) {
+        for $other_pos in 0..<($env.DIRS_LIST | length) {
+            dirs goto $cur_pos
+            assert equal $env.PWD ($exp_dir | get $cur_pos) "initial position as expected"
+
+            dirs goto $other_pos
+            assert equal $env.DIRS_POSITION $other_pos "goto moved index to correct slot"
+            assert equal $env.PWD ($exp_dir | get $other_pos) "goto changed working directory correctly"
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10696

# Description

As reported, you could mess up the ring of remembered directories in `std dirs` (a.k.a the `shells` commands) with a sequence like this:
```
~/test> mkdir b c

~/test> pushd b
~/test/b> cd ../c
~/test/c> goto 0
~/test> goto 1
## expect to end up in ~/test/c
## observe you're in ~/test/b
~/test/b>
```
Problem was `dirs goto` was not updating the remembered directories before leaving the current slot for some other.  This matters if the user did a manual `cd` (which cannot update the remembered directories ring)

# User-Facing Changes
None! it just works :tm:

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
