### PR TITLE
add color-backtrace crate for more intuitive backtraces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,6 +698,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-backtrace"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fd80a270c0671379f388c8204deb6a746bb4eac8a6c03fe2460b2c0127ea0"
+dependencies = [
+ "backtrace",
+ "termcolor",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +2658,7 @@ name = "nu"
 version = "0.86.1"
 dependencies = [
  "assert_cmd",
+ "color-backtrace",
  "criterion",
  "crossterm 0.27.0",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ nu-utils = { path = "./crates/nu-utils", version = "0.86.1" }
 nu-ansi-term = "0.49.0"
 reedline = { version = "0.25.0", features = ["bashisms", "sqlite"] }
 
+color-backtrace = "0.6.1"
 crossterm = "0.27"
 ctrlc = "3.4"
 log = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
         miette_hook(x);
     }));
 
-    // This allows more intutive backtraces
+    // This allows more intuitive backtraces
     color_backtrace::install();
 
     // Get initial current working directory.

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,9 @@ fn main() -> Result<()> {
         miette_hook(x);
     }));
 
+    // This allows more intutive backtraces
+    color_backtrace::install();
+
     // Get initial current working directory.
     let init_cwd = get_init_cwd();
     let mut engine_state = get_engine_state();


### PR DESCRIPTION
# Description

Just throwing up this PR because color-backtrace seemed to produce more useful backtraces. Just curious what others think.

Did this:
1. RUST_BACKTRACE=full cargo r
2. ❯ def test01 [] {
     let sorted = [storm]
     $sorted | range 1.. | zip ($sorted | range ..(-2))
  }
3. test01

I like how it shows the code snippet.

![image](https://github.com/nushell/nushell/assets/343840/1302e766-dfac-4749-a465-85bf53060532)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
