### PR TITLE
Bump version for `0.86.0` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "nu"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "assert_cmd",
  "criterion",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cli"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "chrono",
  "crossterm 0.27.0",
@@ -2708,7 +2708,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-base"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "indexmap 2.0.2",
  "miette",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-dataframe"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "chrono",
  "fancy-regex",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-extra"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "ahash",
  "fancy-regex",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "fancy-regex",
  "itertools 0.11.0",
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "nu-color-config"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "nu-ansi-term",
  "nu-engine",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "nu-command"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "alphanumeric-sort",
  "base64",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "nu-glob",
  "nu-path",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "nu-explore"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "ansi-str",
  "crossterm 0.27.0",
@@ -2920,14 +2920,14 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "doc-comment",
 ]
 
 [[package]]
 name = "nu-json"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "linked-hash-map",
  "num-traits",
@@ -2936,7 +2936,7 @@ dependencies = [
 
 [[package]]
 name = "nu-parser"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "bytesize",
  "chrono",
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "dirs-next",
  "omnipath",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "bincode",
  "nu-engine",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "nu-pretty-hex"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "heapless",
  "nu-ansi-term",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "byte-unit",
  "chrono",
@@ -3007,7 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "nu-std"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "miette",
  "nu-engine",
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "chrono",
  "libc",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "nu-table"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "fancy-regex",
  "nu-ansi-term",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "nu-term-grid"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "nu-utils",
  "unicode-width",
@@ -3056,7 +3056,7 @@ dependencies = [
 
 [[package]]
 name = "nu-test-support"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "hamcrest2",
  "nu-glob",
@@ -3069,7 +3069,7 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "crossterm_winapi",
  "log",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_example"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3099,7 +3099,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_formats"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "eml-parser",
  "ical",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_gstat"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "git2",
  "nu-plugin",
@@ -3120,7 +3120,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_inc"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_query"
-version = "0.85.1"
+version = "0.86.0"
 dependencies = [
  "gjson",
  "nu-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
 rust-version = "1.60"
-version = "0.85.1"
+version = "0.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -46,26 +46,26 @@ members = [
 ]
 
 [dependencies]
-nu-cli = { path = "./crates/nu-cli", version = "0.85.1" }
-nu-color-config = { path = "./crates/nu-color-config", version = "0.85.1" }
-nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.85.1" }
-nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.85.1" }
-nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.85.1", features = ["dataframe"], optional = true }
-nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.85.1", optional = true }
-nu-command = { path = "./crates/nu-command", version = "0.85.1" }
-nu-engine = { path = "./crates/nu-engine", version = "0.85.1" }
-nu-explore = { path = "./crates/nu-explore", version = "0.85.1" }
-nu-json = { path = "./crates/nu-json", version = "0.85.1" }
-nu-parser = { path = "./crates/nu-parser", version = "0.85.1" }
-nu-path = { path = "./crates/nu-path", version = "0.85.1" }
-nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.85.1" }
-nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.85.1" }
-nu-protocol = { path = "./crates/nu-protocol", version = "0.85.1" }
-nu-system = { path = "./crates/nu-system", version = "0.85.1" }
-nu-table = { path = "./crates/nu-table", version = "0.85.1" }
-nu-term-grid = { path = "./crates/nu-term-grid", version = "0.85.1" }
-nu-std = { path = "./crates/nu-std", version = "0.85.1" }
-nu-utils = { path = "./crates/nu-utils", version = "0.85.1" }
+nu-cli = { path = "./crates/nu-cli", version = "0.86.0" }
+nu-color-config = { path = "./crates/nu-color-config", version = "0.86.0" }
+nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.86.0" }
+nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.86.0" }
+nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.86.0", features = ["dataframe"], optional = true }
+nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.86.0", optional = true }
+nu-command = { path = "./crates/nu-command", version = "0.86.0" }
+nu-engine = { path = "./crates/nu-engine", version = "0.86.0" }
+nu-explore = { path = "./crates/nu-explore", version = "0.86.0" }
+nu-json = { path = "./crates/nu-json", version = "0.86.0" }
+nu-parser = { path = "./crates/nu-parser", version = "0.86.0" }
+nu-path = { path = "./crates/nu-path", version = "0.86.0" }
+nu-plugin = { path = "./crates/nu-plugin", optional = true, version = "0.86.0" }
+nu-pretty-hex = { path = "./crates/nu-pretty-hex", version = "0.86.0" }
+nu-protocol = { path = "./crates/nu-protocol", version = "0.86.0" }
+nu-system = { path = "./crates/nu-system", version = "0.86.0" }
+nu-table = { path = "./crates/nu-table", version = "0.86.0" }
+nu-term-grid = { path = "./crates/nu-term-grid", version = "0.86.0" }
+nu-std = { path = "./crates/nu-std", version = "0.86.0" }
+nu-utils = { path = "./crates/nu-utils", version = "0.86.0" }
 nu-ansi-term = "0.49.0"
 reedline = { version = "0.24.0", features = ["bashisms", "sqlite"] }
 
@@ -95,7 +95,7 @@ nix = { version = "0.27", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-nu-test-support = { path = "./crates/nu-test-support", version = "0.85.1" }
+nu-test-support = { path = "./crates/nu-test-support", version = "0.86.0" }
 assert_cmd = "2.0"
 criterion = "0.5"
 pretty_assertions = "1.4"

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -5,25 +5,25 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cli"
 edition = "2021"
 license = "MIT"
 name = "nu-cli"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 bench = false
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.85.1" }
-nu-command = { path = "../nu-command", version = "0.85.1" }
-nu-test-support = { path = "../nu-test-support", version = "0.85.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.86.0" }
+nu-command = { path = "../nu-command", version = "0.86.0" }
+nu-test-support = { path = "../nu-test-support", version = "0.86.0" }
 rstest = { version = "0.18.1", default-features = false }
 
 [dependencies]
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.85.1" }
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-path = { path = "../nu-path", version = "0.85.1" }
-nu-parser = { path = "../nu-parser", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.85.1" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.86.0" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-path = { path = "../nu-path", version = "0.86.0" }
+nu-parser = { path = "../nu-parser", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.86.0" }
 nu-ansi-term = "0.49.0"
 reedline = { version = "0.24.0", features = ["bashisms", "sqlite"] }
 

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-base"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-base"
-version = "0.85.1"
+version = "0.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-parser = { path = "../nu-parser", version = "0.85.1" }
-nu-path = { path = "../nu-path", version = "0.85.1" }
-nu-protocol = { version = "0.85.1", path = "../nu-protocol" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-parser = { path = "../nu-parser", version = "0.86.0" }
+nu-path = { path = "../nu-path", version = "0.86.0" }
+nu-protocol = { version = "0.86.0", path = "../nu-protocol" }
 indexmap = { version = "2.0" }
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-dataframe"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-dataframe"
-version = "0.85.1"
+version = "0.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,9 +13,9 @@ version = "0.85.1"
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-parser = { path = "../nu-parser", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-parser = { path = "../nu-parser", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
 
 # Potential dependencies for extras
 chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
@@ -61,5 +61,5 @@ dataframe = ["num", "polars", "polars-io", "sqlparser"]
 default = []
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.85.1" }
-nu-test-support = { path = "../nu-test-support", version = "0.85.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.86.0" }
+nu-test-support = { path = "../nu-test-support", version = "0.86.0" }

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-cmd-extra"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-extra"
-version = "0.85.1"
+version = "0.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,11 +13,11 @@ version = "0.85.1"
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-parser = { path = "../nu-parser", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.85.1" }
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-parser = { path = "../nu-parser", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.86.0" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
 
 # Potential dependencies for extras
 heck = "0.4.1"
@@ -27,8 +27,8 @@ nu-ansi-term = "0.49.0"
 fancy-regex = "0.11.0"
 rust-embed = "8.0.0"
 serde = "1.0.164"
-nu-pretty-hex = { version = "0.85.1", path = "../nu-pretty-hex" }
-nu-json = { version = "0.85.1", path = "../nu-json" }
+nu-pretty-hex = { version = "0.86.0", path = "../nu-pretty-hex" }
+nu-json = { version = "0.86.0", path = "../nu-json" }
 serde_urlencoded = "0.7.1"
 htmlescape = "0.3.1"
 
@@ -37,6 +37,6 @@ extra = ["default"]
 default = []
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.85.1" }
-nu-command = { path = "../nu-command", version = "0.85.1" }
-nu-test-support = { path = "../nu-test-support", version = "0.85.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.86.0" }
+nu-command = { path = "../nu-command", version = "0.86.0" }
+nu-test-support = { path = "../nu-test-support", version = "0.86.0" }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -6,16 +6,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-cmd-lang"
 edition = "2021"
 license = "MIT"
 name = "nu-cmd-lang"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-parser = { path = "../nu-parser", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-parser = { path = "../nu-parser", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
 nu-ansi-term = "0.49.0"
 
 fancy-regex = "0.11"

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -5,19 +5,19 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-color-confi
 edition = "2021"
 license = "MIT"
 name = "nu-color-config"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
 nu-ansi-term = "0.49.0"
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-json = { path = "../nu-json", version = "0.85.1" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-json = { path = "../nu-json", version = "0.86.0" }
 
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
-nu-test-support = { path = "../nu-test-support", version = "0.85.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.86.0" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-command"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-command"
-version = "0.85.1"
+version = "0.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,19 +14,19 @@ bench = false
 
 [dependencies]
 nu-ansi-term = "0.49.0"
-nu-cmd-base = { path = "../nu-cmd-base", version = "0.85.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.85.1" }
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-glob = { path = "../nu-glob", version = "0.85.1" }
-nu-json = { path = "../nu-json", version = "0.85.1" }
-nu-parser = { path = "../nu-parser", version = "0.85.1" }
-nu-path = { path = "../nu-path", version = "0.85.1" }
-nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
-nu-system = { path = "../nu-system", version = "0.85.1" }
-nu-table = { path = "../nu-table", version = "0.85.1" }
-nu-term-grid = { path = "../nu-term-grid", version = "0.85.1" }
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
+nu-cmd-base = { path = "../nu-cmd-base", version = "0.86.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.86.0" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-glob = { path = "../nu-glob", version = "0.86.0" }
+nu-json = { path = "../nu-json", version = "0.86.0" }
+nu-parser = { path = "../nu-parser", version = "0.86.0" }
+nu-path = { path = "../nu-path", version = "0.86.0" }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
+nu-system = { path = "../nu-system", version = "0.86.0" }
+nu-table = { path = "../nu-table", version = "0.86.0" }
+nu-term-grid = { path = "../nu-term-grid", version = "0.86.0" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
 
 alphanumeric-sort = "1.5"
 base64 = "0.21"
@@ -123,8 +123,8 @@ trash-support = ["trash"]
 which-support = ["which"]
 
 [dev-dependencies]
-nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.85.1" }
-nu-test-support = { path = "../nu-test-support", version = "0.85.1" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.86.0" }
+nu-test-support = { path = "../nu-test-support", version = "0.86.0" }
 
 dirs-next = "2.0"
 mockito = { version = "1.2", default-features = false }

--- a/crates/nu-engine/Cargo.toml
+++ b/crates/nu-engine/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-engine"
 edition = "2021"
 license = "MIT"
 name = "nu-engine"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.85.1" }
-nu-path = { path = "../nu-path", version = "0.85.1" }
-nu-glob = { path = "../nu-glob", version = "0.85.1" }
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
+nu-protocol = { path = "../nu-protocol", features = ["plugin"], version = "0.86.0" }
+nu-path = { path = "../nu-path", version = "0.86.0" }
+nu-glob = { path = "../nu-glob", version = "0.86.0" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
 
 [features]
 plugin = []

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -5,20 +5,20 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-explore"
 edition = "2021"
 license = "MIT"
 name = "nu-explore"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 bench = false
 
 [dependencies]
 nu-ansi-term = "0.49.0"
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
-nu-parser = { path = "../nu-parser", version = "0.85.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.85.1" }
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-table = { path = "../nu-table", version = "0.85.1" }
-nu-json = { path = "../nu-json", version = "0.85.1" }
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
+nu-parser = { path = "../nu-parser", version = "0.86.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.86.0" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-table = { path = "../nu-table", version = "0.86.0" }
+nu-json = { path = "../nu-json", version = "0.86.0" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
 
 terminal_size = "0.2"
 strip-ansi-escapes = "0.2.0"

--- a/crates/nu-glob/Cargo.toml
+++ b/crates/nu-glob/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu-glob"
-version = "0.85.1"
+version = "0.86.0"
 authors = ["The Nushell Project Developers", "The Rust Project Developers"]
 license = "MIT/Apache-2.0"
 description = """

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-json"
 edition = "2021"
 license = "MIT"
 name = "nu-json"
-version = "0.85.1"
+version = "0.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -22,5 +22,5 @@ num-traits = "0.2"
 serde = "1.0"
 
 [dev-dependencies]
-# nu-path = { path="../nu-path", version = "0.85.1" }
+# nu-path = { path="../nu-path", version = "0.86.0" }
 # serde_json = "1.0"

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -5,17 +5,17 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-parser"
 edition = "2021"
 license = "MIT"
 name = "nu-parser"
-version = "0.85.1"
+version = "0.86.0"
 exclude = ["/fuzz"]
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-path = { path = "../nu-path", version = "0.85.1" }
-nu-plugin = { path = "../nu-plugin", optional = true, version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-path = { path = "../nu-path", version = "0.86.0" }
+nu-plugin = { path = "../nu-plugin", optional = true, version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
 
 bytesize = "1.3"
 chrono = { default-features = false, features = ['std'], version = "0.4" }

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-path"
 edition = "2021"
 license = "MIT"
 name = "nu-path"
-version = "0.85.1"
+version = "0.86.0"
 exclude = ["/fuzz"]
 
 [lib]

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -5,14 +5,14 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-plugin"
 edition = "2021"
 license = "MIT"
 name = "nu-plugin"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
 
 bincode = "1.3"
 rmp-serde = "1.1"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-pretty-hex"
 edition = "2021"
 license = "MIT"
 name = "nu-pretty-hex"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 doctest = false

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-protocol"
 edition = "2021"
 license = "MIT"
 name = "nu-protocol"
-version = "0.85.1"
+version = "0.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -13,9 +13,9 @@ version = "0.85.1"
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
-nu-path = { path = "../nu-path", version = "0.85.1" }
-nu-system = { path = "../nu-system", version = "0.85.1" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
+nu-path = { path = "../nu-path", version = "0.86.0" }
+nu-system = { path = "../nu-system", version = "0.86.0" }
 
 byte-unit = "4.0"
 chrono = { version = "0.4", features = [ "serde", "std", "unstable-locales" ], default-features = false }
@@ -37,5 +37,5 @@ plugin = ["serde_json"]
 serde_json = "1.0"
 strum = "0.25"
 strum_macros = "0.25"
-nu-test-support = { path = "../nu-test-support", version = "0.85.1" }
+nu-test-support = { path = "../nu-test-support", version = "0.86.0" }
 rstest = "0.18"

--- a/crates/nu-std/Cargo.toml
+++ b/crates/nu-std/Cargo.toml
@@ -5,10 +5,10 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-std"
 edition = "2021"
 license = "MIT"
 name = "nu-std"
-version = "0.85.1"
+version = "0.86.0"
 
 [dependencies]
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }
-nu-parser = { version = "0.85.1", path = "../nu-parser" }
-nu-protocol = { version = "0.85.1", path = "../nu-protocol" }
-nu-engine = { version = "0.85.1", path = "../nu-engine" }
+nu-parser = { version = "0.86.0", path = "../nu-parser" }
+nu-protocol = { version = "0.86.0", path = "../nu-protocol" }
+nu-engine = { version = "0.86.0", path = "../nu-engine" }

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["The Nushell Project Developers", "procs creators"]
 description = "Nushell system querying"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-system"
 name = "nu-system"
-version = "0.85.1"
+version = "0.86.0"
 edition = "2021"
 license = "MIT"
 

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -5,20 +5,20 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-table"
 edition = "2021"
 license = "MIT"
 name = "nu-table"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
-nu-color-config = { path = "../nu-color-config", version = "0.85.1" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
+nu-color-config = { path = "../nu-color-config", version = "0.86.0" }
 nu-ansi-term = "0.49.0"
 once_cell = "1.18"
 fancy-regex = "0.11"
 tabled = { version = "0.14.0", features = ["color"], default-features = false }
 
 [dev-dependencies]
-# nu-test-support = { path="../nu-test-support", version = "0.85.1"  }
+# nu-test-support = { path="../nu-test-support", version = "0.86.0"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-term-grid"
 edition = "2021"
 license = "MIT"
 name = "nu-term-grid"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 bench = false
 
 [dependencies]
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
 
 unicode-width = "0.1"

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -5,16 +5,16 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu-test-suppor
 edition = "2021"
 license = "MIT"
 name = "nu-test-support"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 doctest = false
 bench = false
 
 [dependencies]
-nu-path = { path = "../nu-path", version = "0.85.1" }
-nu-glob = { path = "../nu-glob", version = "0.85.1" }
-nu-utils = { path = "../nu-utils", version = "0.85.1" }
+nu-path = { path = "../nu-path", version = "0.86.0" }
+nu-glob = { path = "../nu-glob", version = "0.86.0" }
+nu-utils = { path = "../nu-utils", version = "0.86.0" }
 
 num-format = "0.4"
 which = "4.3"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 name = "nu-utils"
 repository = "https://github.com/nushell/nushell/tree/main/crates/nu-utils"
-version = "0.85.1"
+version = "0.86.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -1,6 +1,6 @@
 # Nushell Config File
 #
-# version = "0.85.1"
+# version = "0.86.0"
 
 # For more information on defining custom themes, see
 # https://www.nushell.sh/book/coloring_and_theming.html

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -1,6 +1,6 @@
 # Nushell Environment Config File
 #
-# version = "0.85.1"
+# version = "0.86.0"
 
 def create_left_prompt [] {
     let home =  $nu.home-path

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -10,7 +10,7 @@ name = "nu_plugin_custom_values"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0", features = ["plugin"] }
 serde = { version = "1.0", default-features = false }
 typetag = "0.2"

--- a/crates/nu_plugin_example/Cargo.toml
+++ b/crates/nu_plugin_example/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_exam
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_example"
-version = "0.85.1"
+version = "0.86.0"
 
 [[bin]]
 name = "nu_plugin_example"
@@ -15,5 +15,5 @@ bench = false
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0", features = ["plugin"] }

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -5,12 +5,12 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_form
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_formats"
-version = "0.85.1"
+version = "0.86.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0", features = ["plugin"] }
 
 indexmap = "2.0"
 eml-parser = "0.1"

--- a/crates/nu_plugin_gstat/Cargo.toml
+++ b/crates/nu_plugin_gstat/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_gsta
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_gstat"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_gstat"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
 
 git2 = "0.18"

--- a/crates/nu_plugin_inc/Cargo.toml
+++ b/crates/nu_plugin_inc/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_inc"
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_inc"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 doctest = false
@@ -16,7 +16,7 @@ name = "nu_plugin_inc"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1", features = ["plugin"] }
+nu-plugin = { path = "../nu-plugin", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0", features = ["plugin"] }
 
 semver = "1.0"

--- a/crates/nu_plugin_query/Cargo.toml
+++ b/crates/nu_plugin_query/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_quer
 edition = "2021"
 license = "MIT"
 name = "nu_plugin_query"
-version = "0.85.1"
+version = "0.86.0"
 
 [lib]
 doctest = false
@@ -16,9 +16,9 @@ name = "nu_plugin_query"
 bench = false
 
 [dependencies]
-nu-plugin = { path = "../nu-plugin", version = "0.85.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.85.1" }
-nu-engine = { path = "../nu-engine", version = "0.85.1" }
+nu-plugin = { path = "../nu-plugin", version = "0.86.0" }
+nu-protocol = { path = "../nu-protocol", version = "0.86.0" }
+nu-engine = { path = "../nu-engine", version = "0.86.0" }
 
 gjson = "0.8"
 scraper = { default-features = false, version = "0.17" }


### PR DESCRIPTION
## Release checklist:

- [x] `uu_cp` on crates.io #10725
- [x] new `reedline` released and used nushell/reedline#645
- [x] check of workspace dependency DAG
- [x] release notes ready: https://github.com/nushell/nushell.github.io/pull/1071
