### PR TITLE
allow `compact` to also compact empty strings

### DIFF
--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -130,10 +130,9 @@ pub fn compact(
                     }
                     Value::String { val, .. } => {
                         if val.is_empty() {
-                            false
-                        } else {
-                            true
+                            return false;
                         }
+                        true
                     }
                     // Any non-Nothing, non-record should be kept
                     _ => true,

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -127,27 +127,21 @@ pub fn compact(
                             }
                         }
 
-                        if compact_empties {
-                            if val.is_empty() {
-                                return false;
-                            }
+                        if compact_empties && val.is_empty() {
+                            return false;
                         }
                         // No defined columns contained Nothing
                         true
                     }
                     Value::List { vals, .. } => {
-                        if compact_empties {
-                            if vals.is_empty() {
-                                return false;
-                            }
+                        if compact_empties && vals.is_empty() {
+                            return false;
                         }
                         true
                     }
                     Value::String { val, .. } => {
-                        if compact_empties {
-                            if val.is_empty() {
-                                return false;
-                            }
+                        if compact_empties && val.is_empty() {
+                            return false;
                         }
                         true
                     }

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -99,7 +99,7 @@ pub fn compact(
                 match item {
                     // Nothing is filtered out
                     Value::Nothing { .. } => false,
-                    Value::Record { .. } => {
+                    Value::Record { val, .. } => {
                         for column in columns.iter() {
                             match item.get_data_by_key(column) {
                                 None => return false,
@@ -115,7 +115,17 @@ pub fn compact(
                                 }
                             }
                         }
+
+                        if val.is_empty() {
+                            return false;
+                        }
                         // No defined columns contained Nothing
+                        true
+                    }
+                    Value::List { vals, .. } => {
+                        if vals.is_empty() {
+                            return false;
+                        }
                         true
                     }
                     Value::String { val, .. } => {

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -80,7 +80,7 @@ impl Command for Compact {
             },
             Example {
                 description: "Filter out all instances of null and empty items from a list",
-                example: r#"[1, null, 2, "", {}, 3, [], 5] | compact --empty"#,
+                example: r#"[1, null, 2, "", 3, [], 4, {}, 5] | compact --empty"#,
                 result: Some(Value::test_list(vec![
                     Value::test_int(1),
                     Value::test_int(2),

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -52,12 +52,12 @@ impl Command for Compact {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Filter out all records where 'Hello' is null (returns nothing)",
+                description: "Filter out all records where 'Hello' is null",
                 example: r#"[["Hello" "World"]; [null 3]] | compact Hello"#,
                 result: Some(Value::test_list(vec![])),
             },
             Example {
-                description: "Filter out all records where 'World' is null (Returns the table)",
+                description: "Filter out all records where 'World' is null",
                 example: r#"[["Hello" "World"]; [null 3]] | compact World"#,
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                     "Hello" => Value::nothing(Span::test_data()),
@@ -65,11 +65,20 @@ impl Command for Compact {
                 })])),
             },
             Example {
-                description: "Filter out all instances of nothing from a list (Returns [1,2])",
+                description: "Filter out all instances of null from a list",
                 example: r#"[1, null, 2] | compact"#,
                 result: Some(Value::test_list(vec![
                     Value::test_int(1),
                     Value::test_int(2),
+                ])),
+            },
+            Example {
+                description: "Filter out all instances of null and empty string from a list",
+                example: r#"[1, null, 2, "", 3] | compact"#,
+                result: Some(Value::test_list(vec![
+                    Value::test_int(1),
+                    Value::test_int(2),
+                    Value::test_int(3),
                 ])),
             },
         ]
@@ -98,11 +107,23 @@ pub fn compact(
                                     if let Value::Nothing { .. } = x {
                                         return false;
                                     }
+                                    if let Value::String { val, .. } = x {
+                                        if val.is_empty() {
+                                            return false;
+                                        }
+                                    }
                                 }
                             }
                         }
                         // No defined columns contained Nothing
                         true
+                    }
+                    Value::String { val, .. } => {
+                        if val.is_empty() {
+                            false
+                        } else {
+                            true
+                        }
                     }
                     // Any non-Nothing, non-record should be kept
                     _ => true,


### PR DESCRIPTION
# Description

This change allows `compact` to also compact things with empty strings, empty lists, and empty records if the `--empty` switch is used. Let's add a quality-of-life improvement here to just compact all this mess. If this is a bad idea, please cite examples demonstrating why.

```
❯ [[name position]; [Francis Lead] [Igor TechLead] [Aya null]] | compact position
╭#┬─name──┬position╮
│0│Francis│Lead    │
│1│Igor   │TechLead│
╰─┴───────┴────────╯
❯ [[name position]; [Francis Lead] [Igor TechLead] [Aya ""]] | compact position --empty
╭#┬─name──┬position╮
│0│Francis│Lead    │
│1│Igor   │TechLead│
╰─┴───────┴────────╯
❯ [1, null, 2, "", 3, [], 4, {}, 5] | compact
╭─┬─────────────────╮
│0│                1│
│1│                2│
│2│                 │
│3│                3│
│4│[list 0 items]   │
│5│                4│
│6│{record 0 fields}│
│7│                5│
╰─┴─────────────────╯
❯ [1, null, 2, "", 3, [], 4, {}, 5] | compact --empty
╭─┬─╮
│0│1│
│1│2│
│2│3│
│3│4│
│4│5│
╰─┴─╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
