### PR TITLE
Revert "add color-backtrace crate (#10942)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,16 +698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color-backtrace"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150fd80a270c0671379f388c8204deb6a746bb4eac8a6c03fe2460b2c0127ea0"
-dependencies = [
- "backtrace",
- "termcolor",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,7 +2648,6 @@ name = "nu"
 version = "0.86.1"
 dependencies = [
  "assert_cmd",
- "color-backtrace",
  "criterion",
  "crossterm 0.27.0",
  "ctrlc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ nu-utils = { path = "./crates/nu-utils", version = "0.86.1" }
 nu-ansi-term = "0.49.0"
 reedline = { version = "0.25.0", features = ["bashisms", "sqlite"] }
 
-color-backtrace = "0.6.1"
 crossterm = "0.27"
 ctrlc = "3.4"
 log = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,9 +59,6 @@ fn main() -> Result<()> {
         miette_hook(x);
     }));
 
-    // This allows more intuitive backtraces
-    color_backtrace::install();
-
     // Get initial current working directory.
     let init_cwd = get_init_cwd();
     let mut engine_state = get_engine_state();


### PR DESCRIPTION
The `color-backtrace` crate does not seem to either handle the terminal
modes well or operate in a way that the unwinding has not yet succeeded
to reach the backup disablement of the terminal raw mode in
`reedline::Reedline`'s `Drop` implementation.

This reverts commit d83887106378dfd1d77e94c4a51242f42ea336f3.

Fixes #11029
