### PR TITLE
Fix (http) get `HTTP_PROXY` from `$env`

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -28,7 +28,11 @@ pub enum BodyType {
 
 // Only panics if the user agent is invalid but we define it statically so either
 // it always or never fails
-pub fn http_client(allow_insecure: bool) -> ureq::Agent {
+pub fn http_client(
+    allow_insecure: bool,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+) -> ureq::Agent {
     let tls = native_tls::TlsConnector::builder()
         .danger_accept_invalid_certs(allow_insecure)
         .build()
@@ -38,7 +42,7 @@ pub fn http_client(allow_insecure: bool) -> ureq::Agent {
         .user_agent("nushell")
         .tls_connector(std::sync::Arc::new(tls));
 
-    if let Some(http_proxy) = retrieve_http_proxy_from_env() {
+    if let Some(http_proxy) = retrieve_http_proxy_from_env(engine_state, stack) {
         if let Ok(proxy) = ureq::Proxy::new(http_proxy) {
             agent_builder = agent_builder.proxy(proxy);
         }
@@ -645,10 +649,16 @@ pub fn request_handle_response_headers(
     }
 }
 
-fn retrieve_http_proxy_from_env() -> Option<String> {
-    std::env::vars()
-        .find(|(key, _)| key == "http_proxy")
-        .or(std::env::vars().find(|(key, _)| key == "HTTP_PROXY"))
-        .or(std::env::vars().find(|(key, _)| key == "ALL_PROXY"))
-        .map(|(_, value)| value)
+fn retrieve_http_proxy_from_env(engine_state: &EngineState, stack: &mut Stack) -> Option<String> {
+    let proxy_value: Option<Value> = stack
+        .get_env_var(engine_state, "http_proxy")
+        .or(stack.get_env_var(engine_state, "HTTP_PROXY"))
+        .or(stack.get_env_var(engine_state, "ALL_PROXY"));
+    match proxy_value {
+        Some(value) => match value.as_string() {
+            Ok(proxy) => Some(proxy),
+            _ => None,
+        },
+        _ => None,
+    }
 }

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -653,6 +653,8 @@ fn retrieve_http_proxy_from_env(engine_state: &EngineState, stack: &mut Stack) -
     let proxy_value: Option<Value> = stack
         .get_env_var(engine_state, "http_proxy")
         .or(stack.get_env_var(engine_state, "HTTP_PROXY"))
+        .or(stack.get_env_var(engine_state, "https_proxy"))
+        .or(stack.get_env_var(engine_state, "HTTPS_PROXY"))
         .or(stack.get_env_var(engine_state, "ALL_PROXY"));
     match proxy_value {
         Some(value) => match value.as_string() {

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -187,7 +187,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure);
+    let client = http_client(args.insecure, engine_state, stack);
     let mut request = client.delete(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -171,7 +171,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure);
+    let client = http_client(args.insecure, engine_state, stack);
     let mut request = client.get(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -132,12 +132,14 @@ fn run_head(
     };
     let ctrl_c = engine_state.ctrlc.clone();
 
-    helper(call, args, ctrl_c)
+    helper(engine_state, stack, call, args, ctrl_c)
 }
 
 // Helper function that actually goes to retrieve the resource from the url given
 // The Option<String> return a possible file extension which can be used in AutoConvert commands
 fn helper(
+    engine_state: &EngineState,
+    stack: &mut Stack,
     call: &Call,
     args: Arguments,
     ctrlc: Option<Arc<AtomicBool>>,
@@ -145,7 +147,7 @@ fn helper(
     let span = args.url.span();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure);
+    let client = http_client(args.insecure, engine_state, stack);
     let mut request = client.head(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -160,7 +160,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure);
+    let client = http_client(args.insecure, engine_state, stack);
     let mut request = client.request("OPTIONS", &requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -179,7 +179,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure);
+    let client = http_client(args.insecure, engine_state, stack);
     let mut request = client.patch(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -177,7 +177,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure);
+    let client = http_client(args.insecure, engine_state, stack);
     let mut request = client.post(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -177,7 +177,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure);
+    let client = http_client(args.insecure, engine_state, stack);
     let mut request = client.put(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;


### PR DESCRIPTION
# Description

This PR closes this [issue](https://github.com/nushell/nushell/issues/11025)

# User-Facing Changes

Setting the environment variable HTTP_PROXY using $env.HTTP_PROXY will work.

# Before

```bash
~> $env.HTTP_PROXY = http://127.0.0.1:7890 | http get https://lumtest.com/myip.json | get country
IR # (direct)
```

# After

```bash
~> $env.HTTP_PROXY = http://127.0.0.1:7890 | http get https://lumtest.com/myip.json | get country
DE # (with proxy)
```