### PR TITLE
Implement modulo for duration

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -3445,6 +3445,13 @@ impl Value {
                     Err(ShellError::DivisionByZero { span: op })
                 }
             }
+            (Value::Duration { val: lhs, .. }, Value::Duration { val: rhs, .. }) => {
+                if *rhs != 0 {
+                    Ok(Value::duration(lhs % rhs, span))
+                } else {
+                    Err(ShellError::DivisionByZero { span: op })
+                }
+            }
             (Value::CustomValue { val: lhs, .. }, rhs) => {
                 lhs.operation(span, Operator::Math(Math::Modulo), op, rhs)
             }

--- a/src/tests/test_math.rs
+++ b/src/tests/test_math.rs
@@ -121,6 +121,14 @@ fn test_filesize_op() -> TestResult {
 }
 
 #[test]
+fn test_duration_op() -> TestResult {
+    run_test("4min + 20sec", "4min 20sec").unwrap();
+    run_test("42sec * 2", "1min 24sec").unwrap();
+    run_test("(3min + 14sec) / 2", "1min 37sec").unwrap();
+    run_test("(4min + 20sec) mod 69sec", "53sec")
+}
+
+#[test]
 fn lt() -> TestResult {
     run_test("1 < 3", "true").unwrap();
     run_test("3 < 3", "false").unwrap();


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds the ability to use modulo with durations:

```nu
(2min + 31sec) mod 20sec # 11sec
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Allows to use `<duration> mod <duration>`