### PR TITLE
Bump `procfs` to 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,12 +2259,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
@@ -2885,6 +2879,7 @@ dependencies = [
  "pathdiff",
  "percent-encoding",
  "print-positions",
+ "procfs",
  "quick-xml",
  "quickcheck",
  "quickcheck_macros",
@@ -4156,17 +4151,28 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ca7f9f29bab5844ecd8fdb3992c5969b6622bb9609b9502fef9b4310e3f1f"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.4.1",
  "chrono",
  "flate2",
  "hex",
  "lazy_static",
- "rustix 0.36.17",
+ "procfs-core",
+ "rustix 0.38.21",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.4.1",
+ "chrono",
+ "hex",
 ]
 
 [[package]]
@@ -4570,20 +4576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "0.36.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305efbd14fde4139eb501df5f136994bb520b033fa9fbdce287507dc23b8c7ed"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.4",
- "windows-sys 0.45.0",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -106,6 +106,9 @@ libc = "0.2"
 umask = "2.1"
 nix = { version = "0.27", default-features = false, features = ["user"] }
 
+[target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android"), not(target_os = "ios")))'.dependencies]
+procfs = "0.16.0"
+
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
 optional = true
 version = "3.1"

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -14,6 +14,14 @@ use nu_protocol::{
     Category, Example, IntoInterruptiblePipelineData, PipelineData, Record, ShellError, Signature,
     Type, Value,
 };
+#[cfg(all(
+    unix,
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    not(target_os = "android"),
+    not(target_os = "ios")
+))]
+use procfs::WithCurrentSystemInfo;
 
 use std::time::Duration;
 
@@ -127,13 +135,11 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
                         Vec::new(),
                     )
                 })?;
-                let proc_start = match proc_stat.starttime() {
-                    Ok(t) => t,
-                    Err(_) => {
-                        // If we can't get the start time, just use the current time
-                        chrono::Local::now()
-                    }
-                };
+                // If we can't get the start time, just use the current time
+                let proc_start = proc_stat
+                    .starttime()
+                    .get()
+                    .unwrap_or_else(|_| chrono::Local::now());
                 record.push("start_time", Value::date(proc_start.into(), span));
                 record.push("user_id", Value::int(proc.curr_proc.owner() as i64, span));
                 // These work and may be helpful, but it just seemed crowded

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -21,7 +21,7 @@ sysinfo = "0.29"
 nix = { version = "0.27", default-features = false, features = ["fs", "term", "process", "signal"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-procfs = "0.15"
+procfs = "0.16"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc = "0.14"

--- a/crates/nu-system/src/linux.rs
+++ b/crates/nu-system/src/linux.rs
@@ -1,6 +1,6 @@
 use log::info;
 use procfs::process::{FDInfo, Io, Process, Stat, Status};
-use procfs::{ProcError, ProcessCgroup};
+use procfs::{ProcError, ProcessCGroups, WithCurrentSystemInfo};
 use std::path::PathBuf;
 use std::thread;
 use std::time::{Duration, Instant};
@@ -25,7 +25,7 @@ impl ProcessTask {
         }
     }
 
-    pub fn cgroups(&self) -> Result<Vec<ProcessCgroup>, ProcError> {
+    pub fn cgroups(&self) -> Result<ProcessCGroups, ProcError> {
         match self {
             ProcessTask::Process(x) => x.cgroups(),
             _ => Err(ProcError::Other("not supported".to_string())),
@@ -218,7 +218,7 @@ impl ProcessInfo {
     /// Memory size in number of bytes
     pub fn mem_size(&self) -> u64 {
         match self.curr_proc.stat() {
-            Ok(p) => p.rss_bytes(),
+            Ok(p) => p.rss_bytes().get(),
             Err(_) => 0,
         }
     }


### PR DESCRIPTION
Fix the breaking changes.
Get's rid of some outdated transitive dependencies.
Sadly we need to expose more of `procfs` to `nu-command` based on how
the features of `nu-system` are exposed right now.

Conditional compilation/dependencies from hell included

Supersedes #11101
