### PR TITLE
Implement hash records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
 name = "nu-command"
 version = "0.85.1"
 dependencies = [
+ "ahash",
  "alphanumeric-sort",
  "base64",
  "bracoxide",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -93,6 +93,7 @@ wax = { version = "0.6" }
 which = { version = "4.4", optional = true }
 bracoxide = "0.1.2"
 chardetng = "0.1.17"
+ahash = "0.8.3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51"

--- a/crates/nu-command/src/conversions/into/mod.rs
+++ b/crates/nu-command/src/conversions/into/mod.rs
@@ -7,6 +7,7 @@ mod filesize;
 mod float;
 mod int;
 mod record;
+mod record_hashmap;
 mod string;
 mod value;
 
@@ -19,5 +20,6 @@ pub use duration::SubCommand as IntoDuration;
 pub use float::SubCommand as IntoFloat;
 pub use int::SubCommand as IntoInt;
 pub use record::SubCommand as IntoRecord;
+pub use record_hashmap::SubCommand as IntoRecordHashMap;
 pub use string::SubCommand as IntoString;
 pub use value::IntoValue;

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -33,7 +33,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "record", "hash", "map", "lookup", "table"]
+        vec!["convert", "map"]
     }
 
     fn run(

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -24,6 +24,7 @@ impl Command for SubCommand {
                 (Type::Record(vec![]), Type::Record(vec![])),
                 (Type::Table(vec![]), Type::Record(vec![])),
             ])
+            .switch("hashmap", "convert table to hash map", Some('H'))
             .category(Category::Conversions)
     }
 
@@ -32,7 +33,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert"]
+        vec!["convert", "record", "hash", "map", "lookup", "table"]
     }
 
     fn run(
@@ -144,7 +145,8 @@ fn into_record(
     let input = input.into_value(call.head);
     let input_type = input.get_type();
     let span = input.span();
-    let res = match input {
+
+    let res: Value = match input {
         Value::Date { val, .. } => parse_date_into_record(val, span),
         Value::Duration { val, .. } => parse_duration_into_record(val, span),
         Value::List { mut vals, .. } => match input_type {
@@ -164,7 +166,7 @@ fn into_record(
                 .collect(),
             span,
         ),
-        Value::Record { val, .. } => Value::record(val, span),
+        Value::Record { .. } => input,
         Value::Error { .. } => input,
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
@@ -176,6 +178,7 @@ fn into_record(
             call.head,
         ),
     };
+
     Ok(res.into_pipeline_data())
 }
 

--- a/crates/nu-command/src/conversions/into/record_hashmap.rs
+++ b/crates/nu-command/src/conversions/into/record_hashmap.rs
@@ -25,7 +25,7 @@ impl Command for SubCommand {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["convert", "record", "hash", "map", "lookup", "table"]
+        vec!["convert", "map", "lookup", "table"]
     }
 
     fn run(

--- a/crates/nu-command/src/conversions/into/record_hashmap.rs
+++ b/crates/nu-command/src/conversions/into/record_hashmap.rs
@@ -1,0 +1,164 @@
+use ahash::{HashMap, HashMapExt};
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    record, Category, Example, IntoPipelineData, LazyRecord, PipelineData, Record, ShellError,
+    Signature, Span, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct SubCommand;
+
+impl Command for SubCommand {
+    fn name(&self) -> &str {
+        "into hash-record"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("into hash-record")
+            .input_output_types(vec![(Type::Record(vec![]), Type::Record(vec![]))])
+            .category(Category::Conversions)
+    }
+
+    fn usage(&self) -> &str {
+        "Convert a record into a hashmap"
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["convert", "record", "hash", "map", "lookup", "table"]
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        into_record(engine_state, call, input)
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Create a hash map from a record",
+            example: r#"{shell: "Nushell", best: true, uwu: "owo"} | into hash-record"#,
+            result: Some(Value::Record {
+                val: record!(
+                  "shell" => Value::string("Nushell".to_string(), Span::unknown()),
+                  "best" => Value::bool(true, Span::unknown()),
+                  "uwu" => Value::string("owo".to_string(), Span::unknown()),
+                ),
+                internal_span: Span::unknown(),
+            }),
+        }]
+    }
+}
+
+fn into_record(
+    _engine_state: &EngineState,
+    call: &Call,
+    input: PipelineData,
+) -> Result<PipelineData, ShellError> {
+    let input = input.into_value(call.head);
+    let span = input.span();
+
+    let map = match input {
+        Value::Record { val, .. } => {
+            Value::lazy_record(Box::new(NuHashMapRecord::from_record(val, span)), span)
+        }
+        _ => Value::error(
+            ShellError::CantConvert {
+                from_type: input.get_type().to_string(),
+                to_type: "record".to_string(),
+                span,
+                help: None,
+            },
+            span,
+        ),
+    };
+    Ok(map.into_pipeline_data())
+}
+
+#[derive(Clone)]
+pub struct NuHashMapRecord {
+    hash_map: HashMap<String, Value>,
+    cols: Vec<String>,
+    span: Span,
+}
+
+impl std::fmt::Debug for NuHashMapRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NuLazyRecord").finish()
+    }
+}
+
+impl NuHashMapRecord {
+    fn from_record(record: Record, span: Span) -> Self {
+        let len = record.cols.len();
+        let mut hash_map: HashMap<String, Value> = HashMap::with_capacity(len);
+        for i in 0..len {
+            hash_map.insert(record.cols[i].clone(), record.vals[i].clone());
+        }
+
+        Self {
+            hash_map,
+            cols: record.cols,
+            span,
+        }
+    }
+}
+
+impl<'a> LazyRecord<'a> for NuHashMapRecord {
+    fn column_names(&'a self) -> Vec<&'a str> {
+        self.cols.iter().map(|col| col.as_str()).collect()
+    }
+
+    fn get_column_value(&self, column: &str) -> Result<Value, ShellError> {
+        match self.hash_map.get(column) {
+            Some(value) => Ok(value.clone()),
+            None => Err(ShellError::CantFindColumn {
+                col_name: column.to_string(),
+                span: self.span,
+                src_span: self.span,
+            }),
+        }
+    }
+
+    fn get_column_value_opt(&self, column: &str) -> Option<Result<Value, ShellError>> {
+        self.hash_map.get(column).map(|value| Ok(value.clone()))
+    }
+
+    fn span(&self) -> Span {
+        self.span
+    }
+
+    fn clone_value(&self, span: Span) -> Value {
+        Value::lazy_record(Box::new(self.clone()), span)
+    }
+
+    fn collect(&'a self) -> Result<Value, ShellError> {
+        let len = self.hash_map.len();
+
+        let mut cols: Vec<String> = Vec::with_capacity(len);
+        let mut vals: Vec<Value> = Vec::with_capacity(len);
+
+        for (col, val) in self.hash_map.iter() {
+            cols.push(col.to_string());
+            vals.push(val.clone());
+        }
+
+        Ok(Value::record(Record { cols, vals }, self.span))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(SubCommand {})
+    }
+}

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -293,6 +293,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             IntoFilesize,
             IntoInt,
             IntoRecord,
+            IntoRecordHashMap,
             IntoString,
             IntoValue,
         };

--- a/crates/nu-protocol/src/value/lazy_record.rs
+++ b/crates/nu-protocol/src/value/lazy_record.rs
@@ -11,6 +11,15 @@ pub trait LazyRecord<'a>: fmt::Debug + Send + Sync {
     // Get 1 specific column value
     fn get_column_value(&self, column: &str) -> Result<Value, ShellError>;
 
+    // Returns None if the column doesn't exist and Some(Result) if it does
+    fn get_column_value_opt(&'a self, column: &str) -> Option<Result<Value, ShellError>> {
+        if self.column_names().contains(&column) {
+            Some(self.get_column_value(column))
+        } else {
+            None
+        }
+    }
+
     fn span(&self) -> Span;
 
     // Convert the lazy record into a regular Value::Record by collecting all its columns

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -108,7 +108,7 @@ fn allow_missing_optional_params() -> TestResult {
 fn help_present_in_def() -> TestResult {
     run_test_contains(
         "def foo [] {}; help foo;",
-        "Display the help message for this command",
+        "Display the help message for this command".into(),
     )
 }
 

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -1,16 +1,21 @@
 use crate::tests::{fail_test, run_test, run_test_contains, TestResult};
 
+use super::TestContains;
+
 // cargo version prints a string of the form:
 // cargo 1.60.0 (d1fd9fe2c 2022-03-01)
 
 #[test]
 fn known_external_runs() -> TestResult {
-    run_test_contains(r#"extern "cargo version" []; cargo version"#, "cargo")
+    run_test_contains(
+        r#"extern "cargo version" []; cargo version"#,
+        "cargo".into(),
+    )
 }
 
 #[test]
 fn known_external_unknown_flag() -> TestResult {
-    run_test_contains(r#"extern "cargo" []; cargo --version"#, "cargo")
+    run_test_contains(r#"extern "cargo" []; cargo --version"#, "cargo".into())
 }
 
 /// GitHub issues #5179, #4618
@@ -18,7 +23,7 @@ fn known_external_unknown_flag() -> TestResult {
 fn known_external_alias() -> TestResult {
     run_test_contains(
         r#"extern "cargo version" []; alias cv = cargo version; cv"#,
-        "cargo",
+        "cargo".into(),
     )
 }
 
@@ -27,7 +32,7 @@ fn known_external_alias() -> TestResult {
 fn known_external_subcommand_alias() -> TestResult {
     run_test_contains(
         r#"extern "cargo version" []; alias c = cargo; c version"#,
-        "cargo",
+        "cargo".into(),
     )
 }
 
@@ -35,7 +40,7 @@ fn known_external_subcommand_alias() -> TestResult {
 fn known_external_complex_unknown_args() -> TestResult {
     run_test_contains(
         "extern echo []; echo foo -b -as -9 --abc -- -Dxmy=AKOO - bar",
-        "foo -b -as -9 --abc -- -Dxmy=AKOO - bar",
+        "foo -b -as -9 --abc -- -Dxmy=AKOO - bar".into(),
     )
 }
 
@@ -49,13 +54,13 @@ fn known_external_from_module() -> TestResult {
         use spam echo
         echo foo -b -as -9 --abc -- -Dxmy=AKOO - bar
         "#,
-        "foo -b -as -9 --abc -- -Dxmy=AKOO - bar",
+        "foo -b -as -9 --abc -- -Dxmy=AKOO - bar".into(),
     )
 }
 
 #[test]
 fn known_external_short_flag_batch_arg_allowed() -> TestResult {
-    run_test_contains("extern echo [-a, -b: int]; echo -ab 10", "-b 10")
+    run_test_contains("extern echo [-a, -b: int]; echo -ab 10", "-b 10".into())
 }
 
 #[test]
@@ -115,10 +120,8 @@ fn known_external_subcommand_from_module() -> TestResult {
             use cargo;
             cargo check -h
         "#,
-        #[cfg(windows)]
-        "cargo.exe check",
-        #[cfg(not(windows))]
-        "cargo check",
+        // on some windows machines, cargo.exe seems to be reported as the binary name instead of cargo
+        TestContains::AnyOf(vec!["cargo.exe check", "cargo check"]),
     )
 }
 
@@ -134,9 +137,7 @@ fn known_external_aliased_subcommand_from_module() -> TestResult {
             alias cc = cargo check;
             cc -h
         "#,
-        #[cfg(windows)]
-        "cargo.exe check",
-        #[cfg(not(windows))]
-        "cargo check",
+        // on some windows machines, cargo.exe seems to be reported as the binary name instead of cargo
+        TestContains::AnyOf(vec!["cargo.exe check", "cargo check"]),
     )
 }

--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -115,6 +115,9 @@ fn known_external_subcommand_from_module() -> TestResult {
             use cargo;
             cargo check -h
         "#,
+        #[cfg(windows)]
+        "cargo.exe check",
+        #[cfg(not(windows))]
         "cargo check",
     )
 }
@@ -131,6 +134,9 @@ fn known_external_aliased_subcommand_from_module() -> TestResult {
             alias cc = cargo check;
             cc -h
         "#,
+        #[cfg(windows)]
+        "cargo.exe check",
+        #[cfg(not(windows))]
         "cargo check",
     )
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -62,7 +62,7 @@ fn alias_2_multi_word() -> TestResult {
 #[ignore = "TODO: Allow alias to alias existing command with the same name"]
 #[test]
 fn alias_recursion() -> TestResult {
-    run_test_contains(r#"alias ls = ls -a; ls"#, " ")
+    run_test_contains(r#"alias ls = ls -a; ls"#, " ".into())
 }
 
 #[test]
@@ -258,7 +258,7 @@ fn commands_have_usage() -> TestResult {
     # To see if I have cool usage
     def foo [] {}
     help foo"#,
-        "cool usage",
+        "cool usage".into(),
     )
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR implements hash maps using lazy records. They can be created like so:
```nu
{shell: "Nushell", best: true, uwu: "owo"} | into hash-record
```

This uses Hashmaps combined with lazy record to allow *faster* lookup. Note that to obtain even better performance, a custom non-default hashing method is used ([`ahash`](https://crates.io/crates/ahash)).

![WhatsApp Image 2023-10-17 at 14 14 59_57840df3](https://github.com/nushell/nushell/assets/25441359/516eda90-9ea0-4928-adcb-b243b0e28e55)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Adds a new command: `into hash-record`

## Additional notes
This PR also fixes an issue with tests on windows, on certain setups, `cargo` reports the binary name as `cargo.exe` which makes some tests that expect the stdout to contain `cargo check` to fail.