### PR TITLE
Refactor `find` in terms of clean `Record` API

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -253,26 +253,29 @@ fn find_with_regex(
     input.filter(
         move |value| match value {
             Value::String { val, .. } => re.is_match(val.as_str()).unwrap_or(false) != invert,
-            Value::Record {
-                val: Record { vals, .. },
-                ..
-            }
-            | Value::List { vals, .. } => values_match_find(vals, &re, &config, invert),
+            Value::Record { val, .. } => values_match_find(val.values(), &re, &config, invert),
+            Value::List { vals, .. } => values_match_find(vals, &re, &config, invert),
             _ => false,
         },
         ctrlc,
     )
 }
 
-fn values_match_find(values: &[Value], re: &Regex, config: &Config, invert: bool) -> bool {
+fn values_match_find<'a, I>(values: I, re: &Regex, config: &Config, invert: bool) -> bool
+where
+    I: IntoIterator<Item = &'a Value>,
+{
     match invert {
         true => !record_matches_regex(values, re, config),
         false => record_matches_regex(values, re, config),
     }
 }
 
-fn record_matches_regex(values: &[Value], re: &Regex, config: &Config) -> bool {
-    values.iter().any(|v| {
+fn record_matches_regex<'a, I>(values: I, re: &Regex, config: &Config) -> bool
+where
+    I: IntoIterator<Item = &'a Value>,
+{
+    values.into_iter().any(|v| {
         re.is_match(v.into_string(" ", config).as_str())
             .unwrap_or(false)
     })

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -555,13 +555,10 @@ fn record_matches_term(
     term: &Value,
     span: Span,
 ) -> bool {
-    let cols_to_search = if columns_to_search.is_empty() {
-        &record.cols
-    } else {
-        columns_to_search
-    };
+    // Only perform column selection if given columns.
+    let col_select = !columns_to_search.is_empty();
     record.iter().any(|(col, val)| {
-        if !cols_to_search.contains(col) {
+        if col_select && !columns_to_search.contains(col) {
             return false;
         }
         let lower_val = if !val.is_error() {


### PR DESCRIPTION
# Description
Rewrite `find` internals with the same principles as in #10927.

Here we can remove an unnecessary lookup accross all columns when not narrowing find to particular columns

- Change `find` internal fns to use iterators
- Remove unnecessary quadratic lookup in `find`
- Refactor `find` record highlight logic
# User-Facing Changes
Should provide a small speedup when not providing `find --columns`

# Tests + Formatting
(-)
