### PR TITLE
Match toolkit clippy settings to CI clippy settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ name: continuous-integration
 env:
   NUSHELL_CARGO_PROFILE: ci
   NU_LOG_LEVEL: DEBUG
+  # If changing these settings also change toolkit.nu
   CLIPPY_OPTIONS: "-D warnings -D clippy::unwrap_used"
 
 jobs:
@@ -47,9 +48,10 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
+        # If changing these settings also change toolkit.nu
       - name: Clippy
         run: cargo clippy --workspace ${{ matrix.flags }} --exclude nu_plugin_* -- $CLIPPY_OPTIONS
-      
+
         # In tests we don't have to deny unwrap
       - name: Clippy of tests
         run: cargo clippy --tests --workspace ${{ matrix.flags }} --exclude nu_plugin_* -- -D warnings

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -39,14 +39,43 @@ export def clippy [
         print $"running ('toolkit clippy' | pretty-format-command)"
     }
 
+    # If changing these settings also change CI settings in .github/workflows/ci.yml
     try {(
         cargo clippy
             --workspace
-            --tests
+            --exclude nu_plugin_*
             --features ($features | str join ",")
         --
             -D warnings
-    )} catch {
+            -D clippy::unwrap_used
+    )
+
+    if $verbose {
+        print $"running ('toolkit clippy' | pretty-format-command) on tests"
+    }
+    # In tests we don't have to deny unwrap
+    (
+        cargo clippy
+            --tests
+            --workspace
+            --exclude nu_plugin_*
+            --features ($features | str join ",")
+        --
+            -D warnings
+    )
+
+    if $verbose {
+        print $"running ('toolkit clippy' | pretty-format-command) on plugins"
+    }
+    (
+        cargo clippy
+            --package nu_plugin_*
+        --
+            -D warnings
+            -D clippy::unwrap_used
+    )
+
+    } catch {
         error make --unspanned {
             msg: $"\nplease fix the above ('clippy' | pretty-format-command) errors before continuing!"
         }


### PR DESCRIPTION
# Description

I've had a few PRs fail clippy in CI after they pass `toolkit check pr` because the clippy settings are different.  This brings `toolkit.nu` into alignment with CI and leaves notes to prompt future synchronization.

# User-Facing Changes

N/A

# Tests + Formatting

`cargo` output elided:

```
❯ toolkit check pr
running `toolkit fmt`
running `toolkit clippy`
running `toolkit clippy` on tests
running `toolkit clippy` on plugins
running `toolkit test`
running `toolkit test stdlib`
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
```

# After Submitting

N/A