### PR TITLE
fix custom command's default value

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3134,7 +3134,11 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                 // The = symbol separates a variable from its default value
                 else if contents == b"=" {
                     match parse_mode {
-                        ParseMode::ArgMode | ParseMode::TypeMode => {
+                        ParseMode::TypeMode => {
+                            arg_explicit_type = true;
+                            parse_mode = ParseMode::DefaultValueMode;
+                        }
+                        ParseMode::ArgMode => {
                             parse_mode = ParseMode::DefaultValueMode;
                         }
                         ParseMode::AfterCommaArgMode => {
@@ -3445,7 +3449,6 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         *arg = Some(syntax_shape);
                                     }
                                 }
-                                arg_explicit_type = true;
                             }
                             parse_mode = ParseMode::ArgMode;
                         }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3564,6 +3564,9 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     }
                                 }
                             }
+                            // after setting a default value, we'll go to new parameter
+                            // so `arg_explicit_type` should be false again.
+                            arg_explicit_type = false;
                             parse_mode = ParseMode::ArgMode;
                         }
                     }

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -82,6 +82,20 @@ fn custom_switch2() -> TestResult {
 }
 
 #[test]
+fn custom_switch3() -> TestResult {
+    run_test(
+        r#"def florb [
+            --age: int = 0,
+            --name = "foobar"
+        ] { 
+            ($age | into string) + $name
+        };
+        florb"#,
+        "0foobar",
+    )
+}
+
+#[test]
 fn simple_var_closing() -> TestResult {
     run_test("let $x = 10; def foo [] { $x }; foo", "10")
 }

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -85,13 +85,27 @@ fn custom_switch2() -> TestResult {
 fn custom_switch3() -> TestResult {
     run_test(
         r#"def florb [
-            --age: int = 0,
+            --age: int = 0
             --name = "foobar"
         ] { 
             ($age | into string) + $name
-        };
+        }
         florb"#,
         "0foobar",
+    )
+}
+
+#[test]
+fn custom_switch4() -> TestResult {
+    run_test(
+        r#"def florb [
+            --age: int
+            --name = "foobar"
+        ] {
+            ($age | into string) + $name
+        }
+        florb --age 3"#,
+        "3foobar",
     )
 }
 


### PR DESCRIPTION
# Description
Fixes: #11033

Sorry for the issue, it's a regression which introduce by this pr: #10456.
And this pr is going to fix it.

About the change: create a new field named `type_annotated` for `Arg::Flag` and `Arg::Signature` instead of `arg_explicit_type` variable.
When we meet a type in `TypeMode`, we set `type_annotated` field of the argument to be true, then we know that if the arg have a annotated type easily