### PR TITLE
Extract common logic for setting error in `parse_short_flags`

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -474,53 +474,28 @@ fn parse_short_flags(
                 }
             }
 
-            if found_short_flags.is_empty() {
-                let arg_contents = working_set.get_span_contents(arg_span);
-
+            if found_short_flags.is_empty()
                 // check to see if we have a negative number
-                if let Some(positional) = sig.get_positional(positional_idx) {
-                    if positional.shape == SyntaxShape::Int
-                        || positional.shape == SyntaxShape::Number
-                    {
-                        if String::from_utf8_lossy(arg_contents).parse::<f64>().is_ok() {
-                            return None;
-                        } else if let Some(first) = unmatched_short_flags.first() {
-                            let contents = working_set.get_span_contents(*first);
-                            working_set.error(ParseError::UnknownFlag(
-                                sig.name.clone(),
-                                format!("-{}", String::from_utf8_lossy(contents)),
-                                *first,
-                                sig.clone().formatted_flags(),
-                            ));
-                        }
-                    } else if let Some(first) = unmatched_short_flags.first() {
-                        let contents = working_set.get_span_contents(*first);
-                        working_set.error(ParseError::UnknownFlag(
-                            sig.name.clone(),
-                            format!("-{}", String::from_utf8_lossy(contents)),
-                            *first,
-                            sig.clone().formatted_flags(),
-                        ));
-                    }
-                } else if let Some(first) = unmatched_short_flags.first() {
-                    let contents = working_set.get_span_contents(*first);
-                    working_set.error(ParseError::UnknownFlag(
-                        sig.name.clone(),
-                        format!("-{}", String::from_utf8_lossy(contents)),
-                        *first,
-                        sig.clone().formatted_flags(),
-                    ));
-                }
-            } else if !unmatched_short_flags.is_empty() {
-                if let Some(first) = unmatched_short_flags.first() {
-                    let contents = working_set.get_span_contents(*first);
-                    working_set.error(ParseError::UnknownFlag(
-                        sig.name.clone(),
-                        format!("-{}", String::from_utf8_lossy(contents)),
-                        *first,
-                        sig.clone().formatted_flags(),
-                    ));
-                }
+                && matches!(
+                    sig.get_positional(positional_idx),
+                    Some(PositionalArg {
+                        shape: SyntaxShape::Int | SyntaxShape::Number,
+                        ..
+                    })
+                )
+                && String::from_utf8_lossy(working_set.get_span_contents(arg_span))
+                    .parse::<f64>()
+                    .is_ok()
+            {
+                return None;
+            } else if let Some(first) = unmatched_short_flags.first() {
+                let contents = working_set.get_span_contents(*first);
+                working_set.error(ParseError::UnknownFlag(
+                    sig.name.clone(),
+                    format!("-{}", String::from_utf8_lossy(contents)),
+                    *first,
+                    sig.clone().formatted_flags(),
+                ));
             }
 
             Some(found_short_flags)


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Since the `else` clause for the nested branches check for the first unmatched argument, this PR brings together all the conditions where the positional argument shape is numeric using the `matches!` keyword. This also allows us to and (`&&`) the condition with when no short flags are found unlike the `if let ...` statements. Finally, we can handle any `unmatched_short_flags` at one place.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No user facing changes.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Tests are passing.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
