### PR TITLE
make `exec` cross-platform experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,17 @@ dependencies = [
 
 [[package]]
 name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
@@ -2207,7 +2218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229004ebba9d1d5caf41623f1523b6d52abb47d9f6ab87f7e6fc992e3b854aef"
 dependencies = [
  "bindgen",
- "errno",
+ "errno 0.3.4",
  "libc",
 ]
 
@@ -2814,6 +2825,7 @@ dependencies = [
  "dirs-next",
  "dtparse",
  "encoding_rs",
+ "errno 0.2.8",
  "fancy-regex",
  "filesize",
  "filetime",
@@ -4465,7 +4477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
 dependencies = [
  "bitflags 1.3.2",
- "errno",
+ "errno 0.3.4",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.1.4",
@@ -4479,7 +4491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4279d76516df406a8bd37e7dff53fd37d1a093f997a3c34a5c21658c126db06d"
 dependencies = [
  "bitflags 1.3.2",
- "errno",
+ "errno 0.3.4",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
@@ -4493,7 +4505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f9da0cbd88f9f09e7814e388301c8414c51c62aa6ce1e4b5c551d49d96e531"
 dependencies = [
  "bitflags 2.4.0",
- "errno",
+ "errno 0.3.4",
  "libc",
  "linux-raw-sys 0.4.8",
  "windows-sys 0.48.0",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -42,6 +42,7 @@ dialoguer = { default-features = false, features = ["fuzzy-select"], version = "
 digest = { default-features = false, version = "0.10" }
 dtparse = "2.0"
 encoding_rs = "0.8"
+errno = "0.2"
 fancy-regex = "0.11"
 filesize = "0.2"
 filetime = "0.2"
@@ -50,6 +51,7 @@ htmlescape = "0.3"
 indexmap = "2.0"
 indicatif = "0.17"
 itertools = "0.11"
+libc = "0.2.8"
 log = "0.4"
 lscolors = { version = "0.15", default-features = false, features = ["nu-ansi-term"] }
 md5 = { package = "md-5", version = "0.10" }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -145,7 +145,6 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             ViewSpan,
         };
 
-        #[cfg(unix)]
         bind_command! { Exec }
 
         #[cfg(windows)]

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -1,10 +1,10 @@
-use super::run_external::create_external_command;
-use nu_engine::{current_dir, CallExt};
+use nu_engine::CallExt;
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
     Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type,
 };
+#[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
 #[derive(Clone)]
@@ -19,16 +19,13 @@ impl Command for Exec {
         Signature::build("exec")
             .input_output_types(vec![(Type::Nothing, Type::Any)])
             .required("command", SyntaxShape::String, "the command to execute")
+            .rest("rest", SyntaxShape::Any, "the arguments for the command")
             .allows_unknown_args()
             .category(Category::System)
     }
 
     fn usage(&self) -> &str {
         "Execute a command, replacing the current process."
-    }
-
-    fn extra_usage(&self) -> &str {
-        "Currently supported only on Unix-based systems."
     }
 
     fn run(
@@ -64,28 +61,9 @@ fn exec(
 ) -> Result<PipelineData, ShellError> {
     let name: Spanned<String> = call.req(engine_state, stack, 0)?;
     let name_span = name.span;
+    let args: Vec<String> = call.rest(engine_state, stack, 1)?;
 
-    let redirect_stdout = call.has_flag("redirect-stdout");
-    let redirect_stderr = call.has_flag("redirect-stderr");
-    let redirect_combine = call.has_flag("redirect-combine");
-    let trim_end_newline = call.has_flag("trim-end-newline");
-
-    let external_command = create_external_command(
-        engine_state,
-        stack,
-        call,
-        redirect_stdout,
-        redirect_stderr,
-        redirect_combine,
-        trim_end_newline,
-    )?;
-
-    let cwd = current_dir(engine_state, stack)?;
-    let mut command = external_command.spawn_simple_command(&cwd.to_string_lossy())?;
-    command.current_dir(cwd);
-    command.envs(&external_command.env_vars);
-
-    let err = command.exec(); // this replaces our process, should not return
+    let err = ExecCommand::new(name.item).args(&args[1..]).exec();
 
     Err(ShellError::GenericError(
         "Error on exec".to_string(),
@@ -94,4 +72,233 @@ fn exec(
         None,
         Vec::new(),
     ))
+}
+
+//--------------------------------------------------------------------------------------------------
+// Borrowed from https://github.com/faradayio/exec-rs which seems not very well supported because
+// the windows parts were in a PR that I merged below. Now exec works cross-platform.
+//
+
+// A simple wrapper around the C library's `execvp` function.
+//
+// For examples, see [the repository](https://github.com/faradayio/exec-rs).
+//
+// We'd love to fully integrate this with `std::process::Command`, but
+// that module doesn't export sufficient hooks to allow us to add a new
+// way to execute a program.
+
+extern crate errno;
+extern crate libc;
+
+use errno::{errno, Errno};
+use std::error;
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::iter::{IntoIterator, Iterator};
+use std::ptr;
+
+/// Represents an error calling `exec`.
+///
+/// This is marked `#[must_use]`, which is unusual for error types.
+/// Normally, the fact that `Result` is marked in this fashion is
+/// sufficient, but in this case, this error is returned bare from
+/// functions that only return a result if they fail.
+#[derive(Debug)]
+#[must_use]
+pub enum Error {
+    /// One of the strings passed to `execv` contained an internal null byte
+    /// and can't be passed correctly to C.
+    NullByteInArgument,
+    /// An error was returned by the system.
+    Errno(Errno),
+}
+
+impl error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::NullByteInArgument => write!(f, "interior NUL byte in string argument to exec"),
+            Error::Errno(err) => write!(f, "couldn't exec process: {}", err),
+        }
+    }
+}
+
+impl From<Errno> for Error {
+    fn from(err: Errno) -> Error {
+        Error::Errno(err)
+    }
+}
+
+/// Like `try!`, but it just returns the error directly without wrapping it
+/// in `Err`.  For functions that only return if something goes wrong.
+macro_rules! exec_try {
+    ( $ expr : expr ) => {
+        match $expr {
+            Ok(val) => val,
+            Err(err) => return From::from(err),
+        }
+    };
+}
+
+/// Run `program` with `args`, completely replacing the currently running
+/// program.  If it returns at all, it always returns an error.
+///
+/// Note that `program` and the first element of `args` will normally be
+/// identical.  The former is the program we ask the operating system to
+/// run, and the latter is the value that will show up in `argv[0]` when
+/// the program executes.  On POSIX systems, these can technically be
+/// completely different, and we've perserved that much of the low-level
+/// API here.
+///
+/// # Examples
+///
+/// ```no_run
+/// let err = exec::execvp("echo", &["echo", "foo"]);
+/// println!("Error: {}", err);
+/// ```
+pub fn execvp<S, I>(program: S, args: I) -> Error
+where
+    S: AsRef<OsStr>,
+    I: IntoIterator,
+    I::Item: AsRef<OsStr>,
+{
+    execvp_impl(program, args)
+}
+
+#[cfg(unix)]
+fn execvp_impl<S, I>(program: S, args: I) -> Error
+where
+    S: AsRef<OsStr>,
+    I: IntoIterator,
+    I::Item: AsRef<OsStr>,
+{
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    // Add null terminations to our strings and our argument array,
+    // converting them into a C-compatible format.
+    let program_cstring =
+        exec_try!(CString::new(program.as_ref().as_bytes()).map_err(|_| Error::NullByteInArgument));
+    let arg_cstrings = exec_try!(args
+        .into_iter()
+        .map(|arg| { CString::new(arg.as_ref().as_bytes()).map_err(|_| Error::NullByteInArgument) })
+        .collect::<Result<Vec<_>, _>>());
+    let mut arg_charptrs: Vec<_> = arg_cstrings.iter().map(|arg| arg.as_ptr()).collect();
+    arg_charptrs.push(ptr::null());
+
+    // Use an `unsafe` block so that we can call directly into C.
+    let res = unsafe { libc::execvp(program_cstring.as_ptr(), arg_charptrs.as_ptr()) };
+
+    // Handle our error result.
+    if res < 0 {
+        Error::Errno(errno())
+    } else {
+        // Should never happen.
+        panic!("execvp returned unexpectedly")
+    }
+}
+
+#[cfg(windows)]
+extern "C" {
+    // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/execvp-wexecvp
+    pub fn _wexecvp(
+        cmdname: *const libc::wchar_t,
+        argv: *const *const libc::wchar_t,
+    ) -> libc::intptr_t;
+}
+
+#[cfg(windows)]
+fn execvp_impl<S, I>(program: S, args: I) -> Error
+where
+    S: AsRef<OsStr>,
+    I: IntoIterator,
+    I::Item: AsRef<OsStr>,
+{
+    use std::os::windows::ffi::OsStrExt;
+
+    let wcstring = |s: &OsStr| -> Result<Vec<u16>, Error> {
+        let mut vec: Vec<u16> = s.encode_wide().collect();
+        if vec.iter().any(|&x| x == 0) {
+            // We have an interior null.
+            // The Unix impl includes a NulError, but that's only constructible using CString.
+            Err(Error::NullByteInArgument)
+        } else {
+            vec.push(0); // append null terminator
+            Ok(vec)
+        }
+    };
+
+    let program_wide = exec_try!(wcstring(program.as_ref()));
+    let args_wide = exec_try!(args
+        .into_iter()
+        .map(|arg| wcstring(arg.as_ref()))
+        .collect::<Result<Vec<_>, _>>());
+    let mut arg_ptrs: Vec<_> = args_wide.iter().map(|arg| arg.as_ptr()).collect();
+    arg_ptrs.push(ptr::null());
+
+    let res = unsafe { _wexecvp(program_wide.as_ptr(), arg_ptrs.as_ptr()) };
+
+    // Handle our error result.
+    if res < 0 {
+        Error::Errno(errno())
+    } else {
+        // Should never happen.
+        panic!("_wexecvp returned unexpectedly")
+    }
+}
+
+/// Build a command to execute.  This has an API which is deliberately
+/// similar to `std::process::Command`.
+///
+/// ```no_run
+/// let err = exec::ExecCommand::new("echo")
+///     .arg("hello")
+///     .arg("world")
+///     .exec();
+/// println!("Error: {}", err);
+/// ```
+///
+/// If the `exec` function succeeds, it will never return.
+pub struct ExecCommand {
+    /// The program name and arguments, in typical C `argv` style.
+    argv: Vec<OsString>,
+}
+
+impl ExecCommand {
+    /// Create a new command builder, specifying the program to run.  The
+    /// program will be searched for using the usual rules for `PATH`.
+    pub fn new<S: AsRef<OsStr>>(program: S) -> ExecCommand {
+        ExecCommand {
+            argv: vec![program.as_ref().to_owned()],
+        }
+    }
+
+    /// Add an argument to the command builder.  This can be chained.
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut ExecCommand {
+        self.argv.push(arg.as_ref().to_owned());
+        self
+    }
+
+    /// Add multiple arguments to the command builder.  This can be
+    /// chained.
+    ///
+    /// ```no_run
+    /// let err = exec::ExecCommand::new("echo")
+    ///     .args(&["hello", "world"])
+    ///     .exec();
+    /// println!("Error: {}", err);
+    /// ```
+    pub fn args<S: AsRef<OsStr>>(&mut self, args: &[S]) -> &mut ExecCommand {
+        for arg in args {
+            self.arg(arg.as_ref());
+        }
+        self
+    }
+
+    /// Execute the command we built.  If this function succeeds, it will
+    /// never return.
+    pub fn exec(&mut self) -> Error {
+        execvp(&self.argv[0], &self.argv)
+    }
 }

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -1,5 +1,4 @@
 mod complete;
-#[cfg(unix)]
 mod exec;
 mod nu_check;
 #[cfg(any(
@@ -16,7 +15,6 @@ mod sys;
 mod which_;
 
 pub use complete::Complete;
-#[cfg(unix)]
 pub use exec::Exec;
 pub use nu_check::NuCheck;
 #[cfg(any(


### PR DESCRIPTION
# Description

This PR aims to make our `exec` command cross-platform and is prototyp. It embeds the exec-rs crate so I could manually merge the Windows parts. More cross-platform testing is needed.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
