### PR TITLE
make reject support list input directly

### DIFF
--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -89,6 +89,7 @@ impl Command for Reject {
                                 };
                                 new_columns.push(cv.clone());
                             }
+                            Value::CellPath { val, .. } => new_columns.push(val),
                             y => {
                                 return Err(ShellError::CantConvert {
                                     to_type: "cell path".into(),
@@ -188,6 +189,15 @@ impl Command for Reject {
                 description: "Reject columns by a provided list of columns",
                 example: "let cols = [size type];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | reject $cols",
                 result: None
+            },
+            Example {
+                description: "Reject columns by a list of columns directly",
+                example: r#"[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | reject ["size", "type"]"#,
+                result: Some(Value::test_list(
+                    vec![
+                        Value::test_record(record! {"name" =>  Value::test_string("Cargo.toml")}),
+                        Value::test_record(record! {"name" => Value::test_string("Cargo.lock")})],
+                )),
             },
             Example {
                 description: "Reject rows by a provided list of rows",

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -93,6 +93,9 @@ produce a table, a list will produce a list, and a record will produce a record.
                                 };
                                 new_columns.push(cv.clone());
                             }
+                            Value::CellPath { val, .. } => {
+                                new_columns.push(val);
+                            }
                             y => {
                                 return Err(ShellError::CantConvert {
                                     to_type: "cell path".into(),
@@ -178,6 +181,15 @@ produce a table, a list will produce a list, and a record will produce a record.
                 description: "Select columns by a provided list of columns",
                 example: "let cols = [name type];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select $cols",
                 result: None
+            },
+            Example {
+                description: "Select columns by a provided list of columns",
+                example: r#"[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select ["name", "type"]"#,
+                result: Some(Value::test_list(
+                    vec![
+                        Value::test_record(record! {"name" => Value::test_string("Cargo.toml"), "type" => Value::test_string("type")}),
+                        Value::test_record(record! {"name" => Value::test_string("Cargo.lock"), "type" => Value::test_string("type")})],
+                ))
             },
             Example {
                 description: "Select rows by a provided list of rows",

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -187,8 +187,8 @@ produce a table, a list will produce a list, and a record will produce a record.
                 example: r#"[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select ["name", "type"]"#,
                 result: Some(Value::test_list(
                     vec![
-                        Value::test_record(record! {"name" => Value::test_string("Cargo.toml"), "type" => Value::test_string("type")}),
-                        Value::test_record(record! {"name" => Value::test_string("Cargo.lock"), "type" => Value::test_string("type")})],
+                        Value::test_record(record! {"name" => Value::test_string("Cargo.toml"), "type" => Value::test_string("toml")}),
+                        Value::test_record(record! {"name" => Value::test_string("Cargo.lock"), "type" => Value::test_string("toml")})],
                 ))
             },
             Example {


### PR DESCRIPTION
# Description
Fixes: #10895 

It's because `reject` and `select` command can't handle list of CellPath input directly.
After this pr, the following should be ok:
```nushell
❯ [{'a': 1, 'b': 2, 'c': 3}, {'a': 1, 'b': 2, 'c': 3}] | reject ['a', 'b']
╭───┬───╮
│ # │ c │
├───┼───┤
│ 0 │ 3 │
│ 1 │ 3 │
╰───┴───╯
❯ [{'a': 1, 'b': 2, 'c': 3}, {'a': 1, 'b': 2, 'c': 3}] | select ['a', 'b']
╭───┬───┬───╮
│ # │ a │ b │
├───┼───┼───┤
│ 0 │ 1 │ 2 │
│ 1 │ 1 │ 2 │
╰───┴───┴───╯
```
