### PR TITLE
Fix toolkit to run workspace on 'check pr' (issue #10906)

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -267,9 +267,17 @@ export def "check pr" [
     print $"running ('toolkit test' | pretty-format-command)"
     try {
         if $fast {
-            test --features $features --fast
+            if ($features | is-empty) {
+                test --workspace --fast
+            } else {
+                test --features $features --fast
+            }
         } else {
-            test --features $features
+            if ($features | is-empty) {
+                test --workspace
+            } else {
+                test --features $features
+            }
         }
     } catch {
         return (report --fail-test)


### PR DESCRIPTION
- Fixes #10906 

No rust  changes, just tookit.nu. When `check pr` is run, it should now run with the `--workspace` argument so all tests are run.