### PR TITLE
Fix tests for cargo.exe check command

### DIFF
--- a/src/tests/test_known_external.rs
+++ b/src/tests/test_known_external.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use crate::tests::{fail_test, run_test, run_test_contains, TestResult};
 
 // cargo version prints a string of the form:
@@ -107,7 +109,8 @@ fn known_external_misc_values() -> TestResult {
 /// GitHub issue #7822
 #[test]
 fn known_external_subcommand_from_module() -> TestResult {
-    run_test_contains(
+    let output = Command::new("cargo").arg("check").arg("-h").output()?;
+    run_test(
         r#"
             module cargo {
                 export extern check []
@@ -115,14 +118,15 @@ fn known_external_subcommand_from_module() -> TestResult {
             use cargo;
             cargo check -h
         "#,
-        "cargo check",
+        String::from_utf8(output.stdout)?.trim(),
     )
 }
 
 /// GitHub issue #7822
 #[test]
 fn known_external_aliased_subcommand_from_module() -> TestResult {
-    run_test_contains(
+    let output = Command::new("cargo").arg("check").arg("-h").output()?;
+    run_test(
         r#"
             module cargo {
                 export extern check []
@@ -131,6 +135,6 @@ fn known_external_aliased_subcommand_from_module() -> TestResult {
             alias cc = cargo check;
             cc -h
         "#,
-        "cargo check",
+        String::from_utf8(output.stdout)?.trim(),
     )
 }


### PR DESCRIPTION
This pull request fixes the tests for the `cargo.exe check` command. The tests were failing due `cargo check -h` sometimes reporting `cargo.exe` as the binary and thus not containing `cargo check` in the output.

The fix involves using the `Command` module from the `std::process` library to run the command and comparing its output to the expected output. No changes were made to the codebase itself.