### PR TITLE
Refactor `table` cmd and `nu-table` with Record API

### DIFF
--- a/crates/nu-table/src/types/expanded.rs
+++ b/crates/nu-table/src/types/expanded.rs
@@ -344,8 +344,7 @@ fn expanded_table_list(input: &[Value], cfg: Cfg<'_>) -> TableResult {
 fn expanded_table_kv(record: &Record, cfg: Cfg<'_>) -> StringResult {
     let theme = load_theme_from_config(cfg.opts.config);
     let key_width = record
-        .cols
-        .iter()
+        .columns()
         .map(|col| string_width(col))
         .max()
         .unwrap_or(0);


### PR DESCRIPTION
# Description
- Simplify `table` record highlight with `.get_mut`
  - pretty straight forward
- Use record iterators in `table` abbreviation logic
  - This required some rework if we go from guaranted contiguous arrays to iterators
- Refactor `nu-table` internals to new record API
# User-Facing Changes
None intened

# Tests + Formatting
(-)
