### PR TITLE
updated NU_LIB_DIRS delimiter for command line

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -262,7 +262,7 @@ impl Command for Nu {
             .named(
                 "include-path",
                 SyntaxShape::String,
-                "set the NU_LIB_DIRS for the given script (semicolon-delimited)",
+                "set the NU_LIB_DIRS for the given script (delimited by char record_sep ('\x1e'))",
                 Some('I'),
             )
             .switch("interactive", "start as an interactive shell", Some('i'))


### PR DESCRIPTION
# Description

This PR corrects some help text by stating what the real delimiter is for the `--include-path` command line parameter which is `char record_sep` aka `\x1e`. Up to this point, this has really only been used for the vscode extension to setup the NU_LIB_DIRS env var correctly. We tried `:` and `;` and neither would work so we had to choose something that wouldn't be confused so easily.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
