### PR TITLE
Convert ShellError::CommandNotFound to named fields

### DIFF
--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -95,7 +95,7 @@ You can also learn more at https://www.nushell.sh/book/"#;
                 result
             };
 
-            let result = if let Err(ShellError::CommandNotFound(_)) = result {
+            let result = if let Err(ShellError::CommandNotFound { .. }) = result {
                 help_modules(engine_state, stack, call)
             } else {
                 result

--- a/crates/nu-command/src/help/help_commands.rs
+++ b/crates/nu-command/src/help/help_commands.rs
@@ -114,10 +114,9 @@ pub fn help_commands(
                     .into_pipeline_data(),
             )
         } else {
-            Err(ShellError::CommandNotFound(span(&[
-                rest[0].span,
-                rest[rest.len() - 1].span,
-            ])))
+            Err(ShellError::CommandNotFound {
+                span: span(&[rest[0].span, rest[rest.len() - 1].span]),
+            })
         }
     }
 }

--- a/crates/nu-command/src/help/help_externs.rs
+++ b/crates/nu-command/src/help/help_externs.rs
@@ -133,10 +133,9 @@ pub fn help_externs(
                     .into_pipeline_data(),
             )
         } else {
-            Err(ShellError::CommandNotFound(span(&[
-                rest[0].span,
-                rest[rest.len() - 1].span,
-            ])))
+            Err(ShellError::CommandNotFound {
+                span: span(&[rest[0].span, rest[rest.len() - 1].span]),
+            })
         }
     }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -795,10 +795,10 @@ fn eval_element_with_input(
                         )
                     })
                 } else {
-                    Err(ShellError::CommandNotFound(*span))
+                    Err(ShellError::CommandNotFound { span: *span })
                 }
             }
-            _ => Err(ShellError::CommandNotFound(*span)),
+            _ => Err(ShellError::CommandNotFound { span: *span }),
         },
         PipelineElement::SeparateRedirection {
             out: (out_span, out_expr),
@@ -842,14 +842,14 @@ fn eval_element_with_input(
                         )
                     })
                 } else {
-                    Err(ShellError::CommandNotFound(*out_span))
+                    Err(ShellError::CommandNotFound { span: *out_span })
                 }
             }
             (_out_other, err_other) => {
                 if let Expr::String(_) = err_other {
-                    Err(ShellError::CommandNotFound(*out_span))
+                    Err(ShellError::CommandNotFound { span: *out_span })
                 } else {
-                    Err(ShellError::CommandNotFound(*err_span))
+                    Err(ShellError::CommandNotFound { span: *err_span })
                 }
             }
         },

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -685,7 +685,10 @@ pub enum ShellError {
     /// Check the spelling for the requested command and try again. Are you sure it's defined and your configurations are loading correctly? Can you execute it?
     #[error("Command not found")]
     #[diagnostic(code(nu::shell::command_not_found))]
-    CommandNotFound(#[label("command not found")] Span),
+    CommandNotFound {
+        #[label("command not found")]
+        span: Span,
+    },
 
     /// This alias could not be found
     ///


### PR DESCRIPTION
# Description

Part of #10700

# User-Facing Changes

None

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A