### PR TITLE
bump rust-toolchain to 1.72.1

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -304,8 +304,9 @@ fn highlight_terms_in_record_with_search_columns(
         let val_str = val.into_string("", config);
         let Some(term_str) = term_strs
             .iter()
-            .find(|term_str| contains_ignore_case(&val_str, term_str)) else {
-                continue;
+            .find(|term_str| contains_ignore_case(&val_str, term_str))
+        else {
+            continue;
         };
 
         let highlighted_str =

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -269,10 +269,10 @@ fn cd_permission_denied_folder() {
         sandbox.mkdir("banned");
         let actual = nu!(
             cwd: dirs.test(),
-            r#"
+            r"
                 icacls banned /deny BUILTIN\Administrators:F
                 cd banned
-            "#
+            "
         );
         assert!(actual.err.contains("Folder is not able to read"));
     });

--- a/crates/nu-command/tests/commands/path/parse.rs
+++ b/crates/nu-command/tests/commands/path/parse.rs
@@ -5,11 +5,11 @@ use nu_test_support::{nu, pipeline};
 fn parses_single_path_prefix() {
     let actual = nu!(
         cwd: "tests", pipeline(
-        r#"
+        r"
             echo 'C:\users\viking\spam.txt'
             | path parse
             | get prefix
-        "#
+        "
     ));
 
     assert_eq!(actual.out, "C:");

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -183,6 +183,7 @@ fn from_csv_text_with_tab_separator_to_table() {
 }
 
 #[test]
+#[allow(clippy::needless_raw_string_hashes)]
 fn from_csv_text_with_comments_to_table() {
     Playground::setup("filter_from_csv_test_5", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -106,6 +106,7 @@ fn from_tsv_text_to_table() {
 }
 
 #[test]
+#[allow(clippy::needless_raw_string_hashes)]
 fn from_tsv_text_with_comments_to_table() {
     Playground::setup("filter_from_tsv_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -969,9 +969,9 @@ fn get_name(psid: PSID) -> Option<(String, String)> {
         let ret = LookupAccountSidW(
             ptr::null::<u16>() as *mut u16,
             psid,
-            name.as_mut_ptr() as *mut u16,
+            name.as_mut_ptr(),
             &mut cc_name,
-            domainname.as_mut_ptr() as *mut u16,
+            domainname.as_mut_ptr(),
             &mut cc_domainname,
             &mut pe_use,
         );

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.71.1"
+channel = "1.72.1"

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -10,7 +10,7 @@ fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
 
 #[cfg(target_os = "windows")]
 fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
-    const VERBATIM_PREFIX: &str = r#"\\?\"#;
+    const VERBATIM_PREFIX: &str = r"\\?\";
     let p = p.as_ref().display().to_string();
     if let Some(stripped) = p.strip_prefix(VERBATIM_PREFIX) {
         stripped.to_string()


### PR DESCRIPTION
# Description

This PR follows our process of staying 2 releases behind rust. 1.74.0 was released today so we update to 1.72.1.

Reference https://releases.rs/

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
