### PR TITLE
add "default" table theme

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -320,14 +320,20 @@ fn get_theme_flag(
     state: &EngineState,
     stack: &mut Stack,
 ) -> Result<Option<TableMode>, ShellError> {
-    call.get_flag(state, stack, "theme")?
+    let theme_name = call.get_flag(state, stack, "theme")?;
+    theme_name
+        .clone()
         .map(|theme: String| TableMode::from_str(&theme))
         .transpose()
         .map_err(|err| ShellError::CantConvert {
             to_type: String::from("theme"),
             from_type: String::from("string"),
             span: call.span(),
-            help: Some(String::from(err)),
+            help: Some(format!(
+                "{}, Found {}",
+                String::from(err),
+                theme_name.unwrap_or("".to_string())
+            )),
         })
 }
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -330,7 +330,7 @@ fn get_theme_flag(
             from_type: String::from("string"),
             span: call.span(),
             help: Some(format!(
-                "{}, Found {}",
+                "{}, but found '{}'.",
                 String::from(err),
                 theme_name.unwrap_or("".to_string())
             )),

--- a/crates/nu-protocol/src/config/table.rs
+++ b/crates/nu-protocol/src/config/table.rs
@@ -11,6 +11,7 @@ pub enum TableMode {
     Compact,
     WithLove,
     CompactDouble,
+    Default,
     #[default]
     Rounded,
     Reinforced,
@@ -35,6 +36,7 @@ impl FromStr for TableMode {
             "compact" => Ok(Self::Compact),
             "with_love" => Ok(Self::WithLove),
             "compact_double" => Ok(Self::CompactDouble),
+            "default" => Ok(Self::Rounded),
             "rounded" => Ok(Self::Rounded),
             "reinforced" => Ok(Self::Reinforced),
             "heavy" => Ok(Self::Heavy),
@@ -60,6 +62,7 @@ impl ReconstructVal for TableMode {
                 TableMode::Compact => "compact",
                 TableMode::WithLove => "with_love",
                 TableMode::CompactDouble => "compact_double",
+                TableMode::Default => "rounded",
                 TableMode::Rounded => "rounded",
                 TableMode::Reinforced => "reinforced",
                 TableMode::Heavy => "heavy",

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -182,6 +182,7 @@ pub fn load_theme(mode: TableMode) -> TableTheme {
         TableMode::Compact => TableTheme::compact(),
         TableMode::WithLove => TableTheme::with_love(),
         TableMode::CompactDouble => TableTheme::compact_double(),
+        TableMode::Default => TableTheme::rounded(),
         TableMode::Rounded => TableTheme::rounded(),
         TableMode::Reinforced => TableTheme::reinforced(),
         TableMode::Heavy => TableTheme::heavy(),


### PR DESCRIPTION
# Description

This PR fixes a minor bug that prevented this command from running.
```nushell
table --list | each {|r| print ($r); print (ls | first 3 | table --theme $r)}
```
Here's the output now of the first few themes.
![image](https://github.com/nushell/nushell/assets/343840/21bc8942-5106-4b6a-8905-e90d6cb9a153)

It prevented it from running because "default" wasn't a real table theme. Now "default" is a synonym of rounded.

Also tweaked the error message when a bad theme name is provided.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
