### PR TITLE
Convert ShellError::UnsupportedInput to named fields

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/datepart.rs
@@ -124,12 +124,12 @@ impl Command for ExprDatePart {
             "microsecond" => expr_dt.microsecond(),
             "nanosecond" => expr_dt.nanosecond(),
             _ => {
-                return Err(ShellError::UnsupportedInput(
-                    format!("{} is not a valid datepart, expected one of year, month, day, hour, minute, second, millisecond, microsecond, nanosecond", part.item),
-                    "value originates from here".to_string(),
-                    call.head,
-                    part.span,
-                ));
+                return Err(ShellError::UnsupportedInput {
+                    msg: format!("{} is not a valid datepart, expected one of year, month, day, hour, minute, second, millisecond, microsecond, nanosecond", part.item),
+                    input: "value originates from here".to_string(),
+                    msg_span: call.head,
+                    input_span: part.span,
+                });
             }
         }.into();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/indexes/arg_true.rs
@@ -98,12 +98,12 @@ fn command(
             let value = NuDataFrame::dataframe_into_value(res, call.head);
             Ok(PipelineData::Value(value, None))
         }
-        _ => Err(ShellError::UnsupportedInput(
-            "Expected the dataframe to have a column".to_string(),
-            "".to_string(),
-            call.head,
-            call.head,
-        )),
+        _ => Err(ShellError::UnsupportedInput {
+            msg: "Expected the dataframe to have a column".to_string(),
+            input: "".to_string(),
+            msg_span: call.head,
+            input_span: call.head,
+        }),
     }
 }
 

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
@@ -855,13 +855,13 @@ fn series_to_values(
                         Some(val) => val,
                         None => {
                             return Value::error(
-                                ShellError::UnsupportedInput(
-                                    "The given local datetime representation is invalid."
+                                ShellError::UnsupportedInput {
+                                    msg: "The given local datetime representation is invalid."
                                         .to_string(),
-                                    format!("timestamp is {a:?}"),
-                                    span,
-                                    Span::unknown(),
-                                ),
+                                    input: format!("timestamp is {a:?}"),
+                                    msg_span: span,
+                                    input_span: Span::unknown(),
+                                },
                                 span,
                             )
                         }
@@ -871,13 +871,13 @@ fn series_to_values(
                         Some(val) => val,
                         None => {
                             return Value::error(
-                                ShellError::UnsupportedInput(
-                                    "The given local datetime representation is invalid."
+                                ShellError::UnsupportedInput {
+                                    msg: "The given local datetime representation is invalid."
                                         .to_string(),
-                                    format!("timestamp is {a:?}"),
-                                    span,
-                                    Span::unknown(),
-                                ),
+                                    input: format!("timestamp is {a:?}"),
+                                    msg_span: span,
+                                    input_span: Span::unknown(),
+                                },
                                 span,
                             )
                         }
@@ -923,13 +923,13 @@ fn series_to_values(
                         Some(val) => val,
                         None => {
                             return Value::error(
-                                ShellError::UnsupportedInput(
-                                    "The given local datetime representation is invalid."
+                                ShellError::UnsupportedInput {
+                                    msg: "The given local datetime representation is invalid."
                                         .to_string(),
-                                    format!("timestamp is {a:?}"),
-                                    span,
-                                    Span::unknown(),
-                                ),
+                                    input: format!("timestamp is {a:?}"),
+                                    msg_span: span,
+                                    input_span: Span::unknown(),
+                                },
                                 span,
                             )
                         }
@@ -939,13 +939,13 @@ fn series_to_values(
                         Some(val) => val,
                         None => {
                             return Value::error(
-                                ShellError::UnsupportedInput(
-                                    "The given local datetime representation is invalid."
+                                ShellError::UnsupportedInput {
+                                    msg: "The given local datetime representation is invalid."
                                         .to_string(),
-                                    format!("timestamp is {a:?}"),
-                                    span,
-                                    Span::unknown(),
-                                ),
+                                    input: format!("timestamp is {a:?}"),
+                                    msg_span: span,
+                                    input_span: Span::unknown(),
+                                },
                                 span,
                             )
                         }

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/mod.rs
@@ -427,11 +427,11 @@ pub fn expr_to_value(expr: &Expr, span: Span) -> Result<Value, ShellError> {
         }
         // the parameter polars_plan::dsl::selector::Selector is not publicly exposed.
         // I am not sure what we can meaningfully do with this at this time.
-        Expr::Selector(_) => Err(ShellError::UnsupportedInput(
-            "Expressions of type Selector to Nu Values is not yet supported".to_string(),
-            format!("Expression is {expr:?}"),
-            span,
-            Span::unknown(),
-        )),
+        Expr::Selector(_) => Err(ShellError::UnsupportedInput {
+            msg: "Expressions of type Selector to Nu Values is not yet supported".to_string(),
+            input: format!("Expression is {expr:?}"),
+            msg_span: span,
+            input_span: Span::unknown(),
+        }),
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -60,12 +60,12 @@ impl Command for BitsNot {
         let bytes_len = get_number_bytes(number_bytes.as_ref());
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
-                return Err(ShellError::UnsupportedInput(
-                    "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
-                    "value originates from here".to_string(),
-                    head,
-                    val.span,
-                ));
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
+                    input: "value originates from here".to_string(),
+                    msg_span: head,
+                    input_span: val.span,
+                });
             }
         }
 

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -63,12 +63,12 @@ impl Command for BitsRol {
         let bytes_len = get_number_bytes(number_bytes.as_ref());
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
-                return Err(ShellError::UnsupportedInput(
-                    "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
-                    "value originates from here".to_string(),
-                    head,
-                    val.span,
-                ));
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
+                    input: "value originates from here".to_string(),
+                    msg_span: head,
+                    input_span: val.span,
+                });
             }
         }
         // This doesn't match explicit nulls

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -63,12 +63,12 @@ impl Command for BitsRor {
         let bytes_len = get_number_bytes(number_bytes.as_ref());
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
-                return Err(ShellError::UnsupportedInput(
-                    "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
-                    "value originates from here".to_string(),
-                    head,
-                    val.span,
-                ));
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
+                    input: "value originates from here".to_string(),
+                    msg_span: head,
+                    input_span: val.span,
+                });
             }
         }
         // This doesn't match explicit nulls

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -63,12 +63,12 @@ impl Command for BitsShl {
         let bytes_len = get_number_bytes(number_bytes.as_ref());
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
-                return Err(ShellError::UnsupportedInput(
-                    "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
-                    "value originates from here".to_string(),
-                    head,
-                    val.span,
-                ));
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
+                    input: "value originates from here".to_string(),
+                    msg_span: head,
+                    input_span: val.span,
+                });
             }
         }
         // This doesn't match explicit nulls

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -63,12 +63,12 @@ impl Command for BitsShr {
         let bytes_len = get_number_bytes(number_bytes.as_ref());
         if let NumberBytes::Invalid = bytes_len {
             if let Some(val) = number_bytes {
-                return Err(ShellError::UnsupportedInput(
-                    "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
-                    "value originates from here".to_string(),
-                    head,
-                    val.span,
-                ));
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
+                    input: "value originates from here".to_string(),
+                    msg_span: head,
+                    input_span: val.span,
+                });
             }
         }
         // This doesn't match explicit nulls

--- a/crates/nu-cmd-extra/src/extra/filters/rotate.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/rotate.rs
@@ -200,13 +200,12 @@ pub fn rotate(
             }
         }
     } else {
-        return Err(ShellError::UnsupportedInput(
-            "list input is empty".to_string(),
-            "value originates from here".into(),
-            call.head,
-            // TODO: Maybe make all Pipelines have spans, so that this doesn't need to be unwrapped.
-            span.unwrap_or(call.head),
-        ));
+        return Err(ShellError::UnsupportedInput {
+            msg: "list input is empty".to_string(),
+            input: "value originates from here".into(),
+            msg_span: call.head,
+            input_span: span.unwrap_or(call.head),
+        });
     }
 
     let total_columns = &old_column_names.len();

--- a/crates/nu-cmd-extra/src/extra/formats/from/url.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/from/url.rs
@@ -61,12 +61,12 @@ fn from_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError>
 
             Ok(PipelineData::Value(Value::record(record, head), metadata))
         }
-        _ => Err(ShellError::UnsupportedInput(
-            "String not compatible with URL encoding".to_string(),
-            "value originates from here".into(),
-            head,
-            span,
-        )),
+        _ => Err(ShellError::UnsupportedInput {
+            msg: "String not compatible with URL encoding".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: span,
+        }),
     }
 }
 

--- a/crates/nu-cmd-extra/src/extra/math/arccos.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccos.rs
@@ -84,12 +84,13 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
                 Value::float(val, span)
             } else {
                 Value::error(
-                    ShellError::UnsupportedInput(
-                        "'arccos' undefined for values outside the closed interval [-1, 1].".into(),
-                        "value originates from here".into(),
-                        head,
-                        span,
-                    ),
+                    ShellError::UnsupportedInput {
+                        msg: "'arccos' undefined for values outside the closed interval [-1, 1]."
+                            .into(),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span: span,
+                    },
                     span,
                 )
             }

--- a/crates/nu-cmd-extra/src/extra/math/arccosh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arccosh.rs
@@ -74,12 +74,12 @@ fn operate(value: Value, head: Span) -> Value {
                 Value::float(val, span)
             } else {
                 Value::error(
-                    ShellError::UnsupportedInput(
-                        "'arccosh' undefined for values below 1.".into(),
-                        "value originates from here".into(),
-                        head,
-                        span,
-                    ),
+                    ShellError::UnsupportedInput {
+                        msg: "'arccosh' undefined for values below 1.".into(),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span: span,
+                    },
                     span,
                 )
             }

--- a/crates/nu-cmd-extra/src/extra/math/arcsin.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arcsin.rs
@@ -85,12 +85,13 @@ fn operate(value: Value, head: Span, use_degrees: bool) -> Value {
                 Value::float(val, span)
             } else {
                 Value::error(
-                    ShellError::UnsupportedInput(
-                        "'arcsin' undefined for values outside the closed interval [-1, 1].".into(),
-                        "value originates from here".into(),
-                        head,
-                        span,
-                    ),
+                    ShellError::UnsupportedInput {
+                        msg: "'arcsin' undefined for values outside the closed interval [-1, 1]."
+                            .into(),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span: span,
+                    },
                     span,
                 )
             }

--- a/crates/nu-cmd-extra/src/extra/math/arctanh.rs
+++ b/crates/nu-cmd-extra/src/extra/math/arctanh.rs
@@ -74,12 +74,13 @@ fn operate(value: Value, head: Span) -> Value {
                 Value::float(val, span)
             } else {
                 Value::error(
-                    ShellError::UnsupportedInput(
-                        "'arctanh' undefined for values outside the open interval (-1, 1).".into(),
-                        "value originates from here".into(),
-                        head,
-                        span,
-                    ),
+                    ShellError::UnsupportedInput {
+                        msg: "'arctanh' undefined for values outside the open interval (-1, 1)."
+                            .into(),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span: span,
+                    },
                     head,
                 )
             }

--- a/crates/nu-cmd-extra/src/extra/math/ln.rs
+++ b/crates/nu-cmd-extra/src/extra/math/ln.rs
@@ -74,12 +74,12 @@ fn operate(value: Value, head: Span) -> Value {
                 Value::float(val, span)
             } else {
                 Value::error(
-                    ShellError::UnsupportedInput(
-                        "'ln' undefined for values outside the open interval (0, Inf).".into(),
-                        "value originates from here".into(),
-                        head,
-                        span,
-                    ),
+                    ShellError::UnsupportedInput {
+                        msg: "'ln' undefined for values outside the open interval (0, Inf).".into(),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span: span,
+                    },
                     span,
                 )
             }

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/hex.rs
@@ -108,26 +108,14 @@ fn action(
         Value::Binary { val, .. } => match hex_config.action_type {
             ActionType::Encode => Value::string(hex_encode(val.as_ref()), command_span),
             ActionType::Decode => Value::error(
-                ShellError::UnsupportedInput(
-                    "Binary data can only be encoded".to_string(),
-                    "value originates from here".into(),
-                    command_span,
-                    // This line requires the Value::Error {} match above.
-                    input.span(),
-                ),
+                ShellError::UnsupportedInput { msg: "Binary data can only be encoded".to_string(), input: "value originates from here".into(), msg_span: command_span, input_span: input.span() },
                 command_span,
             ),
         },
         Value::String { val, .. } => {
             match hex_config.action_type {
                 ActionType::Encode => Value::error(
-                    ShellError::UnsupportedInput(
-                        "String value can only be decoded".to_string(),
-                        "value originates from here".into(),
-                        command_span,
-                        // This line requires the Value::Error {} match above.
-                        input.span(),
-                    ),
+                    ShellError::UnsupportedInput { msg: "String value can only be decoded".to_string(), input: "value originates from here".into(), msg_span: command_span, input_span: input.span() },
                     command_span,
                 ),
 

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -176,13 +176,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         Value::Error { .. } => input.clone(),
 
         other => Value::error(
-            ShellError::UnsupportedInput(
-                "Only binary values are supported".into(),
-                format!("input type: {:?}", other.get_type()),
-                head,
-                // This line requires the Value::Error match above.
-                other.span(),
-            ),
+            ShellError::UnsupportedInput {
+                msg: "Only binary values are supported".into(),
+                input: format!("input type: {:?}", other.get_type()),
+                msg_span: head,
+                input_span: other.span(),
+            },
             head,
         ),
     }

--- a/crates/nu-command/src/charting/hashable_value.rs
+++ b/crates/nu-command/src/charting/hashable_value.rs
@@ -102,12 +102,12 @@ impl HashableValue {
 
             // Explicitly propagate errors instead of dropping them.
             Value::Error { error, .. } => Err(*error),
-            _ => Err(ShellError::UnsupportedInput(
-                "input value is not hashable".into(),
-                format!("input type: {:?}", value.get_type()),
-                span,
-                value.span(),
-            )),
+            _ => Err(ShellError::UnsupportedInput {
+                msg: "input value is not hashable".into(),
+                input: format!("input type: {:?}", value.get_type()),
+                msg_span: span,
+                input_span: value.span(),
+            }),
         }
     }
 

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -162,14 +162,9 @@ fn run_histogram(
                         let t = v.get_type();
                         let span = v.span();
                         inputs.push(HashableValue::from_value(v, head_span).map_err(|_| {
-                        ShellError::UnsupportedInput(
-                            "Since --column-name was not provided, only lists of hashable values are supported.".to_string(),
-                            format!(
+                        ShellError::UnsupportedInput { msg: "Since --column-name was not provided, only lists of hashable values are supported.".to_string(), input: format!(
                                 "input type: {t:?}"
-                            ),
-                            head_span,
-                            span,
-                        )
+                            ), msg_span: head_span, input_span: span }
                     })?)
                     }
                 }

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -81,12 +81,12 @@ impl Command for LoadEnv {
                     }
                     Ok(PipelineData::empty())
                 }
-                _ => Err(ShellError::UnsupportedInput(
-                    "'load-env' expects a single record".into(),
-                    "value originated from here".into(),
-                    span,
-                    input.span().unwrap_or(span),
-                )),
+                _ => Err(ShellError::UnsupportedInput {
+                    msg: "'load-env' expects a single record".into(),
+                    input: "value originated from here".into(),
+                    msg_span: span,
+                    input_span: input.span().unwrap_or(span),
+                }),
             },
         }
     }

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -469,13 +469,12 @@ fn find_with_rest_and_highlight(
                             // Propagate errors by explicitly matching them before the final case.
                             Value::Error { error, .. } => return Err(*error),
                             other => {
-                                return Err(ShellError::UnsupportedInput(
-                                    "unsupported type from raw stream".into(),
-                                    format!("input: {:?}", other.get_type()),
-                                    span,
-                                    // This line requires the Value::Error match above.
-                                    other.span(),
-                                ));
+                                return Err(ShellError::UnsupportedInput {
+                                    msg: "unsupported type from raw stream".into(),
+                                    input: format!("input: {:?}", other.get_type()),
+                                    msg_span: span,
+                                    input_span: other.span(),
+                                });
                             }
                         }
                     }

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -208,12 +208,7 @@ fn flat_value(columns: &[CellPath], item: &Value, name_tag: Span, all: bool) -> 
                 }
                 Value::List { vals, .. } if all && vals.iter().all(|f| f.as_record().is_ok()) => {
                     if need_flatten && inner_table.is_some() {
-                        return vec![Value::error( ShellError::UnsupportedInput(
-                                    "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(),
-                                    "value originates from here".into(),
-                                    s,
-                                    span
-                                ), span)
+                        return vec![Value::error( ShellError::UnsupportedInput { msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(), input: "value originates from here".into(), msg_span: s, input_span: span }, span)
                             ];
                     }
                     // it's a table (a list of record, we can flatten inner record)
@@ -244,12 +239,7 @@ fn flat_value(columns: &[CellPath], item: &Value, name_tag: Span, all: bool) -> 
                 }
                 Value::List { vals: values, .. } => {
                     if need_flatten && inner_table.is_some() {
-                        return vec![Value::error( ShellError::UnsupportedInput(
-                                "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(),
-                                "value originates from here".into(),
-                                s,
-                                span
-                            ), span)
+                        return vec![Value::error( ShellError::UnsupportedInput { msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(), input: "value originates from here".into(), msg_span: s, input_span: span }, span)
                         ];
                     }
 

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -89,18 +89,18 @@ impl Command for Join {
                 let result = join(rows_1, rows_2, l_on, r_on, join_type, span);
                 Ok(PipelineData::Value(result, None))
             }
-            _ => Err(ShellError::UnsupportedInput(
-                "(PipelineData<table>, table, string, string)".into(),
-                format!(
+            _ => Err(ShellError::UnsupportedInput {
+                msg: "(PipelineData<table>, table, string, string)".into(),
+                input: format!(
                     "({:?}, {:?}, {:?} {:?})",
                     collected_input,
                     table_2.get_type(),
                     l_on.get_type(),
                     r_on.get_type(),
                 ),
-                span,
-                span,
-            )),
+                msg_span: span,
+                input_span: span,
+            }),
         }
     }
 
@@ -126,12 +126,12 @@ fn join_type(call: &Call) -> Result<JoinType, nu_protocol::ShellError> {
         (false, true, false, false) => Ok(JoinType::Left),
         (false, false, true, false) => Ok(JoinType::Right),
         (false, false, false, true) => Ok(JoinType::Outer),
-        _ => Err(ShellError::UnsupportedInput(
-            "Choose one of: --inner, --left, --right, --outer".into(),
-            "".into(),
-            call.head,
-            call.head,
-        )),
+        _ => Err(ShellError::UnsupportedInput {
+            msg: "Choose one of: --inner, --left, --right, --outer".into(),
+            input: "".into(),
+            msg_span: call.head,
+            input_span: call.head,
+        }),
     }
 }
 

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -204,16 +204,9 @@ fn rename(
                                                 "already checked column to rename still exists",
                                             );
                                         return Value::error(
-                                            ShellError::UnsupportedInput(
-                                                format!(
+                                            ShellError::UnsupportedInput { msg: format!(
                                                     "The column '{not_exists_column}' does not exist in the input",
-                                                ),
-                                                "value originated from here".into(),
-                                                // Arrow 1 points at the specified column name,
-                                                head_span,
-                                                // Arrow 2 points at the input value.
-                                                span,
-                                            ),
+                                                ), input: "value originated from here".into(), msg_span: head_span, input_span: span },
                                             span,
                                         );
                                     }

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -95,12 +95,12 @@ fn collect_binary(input: PipelineData, span: Span) -> Result<Vec<u8>, ShellError
             }
             Some(Value::Error { error, .. }) => return Err(*error),
             Some(x) => {
-                return Err(ShellError::UnsupportedInput(
-                    "Expected binary from pipeline".to_string(),
-                    "value originates from here".into(),
-                    span,
-                    x.span(),
-                ))
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Expected binary from pipeline".to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: span,
+                    input_span: x.span(),
+                })
             }
             None => break,
         }
@@ -117,13 +117,11 @@ fn from_ods(
     let span = input.span();
     let bytes = collect_binary(input, head)?;
     let buf: Cursor<Vec<u8>> = Cursor::new(bytes);
-    let mut ods = Ods::<_>::new(buf).map_err(|_| {
-        ShellError::UnsupportedInput(
-            "Could not load ODS file".to_string(),
-            "value originates from here".into(),
-            head,
-            span.unwrap_or(head),
-        )
+    let mut ods = Ods::<_>::new(buf).map_err(|_| ShellError::UnsupportedInput {
+        msg: "Could not load ODS file".to_string(),
+        input: "value originates from here".into(),
+        msg_span: head,
+        input_span: span.unwrap_or(head),
     })?;
 
     let mut dict = IndexMap::new();
@@ -160,12 +158,12 @@ fn from_ods(
 
             dict.insert(sheet_name, Value::list(sheet_output, head));
         } else {
-            return Err(ShellError::UnsupportedInput(
-                "Could not load sheet".to_string(),
-                "value originates from here".into(),
-                head,
-                span.unwrap_or(head),
-            ));
+            return Err(ShellError::UnsupportedInput {
+                msg: "Could not load sheet".to_string(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: span.unwrap_or(head),
+            });
         }
     }
 

--- a/crates/nu-command/src/formats/from/xlsx.rs
+++ b/crates/nu-command/src/formats/from/xlsx.rs
@@ -94,12 +94,12 @@ fn collect_binary(input: PipelineData, span: Span) -> Result<Vec<u8>, ShellError
                 bytes.extend_from_slice(&b);
             }
             Some(x) => {
-                return Err(ShellError::UnsupportedInput(
-                    "Expected binary from pipeline".to_string(),
-                    "value originates from here".into(),
-                    span,
-                    x.span(),
-                ))
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Expected binary from pipeline".to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: span,
+                    input_span: x.span(),
+                })
             }
             None => break,
         }
@@ -116,13 +116,11 @@ fn from_xlsx(
     let span = input.span();
     let bytes = collect_binary(input, head)?;
     let buf: Cursor<Vec<u8>> = Cursor::new(bytes);
-    let mut xlsx = Xlsx::<_>::new(buf).map_err(|_| {
-        ShellError::UnsupportedInput(
-            "Could not load XLSX file".to_string(),
-            "value originates from here".into(),
-            head,
-            span.unwrap_or(head),
-        )
+    let mut xlsx = Xlsx::<_>::new(buf).map_err(|_| ShellError::UnsupportedInput {
+        msg: "Could not load XLSX file".to_string(),
+        input: "value originates from here".into(),
+        msg_span: head,
+        input_span: span.unwrap_or(head),
     })?;
 
     let mut dict = IndexMap::new();
@@ -159,12 +157,12 @@ fn from_xlsx(
 
             dict.insert(sheet_name, Value::list(sheet_output, head));
         } else {
-            return Err(ShellError::UnsupportedInput(
-                "Could not load sheet".to_string(),
-                "value originates from here".into(),
-                head,
-                span.unwrap_or(head),
-            ));
+            return Err(ShellError::UnsupportedInput {
+                msg: "Could not load sheet".to_string(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: span.unwrap_or(head),
+            });
         }
     }
 

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -126,12 +126,12 @@ fn to_string_tagged_value(
 }
 
 fn make_unsupported_input_error(value: &Value, head: Span, span: Span) -> ShellError {
-    ShellError::UnsupportedInput(
-        "Unexpected type".to_string(),
-        format!("input type: {:?}", value.get_type()),
-        head,
-        span,
-    )
+    ShellError::UnsupportedInput {
+        msg: "Unexpected type".to_string(),
+        input: format!("input type: {:?}", value.get_type()),
+        msg_span: head,
+        input_span: span,
+    }
 }
 
 pub fn find_non_record(values: &[Value]) -> Option<&Value> {

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -131,28 +131,28 @@ pub fn value_to_string(
             let mut s = String::with_capacity(2 * val.len());
             for byte in val {
                 if write!(s, "{byte:02X}").is_err() {
-                    return Err(ShellError::UnsupportedInput(
-                        "could not convert binary to string".into(),
-                        "value originates from here".into(),
-                        span,
-                        v.span(),
-                    ));
+                    return Err(ShellError::UnsupportedInput {
+                        msg: "could not convert binary to string".into(),
+                        input: "value originates from here".into(),
+                        msg_span: span,
+                        input_span: v.span(),
+                    });
                 }
             }
             Ok(format!("0x[{s}]"))
         }
-        Value::Block { .. } => Err(ShellError::UnsupportedInput(
-            "blocks are currently not nuon-compatible".into(),
-            "value originates from here".into(),
-            span,
-            v.span(),
-        )),
-        Value::Closure { .. } => Err(ShellError::UnsupportedInput(
-            "closures are currently not nuon-compatible".into(),
-            "value originates from here".into(),
-            span,
-            v.span(),
-        )),
+        Value::Block { .. } => Err(ShellError::UnsupportedInput {
+            msg: "blocks are currently not nuon-compatible".into(),
+            input: "value originates from here".into(),
+            msg_span: span,
+            input_span: v.span(),
+        }),
+        Value::Closure { .. } => Err(ShellError::UnsupportedInput {
+            msg: "closures are currently not nuon-compatible".into(),
+            input: "value originates from here".into(),
+            msg_span: span,
+            input_span: v.span(),
+        }),
         Value::Bool { val, .. } => {
             if *val {
                 Ok("true".to_string())
@@ -160,18 +160,18 @@ pub fn value_to_string(
                 Ok("false".to_string())
             }
         }
-        Value::CellPath { .. } => Err(ShellError::UnsupportedInput(
-            "cell-paths are currently not nuon-compatible".to_string(),
-            "value originates from here".into(),
-            span,
-            v.span(),
-        )),
-        Value::CustomValue { .. } => Err(ShellError::UnsupportedInput(
-            "custom values are currently not nuon-compatible".to_string(),
-            "value originates from here".into(),
-            span,
-            v.span(),
-        )),
+        Value::CellPath { .. } => Err(ShellError::UnsupportedInput {
+            msg: "cell-paths are currently not nuon-compatible".to_string(),
+            input: "value originates from here".into(),
+            msg_span: span,
+            input_span: v.span(),
+        }),
+        Value::CustomValue { .. } => Err(ShellError::UnsupportedInput {
+            msg: "custom values are currently not nuon-compatible".to_string(),
+            input: "value originates from here".into(),
+            msg_span: span,
+            input_span: v.span(),
+        }),
         Value::Date { val, .. } => Ok(val.to_rfc3339()),
         // FIXME: make durations use the shortest lossless representation.
         Value::Duration { val, .. } => Ok(format!("{}ns", *val)),
@@ -241,12 +241,12 @@ pub fn value_to_string(
                 ))
             }
         }
-        Value::MatchPattern { .. } => Err(ShellError::UnsupportedInput(
-            "match patterns are currently not nuon-compatible".to_string(),
-            "value originates from here".into(),
-            span,
-            v.span(),
-        )),
+        Value::MatchPattern { .. } => Err(ShellError::UnsupportedInput {
+            msg: "match patterns are currently not nuon-compatible".to_string(),
+            input: "value originates from here".into(),
+            msg_span: span,
+            input_span: v.span(),
+        }),
         Value::Nothing { .. } => Ok("null".to_string()),
         Value::Range { val, .. } => Ok(format!(
             "{}..{}{}",

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -137,12 +137,12 @@ fn value_to_toml_value(
         Value::Record { .. } => helper(engine_state, v),
         // Propagate existing errors
         Value::Error { error, .. } => Err(*error.clone()),
-        _ => Err(ShellError::UnsupportedInput(
-            format!("{:?} is not valid top-level TOML", v.get_type()),
-            "value originates from here".into(),
-            head,
-            v.span(),
-        )),
+        _ => Err(ShellError::UnsupportedInput {
+            msg: format!("{:?} is not valid top-level TOML", v.get_type()),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: v.span(),
+        }),
     }
 }
 

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -50,12 +50,12 @@ impl Command for SubCommand {
         let base: Spanned<f64> = call.req(engine_state, stack, 0)?;
 
         if base.item <= 0.0f64 {
-            return Err(ShellError::UnsupportedInput(
-                "Base has to be greater 0".into(),
-                "value originates from here".into(),
-                head,
-                base.span,
-            ));
+            return Err(ShellError::UnsupportedInput {
+                msg: "Base has to be greater 0".into(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: base.span,
+            });
         }
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
@@ -103,13 +103,13 @@ fn operate(value: Value, head: Span, base: f64) -> Value {
 
             if val <= 0.0 {
                 return Value::error(
-                    ShellError::UnsupportedInput(
-                        "'math log' undefined for values outside the open interval (0, Inf)."
+                    ShellError::UnsupportedInput {
+                        msg: "'math log' undefined for values outside the open interval (0, Inf)."
                             .into(),
-                        "value originates from here".into(),
-                        head,
-                        span,
-                    ),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span: span,
+                    },
                     span,
                 );
             }

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -107,14 +107,14 @@ pub fn median(values: &[Value], span: Span, head: Span) -> Result<Value, ShellEr
     match take {
         Pick::Median => {
             let idx = (values.len() as f64 / 2.0).floor() as usize;
-            let out = sorted.get(idx).ok_or_else(|| {
-                ShellError::UnsupportedInput(
-                    "Empty input".to_string(),
-                    "value originates from here".into(),
-                    head,
-                    span,
-                )
-            })?;
+            let out = sorted
+                .get(idx)
+                .ok_or_else(|| ShellError::UnsupportedInput {
+                    msg: "Empty input".to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: span,
+                })?;
             Ok(out.clone())
         }
         Pick::MedianAverage => {
@@ -123,25 +123,21 @@ pub fn median(values: &[Value], span: Span, head: Span) -> Result<Value, ShellEr
 
             let left = sorted
                 .get(idx_start)
-                .ok_or_else(|| {
-                    ShellError::UnsupportedInput(
-                        "Empty input".to_string(),
-                        "value originates from here".into(),
-                        head,
-                        span,
-                    )
+                .ok_or_else(|| ShellError::UnsupportedInput {
+                    msg: "Empty input".to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: span,
                 })?
                 .clone();
 
             let right = sorted
                 .get(idx_end)
-                .ok_or_else(|| {
-                    ShellError::UnsupportedInput(
-                        "Empty input".to_string(),
-                        "value originates from here".into(),
-                        head,
-                        span,
-                    )
+                .ok_or_else(|| ShellError::UnsupportedInput {
+                    msg: "Empty input".to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: span,
                 })?
                 .clone();
 

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -138,12 +138,12 @@ pub fn mode(values: &[Value], _span: Span, head: Span) -> Result<Value, ShellErr
                 Ok(HashableType::new(val.to_ne_bytes(), NumberTypes::Filesize))
             }
             Value::Error { error, .. } => Err(*error.clone()),
-            other => Err(ShellError::UnsupportedInput(
-                "Unable to give a result with this input".to_string(),
-                "value originates from here".into(),
-                head,
-                other.span(),
-            )),
+            other => Err(ShellError::UnsupportedInput {
+                msg: "Unable to give a result with this input".to_string(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: other.span(),
+            }),
         })
         .collect::<Result<Vec<HashableType>, ShellError>>()?;
 

--- a/crates/nu-command/src/math/reducers.rs
+++ b/crates/nu-command/src/math/reducers.rs
@@ -23,13 +23,11 @@ pub fn reducer_for(command: Reduce) -> ReducerFunction {
 pub fn max(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError> {
     let mut biggest = data
         .first()
-        .ok_or_else(|| {
-            ShellError::UnsupportedInput(
-                "Empty input".to_string(),
-                "value originates from here".into(),
-                head,
-                span,
-            )
+        .ok_or_else(|| ShellError::UnsupportedInput {
+            msg: "Empty input".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: span,
         })?
         .clone();
 
@@ -54,13 +52,11 @@ pub fn max(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
 pub fn min(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError> {
     let mut smallest = data
         .first()
-        .ok_or_else(|| {
-            ShellError::UnsupportedInput(
-                "Empty input".to_string(),
-                "value originates from here".into(),
-                head,
-                span,
-            )
+        .ok_or_else(|| ShellError::UnsupportedInput {
+            msg: "Empty input".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: span,
         })?
         .clone();
 
@@ -96,12 +92,12 @@ pub fn sum(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
             }
         }
 
-        None => Err(ShellError::UnsupportedInput(
-            "Empty input".to_string(),
-            "value originates from here".into(),
-            head,
-            span,
-        )),
+        None => Err(ShellError::UnsupportedInput {
+            msg: "Empty input".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: span,
+        }),
     }?;
 
     for value in &data {
@@ -114,12 +110,13 @@ pub fn sum(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellError
             }
             Value::Error { error, .. } => return Err(*error.clone()),
             other => {
-                return Err(ShellError::UnsupportedInput(
-                    "Attempted to compute the sum of a value that cannot be summed".to_string(),
-                    "value originates from here".into(),
-                    head,
-                    other.span(),
-                ));
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Attempted to compute the sum of a value that cannot be summed"
+                        .to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: other.span(),
+                });
             }
         }
     }
@@ -137,12 +134,12 @@ pub fn product(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellE
                 _ => Ok(Value::nothing(head)),
             }
         }
-        None => Err(ShellError::UnsupportedInput(
-            "Empty input".to_string(),
-            "value originates from here".into(),
-            head,
-            span,
-        )),
+        None => Err(ShellError::UnsupportedInput {
+            msg: "Empty input".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: span,
+        }),
     }?;
 
     for value in &data {
@@ -152,13 +149,13 @@ pub fn product(data: Vec<Value>, span: Span, head: Span) -> Result<Value, ShellE
             }
             Value::Error { error, .. } => return Err(*error.clone()),
             other => {
-                return Err(ShellError::UnsupportedInput(
-                    "Attempted to compute the product of a value that cannot be multiplied"
+                return Err(ShellError::UnsupportedInput {
+                    msg: "Attempted to compute the product of a value that cannot be multiplied"
                         .to_string(),
-                    "value originates from here".into(),
-                    head,
-                    other.span(),
-                ));
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: other.span(),
+                });
             }
         }
     }

--- a/crates/nu-command/src/math/sqrt.rs
+++ b/crates/nu-command/src/math/sqrt.rs
@@ -93,12 +93,12 @@ fn operate(value: Value, head: Span) -> Value {
 
 fn error_negative_sqrt(head: Span, span: Span) -> Value {
     Value::error(
-        ShellError::UnsupportedInput(
-            String::from("Can't square root a negative number"),
-            "value originates from here".into(),
-            head,
-            span,
-        ),
+        ShellError::UnsupportedInput {
+            msg: String::from("Can't square root a negative number"),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: span,
+        },
         span,
     )
 }

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -49,12 +49,12 @@ fn helper_for_tables(
         }
     }
     if column_totals.keys().len() == 0 {
-        return Err(ShellError::UnsupportedInput(
-            "Unable to give a result with this input".to_string(),
-            "value originates from here".into(),
-            name,
-            val_span,
-        ));
+        return Err(ShellError::UnsupportedInput {
+            msg: "Unable to give a result with this input".to_string(),
+            input: "value originates from here".into(),
+            msg_span: name,
+            input_span: val_span,
+        });
     }
 
     Ok(Value::record(column_totals.into_iter().collect(), name))
@@ -107,13 +107,13 @@ pub fn calculate(
         }
         PipelineData::Value(val, ..) => mf(&[val], span, name),
         PipelineData::Empty { .. } => Err(ShellError::PipelineEmpty { dst_span: name }),
-        val => Err(ShellError::UnsupportedInput(
-            "Only ints, floats, lists, records, or ranges are supported".into(),
-            "value originates from here".into(),
-            name,
-            // This requires both the ListStream and Empty match arms to be above it.
-            val.span()
+        val => Err(ShellError::UnsupportedInput {
+            msg: "Only ints, floats, lists, records, or ranges are supported".into(),
+            input: "value originates from here".into(),
+            msg_span: name,
+            input_span: val
+                .span()
                 .expect("non-Empty non-ListStream PipelineData had no span"),
-        )),
+        }),
     }
 }

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -65,12 +65,13 @@ fn sum_of_squares(values: &[Value], span: Span) -> Result<Value, ShellError> {
         let v = match &value {
             Value::Int { .. } | Value::Float { .. } => Ok(value),
             Value::Error { error, .. } => Err(*error.clone()),
-            _ => Err(ShellError::UnsupportedInput(
-                "Attempted to compute the sum of squares of a non-int, non-float value".to_string(),
-                "value originates from here".into(),
-                span,
-                value.span(),
-            )),
+            _ => Err(ShellError::UnsupportedInput {
+                msg: "Attempted to compute the sum of squares of a non-int, non-float value"
+                    .to_string(),
+                input: "value originates from here".into(),
+                msg_span: span,
+                input_span: value.span(),
+            }),
         }?;
         let v_squared = &v.mul(span, v, span)?;
         sum_x2 = sum_x2.add(span, v_squared, span)?;

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -56,13 +56,8 @@ pub fn http_parse_url(
     let url = match url::Url::parse(&requested_url) {
         Ok(u) => u,
         Err(_e) => {
-            return Err(ShellError::UnsupportedInput(
-                "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com"
-                    .to_string(),
-                format!("value: '{requested_url:?}'"),
-                call.head,
-                span,
-            ));
+            return Err(ShellError::UnsupportedInput { msg: "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com"
+                    .to_string(), input: format!("value: '{requested_url:?}'"), msg_span: call.head, input_span: span });
         }
     };
 

--- a/crates/nu-command/src/network/url/build_query.rs
+++ b/crates/nu-command/src/network/url/build_query.rs
@@ -75,12 +75,12 @@ fn to_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> {
                                 row_vec.push((k.clone(), s.to_string()));
                             }
                             _ => {
-                                return Err(ShellError::UnsupportedInput(
-                                    "Expected a record with string values".to_string(),
-                                    "value originates from here".into(),
-                                    head,
-                                    span,
-                                ));
+                                return Err(ShellError::UnsupportedInput {
+                                    msg: "Expected a record with string values".to_string(),
+                                    input: "value originates from here".into(),
+                                    msg_span: head,
+                                    input_span: span,
+                                });
                             }
                         }
                     }
@@ -97,12 +97,12 @@ fn to_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> {
                 }
                 // Propagate existing errors
                 Value::Error { error, .. } => Err(*error),
-                other => Err(ShellError::UnsupportedInput(
-                    "Expected a table from pipeline".to_string(),
-                    "value originates from here".into(),
-                    head,
-                    other.span(),
-                )),
+                other => Err(ShellError::UnsupportedInput {
+                    msg: "Expected a table from pipeline".to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: other.span(),
+                }),
             }
         })
         .collect();

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -104,12 +104,12 @@ impl Command for SubCommand {
                         url_components?.to_url(span)
                     }
                     Value::Error { error, .. } => Err(*error),
-                    other => Err(ShellError::UnsupportedInput(
-                        "Expected a record from pipeline".to_string(),
-                        "value originates from here".into(),
-                        head,
-                        other.span(),
-                    )),
+                    other => Err(ShellError::UnsupportedInput {
+                        msg: "Expected a record from pipeline".to_string(),
+                        input: "value originates from here".into(),
+                        msg_span: head,
+                        input_span: other.span(),
+                    }),
                 }
             })
             .collect();

--- a/crates/nu-command/src/network/url/parse.rs
+++ b/crates/nu-command/src/network/url/parse.rs
@@ -113,21 +113,21 @@ fn parse(value: Value, head: Span, engine_state: &EngineState) -> Result<Pipelin
 
                     Ok(PipelineData::Value(Value::record(record, head), None))
                 }
-                _ => Err(ShellError::UnsupportedInput(
-                    "String not compatible with url-encoding".to_string(),
-                    "value originates from here".into(),
-                    head,
-                    span,
-                )),
+                _ => Err(ShellError::UnsupportedInput {
+                    msg: "String not compatible with url-encoding".to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: span,
+                }),
             }
         }
-        Err(_e) => Err(ShellError::UnsupportedInput(
-            "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com"
+        Err(_e) => Err(ShellError::UnsupportedInput {
+            msg: "Incomplete or incorrect URL. Expected a full URL, e.g., https://www.example.com"
                 .to_string(),
-            "value originates from here".into(),
-            head,
-            span,
-        )),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: span,
+        }),
     }
 }
 

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -180,12 +180,12 @@ fn run(call: &Call, args: &Arguments, input: PipelineData) -> Result<PipelineDat
             metadata,
         )),
         PipelineData::Empty { .. } => Err(ShellError::PipelineEmpty { dst_span: head }),
-        _ => Err(ShellError::UnsupportedInput(
-            "Input value cannot be joined".to_string(),
-            "value originates from here".into(),
-            head,
-            input.span().unwrap_or(call.head),
-        )),
+        _ => Err(ShellError::UnsupportedInput {
+            msg: "Input value cannot be joined".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: input.span().unwrap_or(call.head),
+        }),
     }
 }
 
@@ -249,14 +249,9 @@ fn merge_record(record: &Record, head: Span, span: Span) -> Result<PathBuf, Shel
     for key in &record.cols {
         if !super::ALLOWED_COLUMNS.contains(&key.as_str()) {
             let allowed_cols = super::ALLOWED_COLUMNS.join(", ");
-            return Err(ShellError::UnsupportedInput(
-                format!(
+            return Err(ShellError::UnsupportedInput { msg: format!(
                     "Column '{key}' is not valid for a structured path. Allowed columns on this platform are: {allowed_cols}"
-                ),
-                "value originates from here".into(),
-                head,
-                span
-            ));
+                ), input: "value originates from here".into(), msg_span: head, input_span: span });
         }
     }
 

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -73,12 +73,12 @@ impl Command for Input {
         });
 
         if numchar.item < 1 {
-            return Err(ShellError::UnsupportedInput(
-                "Number of characters to read has to be positive".to_string(),
-                "value originated from here".to_string(),
-                call.head,
-                numchar.span,
-            ));
+            return Err(ShellError::UnsupportedInput {
+                msg: "Number of characters to read has to be positive".to_string(),
+                input: "value originated from here".to_string(),
+                msg_span: call.head,
+                input_span: numchar.span,
+            });
         }
 
         if let Some(prompt) = &prompt {

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -178,21 +178,21 @@ impl EventTypeFilter {
     }
 
     fn wrong_type_error(head: Span, val: &str, val_span: Span) -> ShellError {
-        ShellError::UnsupportedInput(
-            format!("{} is not a valid event type", val),
-            "value originates from here".into(),
-            head,
-            val_span,
-        )
+        ShellError::UnsupportedInput {
+            msg: format!("{} is not a valid event type", val),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: val_span,
+        }
     }
 
     fn bad_list_error(head: Span, value: &Value) -> ShellError {
-        ShellError::UnsupportedInput(
-            "--types expects a list of strings".to_string(),
-            "value originates from here".into(),
-            head,
-            value.span(),
-        )
+        ShellError::UnsupportedInput {
+            msg: "--types expects a list of strings".to_string(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: value.span(),
+        }
     }
 
     /// Enable capturing of all events allowed by this filter.

--- a/crates/nu-command/src/strings/encode_decode/base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/base64.rs
@@ -127,13 +127,12 @@ fn action(
                 Value::string(std::str::from_utf8(&enc_vec).unwrap_or(""), command_span)
             }
             ActionType::Decode => Value::error(
-                ShellError::UnsupportedInput(
-                    "Binary data can only be encoded".to_string(),
-                    "value originates from here".into(),
-                    command_span,
-                    // This line requires the Value::Error {} match above.
-                    input.span(),
-                ),
+                ShellError::UnsupportedInput {
+                    msg: "Binary data can only be encoded".to_string(),
+                    input: "value originates from here".into(),
+                    msg_span: command_span,
+                    input_span: input.span(),
+                },
                 command_span,
             ),
         },

--- a/crates/nu-command/src/strings/encode_decode/decode.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode.rs
@@ -99,12 +99,12 @@ documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#
             }
             // This should be more precise, but due to difficulties in getting spans
             // from PipelineData::ListData, this is as it is.
-            _ => Err(ShellError::UnsupportedInput(
-                "non-binary input".into(),
-                "value originates from here".into(),
-                head,
-                input.span().unwrap_or(head),
-            )),
+            _ => Err(ShellError::UnsupportedInput {
+                msg: "non-binary input".into(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: input.span().unwrap_or(head),
+            }),
         }
     }
 }

--- a/crates/nu-command/src/strings/encode_decode/encode.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode.rs
@@ -113,12 +113,12 @@ documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#
             }
             // This should be more precise, but due to difficulties in getting spans
             // from PipelineData::ListStream, this is as it is.
-            _ => Err(ShellError::UnsupportedInput(
-                "non-string input".into(),
-                "value originates from here".into(),
-                head,
-                input.span().unwrap_or(head),
-            )),
+            _ => Err(ShellError::UnsupportedInput {
+                msg: "non-string input".into(),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: input.span().unwrap_or(head),
+            }),
         }
     }
 }

--- a/crates/nu-command/src/strings/encode_decode/encoding.rs
+++ b/crates/nu-command/src/strings/encode_decode/encoding.rs
@@ -12,12 +12,12 @@ pub fn detect_encoding_name(
     //Guess(TLD=None(usually used in HTML), Allow_UTF8=True)
     let (encoding, is_certain) = detector.guess_assess(None, true);
     if !is_certain {
-        return Err(ShellError::UnsupportedInput(
-            "Input contains unknown encoding, try giving a encoding name".into(),
-            "value originates from here".into(),
-            head,
-            input,
-        ));
+        return Err(ShellError::UnsupportedInput {
+            msg: "Input contains unknown encoding, try giving a encoding name".into(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: input,
+        });
     }
     Ok(encoding)
 }

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -191,13 +191,12 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => input.clone(),
         other => Value::error(
-            ShellError::UnsupportedInput(
-                "Only string values are supported".into(),
-                format!("input type: {:?}", other.get_type()),
-                head,
-                // This line requires the Value::Error match above.
-                other.span(),
-            ),
+            ShellError::UnsupportedInput {
+                msg: "Only string values are supported".into(),
+                input: format!("input type: {:?}", other.get_type()),
+                msg_span: head,
+                input_span: other.span(),
+            },
             head,
         ),
     }

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -198,18 +198,15 @@ fn action(input: &Value, arg: &Arguments, head: Span) -> Value {
                     }
                     _ => input.clone(),
                 },
-                ActionMode::Local => {
-                    Value::error(
-                        ShellError::UnsupportedInput(
-                            "Only string values are supported".into(),
-                            format!("input type: {:?}", other.get_type()),
-                            head,
-                            // This line requires the Value::Error match above.
-                            other.span(),
-                        ),
-                        head,
-                    )
-                }
+                ActionMode::Local => Value::error(
+                    ShellError::UnsupportedInput {
+                        msg: "Only string values are supported".into(),
+                        input: format!("input type: {:?}", other.get_type()),
+                        msg_span: head,
+                        input_span: other.span(),
+                    },
+                    head,
+                ),
             }
         }
     }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -632,7 +632,7 @@ pub enum ShellError {
         input: String,
         #[label("{msg}")]
         msg_span: Span,
-        #[label("input type: {input}")]
+        #[label("{input}")]
         input_span: Span,
     },
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -627,12 +627,14 @@ pub enum ShellError {
     /// This error is fairly generic. Refer to the specific error message for further details.
     #[error("Unsupported input")]
     #[diagnostic(code(nu::shell::unsupported_input))]
-    UnsupportedInput(
-        String,
-        String,
-        #[label("{0}")] Span, // call head (the name of the command itself)
-        #[label("input type: {1}")] Span,
-    ),
+    UnsupportedInput {
+        msg: String,
+        input: String,
+        #[label("{msg}")]
+        msg_span: Span,
+        #[label("input type: {input}")]
+        input_span: Span,
+    },
 
     /// Failed to parse an input into a datetime value.
     ///

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1659,12 +1659,12 @@ impl Value {
                                 // SIGH...
                                 Value::Error { error, .. } => return Err(*error.clone()),
                                 _ => {
-                                    return Err(ShellError::UnsupportedInput(
-                                        "expected table or record".into(),
-                                        format!("input type: {:?}", val.get_type()),
-                                        head_span,
-                                        *span,
-                                    ))
+                                    return Err(ShellError::UnsupportedInput {
+                                        msg: "expected table or record".into(),
+                                        input: format!("input type: {:?}", val.get_type()),
+                                        msg_span: head_span,
+                                        input_span: *span,
+                                    })
                                 }
                             }
                         }
@@ -1697,12 +1697,12 @@ impl Value {
                         *self = record
                     }
                     other => {
-                        return Err(ShellError::UnsupportedInput(
-                            "table or record".into(),
-                            format!("input type: {:?}", other.get_type()),
-                            head_span,
-                            *span,
-                        ))
+                        return Err(ShellError::UnsupportedInput {
+                            msg: "table or record".into(),
+                            input: format!("input type: {:?}", other.get_type()),
+                            msg_span: head_span,
+                            input_span: *span,
+                        })
                     }
                 },
                 PathMember::Int {
@@ -3220,27 +3220,24 @@ impl Value {
                         if let Some(regex) = cache.get(rhs) {
                             regex.is_match(lhs)
                         } else {
-                            let regex = Regex::new(rhs).map_err(|e| {
-                                ShellError::UnsupportedInput(
-                                    format!("{e}"),
-                                    "value originated from here".into(),
-                                    span,
-                                    rhs_span,
-                                )
-                            })?;
+                            let regex =
+                                Regex::new(rhs).map_err(|e| ShellError::UnsupportedInput {
+                                    msg: format!("{e}"),
+                                    input: "value originated from here".into(),
+                                    msg_span: span,
+                                    input_span: rhs_span,
+                                })?;
                             let ret = regex.is_match(lhs);
                             cache.put(rhs.clone(), regex);
                             ret
                         }
                     }
                     Err(_) => {
-                        let regex = Regex::new(rhs).map_err(|e| {
-                            ShellError::UnsupportedInput(
-                                format!("{e}"),
-                                "value originated from here".into(),
-                                span,
-                                rhs_span,
-                            )
+                        let regex = Regex::new(rhs).map_err(|e| ShellError::UnsupportedInput {
+                            msg: format!("{e}"),
+                            input: "value originated from here".into(),
+                            msg_span: span,
+                            input_span: rhs_span,
                         })?;
                         regex.is_match(lhs)
                     }

--- a/crates/nu_plugin_formats/src/from/ics.rs
+++ b/crates/nu_plugin_formats/src/from/ics.rs
@@ -36,12 +36,12 @@ pub fn from_ics_call(call: &EvaluatedCall, input: &Value) -> Result<Value, Label
         match calendar {
             Ok(c) => output.push(calendar_to_value(c, head)),
             Err(e) => output.push(Value::error(
-                ShellError::UnsupportedInput(
-                    format!("input cannot be parsed as .ics ({e})"),
-                    "value originates from here".into(),
-                    head,
-                    span,
-                ),
+                ShellError::UnsupportedInput {
+                    msg: format!("input cannot be parsed as .ics ({e})"),
+                    input: "value originates from here".into(),
+                    msg_span: head,
+                    input_span: span,
+                },
                 span,
             )),
         }

--- a/crates/nu_plugin_formats/src/from/ini.rs
+++ b/crates/nu_plugin_formats/src/from/ini.rs
@@ -40,12 +40,12 @@ pub fn from_ini_call(call: &EvaluatedCall, input: &Value) -> Result<Value, Label
             // all sections with all its key value pairs
             Ok(Value::record(sections, span))
         }
-        Err(err) => Err(ShellError::UnsupportedInput(
-            format!("Could not load ini: {err}"),
-            "value originates from here".into(),
-            head,
-            span,
-        )
+        Err(err) => Err(ShellError::UnsupportedInput {
+            msg: format!("Could not load ini: {err}"),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: span,
+        }
         .into()),
     }
 }

--- a/crates/nu_plugin_formats/src/from/vcf.rs
+++ b/crates/nu_plugin_formats/src/from/vcf.rs
@@ -32,12 +32,12 @@ pub fn from_vcf_call(call: &EvaluatedCall, input: &Value) -> Result<Value, Label
     let iter = parser.map(move |contact| match contact {
         Ok(c) => contact_to_value(c, head),
         Err(e) => Value::error(
-            ShellError::UnsupportedInput(
-                format!("input cannot be parsed as .vcf ({e})"),
-                "value originates from here".into(),
-                head,
-                span,
-            ),
+            ShellError::UnsupportedInput {
+                msg: format!("input cannot be parsed as .vcf ({e})"),
+                input: "value originates from here".into(),
+                msg_span: head,
+                input_span: span,
+            },
             span,
         ),
     });


### PR DESCRIPTION
# Description

This is easy to do with rust-analyzer, but I didn't want to just pump these all out without feedback.

Part of #10700

# User-Facing Changes

None

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A