### PR TITLE
Make hints aware of the current directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4249,8 +4249,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7dc1d1d369c194cf79acc204397aca1fecc4248df3e1c1eabb15e5ef2d16991"
+source = "git+https://github.com/nushell/reedline.git?branch=main#973dbb5f5f2338c18c25ce951bfa42c8d8cacfdf"
 dependencies = [
  "chrono",
  "crossterm 0.27.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 # uu_cp = { git = "https://github.com/uutils/coreutils.git", branch = "main" }
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -22,8 +22,8 @@ use nu_protocol::{
 };
 use nu_utils::utils::perf;
 use reedline::{
-    CursorConfig, DefaultHinter, EditCommand, Emacs, FileBackedHistory, HistorySessionId, Reedline,
-    SqliteBackedHistory, Vi,
+    CursorConfig, CwdAwareHinter, EditCommand, Emacs, FileBackedHistory, HistorySessionId,
+    Reedline, SqliteBackedHistory, Vi,
 };
 use std::{
     env::temp_dir,
@@ -302,7 +302,7 @@ pub fn evaluate_repl(
             line_editor.with_hinter(Box::new({
                 // As of Nov 2022, "hints" color_config closures only get `null` passed in.
                 let style = style_computer.compute("hints", &Value::nothing(Span::unknown()));
-                DefaultHinter::default().with_style(style)
+                CwdAwareHinter::default().with_style(style)
             }))
         } else {
             line_editor.disable_hints()


### PR DESCRIPTION
This commit uses the new `CwdAwareHinter` in reedline. Closes #8883.

# Description

Currently, the history based hints show results from all directories, while most commands make sense only in the directory they were run in. This PR makes hints take the current directory into account.

# User-Facing Changes

Described above.

I haven't yet added a config option for this, because I personally believe folks won't be against it once they try it out. We can add it if people complain, there's some time before the next release.

Fish has this without a config option too.

# Tests + Formatting

If tests are needed, I'll need help as I'm not well versed with the codebase.

