### PR TITLE
Refactor `flatten` command

### DIFF
--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -126,14 +126,13 @@ fn flatten(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let tag = call.head;
     let columns: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
     let metadata = input.metadata();
     let flatten_all = call.has_flag("all");
 
     input
         .flat_map(
-            move |item| flat_value(&columns, &item, tag, flatten_all),
+            move |item| flat_value(&columns, item, flatten_all),
             engine_state.ctrlc.clone(),
         )
         .map(|x| x.set_metadata(metadata))
@@ -159,199 +158,182 @@ enum TableInside<'a> {
     },
 }
 
-fn flat_value(columns: &[CellPath], item: &Value, name_tag: Span, all: bool) -> Vec<Value> {
+fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
     let tag = item.span();
 
-    if item.as_record().is_ok() {
-        let mut out = IndexMap::<String, Value>::new();
-        let mut inner_table = None;
+    match item {
+        Value::Record { val, .. } => {
+            let mut out = IndexMap::<String, Value>::new();
+            let mut inner_table = None;
 
-        let record = match item {
-            Value::Record { val, .. } => val,
-            // Propagate errors by explicitly matching them before the final case.
-            Value::Error { .. } => return vec![item.clone()],
-            other => {
-                return vec![Value::error(
-                    ShellError::OnlySupportsThisInputType {
-                        exp_input_type: "record".into(),
-                        wrong_type: other.get_type().to_string(),
-                        dst_span: name_tag,
-                        src_span: other.span(),
-                    },
-                    name_tag,
-                )];
-            }
-        };
+            for (column_index, (column, value)) in val.iter().enumerate() {
+                let column_requested = columns.iter().find(|c| c.into_string() == *column);
+                let need_flatten = { columns.is_empty() || column_requested.is_some() };
+                let span = value.span();
 
-        let s = item.span();
-
-        for (column_index, (column, value)) in record.iter().enumerate() {
-            let column_requested = columns.iter().find(|c| c.into_string() == *column);
-            let need_flatten = { columns.is_empty() || column_requested.is_some() };
-            let span = value.span();
-
-            match value {
-                Value::Record { val, .. } => {
-                    if need_flatten {
-                        val.iter().for_each(|(col, val)| {
-                            if out.contains_key(col) {
-                                out.insert(format!("{column}_{col}"), val.clone());
-                            } else {
-                                out.insert(col.to_string(), val.clone());
-                            }
-                        })
-                    } else if out.contains_key(column) {
-                        out.insert(format!("{column}_{column}"), value.clone());
-                    } else {
-                        out.insert(column.to_string(), value.clone());
-                    }
-                }
-                Value::List { vals, .. } if all && vals.iter().all(|f| f.as_record().is_ok()) => {
-                    if need_flatten && inner_table.is_some() {
-                        return vec![Value::error( ShellError::UnsupportedInput { msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(), input: "value originates from here".into(), msg_span: s, input_span: span }, span)
-                            ];
-                    }
-                    // it's a table (a list of record, we can flatten inner record)
-                    let mut records = vec![];
-
-                    for v in vals {
-                        if let Ok(r) = v.as_record() {
-                            records.push(r)
-                        }
-                    }
-
-                    if need_flatten {
-                        let cols = records.iter().map(|r| r.cols.clone());
-                        let vals = records.iter().map(|r| r.vals.clone());
-
-                        inner_table = Some(TableInside::FlattenedRows {
-                            columns: cols.collect(),
-                            _span: &s,
-                            values: vals.collect(),
-                            parent_column_name: column,
-                            parent_column_index: column_index,
-                        });
-                    } else if out.contains_key(column) {
-                        out.insert(format!("{column}_{column}"), value.clone());
-                    } else {
-                        out.insert(column.to_string(), value.clone());
-                    }
-                }
-                Value::List { vals: values, .. } => {
-                    if need_flatten && inner_table.is_some() {
-                        return vec![Value::error( ShellError::UnsupportedInput { msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(), input: "value originates from here".into(), msg_span: s, input_span: span }, span)
-                        ];
-                    }
-
-                    if !columns.is_empty() {
-                        let cell_path = column_requested.and_then(|x| match x.members.first() {
-                            Some(PathMember::String { val, span: _, .. }) => Some(val),
-                            _ => None,
-                        });
-
-                        if let Some(r) = cell_path {
-                            inner_table = Some(TableInside::Entries(
-                                r,
-                                &s,
-                                values.iter().collect::<Vec<_>>(),
-                                column_index,
-                            ));
+                match value {
+                    Value::Record { val, .. } => {
+                        if need_flatten {
+                            val.iter().for_each(|(col, val)| {
+                                if out.contains_key(col) {
+                                    out.insert(format!("{column}_{col}"), val.clone());
+                                } else {
+                                    out.insert(col.to_string(), val.clone());
+                                }
+                            })
+                        } else if out.contains_key(column) {
+                            out.insert(format!("{column}_{column}"), value.clone());
                         } else {
                             out.insert(column.to_string(), value.clone());
                         }
-                    } else {
-                        inner_table = Some(TableInside::Entries(
-                            column,
-                            &s,
-                            values.iter().collect::<Vec<_>>(),
-                            column_index,
-                        ));
+                    }
+                    Value::List { vals, .. }
+                        if all && vals.iter().all(|f| f.as_record().is_ok()) =>
+                    {
+                        if need_flatten && inner_table.is_some() {
+                            return vec![Value::error( ShellError::UnsupportedInput { msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(), input: "value originates from here".into(), msg_span: tag, input_span: span }, span)
+                                ];
+                        }
+                        // it's a table (a list of record, we can flatten inner record)
+                        let mut records = vec![];
+
+                        for v in vals {
+                            if let Ok(r) = v.as_record() {
+                                records.push(r)
+                            }
+                        }
+
+                        if need_flatten {
+                            let cols = records.iter().map(|r| r.cols.clone());
+                            let vals = records.iter().map(|r| r.vals.clone());
+
+                            inner_table = Some(TableInside::FlattenedRows {
+                                columns: cols.collect(),
+                                _span: &tag,
+                                values: vals.collect(),
+                                parent_column_name: column,
+                                parent_column_index: column_index,
+                            });
+                        } else if out.contains_key(column) {
+                            out.insert(format!("{column}_{column}"), value.clone());
+                        } else {
+                            out.insert(column.to_string(), value.clone());
+                        }
+                    }
+                    Value::List { vals: values, .. } => {
+                        if need_flatten && inner_table.is_some() {
+                            return vec![Value::error( ShellError::UnsupportedInput { msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(), input: "value originates from here".into(), msg_span: tag, input_span: span }, span)
+                            ];
+                        }
+
+                        if !columns.is_empty() {
+                            let cell_path =
+                                column_requested.and_then(|x| match x.members.first() {
+                                    Some(PathMember::String { val, span: _, .. }) => Some(val),
+                                    _ => None,
+                                });
+
+                            if let Some(r) = cell_path {
+                                inner_table = Some(TableInside::Entries(
+                                    r,
+                                    &tag,
+                                    values.iter().collect::<Vec<_>>(),
+                                    column_index,
+                                ));
+                            } else {
+                                out.insert(column.to_string(), value.clone());
+                            }
+                        } else {
+                            inner_table = Some(TableInside::Entries(
+                                column,
+                                &tag,
+                                values.iter().collect::<Vec<_>>(),
+                                column_index,
+                            ));
+                        }
+                    }
+                    _ => {
+                        out.insert(column.to_string(), value.clone());
                     }
                 }
-                _ => {
-                    out.insert(column.to_string(), value.clone());
-                }
             }
-        }
 
-        let mut expanded = vec![];
-        match inner_table {
-            Some(TableInside::Entries(column, _, entries, parent_column_index)) => {
-                for entry in entries {
-                    let base = out.clone();
-                    let mut record = Record::new();
-                    let mut index = 0;
-                    for (col, val) in base.into_iter() {
-                        // meet the flattened column, push them to result record first
-                        // this can avoid output column order changed.
+            let mut expanded = vec![];
+            match inner_table {
+                Some(TableInside::Entries(column, _, entries, parent_column_index)) => {
+                    for entry in entries {
+                        let base = out.clone();
+                        let mut record = Record::new();
+                        let mut index = 0;
+                        for (col, val) in base.into_iter() {
+                            // meet the flattened column, push them to result record first
+                            // this can avoid output column order changed.
+                            if index == parent_column_index {
+                                record.push(column, entry.clone());
+                            }
+                            record.push(col, val);
+                            index += 1;
+                        }
+                        // the flattened column may be the last column in the original table.
                         if index == parent_column_index {
                             record.push(column, entry.clone());
                         }
-                        record.push(col, val);
-                        index += 1;
+                        expanded.push(Value::record(record, tag));
                     }
-                    // the flattened column may be the last column in the original table.
-                    if index == parent_column_index {
-                        record.push(column, entry.clone());
-                    }
-                    expanded.push(Value::record(record, tag));
                 }
-            }
-            Some(TableInside::FlattenedRows {
-                columns,
-                _span,
-                values,
-                parent_column_name,
-                parent_column_index,
-            }) => {
-                for (inner_cols, inner_vals) in columns.into_iter().zip(values) {
-                    let base = out.clone();
-                    let mut record = Record::new();
-                    let mut index = 0;
+                Some(TableInside::FlattenedRows {
+                    columns,
+                    _span,
+                    values,
+                    parent_column_name,
+                    parent_column_index,
+                }) => {
+                    for (inner_cols, inner_vals) in columns.into_iter().zip(values) {
+                        let base = out.clone();
+                        let mut record = Record::new();
+                        let mut index = 0;
 
-                    for (base_col, base_val) in base.into_iter() {
-                        // meet the flattened column, push them to result record first
-                        // this can avoid output column order changed.
+                        for (base_col, base_val) in base.into_iter() {
+                            // meet the flattened column, push them to result record first
+                            // this can avoid output column order changed.
+                            if index == parent_column_index {
+                                for (col, val) in inner_cols.iter().zip(inner_vals.iter()) {
+                                    if record.contains(col) {
+                                        record.push(
+                                            format!("{parent_column_name}_{col}"),
+                                            val.clone(),
+                                        );
+                                    } else {
+                                        record.push(col, val.clone());
+                                    };
+                                }
+                            }
+
+                            record.push(base_col, base_val);
+                            index += 1;
+                        }
+
+                        // the flattened column may be the last column in the original table.
                         if index == parent_column_index {
                             for (col, val) in inner_cols.iter().zip(inner_vals.iter()) {
                                 if record.contains(col) {
                                     record.push(format!("{parent_column_name}_{col}"), val.clone());
                                 } else {
                                     record.push(col, val.clone());
-                                };
+                                }
                             }
                         }
-
-                        record.push(base_col, base_val);
-                        index += 1;
+                        expanded.push(Value::record(record, tag));
                     }
-
-                    // the flattened column may be the last column in the original table.
-                    if index == parent_column_index {
-                        for (col, val) in inner_cols.iter().zip(inner_vals.iter()) {
-                            if record.contains(col) {
-                                record.push(format!("{parent_column_name}_{col}"), val.clone());
-                            } else {
-                                record.push(col, val.clone());
-                            }
-                        }
-                    }
-                    expanded.push(Value::record(record, tag));
+                }
+                None => {
+                    expanded.push(Value::record(out.into_iter().collect(), tag));
                 }
             }
-            None => {
-                expanded.push(Value::record(out.into_iter().collect(), tag));
-            }
+            expanded
         }
-        expanded
-    } else if item.as_list().is_ok() {
-        if let Value::List { vals, .. } = item {
-            vals.to_vec()
-        } else {
-            vec![]
-        }
-    } else {
-        vec![item.clone()]
+        Value::List { vals, .. } => vals,
+        item => vec![item],
     }
 }
 

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -81,7 +81,7 @@ impl Command for Flatten {
             },
             Example {
                 description: "Flatten inner table",
-                example: "{ a: b, d: [ 1 2 3 4 ],  e: [ 4 3  ] } | flatten d --all",
+                example: "{ a: b, d: [ 1 2 3 4 ], e: [ 4 3 ] } | flatten d --all",
                 result: Some(Value::list(
                     vec![
                         Value::test_record(record! {
@@ -191,9 +191,17 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                         if all && vals.iter().all(|f| f.as_record().is_ok()) =>
                     {
                         if need_flatten && inner_table.is_some() {
-                            return vec![Value::error( ShellError::UnsupportedInput { msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(), input: "value originates from here".into(), msg_span: tag, input_span: span }, span)
-                                ];
+                            return vec![Value::error(
+                                ShellError::UnsupportedInput {
+                                    msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".into(),
+                                    input: "value originates from here".into(),
+                                    msg_span: tag,
+                                    input_span: span
+                                },
+                                span,
+                            )];
                         }
+
                         // it's a table (a list of record, we can flatten inner record)
                         let mut records = vec![];
 
@@ -222,8 +230,15 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                     }
                     Value::List { vals: values, .. } => {
                         if need_flatten && inner_table.is_some() {
-                            return vec![Value::error( ShellError::UnsupportedInput { msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".to_string(), input: "value originates from here".into(), msg_span: tag, input_span: span }, span)
-                            ];
+                            return vec![Value::error(
+                                ShellError::UnsupportedInput {
+                                    msg: "can only flatten one inner list at a time. tried flattening more than one column with inner lists... but is flattened already".into(),
+                                    input: "value originates from here".into(),
+                                    msg_span: tag,
+                                    input_span: span
+                                },
+                                span,
+                            )];
                         }
 
                         if !columns.is_empty() {


### PR DESCRIPTION
# Description
Refactors the `flatten` command to remove a bunch of cloning. This was down by passing ownership of the `Value` to `flat_value`, removing the lifetime on `TableInside`, and using `Vec<Record>` in `FlattenedRows` instead of a pair of `Vec` of columns and values.

For the quick benchmark below, it seems to be twice as fast now:
```nushell
let data = ls crates | where type == dir | each { ls $'($in.name)/**/*' }
timeit { for x in 0..1000 { $data | flatten } }
```
This took 550ms on v0.86.0 and only 230ms on this PR.
But considering that
```nushell
timeit { for x in 0..1000 { $data } }
```
takes 200ms on both versions, then the difference for `flatten` itself is really 250ms vs 30ms -- 8x faster.