### PR TITLE
Add interactive plots using plotly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ dependencies = [
  "ahash",
  "arrow-format",
  "avro-schema",
- "base64",
+ "base64 0.21.4",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -229,6 +229,52 @@ dependencies = [
  "streaming-iterator",
  "strength_reduce",
  "zstd",
+]
+
+[[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a0fc7dcf8bd4ead96b1d36b41df47c14beedf7b0301fc543d8f2384e66a2ec0"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c268a96e01a4c47c8c5c2472aaa570707e006a875ea63e819f75474ceedaf7b4"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -344,9 +390,24 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f2139706359229bfa8f19142ac1155b4b80beafb7a60471ac5dd109d4a19778"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bincode"
@@ -1037,6 +1098,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core 0.20.3",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1185,9 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "derive_more"
@@ -1789,6 +1923,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +2011,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -2772,6 +2922,7 @@ dependencies = [
  "nu-protocol",
  "nu-test-support",
  "num 0.4.1",
+ "plotly",
  "polars",
  "polars-io",
  "serde",
@@ -2835,7 +2986,7 @@ name = "nu-command"
 version = "0.86.1"
 dependencies = [
  "alphanumeric-sort",
- "base64",
+ "base64 0.21.4",
  "bracoxide",
  "byteorder",
  "bytesize",
@@ -3718,6 +3869,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1691dd09e82f428ce8d6310bd6d5da2557c82ff17694d2a32cad7242aea89f"
 dependencies = [
  "array-init-cursor",
+]
+
+[[package]]
+name = "plotly"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7174c07682d8c13cded3fcdf54d9c1d09249b4e821f26e4ab7a60eb39e9783d"
+dependencies = [
+ "askama",
+ "dyn-clone",
+ "erased-serde",
+ "once_cell",
+ "plotly_derive",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
+name = "plotly_derive"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2fcc11cdbc83c1a49ed868156cc485037e01c612b03128ce98519e5662ede63"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4676,18 +4857,18 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4735,6 +4916,34 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling 0.20.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5652,7 +5861,7 @@ version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5ccd538d4a604753ebc2f17cd9946e89b77bf87f6a8e2309667c6f2e87855e3"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "encoding_rs",
  "flate2",
  "log",

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -25,6 +25,7 @@ num = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 sqlparser = { version = "0.36.1", optional = true }
 polars-io = { version = "0.33", features = ["avro"], optional = true }
+plotly = "0.8.4"
 
 [dependencies.polars]
 features = [

--- a/crates/nu-cmd-dataframe/src/dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/mod.rs
@@ -1,6 +1,7 @@
 mod eager;
 mod expressions;
 mod lazy;
+mod plotting;
 mod series;
 mod stub;
 mod utils;

--- a/crates/nu-cmd-dataframe/src/dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/mod.rs
@@ -10,6 +10,7 @@ mod values;
 pub use eager::add_eager_decls;
 pub use expressions::add_expressions;
 pub use lazy::add_lazy_decls;
+pub use plotting::add_plotting_decls;
 pub use series::add_series_decls;
 
 use nu_protocol::engine::{EngineState, StateWorkingSet};
@@ -18,6 +19,7 @@ pub fn add_dataframe_context(mut engine_state: EngineState) -> EngineState {
     let delta = {
         let mut working_set = StateWorkingSet::new(&engine_state);
         working_set.add_decl(Box::new(stub::Dfr));
+        add_plotting_decls(&mut working_set);
         add_series_decls(&mut working_set);
         add_eager_decls(&mut working_set);
         add_expressions(&mut working_set);

--- a/crates/nu-cmd-dataframe/src/dataframe/plotting/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/plotting/mod.rs
@@ -1,0 +1,17 @@
+pub mod scatter;
+use crate::dataframe::plotting::scatter::Scatter;
+use nu_protocol::engine::StateWorkingSet;
+
+pub fn add_lazy_decls(working_set: &mut StateWorkingSet) {
+    macro_rules! bind_command {
+            ( $command:expr ) => {
+                working_set.add_decl(Box::new($command));
+            };
+            ( $( $command:expr ),* ) => {
+                $( working_set.add_decl(Box::new($command)); )*
+            };
+        }
+
+    // Dataframe commands
+    bind_command!(Scatter);
+}

--- a/crates/nu-cmd-dataframe/src/dataframe/plotting/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/plotting/mod.rs
@@ -1,5 +1,5 @@
 pub mod scatter;
-use crate::dataframe::plotting::scatter::Scatter;
+use crate::dataframe::plotting::scatter::ScatterPlot;
 use nu_protocol::engine::StateWorkingSet;
 
 pub fn add_lazy_decls(working_set: &mut StateWorkingSet) {
@@ -13,5 +13,5 @@ pub fn add_lazy_decls(working_set: &mut StateWorkingSet) {
         }
 
     // Dataframe commands
-    bind_command!(Scatter);
+    bind_command!(ScatterPlot);
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/plotting/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/plotting/mod.rs
@@ -2,7 +2,7 @@ pub mod scatter;
 use crate::dataframe::plotting::scatter::ScatterPlot;
 use nu_protocol::engine::StateWorkingSet;
 
-pub fn add_lazy_decls(working_set: &mut StateWorkingSet) {
+pub fn add_plotting_decls(working_set: &mut StateWorkingSet) {
     macro_rules! bind_command {
             ( $command:expr ) => {
                 working_set.add_decl(Box::new($command));

--- a/crates/nu-cmd-dataframe/src/dataframe/plotting/scatter.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/plotting/scatter.rs
@@ -1,0 +1,95 @@
+use plotly::common::Mode;
+use plotly::{Layout, Plot, Scatter};
+
+use crate::dataframe::values::{Column, NuDataFrame};
+
+use nu_protocol::{
+    ast::Call,
+    engine::{Command, EngineState, Stack},
+    Category, Example, PipelineData, ShellError, Signature, Span, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct ScatterPlot;
+
+impl Command for ScatterPlot {
+    fn name(&self) -> &str {
+        "dfr scatter"
+    }
+
+    fn usage(&self) -> &str {
+        "Create and save a scatter plot from dataframe columns."
+    }
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_type(Type::Custom("dataframe".into()), Type::Any)
+            .category(Category::Custom("dataframe".into()))
+            .named(
+                "file",
+                SyntaxShape::Filepath,
+                "file path to save plot",
+                Some('f'),
+            )
+            .named(
+                "xvar",
+                SyntaxShape::String,
+                "variable to plot on the abscissa",
+                Some('x'),
+            )
+            .named(
+                "yvar",
+                SyntaxShape::String,
+                "variable to plot on the ordinate",
+                Some('y'),
+            )
+    }
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            description: "Appends a dataframe as new columns",
+            example: "[[a b]; [1 2] [3 4]] | dfr into-df | dfr scatter a b",
+            result: None,
+        }]
+    }
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        command(engine_state, stack, call, input)
+    }
+}
+
+fn command(
+    engine_state: &EngineState,
+    stack: &mut Stack,
+    call: &Call,
+    input: PipelineData,
+) -> Result<_, ShellError> {
+    let file_name: Spanned<PathBuf> = call.get_flag(engine_state, stack, "file")?;
+
+    let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
+
+    pdf = df.into_polars();
+
+    let x: Option<Spanned<String>> = call.get_flag(engine_state, stack, "xvar")?;
+    let y: Option<Spanned<String>> = call.get_flag(engine_state, stack, "yvar")?;
+
+    let trace1 = Scatter::new(
+        pdf.select(x).into_iter().collect(),
+        pdf.select(y).into_iter().collect(),
+    )
+    .name("trace1")
+    .mode(Mode::Markers);
+
+    let mut plot = Plot::new();
+    plot.add_trace(trace1);
+
+    let layout = Layout::new().title("<b>Scatter Plot</b>".into());
+    plot.set_layout(layout);
+
+    plot.show();
+
+    Ok(())
+}

--- a/crates/nu-cmd-dataframe/src/dataframe/plotting/scatter.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/plotting/scatter.rs
@@ -24,19 +24,13 @@ impl Command for ScatterPlot {
         Signature::build(self.name())
             .input_output_type(Type::Custom("dataframe".into()), Type::Any)
             .category(Category::Custom("dataframe".into()))
-            .named(
-                "file",
-                SyntaxShape::Filepath,
-                "file path to save plot",
-                Some('f'),
-            )
-            .named(
+            .required(
                 "xvar",
                 SyntaxShape::String,
                 "variable to plot on the abscissa",
                 Some('x'),
             )
-            .named(
+            .required(
                 "yvar",
                 SyntaxShape::String,
                 "variable to plot on the ordinate",
@@ -67,18 +61,16 @@ fn command(
     call: &Call,
     input: PipelineData,
 ) -> Result<_, ShellError> {
-    let file_name: Spanned<PathBuf> = call.get_flag(engine_state, stack, "file")?;
-
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     pdf = df.into_polars();
 
-    let x: Option<Spanned<String>> = call.get_flag(engine_state, stack, "xvar")?;
-    let y: Option<Spanned<String>> = call.get_flag(engine_state, stack, "yvar")?;
+    let x: Option<Spanned<String>> = call.req(engine_state, stack, "xvar")?;
+    let y: Option<Spanned<String>> = call.req(engine_state, stack, "yvar")?;
 
     let trace1 = Scatter::new(
-        pdf.select(x).into_iter().collect(),
-        pdf.select(y).into_iter().collect(),
+        pdf.select(&x.item).into_iter().collect(),
+        pdf.select(&y.item).into_iter().collect(),
     )
     .name("trace1")
     .mode(Mode::Markers);

--- a/crates/nu-cmd-dataframe/src/dataframe/plotting/scatter.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/plotting/scatter.rs
@@ -85,3 +85,13 @@ fn command(
 
     Ok(())
 }
+#[cfg(test)]
+mod test {
+    use super::super::super::test_dataframe::test_dataframe;
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        test_dataframe(vec![Box::new(ScatterPlot {})])
+    }
+}


### PR DESCRIPTION
# Description
I really like the ability to perform operations on dataframes within Nushell. This is a draft pull request with a small addition to add interactive plot generation from dataframes using plotly. There is a lot of work that needs to be done to this to bring it to a decently useable level. But I figured I would throw it up here to see if there is any interest before I go any further.  Currently you can pipe a dataframe to dfr scatter and then choose the column names as inputs for a simple scatter plot. This then opens a browser window with the plot. If there is interest here I would be happy to keep working on these features. Please note that the code at this point is definitely not ready for any kind of meaningful use other than generating an example scatter plot from integer values. The rust implementation of plotly doesn't work well with polars dataframes, so quite some work needs to be done there.

# User-Facing Changes
add the command ```dfr scatter```. However, it would be interesting to hear whether it could make sense to just add ```dfr plot``` and then take the plot type as an argument along with values needed to populate different plot types. This would definitely reduce a command explosion.

