### PR TITLE
Add `Record::remove`/`retain`/`retain_mut`

### DIFF
--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -127,6 +127,16 @@ impl Record {
     where
         F: FnMut(&str, &Value) -> bool,
     {
+        self.retain_mut(|k, v| keep(k, v));
+    }
+
+    /// Remove elements in-place that do not satisfy `keep` while allowing mutation of the value.
+    ///
+    /// Note: Panics if `vals.len() > cols.len()`
+    pub fn retain_mut<F>(&mut self, mut keep: F)
+    where
+        F: FnMut(&str, &mut Value) -> bool,
+    {
         let mut idx = 0;
 
         // `Vec::retain` is able to optimize memcopies internally. For maximum benefit as `Value`
@@ -136,7 +146,7 @@ impl Record {
         //
         // As the operations should remain inplace, we don't allocate a separate index `Vec` which
         // could be used to avoid the repeated shifting of `Vec::remove` in cols.
-        self.vals.retain(|val| {
+        self.vals.retain_mut(|val| {
             if keep(self.cols[idx].as_str(), val) {
                 idx += 1;
                 true

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -108,6 +108,21 @@ impl Record {
     /// Remove elements in-place that do not satisfy `keep`
     ///
     /// Note: Panics if `vals.len() > cols.len()`
+    /// ```rust
+    /// use nu_protocol::{record, Value};
+    ///
+    /// let mut rec = record!(
+    ///     "a" => Value::test_nothing(),
+    ///     "b" => Value::test_int(42),
+    ///     "c" => Value::test_nothing(),
+    ///     "d" => Value::test_int(42),
+    ///     );
+    /// rec.retain(|_k, val| !val.is_nothing());
+    /// let mut iter_rec = rec.columns();
+    /// assert_eq!(iter_rec.next().map(String::as_str), Some("b"));
+    /// assert_eq!(iter_rec.next().map(String::as_str), Some("d"));
+    /// assert_eq!(iter_rec.next(), None);
+    /// ```
     pub fn retain<F>(&mut self, mut keep: F)
     where
         F: FnMut(&str, &Value) -> bool,

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -94,6 +94,17 @@ impl Record {
         Some((self.cols.get(idx)?, self.vals.get(idx)?))
     }
 
+    /// Remove single value by key
+    ///
+    /// Returns `None` if key not found
+    ///
+    /// Note: makes strong assumption that keys are unique
+    pub fn remove(&mut self, col: impl AsRef<str>) -> Option<Value> {
+        let idx = self.index_of(col)?;
+        self.cols.remove(idx);
+        Some(self.vals.remove(idx))
+    }
+
     pub fn columns(&self) -> Columns {
         Columns {
             iter: self.cols.iter(),


### PR DESCRIPTION
# Description
While we have now a few ways to add items or iterate over the collection, we don't have a way to cleanly remove items from `Record`. 

This PR fixes that:

- Add `Record.remove()` to remove by key
  - makes the assumption that keys are unique, so can not be used universally, yet (see #10875 for an important example)
- Add naive `Record.retain()` for inplace removal
  - This follows the two separate `retain`/`retain_mut` in the Rust std library types, compared to the value-mutating `retain` in `indexmap`
- Add `Record.retain_mut()` for one-pass pruning

Continuation of #10841 

# User-Facing Changes
None yet.

# Tests + Formatting
Doctests for the `retain`ing fun
