### PR TITLE
remove unwraps in registry_query command

### DIFF
--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -311,7 +311,7 @@ fn reg_value_to_nu_int(reg_value: winreg::RegValue, call_span: Span) -> nu_proto
     let value =
         match reg_value.vtype {
             // See discussion here https://github.com/nushell/nushell/pull/10806#issuecomment-1791832088
-            // "The unwraps here are effecitvely infallible...", so I changed them to expects.
+            // "The unwraps here are effectively infallible...", so I changed them to expects.
             REG_DWORD => u32::from_reg_value(&reg_value)
                 .expect("registry value type should be REG_DWORD") as i64,
             REG_DWORD_BIG_ENDIAN => {

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -308,16 +308,21 @@ fn reg_value_to_nu_list_string(reg_value: winreg::RegValue, call_span: Span) -> 
 }
 
 fn reg_value_to_nu_int(reg_value: winreg::RegValue, call_span: Span) -> nu_protocol::Value {
-    let value = match reg_value.vtype {
-        REG_DWORD => u32::from_reg_value(&reg_value).unwrap() as i64,
-        REG_DWORD_BIG_ENDIAN => {
-            // winreg (v0.51.0) doesn't natively decode REG_DWORD_BIG_ENDIAN
-            u32::from_be_bytes(unsafe { *reg_value.bytes.as_ptr().cast() }) as i64
-        }
-        REG_QWORD => u64::from_reg_value(&reg_value).unwrap() as i64,
-        _ => unreachable!(
-            "registry value type should be REG_DWORD, REG_DWORD_BIG_ENDIAN, or REG_QWORD"
-        ),
-    };
+    let value =
+        match reg_value.vtype {
+            // See discussion here https://github.com/nushell/nushell/pull/10806#issuecomment-1791832088
+            // "The unwraps here are effecitvely infallible...", so I changed them to expects.
+            REG_DWORD => u32::from_reg_value(&reg_value)
+                .expect("registry value type should be REG_DWORD") as i64,
+            REG_DWORD_BIG_ENDIAN => {
+                // winreg (v0.51.0) doesn't natively decode REG_DWORD_BIG_ENDIAN
+                u32::from_be_bytes(unsafe { *reg_value.bytes.as_ptr().cast() }) as i64
+            }
+            REG_QWORD => u64::from_reg_value(&reg_value)
+                .expect("registry value type should be REG_QWORD") as i64,
+            _ => unreachable!(
+                "registry value type should be REG_DWORD, REG_DWORD_BIG_ENDIAN, or REG_QWORD"
+            ),
+        };
     Value::int(value, call_span)
 }


### PR DESCRIPTION
# Description

After talking to @CAD97, I decided to change these unwraps to expects. See the comments. The bigger question is, how did unwrap pass the CI?

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
