### PR TITLE
Convert PluginFailedToDecode to named fields

### DIFF
--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -320,7 +320,9 @@ pub fn serve_plugin(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
                                 .map(|custom_value| {
                                     Value::custom_value(custom_value, plugin_data.span)
                                 })
-                                .map_err(|err| ShellError::PluginFailedToDecode(err.to_string()))
+                                .map_err(|err| ShellError::PluginFailedToDecode {
+                                    msg: err.to_string(),
+                                })
                         }
                     };
 
@@ -353,7 +355,9 @@ pub fn serve_plugin(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
                 }
                 PluginCall::CollapseCustomValue(plugin_data) => {
                     let response = bincode::deserialize::<Box<dyn CustomValue>>(&plugin_data.data)
-                        .map_err(|err| ShellError::PluginFailedToDecode(err.to_string()))
+                        .map_err(|err| ShellError::PluginFailedToDecode {
+                            msg: err.to_string(),
+                        })
                         .and_then(|val| val.to_base_value(plugin_data.span))
                         .map(Box::new)
                         .map_err(LabeledError::from)

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -93,7 +93,7 @@ impl From<ShellError> for LabeledError {
                 msg,
                 span: None,
             },
-            ShellError::PluginFailedToDecode(msg) => LabeledError {
+            ShellError::PluginFailedToDecode { msg } => LabeledError {
                 label: "Plugin failed to decode".into(),
                 msg,
                 span: None,

--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -24,8 +24,9 @@ impl PluginEncoder for MsgPackSerializer {
         &self,
         reader: &mut impl std::io::BufRead,
     ) -> Result<crate::protocol::PluginCall, nu_protocol::ShellError> {
-        rmp_serde::from_read(reader)
-            .map_err(|err| ShellError::PluginFailedToDecode(err.to_string()))
+        rmp_serde::from_read(reader).map_err(|err| ShellError::PluginFailedToDecode {
+            msg: err.to_string(),
+        })
     }
 
     fn encode_response(
@@ -41,8 +42,9 @@ impl PluginEncoder for MsgPackSerializer {
         &self,
         reader: &mut impl std::io::BufRead,
     ) -> Result<PluginResponse, ShellError> {
-        rmp_serde::from_read(reader)
-            .map_err(|err| ShellError::PluginFailedToDecode(err.to_string()))
+        rmp_serde::from_read(reader).map_err(|err| ShellError::PluginFailedToDecode {
+            msg: err.to_string(),
+        })
     }
 }
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -750,9 +750,9 @@ pub enum ShellError {
     /// ## Resolution
     ///
     /// This is either an issue with the inputs to a plugin (bad JSON?) or a bug in the plugin itself. Fix or report as appropriate.
-    #[error("Plugin failed to decode: {0}")]
+    #[error("Plugin failed to decode: {msg}")]
     #[diagnostic(code(nu::shell::plugin_failed_to_decode))]
-    PluginFailedToDecode(String),
+    PluginFailedToDecode { msg: String },
 
     /// I/O operation interrupted.
     ///


### PR DESCRIPTION
# Description

Part of #10700

# User-Facing Changes

None

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A