### PR TITLE
feat: Add default docs for aliases, generated from the command they point to

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -155,3 +155,11 @@ fn alias_ordering() {
     let actual = nu!(r#"alias bar = echo; def echo [] { 'dummy echo' }; bar 'foo'"#);
     assert_eq!(actual.out, "foo");
 }
+
+#[test]
+fn alias_default_help() {
+    let actual = nu!("alias teapot = echo 'I am a beautiful teapot'; help teapot");
+    // There must be at least one line of help
+    let first_help_line = actual.out.lines().next().unwrap();
+    assert!(first_help_line.starts_with("Alias for `echo 'I am a beautiful teapot'`"));
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Adds a default "usage" documentation for undocumented aliases, helping users understand where commands are coming from when auto completing.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

There is now a line of help in auto-completion of commands when using `to<Tab>`:

```
> to<Tab>
to          Translate structured data to a format.
top
toe
toto        Alias for `echo "abc"`
tops
```

Additionally, the `help <alias>` command now has a first line instead of starting with two empty lines:

Previously:

```
alias toto = echo "abc"; help toto
                                  <-- blank line here

Alias: toto

Expansion:
  echo "abc"
```

Now:

```
alias toto = echo "abc"; help toto
Alias for `echo "abc"`

Alias: toto

Expansion:
  echo "abc"
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

I added a test to ensure the doc line is generated as expected, even with longer commands (not simple alias like `alias g = git`)

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Should I update the book ?
