### PR TITLE
Add `from tar` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,6 +2912,7 @@ dependencies = [
  "sha2",
  "sysinfo",
  "tabled",
+ "tar",
  "terminal_size 0.3.0",
  "titlecase",
  "toml 0.8.1",
@@ -5196,6 +5197,17 @@ dependencies = [
  "ansitok",
  "papergrid",
  "unicode-width",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -81,6 +81,7 @@ serde_yaml = "0.9"
 sha2 = "0.10"
 sysinfo = "0.29"
 tabled = { version = "0.14.0", features = ["color"], default-features = false }
+tar = "0.4.40"
 terminal_size = "0.3"
 titlecase = "2.0"
 toml = "0.8"

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -257,6 +257,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             FromNuon,
             FromOds,
             FromSsv,
+            FromTar,
             FromToml,
             FromTsv,
             FromXlsx,

--- a/crates/nu-command/src/formats/from/mod.rs
+++ b/crates/nu-command/src/formats/from/mod.rs
@@ -5,6 +5,7 @@ mod json;
 mod nuon;
 mod ods;
 mod ssv;
+mod tar;
 mod toml;
 mod tsv;
 mod xlsx;
@@ -12,6 +13,7 @@ mod xml;
 mod yaml;
 
 pub use self::csv::FromCsv;
+pub use self::tar::FromTar;
 pub use self::toml::FromToml;
 pub use command::From;
 pub use json::FromJson;

--- a/crates/nu-command/src/formats/from/tar.rs
+++ b/crates/nu-command/src/formats/from/tar.rs
@@ -1,0 +1,232 @@
+use chrono::{DateTime, Utc};
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, IntoPipelineData, PipelineData, RawStream, Record, ShellError, Signature, Span, Type,
+    Value,
+};
+use std::io::Read;
+use tar::{Archive, Header};
+
+#[derive(Clone)]
+pub struct FromTar;
+
+impl Command for FromTar {
+    fn name(&self) -> &str {
+        "from tar"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::Binary, Type::Table(vec![]))])
+            .switch("list", "List archive contents", Some('t'))
+            .switch(
+                "long",
+                "Get all available columns for each entry (default without --list)",
+                Some('l'),
+            )
+            .category(Category::Formats)
+    }
+
+    fn usage(&self) -> &str {
+        "Extract or list files from a tape archive"
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let list = call.has_flag("list");
+        let long = !list || call.has_flag("long");
+
+        let (mut archive, input_span) = open_archive(input, call)?;
+
+        let entries = archive.entries().map_err(|e| io_error(e, input_span))?;
+
+        let mut result = vec![];
+
+        for entry in entries {
+            let entry = entry.map_err(|e| io_error(e, input_span))?;
+
+            let record = entry_to_record(entry, list, long, input_span, call.head)?;
+
+            result.push(record);
+        }
+
+        Ok(Value::list(result, call.head).into_pipeline_data())
+    }
+}
+
+fn io_error(error: std::io::Error, span: Span) -> ShellError {
+    ShellError::IOErrorSpanned(error.to_string(), span)
+}
+
+fn entry_to_record(
+    mut entry: tar::Entry<'_, RawStream>,
+    list: bool,
+    long: bool,
+    input_span: Span,
+    tar_span: Span,
+) -> Result<Value, ShellError> {
+    let mut record = Record::new();
+
+    let header = entry.header();
+
+    let path = entry.path().map_err(|e| io_error(e, input_span))?;
+    let name = path.to_string_lossy().to_string();
+    record.push("name", Value::string(&name, tar_span));
+
+    let entry_type = header_to_entry_type(header);
+    record.push("type", Value::string(entry_type, tar_span));
+
+    if long {
+        let mode = header.mode().map_err(|e| io_error(e, input_span))?;
+        let mode = umask::Mode::from(mode).to_string();
+        record.push("mode", Value::string(mode, tar_span));
+
+        let user = match entry.header().username() {
+            Ok(Some(user)) => Value::string(user, tar_span),
+            _ => {
+                let uid = header.uid().map_err(|e| io_error(e, input_span))?;
+                Value::int(uid as i64, tar_span)
+            }
+        };
+        record.push("user", user);
+
+        let group = match entry.header().groupname() {
+            Ok(Some(group)) => Value::string(group, tar_span),
+            _ => {
+                let gid = header.gid().map_err(|e| io_error(e, input_span))?;
+                Value::int(gid as i64, tar_span)
+            }
+        };
+        record.push("group", group);
+
+        if let Some(major) = entry
+            .header()
+            .device_major()
+            .map_err(|e| io_error(e, input_span))?
+        {
+            record.push("major", Value::int(major.into(), tar_span));
+        }
+
+        if let Some(minor) = entry
+            .header()
+            .device_minor()
+            .map_err(|e| io_error(e, input_span))?
+        {
+            record.push("minor", Value::int(minor.into(), tar_span));
+        }
+    }
+
+    let size = header_to_size(header, input_span)?;
+    record.push("size", Value::filesize(size, tar_span));
+
+    if long {
+        if let Some(gnu_header) = header.as_gnu() {
+            let ctime = gnu_header.ctime().map_err(|e| io_error(e, input_span))?;
+            let created = timestamp_to_date(ctime, &name, input_span)?;
+            record.push("created", Value::date(created.into(), tar_span));
+
+            let atime = gnu_header.atime().map_err(|e| io_error(e, input_span))?;
+            let accessed = timestamp_to_date(atime, &name, input_span)?;
+            record.push("accessed", Value::date(accessed.into(), tar_span));
+        }
+    }
+
+    let mtime = header.mtime().map_err(|e| io_error(e, input_span))?;
+    let modified = timestamp_to_date(mtime, &name, input_span)?;
+    record.push("modified", Value::date(modified.into(), tar_span));
+
+    if !list {
+        let mut body = vec![];
+
+        entry
+            .read_to_end(&mut body)
+            .map_err(|e| io_error(e, input_span))?;
+
+        record.push("data", Value::binary(body, tar_span));
+    }
+
+    Ok(Value::record(record, tar_span))
+}
+
+fn header_to_entry_type(header: &Header) -> String {
+    use tar::EntryType::*;
+
+    match header.entry_type() {
+        Regular => "file",
+        Link => "link",
+        Symlink => "symlink",
+        Char => "char device",
+        Block => "block device",
+        Directory => "dir",
+        Fifo => "pipe",
+        Continuous => "contiguous",
+        GNULongName => "GNU long name",
+        GNULongLink => "GNU long link",
+        GNUSparse => "GNU sparse file",
+        XGlobalHeader => "pax global extension",
+        XHeader => "pax local extension",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn header_to_size(header: &Header, input_span: Span) -> Result<i64, ShellError> {
+    let size = header.entry_size().map_err(|e| io_error(e, input_span))?;
+
+    Ok(size as i64)
+}
+
+fn open_archive(
+    input: PipelineData,
+    call: &Call,
+) -> Result<(Archive<RawStream>, Span), ShellError> {
+    let (value, span) = to_binary_stream(input, call.head)?;
+
+    let archive = Archive::new(value);
+
+    Ok((archive, span))
+}
+
+fn timestamp_to_date(
+    timestamp: u64,
+    name: &str,
+    input_span: Span,
+) -> Result<DateTime<Utc>, ShellError> {
+    DateTime::from_timestamp(timestamp as i64, 0).ok_or_else(|| ShellError::CantConvert {
+        to_type: "datetime".into(),
+        from_type: "unix timestamp".into(),
+        span: input_span,
+        help: Some(format!("tar file entry {name} is too far in the future")),
+    })
+}
+
+fn to_binary_stream(input: PipelineData, span: Span) -> Result<(RawStream, Span), ShellError> {
+    match input {
+        PipelineData::Empty => Err(ShellError::PipelineEmpty { dst_span: span }),
+        PipelineData::ExternalStream {
+            stdout: None, span, ..
+        } => Err(ShellError::TypeMismatch {
+            err_message: "binary (try open -r)".into(),
+            span,
+        }),
+        PipelineData::ExternalStream {
+            stdout: Some(stdout),
+            span,
+            ..
+        } => Ok((stdout, span)),
+        _ => {
+            let src_span = input.span().unwrap_or(Span::unknown());
+            Err(ShellError::PipelineMismatch {
+                exp_input_type: "binary stream (try open -r)".into(),
+                dst_span: span,
+                src_span,
+            })
+        }
+    }
+}


### PR DESCRIPTION
# Description

See #9652 

This is a work-in-progress and probably needs deeper changes to be acceptable.

Currently supports extracting or listing tape archives as supported by the [`tar` crate](https://docs.rs/tar/latest/tar/index.html).

`from tar` requires the input be a binary stream

The contents of a tar file may be listed with `-t`/`--list`, otherwise the body contents and all tar fields available are included in the output.

Currently the entire tar contents are loaded into memory because the `tar` crate may return errors in the middle of reading and `PipelineData::ListStream` does not seem to support that in a friendly way, nor does `PipelineData::ExternalStream` allow outputting a `Record` type.

TODO:
- [ ] Output filtering
- [ ] Output string body for known file extensions like `open`
- [ ] Usage examples
- [ ] Don't load the entire tar content into memory before sending the first record to the pipeline

# User-Facing Changes

* Users can extract from tar files

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
