### PR TITLE
Fix `rm` path handling

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -250,7 +250,7 @@ fn rm(
             Ok(files) => {
                 for file in files {
                     match file {
-                        Ok(ref f) => {
+                        Ok(f) => {
                             if !target_exists {
                                 target_exists = true;
                             }
@@ -263,7 +263,9 @@ fn rm(
                                 continue;
                             }
 
-                            all_targets.entry(f.clone()).or_insert_with(|| target.span);
+                            all_targets
+                                .entry(currentdir_path.join(f))
+                                .or_insert_with(|| target.span);
                         }
                         Err(e) => {
                             return Err(ShellError::GenericError(

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -264,7 +264,7 @@ fn rm(
                             }
 
                             all_targets
-                                .entry(currentdir_path.join(f))
+                                .entry(nu_path::expand_path_with(f, &currentdir_path))
                                 .or_insert_with(|| target.span);
                         }
                         Err(e) => {

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -375,6 +375,21 @@ fn removes_symlink() {
     });
 }
 
+#[test]
+fn removes_file_after_cd() {
+    Playground::setup("rm_after_cd", |dirs, sandbox| {
+        sandbox.with_files(vec![EmptyFile("delete.txt")]);
+
+        nu!(
+            cwd: dirs.root(),
+            "let file = 'delete.txt'; cd rm_after_cd; rm $file",
+        );
+
+        let path = dirs.test().join("delete.txt");
+        assert!(!path.exists());
+    })
+}
+
 struct Cleanup<'a> {
     dir_to_clean: &'a Path,
 }


### PR DESCRIPTION
# Description
Fixes issue #11061 where `rm` fails to find a file after a `cd`.  It looks like the new glob functions do not return absolute file paths which we forgot to account for.

# Tests
Added a test (fails on current main, but passes with this PR).
