### PR TITLE
Restore test_config tests

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,6 +3,7 @@ mod test_bits;
 mod test_cell_path;
 mod test_commandline;
 mod test_conditionals;
+mod test_config;
 mod test_config_path;
 mod test_converters;
 mod test_custom_commands;

--- a/src/tests/test_config.rs
+++ b/src/tests/test_config.rs
@@ -1,10 +1,9 @@
-use crate::tests::{run_test, TestResult};
-
-use super::run_test_with_default_config;
+use super::run_test_std;
+use crate::tests::TestResult;
 
 #[test]
 fn mutate_nu_config() -> TestResult {
-    run_test_with_default_config(
+    run_test_std(
         r#"$env.config.footer_mode = 30; $env.config.footer_mode"#,
         "30",
     )
@@ -12,39 +11,67 @@ fn mutate_nu_config() -> TestResult {
 
 #[test]
 fn mutate_nu_config_nested_ls() -> TestResult {
-    run_test_with_default_config(
-        r#"$env.config.ls.user_ls_colors = false; $env.config.ls.user_ls_colors"#,
+    run_test_std(
+        r#"$env.config.ls.clickable_links = false; $env.config.ls.clickable_links"#,
         "false",
     )
 }
 
 #[test]
 fn mutate_nu_config_nested_table() -> TestResult {
-    run_test_with_default_config(
-        r#"$env.config.table.trim.wrapping_try_keep_words = false; $env.config.table.trim.wrapping_try_keep_words"#,
+    run_test_std(
+        r#"
+            $env.config.table.trim.methodology = wrapping
+            $env.config.table.trim.wrapping_try_keep_words = false
+            $env.config.table.trim.wrapping_try_keep_words
+        "#,
         "false",
     )
 }
 
 #[test]
 fn mutate_nu_config_nested_menu() -> TestResult {
-    run_test_with_default_config(
-        r#"$env.config.menu.2.type.columns = 3; $env.config.menu.2.type.columns"#,
+    run_test_std(
+        r#"
+            $env.config.menus = [
+                {
+                  name: menu
+                  only_buffer_difference: true
+                  marker: "M "
+                  type: {}
+                  style: {}
+                }
+            ];
+            $env.config.menus.0.type.columns = 3;
+            $env.config.menus.0.type.columns
+        "#,
         "3",
     )
 }
 
 #[test]
 fn mutate_nu_config_nested_keybindings() -> TestResult {
-    run_test_with_default_config(
-        r#"$env.config.keybindings.5.keycode = 'char_x'; $env.config.keybindings.5.keycode"#,
+    run_test_std(
+        r#"
+            $env.config.keybindings = [
+                {
+                  name: completion_previous
+                  modifier: shift
+                  keycode: backtab
+                  mode: [ vi_normal, vi_insert ]
+                  event: { send: menuprevious }
+                }
+            ];
+            $env.config.keybindings.0.keycode = 'char_x';
+            $env.config.keybindings.0.keycode
+        "#,
         "char_x",
     )
 }
 
 #[test]
 fn mutate_nu_config_nested_color_nested() -> TestResult {
-    run_test_with_default_config(
+    run_test_std(
         r#"$env.config.color_config.shape_flag = 'cyan'; $env.config.color_config.shape_flag"#,
         "cyan",
     )
@@ -52,7 +79,7 @@ fn mutate_nu_config_nested_color_nested() -> TestResult {
 
 #[test]
 fn mutate_nu_config_nested_completion() -> TestResult {
-    run_test_with_default_config(
+    run_test_std(
         r#"$env.config.completions.external.enable = false; $env.config.completions.external.enable"#,
         "false",
     )
@@ -60,7 +87,7 @@ fn mutate_nu_config_nested_completion() -> TestResult {
 
 #[test]
 fn mutate_nu_config_nested_history() -> TestResult {
-    run_test_with_default_config(
+    run_test_std(
         r#"$env.config.history.max_size = 100; $env.config.history.max_size"#,
         "100",
     )
@@ -68,7 +95,7 @@ fn mutate_nu_config_nested_history() -> TestResult {
 
 #[test]
 fn mutate_nu_config_nested_filesize() -> TestResult {
-    run_test_with_default_config(
+    run_test_std(
         r#"$env.config.filesize.format = 'kb'; $env.config.filesize.format"#,
         "kb",
     )


### PR DESCRIPTION
# Description

These tests got orphaned and they would be a good place to test behavior I want to add for #10867

# User-Facing Changes

None

# Tests + Formatting

Tests were updated to account for removed test infrastructure

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A