### PR TITLE
Move to clearer reedline keyboard enhancement API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.25.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#973dbb5f5f2338c18c25ce951bfa42c8d8cacfdf"
+source = "git+https://github.com/sholderbach/reedline.git?branch=enhancement-handling#cde7c891ac3f62cdeae9b1d4b6b2607ea9e40126"
 dependencies = [
  "chrono",
  "crossterm 0.27.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.25.0"
-source = "git+https://github.com/sholderbach/reedline.git?branch=enhancement-handling#cde7c891ac3f62cdeae9b1d4b6b2607ea9e40126"
+source = "git+https://github.com/nushell/reedline.git?branch=main#879272643fd4ba3409429052aca9a8cd56ba3dab"
 dependencies = [
  "chrono",
  "crossterm 0.27.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/sholderbach/reedline.git", branch = "enhancement-handling" }
+reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 # uu_cp = { git = "https://github.com/uutils/coreutils.git", branch = "main" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+reedline = { git = "https://github.com/sholderbach/reedline.git", branch = "enhancement-handling" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 # uu_cp = { git = "https://github.com/uutils/coreutils.git", branch = "main" }
 


### PR DESCRIPTION
Go from the ill-defined `enable/disable` pairs to `.use_...` builders
This alleviates unclear properties when the underlying enhancements are
enabled. Now they are enabed when entering `Reedline::read_line` and
disabled when exiting that.

Furthermore allow setting `$env.config.use_kitty_protocol` to have an
effect when toggling during runtime. Previously it was only enabled when
receiving a value from `config.nu`. I kept the warning code there to not
pollute the log. We could move it into the REPL-loop if desired

Not sure if we should actively block the enabling of `bracketed_paste`
on Windows. Need to test what happens if it just doesn't do anything we
could remove the `cfg!` switch. At least for WSL2 Windows Terminal
already supports bracketed paste. `target_os = windows` is a bad
predictor for `conhost.exe`.

Depends on https://github.com/nushell/reedline/pull/659
(pointing to personal fork)

Closes https://github.com/nushell/nushell/issues/10982
Supersedes https://github.com/nushell/nushell/pull/10998
