### PR TITLE
allow `items` to properly evaluate block settings

### DIFF
--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -53,7 +53,6 @@ impl Command for Items {
         let orig_env_vars = stack.env_vars.clone();
         let orig_env_hidden = stack.env_hidden.clone();
         let span = call.head;
-        let redirect_stdout = call.redirect_stdout;
         let redirect_stderr = call.redirect_stderr;
 
         let input_span = input.span().unwrap_or(call.head);
@@ -80,7 +79,7 @@ impl Command for Items {
                 &mut stack,
                 &block,
                 PipelineData::empty(),
-                redirect_stdout,
+                true,
                 redirect_stderr,
             ) {
                 Ok(v) => Some(v.into_value(span)),
@@ -123,7 +122,8 @@ impl Command for Items {
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            example: "{ new: york, san: francisco } | items {|key, value| $'($key) ($value)' }",
+            example:
+                "{ new: york, san: francisco } | items {|key, value| echo $'($key) ($value)' }",
             description: "Iterate over each key-value pair of a record",
             result: Some(Value::list(
                 vec![


### PR DESCRIPTION
# Description

@jntrnr discovered that `items` wasn't properly setting the `eval_block_with_early_return()` block settings. This change fixes that which allows `echo` to be redirected and therefore pass data through the pipeline.

Without `echo`
```nushell
❯ { new: york, san: francisco } | items {|key, value| $'($key) ($value)' }
╭─┬─────────────╮
│0│new york     │
│1│san francisco│
╰─┴─────────────╯
```
With `echo`
```nushell
❯ { new: york, san: francisco } | items {|key, value| echo $'($key) ($value)' }
╭─┬─────────────╮
│0│new york     │
│1│san francisco│
╰─┴─────────────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
