### PR TITLE
Do not panic at startup if history files are not writable

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -459,7 +459,7 @@ pub fn evaluate_repl(
                             c
                         })
                         .into_diagnostic()
-                        .unwrap_or_else(|e| report_error_new(&engine_state, e.as_ref()));
+                        .unwrap_or_else(|e| report_error_new(engine_state, e.as_ref()));
                 }
 
                 // Right before we start running the code the user gave us, fire the `pre_execution`
@@ -608,7 +608,7 @@ pub fn evaluate_repl(
                             c
                         })
                         .into_diagnostic()
-                        .unwrap_or_else(|e| report_error_new(&engine_state, e.as_ref()));
+                        .unwrap_or_else(|e| report_error_new(engine_state, e.as_ref()));
                 }
 
                 if shell_integration {
@@ -752,7 +752,7 @@ fn update_line_editor_history(
             line_editor
         }
         Err(e) => {
-            report_error_new(&engine_state, e.as_ref());
+            report_error_new(engine_state, e.as_ref());
             line_editor
         }
     }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -449,7 +449,10 @@ pub fn evaluate_repl(
         match input {
             Ok(Signal::Success(s)) => {
                 let hostname = sys.host_name();
-                if !s.is_empty() {
+                let history_supports_meta =
+                    matches!(config.history_file_format, HistoryFileFormat::Sqlite);
+                if history_supports_meta && !s.is_empty() && line_editor.has_last_command_context()
+                {
                     line_editor
                         .update_last_command_context(&|mut c| {
                             c.start_timestamp = Some(chrono::Utc::now());
@@ -598,7 +601,8 @@ pub fn evaluate_repl(
                     Value::string(format!("{}", cmd_duration.as_millis()), Span::unknown()),
                 );
 
-                if !s.is_empty() {
+                if history_supports_meta && !s.is_empty() && line_editor.has_last_command_context()
+                {
                     line_editor
                         .update_last_command_context(&|mut c| {
                             c.duration = Some(cmd_duration);


### PR DESCRIPTION
Print a warning message, instead.

fixes #10963


This is a draft with just a few `println!` instead of panics, but there are probably more suitable functions for error reporting.

In the meantime I also folded the function `store_history_id_in_engine`, effectively used only once. Can split this change in a separate commit if preferred.
