### PR TITLE
readd update flag to cp command

### DIFF
--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -46,6 +46,11 @@ impl Command for UCp {
                 Some('f'),
             )
             .switch("interactive", "ask before overwriting files", Some('i'))
+            .switch(
+                "update",
+                "copy only when the SOURCE file is newer than the destination file or when the destination file is missing",
+                Some('u')
+            )
             .switch("progress", "display a progress bar", Some('p'))
             .switch("no-clobber", "do not overwrite an existing file", Some('n'))
             .switch("debug", "explain how a file is copied. Implies -v", None)
@@ -87,6 +92,7 @@ impl Command for UCp {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let interactive = call.has_flag("interactive");
+        let update = if call.has_flag("update") { UpdateMode::ReplaceIfOlder } else { UpdateMode::ReplaceAll };
         let force = call.has_flag("force");
         let no_clobber = call.has_flag("no-clobber");
         let progress = call.has_flag("progress");
@@ -207,7 +213,7 @@ impl Command for UCp {
             attributes: uu_cp::Attributes::NONE,
             backup_suffix: String::from("~"),
             target_dir: None,
-            update: UpdateMode::ReplaceAll,
+            update: update,
         };
 
         if let Err(error) = uu_cp::copy(&sources, &target_path, &options) {

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -217,7 +217,7 @@ impl Command for UCp {
             attributes: uu_cp::Attributes::NONE,
             backup_suffix: String::from("~"),
             target_dir: None,
-            update: update,
+            update,
         };
 
         if let Err(error) = uu_cp::copy(&sources, &target_path, &options) {

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -92,7 +92,11 @@ impl Command for UCp {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let interactive = call.has_flag("interactive");
-        let update = if call.has_flag("update") { UpdateMode::ReplaceIfOlder } else { UpdateMode::ReplaceAll };
+        let update = if call.has_flag("update") {
+            UpdateMode::ReplaceIfOlder
+        } else {
+            UpdateMode::ReplaceAll
+        };
         let force = call.has_flag("force");
         let no_clobber = call.has_flag("no-clobber");
         let progress = call.has_flag("progress");

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -7,7 +7,7 @@ use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type,
 };
 use std::path::PathBuf;
-use uu_cp::{BackupMode, UpdateMode};
+use uu_cp::{BackupMode, CopyMode, UpdateMode};
 
 // TODO: related to uucore::error::set_exit_code(EXIT_ERR)
 // const EXIT_ERR: i32 = 1;
@@ -81,6 +81,11 @@ impl Command for UCp {
                 example: "cp *.txt dir_a",
                 result: None,
             },
+            Example {
+                description: "Copy only if source file is newer than target file",
+                example: "cp -u a b",
+                result: None,
+            },
         ]
     }
 
@@ -92,10 +97,10 @@ impl Command for UCp {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let interactive = call.has_flag("interactive");
-        let update = if call.has_flag("update") {
-            UpdateMode::ReplaceIfOlder
+        let (update, copy_mode) = if call.has_flag("update") {
+            (UpdateMode::ReplaceIfOlder, CopyMode::Update)
         } else {
-            UpdateMode::ReplaceAll
+            (UpdateMode::ReplaceAll, CopyMode::Copy)
         };
         let force = call.has_flag("force");
         let no_clobber = call.has_flag("no-clobber");
@@ -208,7 +213,7 @@ impl Command for UCp {
             backup: BackupMode::NoBackup,
             copy_contents: false,
             cli_dereference: false,
-            copy_mode: uu_cp::CopyMode::Copy,
+            copy_mode,
             no_target_dir: false,
             one_file_system: false,
             parents: false,

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -582,7 +582,6 @@ fn copy_file_with_read_permission_impl(progress: bool) {
     });
 }
 
-#[ignore = "not implemented with ucp"]
 #[test]
 fn copy_file_with_update_flag() {
     copy_file_with_update_flag_impl(false);


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
- this PR should close #10819
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Behaviour is similar to pre 0.86.0 behaviour of the cp command and should as such not have a user-facing change, only compared to the current version, were the option is readded.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
I don't know how and where to test this functionality.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
I guess the documentation will be automatically updated and as this feature is no further highlighted, probably, no more work will be needed here.

# Considerations
coreutils actually allows a third option:
```
pub enum UpdateMode {
    // --update=`all`,
    ReplaceAll,
    // --update=`none`
    ReplaceNone,
    // --update=`older`
    // -u
    ReplaceIfOlder,
}
```
namely `ReplaceNone`, which I have not added. Also I think that specifying `--update 'abc'` is non functional.