### PR TITLE
Send only absolute paths to uu_cp

### DIFF
--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -201,6 +201,14 @@ impl Command for UCp {
             sources.append(&mut app_vals);
         }
 
+        // Make sure to send absolute paths to avoid uu_cp looking for cwd in std::env which is not
+        // supported in Nushell
+        for src in sources.iter_mut() {
+            if !src.is_absolute() {
+                *src = nu_path::expand_path_with(&src, &cwd);
+            }
+        }
+
         let options = uu_cp::Options {
             overwrite,
             reflink_mode,

--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -50,11 +50,11 @@ impl Command for UMkdir {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let path = current_dir(engine_state, stack)?;
+        let cwd = current_dir(engine_state, stack)?;
         let mut directories = call
             .rest::<String>(engine_state, stack, 0)?
             .into_iter()
-            .map(|dir| path.join(dir))
+            .map(|dir| nu_path::expand_path_with(dir, &cwd))
             .peekable();
 
         let is_verbose = call.has_flag("verbose");

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use nu_test_support::fs::file_contents;
 use nu_test_support::fs::{
     files_exist_at, AbsoluteFile,
@@ -5,7 +7,6 @@ use nu_test_support::fs::{
 };
 use nu_test_support::nu;
 use nu_test_support::playground::Playground;
-use std::path::Path;
 
 fn get_file_hash<T: std::fmt::Display>(file: T) -> String {
     nu!("open -r {} | to text | hash md5", file).out
@@ -127,9 +128,9 @@ fn copies_the_directory_inside_directory_if_path_to_copy_is_directory_and_with_r
             vec![
                 Path::new("yehuda.txt"),
                 Path::new("jttxt"),
-                Path::new("andres.txt")
+                Path::new("andres.txt"),
             ],
-            &expected_dir
+            &expected_dir,
         ));
     })
 }
@@ -175,15 +176,15 @@ fn deep_copies_with_recursive_flag_impl(progress: bool) {
         assert!(expected_dir.exists());
         assert!(files_exist_at(
             vec![Path::new("errors.txt"), Path::new("multishells.txt")],
-            jts_expected_copied_dir
+            jts_expected_copied_dir,
         ));
         assert!(files_exist_at(
             vec![Path::new("coverage.txt"), Path::new("commands.txt")],
-            andres_expected_copied_dir
+            andres_expected_copied_dir,
         ));
         assert!(files_exist_at(
             vec![Path::new("defer-evaluation.txt")],
-            yehudas_expected_copied_dir
+            yehudas_expected_copied_dir,
         ));
     })
 }
@@ -221,7 +222,7 @@ fn copies_using_path_with_wildcard_impl(progress: bool) {
                 Path::new("sgml_description.json"),
                 Path::new("utf16.ini"),
             ],
-            dirs.test()
+            dirs.test(),
         ));
 
         // Check integrity after the copy is done
@@ -266,7 +267,7 @@ fn copies_using_a_glob_impl(progress: bool) {
                 Path::new("sgml_description.json"),
                 Path::new("utf16.ini"),
             ],
-            dirs.test()
+            dirs.test(),
         ));
 
         // Check integrity after the copy is done
@@ -340,7 +341,7 @@ fn copy_files_using_glob_two_parents_up_using_multiple_dots_imp(progress: bool) 
                 "kevin.txt",
                 "many_more.ppl",
             ],
-            dirs.test()
+            dirs.test(),
         ));
     })
 }

--- a/crates/nu-command/tests/commands/cp.rs
+++ b/crates/nu-command/tests/commands/cp.rs
@@ -615,3 +615,18 @@ fn copy_file_with_update_flag_impl(progress: bool) {
         assert_eq!(actual.out, "newest_body");
     });
 }
+
+#[test]
+fn cp_with_cd() {
+    Playground::setup("cp_test_20", |_dirs, sandbox| {
+        sandbox
+            .mkdir("tmp_dir")
+            .with_files(vec![FileWithContent("tmp_dir/file.txt", "body")]);
+
+        let actual = nu!(
+            cwd: sandbox.cwd(),
+            r#"do { cd tmp_dir; let f = 'file.txt'; cp $f .. }; open file.txt"#,
+        );
+        assert!(actual.out.contains("body"));
+    });
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes https://github.com/nushell/nushell/issues/10832

Replaces: https://github.com/nushell/nushell/pull/10843

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
