### PR TITLE
deprecate `extern-wrapped` and `export extern-wrapped`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/export_extern_wrapped.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_extern_wrapped.rs
@@ -34,11 +34,21 @@ impl Command for ExportExternWrapped {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         _stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        nu_protocol::report_error_new(
+            engine_state,
+            &ShellError::GenericError(
+                "Deprecated command".into(),
+                "`export extern-wrapped` is deprecated and will be removed in 0.88.".into(),
+                Some(call.head),
+                Some("Use `export def --wrapped` instead".into()),
+                vec![],
+            ),
+        );
         Ok(PipelineData::empty())
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/extern_wrapped.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_wrapped.rs
@@ -37,11 +37,21 @@ impl Command for ExternWrapped {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         _stack: &mut Stack,
-        _call: &Call,
+        call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        nu_protocol::report_error_new(
+            engine_state,
+            &ShellError::GenericError(
+                "Deprecated command".into(),
+                "`extern-wrapped` is deprecated and will be removed in 0.88.".into(),
+                Some(call.head),
+                Some("Use `def --wrapped` instead".into()),
+                vec![],
+            ),
+        );
         Ok(PipelineData::empty())
     }
 


### PR DESCRIPTION
follow-up to
- https://github.com/nushell/nushell/pull/10566

# Description
this PR deprecates the use of `extern-wrapped` and `export extern-wrapped`

these two core commands will be removed in 0.88

# User-Facing Changes
using `extern-wrapped` will give a warning
```nushell
> extern-wrapped foo [...args] { print "foo" }; foo
Error:   × Deprecated command
   ╭─[entry #2:1:1]
 1 │ extern-wrapped foo [...args] { print "foo" }; foo
   · ───────┬──────
   ·        ╰── `extern-wrapped` is deprecated and will be removed in 0.88.
   ╰────
  help: Use `def --wrapped` instead


foo
```

# Tests + Formatting

# After Submitting