### PR TITLE
Bump `sysinfo` to 0.29.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5192,9 +5192,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.10"
+version = "0.29.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
+checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",


### PR DESCRIPTION
I discovered [a condition in which `sysinfo` would segfault](https://github.com/GuillaumeGomez/sysinfo/issues/1154), thereby causing nushell to segfault when the `sys` command was run (perhaps the cause of [this](https://github.com/nushell/nushell/issues/10987)). The segfault was fixed in `sysinfo`, I'm just bumping the version here.