### PR TITLE
Allow empty list inputs in `group-by` and return empty record

### DIFF
--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -128,12 +128,9 @@ pub fn group_by(
     let values: Vec<Value> = input.into_iter().collect();
 
     if values.is_empty() {
-        return Err(ShellError::GenericError(
-            "expected table from pipeline".into(),
-            "requires a table input".into(),
-            Some(span),
+        return Ok(PipelineData::Value(
+            Value::record(Record::new(), Span::unknown()),
             None,
-            Vec::new(),
         ));
     }
 

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -97,9 +97,10 @@ fn errors_if_column_not_found() {
 }
 
 #[test]
-fn errors_if_input_empty() {
-    let actual = nu!("group-by date");
-    assert!(actual.err.contains("expected table from pipeline"));
+fn group_by_on_empty_list_returns_empty_record() {
+    let actual = nu!("[[a b]; [1 2]] | where false | group-by a");
+    assert!(actual.err.is_empty());
+    assert!(actual.out.contains("empty record"));
 }
 
 #[test]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->


# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Changed `group-by` behavior to accept empty list as input and return an empty record instead of throwing an error. I also replaced `errors_if_input_empty()` test to reflect the new expected behavior.

See #10713 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
