### PR TITLE
Ansi as const

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -655,141 +655,10 @@ Operating system commands:
         engine_state: &EngineState,
         stack: &mut Stack,
         call: &Call,
-        _input: PipelineData,
+        input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let list: bool = call.has_flag("list");
-        let escape: bool = call.has_flag("escape");
-        let osc: bool = call.has_flag("osc");
-        let use_ansi_coloring = engine_state.get_config().use_ansi_coloring;
-
-        if list {
-            return generate_ansi_code_list(engine_state, call.head, use_ansi_coloring);
-        }
-
-        // The code can now be one of the ansi abbreviations like green_bold
-        // or it can be a record like this: { fg: "#ff0000" bg: "#00ff00" attr: bli }
-        // this record is defined in nu-color-config crate
-        let code: Value = match call.opt(engine_state, stack, 0)? {
-            Some(c) => c,
-            None => {
-                return Err(ShellError::MissingParameter {
-                    param_name: "code".into(),
-                    span: call.head,
-                })
-            }
-        };
-
-        let param_is_string = matches!(code, Value::String { .. });
-
-        if escape && osc {
-            return Err(ShellError::IncompatibleParameters {
-                left_message: "escape".into(),
-                left_span: call
-                    .get_named_arg("escape")
-                    .expect("Unexpected missing argument")
-                    .span,
-                right_message: "osc".into(),
-                right_span: call
-                    .get_named_arg("osc")
-                    .expect("Unexpected missing argument")
-                    .span,
-            });
-        }
-
-        let code_string = if param_is_string {
-            code.as_string().expect("error getting code as string")
-        } else {
-            "".to_string()
-        };
-
-        let param_is_valid_string = param_is_string && !code_string.is_empty();
-
-        if (escape || osc) && (param_is_valid_string) {
-            let code_vec: Vec<char> = code_string.chars().collect();
-            if code_vec[0] == '\\' {
-                let span = match call.get_flag_expr("escape") {
-                    Some(expr) => expr.span,
-                    None => call.head,
-                };
-
-                return Err(ShellError::TypeMismatch {
-                    err_message: "no need for escape characters".into(),
-                    span,
-                });
-            }
-        }
-
-        let output = if escape && param_is_valid_string {
-            format!("\x1b[{code_string}")
-        } else if osc && param_is_valid_string {
-            // Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
-            // OCS's need to end with either:
-            // bel '\x07' char
-            // string terminator aka st '\\' char
-            format!("\x1b]{code_string}")
-        } else if param_is_valid_string {
-            // parse hex colors like #00FF00
-            if code_string.starts_with('#') {
-                match nu_color_config::color_from_hex(&code_string) {
-                    Ok(color) => match color {
-                        Some(c) => c.prefix().to_string(),
-                        None => Color::White.prefix().to_string(),
-                    },
-                    Err(err) => {
-                        return Err(ShellError::GenericError(
-                            "error parsing hex color".to_string(),
-                            format!("{err}"),
-                            Some(code.span()),
-                            None,
-                            Vec::new(),
-                        ));
-                    }
-                }
-            } else {
-                match str_to_ansi(&code_string) {
-                    Some(c) => c,
-                    None => {
-                        return Err(ShellError::TypeMismatch {
-                            err_message: String::from("Unknown ansi code"),
-                            span: call
-                                .positional_nth(0)
-                                .expect("Unexpected missing argument")
-                                .span,
-                        })
-                    }
-                }
-            }
-        } else {
-            // This is a record that should look like
-            // { fg: "#ff0000" bg: "#00ff00" attr: bli }
-            let record = code.as_record()?;
-            // create a NuStyle to parse the information into
-            let mut nu_style = nu_color_config::NuStyle {
-                fg: None,
-                bg: None,
-                attr: None,
-            };
-            // Iterate and populate NuStyle with real values
-            for (k, v) in record {
-                match k.as_str() {
-                    "fg" => nu_style.fg = Some(v.as_string()?),
-                    "bg" => nu_style.bg = Some(v.as_string()?),
-                    "attr" => nu_style.attr = Some(v.as_string()?),
-                    _ => {
-                        return Err(ShellError::IncompatibleParametersSingle {
-                            msg: format!("unknown ANSI format key: expected one of ['fg', 'bg', 'attr'], found '{k}'"),
-                            span: code.span(),
-                        })
-                    }
-                }
-            }
-            // Now create a nu_ansi_term::Style from the NuStyle
-            let style = nu_color_config::parse_nustyle(nu_style);
-            // Return the prefix string. The prefix is the Ansi String. The suffix would be 0m, reset/stop coloring.
-            style.prefix().to_string()
-        };
-
-        Ok(Value::string(output, call.head).into_pipeline_data())
+        let code: Value = call.req(engine_state, stack, 0)?;
+        run(code, engine_state, call, input)
     }
 
     fn run_const(
@@ -798,121 +667,119 @@ Operating system commands:
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let list: bool = call.has_flag("list");
-        let escape: bool = call.has_flag("escape");
-        let osc: bool = call.has_flag("osc");
-        let use_ansi_coloring = engine_state.get_config().use_ansi_coloring;
+        let code: Value = call.req_const(working_set, 0)?;
+        run(code, working_set.permanent(), call, input)
+    }
+}
 
-        if list {
-            return generate_ansi_code_list(engine_state, call.head, use_ansi_coloring);
-        }
+fn run(
+    code: Value,
+    engine_state: &EngineState,
+    call: &Call,
+    _input: PipelineData,
+) -> Result<PipelineData, ShellError> {
+    let list: bool = call.has_flag("list");
+    let escape: bool = call.has_flag("escape");
+    let osc: bool = call.has_flag("osc");
+    let use_ansi_coloring = engine_state.get_config().use_ansi_coloring;
 
-        // The code can now be one of the ansi abbreviations like green_bold
-        // or it can be a record like this: { fg: "#ff0000" bg: "#00ff00" attr: bli }
-        // this record is defined in nu-color-config crate
-        let code: Value = match call.opt(engine_state, stack, 0)? {
-            Some(c) => c,
-            None => {
-                return Err(ShellError::MissingParameter {
-                    param_name: "code".into(),
-                    span: call.head,
-                })
-            }
-        };
+    if list {
+        return generate_ansi_code_list(engine_state, call.head, use_ansi_coloring);
+    }
 
-        let param_is_string = matches!(code, Value::String { .. });
+    let param_is_string = matches!(code, Value::String { .. });
 
-        if escape && osc {
-            return Err(ShellError::IncompatibleParameters {
-                left_message: "escape".into(),
-                left_span: call
-                    .get_named_arg("escape")
-                    .expect("Unexpected missing argument")
-                    .span,
-                right_message: "osc".into(),
-                right_span: call
-                    .get_named_arg("osc")
-                    .expect("Unexpected missing argument")
-                    .span,
+    if escape && osc {
+        return Err(ShellError::IncompatibleParameters {
+            left_message: "escape".into(),
+            left_span: call
+                .get_named_arg("escape")
+                .expect("Unexpected missing argument")
+                .span,
+            right_message: "osc".into(),
+            right_span: call
+                .get_named_arg("osc")
+                .expect("Unexpected missing argument")
+                .span,
+        });
+    }
+
+    let code_string = if param_is_string {
+        code.as_string().expect("error getting code as string")
+    } else {
+        "".to_string()
+    };
+
+    let param_is_valid_string = param_is_string && !code_string.is_empty();
+
+    if (escape || osc) && (param_is_valid_string) {
+        let code_vec: Vec<char> = code_string.chars().collect();
+        if code_vec[0] == '\\' {
+            let span = match call.get_flag_expr("escape") {
+                Some(expr) => expr.span,
+                None => call.head,
+            };
+
+            return Err(ShellError::TypeMismatch {
+                err_message: "no need for escape characters".into(),
+                span,
             });
         }
+    }
 
-        let code_string = if param_is_string {
-            code.as_string().expect("error getting code as string")
+    let output = if escape && param_is_valid_string {
+        format!("\x1b[{code_string}")
+    } else if osc && param_is_valid_string {
+        // Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
+        // OCS's need to end with either:
+        // bel '\x07' char
+        // string terminator aka st '\\' char
+        format!("\x1b]{code_string}")
+    } else if param_is_valid_string {
+        // parse hex colors like #00FF00
+        if code_string.starts_with('#') {
+            match nu_color_config::color_from_hex(&code_string) {
+                Ok(color) => match color {
+                    Some(c) => c.prefix().to_string(),
+                    None => Color::White.prefix().to_string(),
+                },
+                Err(err) => {
+                    return Err(ShellError::GenericError(
+                        "error parsing hex color".to_string(),
+                        format!("{err}"),
+                        Some(code.span()),
+                        None,
+                        Vec::new(),
+                    ));
+                }
+            }
         } else {
-            "".to_string()
-        };
-
-        let param_is_valid_string = param_is_string && !code_string.is_empty();
-
-        if (escape || osc) && (param_is_valid_string) {
-            let code_vec: Vec<char> = code_string.chars().collect();
-            if code_vec[0] == '\\' {
-                let span = match call.get_flag_expr("escape") {
-                    Some(expr) => expr.span,
-                    None => call.head,
-                };
-
-                return Err(ShellError::TypeMismatch {
-                    err_message: "no need for escape characters".into(),
-                    span,
-                });
+            match str_to_ansi(&code_string) {
+                Some(c) => c,
+                None => {
+                    return Err(ShellError::TypeMismatch {
+                        err_message: String::from("Unknown ansi code"),
+                        span: call
+                            .positional_nth(0)
+                            .expect("Unexpected missing argument")
+                            .span,
+                    })
+                }
             }
         }
-
-        let output = if escape && param_is_valid_string {
-            format!("\x1b[{code_string}")
-        } else if osc && param_is_valid_string {
-            // Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
-            // OCS's need to end with either:
-            // bel '\x07' char
-            // string terminator aka st '\\' char
-            format!("\x1b]{code_string}")
-        } else if param_is_valid_string {
-            // parse hex colors like #00FF00
-            if code_string.starts_with('#') {
-                match nu_color_config::color_from_hex(&code_string) {
-                    Ok(color) => match color {
-                        Some(c) => c.prefix().to_string(),
-                        None => Color::White.prefix().to_string(),
-                    },
-                    Err(err) => {
-                        return Err(ShellError::GenericError(
-                            "error parsing hex color".to_string(),
-                            format!("{err}"),
-                            Some(code.span()),
-                            None,
-                            Vec::new(),
-                        ));
-                    }
-                }
-            } else {
-                match str_to_ansi(&code_string) {
-                    Some(c) => c,
-                    None => {
-                        return Err(ShellError::TypeMismatch {
-                            err_message: String::from("Unknown ansi code"),
-                            span: call
-                                .positional_nth(0)
-                                .expect("Unexpected missing argument")
-                                .span,
-                        })
-                    }
-                }
-            }
-        } else {
-            // This is a record that should look like
-            // { fg: "#ff0000" bg: "#00ff00" attr: bli }
-            let record = code.as_record()?;
-            // create a NuStyle to parse the information into
-            let mut nu_style = nu_color_config::NuStyle {
-                fg: None,
-                bg: None,
-                attr: None,
-            };
-            // Iterate and populate NuStyle with real values
-            for (k, v) in record {
-                match k.as_str() {
+    } else {
+        // This is a record that should look like
+        // { fg: "#ff0000" bg: "#00ff00" attr: bli }
+        let record = code.as_record()?;
+        // create a NuStyle to parse the information into
+        let mut nu_style = nu_color_config::NuStyle {
+            fg: None,
+            bg: None,
+            attr: None,
+        };
+        // Iterate and populate NuStyle with real values
+        for (k, v) in record {
+            match k.as_str() {
                     "fg" => nu_style.fg = Some(v.as_string()?),
                     "bg" => nu_style.bg = Some(v.as_string()?),
                     "attr" => nu_style.attr = Some(v.as_string()?),
@@ -923,15 +790,14 @@ Operating system commands:
                         })
                     }
                 }
-            }
-            // Now create a nu_ansi_term::Style from the NuStyle
-            let style = nu_color_config::parse_nustyle(nu_style);
-            // Return the prefix string. The prefix is the Ansi String. The suffix would be 0m, reset/stop coloring.
-            style.prefix().to_string()
-        };
+        }
+        // Now create a nu_ansi_term::Style from the NuStyle
+        let style = nu_color_config::parse_nustyle(nu_style);
+        // Return the prefix string. The prefix is the Ansi String. The suffix would be 0m, reset/stop coloring.
+        style.prefix().to_string()
+    };
 
-        Ok(Value::string(output, call.head).into_pipeline_data())
-    }
+    Ok(Value::string(output, call.head).into_pipeline_data())
 }
 
 pub fn str_to_ansi(s: &str) -> Option<String> {

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -646,6 +646,10 @@ Operating system commands:
         vec!["text-color", "text-style", "colors"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -791,6 +791,147 @@ Operating system commands:
 
         Ok(Value::string(output, call.head).into_pipeline_data())
     }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let list: bool = call.has_flag("list");
+        let escape: bool = call.has_flag("escape");
+        let osc: bool = call.has_flag("osc");
+        let use_ansi_coloring = engine_state.get_config().use_ansi_coloring;
+
+        if list {
+            return generate_ansi_code_list(engine_state, call.head, use_ansi_coloring);
+        }
+
+        // The code can now be one of the ansi abbreviations like green_bold
+        // or it can be a record like this: { fg: "#ff0000" bg: "#00ff00" attr: bli }
+        // this record is defined in nu-color-config crate
+        let code: Value = match call.opt(engine_state, stack, 0)? {
+            Some(c) => c,
+            None => {
+                return Err(ShellError::MissingParameter {
+                    param_name: "code".into(),
+                    span: call.head,
+                })
+            }
+        };
+
+        let param_is_string = matches!(code, Value::String { .. });
+
+        if escape && osc {
+            return Err(ShellError::IncompatibleParameters {
+                left_message: "escape".into(),
+                left_span: call
+                    .get_named_arg("escape")
+                    .expect("Unexpected missing argument")
+                    .span,
+                right_message: "osc".into(),
+                right_span: call
+                    .get_named_arg("osc")
+                    .expect("Unexpected missing argument")
+                    .span,
+            });
+        }
+
+        let code_string = if param_is_string {
+            code.as_string().expect("error getting code as string")
+        } else {
+            "".to_string()
+        };
+
+        let param_is_valid_string = param_is_string && !code_string.is_empty();
+
+        if (escape || osc) && (param_is_valid_string) {
+            let code_vec: Vec<char> = code_string.chars().collect();
+            if code_vec[0] == '\\' {
+                let span = match call.get_flag_expr("escape") {
+                    Some(expr) => expr.span,
+                    None => call.head,
+                };
+
+                return Err(ShellError::TypeMismatch {
+                    err_message: "no need for escape characters".into(),
+                    span,
+                });
+            }
+        }
+
+        let output = if escape && param_is_valid_string {
+            format!("\x1b[{code_string}")
+        } else if osc && param_is_valid_string {
+            // Operating system command aka osc  ESC ] <- note the right brace, not left brace for osc
+            // OCS's need to end with either:
+            // bel '\x07' char
+            // string terminator aka st '\\' char
+            format!("\x1b]{code_string}")
+        } else if param_is_valid_string {
+            // parse hex colors like #00FF00
+            if code_string.starts_with('#') {
+                match nu_color_config::color_from_hex(&code_string) {
+                    Ok(color) => match color {
+                        Some(c) => c.prefix().to_string(),
+                        None => Color::White.prefix().to_string(),
+                    },
+                    Err(err) => {
+                        return Err(ShellError::GenericError(
+                            "error parsing hex color".to_string(),
+                            format!("{err}"),
+                            Some(code.span()),
+                            None,
+                            Vec::new(),
+                        ));
+                    }
+                }
+            } else {
+                match str_to_ansi(&code_string) {
+                    Some(c) => c,
+                    None => {
+                        return Err(ShellError::TypeMismatch {
+                            err_message: String::from("Unknown ansi code"),
+                            span: call
+                                .positional_nth(0)
+                                .expect("Unexpected missing argument")
+                                .span,
+                        })
+                    }
+                }
+            }
+        } else {
+            // This is a record that should look like
+            // { fg: "#ff0000" bg: "#00ff00" attr: bli }
+            let record = code.as_record()?;
+            // create a NuStyle to parse the information into
+            let mut nu_style = nu_color_config::NuStyle {
+                fg: None,
+                bg: None,
+                attr: None,
+            };
+            // Iterate and populate NuStyle with real values
+            for (k, v) in record {
+                match k.as_str() {
+                    "fg" => nu_style.fg = Some(v.as_string()?),
+                    "bg" => nu_style.bg = Some(v.as_string()?),
+                    "attr" => nu_style.attr = Some(v.as_string()?),
+                    _ => {
+                        return Err(ShellError::IncompatibleParametersSingle {
+                            msg: format!("unknown ANSI format key: expected one of ['fg', 'bg', 'attr'], found '{k}'"),
+                            span: code.span(),
+                        })
+                    }
+                }
+            }
+            // Now create a nu_ansi_term::Style from the NuStyle
+            let style = nu_color_config::parse_nustyle(nu_style);
+            // Return the prefix string. The prefix is the Ansi String. The suffix would be 0m, reset/stop coloring.
+            style.prefix().to_string()
+        };
+
+        Ok(Value::string(output, call.head).into_pipeline_data())
+    }
 }
 
 pub fn str_to_ansi(s: &str) -> Option<String> {

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -1,6 +1,6 @@
 use nu_ansi_term::*;
 use nu_engine::CallExt;
-use nu_protocol::engine::{EngineState, Stack};
+use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
 use nu_protocol::record;
 use nu_protocol::{
     ast::Call, engine::Command, Category, Example, IntoInterruptiblePipelineData, IntoPipelineData,


### PR DESCRIPTION
related to
- #10239

# Description
this PR makes `ansi` a parse-time constant command.

this mostly
- moves the `run` method of the command to a `run` function
- adds a `run_const` method to `Command`
- uses `call.req` and `call.req_const` to get the color `code`

# User-Facing Changes
this will allow things like
```nushell
const FOO = (ansi red)
```
or
```nushell
const BAR = $"(ansi blue)bar(ansi reset)"
```

# Tests + Formatting

# After Submitting
