### PR TITLE
Limit `run-external --redirect-combine sh` test to not(Windows)

### DIFF
--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -321,6 +321,7 @@ fn quotes_trimmed_when_shelling_out() {
     assert_eq!(actual.out, "foo");
 }
 
+#[cfg(not(windows))]
 #[test]
 fn redirect_combine() {
     Playground::setup("redirect_combine", |dirs, _| {


### PR DESCRIPTION
# Description

Limit the test `-p nu-command --test main commands::run_external::redirect_combine` which uses `sh` to running on `not(Windows)` like is done for other tests assuming unixy CLI items; `sh` doesn't exist on Windows.

# User-Facing Changes

None; this is a change to tests only.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`