### PR TITLE
Remove registry clean_string hack

### DIFF
--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -174,12 +174,6 @@ fn get_reg_hive(call: &Call) -> Result<RegKey, ShellError> {
     Ok(RegKey::predef(hkey))
 }
 
-fn clean_string(string: &str) -> String {
-    string
-        .trim_start_matches('"')
-        .trim_end_matches('"')
-        .replace("\\\\", "\\")
-}
 fn reg_value_to_nu_value(
     reg_value: winreg::RegValue,
     call_span: Span,
@@ -187,11 +181,11 @@ fn reg_value_to_nu_value(
     match reg_value.vtype {
         REG_NONE => (Value::nothing(call_span), reg_value.vtype),
         REG_SZ => (
-            Value::string(clean_string(&reg_value.to_string()), call_span),
+            Value::string(reg_value.to_string(), call_span),
             reg_value.vtype,
         ),
         REG_EXPAND_SZ => (
-            Value::string(clean_string(&reg_value.to_string()), call_span),
+            Value::string(reg_value.to_string(), call_span),
             reg_value.vtype,
         ),
         REG_BINARY => (Value::binary(reg_value.bytes, call_span), reg_value.vtype),
@@ -210,23 +204,23 @@ fn reg_value_to_nu_value(
             reg_value.vtype,
         ),
         REG_LINK => (
-            Value::string(clean_string(&reg_value.to_string()), call_span),
+            Value::string(reg_value.to_string(), call_span),
             reg_value.vtype,
         ),
         REG_MULTI_SZ => (
-            Value::string(clean_string(&reg_value.to_string()), call_span),
+            Value::string(reg_value.to_string(), call_span),
             reg_value.vtype,
         ),
         REG_RESOURCE_LIST => (
-            Value::string(clean_string(&reg_value.to_string()), call_span),
+            Value::string(reg_value.to_string(), call_span),
             reg_value.vtype,
         ),
         REG_FULL_RESOURCE_DESCRIPTOR => (
-            Value::string(clean_string(&reg_value.to_string()), call_span),
+            Value::string(reg_value.to_string(), call_span),
             reg_value.vtype,
         ),
         REG_RESOURCE_REQUIREMENTS_LIST => (
-            Value::string(clean_string(&reg_value.to_string()), call_span),
+            Value::string(reg_value.to_string(), call_span),
             reg_value.vtype,
         ),
         REG_QWORD => (


### PR DESCRIPTION
# Description

Remove the `clean_string` hack used in `registry query`.

This was a workaround for a [bug][gentoo90/winreg-rs#52] in winreg which has since [been fixed][edf9eef] and released in [winreg v0.12.0].

winreg now properly displays strings in RegKey's Display impl instead of outputting their debug representation. We remove our `clean_string` such
that registry entries which happen to start/end with `"` or contain `\\` won't get mangled. This is very important for entries in UNC path format
as those begin with a double backslash.

[gentoo90/winreg-rs#52]: <https://github.com/gentoo90/winreg-rs/issues/52>
[edf9eef]: <https://github.com/gentoo90/winreg-rs/commit/edf9eef38fd6bda9f8acb6dfea9b846738c29ff0>
[winreg v0.12.0]: <https://github.com/gentoo90/winreg-rs/releases/tag/v0.12.0>

# User-Facing Changes

- `registry query` used to accidentally mangle values that contain a literal `\\`, such as UNC paths. It no longer does so.

# Tests + Formatting

- [X] `toolkit check pr`
  - :green_circle: `toolkit fmt`
  - :green_circle: `toolkit clippy`
  - :green_circle: `toolkit test`
  - :green_circle: `toolkit test stdlib`