### PR TITLE
`group-by` now returns a table instead of a record

### DIFF
--- a/crates/nu-std/std/testing.nu
+++ b/crates/nu-std/std/testing.nu
@@ -72,11 +72,10 @@ def create-test-record [] nothing -> record<before-each: string, after-each: str
             valid-annotations
             | get $x.annotation
         }
-        | group-by annotation
-        | transpose key value
-        | update value {|x|
-            $x.value.function_name
-            | if $x.key in ["test", "test-skip"] {
+        | group-by --to-table annotation
+        | update items {|x|
+            $x.items.function_name
+            | if $x.group in ["test", "test-skip"] {
                 $in
             } else {
                 get 0


### PR DESCRIPTION
# Description

Previously `group-by` returned a record containing each group as a column. This data layout is hard to work with for some tasks because you have to further manipulate the result to do things like determine the number of items in each group, or the number of groups.  `transpose` will turn the record returned by `group-by` into a table, but this is expensive when `group-by` is run on a large input.

In a discussion with @fdncred [several workarounds](https://github.com/nushell/nushell/discussions/10462) to common tasks were discussed, but they seem unsatisfying in general.

Now when `group-by --to-table` is used a table is returned with the columns "groups" and "items" making it easier to do things like count the number of groups (`| length`) or count the number of items in each group (`| each {|g| $g.items | length`)

# User-Facing Changes

* `group-by` returns a `table` with "group" and "items" columns instead of a `record` with one column per group name

# Tests + Formatting

Tests for `group-by` were updated

# After Submitting

* No breaking changes were made. The new `--to-table` switch should be added automatically to the [`group-by` documentation](https://www.nushell.sh/commands/docs/group-by.html)