### PR TITLE
Refactor `Value` cell path functions to fix bugs

### DIFF
--- a/crates/nu-command/tests/commands/insert.rs
+++ b/crates/nu-command/tests/commands/insert.rs
@@ -87,3 +87,17 @@ fn lazy_record_test_values() {
     );
     assert_eq!(actual.out, "3");
 }
+
+#[test]
+fn deep_cell_path_creates_all_nested_records() {
+    let actual = nu!(r#"{a: {}} | insert a.b.c 0 | get a.b.c"#);
+    assert_eq!(actual.out, "0");
+}
+
+#[test]
+fn inserts_all_rows_in_table_in_record() {
+    let actual = nu!(
+        r#"{table: [[col]; [{a: 1}], [{a: 1}]]} | insert table.col.b 2 | get table.col.b | to nuon"#
+    );
+    assert_eq!(actual.out, "[2, 2]");
+}

--- a/crates/nu-command/tests/commands/upsert.rs
+++ b/crates/nu-command/tests/commands/upsert.rs
@@ -90,3 +90,17 @@ fn upsert_support_lazy_record() {
         nu!(r#"let x = (lazy make -c ["h"] -g {|a| $a | str upcase}); $x | upsert aa 10 | get aa"#);
     assert_eq!(actual.out, "10");
 }
+
+#[test]
+fn deep_cell_path_creates_all_nested_records() {
+    let actual = nu!(r#"{a: {}} | insert a.b.c 0 | get a.b.c"#);
+    assert_eq!(actual.out, "0");
+}
+
+#[test]
+fn upserts_all_rows_in_table_in_record() {
+    let actual = nu!(
+        r#"{table: [[col]; [{a: 1}], [{a: 1}]]} | insert table.col.b 2 | get table.col.b | to nuon"#
+    );
+    assert_eq!(actual.out, "[2, 2]");
+}

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1144,15 +1144,17 @@ impl Value {
                                 Value::Record { val: record, .. } => {
                                     if let Some(val) = record.get_mut(col_name) {
                                         val.upsert_data_at_cell_path(path, new_val.clone())?;
-                                    } else if path.is_empty() {
-                                        record.push(col_name, new_val);
-                                        break;
                                     } else {
-                                        let mut new_col =
-                                            Value::record(Record::new(), new_val.span());
-                                        new_col.upsert_data_at_cell_path(path, new_val)?;
-                                        vals.push(new_col);
-                                        break;
+                                        let new_col = if path.is_empty() {
+                                            new_val.clone()
+                                        } else {
+                                            let mut new_col =
+                                                Value::record(Record::new(), new_val.span());
+                                            new_col
+                                                .upsert_data_at_cell_path(path, new_val.clone())?;
+                                            new_col
+                                        };
+                                        record.push(col_name, new_col);
                                     }
                                 }
                                 Value::Error { error, .. } => return Err(*error.clone()),
@@ -1177,7 +1179,6 @@ impl Value {
                                 new_col.upsert_data_at_cell_path(path, new_val)?;
                                 new_col
                             };
-
                             record.push(col_name, new_col);
                         }
                     }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -976,7 +976,7 @@ impl Value {
                                 span: *origin_span,
                             });
                         }
-                        Value::Error { error, .. } => return Err(*error.to_owned()),
+                        Value::Error { error, .. } => return Err(*error.clone()),
                         x => {
                             return Err(ShellError::IncompatiblePathAccess {
                                 type_name: format!("{}", x.get_type()),
@@ -1011,7 +1011,7 @@ impl Value {
                                 return Err(ShellError::DidYouMean(suggestion, *origin_span));
                             } else {
                                 return Err(ShellError::CantFindColumn {
-                                    col_name: column_name.to_string(),
+                                    col_name: column_name.clone(),
                                     span: *origin_span,
                                     src_span: span,
                                 });
@@ -1028,7 +1028,7 @@ impl Value {
                                 return Err(ShellError::DidYouMean(suggestion, *origin_span));
                             } else {
                                 return Err(ShellError::CantFindColumn {
-                                    col_name: column_name.to_string(),
+                                    col_name: column_name.clone(),
                                     span: *origin_span,
                                     src_span: span,
                                 });
@@ -1054,7 +1054,7 @@ impl Value {
                                         output.push(result);
                                     } else {
                                         return Err(ShellError::CantFindColumn {
-                                            col_name: column_name.to_string(),
+                                            col_name: column_name.clone(),
                                             span: *origin_span,
                                             src_span: val.span(),
                                         });
@@ -1063,7 +1063,7 @@ impl Value {
                                     output.push(Value::nothing(*origin_span));
                                 } else {
                                     return Err(ShellError::CantFindColumn {
-                                        col_name: column_name.to_string(),
+                                        col_name: column_name.clone(),
                                         span: *origin_span,
                                         src_span: val.span(),
                                     });
@@ -1078,7 +1078,7 @@ impl Value {
                         Value::Nothing { .. } if *optional => {
                             return Ok(Value::nothing(*origin_span)); // short-circuit
                         }
-                        Value::Error { error, .. } => return Err(*error.to_owned()),
+                        Value::Error { error, .. } => return Err(*error.clone()),
                         x => {
                             return Err(ShellError::IncompatiblePathAccess {
                                 type_name: format!("{}", x.get_type()),
@@ -1156,10 +1156,10 @@ impl Value {
                                         }
                                     }
                                 }
-                                Value::Error { error, .. } => return Err(*error.to_owned()),
+                                Value::Error { error, .. } => return Err(*error.clone()),
                                 v => {
                                     return Err(ShellError::CantFindColumn {
-                                        col_name: col_name.to_string(),
+                                        col_name: col_name.clone(),
                                         span: *span,
                                         src_span: v.span(),
                                     });
@@ -1194,10 +1194,10 @@ impl Value {
                         record.upsert_data_at_cell_path(cell_path, new_val)?;
                         *self = record;
                     }
-                    Value::Error { error, .. } => return Err(*error.to_owned()),
+                    Value::Error { error, .. } => return Err(*error.clone()),
                     v => {
                         return Err(ShellError::CantFindColumn {
-                            col_name: col_name.to_string(),
+                            col_name: col_name.clone(),
                             span: *span,
                             src_span: v.span(),
                         });
@@ -1220,7 +1220,7 @@ impl Value {
                             });
                         }
                     }
-                    Value::Error { error, .. } => return Err(*error.to_owned()),
+                    Value::Error { error, .. } => return Err(*error.clone()),
                     v => {
                         return Err(ShellError::NotAList {
                             dst_span: *span,
@@ -1283,16 +1283,16 @@ impl Value {
                                     }
                                     if !found {
                                         return Err(ShellError::CantFindColumn {
-                                            col_name: col_name.to_string(),
+                                            col_name: col_name.clone(),
                                             span: *span,
                                             src_span: v_span,
                                         });
                                     }
                                 }
-                                Value::Error { error, .. } => return Err(*error.to_owned()),
+                                Value::Error { error, .. } => return Err(*error.clone()),
                                 v => {
                                     return Err(ShellError::CantFindColumn {
-                                        col_name: col_name.to_string(),
+                                        col_name: col_name.clone(),
                                         span: *span,
                                         src_span: v.span(),
                                     });
@@ -1311,7 +1311,7 @@ impl Value {
                         }
                         if !found {
                             return Err(ShellError::CantFindColumn {
-                                col_name: col_name.to_string(),
+                                col_name: col_name.clone(),
                                 span: *span,
                                 src_span: v_span,
                             });
@@ -1323,10 +1323,10 @@ impl Value {
                         record.update_data_at_cell_path(cell_path, new_val)?;
                         *self = record;
                     }
-                    Value::Error { error, .. } => return Err(*error.to_owned()),
+                    Value::Error { error, .. } => return Err(*error.clone()),
                     v => {
                         return Err(ShellError::CantFindColumn {
-                            col_name: col_name.to_string(),
+                            col_name: col_name.clone(),
                             span: *span,
                             src_span: v.span(),
                         });
@@ -1347,7 +1347,7 @@ impl Value {
                             });
                         }
                     }
-                    Value::Error { error, .. } => return Err(*error.to_owned()),
+                    Value::Error { error, .. } => return Err(*error.clone()),
                     v => {
                         return Err(ShellError::NotAList {
                             dst_span: *span,
@@ -1383,7 +1383,7 @@ impl Value {
                                     Value::Record { val: record, .. } => {
                                         if record.remove(col_name).is_none() && !optional {
                                             return Err(ShellError::CantFindColumn {
-                                                col_name: col_name.to_string(),
+                                                col_name: col_name.clone(),
                                                 span: *span,
                                                 src_span: v_span,
                                             });
@@ -1391,7 +1391,7 @@ impl Value {
                                     }
                                     v => {
                                         return Err(ShellError::CantFindColumn {
-                                            col_name: col_name.to_string(),
+                                            col_name: col_name.clone(),
                                             span: *span,
                                             src_span: v.span(),
                                         });
@@ -1403,7 +1403,7 @@ impl Value {
                         Value::Record { val: record, .. } => {
                             if record.remove(col_name).is_none() && !optional {
                                 return Err(ShellError::CantFindColumn {
-                                    col_name: col_name.to_string(),
+                                    col_name: col_name.clone(),
                                     span: *span,
                                     src_span: v_span,
                                 });
@@ -1418,7 +1418,7 @@ impl Value {
                             Ok(())
                         }
                         v => Err(ShellError::CantFindColumn {
-                            col_name: col_name.to_string(),
+                            col_name: col_name.clone(),
                             span: *span,
                             src_span: v.span(),
                         }),
@@ -1473,7 +1473,7 @@ impl Value {
                                         }
                                         if !found && !optional {
                                             return Err(ShellError::CantFindColumn {
-                                                col_name: col_name.to_string(),
+                                                col_name: col_name.clone(),
                                                 span: *span,
                                                 src_span: v_span,
                                             });
@@ -1481,7 +1481,7 @@ impl Value {
                                     }
                                     v => {
                                         return Err(ShellError::CantFindColumn {
-                                            col_name: col_name.to_string(),
+                                            col_name: col_name.clone(),
                                             span: *span,
                                             src_span: v.span(),
                                         });
@@ -1501,7 +1501,7 @@ impl Value {
                             }
                             if !found && !optional {
                                 return Err(ShellError::CantFindColumn {
-                                    col_name: col_name.to_string(),
+                                    col_name: col_name.clone(),
                                     span: *span,
                                     src_span: v_span,
                                 });
@@ -1516,7 +1516,7 @@ impl Value {
                             Ok(())
                         }
                         v => Err(ShellError::CantFindColumn {
-                            col_name: col_name.to_string(),
+                            col_name: col_name.clone(),
                             span: *span,
                             src_span: v.span(),
                         }),
@@ -1573,7 +1573,7 @@ impl Value {
                                         if col == col_name {
                                             if cell_path.len() == 1 {
                                                 return Err(ShellError::ColumnAlreadyExists {
-                                                    col_name: col_name.to_string(),
+                                                    col_name: col_name.clone(),
                                                     span: *span,
                                                     src_span: v_span,
                                                 });
@@ -1607,7 +1607,7 @@ impl Value {
                             if col == col_name {
                                 if cell_path.len() == 1 {
                                     return Err(ShellError::ColumnAlreadyExists {
-                                        col_name: col_name.to_string(),
+                                        col_name: col_name.clone(),
                                         span: *span,
                                         src_span: v_span,
                                     });

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1049,7 +1049,6 @@ impl Value {
                                 .into_iter()
                                 .map(|val| {
                                     let val_span = val.span();
-                                    // only look in records; this avoids unintentionally recursing into deeply nested tables
                                     match val {
                                         Value::Record { val, .. } => {
                                             if let Some(found) = val.iter().rev().find(|x| {
@@ -1062,6 +1061,13 @@ impl Value {
                                                 Ok(found.1.clone()) // TODO: avoid clone here
                                             } else if *optional {
                                                 Ok(Value::nothing(*origin_span))
+                                            } else if let Some(suggestion) =
+                                                did_you_mean(val.columns(), column_name)
+                                            {
+                                                return Err(ShellError::DidYouMean(
+                                                    suggestion,
+                                                    *origin_span,
+                                                ));
                                             } else {
                                                 Err(ShellError::CantFindColumn {
                                                     col_name: column_name.clone(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -894,26 +894,6 @@ impl Value {
         }
     }
 
-    /// Check if the content is empty
-    pub fn is_empty(&self) -> bool {
-        match self {
-            Value::String { val, .. } => val.is_empty(),
-            Value::List { vals, .. } => vals.is_empty(),
-            Value::Record { val, .. } => val.is_empty(),
-            Value::Binary { val, .. } => val.is_empty(),
-            Value::Nothing { .. } => true,
-            _ => false,
-        }
-    }
-
-    pub fn is_nothing(&self) -> bool {
-        matches!(self, Value::Nothing { .. })
-    }
-
-    pub fn is_error(&self) -> bool {
-        matches!(self, Value::Error { .. })
-    }
-
     /// Follow a given cell path into the value: for example accessing select elements in a stream or list
     pub fn follow_cell_path(
         self,
@@ -1680,6 +1660,26 @@ impl Value {
             }
         }
         Ok(())
+    }
+
+    /// Check if the content is empty
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Value::String { val, .. } => val.is_empty(),
+            Value::List { vals, .. } => vals.is_empty(),
+            Value::Record { val, .. } => val.is_empty(),
+            Value::Binary { val, .. } => val.is_empty(),
+            Value::Nothing { .. } => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_nothing(&self) -> bool {
+        matches!(self, Value::Nothing { .. })
+    }
+
+    pub fn is_error(&self) -> bool {
+        matches!(self, Value::Error { .. })
     }
 
     pub fn is_true(&self) -> bool {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1540,13 +1540,27 @@ impl Value {
                                                 src_span: v_span,
                                             });
                                         } else {
-                                            return val.insert_data_at_cell_path(
-                                                path, new_val, head_span,
-                                            );
+                                            val.insert_data_at_cell_path(
+                                                path,
+                                                new_val.clone(),
+                                                head_span,
+                                            )?;
                                         }
+                                    } else {
+                                        let new_col = if path.is_empty() {
+                                            new_val.clone()
+                                        } else {
+                                            let mut new_col =
+                                                Value::record(Record::new(), new_val.span());
+                                            new_col.insert_data_at_cell_path(
+                                                path,
+                                                new_val.clone(),
+                                                head_span,
+                                            )?;
+                                            new_col
+                                        };
+                                        record.push(col_name, new_col);
                                     }
-
-                                    record.push(col_name, new_val.clone());
                                 }
                                 Value::Error { error, .. } => return Err(*error.clone()),
                                 _ => {
@@ -1569,11 +1583,22 @@ impl Value {
                                     src_span: v_span,
                                 });
                             } else {
-                                return val.insert_data_at_cell_path(path, new_val, head_span);
+                                val.insert_data_at_cell_path(path, new_val, head_span)?;
                             }
+                        } else {
+                            let new_col = if path.is_empty() {
+                                new_val.clone()
+                            } else {
+                                let mut new_col = Value::record(Record::new(), new_val.span());
+                                new_col.insert_data_at_cell_path(
+                                    path,
+                                    new_val.clone(),
+                                    head_span,
+                                )?;
+                                new_col
+                            };
+                            record.push(col_name, new_col);
                         }
-
-                        record.push(col_name, new_val);
                     }
                     Value::LazyRecord { val, .. } => {
                         // convert to Record first.

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1064,10 +1064,10 @@ impl Value {
                                             } else if let Some(suggestion) =
                                                 did_you_mean(val.columns(), column_name)
                                             {
-                                                return Err(ShellError::DidYouMean(
+                                                Err(ShellError::DidYouMean(
                                                     suggestion,
                                                     *origin_span,
-                                                ));
+                                                ))
                                             } else {
                                                 Err(ShellError::CantFindColumn {
                                                     col_name: column_name.clone(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1090,7 +1090,7 @@ impl Value {
                         Value::Nothing { .. } if *optional => {
                             return Ok(Value::nothing(*origin_span)); // short-circuit
                         }
-                        Value::Error { error, .. } => return Err(*error.clone()),
+                        Value::Error { error, .. } => return Err(*error),
                         x => {
                             return Err(ShellError::IncompatiblePathAccess {
                                 type_name: format!("{}", x.get_type()),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -977,7 +977,7 @@ impl Value {
                                 span: *origin_span,
                             });
                         }
-                        Value::Error { error, .. } => return Err(*error.clone()),
+                        Value::Error { error, .. } => return Err(*error),
                         x => {
                             return Err(ShellError::IncompatiblePathAccess {
                                 type_name: format!("{}", x.get_type()),


### PR DESCRIPTION
# Description
Slightly refactors the cell path functions (`insert_data_at_cell_path`, etc.) for `Value` to fix a few bugs and ensure consistent behavior. Namely, case (in)sensitivity now applies to lazy records just like it does for regular `Records`. Also, the insert behavior of `insert` and `upsert` now match, alongside fixing a few related bugs described below. Otherwise, a few places were changed to use the `Record` API.

# Tests
Added tests for two bugs:
- `{a: {}} | insert a.b.c 0`: before this PR, doesn't create the innermost record `c`.
- `{table: [[col]; [{a: 1}], [{a: 1}]]} | insert table.col.b 2`: before this PR, doesn't add the field `b: 2` to each row.