### PR TITLE
Exit the release job if creating binary package failed

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -160,7 +160,13 @@ if $os in [$USE_UBUNTU, 'macos-latest'] {
     let archive = $'($dist)/($dest).tar.gz'
 
     mkdir $dest
-    $files | each {|it| mv $it $dest } | ignore
+    $files | each {|it|
+        if not ($it | path exists) {
+            print $'(ansi r)($it) not exists, abort...(ansi reset)'
+            exit 1
+        }
+        mv $it $dest
+    } | ignore
 
     print $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls $dest
 


### PR DESCRIPTION
Try to exit the job if creating binary package failed, related issue: https://github.com/nushell/nightly/issues/15
