### PR TITLE
deprecate `glob --not` in favor of `glob --prune`

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -117,12 +117,12 @@ impl Command for Glob {
             },
             Example {
                 description: "Search for files named tsconfig.json that are not in node_modules directories",
-                example: r#"glob **/tsconfig.json --not [**/node_modules/**]"#,
+                example: r#"glob **/tsconfig.json --prune [**/node_modules/**]"#,
                 result: None,
             },
             Example {
                 description: "Search for all files that are not in the target nor .git directories",
-                example: r#"glob **/* --not [**/target/** **/.git/** */]"#,
+                example: r#"glob **/* --prune [**/target/** **/.git/** */]"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -46,7 +46,7 @@ impl Command for Glob {
             .named(
                 "not",
                 SyntaxShape::List(Box::new(SyntaxShape::String)),
-                "Patterns to exclude from the results",
+                "DEPRECATED OPTION: Patterns to exclude from the results",
                 Some('n'),
             )
             .named(
@@ -146,6 +146,20 @@ impl Command for Glob {
         let no_dirs = call.has_flag("no-dir");
         let no_files = call.has_flag("no-file");
         let no_symlinks = call.has_flag("no-symlink");
+
+        if call.has_flag("not") {
+            nu_protocol::report_error_new(
+                engine_state,
+                &ShellError::GenericError(
+                    "Deprecated option".into(),
+                    "`glob --prune {list<string>}` is deprecated and will be removed in 0.88."
+                        .into(),
+                    Some(call.head),
+                    Some("Please use `glob --prune {list<string>}` instead.".into()),
+                    vec![],
+                ),
+            );
+        }
 
         let not_flag: Option<Value> = call.get_flag(engine_state, stack, "not")?;
         let prune_flag: Option<Value> = call.get_flag(engine_state, stack, "prune")?;


### PR DESCRIPTION
# Description
looking at the [Wax documentation about `wax::Walk.not`](https://docs.rs/wax/latest/wax/struct.Walk.html#examples), especially
> therefore does not read directory trees from the file system when a directory matches an [exhaustive glob expression](https://docs.rs/wax/latest/wax/trait.Pattern.html#tymethod.is_exhaustive)

this looks like a *pruning* operation to me, right? :open_mouth: 
i wanted to make the `glob` option `--not` clearer about that, because
>   -n, --not <List(String)> - Patterns to exclude from the results

from `help glob` is not very explicit about whether the search is pruned when entering a directory matching a pattern in `--not` or just removing it from the output :confused: 

## changelog
this PR proposes to rename the `glob --not` option to `glob --prune` and make it's documentation more explicit :yum: 

## benchmarking
to support the *pruning* behaviour put forward above, i've run a benchmark
1. define two closures to compare the behaviour between removing patterns manually or using `--not`
```nushell
let where = {
    [.*/\.local/.*, .*/documents/.*, .*/\.config/.*]
        | reduce --fold (glob **) {|pat, acc| $acc | where $it !~ $pat}
        | length
}
```
```nushell
let not = { glob ** --not [**/.local/**, **/documents/**, **/.config/**] | length }
```
2. run the two to make sure they give similar results
```nushell
> do $where
33424
```
```nushell
> do $not
33420
```
:ok_hand: 
3. measure the performance
```nushell
use std bench
```
```nushell
> bench --verbose --pretty --rounds 25 $not
44ms 52µs 285ns +/- 977µs 571ns
```
```nushell
> bench --verbose --pretty --rounds 5 $where
1sec 250ms 187µs 99ns +/- 8ms 538µs 57ns
```

:point_right: we can see that the results are (almost) the same but `--not` is much faster, looks like pruning :yum: 

# User-Facing Changes
- `--not` will give a warning message but still work
- `--prune` will work just as `--not` without warning and with a more explicit doc
- `--prune` and `--not` at the same time will give an error

# Tests + Formatting
this PR fixes the examples of `glob` using the `--not` option.

# After Submitting
prepare the removal PR and mention in release notes.