### PR TITLE
Implement LSP Text Document Synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,8 +2312,7 @@ dependencies = [
 [[package]]
 name = "lsp-server"
 version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b52dccdf3302eefab8c8a1273047f0a3c3dca4b527c8458d00c09484c8371928"
+source = "git+https://github.com/schrieveslaach/rust-analyzer.git?branch=cancelable-initialization#f95d538d3af1eac9266b898c8bed384c1498edfc"
 dependencies = [
  "crossbeam-channel",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,6 +2972,7 @@ name = "nu-lsp"
 version = "0.87.0"
 dependencies = [
  "assert-json-diff",
+ "crossbeam-channel",
  "lsp-server",
  "lsp-types",
  "miette",

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -16,7 +16,7 @@ reedline = { version = "0.26" }
 
 crossbeam-channel = "0.5.8"
 lsp-types = "0.94.1"
-lsp-server = "0.7.4"
+lsp-server = { version = "0.7.4", git = "https://github.com/schrieveslaach/rust-analyzer.git", branch = "cancelable-initialization" }
 miette = "5.10"
 ropey = "1.6.1"
 serde = "1.0"

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -14,6 +14,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.87.0" }
 
 reedline = { version = "0.26" }
 
+crossbeam-channel = "0.5.8"
 lsp-types = "0.94.1"
 lsp-server = "0.7.4"
 miette = "5.10"

--- a/crates/nu-lsp/src/diagnostics.rs
+++ b/crates/nu-lsp/src/diagnostics.rs
@@ -1,0 +1,147 @@
+use lsp_types::{
+    notification::{Notification, PublishDiagnostics},
+    Diagnostic, DiagnosticSeverity, PublishDiagnosticsParams, Url,
+};
+use miette::{IntoDiagnostic, Result};
+use nu_parser::parse;
+use nu_protocol::{
+    engine::{EngineState, StateWorkingSet},
+    eval_const::create_nu_constant,
+    Span, Value, NU_VARIABLE_ID,
+};
+
+use crate::LanguageServer;
+
+impl LanguageServer {
+    pub(crate) fn publish_diagnostics_for_file(
+        &self,
+        uri: Url,
+        engine_state: &mut EngineState,
+    ) -> Result<()> {
+        let cwd = std::env::current_dir().expect("Could not get current working directory.");
+        engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
+
+        let Ok(nu_const) = create_nu_constant(engine_state, Span::unknown()) else {
+            return Ok(());
+        };
+        engine_state.set_variable_const_val(NU_VARIABLE_ID, nu_const);
+
+        let mut working_set = StateWorkingSet::new(engine_state);
+
+        let Some((rope_of_file, file_path)) = self.rope(&uri) else {
+            return Ok(());
+        };
+
+        let contents = rope_of_file.bytes().collect::<Vec<u8>>();
+        let offset = working_set.next_span_start();
+        parse(
+            &mut working_set,
+            Some(&file_path.to_string_lossy()),
+            &contents,
+            false,
+        );
+
+        let mut diagnostics = PublishDiagnosticsParams {
+            uri,
+            diagnostics: Vec::new(),
+            version: None,
+        };
+
+        for err in working_set.parse_errors.iter() {
+            let message = err.to_string();
+
+            diagnostics.diagnostics.push(Diagnostic {
+                range: Self::span_to_range(&err.span(), rope_of_file, offset),
+                severity: Some(DiagnosticSeverity::ERROR),
+                message,
+                ..Default::default()
+            });
+        }
+
+        self.connection
+            .sender
+            .send(lsp_server::Message::Notification(
+                lsp_server::Notification::new(PublishDiagnostics::METHOD.to_string(), diagnostics),
+            ))
+            .into_diagnostic()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use lsp_types::Url;
+    use nu_test_support::fs::fixtures;
+
+    use crate::tests::{initialize_language_server, open, update};
+
+    #[test]
+    fn publish_diagnostics_variable_does_not_exists() {
+        let (client_connection, _recv) = initialize_language_server();
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("diagnostics");
+        script.push("var.nu");
+        let script = Url::from_file_path(script).unwrap();
+
+        let notification = open(&client_connection, script.clone());
+
+        assert_json_eq!(
+            notification,
+            serde_json::json!({
+                "method": "textDocument/publishDiagnostics",
+                "params": {
+                    "uri": script,
+                    "diagnostics": [{
+                        "range": {
+                            "start": { "line": 0, "character": 6 },
+                            "end": { "line": 0, "character": 30 }
+                        },
+                        "message": "Variable not found.",
+                        "severity": 1
+                    }]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn publish_diagnostics_fixed_unknown_variable() {
+        let (client_connection, _recv) = initialize_language_server();
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("diagnostics");
+        script.push("var.nu");
+        let script = Url::from_file_path(script).unwrap();
+
+        open(&client_connection, script.clone());
+        let notification = update(
+            &client_connection,
+            script.clone(),
+            String::from("$env"),
+            Some(lsp_types::Range {
+                start: lsp_types::Position {
+                    line: 0,
+                    character: 6,
+                },
+                end: lsp_types::Position {
+                    line: 0,
+                    character: 30,
+                },
+            }),
+        );
+
+        assert_json_eq!(
+            notification,
+            serde_json::json!({
+                "method": "textDocument/publishDiagnostics",
+                "params": {
+                    "uri": script,
+                    "diagnostics": []
+                }
+            })
+        );
+    }
+}

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -74,11 +74,9 @@ impl LanguageServer {
         })
         .expect("Must be serializable");
 
-        // TODO: raise a PR to add ctrlc support otherwise it is impossible to use ctrl-c to quit
-        // the process in the initialization stage
         let _initialization_params = self
             .connection
-            .initialize(server_capabilities)
+            .initialize_while(server_capabilities, || !ctrlc.load(Ordering::SeqCst))
             .into_diagnostic()?;
 
         while !ctrlc.load(Ordering::SeqCst) {

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -1,11 +1,19 @@
-use std::{fs::File, io::Cursor, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use lsp_server::{Connection, IoThreads, Message, Response, ResponseError};
 use lsp_types::{
     request::{Completion, GotoDefinition, HoverRequest, Request},
     CompletionItem, CompletionParams, CompletionResponse, CompletionTextEdit, GotoDefinitionParams,
     GotoDefinitionResponse, Hover, HoverContents, HoverParams, Location, MarkupContent, MarkupKind,
-    OneOf, Range, ServerCapabilities, TextEdit, Url,
+    OneOf, Range, ServerCapabilities, TextDocumentSyncKind, TextEdit, Url,
 };
 use miette::{IntoDiagnostic, Result};
 use nu_cli::NuCompleter;
@@ -17,6 +25,8 @@ use nu_protocol::{
 use reedline::Completer;
 use ropey::Rope;
 
+mod notification;
+
 #[derive(Debug)]
 enum Id {
     Variable(VarId),
@@ -27,6 +37,7 @@ enum Id {
 pub struct LanguageServer {
     connection: Connection,
     io_threads: Option<IoThreads>,
+    ropes: BTreeMap<PathBuf, Rope>,
 }
 
 impl LanguageServer {
@@ -42,11 +53,19 @@ impl LanguageServer {
         Ok(Self {
             connection,
             io_threads,
+            ropes: BTreeMap::new(),
         })
     }
 
-    pub fn serve_requests(self, engine_state: EngineState) -> Result<()> {
+    pub fn serve_requests(
+        mut self,
+        engine_state: EngineState,
+        ctrlc: Arc<AtomicBool>,
+    ) -> Result<()> {
         let server_capabilities = serde_json::to_value(&ServerCapabilities {
+            text_document_sync: Some(lsp_types::TextDocumentSyncCapability::Kind(
+                TextDocumentSyncKind::INCREMENTAL,
+            )),
             definition_provider: Some(OneOf::Left(true)),
             hover_provider: Some(lsp_types::HoverProviderCapability::Simple(true)),
             completion_provider: Some(lsp_types::CompletionOptions::default()),
@@ -54,12 +73,26 @@ impl LanguageServer {
         })
         .expect("Must be serializable");
 
+        // TODO: raise a PR to add ctrlc support otherwise it is impossible to use ctrl-c to quit
+        // the process in the initialization stage
         let _initialization_params = self
             .connection
             .initialize(server_capabilities)
             .into_diagnostic()?;
 
-        for msg in &self.connection.receiver {
+        while !ctrlc.load(Ordering::SeqCst) {
+            let msg = match self
+                .connection
+                .receiver
+                .recv_timeout(Duration::from_secs(1))
+            {
+                Ok(msg) => msg,
+                Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
+                    continue;
+                }
+                Err(_) => break,
+            };
+
             match msg {
                 Message::Request(request) => {
                     if self
@@ -71,25 +104,34 @@ impl LanguageServer {
                     }
 
                     let mut engine_state = engine_state.clone();
-                    match request.method.as_str() {
-                        GotoDefinition::METHOD => {
-                            self.handle_lsp_request(
-                                &mut engine_state,
-                                request,
-                                Self::goto_definition,
-                            )?;
+                    let resp = match request.method.as_str() {
+                        GotoDefinition::METHOD => Self::handle_lsp_request(
+                            &mut engine_state,
+                            request,
+                            |engine_state, params| self.goto_definition(engine_state, params),
+                        ),
+                        HoverRequest::METHOD => Self::handle_lsp_request(
+                            &mut engine_state,
+                            request,
+                            |engine_state, params| self.hover(engine_state, params),
+                        ),
+                        Completion::METHOD => Self::handle_lsp_request(
+                            &mut engine_state,
+                            request,
+                            |engine_state, params| self.complete(engine_state, params),
+                        ),
+                        _ => {
+                            continue;
                         }
-                        HoverRequest::METHOD => {
-                            self.handle_lsp_request(&mut engine_state, request, Self::hover)?;
-                        }
-                        Completion::METHOD => {
-                            self.handle_lsp_request(&mut engine_state, request, Self::complete)?;
-                        }
-                        _ => {}
-                    }
+                    };
+
+                    self.connection
+                        .sender
+                        .send(Message::Response(resp))
+                        .into_diagnostic()?;
                 }
                 Message::Response(_) => {}
-                Message::Notification(_) => {}
+                Message::Notification(notification) => self.handle_lsp_notification(notification),
             }
         }
 
@@ -101,41 +143,36 @@ impl LanguageServer {
     }
 
     fn handle_lsp_request<P, H, R>(
-        &self,
         engine_state: &mut EngineState,
         req: lsp_server::Request,
-        param_handler: H,
-    ) -> Result<()>
+        mut param_handler: H,
+    ) -> Response
     where
         P: serde::de::DeserializeOwned,
-        H: Fn(&mut EngineState, &P) -> Option<R>,
+        H: FnMut(&mut EngineState, &P) -> Option<R>,
         R: serde::ser::Serialize,
     {
-        let resp = {
-            match serde_json::from_value::<P>(req.params) {
-                Ok(params) => Response {
-                    id: req.id,
-                    result: param_handler(engine_state, &params)
-                        .and_then(|response| serde_json::to_value(response).ok()),
-                    error: None,
-                },
+        match serde_json::from_value::<P>(req.params) {
+            Ok(params) => Response {
+                id: req.id,
+                result: Some(
+                    param_handler(engine_state, &params)
+                        .and_then(|response| serde_json::to_value(response).ok())
+                        .unwrap_or(serde_json::Value::Null),
+                ),
+                error: None,
+            },
 
-                Err(err) => Response {
-                    id: req.id,
-                    result: None,
-                    error: Some(ResponseError {
-                        code: 1,
-                        message: err.to_string(),
-                        data: None,
-                    }),
-                },
-            }
-        };
-
-        self.connection
-            .sender
-            .send(Message::Response(resp))
-            .into_diagnostic()
+            Err(err) => Response {
+                id: req.id,
+                result: None,
+                error: Some(ResponseError {
+                    code: 1,
+                    message: err.to_string(),
+                    data: None,
+                }),
+            },
+        }
     }
 
     fn span_to_range(span: &Span, rope_of_file: &Rope, offset: usize) -> lsp_types::Range {
@@ -158,79 +195,84 @@ impl LanguageServer {
         lsp_types::Range { start, end }
     }
 
-    fn lsp_position_to_location(position: &lsp_types::Position, rope_of_file: &Rope) -> usize {
+    pub fn lsp_position_to_location(position: &lsp_types::Position, rope_of_file: &Rope) -> usize {
         let line_idx = rope_of_file.line_to_char(position.line as usize);
         line_idx + position.character as usize
     }
 
     fn find_id(
         working_set: &mut StateWorkingSet,
-        file_path: &str,
-        file: &[u8],
+        path: &Path,
+        file: &Rope,
         location: usize,
     ) -> Option<(Id, usize, Span)> {
-        let file_id = working_set.add_file(file_path.to_string(), file);
-        let offset = working_set.get_span_for_file(file_id).start;
-        let block = parse(working_set, Some(file_path), file, false);
+        let file_path = path.to_string_lossy();
+
+        // TODO: think about passing down the rope into the working_set
+        let contents = file.bytes().collect::<Vec<u8>>();
+        let block = parse(working_set, Some(&file_path), &contents, false);
         let flattened = flatten_block(working_set, &block);
 
+        let offset = working_set.get_span_for_filename(&file_path)?.start;
         let location = location + offset;
-        for item in flattened {
-            if location >= item.0.start && location < item.0.end {
-                match &item.1 {
+
+        for (span, shape) in flattened {
+            if location >= span.start && location < span.end {
+                match &shape {
                     FlatShape::Variable(var_id) | FlatShape::VarDecl(var_id) => {
-                        return Some((Id::Variable(*var_id), offset, item.0));
+                        return Some((Id::Variable(*var_id), offset, span));
                     }
                     FlatShape::InternalCall(decl_id) => {
-                        return Some((Id::Declaration(*decl_id), offset, item.0));
+                        return Some((Id::Declaration(*decl_id), offset, span));
                     }
-                    _ => return Some((Id::Value(item.1), offset, item.0)),
+                    _ => return Some((Id::Value(shape), offset, span)),
                 }
             }
         }
         None
     }
 
-    fn read_in_file<'a>(
-        engine_state: &'a mut EngineState,
-        file_path: &str,
-    ) -> Result<(Vec<u8>, StateWorkingSet<'a>)> {
-        let file = std::fs::read(file_path).into_diagnostic()?;
+    fn rope<'a, 'b: 'a>(&'b mut self, file_url: &Url) -> Option<(&'a Rope, &'a PathBuf)> {
+        let file_path = file_url.to_file_path().ok()?;
 
-        engine_state.start_in_file(Some(file_path));
+        self.ropes
+            .get_key_value(&file_path)
+            .map(|(path, rope)| (rope, path))
+    }
+
+    fn read_in_file<'a>(
+        &mut self,
+        engine_state: &'a mut EngineState,
+        file_url: &Url,
+    ) -> Option<(&Rope, &PathBuf, StateWorkingSet<'a>)> {
+        let (file, path) = self.rope(file_url)?;
+
+        // TODO: AsPath thingy
+        engine_state.start_in_file(Some(&path.to_string_lossy()));
 
         let working_set = StateWorkingSet::new(engine_state);
 
-        Ok((file, working_set))
+        Some((file, path, working_set))
     }
 
     fn goto_definition(
+        &mut self,
         engine_state: &mut EngineState,
         params: &GotoDefinitionParams,
     ) -> Option<GotoDefinitionResponse> {
         let cwd = std::env::current_dir().expect("Could not get current working directory.");
         engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
-        let file_path = params
-            .text_document_position_params
-            .text_document
-            .uri
-            .to_file_path()
-            .ok()?;
-
-        let file_path = file_path.to_string_lossy();
-
-        let (file, mut working_set) = Self::read_in_file(engine_state, &file_path).ok()?;
-        let rope_of_file = Rope::from_reader(Cursor::new(&file)).ok()?;
+        let (file, path, mut working_set) = self.read_in_file(
+            engine_state,
+            &params.text_document_position_params.text_document.uri,
+        )?;
 
         let (id, _, _) = Self::find_id(
             &mut working_set,
-            &file_path,
-            &file,
-            Self::lsp_position_to_location(
-                &params.text_document_position_params.position,
-                &rope_of_file,
-            ),
+            path,
+            file,
+            Self::lsp_position_to_location(&params.text_document_position_params.position, file),
         )?;
 
         match id {
@@ -242,7 +284,7 @@ impl LanguageServer {
                             if span.start >= *file_start && span.start < *file_end {
                                 return Some(GotoDefinitionResponse::Scalar(Location {
                                     uri: Url::from_file_path(file_path).ok()?,
-                                    range: Self::span_to_range(span, &rope_of_file, *file_start),
+                                    range: Self::span_to_range(span, file, *file_start),
                                 }));
                             }
                         }
@@ -261,11 +303,7 @@ impl LanguageServer {
                                 .text_document
                                 .uri
                                 .clone(),
-                            range: Self::span_to_range(
-                                &var.declaration_span,
-                                &rope_of_file,
-                                *file_start,
-                            ),
+                            range: Self::span_to_range(&var.declaration_span, file, *file_start),
                         }));
                     }
                 }
@@ -275,30 +313,20 @@ impl LanguageServer {
         None
     }
 
-    fn hover(engine_state: &mut EngineState, params: &HoverParams) -> Option<Hover> {
+    fn hover(&mut self, engine_state: &mut EngineState, params: &HoverParams) -> Option<Hover> {
         let cwd = std::env::current_dir().expect("Could not get current working directory.");
         engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
-        let file_path = params
-            .text_document_position_params
-            .text_document
-            .uri
-            .to_file_path()
-            .ok()?;
-
-        let file_path = file_path.to_string_lossy();
-
-        let (file, mut working_set) = Self::read_in_file(engine_state, &file_path).ok()?;
-        let rope_of_file = Rope::from_reader(Cursor::new(&file)).ok()?;
+        let (file, path, mut working_set) = self.read_in_file(
+            engine_state,
+            &params.text_document_position_params.text_document.uri,
+        )?;
 
         let (id, _, _) = Self::find_id(
             &mut working_set,
-            &file_path,
-            &file,
-            Self::lsp_position_to_location(
-                &params.text_document_position_params.position,
-                &rope_of_file,
-            ),
+            path,
+            file,
+            Self::lsp_position_to_location(&params.text_document_position_params.position, file),
         )?;
 
         match id {
@@ -489,27 +517,23 @@ impl LanguageServer {
     }
 
     fn complete(
+        &mut self,
         engine_state: &mut EngineState,
         params: &CompletionParams,
     ) -> Option<CompletionResponse> {
         let cwd = std::env::current_dir().expect("Could not get current working directory.");
         engine_state.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
-        let file_path = params
-            .text_document_position
-            .text_document
-            .uri
-            .to_file_path()
-            .ok()?;
-
-        let file_path = file_path.to_string_lossy();
-        let rope_of_file = Rope::from_reader(File::open(file_path.as_ref()).ok()?).ok()?;
+        let (rope_of_file, _, _) = self.read_in_file(
+            engine_state,
+            &params.text_document_position.text_document.uri,
+        )?;
 
         let stack = Stack::new();
         let mut completer = NuCompleter::new(Arc::new(engine_state.clone()), stack);
 
         let location =
-            Self::lsp_position_to_location(&params.text_document_position.position, &rope_of_file);
+            Self::lsp_position_to_location(&params.text_document_position.position, rope_of_file);
         let results = completer.complete(&rope_of_file.to_string(), location);
         if results.is_empty() {
             None
@@ -545,15 +569,16 @@ mod tests {
     use super::*;
     use assert_json_diff::assert_json_eq;
     use lsp_types::{
-        notification::{Exit, Initialized, Notification},
+        notification::{DidOpenTextDocument, Exit, Initialized, Notification},
         request::{Completion, GotoDefinition, HoverRequest, Initialize, Request, Shutdown},
-        CompletionParams, GotoDefinitionParams, InitializeParams, InitializedParams,
-        TextDocumentIdentifier, TextDocumentPositionParams, Url,
+        CompletionParams, DidOpenTextDocumentParams, GotoDefinitionParams, InitializeParams,
+        InitializedParams, TextDocumentIdentifier, TextDocumentItem, TextDocumentPositionParams,
+        Url,
     };
     use nu_test_support::fs::{fixtures, root};
     use std::sync::mpsc::Receiver;
 
-    fn initialize_language_server() -> (Connection, Receiver<Result<()>>) {
+    pub fn initialize_language_server() -> (Connection, Receiver<Result<()>>) {
         use std::sync::mpsc;
         let (client_connection, server_connection) = Connection::memory();
         let lsp_server = LanguageServer::initialize_connection(server_connection, None).unwrap();
@@ -562,7 +587,7 @@ mod tests {
         std::thread::spawn(move || {
             let engine_state = nu_cmd_lang::create_default_context();
             let engine_state = nu_command::add_shell_command_context(engine_state);
-            send.send(lsp_server.serve_requests(engine_state))
+            send.send(lsp_server.serve_requests(engine_state, Arc::new(AtomicBool::new(false))))
         });
 
         client_connection
@@ -651,16 +676,41 @@ mod tests {
             .receiver
             .recv_timeout(std::time::Duration::from_secs(2))
             .unwrap();
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
 
-        assert!(matches!(
-            resp,
-            Message::Response(response) if response.result.is_none()
-        ));
+        assert_json_eq!(result, serde_json::json!(null));
     }
 
-    fn goto_definition(uri: Url, line: u32, character: u32) -> Message {
-        let (client_connection, _recv) = initialize_language_server();
+    pub fn open(client_connection: &Connection, uri: Url) {
+        let text = std::fs::read_to_string(uri.to_file_path().unwrap()).unwrap();
 
+        client_connection
+            .sender
+            .send(Message::Notification(lsp_server::Notification {
+                method: DidOpenTextDocument::METHOD.to_string(),
+                params: serde_json::to_value(DidOpenTextDocumentParams {
+                    text_document: TextDocumentItem {
+                        uri,
+                        language_id: String::from("nu"),
+                        version: 1,
+                        text,
+                    },
+                })
+                .unwrap(),
+            }))
+            .unwrap();
+    }
+
+    fn goto_definition(
+        client_connection: &Connection,
+        uri: Url,
+        line: u32,
+        character: u32,
+    ) -> Message {
         client_connection
             .sender
             .send(Message::Request(lsp_server::Request {
@@ -686,13 +736,17 @@ mod tests {
 
     #[test]
     fn goto_definition_of_variable() {
+        let (client_connection, _recv) = initialize_language_server();
+
         let mut script = fixtures();
         script.push("lsp");
         script.push("goto");
         script.push("var.nu");
         let script = Url::from_file_path(script).unwrap();
 
-        let resp = goto_definition(script.clone(), 2, 12);
+        open(&client_connection, script.clone());
+
+        let resp = goto_definition(&client_connection, script.clone(), 2, 12);
         let result = if let Message::Response(response) = resp {
             response.result
         } else {
@@ -713,13 +767,17 @@ mod tests {
 
     #[test]
     fn goto_definition_of_command() {
+        let (client_connection, _recv) = initialize_language_server();
+
         let mut script = fixtures();
         script.push("lsp");
         script.push("goto");
         script.push("command.nu");
         let script = Url::from_file_path(script).unwrap();
 
-        let resp = goto_definition(script.clone(), 4, 1);
+        open(&client_connection, script.clone());
+
+        let resp = goto_definition(&client_connection, script.clone(), 4, 1);
         let result = if let Message::Response(response) = resp {
             response.result
         } else {
@@ -740,13 +798,17 @@ mod tests {
 
     #[test]
     fn goto_definition_of_command_parameter() {
+        let (client_connection, _recv) = initialize_language_server();
+
         let mut script = fixtures();
         script.push("lsp");
         script.push("goto");
         script.push("command.nu");
         let script = Url::from_file_path(script).unwrap();
 
-        let resp = goto_definition(script.clone(), 1, 14);
+        open(&client_connection, script.clone());
+
+        let resp = goto_definition(&client_connection, script.clone(), 1, 14);
         let result = if let Message::Response(response) = resp {
             response.result
         } else {
@@ -765,9 +827,7 @@ mod tests {
         );
     }
 
-    fn hover(uri: Url, line: u32, character: u32) -> Message {
-        let (client_connection, _recv) = initialize_language_server();
-
+    pub fn hover(client_connection: &Connection, uri: Url, line: u32, character: u32) -> Message {
         client_connection
             .sender
             .send(Message::Request(lsp_server::Request {
@@ -792,13 +852,17 @@ mod tests {
 
     #[test]
     fn hover_on_variable() {
+        let (client_connection, _recv) = initialize_language_server();
+
         let mut script = fixtures();
         script.push("lsp");
         script.push("hover");
         script.push("var.nu");
         let script = Url::from_file_path(script).unwrap();
 
-        let resp = hover(script.clone(), 2, 0);
+        open(&client_connection, script.clone());
+
+        let resp = hover(&client_connection, script.clone(), 2, 0);
         let result = if let Message::Response(response) = resp {
             response.result
         } else {
@@ -815,13 +879,17 @@ mod tests {
 
     #[test]
     fn hover_on_command() {
+        let (client_connection, _recv) = initialize_language_server();
+
         let mut script = fixtures();
         script.push("lsp");
         script.push("hover");
         script.push("command.nu");
         let script = Url::from_file_path(script).unwrap();
 
-        let resp = hover(script.clone(), 3, 0);
+        open(&client_connection, script.clone());
+
+        let resp = hover(&client_connection, script.clone(), 3, 0);
         let result = if let Message::Response(response) = resp {
             response.result
         } else {
@@ -839,9 +907,7 @@ mod tests {
         );
     }
 
-    fn complete(uri: Url, line: u32, character: u32) -> Message {
-        let (client_connection, _recv) = initialize_language_server();
-
+    fn complete(client_connection: &Connection, uri: Url, line: u32, character: u32) -> Message {
         client_connection
             .sender
             .send(Message::Request(lsp_server::Request {
@@ -868,13 +934,17 @@ mod tests {
 
     #[test]
     fn complete_on_variable() {
+        let (client_connection, _recv) = initialize_language_server();
+
         let mut script = fixtures();
         script.push("lsp");
         script.push("completion");
         script.push("var.nu");
         let script = Url::from_file_path(script).unwrap();
 
-        let resp = complete(script, 2, 9);
+        open(&client_connection, script.clone());
+
+        let resp = complete(&client_connection, script, 2, 9);
         let result = if let Message::Response(response) = resp {
             response.result
         } else {
@@ -900,13 +970,17 @@ mod tests {
 
     #[test]
     fn complete_command_with_space() {
+        let (client_connection, _recv) = initialize_language_server();
+
         let mut script = fixtures();
         script.push("lsp");
         script.push("completion");
         script.push("command.nu");
         let script = Url::from_file_path(script).unwrap();
 
-        let resp = complete(script, 0, 8);
+        open(&client_connection, script.clone());
+
+        let resp = complete(&client_connection, script, 0, 8);
         let result = if let Message::Response(response) = resp {
             response.result
         } else {

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -317,6 +317,15 @@ impl<'a> StateWorkingSet<'a> {
         self.num_virtual_paths() - 1
     }
 
+    pub fn get_span_for_filename(&self, filename: &str) -> Option<Span> {
+        let (file_id, ..) = self
+            .files()
+            .enumerate()
+            .find(|(_, (fname, _, _))| fname == filename)?;
+
+        Some(self.get_span_for_file(file_id))
+    }
+
     pub fn get_span_for_file(&self, file_id: usize) -> Span {
         let result = self
             .files()

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ fn main() -> Result<()> {
     }
 
     if parsed_nu_cli_args.lsp {
-        return LanguageServer::initialize_stdio_connection()?.serve_requests(engine_state);
+        return LanguageServer::initialize_stdio_connection()?.serve_requests(engine_state, ctrlc);
     }
 
     // IDE commands

--- a/tests/fixtures/lsp/diagnostics/var.nu
+++ b/tests/fixtures/lsp/diagnostics/var.nu
@@ -1,0 +1,1 @@
+print $this_var_is_not_defined


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

This commit provides the initial implementation of text document synchronization of the language server protocol: textDocument/didOpen, textDocument/didChange and textDocument/didClose (see #10794)

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes

Completions work better then before (see [comment here](https://github.com/nushell/vscode-nushell-lang/pull/162#issuecomment-1791036239)). The demo show that Nushell opens the line buffer editor, that starts Neovim with Nushell as configured language server which has completions working.

![output](https://github.com/nushell/nushell/assets/16558417/bbe15085-1695-44a5-906c-792ddb393b44)


<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
