### PR TITLE
When using redirection, if a command generates non-zero exit code, the script should stop running

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -163,7 +163,7 @@ fn same_target_redirection_with_too_much_stderr_not_hang_nushell() {
 fn redirection_keep_exit_codes() {
     let out = nu!("do -i { nu --testbin fail e> a.txt } | complete | get exit_code");
     // needs to use contains "1", because it complete will output `Some(RawStream)`.
-    assert!(out.out.contains("1"));
+    assert!(out.out.contains('1'));
 }
 
 #[test]
@@ -174,7 +174,7 @@ fn redirection_with_non_zero_exit_code_should_stop_from_running() {
                 cwd: dirs.test(),
                 &format!("nu --testbin fail {redirection} log.txt; echo 3")
             );
-            assert!(!output.out.contains("3"));
+            assert!(!output.out.contains('3'));
         }
     });
 
@@ -184,7 +184,7 @@ fn redirection_with_non_zero_exit_code_should_stop_from_running() {
                 cwd: dirs.test(),
                 &format!("nu --testbin fail {out} log.txt {err} err_log.txt; echo 3")
             );
-            assert!(!output.out.contains("3"));
+            assert!(!output.out.contains('3'));
         }
     })
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -829,7 +829,7 @@ fn eval_element_with_input(
                                     // but here in redirection context, we make it returns ExternalStream
                                     // So nu handles exit_code correctly
                                     //
-                                    // Also, we don't want to run commands if it exit with non-zero
+                                    // Also, we don't want to run remaining commands if this command exits with non-zero
                                     // exit code, so we need to consume and check exit_code too
                                     might_consume_external_result(PipelineData::ExternalStream {
                                         stdout: None,

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -828,17 +828,17 @@ fn eval_element_with_input(
                                     // save is internal command, normally it exists with non-ExternalStream
                                     // but here in redirection context, we make it returns ExternalStream
                                     // So nu handles exit_code correctly
-                                    (
-                                        PipelineData::ExternalStream {
-                                            stdout: None,
-                                            stderr: None,
-                                            exit_code,
-                                            span: *span,
-                                            metadata: None,
-                                            trim_end_newline: false,
-                                        },
-                                        false,
-                                    )
+                                    //
+                                    // Also, we don't want to run commands if it exit with non-zero
+                                    // exit code, so we need to consume and check exit_code too
+                                    might_consume_external_result(PipelineData::ExternalStream {
+                                        stdout: None,
+                                        stderr: None,
+                                        exit_code,
+                                        span: *span,
+                                        metadata: None,
+                                        trim_end_newline: false,
+                                    })
                                 })
                             }
                             Some(out_stream) => {
@@ -854,7 +854,7 @@ fn eval_element_with_input(
                                     input,
                                 ));
 
-                                Ok((
+                                Ok(might_consume_external_result(
                                     PipelineData::ExternalStream {
                                         stdout: out_stream,
                                         stderr: None,
@@ -863,7 +863,6 @@ fn eval_element_with_input(
                                         metadata: None,
                                         trim_end_newline: false,
                                     },
-                                    false,
                                 ))
                             }
                         }
@@ -903,17 +902,14 @@ fn eval_element_with_input(
                         // save is internal command, normally it exists with non-ExternalStream
                         // but here in redirection context, we make it returns ExternalStream
                         // So nu handles exit_code correctly
-                        (
-                            PipelineData::ExternalStream {
-                                stdout: None,
-                                stderr: None,
-                                exit_code,
-                                span: *out_span,
-                                metadata: None,
-                                trim_end_newline: false,
-                            },
-                            false,
-                        )
+                        might_consume_external_result(PipelineData::ExternalStream {
+                            stdout: None,
+                            stderr: None,
+                            exit_code,
+                            span: *out_span,
+                            metadata: None,
+                            trim_end_newline: false,
+                        })
                     })
                 } else {
                     Err(ShellError::CommandNotFound { span: *out_span })
@@ -1098,9 +1094,6 @@ pub fn eval_block(
             );
 
             match (eval_result, redirect_stderr) {
-                (Ok((pipeline_data, _)), true) => {
-                    input = pipeline_data;
-                }
                 (Err(error), true) => {
                     input = PipelineData::Value(
                         Value::error(
@@ -1110,7 +1103,7 @@ pub fn eval_block(
                         None,
                     )
                 }
-                (output, false) => {
+                (output, _) => {
                     let output = output?;
                     input = output.0;
                     // external command may runs to failed


### PR DESCRIPTION
# Description
Fixes: #11153

To make sure scripts stop from running on non-zero exit code, we need to invoke `might_consume_external_result` on `PipelineData::ExternalStream`, so it can tell nushell if this command exists with non-zero exit code.

And this pr also adjusts some test cases.

# User-Facing Changes
```nushell
^false out> /dev/null; print "ok"
```

After this pr, it shouldn't print ok.

# Tests + Formatting
Done

