### PR TITLE
use `to_lowercase` in `str downcase`

### DIFF
--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -121,7 +121,7 @@ fn operate(
 
 fn action(input: &Value, head: Span) -> Value {
     match input {
-        Value::String { val, .. } => Value::string(val.to_ascii_lowercase(), head),
+        Value::String { val, .. } => Value::string(val.to_lowercase(), head),
         Value::Error { .. } => input.clone(),
         _ => Value::error(
             ShellError::OnlySupportsThisInputType {


### PR DESCRIPTION
# Description
as we can see in the [documentation of `str.to_lowercase`](https://doc.rust-lang.org/std/primitive.str.html#method.to_lowercase), not only ASCII symbols have lower and upper variants.

- `str upcase` uses the correct method to convert the string
https://github.com/nushell/nushell/blob/7ac5a01e2f5020a1295697edab727cd62a5844b7/crates/nu-command/src/strings/str_/case/upcase.rs#L93
- `str downcase` incorrectly converts only ASCII characters
https://github.com/nushell/nushell/blob/7ac5a01e2f5020a1295697edab727cd62a5844b7/crates/nu-command/src/strings/str_/case/downcase.rs#L124

this PR uses `str.to_lower_case` instead of `str.to_ascii_lowercase` in `str downcase`.

# User-Facing Changes
- upcase still works fine
```nushell
~ l> "ὀδυσσεύς" | str upcase
ὈΔΥΣΣΕΎΣ
```
- downcase now works

:point_right: before
```nushell
~ l> "ὈΔΥΣΣΕΎΣ" | str downcase
ὈΔΥΣΣΕΎΣ
```
:point_right: after
```nushell
~ l> "ὈΔΥΣΣΕΎΣ" | str downcase
ὀδυσσεύς
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
