### PR TITLE
Change `input list` to return null

### DIFF
--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -235,11 +235,11 @@ impl Command for InputList {
                     opts.iter().map(|s| options[*s].value.clone()).collect(),
                     head,
                 ),
-                None => Value::list(vec![], head),
+                None => Value::nothing(head),
             },
             InteractMode::Single(res) => match res {
                 Some(opt) => options[opt].value.clone(),
-                None => Value::string("".to_string(), head),
+                None => Value::nothing(head),
             },
         }
         .into_pipeline_data())


### PR DESCRIPTION
Now the `input list` command, when nothing is selected, will return a null instead of empty string or an empty list.

Resolves #10909.


# User-Facing Changes

`input list` now returns a `null` when nothing is selected.