### PR TITLE
deprecate `def-env`  and `export def-env`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/def_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def_env.rs
@@ -37,11 +37,21 @@ impl Command for DefEnv {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         _stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        nu_protocol::report_error_new(
+            engine_state,
+            &ShellError::GenericError(
+                "Deprecated command".into(),
+                "`def-env` is deprecated and will be removed in 0.88.".into(),
+                Some(call.head),
+                Some("Use `def --env` instead".into()),
+                vec![],
+            ),
+        );
         Ok(PipelineData::empty())
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/export_def_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def_env.rs
@@ -62,11 +62,21 @@ export def-env cd_with_fallback [arg = ""] {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         _stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        nu_protocol::report_error_new(
+            engine_state,
+            &ShellError::GenericError(
+                "Deprecated command".into(),
+                "`export def-env` is deprecated and will be removed in 0.88.".into(),
+                Some(call.head),
+                Some("Use `export def --env` instead".into()),
+                vec![],
+            ),
+        );
         Ok(PipelineData::empty())
     }
 


### PR DESCRIPTION
follow-up to
- https://github.com/nushell/nushell/pull/10566

# Description
this PR deprecates the use of `def-env` and `export def-env`

these two core commands will be removed in 0.88

# User-Facing Changes
using `def-env` will give a warning
```nushell
> def-env foo [] { print "foo" }; foo
Error:   × Deprecated command
   ╭─[entry #1:1:1]
 1 │ def-env foo [] { print "foo" }; foo
   · ───┬───
   ·    ╰── `def-env` is deprecated and will be removed in 0.88.
   ╰────
  help: Use `def --env` instead


foo
```

# Tests + Formatting

# After Submitting