### PR TITLE
into binary -c: return 0 as single byte

### DIFF
--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -187,12 +187,14 @@ pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
             let val = if cfg!(target_endian = "little") {
                 match val.iter().rposition(|&x| x != 0) {
                     Some(idx) => &val[..idx + 1],
-                    None => &val,
+
+                    // all 0s should just return a single 0 byte
+                    None => &[0],
                 }
             } else {
                 match val.iter().position(|&x| x != 0) {
                     Some(idx) => &val[idx..],
-                    None => &val,
+                    None => &[0],
                 }
             };
 


### PR DESCRIPTION
# Description

The `into binary` command has a `-c` flag which strips any leading 0s in the most significant digits to represent the minimal number of bytes, rather than the system's complete in-memory representation of the input.

However, currently giving 0 as input results in eight 0 bytes even with the `-c` flag, which is inconsistent with the purpose of the flag.

```nu
❯ : 345678 | into binary
Length: 8 (0x8) bytes | printable whitespace ascii_other non_ascii
00000000:   4e 46 05 00  00 00 00 00                             NF•00000

❯ : 345678 | into binary -c
Length: 3 (0x3) bytes | printable whitespace ascii_other non_ascii
00000000:   4e 46 05

❯ : 0 | into binary
Length: 8 (0x8) bytes | printable whitespace ascii_other non_ascii
00000000:   00 00 00 00  00 00 00 00                             00000000

❯ : 0 | into binary -c
Length: 8 (0x8) bytes | printable whitespace ascii_other non_ascii
00000000:   00 00 00 00  00 00 00 00                             00000000
```

This change fixes this behavior so that if the entire input results in all 0 bytes, only a single 0 byte is returned.

```nu
❯ : ~/src/nushell/target/aarch64-linux-android/debug/nu -c '0 | into binar
y -c'
Length: 1 (0x1) bytes | printable whitespace ascii_other non_ascii
00000000:   00
```

# User-Facing Changes

Values which result in all null bytes will be truncated to a single byte when `-c` is given. This could potentially be considered a breaking change if this behavior was relied upon in some way.
