### PR TITLE
Convert ShellError::AliasNotFound to named fields

### DIFF
--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -89,7 +89,7 @@ You can also learn more at https://www.nushell.sh/book/"#;
         } else {
             let result = help_aliases(engine_state, stack, call);
 
-            let result = if let Err(ShellError::AliasNotFound(_)) = result {
+            let result = if let Err(ShellError::AliasNotFound { .. }) = result {
                 help_commands(engine_state, stack, call)
             } else {
                 result

--- a/crates/nu-command/src/help/help_aliases.rs
+++ b/crates/nu-command/src/help/help_aliases.rs
@@ -119,15 +119,15 @@ pub fn help_aliases(
         }
 
         let Some(alias) = engine_state.find_decl(name.as_bytes(), &[]) else {
-            return Err(ShellError::AliasNotFound(span(
-                &rest.iter().map(|r| r.span).collect::<Vec<Span>>(),
-            )));
+            return Err(ShellError::AliasNotFound {
+                span: span(&rest.iter().map(|r| r.span).collect::<Vec<Span>>()),
+            });
         };
 
         let Some(alias) = engine_state.get_decl(alias).as_alias() else {
-            return Err(ShellError::AliasNotFound(span(
-                &rest.iter().map(|r| r.span).collect::<Vec<Span>>(),
-            )));
+            return Err(ShellError::AliasNotFound {
+                span: span(&rest.iter().map(|r| r.span).collect::<Vec<Span>>()),
+            });
         };
 
         let alias_expansion =

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -701,7 +701,10 @@ pub enum ShellError {
     /// The alias does not exist in the current scope. It might exist in another scope or overlay or be hidden.
     #[error("Alias not found")]
     #[diagnostic(code(nu::shell::alias_not_found))]
-    AliasNotFound(#[label("alias not found")] Span),
+    AliasNotFound {
+        #[label("alias not found")]
+        span: Span,
+    },
 
     /// A flag was not found.
     #[error("Flag not found")]


### PR DESCRIPTION
# Description

Part of #10700

# User-Facing Changes

None

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A