### PR TITLE
Convert PluginFailedToEncode to named fields

### DIFF
--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -339,7 +339,10 @@ pub fn serve_plugin(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
                                         PluginResponse::PluginData(name, PluginData { data, span })
                                     }
                                     Err(err) => PluginResponse::Error(
-                                        ShellError::PluginFailedToEncode(err.to_string()).into(),
+                                        ShellError::PluginFailedToEncode {
+                                            msg: err.to_string(),
+                                        }
+                                        .into(),
                                     ),
                                 },
                                 value => PluginResponse::Value(Box::new(value)),

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -88,7 +88,7 @@ impl From<ShellError> for LabeledError {
                 msg,
                 span: None,
             },
-            ShellError::PluginFailedToEncode(msg) => LabeledError {
+            ShellError::PluginFailedToEncode { msg } => LabeledError {
                 label: "Plugin failed to encode".into(),
                 msg,
                 span: None,

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -17,16 +17,18 @@ impl PluginEncoder for JsonSerializer {
         plugin_call: &crate::protocol::PluginCall,
         writer: &mut impl std::io::Write,
     ) -> Result<(), nu_protocol::ShellError> {
-        serde_json::to_writer(writer, plugin_call)
-            .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
+        serde_json::to_writer(writer, plugin_call).map_err(|err| ShellError::PluginFailedToEncode {
+            msg: err.to_string(),
+        })
     }
 
     fn decode_call(
         &self,
         reader: &mut impl std::io::BufRead,
     ) -> Result<crate::protocol::PluginCall, nu_protocol::ShellError> {
-        serde_json::from_reader(reader)
-            .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
+        serde_json::from_reader(reader).map_err(|err| ShellError::PluginFailedToEncode {
+            msg: err.to_string(),
+        })
     }
 
     fn encode_response(
@@ -34,16 +36,20 @@ impl PluginEncoder for JsonSerializer {
         plugin_response: &PluginResponse,
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError> {
-        serde_json::to_writer(writer, plugin_response)
-            .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
+        serde_json::to_writer(writer, plugin_response).map_err(|err| {
+            ShellError::PluginFailedToEncode {
+                msg: err.to_string(),
+            }
+        })
     }
 
     fn decode_response(
         &self,
         reader: &mut impl std::io::BufRead,
     ) -> Result<PluginResponse, ShellError> {
-        serde_json::from_reader(reader)
-            .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
+        serde_json::from_reader(reader).map_err(|err| ShellError::PluginFailedToEncode {
+            msg: err.to_string(),
+        })
     }
 }
 

--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -16,8 +16,11 @@ impl PluginEncoder for MsgPackSerializer {
         plugin_call: &crate::protocol::PluginCall,
         writer: &mut impl std::io::Write,
     ) -> Result<(), nu_protocol::ShellError> {
-        rmp_serde::encode::write(writer, plugin_call)
-            .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
+        rmp_serde::encode::write(writer, plugin_call).map_err(|err| {
+            ShellError::PluginFailedToEncode {
+                msg: err.to_string(),
+            }
+        })
     }
 
     fn decode_call(
@@ -33,8 +36,11 @@ impl PluginEncoder for MsgPackSerializer {
         plugin_response: &PluginResponse,
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError> {
-        rmp_serde::encode::write(writer, plugin_response)
-            .map_err(|err| ShellError::PluginFailedToEncode(err.to_string()))
+        rmp_serde::encode::write(writer, plugin_response).map_err(|err| {
+            ShellError::PluginFailedToEncode {
+                msg: err.to_string(),
+            }
+        })
     }
 
     fn decode_response(

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -741,9 +741,9 @@ pub enum ShellError {
     /// ## Resolution
     ///
     /// This is likely a bug with the plugin itself.
-    #[error("Plugin failed to encode: {0}")]
+    #[error("Plugin failed to encode: {msg}")]
     #[diagnostic(code(nu::shell::plugin_failed_to_encode))]
-    PluginFailedToEncode(String),
+    PluginFailedToEncode { msg: String },
 
     /// A message to a plugin failed to decode.
     ///


### PR DESCRIPTION
# Description

Part of #10700

# User-Facing Changes

None

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A