### PR TITLE
add `list<string> -> string` to `last`

### DIFF
--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -20,7 +20,6 @@ impl Command for Last {
     fn signature(&self) -> Signature {
         Signature::build("last")
             .input_output_types(vec![
-                (Type::List(Box::new(Type::String)), Type::String),
                 (
                     // TODO: This variant duplicates the functionality of
                     // `take`. See #6611, #6611, #6893

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -21,15 +21,6 @@ impl Command for Last {
         Signature::build("last")
             .input_output_types(vec![
                 (
-                    // TODO: This variant duplicates the functionality of
-                    // `take`. See #6611, #6611, #6893
-                    // TODO: This is too permissive; if we could express this
-                    // using a type parameter style it would be List<T> ->
-                    // List<T>.
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-                (
                     // TODO: This is too permissive; if we could express this
                     // using a type parameter it would be List<T> -> T.
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -20,6 +20,7 @@ impl Command for Last {
     fn signature(&self) -> Signature {
         Signature::build("last")
             .input_output_types(vec![
+                (Type::List(Box::new(Type::String)), Type::String),
                 (
                     // TODO: This variant duplicates the functionality of
                     // `take`. See #6611, #6611, #6893


### PR DESCRIPTION
this should
- close https://github.com/nushell/nushell/issues/11134

# Description
this is band-aid...
but it should address the issue in https://github.com/nushell/nushell/issues/11134 until we have a better long-term fix for this i/o types bug :innocent: 

# User-Facing Changes
the following will now parse and run fine
```nushell
def get-initial-commit []: nothing -> string {
    ^git rev-list HEAD | lines | last
}
```

# Tests + Formatting

# After Submitting