### PR TITLE
allow `sort-by` to work with records

### DIFF
--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -17,11 +17,12 @@ impl Command for SortBy {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("sort-by")
             .input_output_types(vec![
-                (Type::Table(vec![]), Type::Table(vec![])),
                 (
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
+                (Type::Record(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::Table(vec![])),
             ])
             .rest("columns", SyntaxShape::Any, "the column(s) to sort by")
             .switch("reverse", "Sort in reverse order", Some('r'))


### PR DESCRIPTION
# Description

This PR restores and old functionality that must of been broken with the input_output_types() updating. It allows commands like this to work again.

```nushell
open $nu.history-path | 
  get history.command_line | 
  split column ' ' cmd | 
  group-by cmd --to-table | 
  update items {|u| $u.items | length} | 
  sort-by items -r | 
  first 10 | 
  table -n 1
```
output
```
╭#─┬group─┬items╮
│1 │exit  │ 3004│
│2 │ls    │ 2591│
│3 │git   │ 1678│
│4 │help  │ 1549│
│5 │open  │ 1374│
│6 │cd    │ 1186│
│7 │cargo │  944│
│8 │let   │  784│
│9 │source│  755│
│10│z     │  486│
╰#─┴group─┴items╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
