### PR TITLE
deprecate `std testing`

### DIFF
--- a/crates/nu-std/std/testing.nu
+++ b/crates/nu-std/std/testing.nu
@@ -290,7 +290,7 @@ export def run-tests [
     print $"Warning:   (char -u 26a0) (ansi yellow_bold)deprecated_module(ansi reset)"
     print "| the `std testing run-tests` command is deprecated and will be removed in Nushell 0.90"
     print ""
-    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`modules/testing run-tests`]\(https://github.com/amtoine/nu_scripts/tree/main/modules#testing\)(ansi reset) or (ansi {fg: cyan, attr: du})[`nushell/nupm`]\(https://github.com/nushell/nupm\)(ansi reset)"
+    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`modules/testing run-tests`]\(https://github.com/nushell/nu_scripts/tree/main/modules#testing\)(ansi reset) or (ansi {fg: cyan, attr: du})[`nushell/nupm`]\(https://github.com/nushell/nupm\)(ansi reset)"
 
     let available_threads = (sys | get cpu | length)
 

--- a/crates/nu-std/std/testing.nu
+++ b/crates/nu-std/std/testing.nu
@@ -290,7 +290,7 @@ export def run-tests [
     print $"Warning:   (char -u 26a0) (ansi yellow_bold)deprecated_module(ansi reset)"
     print "| the `std testing run-tests` command is deprecated and will be removed in Nushell 0.90"
     print ""
-    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`modules/testing run-tests`]\(https://github.com/amtoine/nu_scripts/tree/main/modules#testing\)(ansi reset)"
+    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`modules/testing run-tests`]\(https://github.com/amtoine/nu_scripts/tree/main/modules#testing\)(ansi reset) or (ansi {fg: cyan, attr: du})[`nushell/nupm`]\(https://github.com/nushell/nupm\)(ansi reset)"
 
     let available_threads = (sys | get cpu | length)
 

--- a/crates/nu-std/std/testing.nu
+++ b/crates/nu-std/std/testing.nu
@@ -287,6 +287,10 @@ export def run-tests [
     --list,                               # list the selected tests without running them.
     --threads: int@"nu-complete threads", # Amount of threads to use for parallel execution. Default: All threads are utilized
 ] {
+    print $"Warning:   (char -u 26a0) (ansi yellow_bold)deprecated_module(ansi reset)"
+    print "| the `std testing run-tests` command is deprecated and will be removed in Nushell 0.90"
+    print ""
+    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`modules/testing run-tests`]\(https://github.com/amtoine/nu_scripts/tree/main/modules#testing\)(ansi reset)"
 
     let available_threads = (sys | get cpu | length)
 


### PR DESCRIPTION
# Description
this PR deprecates the `std testing` module in favor of Nupm.
the plan is to simply hide the module to the user but still use it internally when running the tests so that
- users don't start to use this module and rather focus on Nupm
- devs don't have to install anything to run the tests locally, they can just use `toolkit test stdlib` for instance

the deprecation message will be very similar to https://github.com/nushell/nushell/pull/11097

> **Note**
> to demonstrate that the removal of such a command from the exposed modules of `std` will be transparent and not require the user to install anything, i have it [prepared in a branch based on this PR](https://github.com/amtoine/nushell/compare/deprecate-std-testing...amtoine:nushell:hide-std-testing)
> running `toolkit test stdlib` will run the standard library tests without an issue and yet `use std testing` won't work :ok_hand: 

# User-Facing Changes
`std testing run-tests` will be removed in `0.90`

# Tests + Formatting

# After Submitting