### PR TITLE
Pin reedline to 0.26 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,8 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.25.0"
-source = "git+https://github.com/nushell/reedline.git?branch=main#879272643fd4ba3409429052aca9a8cd56ba3dab"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a093a20a6c473247c2e9971aaf4cedf9041bcd3f444dc7fad667d3b6b7a5fd"
 dependencies = [
  "chrono",
  "crossterm 0.27.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ nu-term-grid = { path = "./crates/nu-term-grid", version = "0.86.1" }
 nu-std = { path = "./crates/nu-std", version = "0.86.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.86.1" }
 nu-ansi-term = "0.49.0"
-reedline = { version = "0.25.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.26.0", features = ["bashisms", "sqlite"] }
 
 crossterm = "0.27"
 ctrlc = "3.4"
@@ -166,7 +166,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
+# reedline = { git = "https://github.com/nushell/reedline.git", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 # uu_cp = { git = "https://github.com/uutils/coreutils.git", branch = "main" }
 

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -25,7 +25,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.86.1" }
 nu-utils = { path = "../nu-utils", version = "0.86.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.86.1" }
 nu-ansi-term = "0.49.0"
-reedline = { version = "0.25.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.26.0", features = ["bashisms", "sqlite"] }
 
 chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.27"

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 nu-cli = { path = "../nu-cli", version = "0.86.1" }
 nu-parser = { path = "../nu-parser", version = "0.86.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.86.1" }
-reedline = { version = "0.25" }
+reedline = { version = "0.26" }
 
 lsp-types = "0.94.1"
 lsp-server = "0.7.4"


### PR DESCRIPTION
See full release notes:
https://github.com/nushell/reedline/releases/tag/v0.26.0
