### PR TITLE
Add support for type match patterns

### DIFF
--- a/crates/nu-command/tests/commands/match_.rs
+++ b/crates/nu-command/tests/commands/match_.rs
@@ -229,30 +229,29 @@ fn match_with_guard_no_expr_after_if() {
 
 #[test]
 fn match_typed_variables_int() {
-    let actual = nu!("match 4 { $s: string => { $s }, $x: int => { $x }, _ => { 0 } }");
+    let actual = nu!("match 4 { $s: string => { 'no' }, $x: int => { 'yes' }, _ => { 'what' } }");
 
-    assert_eq!(actual.out, "4");
+    assert_eq!(actual.out, "yes");
 }
 
 #[test]
 fn match_typed_variables_string() {
-    let actual = nu!("match 'hello' { $s: string => { $s }, $x: int => { $x }, _ => { 0 } }");
+    let actual =
+        nu!("match 'hello' { $s: string => { 'yes' }, $x: int => { 'no' }, _ => { 'what' } }");
 
-    assert_eq!(actual.out, "hello");
+    assert_eq!(actual.out, "yes");
 }
 
 #[test]
 fn match_typed_variables_int_with_guard() {
     let actual = nu!(
-        cwd: ".",
-        "match 12 { $s: string => { $s }, $x: int if (($x mod 2) == 0) => { 'even' }, $x: int => { 'odd' }, _ => { 'what' } }"
+        "match 12 { $s: string => { 'str' }, $x: int if (($x mod 2) == 0) => { 'even' }, $x: int => { 'odd' }, _ => { 'what' } }"
     );
 
     assert_eq!(actual.out, "even");
 
     let actual = nu!(
-        cwd: ".",
-        "match 13 { $s: string => { $s }, $x: int if (($x mod 2) == 0) => { 'even' }, $x: int => { 'odd' }, _ => { 'what' } }"
+        "match 13 { $s: string => { 'str' }, $x: int if (($x mod 2) == 0) => { 'even' }, $x: int => { 'odd' }, _ => { 'what' } }"
     );
 
     assert_eq!(actual.out, "odd");

--- a/crates/nu-command/tests/commands/match_.rs
+++ b/crates/nu-command/tests/commands/match_.rs
@@ -278,7 +278,7 @@ fn match_subtyping_list() {
 
     // lists are covariant
     let actual = nu!(
-        "match [1 2 3] { $s: number => { 'no' }, $x: list<string> => { 'yes' }, _ => { 'what' } }"
+        "match [1 2 3] { $s: number => { 'no' }, $x: list<number> => { 'yes' }, _ => { 'what' } }"
     );
 
     assert_eq!(actual.out, "yes");

--- a/crates/nu-command/tests/commands/match_.rs
+++ b/crates/nu-command/tests/commands/match_.rs
@@ -226,3 +226,34 @@ fn match_with_guard_no_expr_after_if() {
 
     assert!(actual.err.contains("Match guard without an expression"));
 }
+
+#[test]
+fn match_typed_variables_int() {
+    let actual = nu!("match 4 { $s: string => { $s }, $x: int => { $x }, _ => { 0 } }");
+
+    assert_eq!(actual.out, "4");
+}
+
+#[test]
+fn match_typed_variables_string() {
+    let actual = nu!("match 'hello' { $s: string => { $s }, $x: int => { $x }, _ => { 0 } }");
+
+    assert_eq!(actual.out, "hello");
+}
+
+#[test]
+fn match_typed_variables_int_with_guard() {
+    let actual = nu!(
+        cwd: ".",
+        "match 12 { $s: string => { $s }, $x: int if (($x mod 2) == 0) => { 'even' }, $x: int => { 'odd' }, _ => { 'what' } }"
+    );
+
+    assert_eq!(actual.out, "even");
+
+    let actual = nu!(
+        cwd: ".",
+        "match 13 { $s: string => { $s }, $x: int if (($x mod 2) == 0) => { 'even' }, $x: int => { 'odd' }, _ => { 'what' } }"
+    );
+
+    assert_eq!(actual.out, "odd");
+}

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -624,14 +624,13 @@ pub fn flatten_pattern(match_pattern: &MatchPattern) -> Vec<(Span, FlatShape)> {
         Pattern::Value(_) => {
             output.push((match_pattern.span, FlatShape::MatchPattern));
         }
-        Pattern::Type(_, var_id) => match var_id {
-            Some(var_id) => {
+        Pattern::Type(_, var_id) => {
+            output.push((match_pattern.span, FlatShape::MatchPattern));
+
+            if let Some(var_id) = var_id {
                 output.push((match_pattern.span, FlatShape::VarDecl(*var_id)));
             }
-            None => {
-                output.push((match_pattern.span, FlatShape::MatchPattern));
-            }
-        },
+        }
         Pattern::Variable(var_id) => {
             output.push((match_pattern.span, FlatShape::VarDecl(*var_id)));
         }

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -624,6 +624,14 @@ pub fn flatten_pattern(match_pattern: &MatchPattern) -> Vec<(Span, FlatShape)> {
         Pattern::Value(_) => {
             output.push((match_pattern.span, FlatShape::MatchPattern));
         }
+        Pattern::Type(_, var_id) => match var_id {
+            Some(var_id) => {
+                output.push((match_pattern.span, FlatShape::VarDecl(*var_id)));
+            }
+            None => {
+                output.push((match_pattern.span, FlatShape::MatchPattern));
+            }
+        },
         Pattern::Variable(var_id) => {
             output.push((match_pattern.span, FlatShape::VarDecl(*var_id)));
         }

--- a/crates/nu-parser/src/parse_patterns.rs
+++ b/crates/nu-parser/src/parse_patterns.rs
@@ -156,7 +156,7 @@ pub fn parse_opt_typed_variable_pattern(
 
     let type_name = working_set.get_span_contents(type_token.span).to_vec();
 
-    let typ = parse_type(working_set, type_name.as_slice(), span);
+    let typ = parse_type(working_set, type_name.as_slice(), type_token.span);
 
     MatchPattern {
         pattern: Pattern::Type(typ, Some(var_id)),

--- a/crates/nu-parser/src/parse_patterns.rs
+++ b/crates/nu-parser/src/parse_patterns.rs
@@ -154,9 +154,19 @@ pub fn parse_opt_typed_variable_pattern(
         return garbage(span);
     };
 
-    let type_name = working_set.get_span_contents(type_token.span).to_vec();
+    let last_token = iter.last();
 
-    let typ = parse_type(working_set, type_name.as_slice(), type_token.span);
+    let end = if let Some(last_token) = last_token {
+        last_token.span.end
+    } else {
+        type_token.span.end
+    };
+
+    let new_span = Span::new(type_token.span.start, end);
+
+    let type_name = working_set.get_span_contents(new_span).to_vec();
+
+    let typ = parse_type(working_set, type_name.as_slice(), new_span);
 
     MatchPattern {
         pattern: Pattern::Type(typ, Some(var_id)),

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4036,11 +4036,11 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
 
         let start = output[position].span.start;
 
-        // look for the either the next => or if
+        // look for the either the next "=>", "if" or "|"
         while position < output.len() {
             let contents = working_set.get_span_contents(output[position].span);
 
-            if contents == b"=>" || contents == b"if" {
+            if contents == b"=>" || contents == b"if" || contents == b"|" {
                 position -= 1;
                 break;
             }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4036,17 +4036,22 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
 
         let start = output[position].span.start;
 
-        // if next token is ':', then we include it as well as the next token
-        if position + 1 < output.len()
-            && working_set.get_span_contents(output[position + 1].span) == b":"
-        {
-            position += 2;
+        // look for the either the next => or if
+        while position < output.len() {
+            let contents = working_set.get_span_contents(output[position].span);
+
+            if contents == b"=>" || contents == b"if" {
+                position -= 1;
+                break;
+            }
+
+            position += 1;
         }
 
-        let end = output[position].span.end;
+        let pattern_span = Span::new(start, output[position].span.end);
 
         // First parse the pattern
-        let mut pattern = parse_pattern(working_set, Span::new(start, end));
+        let mut pattern = parse_pattern(working_set, pattern_span);
 
         position += 1;
 

--- a/crates/nu-protocol/src/ast/match_pattern.rs
+++ b/crates/nu-protocol/src/ast/match_pattern.rs
@@ -1,5 +1,5 @@
 use super::Expression;
-use crate::{Span, VarId};
+use crate::{Span, Type, VarId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -21,6 +21,7 @@ pub enum Pattern {
     List(Vec<MatchPattern>),
     Value(Expression),
     Variable(VarId),
+    Type(Type, Option<VarId>),
     Or(Vec<MatchPattern>),
     Rest(VarId), // the ..$foo pattern
     IgnoreRest,  // the .. pattern
@@ -43,6 +44,11 @@ impl Pattern {
                 }
             }
             Pattern::Variable(var_id) => output.push(*var_id),
+            Pattern::Type(_, var_id) => {
+                if let Some(var_id) = var_id {
+                    output.push(*var_id);
+                }
+            }
             Pattern::Or(patterns) => {
                 for pattern in patterns {
                     output.append(&mut pattern.variables());

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -45,6 +45,12 @@ impl Matcher for Pattern {
                 matches.push((*var_id, value.clone()));
                 true
             }
+            Pattern::Type(ty, var_id) => {
+                if let Some(var_id) = var_id {
+                    matches.push((*var_id, value.clone()));
+                }
+                value.get_type().is_subtype(ty)
+            }
             Pattern::List(items) => match &value {
                 Value::List { vals, .. } => {
                     if items.len() > vals.len() {


### PR DESCRIPTION
This pull request adds support for type match patterns, which allows users to match values based on their type. It includes changes to the `parse_pattern` function to handle typed variable patterns, as well as changes to the `Pattern` enum to support type patterns. Additionally, new tests have been added to ensure that type match patterns are working correctly.

```nu
match 4 { 
  $s: string => { 'we have a string' }, 
  $x: int => { 'we have a number' },
   _ => { 'what ?' } 
}
// we have a  number
```