### PR TITLE
Add `history migrate` command

### DIFF
--- a/crates/nu-cli/src/commands/default_context.rs
+++ b/crates/nu-cli/src/commands/default_context.rs
@@ -15,6 +15,7 @@ pub fn add_cli_context(mut engine_state: EngineState) -> EngineState {
         bind_command! {
             Commandline,
             History,
+            HistoryMigrate,
             HistorySession,
             Keybindings,
             KeybindingsDefault,

--- a/crates/nu-cli/src/commands/history_migrate.rs
+++ b/crates/nu-cli/src/commands/history_migrate.rs
@@ -1,5 +1,13 @@
+use chrono::DateTime;
+use log;
 use nu_protocol::engine::Command;
-use nu_protocol::{PipelineData, ShellError, Signature, Type};
+use nu_protocol::{
+    record, IntoInterruptiblePipelineData, PipelineData, ShellError, Signature, Type, Value,
+};
+use reedline::{
+    FileBackedHistory, History as ReedlineHistory, HistoryItem, SearchDirection, SearchQuery,
+    SqliteBackedHistory,
+};
 
 #[derive(Clone)]
 pub struct HistoryMigrate;
@@ -27,12 +35,56 @@ impl Command for HistoryMigrate {
         let head = call.head;
 
         if let Some(config_path) = nu_path::config_dir() {
+            let ctrlc = engine_state.ctrlc.clone();
             let mut plaintext_history_path = config_path.clone();
             let mut sqlite_history_path = config_path;
-            plaintext_history_path.push("nushell/history.txt");
+            plaintext_history_path.push("nushell");
+            plaintext_history_path.push("history.txt");
             sqlite_history_path.push("nushell/history.sqlite3");
 
-            Ok(PipelineData::Empty)
+            let plaintext_history_reader = FileBackedHistory::with_file(
+                engine_state.config.max_history_size as usize,
+                plaintext_history_path.clone(),
+            )
+            .map(|inner| {
+                let boxed: Box<dyn ReedlineHistory> = Box::new(inner);
+                boxed
+            })
+            .ok();
+            let mut sqlite_history_reader =
+                SqliteBackedHistory::with_file(sqlite_history_path.clone(), None, None)
+                    .map(|inner| {
+                        let boxed: Box<dyn ReedlineHistory> = Box::new(inner);
+                        boxed
+                    })
+                    .ok()
+                    .expect("SQLite history not found");
+
+            Ok(plaintext_history_reader
+                .and_then(|h| {
+                    h.search(SearchQuery::everything(SearchDirection::Forward, None))
+                        .ok()
+                })
+                .map(move |entries| {
+                    entries.into_iter().enumerate().map(move |(idx, entry)| {
+                        let history_item =
+                            HistoryItem::from_command_line(entry.command_line.clone());
+                        let history_item = sqlite_history_reader.save(history_item.clone());
+                        Value::record(
+                            record! {
+                                // "idx" => Value::int(idx as i64, head),
+                                // "start_time" => Value::date(history_item.start_timestamp.unwrap_or(chrono::Utc::now()).fixed_offset(), head),
+                                // "command" => Value::string(history_item.command_line.clone(), head),
+                            },
+                            head,
+                        )
+                    })
+                })
+                .ok_or({
+                    println!("History path: {:?}", plaintext_history_path);
+                    ShellError::FileNotFound(head)
+                })?
+                .into_pipeline_data(ctrlc))
         } else {
             Err(ShellError::FileNotFound(head))
         }

--- a/crates/nu-cli/src/commands/history_migrate.rs
+++ b/crates/nu-cli/src/commands/history_migrate.rs
@@ -73,7 +73,11 @@ impl Command for HistoryMigrate {
                         history_item.start_timestamp = Some(DateTime::<Utc>::from(UNIX_EPOCH));
                         let _history_item = sqlite_history.save(history_item);
                     })
-                });
+                })
+                .ok_or(ShellError::FileNotFoundCustom(
+                    "plaintext history file ({plaintext_history_path}) not found".into(),
+                    head,
+                ))?;
 
             Ok(PipelineData::empty())
         } else {

--- a/crates/nu-cli/src/commands/history_migrate.rs
+++ b/crates/nu-cli/src/commands/history_migrate.rs
@@ -1,0 +1,40 @@
+use nu_protocol::engine::Command;
+use nu_protocol::{PipelineData, ShellError, Signature, Type};
+
+#[derive(Clone)]
+pub struct HistoryMigrate;
+
+impl Command for HistoryMigrate {
+    fn name(&self) -> &str {
+        "history migrate"
+    }
+
+    fn usage(&self) -> &str {
+        "Migrate history from plain text to SQLite backend."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("history migrate").input_output_type(Type::Nothing, Type::Nothing)
+    }
+
+    fn run(
+        &self,
+        engine_state: &nu_protocol::engine::EngineState,
+        stack: &mut nu_protocol::engine::Stack,
+        call: &nu_protocol::ast::Call,
+        input: nu_protocol::PipelineData,
+    ) -> Result<nu_protocol::PipelineData, nu_protocol::ShellError> {
+        let head = call.head;
+
+        if let Some(config_path) = nu_path::config_dir() {
+            let mut plaintext_history_path = config_path.clone();
+            let mut sqlite_history_path = config_path;
+            plaintext_history_path.push("nushell/history.txt");
+            sqlite_history_path.push("nushell/history.sqlite3");
+
+            Ok(PipelineData::Empty)
+        } else {
+            Err(ShellError::FileNotFound(head))
+        }
+    }
+}

--- a/crates/nu-cli/src/commands/history_migrate.rs
+++ b/crates/nu-cli/src/commands/history_migrate.rs
@@ -75,19 +75,20 @@ impl Command for HistoryMigrate {
                         .ok()
                 })
                 .map(move |entries| {
-                    let mut unique_entries: Vec<HistoryItem> = vec![];
                     let entries = if !call.has_flag("keep-duplicates") {
+                        let mut unique_entries = sqlite_history
+                            .search(SearchQuery::everything(SearchDirection::Forward, None))
+                            .unwrap_or(Vec::<HistoryItem>::new());
                         entries
                             .into_iter()
                             .filter(|entry| {
-                                match !unique_entries.iter().any(|unique_entry| {
+                                if !unique_entries.iter().any(|unique_entry| {
                                     unique_entry.command_line == entry.command_line
                                 }) {
-                                    true => {
-                                        unique_entries.push(entry.clone());
-                                        true
-                                    }
-                                    false => false,
+                                    unique_entries.push(entry.clone());
+                                    true
+                                } else {
+                                    false
                                 }
                             })
                             .collect::<Vec<HistoryItem>>()

--- a/crates/nu-cli/src/commands/history_migrate.rs
+++ b/crates/nu-cli/src/commands/history_migrate.rs
@@ -1,3 +1,6 @@
+use std::time::{Duration, UNIX_EPOCH};
+
+use chrono::{DateTime, Utc};
 use nu_protocol::engine::Command;
 use nu_protocol::{PipelineData, ShellError, Signature, Type};
 use reedline::{
@@ -64,8 +67,9 @@ impl Command for HistoryMigrate {
                 .unwrap()
                 .into_iter()
                 .for_each(|entry| {
-                    let _history_item = sqlite_history_reader
-                        .save(HistoryItem::from_command_line(entry.command_line));
+                    let mut history_item = HistoryItem::from_command_line(entry.command_line);
+                    history_item.start_timestamp = Some(DateTime::<Utc>::from(UNIX_EPOCH));
+                    let _history_item = sqlite_history_reader.save(history_item);
                 });
 
             Ok(PipelineData::empty())

--- a/crates/nu-cli/src/commands/history_migrate.rs
+++ b/crates/nu-cli/src/commands/history_migrate.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use nu_protocol::engine::Command;
-use nu_protocol::{PipelineData, ShellError, Signature, Type};
+use nu_protocol::{Category, PipelineData, ShellError, Signature, Type};
 use reedline::{
     FileBackedHistory, History as ReedlineHistory, HistoryItem, SearchDirection, SearchQuery,
     SqliteBackedHistory,
@@ -20,7 +20,9 @@ impl Command for HistoryMigrate {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build("history migrate").input_output_type(Type::Nothing, Type::Nothing)
+        Signature::build("history migrate")
+            .input_output_type(Type::Nothing, Type::Nothing)
+            .category(Category::Misc)
     }
 
     fn run(

--- a/crates/nu-cli/src/commands/mod.rs
+++ b/crates/nu-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 mod commandline;
 mod default_context;
 mod history;
+mod history_migrate;
 mod history_session;
 mod keybindings;
 mod keybindings_default;
@@ -9,6 +10,7 @@ mod keybindings_listen;
 
 pub use commandline::Commandline;
 pub use history::History;
+pub use history_migrate::HistoryMigrate;
 pub use history_session::HistorySession;
 pub use keybindings::Keybindings;
 pub use keybindings_default::KeybindingsDefault;


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Add `history migrate` command as requested in #10440. 

## TODO
- [ ] Make sure migration is run as a SQL transaction so if the operation is interrupted it will not partially migrate history
  - This seems like the current behavior of reedline's `save` method, but I don't see where it explicitly starts a transaction. Needs investigation.
- [ ] Add `--overwrite` flag for overwriting the current SQLite history
  - Defaults to appending history
  - Relies on getting a way to clear history without crashing
    - #9575 suggested a way to do it for `history --clear` but it hasn't been merged. 
    - There's also the `clear` method in reedline's `SQLiteBackedHistory` but this crashes as well
    - ~~Looking into how to fix these errors. Reedline's `clear` method seems better to me but then this feature would rely on a PR in reedline~~
- [ ] Benchmark to avoid issue presented in #9403 
- [x] `--keep-duplicates` flag for keeping duplicate entries
  - ~~Currently the `--keep-duplicates` flag only removes duplicates from the plaintext file. Need to check for duplicates in SQLite database as well. Because of this, currently running history migrate will still duplicate some items.~~
- [ ] Change default `start_timestamp` to nushell's first commit datetime: `2019-05-10T09:59:12-07:00`
- [ ] `--history-file` parameter for migrating from a custom file
  -  Probably another PR
