### PR TITLE
fix: only escape path containing numbers if they can be valid floating points

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -148,28 +148,11 @@ pub fn complete_item(
         .collect()
 }
 
-fn path_maybe_number(path: &str) -> bool {
-    let mut has_decimal = false;
-    for c in path.chars() {
-        if !c.is_numeric() {
-            return false;
-        }
-        if c == '.' {
-            if has_decimal {
-                return false;
-            }
-            has_decimal = true;
-        }
-    }
-    true
-}
-
 // Fix files or folders with quotes or hashes
 pub fn escape_path(path: String, dir: bool) -> String {
-    let filename_contaminated =
-        !dir && (path.contains(['\'', '"', ' ', '#', '(', ')']) || path_maybe_number(&path));
+    let filename_contaminated = !dir && path.contains(['\'', '"', ' ', '#', '(', ')']);
     let dirname_contaminated = dir && path.contains(['\'', '"', ' ', '#']);
-    if filename_contaminated || dirname_contaminated {
+    if filename_contaminated || dirname_contaminated || path.parse::<f64>().is_ok() {
         format!("`{path}`")
     } else {
         path

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -148,12 +148,26 @@ pub fn complete_item(
         .collect()
 }
 
+fn path_maybe_number(path: &str) -> bool {
+    let mut has_decimal = false;
+    for c in path.chars() {
+        if !c.is_numeric() {
+            return false;
+        }
+        if c == '.' {
+            if has_decimal {
+                return false;
+            }
+            has_decimal = true;
+        }
+    }
+    true
+}
+
 // Fix files or folders with quotes or hashes
 pub fn escape_path(path: String, dir: bool) -> String {
-    let filename_contaminated = !dir
-        && path.contains([
-            '\'', '"', ' ', '#', '(', ')', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-        ]);
+    let filename_contaminated =
+        !dir && (path.contains(['\'', '"', ' ', '#', '(', ')']) || path_maybe_number(&path));
     let dirname_contaminated = dir && path.contains(['\'', '"', ' ', '#']);
     if filename_contaminated || dirname_contaminated {
         format!("`{path}`")


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

Refer to https://github.com/nushell/nushell/pull/10600#issuecomment-1762863791

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

A path is escaped when it can be entirely parsed as a floating point number. This includes `nan`, `inf` and their negative counterparts since nu also supports them.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Paths with numbers that cannot be ambiguous are no longer surrounded by backticks.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
