### PR TITLE
Add `exec` command for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,12 +1250,23 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.6"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
+checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
 dependencies = [
+ "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,23 +1250,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -145,7 +145,6 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             ViewSpan,
         };
 
-        #[cfg(unix)]
         bind_command! { Exec }
 
         #[cfg(windows)]

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -115,6 +115,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
         bind_command! {
             Complete,
             External,
+            Exec,
             NuCheck,
             Sys,
         };
@@ -144,8 +145,6 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             ViewSource,
             ViewSpan,
         };
-
-        bind_command! { Exec }
 
         #[cfg(windows)]
         bind_command! { RegistryQuery }

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -23,11 +23,12 @@ impl Command for Exec {
     }
 
     fn usage(&self) -> &str {
-        "Execute a command, replacing the current process."
+        "Execute a command, replacing or exiting the current process, depending on platform."
     }
 
     fn extra_usage(&self) -> &str {
-        "Currently supported only on Unix-based systems."
+        r#"On Unix-based systems, the current process is replaced with the command.
+On Windows based systems, Nushell will wait for the command to finish and then exit with the command's exit code."#
     }
 
     fn run(

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -1,5 +1,4 @@
 mod complete;
-#[cfg(unix)]
 mod exec;
 mod nu_check;
 #[cfg(any(
@@ -16,7 +15,6 @@ mod sys;
 mod which_;
 
 pub use complete::Complete;
-#[cfg(unix)]
 pub use exec::Exec;
 pub use nu_check::NuCheck;
 #[cfg(any(

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -24,7 +24,6 @@ mod echo;
 mod empty;
 mod error_make;
 mod every;
-#[cfg(not(windows))]
 mod exec;
 mod export_def;
 mod fill;


### PR DESCRIPTION
# Description
Based of the work and discussion in #10844, this PR adds the `exec` command for Windows. This is done by simply spawning a `std::process::Command` and then immediately exiting via `std::process::exit` once the child process is finished. The child process's exit code is passed to `exit`.

# User-Facing Changes
The `exec` command is now available on Windows, and there should be no change in behaviour for Unix systems.