### PR TITLE
std: add cross platform null-device name

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -336,7 +336,7 @@ export def repeat [
     1..$n | each { $item }
 }
 
-# reutrn a null device file.
+# return a null device file.
 #
 # # Examples
 #     run a command and ignore it's stderr output

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -341,9 +341,9 @@ export def repeat [
 # # Examples
 #     run a command and ignore it's stderr output
 #     > cat xxx.txt e> (null-device)
-export def null-device []: any -> string {
-    if ((sys).host.name | str downcase) == "windows" {
-        "NUL"
+export def null-device []: nothing -> path {
+    if ($nu.os-info.name | str downcase) == "windows" {
+        '\\.\NUL'
     } else {
         "/dev/null"
     }

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -335,3 +335,16 @@ export def repeat [
 
     1..$n | each { $item }
 }
+
+# reutrn a null device file.
+#
+# # Examples
+#     run a command and ignore it's stderr output
+#     > cat xxx.txt e> (null-device)
+export def null-device []: any -> string {
+    if ((sys).host.name | str downcase) == "windows" {
+        "NUL"
+    } else {
+        "/dev/null"
+    }
+}


### PR DESCRIPTION
# Description
We have meet a discord discussion about cross platform `null-device`: https://discord.com/channels/601130461678272522/988303282931912704/1165966467095875624

I want the same feature too...And I think it's good enough to add it into `nu-std`.

Different to https://github.com/nushell/nu_scripts/pull/649/files, I think named it to `null-device`(the name comes from [wiki](https://en.wikipedia.org/wiki/Null_device)) is better than `null-stream`. 
