### PR TITLE
Add more descriptive error message when passing list to from_csv

### DIFF
--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -129,6 +129,12 @@ fn from_csv(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let name = call.head;
+    if let PipelineData::Value(Value::List{..}, _) = input {
+        return Err(ShellError::TypeMismatch {
+            err_message: "received list stream, did you forget to open file with --raw flag?".into(),
+            span: name,
+        });
+    }
 
     let separator = match call.get_flag::<String>(engine_state, stack, "separator")? {
         Some(sep) => {

--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -129,9 +129,10 @@ fn from_csv(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let name = call.head;
-    if let PipelineData::Value(Value::List{..}, _) = input {
+    if let PipelineData::Value(Value::List { .. }, _) = input {
         return Err(ShellError::TypeMismatch {
-            err_message: "received list stream, did you forget to open file with --raw flag?".into(),
+            err_message: "received list stream, did you forget to open file with --raw flag?"
+                .into(),
             span: name,
         });
     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Added statement catching early List passed to CSV and printing more helpful error message. This fixes  #10081. Similar message might be useful for other from_* calls but  I'm not sure if there aren't any converters accepting List as input.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
