### PR TITLE
remove `--not` from `glob`

### DIFF
--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -44,12 +44,6 @@ impl Command for Glob {
                 Some('S'),
             )
             .named(
-                "not",
-                SyntaxShape::List(Box::new(SyntaxShape::String)),
-                "DEPRECATED OPTION: Patterns to exclude from the results",
-                Some('n'),
-            )
-            .named(
                 "exclude",
                 SyntaxShape::List(Box::new(SyntaxShape::String)),
                 "Patterns to exclude from the search: `glob` will not walk the inside of directories matching the excluded patterns.",
@@ -147,35 +141,7 @@ impl Command for Glob {
         let no_files = call.has_flag("no-file");
         let no_symlinks = call.has_flag("no-symlink");
 
-        if call.has_flag("not") {
-            nu_protocol::report_error_new(
-                engine_state,
-                &ShellError::GenericError(
-                    "Deprecated option".into(),
-                    "`glob --not {list<string>}` is deprecated and will be removed in 0.88.".into(),
-                    Some(call.head),
-                    Some("Please use `glob --exclude {list<string>}` instead.".into()),
-                    vec![],
-                ),
-            );
-        }
-
-        let not_flag: Option<Value> = call.get_flag(engine_state, stack, "not")?;
-        let exclude_flag: Option<Value> = call.get_flag(engine_state, stack, "exclude")?;
-
-        let paths_to_exclude = match (not_flag, exclude_flag) {
-            (Some(not_flag), Some(exclude_flag)) => {
-                return Err(ShellError::IncompatibleParameters {
-                    left_message: "Cannot pass --not".into(),
-                    left_span: not_flag.span(),
-                    right_message: "and --exclude".into(),
-                    right_span: exclude_flag.span(),
-                })
-            }
-            (Some(not_flag), None) => Some(not_flag),
-            (None, Some(exclude_flag)) => Some(exclude_flag),
-            (None, None) => None,
-        };
+        let paths_to_exclude: Option<Value> = call.get_flag(engine_state, stack, "exclude")?;
 
         let (not_patterns, not_pattern_span): (Vec<String>, Span) = match paths_to_exclude {
             None => (vec![], span),


### PR DESCRIPTION
follow-up to
- https://github.com/nushell/nushell/pull/10827

> **Important**  
> wait for between 0.87 and 0.88 to land this

# Description
after deprecation comes removal... this PR removes `glob --not` in favor of `glob --exclude`.

# User-Facing Changes
`glob --not` will stop working.

# Tests + Formatting

# After Submitting
i didn't find any use of `glob --not` in the `nu_scripts` so no update required there :+1: 