### PR TITLE
Remove file I/O from tests that don't need it

### DIFF
--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -304,8 +304,9 @@ fn highlight_terms_in_record_with_search_columns(
         let val_str = val.into_string("", config);
         let Some(term_str) = term_strs
             .iter()
-            .find(|term_str| contains_ignore_case(&val_str, term_str)) else {
-                continue;
+            .find(|term_str| contains_ignore_case(&val_str, term_str))
+        else {
+            continue;
         };
 
         let highlighted_str =

--- a/crates/nu-command/tests/commands/compact.rs
+++ b/crates/nu-command/tests/commands/compact.rs
@@ -1,13 +1,8 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn discards_rows_where_given_column_is_empty() {
-    Playground::setup("compact_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_amigos.json",
-            r#"
+    let sample_json = r#"
                 {
                     "amigos": [
                         {"name":   "Yehuda", "rusty_luck": 1},
@@ -16,35 +11,30 @@ fn discards_rows_where_given_column_is_empty() {
                         {"name":"GorbyPuff"}
                     ]
                 }
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_tres_amigos.json
+    let actual = nu!(pipeline(&format!(
+        "
+                '{}' | from json
                 | get amigos
                 | compact rusty_luck
                 | length
-            "
-        ));
+            ",
+        sample_json
+    )));
 
-        assert_eq!(actual.out, "3");
-    });
+    assert_eq!(actual.out, "3");
 }
 #[test]
 fn discards_empty_rows_by_default() {
-    Playground::setup("compact_test_2", |dirs, _| {
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
+    let actual = nu!(pipeline(
+        r#"
                 echo "[1,2,3,14,null]"
                 | from json
                 | compact
                 | length
             "#
-        ));
+    ));
 
-        assert_eq!(actual.out, "4");
-    });
+    assert_eq!(actual.out, "4");
 }

--- a/crates/nu-command/tests/commands/compact.rs
+++ b/crates/nu-command/tests/commands/compact.rs
@@ -15,12 +15,11 @@ fn discards_rows_where_given_column_is_empty() {
 
     let actual = nu!(pipeline(&format!(
         "
-                '{}' | from json
+                {sample_json}
                 | get amigos
                 | compact rusty_luck
                 | length
-            ",
-        sample_json
+            "
     )));
 
     assert_eq!(actual.out, "3");

--- a/crates/nu-command/tests/commands/default.rs
+++ b/crates/nu-command/tests/commands/default.rs
@@ -15,13 +15,12 @@ fn adds_row_data_if_column_missing() {
 
     let actual = nu!(pipeline(&format!(
         "
-                {}
+                {sample}
                 | get amigos
                 | default 1 rusty_luck
                 | where rusty_luck == 1
                 | length
-            ",
-        sample
+            "
     )));
 
     assert_eq!(actual.out, "2");

--- a/crates/nu-command/tests/commands/default.rs
+++ b/crates/nu-command/tests/commands/default.rs
@@ -1,13 +1,8 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn adds_row_data_if_column_missing() {
-    Playground::setup("default_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_amigos.json",
-            r#"
+    let sample = r#"
                 {
                     "amigos": [
                         {"name":   "Yehuda"},
@@ -16,22 +11,20 @@ fn adds_row_data_if_column_missing() {
                         {"name":"GorbyPuff"}
                     ]
                 }
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_tres_amigos.json
+    let actual = nu!(pipeline(&format!(
+        "
+                {}
                 | get amigos
                 | default 1 rusty_luck
                 | where rusty_luck == 1
                 | length
-            "
-        ));
+            ",
+        sample
+    )));
 
-        assert_eq!(actual.out, "2");
-    });
+    assert_eq!(actual.out, "2");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -59,8 +59,7 @@ fn flatten_row_column_explicitly() {
             "#;
 
     let actual = nu!(pipeline(&format!(
-        "{} | flatten people --all | where name == Andres | length",
-        sample
+        "{sample} | flatten people --all | where name == Andres | length"
     )));
 
     assert_eq!(actual.out, "1");
@@ -88,8 +87,7 @@ fn flatten_row_columns_having_same_column_names_flats_separately() {
             "#;
 
     let actual = nu!(pipeline(&format!(
-        "{} | flatten --all | flatten people city | get city_name | length",
-        sample
+        "{sample} | flatten --all | flatten people city | get city_name | length"
     )));
 
     assert_eq!(actual.out, "4");
@@ -117,8 +115,7 @@ fn flatten_table_columns_explicitly() {
             "#;
 
     let actual = nu!(pipeline(&format!(
-        "{} | flatten city --all | where people.name == Katz | length",
-        sample
+        "{sample} | flatten city --all | where people.name == Katz | length",
     )));
 
     assert_eq!(actual.out, "2");
@@ -147,7 +144,7 @@ fn flatten_more_than_one_column_that_are_subtables_not_supported() {
                 ]
             "#;
 
-    let actual = nu!(pipeline(&format!("{} | flatten tags city --all", sample)));
+    let actual = nu!(pipeline(&format!("{sample} | flatten tags city --all")));
 
     assert!(actual.err.contains("tried flattening"));
     assert!(actual.err.contains("but is flattened already"));

--- a/crates/nu-command/tests/commands/flatten.rs
+++ b/crates/nu-command/tests/commands/flatten.rs
@@ -1,5 +1,3 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
@@ -43,10 +41,7 @@ fn flatten_nested_tables() {
 
 #[test]
 fn flatten_row_column_explicitly() {
-    Playground::setup("flatten_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "katz.json",
-            r#"
+    let sample = r#"
                 [
                     {
                         "people": {
@@ -61,24 +56,19 @@ fn flatten_row_column_explicitly() {
                         }
                     }
                 ]
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(),
-            "open katz.json | flatten people --all | where name == Andres | length"
-        );
+    let actual = nu!(pipeline(&format!(
+        "{} | flatten people --all | where name == Andres | length",
+        sample
+    )));
 
-        assert_eq!(actual.out, "1");
-    })
+    assert_eq!(actual.out, "1");
 }
 
 #[test]
 fn flatten_row_columns_having_same_column_names_flats_separately() {
-    Playground::setup("flatten_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "katz.json",
-            r#"
+    let sample = r#"
                 [
                     {
                         "people": {
@@ -95,24 +85,19 @@ fn flatten_row_columns_having_same_column_names_flats_separately() {
                         "city": [{"name": "Oregon"}, {"name": "Brooklin"}]
                     }
                 ]
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(),
-            "open katz.json | flatten --all | flatten people city | get city_name | length"
-        );
+    let actual = nu!(pipeline(&format!(
+        "{} | flatten --all | flatten people city | get city_name | length",
+        sample
+    )));
 
-        assert_eq!(actual.out, "4");
-    })
+    assert_eq!(actual.out, "4");
 }
 
 #[test]
 fn flatten_table_columns_explicitly() {
-    Playground::setup("flatten_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "katz.json",
-            r#"
+    let sample = r#"
                 [
                     {
                         "people": {
@@ -129,24 +114,19 @@ fn flatten_table_columns_explicitly() {
                         "city": ["Oregon", "Brooklin"]
                     }
                 ]
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(),
-            "open katz.json | flatten city --all | where people.name == Katz | length"
-        );
+    let actual = nu!(pipeline(&format!(
+        "{} | flatten city --all | where people.name == Katz | length",
+        sample
+    )));
 
-        assert_eq!(actual.out, "2");
-    })
+    assert_eq!(actual.out, "2");
 }
 
 #[test]
 fn flatten_more_than_one_column_that_are_subtables_not_supported() {
-    Playground::setup("flatten_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "katz.json",
-            r#"
+    let sample = r#"
                 [
                     {
                         "people": {
@@ -165,15 +145,10 @@ fn flatten_more_than_one_column_that_are_subtables_not_supported() {
                         "city": ["Oregon", "Brooklin"]
                     }
                 ]
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(),
-            "open katz.json | flatten tags city --all"
-        );
+    let actual = nu!(pipeline(&format!("{} | flatten tags city --all", sample)));
 
-        assert!(actual.err.contains("tried flattening"));
-        assert!(actual.err.contains("but is flattened already"));
-    })
+    assert!(actual.err.contains("tried flattening"));
+    assert!(actual.err.contains("but is flattened already"));
 }

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -11,12 +11,11 @@ fn groups() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | group-by rusty_at
                 | get "10/11/2013"
                 | length
-            "#,
-        sample
+            "#
     )));
 
     assert_eq!(actual.out, "2");
@@ -48,11 +47,10 @@ fn errors_if_given_unknown_column_name() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                '{}'
+                '{sample}'
                 | from json
                 | group-by {{|| get nu.releases.version }}
-            "#,
-        sample
+            "#
     )));
 
     assert!(actual
@@ -69,7 +67,7 @@ fn errors_if_column_not_found() {
                  [Yehuda, Katz, "10/11/2013", A]]
             "#;
 
-    let actual = nu!(pipeline(&format!("{} | group-by ttype", sample)));
+    let actual = nu!(pipeline(&format!("{sample} | group-by ttype")));
 
     assert!(actual.err.contains("did you mean 'type'"),);
 }

--- a/crates/nu-command/tests/commands/group_by.rs
+++ b/crates/nu-command/tests/commands/group_by.rs
@@ -1,40 +1,30 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn groups() {
-    Playground::setup("group_by_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at,type
-                Andrés,Robalino,10/11/2013,A
-                JT,Turner,10/12/2013,B
-                Yehuda,Katz,10/11/2013,A
-            "#,
-        )]);
+    let sample = r#"
+                [[first_name, last_name, rusty_at, type];
+                 [Andrés, Robalino, "10/11/2013", A],
+                 [JT, Turner, "10/12/2013", B],
+                 [Yehuda, Katz, "10/11/2013", A]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_tres_caballeros.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | group-by rusty_at
                 | get "10/11/2013"
                 | length
-            "#
-        ));
+            "#,
+        sample
+    )));
 
-        assert_eq!(actual.out, "2");
-    })
+    assert_eq!(actual.out, "2");
 }
 
 #[test]
 fn errors_if_given_unknown_column_name() {
-    Playground::setup("group_by_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.json",
-            r#"
+    let sample = r#"
                 {
                     "nu": {
                         "committers": [
@@ -54,46 +44,34 @@ fn errors_if_given_unknown_column_name() {
                         ]
                     }
                 }
+            "#;
+
+    let actual = nu!(pipeline(&format!(
+        r#"
+                '{}'
+                | from json
+                | group-by {{|| get nu.releases.version }}
             "#,
-        )]);
+        sample
+    )));
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_tres_caballeros.json
-                | group-by {|| get nu.releases.version }
-            "#
-        ));
-
-        assert!(actual
-            .err
-            .contains("requires a table with one value for grouping"));
-    })
+    assert!(actual
+        .err
+        .contains("requires a table with one value for grouping"));
 }
 
 #[test]
 fn errors_if_column_not_found() {
-    Playground::setup("group_by_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at,type
-                Andrés,Robalino,10/11/2013,A
-                JT,Turner,10/12/2013,B
-                Yehuda,Katz,10/11/2013,A
-            "#,
-        )]);
+    let sample = r#"
+                [[first_name, last_name, rusty_at, type];
+                 [Andrés, Robalino, "10/11/2013", A],
+                 [JT, Turner, "10/12/2013", B],
+                 [Yehuda, Katz, "10/11/2013", A]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_tres_caballeros.csv
-                | group-by ttype
-            "
-        ));
+    let actual = nu!(pipeline(&format!("{} | group-by ttype", sample)));
 
-        assert!(actual.err.contains("did you mean 'type'"),);
-    })
+    assert!(actual.err.contains("did you mean 'type'"),);
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/histogram.rs
+++ b/crates/nu-command/tests/commands/histogram.rs
@@ -11,13 +11,12 @@ const SAMPLE_INPUT: &str = r#"
 fn summarizes_by_column_given() {
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {SAMPLE_INPUT}
                 | histogram rusty_at countries --percentage-type relative
                 | where rusty_at == "Ecuador"
                 | get countries
                 | get 0
-            "#,
-        SAMPLE_INPUT
+            "#
     )));
 
     assert_eq!(
@@ -31,13 +30,12 @@ fn summarizes_by_column_given() {
 fn summarizes_by_column_given_with_normalize_percentage() {
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {SAMPLE_INPUT}
                 | histogram rusty_at countries
                 | where rusty_at == "Ecuador"
                 | get countries
                 | get 0
-            "#,
-        SAMPLE_INPUT
+            "#
     )));
 
     assert_eq!(actual.out, "*********************************");
@@ -48,14 +46,13 @@ fn summarizes_by_column_given_with_normalize_percentage() {
 fn summarizes_by_values() {
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {SAMPLE_INPUT}
                 | get rusty_at
                 | histogram
                 | where value == "Estados Unidos"
                 | get count
                 | get 0
-            "#,
-        SAMPLE_INPUT
+            "#
     )));
 
     assert_eq!(actual.out, "2");

--- a/crates/nu-command/tests/commands/histogram.rs
+++ b/crates/nu-command/tests/commands/histogram.rs
@@ -1,95 +1,64 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+
+const SAMPLE_INPUT: &'static str = r#"
+                    [[first_name, last_name, rusty_at];
+                     [Andrés, Robalino, Ecuador],
+                     [JT, Turner, "Estados Unidos"],
+                     [Yehuda, Katz, "Estados Unidos"]]
+            "#;
 
 #[test]
 fn summarizes_by_column_given() {
-    Playground::setup("histogram_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at
-                Andrés,Robalino,Ecuador
-                JT,Turner,Estados Unidos
-                Yehuda,Katz,Estados Unidos
-            "#,
-        )]);
-
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_tres_caballeros.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | histogram rusty_at countries --percentage-type relative
                 | where rusty_at == "Ecuador"
                 | get countries
                 | get 0
-            "#
-        ));
+            "#,
+        SAMPLE_INPUT
+    )));
 
-        assert_eq!(
-            actual.out,
-            "**************************************************"
-        );
-        // 50%
-    })
+    assert_eq!(
+        actual.out,
+        "**************************************************"
+    );
+    // 50%
 }
 
 #[test]
 fn summarizes_by_column_given_with_normalize_percentage() {
-    Playground::setup("histogram_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at
-                Andrés,Robalino,Ecuador
-                JT,Turner,Estados Unidos
-                Yehuda,Katz,Estados Unidos
-            "#,
-        )]);
-
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_tres_caballeros.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | histogram rusty_at countries
                 | where rusty_at == "Ecuador"
                 | get countries
                 | get 0
-            "#
-        ));
+            "#,
+        SAMPLE_INPUT
+    )));
 
-        assert_eq!(actual.out, "*********************************");
-        // 33%
-    })
+    assert_eq!(actual.out, "*********************************");
+    // 33%
 }
 
 #[test]
 fn summarizes_by_values() {
-    Playground::setup("histogram_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at
-                Andrés,Robalino,Ecuador
-                JT,Turner,Estados Unidos
-                Yehuda,Katz,Estados Unidos
-            "#,
-        )]);
-
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_tres_caballeros.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | get rusty_at
                 | histogram
                 | where value == "Estados Unidos"
                 | get count
                 | get 0
-            "#
-        ));
+            "#,
+        SAMPLE_INPUT
+    )));
 
-        assert_eq!(actual.out, "2");
-    })
+    assert_eq!(actual.out, "2");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/histogram.rs
+++ b/crates/nu-command/tests/commands/histogram.rs
@@ -1,6 +1,6 @@
 use nu_test_support::{nu, pipeline};
 
-const SAMPLE_INPUT: &'static str = r#"
+const SAMPLE_INPUT: &str = r#"
                     [[first_name, last_name, rusty_at];
                      [Andrés, Robalino, Ecuador],
                      [JT, Turner, "Estados Unidos"],

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -15,12 +15,11 @@ fn all() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | get meals
                 | get calories
                 | math sum
-            "#,
-        sample
+            "#
     )));
 
     assert_eq!(actual.out, "448");

--- a/crates/nu-command/tests/commands/math/sum.rs
+++ b/crates/nu-command/tests/commands/math/sum.rs
@@ -1,14 +1,9 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 use std::str::FromStr;
 
 #[test]
 fn all() {
-    Playground::setup("sum_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "meals.json",
-            r#"
+    let sample = r#"
                 {
                     meals: [
                         {description: "1 large egg", calories: 90},
@@ -16,21 +11,19 @@ fn all() {
                         {description: "1 tablespoon fish oil", calories: 108}
                     ]
                 }
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open meals.json
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | get meals
                 | get calories
                 | math sum
-            "#
-        ));
+            "#,
+        sample
+    )));
 
-        assert_eq!(actual.out, "448");
-    })
+    assert_eq!(actual.out, "448");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/merge.rs
+++ b/crates/nu-command/tests/commands/merge.rs
@@ -1,44 +1,28 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn row() {
-    Playground::setup("merge_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
-            FileWithContentToBeTrimmed(
-                "caballeros.csv",
-                r#"
-                name,country,luck
-                Andrés,Ecuador,0
-                JT,USA,0
-                Jason,Canada,0
-                Yehuda,USA,0
-            "#,
-            ),
-            FileWithContentToBeTrimmed(
-                "new_caballeros.csv",
-                r#"
-                name,country,luck
-                Andrés Robalino,Guayaquil Ecuador,1
-                JT Turner,New Zealand,1
-            "#,
-            ),
-        ]);
+    let left_sample = r#"[[name, country, luck];
+        [Andrés, Ecuador, 0],
+        [JT, USA, 0],
+        [Jason, Canada, 0],
+        [Yehuda, USA, 0]]"#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open caballeros.csv
-                | merge (open new_caballeros.csv)
-                | where country in ["Guayaquil Ecuador" "New Zealand"]
-                | get luck
-                | math sum
-                "#
-        ));
+    let right_sample = r#"[[name, country, luck];
+         ["Andrés Robalino", "Guayaquil Ecuador", 1],
+         ["JT Turner", "New Zealand", 1]]"#;
 
-        assert_eq!(actual.out, "2");
-    });
+    let actual = nu!(pipeline(&format!(
+        r#" ({})
+              | merge ({})
+              | where country in ["Guayaquil Ecuador" "New Zealand"]
+              | get luck
+              | math sum
+                "#,
+        left_sample, right_sample
+    )));
+
+    assert_eq!(actual.out, "2");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/merge.rs
+++ b/crates/nu-command/tests/commands/merge.rs
@@ -13,13 +13,12 @@ fn row() {
          ["JT Turner", "New Zealand", 1]]"#;
 
     let actual = nu!(pipeline(&format!(
-        r#" ({})
-              | merge ({})
+        r#" ({left_sample})
+              | merge ({right_sample})
               | where country in ["Guayaquil Ecuador" "New Zealand"]
               | get luck
               | math sum
-                "#,
-        left_sample, right_sample
+                "#
     )));
 
     assert_eq!(actual.out, "2");

--- a/crates/nu-command/tests/commands/move_/column.rs
+++ b/crates/nu-command/tests/commands/move_/column.rs
@@ -13,14 +13,13 @@ fn moves_a_column_before() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | move column99 --before column1
                 | rename chars
                 | get chars
                 | str trim
                 | str join
-            "#,
-        sample
+            "#
     )));
 
     assert!(actual.out.contains("ANDRES"));
@@ -38,15 +37,14 @@ fn moves_columns_before() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | move column99 column3 --before column2
                 | rename _ chars_1 chars_2
                 | select chars_2 chars_1
                 | upsert new_col {{|f| $f | transpose | get column1 | str trim | str join}}
                 | get new_col
                 | str join
-            "#,
-        sample
+            "#
     )));
 
     assert!(actual.out.contains("ANDRES::JT"));
@@ -65,7 +63,7 @@ fn moves_a_column_after() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | move letters --after and_more
                 | move letters and_more --before column2
                 | rename _ chars_1 chars_2
@@ -73,8 +71,7 @@ fn moves_a_column_after() {
                 | upsert new_col {{|f| $f | transpose | get column1 | str trim | str join}}
                 | get new_col
                 | str join
-            "#,
-        sample
+            "#
     )));
 
     assert!(actual.out.contains("ANDRES::JT"));
@@ -93,13 +90,12 @@ fn moves_columns_after() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {content}
                 | move letters and_more --after column1
                 | columns
                 | select 1 2
                 | str join
-            "#,
-        content
+            "#
     )));
 
     assert!(actual.out.contains("lettersand_more"));

--- a/crates/nu-command/tests/commands/move_/column.rs
+++ b/crates/nu-command/tests/commands/move_/column.rs
@@ -1,130 +1,106 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn moves_a_column_before() {
-    Playground::setup("move_column_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "sample.csv",
-            r#"
-                column1,column2,column3,...,column98,column99,column100
-                -------,-------,-------,---,--------,   A    ,---------
-                -------,-------,-------,---,--------,   N    ,---------
-                -------,-------,-------,---,--------,   D    ,---------
-                -------,-------,-------,---,--------,   R    ,---------
-                -------,-------,-------,---,--------,   E    ,---------
-                -------,-------,-------,---,--------,   S    ,---------
-            "#,
-        )]);
+    let sample = r#"
+                    [[column1 column2 column3 ... column98  column99  column100];
+                    [------- ------- ------- --- -------- "   A    " ---------],
+                    [------- ------- ------- --- -------- "   N    " ---------],
+                    [------- ------- ------- --- -------- "   D    " ---------],
+                    [------- ------- ------- --- -------- "   R    " ---------],
+                    [------- ------- ------- --- -------- "   E    " ---------],
+                    [------- ------- ------- --- -------- "   S    " ---------]]"#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | move column99 --before column1
                 | rename chars
                 | get chars
                 | str trim
                 | str join
-            "#
-        ));
+            "#,
+        sample
+    )));
 
-        assert!(actual.out.contains("ANDRES"));
-    })
+    assert!(actual.out.contains("ANDRES"));
 }
 
 #[test]
 fn moves_columns_before() {
-    Playground::setup("move_column_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "sample.csv",
-            r#"
-                column1,column2,column3,...,column98,column99,column100
-                -------,-------,   A   ,---,--------,   N    ,---------
-                -------,-------,   D   ,---,--------,   R    ,---------
-                -------,-------,   E   ,---,--------,   S    ,---------
-                -------,-------,   :   ,---,--------,   :    ,---------
-                -------,-------,   J   ,---,--------,   T    ,---------
-            "#,
-        )]);
+    let sample = r#"
+                     [[column1 column2  column3  ... column98  column99  column100];
+                      [------- ------- "   A   " --- -------- "   N    " ---------]
+                      [------- ------- "   D   " --- -------- "   R    " ---------]
+                      [------- ------- "   E   " --- -------- "   S    " ---------]
+                      [------- ------- "   :   " --- -------- "   :    " ---------]
+                      [------- ------- "   J   " --- -------- "   T    " ---------]]"#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | move column99 column3 --before column2
                 | rename _ chars_1 chars_2
                 | select chars_2 chars_1
-                | upsert new_col {|f| $f | transpose | get column1 | str trim | str join}
+                | upsert new_col {{|f| $f | transpose | get column1 | str trim | str join}}
                 | get new_col
                 | str join
-            "#
-        ));
+            "#,
+        sample
+    )));
 
-        assert!(actual.out.contains("ANDRES::JT"));
-    })
+    assert!(actual.out.contains("ANDRES::JT"));
 }
 
 #[test]
 fn moves_a_column_after() {
-    Playground::setup("move_column_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "sample.csv",
-            r#"
-                column1,column2,letters,...,column98,and_more,column100
-                -------,-------,   A   ,---,--------,   N    ,---------
-                -------,-------,   D   ,---,--------,   R    ,---------
-                -------,-------,   E   ,---,--------,   S    ,---------
-                -------,-------,   :   ,---,--------,   :    ,---------
-                -------,-------,   J   ,---,--------,   T    ,---------
-            "#,
-        )]);
+    let sample = r#"
+                [[column1 column2  letters  ... column98  and_more  column100];
+                 [------- ------- "   A   " --- -------- "   N    " ---------]
+                 [------- ------- "   D   " --- -------- "   R    " ---------]
+                 [------- ------- "   E   " --- -------- "   S    " ---------]
+                 [------- ------- "   :   " --- -------- "   :    " ---------]
+                 [------- ------- "   J   " --- -------- "   T    " ---------]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | move letters --after and_more
                 | move letters and_more --before column2
                 | rename _ chars_1 chars_2
                 | select chars_1 chars_2
-                | upsert new_col {|f| $f | transpose | get column1 | str trim | str join}
+                | upsert new_col {{|f| $f | transpose | get column1 | str trim | str join}}
                 | get new_col
                 | str join
-            "#
-        ));
+            "#,
+        sample
+    )));
 
-        assert!(actual.out.contains("ANDRES::JT"));
-    })
+    assert!(actual.out.contains("ANDRES::JT"));
 }
 
 #[test]
 fn moves_columns_after() {
-    Playground::setup("move_column_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "sample.csv",
-            r#"
-                column1,column2,letters,...,column98,and_more,column100
-                -------,-------,   A   ,---,--------,   N    ,---------
-                -------,-------,   D   ,---,--------,   R    ,---------
-                -------,-------,   E   ,---,--------,   S    ,---------
-                -------,-------,   :   ,---,--------,   :    ,---------
-                -------,-------,   J   ,---,--------,   T    ,---------
-            "#,
-        )]);
+    let content = r#"
+                [[column1 column2   letters ... column98  and_more  column100];
+                 [------- ------- "   A   " --- -------- "   N    " ---------]
+                 [------- ------- "   D   " --- -------- "   R    " ---------]
+                 [------- ------- "   E   " --- -------- "   S    " ---------]
+                 [------- ------- "   :   " --- -------- "   :    " ---------]
+                 [------- ------- "   J   " --- -------- "   T    " ---------]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open sample.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | move letters and_more --after column1
                 | columns
                 | select 1 2
                 | str join
-            "#
-        ));
+            "#,
+        content
+    )));
 
-        assert!(actual.out.contains("lettersand_more"));
-    })
+    assert!(actual.out.contains("lettersand_more"));
 }

--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -1,116 +1,89 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn changes_the_column_name() {
-    Playground::setup("rename_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_cuatro_mosqueteros.txt",
-            r#"
-                Andrés N. Robalino
-                JT Turner
-                Yehuda Katz
-                Jason Gedge
-            "#,
-        )]);
+    let sample = r#"
+            [["Andrés N. Robalino"],
+             ["JT Turner"],
+             ["Yehuda Katz"],
+             ["Jason Gedge"]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_cuatro_mosqueteros.txt
-                | lines
+    let actual = nu!(pipeline(&format!(
+        "         {}
                 | wrap name
                 | rename mosqueteros
                 | get mosqueteros
                 | length
-                "
-        ));
+                ",
+        sample
+    )));
 
-        assert_eq!(actual.out, "4");
-    })
+    assert_eq!(actual.out, "4");
 }
 
 #[test]
 fn keeps_remaining_original_names_given_less_new_names_than_total_original_names() {
-    Playground::setup("rename_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_cuatro_mosqueteros.txt",
-            r#"
-                Andrés N. Robalino
-                JT Turner
-                Yehuda Katz
-                Jason Gedge
-            "#,
-        )]);
+    let sample = r#"
+            [["Andrés N. Robalino"],
+             ["JT Turner"],
+             ["Yehuda Katz"],
+             ["Jason Gedge"]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_cuatro_mosqueteros.txt
-                | lines
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | wrap name
                 | default "arepa!" hit
                 | rename mosqueteros
                 | get hit
                 | length
-                "#
-        ));
+                "#,
+        sample
+    )));
 
-        assert_eq!(actual.out, "4");
-    })
+    assert_eq!(actual.out, "4");
 }
 
 #[test]
 fn errors_if_no_columns_present() {
-    Playground::setup("rename_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_cuatro_mosqueteros.txt",
-            r#"
-                Andrés N. Robalino
-                JT Turner
-                Yehuda Katz
-                Jason Gedge
-            "#,
-        )]);
+    let sample = r#"
+            [["Andrés N. Robalino"],
+             ["JT Turner"],
+             ["Yehuda Katz"],
+             ["Jason Gedge"]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_cuatro_mosqueteros.txt
-                | lines
+    let actual = nu!(pipeline(&format!(
+        "
+                {}
                 | rename mosqueteros
-                "
-        ));
+                ",
+        sample
+    )));
 
-        assert!(actual.err.contains("command doesn't support"));
-    })
+    assert!(actual.err.contains("command doesn't support"));
 }
 
 #[test]
 fn errors_if_columns_param_is_empty() {
-    Playground::setup("rename_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_cuatro_mosqueteros.txt",
-            r#"
-                Andrés N. Robalino
-                JT Turner
-                Yehuda Katz
-                Jason Gedge
-            "#,
-        )]);
+    let sample = r#"
+            [["Andrés N. Robalino"],
+             ["JT Turner"],
+             ["Yehuda Katz"],
+             ["Jason Gedge"]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_cuatro_mosqueteros.txt
-                | lines
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | wrap name
                 | default "arepa!" hit
-                | rename --column {}
-                "#
-        ));
+                | rename --column {{}}
+                "#,
+        sample
+    )));
 
-        assert!(actual.err.contains("The column info cannot be empty"));
-    })
+    assert!(actual.err.contains("The column info cannot be empty"));
 }

--- a/crates/nu-command/tests/commands/rename.rs
+++ b/crates/nu-command/tests/commands/rename.rs
@@ -10,13 +10,12 @@ fn changes_the_column_name() {
             "#;
 
     let actual = nu!(pipeline(&format!(
-        "         {}
+        "         {sample}
                 | wrap name
                 | rename mosqueteros
                 | get mosqueteros
                 | length
-                ",
-        sample
+                "
     )));
 
     assert_eq!(actual.out, "4");
@@ -33,14 +32,13 @@ fn keeps_remaining_original_names_given_less_new_names_than_total_original_names
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | wrap name
                 | default "arepa!" hit
                 | rename mosqueteros
                 | get hit
                 | length
-                "#,
-        sample
+                "#
     )));
 
     assert_eq!(actual.out, "4");
@@ -57,10 +55,9 @@ fn errors_if_no_columns_present() {
 
     let actual = nu!(pipeline(&format!(
         "
-                {}
+                {sample}
                 | rename mosqueteros
-                ",
-        sample
+                "
     )));
 
     assert!(actual.err.contains("command doesn't support"));
@@ -77,12 +74,11 @@ fn errors_if_columns_param_is_empty() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | wrap name
                 | default "arepa!" hit
                 | rename --column {{}}
-                "#,
-        sample
+                "#
     )));
 
     assert!(actual.err.contains("The column info cannot be empty"));

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -48,13 +48,12 @@ fn complex_nested_columns() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | select nu."0xATYKARNU" nu.committers.name nu.releases.version
                 | get nu_releases_version
                 | where $it > "0.8"
                 | get 0
-            "#,
-        sample
+            "#
     )));
 
     assert_eq!(actual.out, "0.9999999");

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -1,4 +1,4 @@
-use nu_test_support::fs::Stub::{EmptyFile, FileWithContentToBeTrimmed};
+use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
@@ -24,10 +24,7 @@ fn regular_columns() {
 
 #[test]
 fn complex_nested_columns() {
-    Playground::setup("select_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.json",
-            r#"
+    let sample = r#"
                 {
                     "nu": {
                         "committers": [
@@ -47,22 +44,20 @@ fn complex_nested_columns() {
                         ]
                     }
                 }
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_tres_caballeros.json
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | select nu."0xATYKARNU" nu.committers.name nu.releases.version
                 | get nu_releases_version
                 | where $it > "0.8"
                 | get 0
-            "#
-        ));
+            "#,
+        sample
+    )));
 
-        assert_eq!(actual.out, "0.9999999");
-    })
+    assert_eq!(actual.out, "0.9999999");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/skip/until.rs
+++ b/crates/nu-command/tests/commands/skip/until.rs
@@ -23,14 +23,13 @@ fn condition_is_met() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | skip until {{|row| $row."Chicken Collection" == "Red Chickens" }}
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                "#,
-        sample
+                "#
     )));
 
     assert_eq!(actual.out, "6");

--- a/crates/nu-command/tests/commands/skip/until.rs
+++ b/crates/nu-command/tests/commands/skip/until.rs
@@ -1,53 +1,39 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn condition_is_met() {
-    Playground::setup("skip_until_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "caballeros.txt",
-            r#"
-                CHICKEN SUMMARY                        report date: April 29th, 2020
-                --------------------------------------------------------------------
-                Chicken Collection,29/04/2020,30/04/2020,31/04/2020
-                Yellow Chickens,,,
-                Andrés,0,0,1
-                JT,0,0,1
-                Jason,0,0,1
-                Yehuda,0,0,1
-                Blue Chickens,,,
-                Andrés,0,0,1
-                JT,0,0,1
-                Jason,0,0,1
-                Yehuda,0,0,2
-                Red Chickens,,,
-                Andrés,0,0,1
-                JT,0,0,1
-                Jason,0,0,1
-                Yehuda,0,0,3
-            "#,
-        )]);
+    let sample = r#"
+                    [["Chicken Collection", "29/04/2020", "30/04/2020", "31/04/2020"];
+                     ["Yellow Chickens", "", "", ""],
+                     [Andrés, 0, 0, 1],
+                     [JT, 0, 0, 1],
+                     [Jason, 0, 0, 1],
+                     [Yehuda, 0, 0, 1],
+                     ["Blue Chickens", "", "", ""],
+                     [Andrés, 0, 0, 2],
+                     [JT, 0, 0, 2],
+                     [Jason, 0, 0, 2],
+                     [Yehuda, 0, 0, 2],
+                     ["Red Chickens", "", "", ""],
+                     [Andrés, 0, 0, 1],
+                     [JT, 0, 0, 1],
+                     [Jason, 0, 0, 1],
+                     [Yehuda, 0, 0, 3]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open --raw ./caballeros.txt
-                | lines
-                | skip 2
-                | str trim
-                | str join (char nl)
-                | from csv
-                | skip until {|row| $row."Chicken Collection" == "Red Chickens" }
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
+                | skip until {{|row| $row."Chicken Collection" == "Red Chickens" }}
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                "#
-        ));
+                "#,
+        sample
+    )));
 
-        assert_eq!(actual.out, "6");
-    })
+    assert_eq!(actual.out, "6");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/skip/while_.rs
+++ b/crates/nu-command/tests/commands/skip/while_.rs
@@ -1,53 +1,39 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn condition_is_met() {
-    Playground::setup("skip_while_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "caballeros.txt",
-            r#"
-                CHICKEN SUMMARY                        report date: April 29th, 2020
-                --------------------------------------------------------------------
-                Chicken Collection,29/04/2020,30/04/2020,31/04/2020
-                Yellow Chickens,,,
-                Andrés,0,0,1
-                JT,0,0,1
-                Jason,0,0,1
-                Yehuda,0,0,1
-                Blue Chickens,,,
-                Andrés,0,0,1
-                JT,0,0,1
-                Jason,0,0,1
-                Yehuda,0,0,2
-                Red Chickens,,,
-                Andrés,0,0,1
-                JT,0,0,1
-                Jason,0,0,1
-                Yehuda,0,0,3
-            "#,
-        )]);
+    let sample = r#"
+                    [["Chicken Collection", "29/04/2020", "30/04/2020", "31/04/2020"];
+                     ["Yellow Chickens", "", "", ""],
+                     [Andrés, 0, 0, 1],
+                     [JT, 0, 0, 1],
+                     [Jason, 0, 0, 1],
+                     [Yehuda, 0, 0, 1],
+                     ["Blue Chickens", "", "", ""],
+                     [Andrés, 0, 0, 2],
+                     [JT, 0, 0, 2],
+                     [Jason, 0, 0, 2],
+                     [Yehuda, 0, 0, 2],
+                     ["Red Chickens", "", "", ""],
+                     [Andrés, 0, 0, 1],
+                     [JT, 0, 0, 1],
+                     [Jason, 0, 0, 1],
+                     [Yehuda, 0, 0, 3]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open --raw caballeros.txt
-                | lines
-                | skip 2
-                | str trim
-                | str join (char nl)
-                | from csv
-                | skip while {|row| $row."Chicken Collection" != "Red Chickens" }
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
+                | skip while {{|row| $row."Chicken Collection" != "Red Chickens" }}
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                "#
-        ));
+                "#,
+        &sample
+    )));
 
-        assert_eq!(actual.out, "6");
-    })
+    assert_eq!(actual.out, "6");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/skip/while_.rs
+++ b/crates/nu-command/tests/commands/skip/while_.rs
@@ -23,14 +23,13 @@ fn condition_is_met() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | skip while {{|row| $row."Chicken Collection" != "Red Chickens" }}
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                "#,
-        &sample
+                "#
     )));
 
     assert_eq!(actual.out, "6");

--- a/crates/nu-command/tests/commands/split_by.rs
+++ b/crates/nu-command/tests/commands/split_by.rs
@@ -1,33 +1,28 @@
-use nu_test_support::fs::Stub::{EmptyFile, FileWithContentToBeTrimmed};
+use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn splits() {
-    Playground::setup("split_by_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at,type
-                Andrés,Robalino,10/11/2013,A
-                JT,Turner,10/12/2013,B
-                Yehuda,Katz,10/11/2013,A
-            "#,
-        )]);
+    let sample = r#"
+                [[first_name, last_name, rusty_at, type];
+                 [Andrés, Robalino, "10/11/2013", A],
+                 [JT, Turner, "10/12/2013", B],
+                 [Yehuda, Katz, "10/11/2013", A]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open los_tres_caballeros.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                  {}
                 | group-by rusty_at
                 | split-by type
                 | get A."10/11/2013"
                 | length
-            "#
-        ));
+            "#,
+        sample
+    )));
 
-        assert_eq!(actual.out, "2");
-    })
+    assert_eq!(actual.out, "2");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/split_by.rs
+++ b/crates/nu-command/tests/commands/split_by.rs
@@ -13,13 +13,12 @@ fn splits() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                  {}
+                  {sample}
                 | group-by rusty_at
                 | split-by type
                 | get A."10/11/2013"
                 | length
-            "#,
-        sample
+            "#
     )));
 
     assert_eq!(actual.out, "2");

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -1,33 +1,25 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn rows() {
-    Playground::setup("take_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "caballeros.csv",
-            r#"
-                name,lucky_code
-                Andrés,1
-                JT,1
-                Jason,2
-                Yehuda,1
-            "#,
-        )]);
+    let sample = r#"
+        [[name,   lucky_code];
+         [Andrés, 1],
+         [JT    , 1],
+         [Jason , 2],
+         [Yehuda, 1]]"#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open caballeros.csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | take 3
                 | get lucky_code
                 | math sum
-                "#
-        ));
+                "#,
+        &sample
+    )));
 
-        assert_eq!(actual.out, "4");
-    })
+    assert_eq!(actual.out, "4");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/take/rows.rs
+++ b/crates/nu-command/tests/commands/take/rows.rs
@@ -11,12 +11,11 @@ fn rows() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | take 3
                 | get lucky_code
                 | math sum
-                "#,
-        &sample
+                "#
     )));
 
     assert_eq!(actual.out, "4");

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -23,15 +23,14 @@ fn condition_is_met() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | skip while {{|row| $row."Chicken Collection" != "Blue Chickens" }}
                 | take until {{|row| $row."Chicken Collection" == "Red Chickens" }}
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                "#,
-        sample
+                "#
     )));
 
     assert_eq!(actual.out, "8");

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -1,54 +1,44 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn condition_is_met() {
-    Playground::setup("take_until_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "caballeros.txt",
-            r#"
-                CHICKEN SUMMARY                        report date: April 29th, 2020
-                --------------------------------------------------------------------
-                Chicken Collection,29/04/2020,30/04/2020,31/04/2020
-                Yellow Chickens,,,
-                Andrés,1,1,1
-                JT,1,1,1
-                Jason,1,1,1
-                Yehuda,1,1,1
-                Blue Chickens,,,
-                Andrés,1,1,2
-                JT,1,1,2
-                Jason,1,1,2
-                Yehuda,1,1,2
-                Red Chickens,,,
-                Andrés,1,1,3
-                JT,1,1,3
-                Jason,1,1,3
-                Yehuda,1,1,3
-            "#,
-        )]);
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open --raw caballeros.txt
-                | lines
-                | skip 2
-                | str trim
-                | str join (char nl)
-                | from csv
-                | skip while {|row| $row."Chicken Collection" != "Blue Chickens" }
-                | take until {|row| $row."Chicken Collection" == "Red Chickens" }
+    let sample = r#"
+                    [["Chicken Collection", "29/04/2020", "30/04/2020", "31/04/2020"];
+                     ["Yellow Chickens", "", "", ""],
+                     [Andrés, 1, 1, 1],
+                     [JT, 1, 1, 1],
+                     [Jason, 1, 1, 1],
+                     [Yehuda, 1, 1, 1],
+                     ["Blue Chickens", "", "", ""],
+                     [Andrés, 1, 1, 2],
+                     [JT, 1, 1, 2],
+                     [Jason, 1, 1, 2],
+                     [Yehuda, 1, 1, 2],
+                     ["Red Chickens", "", "", ""],
+                     [Andrés, 1, 1, 3],
+                     [JT, 1, 1, 3],
+                     [Jason, 1, 1, 3],
+                     [Yehuda, 1, 1, 3]]
+            "#;
+
+    let actual = nu!(
+        pipeline(
+            &format!(
+                r#"
+                {}
+                | skip while {{|row| $row."Chicken Collection" != "Blue Chickens" }}
+                | take until {{|row| $row."Chicken Collection" == "Red Chickens" }}
                 | skip 1
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                "#
+                "#,
+                sample
+            )
         ));
 
-        assert_eq!(actual.out, "8");
-    })
+    assert_eq!(actual.out, "8");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/take/until.rs
+++ b/crates/nu-command/tests/commands/take/until.rs
@@ -2,7 +2,6 @@ use nu_test_support::{nu, pipeline};
 
 #[test]
 fn condition_is_met() {
-
     let sample = r#"
                     [["Chicken Collection", "29/04/2020", "30/04/2020", "31/04/2020"];
                      ["Yellow Chickens", "", "", ""],
@@ -22,10 +21,8 @@ fn condition_is_met() {
                      [Yehuda, 1, 1, 3]]
             "#;
 
-    let actual = nu!(
-        pipeline(
-            &format!(
-                r#"
+    let actual = nu!(pipeline(&format!(
+        r#"
                 {}
                 | skip while {{|row| $row."Chicken Collection" != "Blue Chickens" }}
                 | take until {{|row| $row."Chicken Collection" == "Red Chickens" }}
@@ -34,9 +31,8 @@ fn condition_is_met() {
                 | get "31/04/2020"
                 | math sum
                 "#,
-                sample
-            )
-        ));
+        sample
+    )));
 
     assert_eq!(actual.out, "8");
 }

--- a/crates/nu-command/tests/commands/take/while_.rs
+++ b/crates/nu-command/tests/commands/take/while_.rs
@@ -23,14 +23,13 @@ fn condition_is_met() {
 
     let actual = nu!(pipeline(&format!(
         r#"
-                {}
+                {sample}
                 | skip 1
                 | take while {{|row| $row."Chicken Collection" != "Blue Chickens"}}
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                "#,
-        sample
+                "#
     )));
 
     assert_eq!(actual.out, "4");

--- a/crates/nu-command/tests/commands/take/while_.rs
+++ b/crates/nu-command/tests/commands/take/while_.rs
@@ -1,53 +1,39 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn condition_is_met() {
-    Playground::setup("take_while_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "caballeros.txt",
-            r#"
-                CHICKEN SUMMARY                        report date: April 29th, 2020
-                --------------------------------------------------------------------
-                Chicken Collection,29/04/2020,30/04/2020,31/04/2020
-                Yellow Chickens,,,
-                Andrés,1,1,1
-                JT,1,1,1
-                Jason,1,1,1
-                Yehuda,1,1,1
-                Blue Chickens,,,
-                Andrés,1,1,2
-                JT,1,1,2
-                Jason,1,1,2
-                Yehuda,1,1,2
-                Red Chickens,,,
-                Andrés,1,1,3
-                JT,1,1,3
-                Jason,1,1,3
-                Yehuda,1,1,3
-            "#,
-        )]);
+    let sample = r#"
+                    [["Chicken Collection", "29/04/2020", "30/04/2020", "31/04/2020"];
+                     ["Yellow Chickens", "", "", ""],
+                     [Andrés, 1, 1, 1],
+                     [JT, 1, 1, 1],
+                     [Jason, 1, 1, 1],
+                     [Yehuda, 1, 1, 1],
+                     ["Blue Chickens", "", "", ""],
+                     [Andrés, 1, 1, 2],
+                     [JT, 1, 1, 2],
+                     [Jason, 1, 1, 2],
+                     [Yehuda, 1, 1, 2],
+                     ["Red Chickens", "", "", ""],
+                     [Andrés, 1, 1, 3],
+                     [JT, 1, 1, 3],
+                     [Jason, 1, 1, 3],
+                     [Yehuda, 1, 1, 3]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            r#"
-                open --raw caballeros.txt
-                | lines
-                | skip 2
-                | str trim
-                | str join (char nl)
-                | from csv
+    let actual = nu!(pipeline(&format!(
+        r#"
+                {}
                 | skip 1
-                | take while {|row| $row."Chicken Collection" != "Blue Chickens"}
+                | take while {{|row| $row."Chicken Collection" != "Blue Chickens"}}
                 | into int "31/04/2020"
                 | get "31/04/2020"
                 | math sum
-                "#
-        ));
+                "#,
+        sample
+    )));
 
-        assert_eq!(actual.out, "4");
-    })
+    assert_eq!(actual.out, "4");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -1,6 +1,6 @@
 use nu_test_support::{nu, pipeline};
 
-const SAMPLE_CSV_CONTENT: &'static str = r#"
+const SAMPLE_CSV_CONTENT: &str = r#"
             [[first_name, last_name, rusty_at, type];
             [Andrés, Robalino, "10/11/2013", A],
             [JT, Turner, "10/12/2013", B],

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -10,10 +10,7 @@ const SAMPLE_CSV_CONTENT: &str = r#"
             "#;
 #[test]
 fn removes_duplicate_rows() {
-    let actual = nu!(pipeline(&format!(
-        "{} | uniq | length ",
-        SAMPLE_CSV_CONTENT
-    )));
+    let actual = nu!(pipeline(&format!("{SAMPLE_CSV_CONTENT} | uniq | length ")));
 
     assert_eq!(actual.out, "3");
 }
@@ -21,8 +18,7 @@ fn removes_duplicate_rows() {
 #[test]
 fn uniq_values() {
     let actual = nu!(pipeline(&format!(
-        "{} | select type | uniq | length ",
-        SAMPLE_CSV_CONTENT
+        "{SAMPLE_CSV_CONTENT} | select type | uniq | length ",
     )));
 
     assert_eq!(actual.out, "2");
@@ -82,10 +78,7 @@ fn nested_json_structures() {
               ]
             "#;
 
-    let actual = nu!(pipeline(&format!(
-        "'{}' | from json | uniq | length",
-        sample
-    )));
+    let actual = nu!(pipeline(&format!("'{sample}' | from json | uniq | length")));
 
     assert_eq!(actual.out, "3");
 }

--- a/crates/nu-command/tests/commands/uniq.rs
+++ b/crates/nu-command/tests/commands/uniq.rs
@@ -1,62 +1,31 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
+const SAMPLE_CSV_CONTENT: &'static str = r#"
+            [[first_name, last_name, rusty_at, type];
+            [Andrés, Robalino, "10/11/2013", A],
+            [JT, Turner, "10/12/2013", B],
+            [Yehuda, Katz, "10/11/2013", A],
+            [JT, Turner, "10/12/2013", B],
+            [Yehuda, Katz, "10/11/2013", A]]
+            "#;
 #[test]
 fn removes_duplicate_rows() {
-    Playground::setup("uniq_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at,type
-                Andrés,Robalino,10/11/2013,A
-                JT,Turner,10/12/2013,B
-                Yehuda,Katz,10/11/2013,A
-                JT,Turner,10/12/2013,B
-                Yehuda,Katz,10/11/2013,A
-            "#,
-        )]);
+    let actual = nu!(pipeline(&format!(
+        "{} | uniq | length ",
+        SAMPLE_CSV_CONTENT
+    )));
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_tres_caballeros.csv
-                | uniq
-                | length
-            "
-        ));
-
-        assert_eq!(actual.out, "3");
-    })
+    assert_eq!(actual.out, "3");
 }
 
 #[test]
 fn uniq_values() {
-    Playground::setup("uniq_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at,type
-                Andrés,Robalino,10/11/2013,A
-                JT,Turner,10/12/2013,B
-                Yehuda,Katz,10/11/2013,A
-                JT,Turner,10/12/2013,B
-                Yehuda,Katz,10/11/2013,A
-            "#,
-        )]);
+    let actual = nu!(pipeline(&format!(
+        "{} | select type | uniq | length ",
+        SAMPLE_CSV_CONTENT
+    )));
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_tres_caballeros.csv
-                | select type
-                | uniq
-                | length
-            "
-        ));
-
-        assert_eq!(actual.out, "2");
-    })
+    assert_eq!(actual.out, "2");
 }
 
 #[test]
@@ -68,10 +37,7 @@ fn uniq_empty() {
 
 #[test]
 fn nested_json_structures() {
-    Playground::setup("uniq_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "nested_json_structures.json",
-            r#"
+    let sample = r#"
             [
                 {
                   "name": "this is duplicated",
@@ -114,19 +80,14 @@ fn nested_json_structures() {
                   }
                 }
               ]
-            "#,
-        )]);
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open nested_json_structures.json
-                | uniq
-                | length
-            "
-        ));
-        assert_eq!(actual.out, "3");
-    })
+    let actual = nu!(pipeline(&format!(
+        "'{}' | from json | uniq | length",
+        sample
+    )));
+
+    assert_eq!(actual.out, "3");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/uniq_by.rs
+++ b/crates/nu-command/tests/commands/uniq_by.rs
@@ -12,11 +12,10 @@ fn removes_duplicate_rows() {
 
     let actual = nu!(pipeline(&format!(
         "
-                {}
+                {sample}
                 | uniq-by last_name
                 | length
-            ",
-        sample
+            "
     )));
 
     assert_eq!(actual.out, "3");

--- a/crates/nu-command/tests/commands/uniq_by.rs
+++ b/crates/nu-command/tests/commands/uniq_by.rs
@@ -1,32 +1,25 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn removes_duplicate_rows() {
-    Playground::setup("uniq_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.csv",
-            r#"
-                first_name,last_name,rusty_at,type
-                Andrés,Robalino,10/11/2013,A
-                Afonso,Turner,10/12/2013,B
-                Yehuda,Katz,10/11/2013,A
-                JT,Turner,11/12/2011,O
-            "#,
-        )]);
+    let sample = r#"
+                    [[first_name , last_name, rusty_at, type];
+                     [Andrés     , Robalino, "10/11/2013", A],
+                     [Afonso     , Turner, "10/12/2013", B],
+                     [Yehuda     , Katz, "10/11/2013", A],
+                     [JT         , Turner, "11/12/2011", O]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_tres_caballeros.csv
+    let actual = nu!(pipeline(&format!(
+        "
+                {}
                 | uniq-by last_name
                 | length
-            "
-        ));
+            ",
+        sample
+    )));
 
-        assert_eq!(actual.out, "3");
-    })
+    assert_eq!(actual.out, "3");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/wrap.rs
+++ b/crates/nu-command/tests/commands/wrap.rs
@@ -11,13 +11,12 @@ fn wrap_rows_into_a_row() {
 
     let actual = nu!(pipeline(&format!(
         "
-                {}
+                {sample}
                 | wrap caballeros
                 | get caballeros
                 | get 0
                 | get last_name
-            ",
-        sample
+            "
     )));
 
     assert_eq!(actual.out, "Robalino");
@@ -34,13 +33,12 @@ fn wrap_rows_into_a_table() {
 
     let actual = nu!(pipeline(&format!(
         "
-                {}
+                {sample}
                 | get last_name
                 | wrap caballero
                 | get 2
                 | get caballero
-            ",
-        sample
+            "
     )));
 
     assert_eq!(actual.out, "Katz");

--- a/crates/nu-command/tests/commands/wrap.rs
+++ b/crates/nu-command/tests/commands/wrap.rs
@@ -1,61 +1,47 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
 #[test]
 fn wrap_rows_into_a_row() {
-    Playground::setup("wrap_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.txt",
-            r#"
-                first_name,last_name
-                Andrés,Robalino
-                JT,Turner
-                Yehuda,Katz
-            "#,
-        )]);
+    let sample = r#"
+                [[first_name, last_name];
+                 [Andrés, Robalino],
+                 [JT, Turner],
+                 [Yehuda, Katz]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_tres_caballeros.txt
-                | from csv
+    let actual = nu!(pipeline(&format!(
+        "
+                {}
                 | wrap caballeros
                 | get caballeros
                 | get 0
                 | get last_name
-            "
-        ));
+            ",
+        sample
+    )));
 
-        assert_eq!(actual.out, "Robalino");
-    })
+    assert_eq!(actual.out, "Robalino");
 }
 
 #[test]
 fn wrap_rows_into_a_table() {
-    Playground::setup("wrap_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "los_tres_caballeros.txt",
-            r#"
-                first_name,last_name
-                Andrés,Robalino
-                JT,Turner
-                Yehuda,Katz
-            "#,
-        )]);
+    let sample = r#"
+                [[first_name, last_name];
+                 [Andrés, Robalino],
+                 [JT, Turner],
+                 [Yehuda, Katz]]
+            "#;
 
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                open los_tres_caballeros.txt
-                | from csv
+    let actual = nu!(pipeline(&format!(
+        "
+                {}
                 | get last_name
                 | wrap caballero
                 | get 2
                 | get caballero
-            "
-        ));
+            ",
+        sample
+    )));
 
-        assert_eq!(actual.out, "Katz");
-    })
+    assert_eq!(actual.out, "Katz");
 }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -13,12 +13,11 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
 
     let actual = nu!(pipeline(&format!(
         "
-            {}
+            {sample}
             | get origin
             | each {{ |it| nu --testbin cococo $it | nu --testbin chop }}
             | get 2
-            ",
-        sample
+            "
     )));
 
     // chop will remove the last escaped double quote from \"Estados Unidos\"
@@ -36,11 +35,10 @@ fn treats_dot_dot_as_path_not_range() {
         "
             mkdir temp;
             cd temp;
-            print (echo {}).name.0 | table;
+            print (echo {sample}).name.0 | table;
             cd ..;
             rmdir temp
-            ",
-        sample
+            "
     )));
 
     // chop will remove the last escaped double quote from \"Estados Unidos\"
@@ -86,12 +84,11 @@ fn subexpression_handles_dot() {
 
     let actual = nu!(pipeline(&format!(
         "
-            {}
+            {sample}
             | get name
             | each {{ |it| nu --testbin chop $it }}
             | get 3
-            ",
-        sample
+            "
     )));
 
     assert_eq!(actual.out, "AndKitKat");

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -1,62 +1,50 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
-use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 use pretty_assertions::assert_eq;
 
 #[test]
 fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
-    Playground::setup("internal_to_external_pipe_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "nu_times.csv",
-            "
-                name,rusty_luck,origin
-                Jason,1,Canada
-                JT,1,New Zealand
-                Andrés,1,Ecuador
-                AndKitKatz,1,Estados Unidos
-            ",
-        )]);
+    let sample = r#"
+                [[name, rusty_luck, origin];
+                 [Jason, 1, Canada],
+                 [JT, 1, "New Zealand"],
+                 [Andrés, 1, Ecuador],
+                 [AndKitKatz, 1, "Estados Unidos"]]
+            "#;
 
-        let actual = nu!(
-        cwd: dirs.test(), pipeline(
+    let actual = nu!(pipeline(&format!(
         "
-            open nu_times.csv
+            {}
             | get origin
-            | each { |it| nu --testbin cococo $it | nu --testbin chop }
+            | each {{ |it| nu --testbin cococo $it | nu --testbin chop }}
             | get 2
-            "
-        ));
+            ",
+        sample
+    )));
 
-        // chop will remove the last escaped double quote from \"Estados Unidos\"
-        assert_eq!(actual.out, "Ecuado");
-    })
+    // chop will remove the last escaped double quote from \"Estados Unidos\"
+    assert_eq!(actual.out, "Ecuado");
 }
 
 #[test]
 fn treats_dot_dot_as_path_not_range() {
-    Playground::setup("dot_dot_dir", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "nu_times.csv",
-            "
+    let sample = r#"
                 name,rusty_luck,origin
                 Jason,1,Canada
-            ",
-        )]);
+            "#;
 
-        let actual = nu!(
-        cwd: dirs.test(), pipeline(
+    let actual = nu!(pipeline(&format!(
         "
             mkdir temp;
             cd temp;
-            print (open ../nu_times.csv).name.0 | table;
+            print ({}).name.0 | table;
             cd ..;
             rmdir temp
-            "
-        ));
+            ",
+        sample
+    )));
 
-        // chop will remove the last escaped double quote from \"Estados Unidos\"
-        assert_eq!(actual.out, "Jason");
-    })
+    // chop will remove the last escaped double quote from \"Estados Unidos\"
+    assert_eq!(actual.out, "Jason");
 }
 
 #[test]
@@ -88,30 +76,25 @@ fn for_loop() {
 
 #[test]
 fn subexpression_handles_dot() {
-    Playground::setup("subexpression_handles_dot", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
-            "nu_times.csv",
-            "
-                name,rusty_luck,origin
-                Jason,1,Canada
-                JT,1,New Zealand
-                Andrés,1,Ecuador
-                AndKitKatz,1,Estados Unidos
-            ",
-        )]);
+    let sample = r#"
+                [[name, rusty_luck, origin];
+                 [Jason, 1, Canada],
+                 [JT, 1, "New Zealand"],
+                 [Andrés, 1, Ecuador],
+                 [AndKitKatz, 1, "Estados Unidos"]]
+            "#;
 
-        let actual = nu!(
-        cwd: dirs.test(), pipeline(
+    let actual = nu!(pipeline(&format!(
         "
-            echo (open nu_times.csv)
+            {}
             | get name
-            | each { |it| nu --testbin chop $it }
+            | each {{ |it| nu --testbin chop $it }}
             | get 3
-            "
-        ));
+            ",
+        sample
+    )));
 
-        assert_eq!(actual.out, "AndKitKat");
-    })
+    assert_eq!(actual.out, "AndKitKat");
 }
 
 #[test]

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -28,15 +28,15 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
 #[test]
 fn treats_dot_dot_as_path_not_range() {
     let sample = r#"
-                name,rusty_luck,origin
-                Jason,1,Canada
+                [[name, rusty_luck, origin];
+                [Jason, 1, Canada]]
             "#;
 
     let actual = nu!(pipeline(&format!(
         "
             mkdir temp;
             cd temp;
-            print ({}).name.0 | table;
+            print (echo {}).name.0 | table;
             cd ..;
             rmdir temp
             ",


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

This PR implements modifications to command tests that write unnecessary json and csv to disk then load it with open, by using nuon literals instead.

- Fixes #7189

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
None

# Tests + Formatting
This only affects existing tests, which still pass.
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
None
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
