### PR TITLE
deprecate `std clip`

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -149,7 +149,7 @@ export def clip [
     print $"Warning:   (char -u 26a0) (ansi yellow_bold)deprecated_command(ansi reset)"
     print "| the `std clip` command is deprecated and will be removed in Nushell 0.89"
     print ""
-    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`nu_plugin_clipboard`]\(https://github.com/FMotalleb/nu_plugin_clipboard\)(ansi reset)"
+    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`modules/system clip`]\(https://github.com/amtoine/nu_scripts/tree/main/modules#system\)(ansi reset)"
 
     let input = $input
         | if $expand { table --expand } else { table }

--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -144,12 +144,17 @@ export def clip [
     --expand (-e) # auto-expand the data given as input
     --codepage (-c): int  # the id of the codepage to use (only on Windows), see https://en.wikipedia.org/wiki/Windows_code_page, e.g. 65001 is for UTF-8
 ] {
-    let input = (
-        $in
+    let input = $in
+
+    print $"Warning:   (char -u 26a0) (ansi yellow_bold)deprecated_command(ansi reset)"
+    print "| the `std clip` command is deprecated and will be removed in Nushell 0.89"
+    print ""
+    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`nu_plugin_clipboard`]\(https://github.com/FMotalleb/nu_plugin_clipboard\)(ansi reset)"
+
+    let input = $input
         | if $expand { table --expand } else { table }
         | into string
         | if $no_strip {} else { ansi strip }
-    )
 
     match $nu.os-info.name {
         "linux" => {


### PR DESCRIPTION
related to 
- https://github.com/nushell/nushell/issues/11041
- https://github.com/nushell/nu_scripts/pull/674

cc/ @FMotalleb 

# Description
reading the [frontpage of the standard library](https://github.com/nushell/nushell/blob/main/crates/nu-std/README.md#--welcome-to-the-standard-library-of-nushell--) and according to the last Nushell meeting, i has been agreed that `std clip` does not belong to the standard library :open_mouth: 
- it is not written in pure Nushell and requires external dependencies which might not even work properly as in https://github.com/nushell/nushell/issues/11041
- it is not a building block to build more complex applications

this PR deprecates the `std clip` command in favor of [`modules/system clip`](https://github.com/nushell/nu_scripts/pull/674) for now.

the `std clip` command will be removed in Nushell 0.89.

# User-Facing Changes
the deprecation warning:
![std-clip-deprecation](https://github.com/nushell/nushell/assets/44101798/84bbdf3c-178c-4191-b0bf-9b1b25c229a2)
> **Note**
> the link has been changed to the `nu_scripts` in fa6c17da0 according to the review comments

# Tests + Formatting

# After Submitting
this will have to be mentionned in the next release note, namely the slight differences between the two commands.