### PR TITLE
rename `unfold` to `generate`

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -382,7 +382,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             Seq,
             SeqDate,
             SeqChar,
-            Unfold,
+            Generate,
         };
 
         // Hash

--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -1,23 +1,22 @@
 use itertools::unfold;
-
 use nu_engine::{eval_block_with_early_return, CallExt};
-use nu_protocol::ast::Call;
-use nu_protocol::engine::{Closure, Command, EngineState, Stack};
 use nu_protocol::{
+    ast::Call,
+    engine::{Closure, Command, EngineState, Stack},
     Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError,
     Signature, Span, Spanned, SyntaxShape, Type, Value,
 };
 
 #[derive(Clone)]
-pub struct Unfold;
+pub struct Generate;
 
-impl Command for Unfold {
+impl Command for Generate {
     fn name(&self) -> &str {
-        "unfold"
+        "generate"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("unfold")
+        Signature::build("generate")
             .input_output_types(vec![
                 (Type::Nothing, Type::List(Box::new(Type::Any))),
                 (
@@ -54,7 +53,7 @@ used as the next argument to the closure, otherwise generation stops.
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "unfold 0 {|i| if $i <= 10 { {out: $i, next: ($i + 2)} }}",
+                example: "generate 0 {|i| if $i <= 10 { {out: $i, next: ($i + 2)} }}",
                 description: "Generate a sequence of numbers",
                 result: Some(Value::list(
                     vec![
@@ -69,7 +68,7 @@ used as the next argument to the closure, otherwise generation stops.
                 )),
             },
             Example {
-                example: "unfold [0, 1] {|fib| {out: $fib.0, next: [$fib.1, ($fib.0 + $fib.1)]} } | first 10",
+                example: "generate [0, 1] {|fib| {out: $fib.0, next: [$fib.1, ($fib.0 + $fib.1)]} } | first 10",
                 description: "Generate a stream of fibonacci numbers",
                 result: Some(Value::list(
                     vec![
@@ -226,6 +225,6 @@ mod test {
     fn test_examples() {
         use crate::test_examples;
 
-        test_examples(Unfold {})
+        test_examples(Generate {})
     }
 }

--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -47,7 +47,7 @@ used as the next argument to the closure, otherwise generation stops.
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["generate", "stream"]
+        vec!["unfold", "stream", "yield", "expand"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/generators/mod.rs
+++ b/crates/nu-command/src/generators/mod.rs
@@ -1,11 +1,11 @@
 mod cal;
+mod generate;
 mod seq;
 mod seq_char;
 mod seq_date;
-mod unfold;
 
 pub use cal::Cal;
+pub use generate::Generate;
 pub use seq::Seq;
 pub use seq_char::SeqChar;
 pub use seq_date::SeqDate;
-pub use unfold::Unfold;

--- a/crates/nu-command/tests/commands/generate.rs
+++ b/crates/nu-command/tests/commands/generate.rs
@@ -1,7 +1,7 @@
 use nu_test_support::{nu, pipeline};
 
 #[test]
-fn unfold_no_next_break() {
+fn generate_no_next_break() {
     let actual = nu!(
         "generate 1 {|x| if $x == 3 { {out: $x}} else { {out: $x, next: ($x + 1)} }} | to nuon"
     );
@@ -10,14 +10,14 @@ fn unfold_no_next_break() {
 }
 
 #[test]
-fn unfold_null_break() {
+fn generate_null_break() {
     let actual = nu!("generate 1 {|x| if $x <= 3 { {out: $x, next: ($x + 1)} }} | to nuon");
 
     assert_eq!(actual.out, "[1, 2, 3]");
 }
 
 #[test]
-fn unfold_allows_empty_output() {
+fn generate_allows_empty_output() {
     let actual = nu!(pipeline(
         r#"
         generate 0 {|x|
@@ -34,7 +34,7 @@ fn unfold_allows_empty_output() {
 }
 
 #[test]
-fn unfold_allows_no_output() {
+fn generate_allows_no_output() {
     let actual = nu!(pipeline(
         r#"
         generate 0 {|x|
@@ -49,7 +49,7 @@ fn unfold_allows_no_output() {
 }
 
 #[test]
-fn unfold_allows_null_state() {
+fn generate_allows_null_state() {
     let actual = nu!(pipeline(
         r#"
         generate 0 {|x|
@@ -68,7 +68,7 @@ fn unfold_allows_null_state() {
 }
 
 #[test]
-fn unfold_allows_null_output() {
+fn generate_allows_null_output() {
     let actual = nu!(pipeline(
         r#"
         generate 0 {|x|
@@ -85,19 +85,19 @@ fn unfold_allows_null_output() {
 }
 
 #[test]
-fn unfold_disallows_extra_keys() {
+fn generate_disallows_extra_keys() {
     let actual = nu!("generate 0 {|x| {foo: bar, out: $x}}");
     assert!(actual.err.contains("Invalid block return"));
 }
 
 #[test]
-fn unfold_disallows_list() {
+fn generate_disallows_list() {
     let actual = nu!("generate 0 {|x| [$x, ($x + 1)]}");
     assert!(actual.err.contains("Invalid block return"));
 }
 
 #[test]
-fn unfold_disallows_primitive() {
+fn generate_disallows_primitive() {
     let actual = nu!("generate 0 {|x| 1}");
     assert!(actual.err.contains("Invalid block return"));
 }

--- a/crates/nu-command/tests/commands/generate.rs
+++ b/crates/nu-command/tests/commands/generate.rs
@@ -2,15 +2,16 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn unfold_no_next_break() {
-    let actual =
-        nu!("unfold 1 {|x| if $x == 3 { {out: $x}} else { {out: $x, next: ($x + 1)} }} | to nuon");
+    let actual = nu!(
+        "generate 1 {|x| if $x == 3 { {out: $x}} else { {out: $x, next: ($x + 1)} }} | to nuon"
+    );
 
     assert_eq!(actual.out, "[1, 2, 3]");
 }
 
 #[test]
 fn unfold_null_break() {
-    let actual = nu!("unfold 1 {|x| if $x <= 3 { {out: $x, next: ($x + 1)} }} | to nuon");
+    let actual = nu!("generate 1 {|x| if $x <= 3 { {out: $x, next: ($x + 1)} }} | to nuon");
 
     assert_eq!(actual.out, "[1, 2, 3]");
 }
@@ -19,7 +20,7 @@ fn unfold_null_break() {
 fn unfold_allows_empty_output() {
     let actual = nu!(pipeline(
         r#"
-        unfold 0 {|x|
+        generate 0 {|x|
           if $x == 1 {
             {next: ($x + 1)}
           } else if $x < 3 {
@@ -36,7 +37,7 @@ fn unfold_allows_empty_output() {
 fn unfold_allows_no_output() {
     let actual = nu!(pipeline(
         r#"
-        unfold 0 {|x|
+        generate 0 {|x|
           if $x < 3 {
             {next: ($x + 1)}
           }
@@ -51,7 +52,7 @@ fn unfold_allows_no_output() {
 fn unfold_allows_null_state() {
     let actual = nu!(pipeline(
         r#"
-        unfold 0 {|x|
+        generate 0 {|x|
           if $x == null {
             {out: "done"}
           } else if $x < 1 {
@@ -70,7 +71,7 @@ fn unfold_allows_null_state() {
 fn unfold_allows_null_output() {
     let actual = nu!(pipeline(
         r#"
-        unfold 0 {|x|
+        generate 0 {|x|
           if $x == 3 {
             {out: "done"}
           } else {
@@ -85,18 +86,18 @@ fn unfold_allows_null_output() {
 
 #[test]
 fn unfold_disallows_extra_keys() {
-    let actual = nu!("unfold 0 {|x| {foo: bar, out: $x}}");
+    let actual = nu!("generate 0 {|x| {foo: bar, out: $x}}");
     assert!(actual.err.contains("Invalid block return"));
 }
 
 #[test]
 fn unfold_disallows_list() {
-    let actual = nu!("unfold 0 {|x| [$x, ($x + 1)]}");
+    let actual = nu!("generate 0 {|x| [$x, ($x + 1)]}");
     assert!(actual.err.contains("Invalid block return"));
 }
 
 #[test]
 fn unfold_disallows_primitive() {
-    let actual = nu!("unfold 0 {|x| 1}");
+    let actual = nu!("generate 0 {|x| 1}");
     assert!(actual.err.contains("Invalid block return"));
 }

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -33,6 +33,7 @@ mod flatten;
 mod for_;
 #[cfg(feature = "extra")]
 mod format;
+mod generate;
 mod get;
 mod glob;
 mod group_by;
@@ -103,7 +104,6 @@ mod touch;
 mod transpose;
 mod try_;
 mod ucp;
-mod unfold;
 mod uniq;
 mod uniq_by;
 mod update;


### PR DESCRIPTION
# Description

This PR renames the `unfold` command to `generate`.
closes #10760

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
