### PR TITLE
remove the last mention to `let-env`

### DIFF
--- a/crates/nu-std/CONTRIBUTING.md
+++ b/crates/nu-std/CONTRIBUTING.md
@@ -118,7 +118,7 @@ is described below:
       Use `export def` to make these names public to your users.
     * If your command is updating environment variables, you must use
       `export def --env` (instead of `export def`) to define the subcommand,
-      `export-env {}` to initialize the environment variables and `let-env` to
+      `export-env {}` to initialize the environment variables and `$env.VAR = val` to
       update them. For an example of a custom command which modifies
       environment variables, see: `./crates/nu-std/lib/dirs.nu`.  
       For an example of a custom command which does *not* modify environment


### PR DESCRIPTION
# Description
just caught a last mention to `let-env` in the `CONTRIBUTING.md` document :yum: 

# User-Facing Changes

# Tests + Formatting

# After Submitting