### PR TITLE
expand paths and split PATH in `std path add`

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -73,6 +73,7 @@ export def --env "path add" [
         $env
             | get $path_name
             | split row (char esep)
+            | path expand
             | if $append { append $paths } else { prepend $paths }
     )}
 

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -53,10 +53,12 @@ export def --env "path add" [
     let path_name = if "PATH" in $env { "PATH" } else { "Path" }
 
     let paths = $paths | each {|p|
-        match ($p | describe | str replace --regex '<.*' '') {
+        let p = match ($p | describe | str replace --regex '<.*' '') {
             "string" => $p,
             "record" => { $p | get --ignore-errors $nu.os-info.name },
         }
+
+        $p | path expand
     }
 
     if null in $paths or ($paths | is-empty) {
@@ -70,6 +72,7 @@ export def --env "path add" [
     load-env {$path_name: (
         $env
             | get $path_name
+            | split row (char esep)
             | if $append { append $paths } else { prepend $paths }
     )}
 

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -37,6 +37,10 @@ def path_add [] {
 
         std path add $target_paths
         assert equal (get_path) [($target_paths | get $nu.os-info.name)]
+
+        load-env {$path_name: ["/usr/bin:/bin"]}
+        std path add "~/foo"
+        assert equal (get_path) [($nu.home-path | path join "foo"), "/usr/bin", "/bin"]
     }
 }
 

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -38,7 +38,7 @@ def path_add [] {
         std path add $target_paths
         assert equal (get_path) ([($target_paths | get $nu.os-info.name)] | path expand)
 
-        load-env {$path_name: ["/foo:/bar"]}
+        load-env {$path_name: [$"/foo(char esep)/bar"]}
         std path add "~/foo"
         assert equal (get_path) (["~/foo", "/foo", "/bar"] | path expand)
     }

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -8,24 +8,23 @@ def path_add [] {
 
     with-env [$path_name []] {
         def get_path [] { $env | get $path_name }
-        def expand_paths []: list<string> -> list<path> { each { path expand } }
 
         assert equal (get_path) []
 
         std path add "/foo/"
-        assert equal (get_path) (["/foo/"] | expand_paths)
+        assert equal (get_path) (["/foo/"] | path expand)
 
         std path add "/bar/" "/baz/"
-        assert equal (get_path) (["/bar/", "/baz/", "/foo/"] | expand_paths)
+        assert equal (get_path) (["/bar/", "/baz/", "/foo/"] | path expand)
 
         load-env {$path_name: []}
 
         std path add "foo"
         std path add "bar" "baz" --append
-        assert equal (get_path) (["foo", "bar", "baz"] | expand_paths)
+        assert equal (get_path) (["foo", "bar", "baz"] | path expand)
 
-        assert equal (std path add "fooooo" --ret) (["fooooo", "foo", "bar", "baz"] | expand_paths)
-        assert equal (get_path) (["fooooo", "foo", "bar", "baz"] | expand_paths)
+        assert equal (std path add "fooooo" --ret) (["fooooo", "foo", "bar", "baz"] | path expand)
+        assert equal (get_path) (["fooooo", "foo", "bar", "baz"] | path expand)
 
         load-env {$path_name: []}
 
@@ -37,11 +36,11 @@ def path_add [] {
         }
 
         std path add $target_paths
-        assert equal (get_path) ([($target_paths | get $nu.os-info.name)] | expand_paths)
+        assert equal (get_path) ([($target_paths | get $nu.os-info.name)] | path expand)
 
         load-env {$path_name: ["/foo:/bar"]}
         std path add "~/foo"
-        assert equal (get_path) (["~/foo", "/foo", "/bar"] | expand_paths)
+        assert equal (get_path) (["~/foo", "/foo", "/bar"] | path expand)
     }
 }
 

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -8,6 +8,7 @@ def path_add [] {
 
     with-env [$path_name []] {
         def get_path [] { $env | get $path_name }
+        def expand_paths []: list<string> -> list<path> { each { path expand } }
 
         assert equal (get_path) []
 
@@ -21,10 +22,10 @@ def path_add [] {
 
         std path add "foo"
         std path add "bar" "baz" --append
-        assert equal (get_path) ["foo", "bar", "baz"]
+        assert equal (get_path) (["foo", "bar", "baz"] | expand_paths)
 
-        assert equal (std path add "fooooo" --ret) ["fooooo", "foo", "bar", "baz"]
-        assert equal (get_path) ["fooooo", "foo", "bar", "baz"]
+        assert equal (std path add "fooooo" --ret) (["fooooo", "foo", "bar", "baz"] | expand_paths)
+        assert equal (get_path) (["fooooo", "foo", "bar", "baz"] | expand_paths)
 
         load-env {$path_name: []}
 
@@ -36,11 +37,11 @@ def path_add [] {
         }
 
         std path add $target_paths
-        assert equal (get_path) [($target_paths | get $nu.os-info.name)]
+        assert equal (get_path) ([($target_paths | get $nu.os-info.name)] | expand_paths)
 
-        load-env {$path_name: ["/usr/bin:/bin"]}
+        load-env {$path_name: ["/foo:/bar"]}
         std path add "~/foo"
-        assert equal (get_path) [($nu.home-path | path join "foo"), "/usr/bin", "/bin"]
+        assert equal (get_path) (["~/foo", "/foo", "/bar"] | expand_paths)
     }
 }
 

--- a/crates/nu-std/tests/test_std.nu
+++ b/crates/nu-std/tests/test_std.nu
@@ -13,10 +13,10 @@ def path_add [] {
         assert equal (get_path) []
 
         std path add "/foo/"
-        assert equal (get_path) ["/foo/"]
+        assert equal (get_path) (["/foo/"] | expand_paths)
 
         std path add "/bar/" "/baz/"
-        assert equal (get_path) ["/bar/", "/baz/", "/foo/"]
+        assert equal (get_path) (["/bar/", "/baz/", "/foo/"] | expand_paths)
 
         load-env {$path_name: []}
 


### PR DESCRIPTION
related to
- https://discord.com/channels/601130461678272522/614593951969574961/1162406310155923626

# Description
this PR
- does a bit of minor refactoring
- makes sure the input paths get expanded
- makes sure the input PATH gets split on ":"
- adds a test
- fixes the other tests

# User-Facing Changes
should give a better overall experience with `std path add`

# Tests + Formatting
adds a new test case to the `path_add` test and fixes the others.

# After Submitting