### PR TITLE
Build `nu-protocol` docs with all features enabled

### DIFF
--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -39,3 +39,6 @@ strum = "0.25"
 strum_macros = "0.25"
 nu-test-support = { path = "../nu-test-support", version = "0.87.2" }
 rstest = "0.18"
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
# Description
Currently, `PluginSignature` does not appear on [`docs.rs`](https://docs.rs/nu-protocol/latest/nu_protocol/index.html), since it is behind the `plugin` feature which is not enabled by default. This PR adds [metadata](https://docs.rs/about/metadata) to the Cargo.toml to get `docs.rs` to build docs with all features enabled.
