### PR TITLE
allow `cd` to set_current_dir

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -132,6 +132,11 @@ impl Command for Cd {
             //FIXME: this only changes the current scope, but instead this environment variable
             //should probably be a block that loads the information from the state in the overlay
             PermissionResult::PermissionOk => {
+                // This set_current_dir is needed because other programs like uutils/coreutils get
+                // information from the environment and if it's not setup properly they will fail. See
+                // note https://github.com/nushell/nushell/issues/10832#issuecomment-1780202986
+                // The key part is that cp doesn't use it explicitly but the syscalls do.
+                std::env::set_current_dir(&path)?;
                 stack.add_env_var("PWD".into(), path_value);
                 Ok(PipelineData::empty())
             }


### PR DESCRIPTION
# Description

This PR changes the `cd` command to also do `std::env::set_current_dir(&path)?;` when changing directories. By doing this #10832 is resolved because the underlying syscalls that do something like `getcwd()` will now work. See https://github.com/nushell/nushell/issues/10832#issuecomment-1780202986 for explanation from Terts and to follow along with the other scenarios that were tried.

I'm not sure if this is a proper fix for nushell because of how we have our own path functionality, but it does resolve the issue. Reviews needed here. cc @kubouch since he wrote much of the path stuff.

fixes #10832

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
