### PR TITLE
Use mozilla-actions/sccache-action to speed up release and nightly release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ env:
   NU_LOG_LEVEL: DEBUG
   # If changing these settings also change toolkit.nu
   CLIPPY_OPTIONS: "-D warnings -D clippy::unwrap_used"
+  RUSTC_WRAPPER: 'sccache'
+  SCCACHE_GHA_ENABLED: 'true'
 
 jobs:
   fmt-clippy:
@@ -39,6 +41,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.1.1
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
@@ -88,6 +93,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
         with:
@@ -119,6 +127,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.1.1
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
@@ -165,6 +176,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.1.1
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.4
 
       - name: Setup Rust toolchain and cache
         uses: actions-rust-lang/setup-rust-toolchain@v1.8.0

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -19,6 +19,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  RUSTC_WRAPPER: 'sccache'
+  SCCACHE_GHA_ENABLED: 'true'
+
 jobs:
   prepare:
     name: Prepare
@@ -132,6 +136,9 @@ jobs:
       run: |
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
 
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
+
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
       # WARN: Keep the rustflags to prevent from the winget submission error: `CAQuietExec:  Error 0xc0000135`
@@ -243,6 +250,9 @@ jobs:
     - name: Update Rust Toolchain Target
       run: |
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  RUSTC_WRAPPER: 'sccache'
-  SCCACHE_GHA_ENABLED: 'true'
-
 jobs:
   standard:
     name: Std
@@ -81,9 +77,6 @@ jobs:
     - name: Update Rust Toolchain Target
       run: |
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
-
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
@@ -173,9 +166,6 @@ jobs:
     - name: Update Rust Toolchain Target
       run: |
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
-
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.8.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  RUSTC_WRAPPER: 'sccache'
+  SCCACHE_GHA_ENABLED: 'true'
+
 jobs:
   standard:
     name: Std
@@ -77,6 +81,9 @@ jobs:
     - name: Update Rust Toolchain Target
       run: |
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
@@ -166,6 +173,9 @@ jobs:
     - name: Update Rust Toolchain Target
       run: |
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml
+
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Setup Rust toolchain and cache
       uses: actions-rust-lang/setup-rust-toolchain@v1.8.0


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

I have tried `mozilla-actions/sccache-action` in the `nushell/nightly` repo for a while, and the workflow running logs could be found here: https://github.com/nushell/nightly/actions/runs/6607933986/attempts/1, the workflow has been run 5 times:
- [Attempt #1](https://github.com/nushell/nightly/actions/runs/6607933986/attempts/1) cost 46min
- [Attempt #2](https://github.com/nushell/nightly/actions/runs/6607933986/attempts/2) cost 34min 
- [Attempt #3](https://github.com/nushell/nightly/actions/runs/6607933986/attempts/3) cost 35min 
- [Attempt #4](https://github.com/nushell/nightly/actions/runs/6607933986/attempts/4) cost 23min
- [Attempt #5](https://github.com/nushell/nightly/actions/runs/6607933986) cost 29min

Some explanations: 

1. `Attempt #1` cost the longest time, as it's the first run and with nothing been cached.
2. All the following running of workflow taken an obvious shorter time, Reduced by 20% to 50%
3. All the binary release time for Linux and macOS have been reduced significantly, however it's not that useful for Windows.

In summary, `mozilla-actions/sccache-action` do improve the release time of workflow. We can give it a try, and the config is quite simple BTW.

