### PR TITLE
Introduce `is` operator and Type literals

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -128,6 +128,7 @@ impl Highlighter for NuHighlighter {
                 FlatShape::Redirection => add_colored_token(&shape.1, next_token),
                 FlatShape::Custom(..) => add_colored_token(&shape.1, next_token),
                 FlatShape::MatchPattern => add_colored_token(&shape.1, next_token),
+                FlatShape::TypeLitteral => add_colored_token(&shape.1, next_token),
             }
             last_seen_span = shape.0.end;
         }
@@ -429,6 +430,7 @@ fn find_matching_block_end_in_expr(
                     None
                 }
             }
+            Expr::Type(_) => None,
         };
     }
     None

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -413,6 +413,13 @@ fn describe_value(
 
             Value::record(record, head)
         }
+        Value::TypeLiteral { val, .. } => Value::record(
+            record!(
+                "type" => Value::string("type", head),
+                "subtype" => Value::string(val.to_string(), head),
+            ),
+            head,
+        ),
     })
 }
 

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -282,6 +282,9 @@ impl<'a> std::fmt::Debug for DebuggableValue<'a> {
             Value::MatchPattern { val, .. } => {
                 write!(f, "MatchPattern({:?})", val)
             }
+            Value::TypeLiteral { val, .. } => {
+                write!(f, "Type({:?})", val)
+            }
         }
     }
 }

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -133,6 +133,7 @@ impl<'a> StyleComputer<'a> {
             | Value::Error { .. }
             | Value::LazyRecord { .. }
             | Value::MatchPattern { .. } => TextStyle::basic_left(),
+            Value::TypeLiteral { .. } => TextStyle::with_style(Left, s),
         }
     }
 

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -265,6 +265,7 @@ fn nu_value_to_string(value: Value, separator: &str) -> String {
         Value::CellPath { val, .. } => val.to_string(),
         Value::CustomValue { val, .. } => val.value_string(),
         Value::MatchPattern { val, .. } => format!("{:?}", val),
+        Value::TypeLiteral { val, .. } => format!("{:?}", val),
     }
 }
 

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -260,5 +260,6 @@ pub fn debug_string_without_formatting(value: &Value) -> String {
         Value::CellPath { val, .. } => val.to_string(),
         Value::CustomValue { val, .. } => val.value_string(),
         Value::MatchPattern { val, .. } => format!("{:?}", val),
+        Value::TypeLiteral { val, .. } => format!("{:?}", val),
     }
 }

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -518,6 +518,7 @@ fn value_should_be_printed(
         },
         Value::Binary { .. } => false,
         Value::MatchPattern { .. } => false,
+        Value::TypeLiteral { .. } => false,
     });
     if invert {
         match_found = !match_found;

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -496,6 +496,7 @@ fn convert_to_value(
             "variable declarations not supported in nuon".into(),
             expr.span,
         )),
+        Expr::Type(ty) => Ok(Value::type_litteral(ty.as_ref().clone(), span)),
     }
 }
 

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -149,6 +149,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
             let collected = val.to_base_value(span)?;
             value_to_json_value(&collected)?
         }
+        Value::TypeLiteral { val, .. } => nu_json::Value::String(val.to_string()),
     })
 }
 

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -287,6 +287,7 @@ pub fn value_to_string(
         // All strings outside data structures are quoted because they are in 'command position'
         // (could be mistaken for commands by the Nu parser)
         Value::String { val, .. } => Ok(escape_quote_string(val)),
+        Value::TypeLiteral { val, .. } => Ok(format!("type<{}>", val,)),
     }
 }
 

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -149,6 +149,7 @@ fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
         Value::CellPath { val, .. } => val.to_string(),
         Value::CustomValue { val, .. } => val.value_string(),
         Value::MatchPattern { val, .. } => format!("{:?}", val),
+        Value::TypeLiteral { val, .. } => format!("<Type {}>", val),
     }
 }
 

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -95,6 +95,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
         ),
         Value::CustomValue { .. } => toml::Value::String("<Custom Value>".to_string()),
         Value::MatchPattern { .. } => toml::Value::String("<Match Pattern>".to_string()),
+        Value::TypeLiteral { val, .. } => toml::Value::String(format!("<Type {}>", val)),
     })
 }
 

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -98,6 +98,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
         ),
         Value::CustomValue { .. } => serde_yaml::Value::Null,
         Value::MatchPattern { .. } => serde_yaml::Value::Null,
+        Value::TypeLiteral { val, .. } => serde_yaml::Value::String(val.to_string()),
     })
 }
 

--- a/crates/nu-command/src/help/help_operators.rs
+++ b/crates/nu-command/src/help/help_operators.rs
@@ -198,6 +198,13 @@ fn generate_operator_info() -> Vec<OperatorInfo> {
             precedence: 0,
         },
         OperatorInfo {
+            op_type: "Comparison".into(),
+            operator: "is".into(),
+            name: "Is".into(),
+            description: "Checks if a value is of a certain type.".into(),
+            precedence: 30,
+        },
+        OperatorInfo {
             op_type: "Math".into(),
             operator: "+".into(),
             name: "Plus".into(),

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -402,6 +402,7 @@ pub fn eval_expression(
                         }
                         Comparison::StartsWith => lhs.starts_with(op_span, &rhs, expr.span),
                         Comparison::EndsWith => lhs.ends_with(op_span, &rhs, expr.span),
+                        Comparison::Is => lhs.is_(op_span, &rhs, expr.span),
                     }
                 }
                 Operator::Bits(bits) => {
@@ -635,6 +636,7 @@ pub fn eval_expression(
         Expr::Signature(_) => Ok(Value::nothing(expr.span)),
         Expr::Garbage => Ok(Value::nothing(expr.span)),
         Expr::Nothing => Ok(Value::nothing(expr.span)),
+        Expr::Type(ty) => Ok(Value::type_litteral(ty.as_ref().clone(), expr.span)),
     }
 }
 

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -40,6 +40,7 @@ pub enum FlatShape {
     String,
     StringInterpolation,
     Table,
+    TypeLitteral,
     Variable(VarId),
     VarDecl(VarId),
 }
@@ -81,6 +82,7 @@ impl Display for FlatShape {
             FlatShape::Table => write!(f, "shape_table"),
             FlatShape::Variable(_) => write!(f, "shape_variable"),
             FlatShape::VarDecl(_) => write!(f, "shape_vardecl"),
+            FlatShape::TypeLitteral => write!(f, "shape_type_litteral"),
         }
     }
 }
@@ -500,6 +502,7 @@ pub fn flatten_expression(
         Expr::VarDecl(var_id) => {
             vec![(expr.span, FlatShape::VarDecl(*var_id))]
         }
+        Expr::Type(_) => vec![(expr.span, FlatShape::TypeLitteral)],
     }
 }
 

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -889,7 +889,7 @@ pub fn math_result_type(
                 }
             },
             Operator::Comparison(Comparison::Is) => match &rhs.ty {
-                Type::TypeLiteral(_) => (Type::Bool, None),
+                Type::TypeLiteral(_) | Type::Any => (Type::Bool, None),
                 _ => {
                     *op = Expression::garbage(op.span);
                     (

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -888,6 +888,23 @@ pub fn math_result_type(
                     )
                 }
             },
+            Operator::Comparison(Comparison::Is) => match &rhs.ty {
+                Type::TypeLiteral(_) => (Type::Bool, None),
+                _ => {
+                    *op = Expression::garbage(op.span);
+                    (
+                        Type::Any,
+                        Some(ParseError::UnsupportedOperationRHS(
+                            "type comparison".into(),
+                            op.span,
+                            lhs.span,
+                            lhs.ty.clone(),
+                            rhs.span,
+                            rhs.ty.clone(),
+                        )),
+                    )
+                }
+            },
             Operator::Bits(Bits::ShiftLeft)
             | Operator::Bits(Bits::ShiftRight)
             | Operator::Bits(Bits::BitOr)

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -2,7 +2,7 @@ use chrono::FixedOffset;
 use serde::{Deserialize, Serialize};
 
 use super::{Call, CellPath, Expression, FullCellPath, MatchPattern, Operator, RangeOperator};
-use crate::{ast::ImportPattern, BlockId, Signature, Span, Spanned, Unit, VarId};
+use crate::{ast::ImportPattern, BlockId, Signature, Span, Spanned, Type, Unit, VarId};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum Expr {
@@ -45,6 +45,7 @@ pub enum Expr {
     Signature(Box<Signature>),
     StringInterpolation(Vec<Expression>),
     MatchPattern(Box<MatchPattern>),
+    Type(Box<Type>),
     Nothing,
     Garbage,
 }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -56,6 +56,7 @@ impl Expression {
                     Operator::Boolean(Boolean::And) => 50,
                     Operator::Boolean(Boolean::Xor) => 45,
                     Operator::Boolean(Boolean::Or) => 40,
+                    Operator::Comparison(Comparison::Is) => 30,
                     Operator::Assignment(_) => 10,
                 }
             }
@@ -289,6 +290,7 @@ impl Expression {
             Expr::ValueWithUnit(expr, _) => expr.has_in_variable(working_set),
             Expr::Var(var_id) => *var_id == IN_VARIABLE_ID,
             Expr::VarDecl(_) => false,
+            Expr::Type(_) => false,
         }
     }
 
@@ -480,6 +482,7 @@ impl Expression {
                 }
             }
             Expr::VarDecl(_) => {}
+            Expr::Type(_) => {}
         }
     }
 
@@ -618,6 +621,7 @@ impl Expression {
             Expr::ValueWithUnit(expr, _) => expr.replace_span(working_set, replaced, new_span),
             Expr::Var(_) => {}
             Expr::VarDecl(_) => {}
+            Expr::Type(_) => {}
         }
     }
 }

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -19,6 +19,7 @@ pub enum Comparison {
     NotIn,
     StartsWith,
     EndsWith,
+    Is,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -89,6 +90,7 @@ impl Display for Operator {
             Operator::Comparison(Comparison::EndsWith) => write!(f, "ends-with"),
             Operator::Comparison(Comparison::In) => write!(f, "in"),
             Operator::Comparison(Comparison::NotIn) => write!(f, "not-in"),
+            Operator::Comparison(Comparison::Is) => write!(f, "is"),
             Operator::Math(Math::Plus) => write!(f, "+"),
             Operator::Math(Math::Append) => write!(f, "++"),
             Operator::Math(Math::Minus) => write!(f, "-"),

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -116,6 +116,9 @@ pub enum SyntaxShape {
     /// A table is allowed, eg `[[first, second]; [1, 2]]`
     Table(Vec<(String, SyntaxShape)>),
 
+    /// A Type literal, eg `int` or `string`
+    TypeLiteral(Box<SyntaxShape>),
+
     /// A variable with optional type, `x` or `x: int`
     VarWithOptType,
 }
@@ -177,6 +180,7 @@ impl SyntaxShape {
             SyntaxShape::String => Type::String,
             SyntaxShape::Table(columns) => Type::Table(mk_ty(columns)),
             SyntaxShape::VarWithOptType => Type::Any,
+            SyntaxShape::TypeLiteral(ty) => Type::TypeLiteral(Box::new(ty.to_type())),
         }
     }
 }
@@ -252,6 +256,7 @@ impl Display for SyntaxShape {
                 write!(f, "one_of({arg_string})")
             }
             SyntaxShape::Nothing => write!(f, "nothing"),
+            SyntaxShape::TypeLiteral(ty) => write!(f, "type<{ty}>"),
         }
     }
 }

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -33,6 +33,7 @@ pub enum Type {
     Signature,
     String,
     Table(Vec<(String, Type)>),
+    TypeLiteral(Box<Type>),
 }
 
 impl Type {
@@ -111,6 +112,7 @@ impl Type {
             Type::Custom(_) => SyntaxShape::Any,
             Type::Signature => SyntaxShape::Signature,
             Type::MatchPattern => SyntaxShape::MatchPattern,
+            Type::TypeLiteral(ty) => SyntaxShape::TypeLiteral(Box::new(ty.to_shape())),
         }
     }
 
@@ -141,6 +143,7 @@ impl Type {
             Type::Binary => String::from("binary"),
             Type::Custom(_) => String::from("custom"),
             Type::Signature => String::from("signature"),
+            Type::TypeLiteral(_) => String::from("type"),
         }
     }
 }
@@ -199,6 +202,7 @@ impl Display for Type {
             Type::Custom(custom) => write!(f, "{custom}"),
             Type::Signature => write!(f, "signature"),
             Type::MatchPattern => write!(f, "match-pattern"),
+            Type::TypeLiteral(ty) => write!(f, "type<{ty}>"),
         }
     }
 }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -343,6 +343,7 @@ impl Value {
                 }
             }),
             Value::Date { val, .. } => Ok(val.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)),
+            Value::TypeLiteral { val, .. } => Ok(val.to_string()),
             x => Err(ShellError::CantConvert {
                 to_type: "string".into(),
                 from_type: x.get_type().to_string(),
@@ -751,7 +752,7 @@ impl Value {
             Value::CellPath { val, .. } => val.to_string(),
             Value::CustomValue { val, .. } => val.value_string(),
             Value::MatchPattern { val, .. } => format!("<Pattern: {:?}>", val),
-            Value::TypeLiteral { val, .. } => format!("<Type: {}>", val),
+            Value::TypeLiteral { val, .. } => val.to_string(),
         }
     }
 
@@ -807,7 +808,7 @@ impl Value {
             Value::CellPath { val, .. } => val.to_string(),
             Value::CustomValue { val, .. } => val.value_string(),
             Value::MatchPattern { .. } => "<Pattern>".into(),
-            Value::TypeLiteral { val, .. } => format!("<Type: {}>", val),
+            Value::TypeLiteral { val, .. } => val.to_string(),
         }
     }
 
@@ -916,7 +917,7 @@ impl Value {
             Value::CellPath { val, .. } => val.to_string(),
             Value::CustomValue { val, .. } => val.value_string(),
             Value::MatchPattern { val, .. } => format!("<Pattern {:?}>", val),
-            Value::TypeLiteral { val, .. } => format!("<Type: {}>", val),
+            Value::TypeLiteral { val, .. } => val.to_string(),
         }
     }
 

--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -70,6 +70,7 @@ def get-all-operators [] { return [
     [Boolean, and, And, "Checks if two values are true.", 50]
     [Boolean, or, Or, "Checks if either value is true.", 40]
     [Boolean, xor, Xor, "Checks if one value is true and the other is false.", 45]
+    [Boolean, is, Is, "Checks if a value is of a certain type.", 30]
 ]}
 
 def "nu-complete list-aliases" [] {

--- a/src/tests/test_math.rs
+++ b/src/tests/test_math.rs
@@ -186,3 +186,32 @@ fn gte_null() -> TestResult {
     run_test("null >= 3 | to nuon", "null").unwrap();
     run_test("null >= null | to nuon", "null")
 }
+
+#[test]
+fn is_() -> TestResult {
+    run_test("1 is type<int>", "true").unwrap();
+    run_test("1 is type<number>", "true").unwrap();
+    run_test("1 is type<any>", "true").unwrap();
+    run_test("1 is type<string>", "false").unwrap();
+
+    run_test("'foo' is type<string>", "true").unwrap();
+    run_test("'foo' is type<any>", "true").unwrap();
+    run_test("'foo' is type<number>", "false").unwrap();
+
+    run_test("null is type<nothing>", "true").unwrap();
+    run_test("null is type<any>", "true").unwrap();
+
+    run_test("[1 2 3] is type<list>", "true").unwrap();
+    run_test("[1 2 3] is type<list<number>>", "true").unwrap();
+    run_test("[1 2 3] is type<list<int>>", "true").unwrap();
+    run_test("[1 2 3] is type<int>", "false").unwrap();
+
+    run_test("[] is type<list>", "true").unwrap();
+    run_test("[] is type<list<any>>", "true").unwrap();
+    run_test("[] is type<list<int>>", "false").unwrap();
+
+    run_test("{a: 1, b: 2} is type<record>", "true").unwrap();
+    run_test("{a: 1, b: 2} is type<record<a: int, b: int>>", "true").unwrap();
+
+    Ok(())
+}

--- a/src/tests/test_math.rs
+++ b/src/tests/test_math.rs
@@ -211,7 +211,7 @@ fn is_() -> TestResult {
     run_test("[] is type<list<int>>", "false").unwrap();
 
     run_test("{a: 1, b: 2} is type<record>", "true").unwrap();
-    run_test("{a: 1, b: 2} is type<record<a: int, b: int>>", "true").unwrap();
+    run_test("{a: 1, b: 2} is type<record<a:int,b:int>>", "true").unwrap();
 
     Ok(())
 }

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -248,10 +248,16 @@ def report [
 #
 # now the whole `toolkit check pr` passes! :tada:
 export def "check pr" [
-    --fast # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
-    --features: list<string> # the list of features to check the current PR on
+    --fast (-f) # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
+    --features (-F): list<string> # the list of features to check the current PR on
+    --all-features (-a) # check the current PR on all the features
 ] {
     $env.NU_TEST_LOCALE_OVERRIDE = 'en_US.utf8';
+    let features = if $all_features {
+        open Cargo.toml | get features | columns
+    } else {
+        $features
+    }
     try {
         fmt --check --verbose
     } catch {


### PR DESCRIPTION
# Description
This PR introduces a new `Value` type, **type literals** as well as an `is` operator. 

## Type Literals

Type literals can be considered as type names, similar to other languages. They can be specified using the `type<...>` syntax i.e `type<int>`. The type of a value can be obtained by using `$value | describe -d | get type`. **Don't hesitate to give your opinion on the matter so that I can make the required changes if need be.**

### Note

I would be in favour of changing `describe`'s behavior in favour of always returning the value type, but it's up to discussion as it would be a breaking change. That would allow people to used `$value | describe` to get the type of a value.

## The `is` operator

This operator, similarly to other languages, returns whether a value is the provided type, or one of its subtypes:

```nu
1 is type<int> # true
1 is type<number> # true
[1 2 3] is type<list<int>> # true
```

In combination with `describe` more complex type checking can be performed: 

```nu
[1 2 3] is ([4 5 6] | describe -d | get type) # true
```

# User-Facing Changes

* New `is` operator
* New `TypeLiteral` value type
* **Potentially** breaking changes on `describe` return type.
