### PR TITLE
fix main not building due to errors later found in describe

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -1,6 +1,6 @@
-use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack, StateWorkingSet};
 use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack, StateWorkingSet},
     record, Category, Example, IntoPipelineData, PipelineData, PipelineMetadata, Record,
     ShellError, Signature, Type, Value,
 };
@@ -110,28 +110,36 @@ impl Command for Describe {
                     )),
                 ))),
             },
-            // TODO: Uncomment these tests when/if we allow external commands in examples.
-            /*
             Example {
                 description: "Describe the type of a stream with detailed information",
-                example: "[1 2 3] | each {|i| $i} | describe -d",
-                result: Some(Value::test_record(record!(
-                    "type" => Value::test_string("stream"),
-                    "origin" => Value::test_string("nushell"),
-                    "subtype" => Value::test_string("int"),
-                ))),
+                example: "[1 2 3] | each {|i| echo $i} | describe -d",
+                result: None // Give "Running external commands not supported" error
+                // result: Some(Value::test_record(record!(
+                //     "type" => Value::test_string("stream"),
+                //     "origin" => Value::test_string("nushell"),
+                //     "subtype" => Value::test_record(record!(
+                //         "type" => Value::test_string("list"),
+                //         "length" => Value::test_int(3),
+                //         "values" => Value::test_list(vec![
+                //             Value::test_string("int"),
+                //             Value::test_string("int"),
+                //             Value::test_string("int"),
+                //         ])
+                //     ))
+                // ))),
             },
             Example {
                 description: "Describe a stream of data, collecting it first",
-                example: "[1 2 3] | each {|i| $i} | describe",
-                result: Some(Value::test_string("list<int> (stream)")),
+                example: "[1 2 3] | each {|i| echo $i} | describe",
+                result: None // Give "Running external commands not supported" error
+                // result: Some(Value::test_string("list<int> (stream)")),
             },
             Example {
                 description: "Describe the input but do not collect streams",
-                example: "[1 2 3] | each {|i| $i} | describe --no-collect",
-                result: Some(Value::test_string("stream")),
+                example: "[1 2 3] | each {|i| echo $i} | describe --no-collect",
+                result: None // Give "Running external commands not supported" error
+                // result: Some(Value::test_string("stream")),
             },
-            */
         ]
     }
 
@@ -145,10 +153,8 @@ fn run(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let metadata = input.metadata().clone();
-
+    let metadata = input.metadata().clone().map(Box::new);
     let head = call.head;
-
     let no_collect: bool = call.has_flag("no-collect");
     let detailed = call.has_flag("detailed");
 


### PR DESCRIPTION
# Description

This is just a fixup PR. There was a describe PR that passed CI but then later didn't pass main. This PR fixes that issue.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
