### PR TITLE
Convert ShellError::DatetimeParseError to named fields

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -288,7 +288,10 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                             Value::date(dt, *span)
                         }
                         None => Value::error(
-                            ShellError::DatetimeParseError(input.debug_value(), *span),
+                            ShellError::DatetimeParseError {
+                                msg: input.debug_value(),
+                                span: *span,
+                            },
                             *span,
                         ),
                     },
@@ -298,7 +301,10 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                             Value::date(dt, *span)
                         }
                         None => Value::error(
-                            ShellError::DatetimeParseError(input.debug_value(), *span),
+                            ShellError::DatetimeParseError {
+                                msg: input.debug_value(),
+                                span: *span,
+                            },
                             *span,
                         ),
                     },

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -79,7 +79,10 @@ fn helper(value: Value, head: Span) -> Value {
         }
         Value::Date { val, .. } => Value::string(humanize_date(val), head),
         _ => Value::error(
-            ShellError::DatetimeParseError(value.debug_value(), head),
+            ShellError::DatetimeParseError {
+                msg: value.debug_value(),
+                span: head,
+            },
             head,
         ),
     }

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -121,7 +121,13 @@ fn helper(val: Value, head: Span) -> Value {
             parse_date_into_table(n, head)
         }
         Value::Date { val, .. } => parse_date_into_table(val, head),
-        _ => Value::error(DatetimeParseError(val.debug_value(), head), head),
+        _ => Value::error(
+            DatetimeParseError {
+                msg: val.debug_value(),
+                span: head,
+            },
+            head,
+        ),
     }
 }
 

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -120,7 +120,13 @@ fn helper(val: Value, head: Span) -> Value {
             parse_date_into_table(n, head)
         }
         Value::Date { val, .. } => parse_date_into_table(val, head),
-        _ => Value::error(DatetimeParseError(val.debug_value(), head), head),
+        _ => Value::error(
+            DatetimeParseError {
+                msg: val.debug_value(),
+                span: head,
+            },
+            head,
+        ),
     }
 }
 

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -122,7 +122,10 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
             _to_timezone(dt.with_timezone(dt.offset()), timezone, head)
         }
         _ => Value::error(
-            ShellError::DatetimeParseError(value.debug_value(), head),
+            ShellError::DatetimeParseError {
+                msg: value.debug_value(),
+                span: head,
+            },
             head,
         ),
     }

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -15,13 +15,19 @@ pub(crate) fn parse_date_from_string(
                 LocalResult::Single(d) => Ok(d),
                 LocalResult::Ambiguous(d, _) => Ok(d),
                 LocalResult::None => Err(Value::error(
-                    ShellError::DatetimeParseError(input.to_string(), span),
+                    ShellError::DatetimeParseError {
+                        msg: input.into(),
+                        span,
+                    },
                     span,
                 )),
             }
         }
         Err(_) => Err(Value::error(
-            ShellError::DatetimeParseError(input.to_string(), span),
+            ShellError::DatetimeParseError {
+                msg: input.into(),
+                span,
+            },
             span,
         )),
     }

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -157,7 +157,10 @@ fn format_helper(value: Value, formatter: &str, formatter_span: Span, head_span:
             }
         }
         _ => Value::error(
-            ShellError::DatetimeParseError(value.debug_value(), head_span),
+            ShellError::DatetimeParseError {
+                msg: value.debug_value(),
+                span: head_span,
+            },
             head_span,
         ),
     }
@@ -175,7 +178,10 @@ fn format_helper_rfc2822(value: Value, span: Span) -> Value {
             }
         }
         _ => Value::error(
-            ShellError::DatetimeParseError(value.debug_value(), span),
+            ShellError::DatetimeParseError {
+                msg: value.debug_value(),
+                span,
+            },
             span,
         ),
     }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -650,7 +650,7 @@ pub enum ShellError {
     /// * "2020-04-12 22:10:57 +02:00"
     /// * "2020-04-12T22:10:57.213231+02:00"
     /// * "Tue, 1 Jul 2003 10:52:37 +0200""#
-    #[error("Unable to parse datetime: [{0}].")]
+    #[error("Unable to parse datetime: [{msg}].")]
     #[diagnostic(
         code(nu::shell::datetime_parse_error),
         help(
@@ -663,7 +663,11 @@ pub enum ShellError {
  * "Tue, 1 Jul 2003 10:52:37 +0200""#
         )
     )]
-    DatetimeParseError(String, #[label("datetime parsing failed")] Span),
+    DatetimeParseError {
+        msg: String,
+        #[label("datetime parsing failed")]
+        span: Span,
+    },
 
     /// A network operation failed.
     ///


### PR DESCRIPTION
# Description

Part of #10700

# User-Facing Changes

None

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A