### PR TITLE
Add `--ignore-error` to reject

### DIFF
--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -22,6 +22,11 @@ impl Command for Reject {
                 (Type::Record(vec![]), Type::Record(vec![])),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
+            .switch(
+                "ignore-errors",
+                "ignore missing data (make all cell path members optional)",
+                Some('i'),
+            )
             .rest(
                 "rest",
                 SyntaxShape::OneOf(vec![
@@ -126,6 +131,14 @@ impl Command for Reject {
             }
         }
         let span = call.head;
+
+        let ignore_errors = call.has_flag("ignore-errors");
+        if ignore_errors {
+            for cell_path in &mut new_columns {
+                cell_path.make_optional();
+            }
+        }
+
         reject(engine_state, span, input, new_columns)
     }
 

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -185,3 +185,9 @@ fn reject_multiple_rows_descending() {
     let actual = nu!("[[a,b];[1 2] [3 4] [5 6]] | reject 2 1 | to nuon");
     assert_eq!(actual.out, "[[a, b]; [1, 2]]");
 }
+
+#[test]
+fn test_ignore_errors_flag() {
+    let actual = nu!("[[a, b]; [1, 2], [3, 4], [5, 6]] | reject 5 -i | to nuon");
+    assert_eq!(actual.out, "[[a, b]; [1, 2], [3, 4], [5, 6]]");
+}

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -191,3 +191,10 @@ fn test_ignore_errors_flag() {
     let actual = nu!("[[a, b]; [1, 2], [3, 4], [5, 6]] | reject 5 -i | to nuon");
     assert_eq!(actual.out, "[[a, b]; [1, 2], [3, 4], [5, 6]]");
 }
+
+#[test]
+fn test_ignore_errors_flag_var() {
+    let actual =
+        nu!("let arg = [5 c]; [[a, b]; [1, 2], [3, 4], [5, 6]] | reject $arg -i | to nuon");
+    assert_eq!(actual.out, "[[a, b]; [1, 2], [3, 4], [5, 6]]");
+}


### PR DESCRIPTION
# Description

Add `--ignore-errors` flag to reject.

This is a PR in reference to #10215 as select has the flag, but reject hasn't

# User-Facing Changes
user can now add `-i` or `--ignore-errors` flag to turn every cell path into option.

```nushell
> let arg = [0 5 a c]
> [[a b];[1 2] [3 4] [5 6]] | reject $a | to nuon
error index to large
# ----
> let arg = [0 5 a c]
> [[a b];[1 2] [3 4] [5 6]] | reject $a -i | to nuon
[[a, b]; [1, 2], [3, 4], [5, 6]]
```