### PR TITLE
Update description and error types for `split-by`

### DIFF
--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -40,13 +40,13 @@ impl Command for SplitBy {
         vec![Example {
             description: "split items by column named \"lang\"",
             example: r#"{
-        '2019': [
-          { name: 'andres', lang: 'rb', year: '2019' },
-          { name: 'jt', lang: 'rs', year: '2019' }
-        ],
-        '2021': [
-          { name: 'storm', lang: 'rs', 'year': '2021' }
-        ]
+    '2019': [
+        { name: 'andres', lang: 'rb', year: '2019' },
+        { name: 'jt', lang: 'rs', year: '2019' }
+    ],
+    '2021': [
+        { name: 'storm', lang: 'rs', 'year': '2021' }
+    ]
     } | split-by lang"#,
             result: Some(Value::test_record(record! {
                     "rb" => Value::test_record(record! {

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -23,7 +23,7 @@ impl Command for SplitBy {
     }
 
     fn usage(&self) -> &str {
-        "Create a new table split."
+        "Split a record into groups"
     }
 
     fn run(
@@ -202,24 +202,18 @@ pub fn data_split(
                     }
                 }
                 _ => {
-                    return Err(ShellError::GenericError(
-                        "unsupported input".into(),
-                        "requires a table with one row for splitting".into(),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    ))
+                    return Err(ShellError::TypeMismatch {
+                        err_message: "requires a record to split".into(),
+                        span,
+                    })
                 }
             }
         }
         _ => {
-            return Err(ShellError::GenericError(
-                "unsupported input".into(),
-                "requires a table with one row for splitting".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            ))
+            return Err(ShellError::TypeMismatch {
+                err_message: "requires a record to split".into(),
+                span,
+            })
         }
     }
 

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -211,7 +211,14 @@ pub fn data_split(
                 }
             }
         }
-        _ => return Err(ShellError::PipelineEmpty { dst_span }),
+        PipelineData::Empty => return Err(ShellError::PipelineEmpty { dst_span }),
+        _ => {
+            return Err(ShellError::PipelineMismatch {
+                exp_input_type: "record".into(),
+                dst_span,
+                src_span: value.span().unwrap_or(Span::unknown()),
+            })
+        }
     }
 
     let record = splits

--- a/crates/nu-command/tests/commands/split_by.rs
+++ b/crates/nu-command/tests/commands/split_by.rs
@@ -31,7 +31,16 @@ fn splits() {
 }
 
 #[test]
-fn errors_if_no_table_given_as_input() {
+fn errors_if_no_input() {
+    Playground::setup("split_by_no_input", |dirs, _sandbox| {
+        let actual = nu!(cwd: dirs.test(), pipeline("split-by type"));
+
+        assert!(actual.err.contains("no input value was piped in"));
+    })
+}
+
+#[test]
+fn errors_if_non_record_input() {
     Playground::setup("split_by_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![
             EmptyFile("los.txt"),
@@ -40,7 +49,11 @@ fn errors_if_no_table_given_as_input() {
             EmptyFile("arepas.clu"),
         ]);
 
-        let actual = nu!(
+        let input_mismatch = nu!(cwd: dirs.test(), pipeline("5 | split-by type"));
+
+        assert!(input_mismatch.err.contains("doesn't support int input"));
+
+        let only_supports = nu!(
             cwd: dirs.test(), pipeline(
             "
                 ls
@@ -49,6 +62,8 @@ fn errors_if_no_table_given_as_input() {
             "
         ));
 
-        assert!(actual.err.contains("requires a record"));
+        assert!(only_supports
+            .err
+            .contains("only Record input data is supported"));
     })
 }

--- a/crates/nu-command/tests/commands/split_by.rs
+++ b/crates/nu-command/tests/commands/split_by.rs
@@ -49,6 +49,6 @@ fn errors_if_no_table_given_as_input() {
             "
         ));
 
-        assert!(actual.err.contains("requires a table"));
+        assert!(actual.err.contains("requires a record"));
     })
 }


### PR DESCRIPTION

# Description

`split-by` only works on a `Record`, the error type was updated to match, and now uses a more-specific type. (Two type fixes for the price of one!)

The `usage` was updated to say "record" as well

# User-Facing Changes

* Providing the wrong type to `split-by` now gives an error messages with the correct required input type

Previously:

```
❯ ls | get name | split-by type
Error:   × unsupported input
   ╭─[entry #267:1:1]
 1 │ ls | get name | split-by type
   ·      ─┬─
   ·       ╰── requires a table with one row for splitting
   ╰────
```

With this PR:

```
❯ ls | get name | split-by type
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[entry #1:1:1]
 1 │ ls | get name | split-by type
   ·      ─┬─
   ·       ╰── requires a record to split
   ╰────
```

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Only generated commands need to be updated