### PR TITLE
Support pattern matching `null` literals

### DIFF
--- a/crates/nu-command/tests/commands/match_.rs
+++ b/crates/nu-command/tests/commands/match_.rs
@@ -133,6 +133,12 @@ fn match_constant_7() {
 }
 
 #[test]
+fn match_null() {
+    let actual = nu!(r#"match null { null => { print "success"}, _ => { print "failure" }}"#);
+    assert_eq!(actual.out, "success");
+}
+
+#[test]
 fn match_or_pattern() {
     let actual = nu!(
         r#"match {b: 7} { {a: $a} | {b: $b} => { print $"success: ($b)" }, _ => { print "failure" }}"#

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -96,6 +96,9 @@ impl Matcher for Pattern {
             Pattern::Value(pattern_value) => {
                 // TODO: Fill this out with the rest of them
                 match &pattern_value.expr {
+                    Expr::Nothing => {
+                        matches!(value, Value::Nothing { .. })
+                    }
                     Expr::Int(x) => {
                         if let Value::Int { val, .. } = &value {
                             x == val


### PR DESCRIPTION
# Description
Support pattern matching against the `null` literal.  Fixes #10799 

### Before
```nushell
> match null { null => "success", _ => "failure" }
failure
```

### After
```nushell
> match null { null => "success", _ => "failure" }
success
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Users can pattern match against a `null` literal.

