### PR TITLE
Remove ShellError::FlagNotFound

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -703,12 +703,6 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::alias_not_found))]
     AliasNotFound(#[label("alias not found")] Span),
 
-    /// A flag was not found.
-    #[error("Flag not found")]
-    #[diagnostic(code(nu::shell::flag_not_found))]
-    // NOTE: Seems to be unused. Removable?
-    FlagNotFound(String, #[label("{0} not found")] Span),
-
     /// Failed to find a file during a nushell operation.
     ///
     /// ## Resolution


### PR DESCRIPTION
# Description

`ShellError::FlagNotFound` had a note that said it may be removable so this PR removes it instead of updating it to named fields per #10700

I can't see this error being used since it was introduced with #4364.  I can't find why or where it was used before that date, though.  There was a large merge with that PR but I can't penetrate the secrets of git to find out where its earlier history went.

# User-Facing Changes

None

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A