### PR TITLE
redirect should have a target

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -264,3 +264,25 @@ fn separate_redirection_support_variable() {
         },
     )
 }
+
+#[test]
+fn redirection_should_have_a_target() {
+    let scripts = [
+        "echo asdf o+e>",
+        "echo asdf o>",
+        "echo asdf e>",
+        "echo asdf o> e>",
+        "echo asdf o> tmp.txt e>",
+        "echo asdf o> e> tmp.txt",
+        "echo asdf o> | ignore",
+        "echo asdf o>; echo asdf",
+    ];
+    for code in scripts {
+        let actual = nu!(code);
+        assert!(
+            actual.err.contains("expected redirection target",),
+            "should be error, code: {}",
+            code
+        );
+    }
+}


### PR DESCRIPTION
# Description
Fixes:  #10830 

The issue happened during lite-parsing, when we want to put a `LiteElement` to a `LitePipeline`, we do nothing if relative redirection target is empty.

So the command `echo aaa o> | ignore` will be interpreted to `echo aaa | ignore`.

This pr is going to check and return an error if redirection target is empty.

# User-Facing Changes
## Before
```
❯ echo aaa o> | ignore   # nothing happened
```

## After
```nushell
❯ echo aaa o> | ignore
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
   ╭─[entry #1:1:1]
 1 │ echo aaa o> | ignore
   ·          ─┬
   ·           ╰── expected redirection target
   ╰────
```

