### PR TITLE
Cp target expansion

### DIFF
--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -209,6 +209,8 @@ impl Command for UCp {
             }
         }
 
+        let target_path = nu_path::expand_path_with(&target_path, &cwd);
+
         let options = uu_cp::Options {
             overwrite,
             reflink_mode,

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -970,6 +970,21 @@ fn test_cp_with_vars() {
     });
 }
 
+#[test]
+fn test_cp_destination_after_cd() {
+    Playground::setup("ucp_test_34", |dirs, sandbox| {
+        sandbox.mkdir("test");
+        sandbox.with_files(vec![EmptyFile("test/file.txt")]);
+        nu!(
+        cwd: dirs.test(),
+            // Defining variable avoid path expansion of cp argument.
+            // If argument was not expanded ucp wrapper should do it
+        "cd test; let file = 'copy.txt'; cp file.txt $file",
+        );
+        assert!(dirs.test().join("test").join("copy.txt").exists());
+    });
+}
+
 #[rstest]
 #[case(r#"'a]c'"#)]
 #[case(r#"'a[c'"#)]


### PR DESCRIPTION
# Description
This PR addresses issue with cp brough up on [discord](https://discord.com/channels/601130461678272522/614593951969574961/1177669443917189130) where target of cp is not correctly expanded.
If one has directory `test` with file `file.txt` in it then the following command (in one line or inside a `do` block):
```nu
cd test; let file = 'copy.txt'; cp file.txt $file
```
will create a `copy.txt` in `.` not in `test` instead. This happens because target of `cp` is a variable which is not expanded unlike a string literal

# User-Facing Changes
`cp` will correctly parse realative target paths

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
