### PR TITLE
disable bracketed paste during the execution of a child

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.25.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#973dbb5f5f2338c18c25ce951bfa42c8d8cacfdf"
+source = "git+https://github.com/nushell/reedline.git?branch=main#c853d71e6615210aad53a937b8ccb2d18cb75958"
 dependencies = [
  "chrono",
  "crossterm 0.27.0",

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -588,6 +588,12 @@ pub fn evaluate_repl(
                         }
                     }
 
+                    // We should not have bracketed paste enabled during the execution
+                    // of a child.
+                    if engine_state.get_config().bracketed_paste {
+                        let _ = line_editor.disable_bracketed_paste();
+                    }
+
                     eval_source(
                         engine_state,
                         stack,
@@ -596,8 +602,9 @@ pub fn evaluate_repl(
                         PipelineData::empty(),
                         false,
                     );
+
+                    // Ensure bracketed paste is enabled again
                     if engine_state.get_config().bracketed_paste {
-                        #[cfg(not(target_os = "windows"))]
                         let _ = line_editor.enable_bracketed_paste();
                     }
                 }


### PR DESCRIPTION
Fixes #10982

Based on by https://github.com/nushell/nushell/pull/9399 by @WindSoilder.

I invite @WindSoilder, @fdncred and @theAkito to test this on their respective platforms.

I can't say I completely understand nushells cli code, but based on @WindSoilder I assumed `eval_source` was responsible for executing the child program.

This PR disables bracketed paste during the execution of children for reasons I explained in https://github.com/nushell/nushell/issues/10982.

To test:
```
1. cargo update
2. cargo run
3. cat
4. paste something inside
```

With this all bracketed paste issues should be fixed.