### PR TITLE
redirection: fix internal commands error with `o+e>` redirection

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -216,12 +216,14 @@ fn redirect_support_variable() {
 
         assert!(output.out.contains("hello"));
 
-        let output = nu!(
+        nu!(
             cwd: dirs.test(),
-            "let x = 'tmp_file'; echo 'hello' out+err> $x; open tmp_file"
+            "let x = 'tmp_file'; echo 'hello there' out+err> $x; open tmp_file"
         );
-
-        assert!(output.out.contains("hello"));
+        // check for stdout redirection file.
+        let expected_out_file = dirs.test().join("tmp_file");
+        let actual = file_contents(expected_out_file);
+        assert!(actual.contains("hello there"));
     })
 }
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1082,7 +1082,6 @@ pub fn eval_block(
         }
 
         if pipeline_idx < (num_pipelines) - 1 {
-            println!("debug pipeline_index: {pipeline_idx}, num_pipelines: {num_pipelines}, input: {input:?}");
             match input {
                 PipelineData::Value(Value::Nothing { .. }, ..) => {}
                 PipelineData::ExternalStream {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -925,15 +925,18 @@ fn eval_element_with_input(
                         *is_subexpression,
                     )?
                 }
-                _ => eval_element_with_input(
-                    engine_state,
-                    stack,
-                    &PipelineElement::Expression(*cmd_span, cmd_exp.clone()),
-                    input,
-                    redirect_stdout,
-                    redirect_stderr,
-                )
-                .map(|x| x.0)?,
+                _ => {
+                    // we need to redirect output, so the result can be saved and pass to `save` command.
+                    eval_element_with_input(
+                        engine_state,
+                        stack,
+                        &PipelineElement::Expression(*cmd_span, cmd_exp.clone()),
+                        input,
+                        true,
+                        redirect_stderr,
+                    )
+                    .map(|x| x.0)?
+                }
             };
             eval_element_with_input(
                 engine_state,
@@ -1079,6 +1082,7 @@ pub fn eval_block(
         }
 
         if pipeline_idx < (num_pipelines) - 1 {
+            println!("debug pipeline_index: {pipeline_idx}, num_pipelines: {num_pipelines}, input: {input:?}");
             match input {
                 PipelineData::Value(Value::Nothing { .. }, ..) => {}
                 PipelineData::ExternalStream {


### PR DESCRIPTION
# Description
Currently the following command is broken:
```nushell
echo a o+e> 1.txt
```

It's because we don't redirect output of `echo` command.  This pr is trying to fix it.