### PR TITLE
Fix `describe -d` for lazy records

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -397,6 +397,7 @@ fn describe_value(
                             describe_value(val.vals[i].clone(), head, engine_state, call)?,
                         );
                     }
+                    record.push("columns", Value::record(record_cols, head));
                 } else {
                     let cols = val.column_names();
                     record.push("length", Value::int(cols.len() as i64, head));
@@ -406,7 +407,7 @@ fn describe_value(
                 record.push("length", Value::int(cols.len() as i64, head));
             }
 
-            Value::record(record!(), head)
+            Value::record(record, head)
         }
     })
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR fixes an overlook from a previous PR. It now correctly returns the details on lazy records.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Describe detailed now returns the expected result.