### PR TITLE
reorder output fields of `str size`

### DIFF
--- a/crates/nu-command/src/strings/str_/size.rs
+++ b/crates/nu-command/src/strings/str_/size.rs
@@ -52,9 +52,9 @@ impl Command for SubCommand {
                     cols: vec![
                         "lines".into(),
                         "words".into(),
-                        "bytes".into(),
                         "chars".into(),
                         "graphemes".into(),
+                        "bytes".into(),
                     ],
                     vals: vec![
                         Value::test_int(1),
@@ -72,16 +72,16 @@ impl Command for SubCommand {
                     cols: vec![
                         "lines".into(),
                         "words".into(),
-                        "bytes".into(),
                         "chars".into(),
                         "graphemes".into(),
+                        "bytes".into(),
                     ],
                     vals: vec![
                         Value::test_int(1),
                         Value::test_int(6),
+                        Value::test_int(6),
+                        Value::test_int(6),
                         Value::test_int(18),
-                        Value::test_int(6),
-                        Value::test_int(6),
                     ],
                 })),
             },
@@ -92,16 +92,16 @@ impl Command for SubCommand {
                     cols: vec![
                         "lines".into(),
                         "words".into(),
-                        "bytes".into(),
                         "chars".into(),
                         "graphemes".into(),
+                        "bytes".into(),
                     ],
                     vals: vec![
                         Value::test_int(1),
                         Value::test_int(2),
-                        Value::test_int(15),
                         Value::test_int(14),
                         Value::test_int(13),
+                        Value::test_int(15),
                     ],
                 })),
             },
@@ -153,9 +153,9 @@ fn counter(contents: &str, span: Span) -> Value {
     let record = record! {
         "lines" => get_count(&counts, Counter::Lines, span),
         "words" => get_count(&counts, Counter::Words, span),
-        "bytes" => get_count(&counts, Counter::Bytes, span),
         "chars" => get_count(&counts, Counter::CodePoints, span),
         "graphemes" => get_count(&counts, Counter::GraphemeClusters, span),
+        "bytes" => get_count(&counts, Counter::Bytes, span),
     };
 
     Value::record(record, span)


### PR DESCRIPTION
# Description
in this PR, i propose to reorder the fields of the output of `str size`.

the logic is that
- lines are made of words
- words are made of characters
- characters are made of graphemes
- graphemes are made of bytes
- bytes are the bottom *type* when it comes to strings

# User-Facing Changes
`$.bytes` is now the last field of the output record from `str size`, the rest is unchanged.
this shouldn't be breaking, it's just about the rendering order, users could already reorder the fields with `move` :+1: 

# Tests + Formatting
example tests have been updated

# After Submitting