### PR TITLE
Reduce code duplication in eval.rs and eval_const.rs

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1337,8 +1337,8 @@ impl Eval for EvalRuntime {
         value.as_string()
     }
 
-    fn eval_variable<'a>(
-        (engine_state, stack): &'a Self::State<'a>,
+    fn eval_variable(
+        (engine_state, stack): Self::State<'_>,
         var_id: VarId,
         span: Span,
     ) -> Result<Value, ShellError> {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1163,4 +1163,8 @@ impl Eval for EvalRuntime {
 
         Ok(Value::string(path.to_string_lossy(), span))
     }
+
+    fn unreachable(expr: &Expression) -> Result<Value, ShellError> {
+        Ok(Value::nothing(expr.span))
+    }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -266,22 +266,6 @@ pub fn eval_expression(
         Expr::Operator(_) => Ok(Value::nothing(expr.span)),
         Expr::MatchPattern(pattern) => Ok(Value::match_pattern(*pattern.clone(), expr.span)),
         Expr::MatchBlock(_) => Ok(Value::nothing(expr.span)), // match blocks are handled by `match`
-        Expr::Filepath(s) => {
-            let cwd = current_dir_str(engine_state, stack)?;
-            let path = expand_path_with(s, cwd);
-
-            Ok(Value::string(path.to_string_lossy(), expr.span))
-        }
-        Expr::Directory(s) => {
-            if s == "-" {
-                Ok(Value::string("-", expr.span))
-            } else {
-                let cwd = current_dir_str(engine_state, stack)?;
-                let path = expand_path_with(s, cwd);
-
-                Ok(Value::string(path.to_string_lossy(), expr.span))
-            }
-        }
         Expr::GlobPattern(s) => {
             let cwd = current_dir_str(engine_state, stack)?;
             let path = expand_path_with(s, cwd);
@@ -966,6 +950,22 @@ impl Eval for EvalRuntime {
         let path = expand_path_with(path, cwd);
 
         Ok(Value::string(path.to_string_lossy(), span))
+    }
+
+    fn eval_directory(
+        engine_state: Self::State<'_>,
+        stack: &mut Self::MutState,
+        path: String,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        if path == "-" {
+            Ok(Value::string("-", span))
+        } else {
+            let cwd = current_dir_str(engine_state, stack)?;
+            let path = expand_path_with(path, cwd);
+
+            Ok(Value::string(path.to_string_lossy(), span))
+        }
     }
 
     fn eval_var(

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1335,16 +1335,16 @@ impl Eval for EvalRuntime {
 
     type MutState = Stack;
 
-    fn value_as_string(value: Value, _: Span) -> Result<String, ShellError> {
-        value.as_string()
-    }
-
-    fn eval_variable(
+    fn eval_var(
         engine_state: Self::State<'_>,
         stack: &mut Stack,
         var_id: VarId,
         span: Span,
     ) -> Result<Value, ShellError> {
         eval_variable(engine_state, stack, var_id, span)
+    }
+
+    fn value_as_string(value: Value, _: Span) -> Result<String, ShellError> {
+        value.as_string()
     }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1159,8 +1159,4 @@ impl Eval for EvalRuntime {
             .collect_string("", config)
             .map(|x| Value::string(x, span))
     }
-
-    fn value_as_string(value: Value, _: Span) -> Result<String, ShellError> {
-        value.as_string()
-    }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1326,3 +1326,17 @@ impl DataSaveJob {
         self.inner.join()
     }
 }
+
+struct EvalRuntime;
+
+impl Eval for EvalRuntime {
+    type State;
+
+    fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
+        todo!()
+    }
+
+    fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {
+        todo!()
+    }
+}

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -6,6 +6,7 @@ use nu_protocol::{
         Expression, Math, Operator, PathMember, PipelineElement, RecordItem, Redirection,
     },
     engine::{Closure, EngineState, Stack},
+    eval_base::Eval,
     DeclId, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, Range, Record,
     ShellError, Span, Spanned, Type, Unit, Value, VarId, ENV_VARIABLE_ID,
 };
@@ -1330,13 +1331,17 @@ impl DataSaveJob {
 struct EvalRuntime;
 
 impl Eval for EvalRuntime {
-    type State;
+    type State<'a> = (&'a EngineState, &'a Stack);
 
-    fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
-        todo!()
+    fn value_as_string(value: Value, _: Span) -> Result<String, ShellError> {
+        value.as_string()
     }
 
-    fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {
-        todo!()
+    fn eval_variable<'a>(
+        (engine_state, stack): &'a Self::State<'a>,
+        var_id: VarId,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        eval_variable(engine_state, stack, var_id, span)
     }
 }

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1331,14 +1331,17 @@ impl DataSaveJob {
 struct EvalRuntime;
 
 impl Eval for EvalRuntime {
-    type State<'a> = (&'a EngineState, &'a Stack);
+    type State<'a> = &'a EngineState;
+
+    type MutState = Stack;
 
     fn value_as_string(value: Value, _: Span) -> Result<String, ShellError> {
         value.as_string()
     }
 
     fn eval_variable(
-        (engine_state, stack): Self::State<'_>,
+        engine_state: Self::State<'_>,
+        stack: &mut Stack,
         var_id: VarId,
         span: Span,
     ) -> Result<Value, ShellError> {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -255,27 +255,19 @@ pub fn eval_expression(
     expr: &Expression,
 ) -> Result<Value, ShellError> {
     match &expr.expr {
-        Expr::VarDecl(_) => Ok(Value::nothing(expr.span)),
-        Expr::ImportPattern(_) => Ok(Value::nothing(expr.span)),
         Expr::Overlay(_) => {
             let name =
                 String::from_utf8_lossy(engine_state.get_span_contents(expr.span)).to_string();
 
             Ok(Value::string(name, expr.span))
         }
-        Expr::Operator(_) => Ok(Value::nothing(expr.span)),
         Expr::MatchPattern(pattern) => Ok(Value::match_pattern(*pattern.clone(), expr.span)),
-        Expr::MatchBlock(_) => Ok(Value::nothing(expr.span)), // match blocks are handled by `match`
         Expr::GlobPattern(s) => {
             let cwd = current_dir_str(engine_state, stack)?;
             let path = expand_path_with(s, cwd);
 
             Ok(Value::string(path.to_string_lossy(), expr.span))
         }
-        Expr::Signature(_) => Ok(Value::nothing(expr.span)),
-        Expr::Garbage => Ok(Value::nothing(expr.span)),
-        Expr::Nothing => Ok(Value::nothing(expr.span)),
-        Expr::Spread(_) => Ok(Value::nothing(expr.span)), // Spread operator only occurs in lists
         _ => <EvalRuntime as Eval>::eval(engine_state, stack, expr),
     }
 }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -12,7 +12,7 @@ use nu_protocol::{
         ImportPatternMember, Pipeline, PipelineElement,
     },
     engine::{StateWorkingSet, DEFAULT_OVERLAY_NAME},
-    eval_const::{eval_constant, value_as_string},
+    eval_const::eval_constant,
     span, Alias, BlockId, DeclId, Exportable, Module, ModuleId, ParseError, PositionalArg,
     ResolvedImportPattern, Span, Spanned, SyntaxShape, Type, VarId,
 };
@@ -2645,7 +2645,7 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 
     let (overlay_name, _) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
-            Ok(val) => match value_as_string(val, expr.span) {
+            Ok(val) => match val.as_string() {
                 Ok(s) => (s, expr.span),
                 Err(err) => {
                     working_set.error(err.wrap(working_set, call_span));
@@ -2694,7 +2694,7 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
-            Ok(val) => match value_as_string(val, expr.span) {
+            Ok(val) => match val.as_string() {
                 Ok(s) => (s, expr.span),
                 Err(err) => {
                     working_set.error(err.wrap(working_set, call_span));
@@ -2717,7 +2717,7 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
     let new_name = if let Some(kw_expression) = call.positional_nth(1) {
         if let Some(new_name_expression) = kw_expression.as_keyword() {
             match eval_constant(working_set, new_name_expression) {
-                Ok(val) => match value_as_string(val, new_name_expression.span) {
+                Ok(val) => match val.as_string() {
                     Ok(s) => Some(Spanned {
                         item: s,
                         span: new_name_expression.span,
@@ -2911,7 +2911,7 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
 
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
-            Ok(val) => match value_as_string(val, expr.span) {
+            Ok(val) => match val.as_string() {
                 Ok(s) => (s, expr.span),
                 Err(err) => {
                     working_set.error(err.wrap(working_set, call_span));
@@ -3372,7 +3372,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeli
                     }
                 };
 
-                let filename = match value_as_string(val, spans[1]) {
+                let filename = match val.as_string() {
                     Ok(s) => s,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, span(&spans[1..])));
@@ -3568,8 +3568,9 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
         .map(|expr| {
             let val =
                 eval_constant(working_set, expr).map_err(|err| err.wrap(working_set, call.head))?;
-            let filename =
-                value_as_string(val, expr.span).map_err(|err| err.wrap(working_set, call.head))?;
+            let filename = val
+                .as_string()
+                .map_err(|err| err.wrap(working_set, call.head))?;
 
             let Some(path) = find_in_dirs(&filename, working_set, &cwd, PLUGIN_DIRS_VAR) else {
                 return Err(ParseError::RegisteredFileNotFound(filename, expr.span));

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -17,7 +17,7 @@ use nu_protocol::{
         RecordItem,
     },
     engine::StateWorkingSet,
-    eval_const::{eval_constant, value_as_string},
+    eval_const::eval_constant,
     span, BlockId, DidYouMean, Flag, ParseError, PositionalArg, Signature, Span, Spanned,
     SyntaxShape, Type, Unit, VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
 };
@@ -2703,7 +2703,7 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
     let head_expr = parse_value(working_set, *head_span, &SyntaxShape::Any);
 
     let (maybe_module_id, head_name) = match eval_constant(working_set, &head_expr) {
-        Ok(val) => match value_as_string(val, head_expr.span) {
+        Ok(val) => match val.as_string() {
             Ok(s) => (working_set.find_module(s.as_bytes()), s.into_bytes()),
             Err(err) => {
                 working_set.error(err.wrap(working_set, span(spans)));

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -277,17 +277,16 @@ pub trait Eval {
                 }
             }
             Expr::Block(block_id) => Ok(Value::block(*block_id, expr.span)),
-            Expr::ImportPattern(_) => todo!(),
-            Expr::Overlay(_) => todo!(),
-            Expr::MatchPattern(_) => todo!(),
-            Expr::MatchBlock(_) => todo!(),
             Expr::RowCondition(block_id) | Expr::Closure(block_id) => {
                 Self::eval_row_condition_or_closure(state, mut_state, *block_id, expr.span)
             }
             Expr::StringInterpolation(exprs) => {
                 Self::eval_string_interpolation(state, mut_state, exprs, expr.span)
             }
-            Expr::Directory(_) => todo!(),
+            Expr::ImportPattern(_) => todo!(),
+            Expr::Overlay(_) => todo!(),
+            Expr::MatchPattern(_) => todo!(),
+            Expr::MatchBlock(_) => todo!(),
             Expr::GlobPattern(_) => todo!(),
             Expr::VarDecl(_) => todo!(),
             Expr::Signature(_) => todo!(),

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -266,15 +266,16 @@ pub trait Eval {
             Expr::Overlay(_) => todo!(),
             Expr::MatchPattern(_) => todo!(),
             Expr::MatchBlock(_) => todo!(),
-            Expr::RowCondition(_) => todo!(),
+            Expr::RowCondition(block_id) | Expr::Closure(block_id) => {
+                Self::eval_row_condition_or_closure(state, mut_state, *block_id, expr.span)
+            }
             Expr::StringInterpolation(_) => todo!(),
             Expr::Directory(_) => todo!(),
             Expr::GlobPattern(_) => todo!(),
+            Expr::VarDecl(_) => todo!(),
             Expr::Signature(_) => todo!(),
             Expr::Spread(_) => todo!(),
-            Expr::VarDecl(_) => todo!(),
             Expr::Operator(_) => todo!(),
-            Expr::Closure(_) => todo!(),
             Expr::Garbage => todo!(),
         }
     }
@@ -306,6 +307,13 @@ pub trait Eval {
         head: &Expression,
         args: &[Expression],
         is_subexpression: bool,
+    ) -> Result<Value, ShellError>;
+
+    fn eval_row_condition_or_closure(
+        state: Self::State<'_>,
+        mut_state: &mut Self::MutState,
+        block_id: usize,
+        span: Span,
     ) -> Result<Value, ShellError>;
 
     fn value_as_string(value: Value, span: Span) -> Result<String, ShellError>;

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -278,13 +278,13 @@ pub trait Eval {
                 Self::eval_glob_pattern(state, mut_state, pattern.clone(), expr.span)
             }
             Expr::MatchPattern(pattern) => Ok(Value::match_pattern(*pattern.clone(), expr.span)),
-            Expr::MatchBlock(_) => Ok(Value::nothing(expr.span)), // match blocks are handled by `match`
-            Expr::VarDecl(_) => Ok(Value::nothing(expr.span)),
-            Expr::ImportPattern(_) => Ok(Value::nothing(expr.span)),
-            Expr::Signature(_) => Ok(Value::nothing(expr.span)),
-            Expr::Spread(_) => Ok(Value::nothing(expr.span)), // Spread operator only occurs in lists
-            Expr::Operator(_) => Ok(Value::nothing(expr.span)),
-            Expr::Garbage => Ok(Value::nothing(expr.span)),
+            Expr::MatchBlock(_) // match blocks are handled by `match`
+            | Expr::VarDecl(_)
+            | Expr::ImportPattern(_)
+            | Expr::Signature(_)
+            | Expr::Spread(_)
+            | Expr::Operator(_)
+            | Expr::Garbage => Self::unreachable(expr),
         }
     }
 
@@ -373,4 +373,7 @@ pub trait Eval {
         pattern: String,
         span: Span,
     ) -> Result<Value, ShellError>;
+
+    /// For expressions that should never actually be evaluated
+    fn unreachable(expr: &Expression) -> Result<Value, ShellError>;
 }

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -23,6 +23,9 @@ pub trait Eval {
             Expr::Float(f) => Ok(Value::float(*f, expr.span)),
             Expr::Binary(b) => Ok(Value::binary(b.clone(), expr.span)),
             Expr::Filepath(path) => Self::eval_filepath(state, mut_state, path.clone(), expr.span),
+            Expr::Directory(path) => {
+                Self::eval_directory(state, mut_state, path.clone(), expr.span)
+            }
             Expr::Var(var_id) => Self::eval_var(state, mut_state, *var_id, expr.span),
             Expr::CellPath(cell_path) => Ok(Value::cell_path(cell_path.clone(), expr.span)),
             Expr::FullCellPath(cell_path) => {
@@ -295,6 +298,13 @@ pub trait Eval {
     }
 
     fn eval_filepath(
+        state: Self::State<'_>,
+        mut_state: &mut Self::MutState,
+        path: String,
+        span: Span,
+    ) -> Result<Value, ShellError>;
+
+    fn eval_directory(
         state: Self::State<'_>,
         mut_state: &mut Self::MutState,
         path: String,

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -1,5 +1,8 @@
 use crate::{
-    ast::{eval_operator, Bits, Boolean, Call, Expr, Expression, Math, Operator, RecordItem},
+    ast::{
+        eval_operator, Bits, Boolean, Call, Comparison, Expr, Expression, Math, Operator,
+        RecordItem,
+    },
     Record, ShellError, Span, Value, VarId,
 };
 use std::collections::HashMap;
@@ -226,7 +229,24 @@ pub trait Eval {
                             Math::Pow => lhs.pow(op_span, &rhs, expr.span),
                         }
                     }
-                    Operator::Comparison(_comparison) => todo!(),
+                    Operator::Comparison(comparison) => {
+                        let lhs = Self::eval(state, mut_state, lhs)?;
+                        let rhs = Self::eval(state, mut_state, rhs)?;
+                        match comparison {
+                            Comparison::LessThan => lhs.lt(op_span, &rhs, expr.span),
+                            Comparison::LessThanOrEqual => lhs.lte(op_span, &rhs, expr.span),
+                            Comparison::GreaterThan => lhs.gt(op_span, &rhs, expr.span),
+                            Comparison::GreaterThanOrEqual => lhs.gte(op_span, &rhs, expr.span),
+                            Comparison::Equal => lhs.eq(op_span, &rhs, expr.span),
+                            Comparison::NotEqual => lhs.ne(op_span, &rhs, expr.span),
+                            Comparison::In => lhs.r#in(op_span, &rhs, expr.span),
+                            Comparison::NotIn => lhs.not_in(op_span, &rhs, expr.span),
+                            Comparison::StartsWith => lhs.starts_with(op_span, &rhs, expr.span),
+                            Comparison::EndsWith => lhs.ends_with(op_span, &rhs, expr.span),
+                            Comparison::RegexMatch => todo!(),
+                            Comparison::NotRegexMatch => todo!(),
+                        }
+                    }
                     Operator::Bits(bits) => {
                         let lhs = Self::eval(state, mut_state, lhs)?;
                         let rhs = Self::eval(state, mut_state, rhs)?;

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -1,0 +1,229 @@
+use crate::{
+    ast::{
+        eval_operator, Bits, Block, Boolean, Call, Comparison, Expr, Expression, Math, Operator,
+        PipelineElement, RecordItem,
+    },
+    engine::{EngineState, StateWorkingSet},
+    record, HistoryFileFormat, PipelineData, Range, Record, ShellError, Span, Value,
+};
+use nu_system::os_info::{get_kernel_version, get_os_arch, get_os_family, get_os_name};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+pub trait Eval {
+    type State<'a>;
+
+    fn eval<'a>(state: Self::State<'a>, expr: &Expression) -> Result<Value, ShellError> {
+        match &expr.expr {
+            Expr::Bool(b) => Ok(Value::bool(*b, expr.span)),
+            Expr::Int(i) => Ok(Value::int(*i, expr.span)),
+            Expr::Float(f) => Ok(Value::float(*f, expr.span)),
+            Expr::Binary(b) => Ok(Value::binary(b.clone(), expr.span)),
+            Expr::Filepath(path) => todo!(),
+            Expr::Var(var_id) => todo!(),
+            Expr::CellPath(cell_path) => Ok(Value::cell_path(cell_path.clone(), expr.span)),
+            Expr::FullCellPath(cell_path) => todo!(),
+            Expr::DateTime(dt) => Ok(Value::date(*dt, expr.span)),
+            Expr::List(x) => {
+                let mut output = vec![];
+                for expr in x {
+                    match &expr.expr {
+                        Expr::Spread(expr) => match Self::eval(state, expr)? {
+                            Value::List { mut vals, .. } => output.append(&mut vals),
+                            _ => return Err(ShellError::CannotSpreadAsList { span: expr.span }),
+                        },
+                        _ => output.push(Self::eval(state, expr)?),
+                    }
+                }
+                Ok(Value::list(output, expr.span))
+            }
+            Expr::Record(items) => {
+                let mut record = Record::new();
+                let mut col_names = HashMap::new();
+                for item in items {
+                    match item {
+                        RecordItem::Pair(col, val) => {
+                            // avoid duplicate cols
+                            let col_name =
+                                Self::value_as_string(Self::eval(state, col)?, expr.span)?;
+                            if let Some(orig_span) = col_names.get(&col_name) {
+                                return Err(ShellError::ColumnDefinedTwice {
+                                    col_name,
+                                    second_use: col.span,
+                                    first_use: *orig_span,
+                                });
+                            } else {
+                                col_names.insert(col_name.clone(), col.span);
+                                record.push(col_name, Self::eval(state, val)?);
+                            }
+                        }
+                        RecordItem::Spread(_, inner) => match Self::eval(state, inner)? {
+                            Value::Record { val: inner_val, .. } => {
+                                for (col_name, val) in inner_val {
+                                    if let Some(orig_span) = col_names.get(&col_name) {
+                                        return Err(ShellError::ColumnDefinedTwice {
+                                            col_name,
+                                            second_use: inner.span,
+                                            first_use: *orig_span,
+                                        });
+                                    } else {
+                                        col_names.insert(col_name.clone(), inner.span);
+                                        record.push(col_name, val);
+                                    }
+                                }
+                            }
+                            _ => return Err(ShellError::CannotSpreadAsRecord { span: inner.span }),
+                        },
+                    }
+                }
+
+                Ok(Value::record(record, expr.span))
+            }
+            Expr::Table(headers, vals) => {
+                let mut output_headers = vec![];
+                for expr in headers {
+                    let header = Self::value_as_string(Self::eval(state, expr)?, expr.span)?;
+                    if let Some(idx) = output_headers
+                        .iter()
+                        .position(|existing| existing == &header)
+                    {
+                        return Err(ShellError::ColumnDefinedTwice {
+                            col_name: header,
+                            second_use: expr.span,
+                            first_use: headers[idx].span,
+                        });
+                    } else {
+                        output_headers.push(header);
+                    }
+                }
+
+                let mut output_rows = vec![];
+                for val in vals {
+                    let mut row = vec![];
+                    for expr in val {
+                        row.push(Self::eval(state, expr)?);
+                    }
+                    // length equality already ensured in parser
+                    output_rows.push(Value::record(
+                        Record::from_raw_cols_vals(output_headers.clone(), row),
+                        expr.span,
+                    ));
+                }
+                Ok(Value::list(output_rows, expr.span))
+            }
+            Expr::Keyword(_, _, expr) => Self::eval(state, expr),
+            Expr::String(s) => Ok(Value::string(s.clone(), expr.span)),
+            Expr::Nothing => Ok(Value::nothing(expr.span)),
+            Expr::ValueWithUnit(expr, unit) => todo!(),
+            Expr::Call(call) => todo!(),
+            Expr::Subexpression(block_id) => todo!(),
+            Expr::Range(from, next, to, operator) => {
+                let from = if let Some(f) = from {
+                    Self::eval(state, f)?
+                } else {
+                    Value::Nothing {
+                        internal_span: expr.span,
+                    }
+                };
+
+                let next = if let Some(s) = next {
+                    Self::eval(state, s)?
+                } else {
+                    Value::Nothing {
+                        internal_span: expr.span,
+                    }
+                };
+
+                let to = if let Some(t) = to {
+                    Self::eval(state, t)?
+                } else {
+                    Value::Nothing {
+                        internal_span: expr.span,
+                    }
+                };
+                Ok(Value::Range {
+                    val: Box::new(crate::Range::new(expr.span, from, next, to, operator)?),
+                    internal_span: expr.span,
+                })
+            }
+            Expr::UnaryNot(expr) => {
+                let lhs = Self::eval(state, expr)?;
+                match lhs {
+                    Value::Bool { val, .. } => Ok(Value::bool(!val, expr.span)),
+                    other => Err(ShellError::TypeMismatch {
+                        err_message: format!("expected bool, found {}", other.get_type()),
+                        span: expr.span,
+                    }),
+                }
+            }
+            Expr::BinaryOp(lhs, op, rhs) => {
+                let op_span = op.span;
+                let op = Self::eval_operator(op)?;
+
+                match op {
+                    Operator::Boolean(boolean) => {
+                        let lhs = Self::eval(state, lhs)?;
+                        match boolean {
+                            Boolean::And => {
+                                if lhs.is_false() {
+                                    Ok(Value::bool(false, expr.span))
+                                } else {
+                                    let rhs = Self::eval(state, rhs)?;
+                                    lhs.and(op_span, &rhs, expr.span)
+                                }
+                            }
+                            Boolean::Or => {
+                                if lhs.is_true() {
+                                    Ok(Value::bool(true, expr.span))
+                                } else {
+                                    let rhs = Self::eval(state, rhs)?;
+                                    lhs.or(op_span, &rhs, expr.span)
+                                }
+                            }
+                            Boolean::Xor => {
+                                let rhs = Self::eval(state, rhs)?;
+                                lhs.xor(op_span, &rhs, expr.span)
+                            }
+                        }
+                    }
+                    Operator::Math(math) => {
+                        let lhs = Self::eval(state, lhs)?;
+                        let rhs = Self::eval(state, rhs)?;
+
+                        match math {
+                            Math::Plus => lhs.add(op_span, &rhs, expr.span),
+                            Math::Minus => lhs.sub(op_span, &rhs, expr.span),
+                            Math::Multiply => lhs.mul(op_span, &rhs, expr.span),
+                            Math::Divide => lhs.div(op_span, &rhs, expr.span),
+                            Math::Append => lhs.append(op_span, &rhs, expr.span),
+                            Math::Modulo => lhs.modulo(op_span, &rhs, expr.span),
+                            Math::FloorDivision => lhs.floor_div(op_span, &rhs, expr.span),
+                            Math::Pow => lhs.pow(op_span, &rhs, expr.span),
+                        }
+                    }
+                    Operator::Comparison(comparison) => todo!(),
+                    Operator::Bits(bits) => {
+                        let lhs = Self::eval(state, lhs)?;
+                        let rhs = Self::eval(state, rhs)?;
+                        match bits {
+                            Bits::BitAnd => lhs.bit_and(op_span, &rhs, expr.span),
+                            Bits::BitOr => lhs.bit_or(op_span, &rhs, expr.span),
+                            Bits::BitXor => lhs.bit_xor(op_span, &rhs, expr.span),
+                            Bits::ShiftLeft => lhs.bit_shl(op_span, &rhs, expr.span),
+                            Bits::ShiftRight => lhs.bit_shr(op_span, &rhs, expr.span),
+                        }
+                    }
+                    Operator::Assignment(_) => todo!(),
+                }
+            }
+            Expr::Block(block_id) => Ok(Value::block(*block_id, expr.span)),
+            _ => todo!(),
+        }
+    }
+
+    fn value_as_string(value: Value, span: Span) -> Result<String, ShellError>;
+
+    fn eval_operator(op: &Expression) -> Result<Operator, ShellError>;
+}

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -29,10 +29,6 @@ pub trait Eval {
             Expr::Var(var_id) => Self::eval_var(state, mut_state, *var_id, expr.span),
             Expr::CellPath(cell_path) => Ok(Value::cell_path(cell_path.clone(), expr.span)),
             Expr::FullCellPath(cell_path) => {
-                // TODO: Both eval.rs and eval_const.rs seem to do the same thing, but
-                // eval_const converts it to a generic error
-                // (there's a todo saying to do better error conversion)
-                // For now, perhaps they could both have the same implementation
                 let value = Self::eval(state, mut_state, &cell_path.head)?;
 
                 value.follow_cell_path(&cell_path.tail, false)
@@ -138,11 +134,6 @@ pub trait Eval {
             Expr::String(s) => Ok(Value::string(s.clone(), expr.span)),
             Expr::Nothing => Ok(Value::nothing(expr.span)),
             Expr::ValueWithUnit(e, unit) => {
-                // The two implementations seem to differ only in the error they give
-                // when expr doesn't evaluate to an Int
-                // eval.rs gives a CantConvert error, while eval_const says NotAConstant
-                // CantConvert seems more appropriate for eval_const too, since the issue isn't that it's not
-                // a constant, it's that it isn't an Int
                 match Self::eval(state, mut_state, e)? {
                     Value::Int { val, .. } => unit.item.to_value(val, unit.span),
                     x => Err(ShellError::CantConvert {

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -13,9 +13,9 @@ use std::{
 };
 
 pub trait Eval {
-    type State<'a>;
+    type State;
 
-    fn eval<'a>(state: Self::State<'a>, expr: &Expression) -> Result<Value, ShellError> {
+    fn eval(state: &Self::State, expr: &Expression) -> Result<Value, ShellError> {
         match &expr.expr {
             Expr::Bool(b) => Ok(Value::bool(*b, expr.span)),
             Expr::Int(i) => Ok(Value::int(*i, expr.span)),
@@ -219,7 +219,22 @@ pub trait Eval {
                 }
             }
             Expr::Block(block_id) => Ok(Value::block(*block_id, expr.span)),
-            _ => todo!(),
+            Expr::ImportPattern(_) => todo!(),
+            Expr::Overlay(_) => todo!(),
+            Expr::ExternalCall(_, _, _) => todo!(),
+            Expr::MatchPattern(_) => todo!(),
+            Expr::MatchBlock(_) => todo!(),
+            Expr::RowCondition(_) => todo!(),
+            Expr::StringInterpolation(_) => todo!(),
+            Expr::Directory(_) => todo!(),
+            Expr::GlobPattern(_) => todo!(),
+            Expr::Signature(_) => todo!(),
+            Expr::Spread(_) => todo!(),
+            Expr::VarDecl(_) => todo!(),
+            Expr::Operator(_) => todo!(),
+            Expr::Closure(_) => todo!(),
+            Expr::Garbage => todo!(),
+            // _ => todo!(),
         }
     }
 

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -20,7 +20,7 @@ pub trait Eval {
             Expr::Float(f) => Ok(Value::float(*f, expr.span)),
             Expr::Binary(b) => Ok(Value::binary(b.clone(), expr.span)),
             Expr::Filepath(_path) => todo!(),
-            Expr::Var(var_id) => Self::eval_variable(state, mut_state, *var_id, expr.span),
+            Expr::Var(var_id) => Self::eval_var(state, mut_state, *var_id, expr.span),
             Expr::CellPath(cell_path) => Ok(Value::cell_path(cell_path.clone(), expr.span)),
             Expr::FullCellPath(_cell_path) => todo!(),
             Expr::DateTime(dt) => Ok(Value::date(*dt, expr.span)),
@@ -244,7 +244,7 @@ pub trait Eval {
         }
     }
 
-    fn eval_variable(
+    fn eval_var(
         state: Self::State<'_>,
         mut_state: &mut Self::MutState,
         var_id: VarId,

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -5,18 +5,18 @@ use crate::{
 use std::collections::HashMap;
 
 pub trait Eval {
-    type State<'a>;
+    type State<'a>: std::marker::Copy;
 
-    fn eval<'a>(state: &'a Self::State<'a>, expr: &Expression) -> Result<Value, ShellError> {
+    fn eval(state: Self::State<'_>, expr: &Expression) -> Result<Value, ShellError> {
         match &expr.expr {
             Expr::Bool(b) => Ok(Value::bool(*b, expr.span)),
             Expr::Int(i) => Ok(Value::int(*i, expr.span)),
             Expr::Float(f) => Ok(Value::float(*f, expr.span)),
             Expr::Binary(b) => Ok(Value::binary(b.clone(), expr.span)),
-            Expr::Filepath(path) => todo!(),
+            Expr::Filepath(_path) => todo!(),
             Expr::Var(var_id) => Self::eval_variable(state, *var_id, expr.span),
             Expr::CellPath(cell_path) => Ok(Value::cell_path(cell_path.clone(), expr.span)),
-            Expr::FullCellPath(cell_path) => todo!(),
+            Expr::FullCellPath(_cell_path) => todo!(),
             Expr::DateTime(dt) => Ok(Value::date(*dt, expr.span)),
             Expr::List(x) => {
                 let mut output = vec![];
@@ -108,9 +108,9 @@ pub trait Eval {
             Expr::Keyword(_, _, expr) => Self::eval(state, expr),
             Expr::String(s) => Ok(Value::string(s.clone(), expr.span)),
             Expr::Nothing => Ok(Value::nothing(expr.span)),
-            Expr::ValueWithUnit(expr, unit) => todo!(),
-            Expr::Call(call) => todo!(),
-            Expr::Subexpression(block_id) => todo!(),
+            Expr::ValueWithUnit(_expr, _unit) => todo!(),
+            Expr::Call(_call) => todo!(),
+            Expr::Subexpression(_block_id) => todo!(),
             Expr::Range(from, next, to, operator) => {
                 let from = if let Some(f) = from {
                     Self::eval(state, f)?
@@ -195,7 +195,7 @@ pub trait Eval {
                             Math::Pow => lhs.pow(op_span, &rhs, expr.span),
                         }
                     }
-                    Operator::Comparison(comparison) => todo!(),
+                    Operator::Comparison(_comparison) => todo!(),
                     Operator::Bits(bits) => {
                         let lhs = Self::eval(state, lhs)?;
                         let rhs = Self::eval(state, rhs)?;
@@ -229,8 +229,8 @@ pub trait Eval {
         }
     }
 
-    fn eval_variable<'a>(
-        state: &'a Self::State<'a>,
+    fn eval_variable(
+        state: Self::State<'_>,
         var_id: VarId,
         span: Span,
     ) -> Result<Value, ShellError>;

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -283,16 +283,16 @@ pub trait Eval {
             Expr::StringInterpolation(exprs) => {
                 Self::eval_string_interpolation(state, mut_state, exprs, expr.span)
             }
-            Expr::ImportPattern(_) => todo!(),
             Expr::Overlay(_) => todo!(),
-            Expr::MatchPattern(_) => todo!(),
-            Expr::MatchBlock(_) => todo!(),
             Expr::GlobPattern(_) => todo!(),
-            Expr::VarDecl(_) => todo!(),
-            Expr::Signature(_) => todo!(),
-            Expr::Spread(_) => todo!(),
-            Expr::Operator(_) => todo!(),
-            Expr::Garbage => todo!(),
+            Expr::VarDecl(_) => Ok(Value::nothing(expr.span)),
+            Expr::ImportPattern(_) => Ok(Value::nothing(expr.span)),
+            Expr::MatchPattern(_) => todo!(),
+            Expr::MatchBlock(_) => Ok(Value::nothing(expr.span)), // match blocks are handled by `match`
+            Expr::Signature(_) => Ok(Value::nothing(expr.span)),
+            Expr::Spread(_) => Ok(Value::nothing(expr.span)), // Spread operator only occurs in lists
+            Expr::Operator(_) => Ok(Value::nothing(expr.span)),
+            Expr::Garbage => Ok(Value::nothing(expr.span)),
         }
     }
 

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::{
-        eval_operator, Bits, Block, Boolean, Call, Comparison, Expr, Expression, Math, Operator,
-        PipelineElement, RecordItem,
+        eval_operator, Assignment, Bits, Block, Boolean, Call, Comparison, Expr, Expression, Math,
+        Operator, PipelineElement, RecordItem,
     },
     engine::{EngineState, StateWorkingSet},
     eval_base::Eval,
@@ -595,6 +595,29 @@ impl Eval for EvalConst {
             eval_const_subexpression(working_set, block, PipelineData::empty(), span)?
                 .into_value(span),
         )
+    }
+
+    fn regex_match(
+        _: &StateWorkingSet,
+        _op_span: Span,
+        _: &Value,
+        _: &Value,
+        _: bool,
+        expr_span: Span,
+    ) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant(expr_span))
+    }
+
+    fn eval_assignment(
+        _: &StateWorkingSet,
+        _: &mut (),
+        _: &Expression,
+        _: &Expression,
+        _: Assignment,
+        _op_span: Span,
+        expr_span: Span,
+    ) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant(expr_span))
     }
 
     fn eval_row_condition_or_closure(

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -584,10 +584,32 @@ impl Eval for EvalConst {
         todo!()
     }
 
+    fn eval_subexpression(
+        working_set: &StateWorkingSet,
+        _: &mut (),
+        block_id: usize,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        let block = working_set.get_block(block_id);
+        Ok(
+            eval_const_subexpression(working_set, block, PipelineData::empty(), span)?
+                .into_value(span),
+        )
+    }
+
     fn eval_row_condition_or_closure(
         _: &StateWorkingSet,
         _: &mut (),
         _: usize,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant(span))
+    }
+
+    fn eval_string_interpolation(
+        _: &StateWorkingSet,
+        _: &mut (),
+        _: &[Expression],
         span: Span,
     ) -> Result<Value, ShellError> {
         Err(ShellError::NotAConstant(span))

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -550,6 +550,15 @@ impl Eval for EvalConst {
         Ok(Value::string(path, span))
     }
 
+    fn eval_directory(
+        _: &StateWorkingSet,
+        _: &mut (),
+        _: String,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant(span))
+    }
+
     fn eval_var(
         working_set: &StateWorkingSet,
         _: &mut (),

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -542,8 +542,8 @@ impl Eval for EvalConst {
     type MutState = ();
 
     fn eval_filepath(
-        _: Self::State<'_>,
-        _: &mut Self::MutState,
+        _: &StateWorkingSet,
+        _: &mut (),
         path: String,
         span: Span,
     ) -> Result<Value, ShellError> {
@@ -563,8 +563,8 @@ impl Eval for EvalConst {
     }
 
     fn eval_call(
-        working_set: Self::State<'_>,
-        _: &mut Self::MutState,
+        working_set: &StateWorkingSet,
+        _: &mut (),
         call: &Call,
         span: Span,
     ) -> Result<Value, ShellError> {
@@ -573,8 +573,8 @@ impl Eval for EvalConst {
     }
 
     fn eval_external_call(
-        _: Self::State<'_>,
-        _: &mut Self::MutState,
+        _: &StateWorkingSet,
+        _: &mut (),
         _: &Expression,
         _: &[Expression],
         _: bool,
@@ -582,6 +582,15 @@ impl Eval for EvalConst {
         // Currently, it gives a generic not_a_constant error,
         // but it may be more helpful to give not_a_const_command
         todo!()
+    }
+
+    fn eval_row_condition_or_closure(
+        _: &StateWorkingSet,
+        _: &mut (),
+        _: usize,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant(span))
     }
 
     fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -4,6 +4,7 @@ use crate::{
         PipelineElement, RecordItem,
     },
     engine::{EngineState, StateWorkingSet},
+    eval_base::Eval,
     record, HistoryFileFormat, PipelineData, Range, Record, ShellError, Span, Value,
 };
 use nu_system::os_info::{get_kernel_version, get_os_arch, get_os_family, get_os_name};
@@ -530,5 +531,19 @@ pub fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
     match value {
         Value::String { val, .. } => Ok(val),
         _ => Err(ShellError::NotAConstant(span)),
+    }
+}
+
+struct EvalConst;
+
+impl Eval for EvalConst {
+    type State;
+
+    fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
+        todo!()
+    }
+
+    fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {
+        todo!()
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -537,7 +537,7 @@ pub fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
 struct EvalConst;
 
 impl Eval for EvalConst {
-    type State<'a> = StateWorkingSet<'a>;
+    type State<'a> = &'a StateWorkingSet<'a>;
 
     fn value_as_string(_value: Value, _span: Span) -> Result<String, ShellError> {
         todo!()

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -266,17 +266,9 @@ pub fn eval_constant(
     expr: &Expression,
 ) -> Result<Value, ShellError> {
     match &expr.expr {
-        Expr::VarDecl(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::Operator(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::MatchBlock(_) => Err(ShellError::NotAConstant(expr.span)),
         Expr::GlobPattern(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::ImportPattern(_) => Err(ShellError::NotAConstant(expr.span)),
         Expr::Overlay(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::Signature(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::StringInterpolation(_) => Err(ShellError::NotAConstant(expr.span)),
         Expr::MatchPattern(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::Spread(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::Garbage => Err(ShellError::NotAConstant(expr.span)),
         _ => <EvalConst as Eval>::eval(working_set, &mut (), expr),
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -539,12 +539,15 @@ struct EvalConst;
 impl Eval for EvalConst {
     type State<'a> = &'a StateWorkingSet<'a>;
 
+    type MutState = ();
+
     fn value_as_string(_value: Value, _span: Span) -> Result<String, ShellError> {
         todo!()
     }
 
     fn eval_variable(
         working_set: &StateWorkingSet,
+        _: &mut (),
         var_id: VarId,
         span: Span,
     ) -> Result<Value, ShellError> {

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -541,6 +541,15 @@ impl Eval for EvalConst {
 
     type MutState = ();
 
+    fn eval_filepath(
+        _: Self::State<'_>,
+        _: &mut Self::MutState,
+        path: String,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        Ok(Value::string(path, span))
+    }
+
     fn eval_var(
         working_set: &StateWorkingSet,
         _: &mut (),
@@ -553,7 +562,29 @@ impl Eval for EvalConst {
         }
     }
 
-    fn value_as_string(_value: Value, _span: Span) -> Result<String, ShellError> {
+    fn eval_call(
+        working_set: Self::State<'_>,
+        _: &mut Self::MutState,
+        call: &Call,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        // TODO: eval.rs uses call.head for the span rather than expr.span
+        Ok(eval_const_call(working_set, call, PipelineData::empty())?.into_value(span))
+    }
+
+    fn eval_external_call(
+        _: Self::State<'_>,
+        _: &mut Self::MutState,
+        _: &Expression,
+        _: &[Expression],
+        _: bool,
+    ) -> Result<Value, ShellError> {
+        // Currently, it gives a generic not_a_constant error,
+        // but it may be more helpful to give not_a_const_command
         todo!()
+    }
+
+    fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
+        value_as_string(value, span)
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -273,14 +273,6 @@ pub fn eval_constant(
     }
 }
 
-/// Get the value as a string
-pub fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
-    match value {
-        Value::String { val, .. } => Ok(val),
-        _ => Err(ShellError::NotAConstant(span)),
-    }
-}
-
 struct EvalConst;
 
 impl Eval for EvalConst {
@@ -392,9 +384,5 @@ impl Eval for EvalConst {
         span: Span,
     ) -> Result<Value, ShellError> {
         Err(ShellError::NotAConstant(span))
-    }
-
-    fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
-        value_as_string(value, span)
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -259,18 +259,11 @@ pub fn eval_constant_with_input(
 }
 
 /// Evaluate a constant value at parse time
-///
-/// Based off eval_expression() in the engine
 pub fn eval_constant(
     working_set: &StateWorkingSet,
     expr: &Expression,
 ) -> Result<Value, ShellError> {
-    match &expr.expr {
-        Expr::GlobPattern(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::Overlay(_) => Err(ShellError::NotAConstant(expr.span)),
-        Expr::MatchPattern(_) => Err(ShellError::NotAConstant(expr.span)),
-        _ => <EvalConst as Eval>::eval(working_set, &mut (), expr),
-    }
+    <EvalConst as Eval>::eval(working_set, &mut (), expr)
 }
 
 struct EvalConst;
@@ -326,10 +319,10 @@ impl Eval for EvalConst {
         _: &Expression,
         _: &[Expression],
         _: bool,
+        span: Span,
     ) -> Result<Value, ShellError> {
-        // Currently, it gives a generic not_a_constant error,
-        // but it may be more helpful to give not_a_const_command
-        todo!()
+        // TODO: It may be more helpful to give not_a_const_command error
+        Err(ShellError::NotAConstant(span))
     }
 
     fn eval_subexpression(
@@ -381,6 +374,19 @@ impl Eval for EvalConst {
         _: &StateWorkingSet,
         _: &mut (),
         _: &[Expression],
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant(span))
+    }
+
+    fn eval_overlay(_: &StateWorkingSet, span: Span) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant(span))
+    }
+
+    fn eval_glob_pattern(
+        _: &StateWorkingSet,
+        _: &mut (),
+        _: String,
         span: Span,
     ) -> Result<Value, ShellError> {
         Err(ShellError::NotAConstant(span))

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     engine::{EngineState, StateWorkingSet},
     eval_base::Eval,
-    record, HistoryFileFormat, PipelineData, Range, Record, ShellError, Span, Value,
+    record, HistoryFileFormat, PipelineData, Range, Record, ShellError, Span, Value, VarId,
 };
 use nu_system::os_info::{get_kernel_version, get_os_arch, get_os_family, get_os_name};
 use std::{
@@ -537,13 +537,20 @@ pub fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
 struct EvalConst;
 
 impl Eval for EvalConst {
-    type State;
+    type State<'a> = StateWorkingSet<'a>;
 
-    fn value_as_string(value: Value, span: Span) -> Result<String, ShellError> {
+    fn value_as_string(_value: Value, _span: Span) -> Result<String, ShellError> {
         todo!()
     }
 
-    fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {
-        todo!()
+    fn eval_variable(
+        working_set: &StateWorkingSet,
+        var_id: VarId,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        match working_set.get_variable(var_id).const_val.as_ref() {
+            Some(val) => Ok(val.clone()),
+            None => Err(ShellError::NotAConstant(span)),
+        }
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -391,4 +391,8 @@ impl Eval for EvalConst {
     ) -> Result<Value, ShellError> {
         Err(ShellError::NotAConstant(span))
     }
+
+    fn unreachable(expr: &Expression) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant(expr.span))
+    }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -541,11 +541,7 @@ impl Eval for EvalConst {
 
     type MutState = ();
 
-    fn value_as_string(_value: Value, _span: Span) -> Result<String, ShellError> {
-        todo!()
-    }
-
-    fn eval_variable(
+    fn eval_var(
         working_set: &StateWorkingSet,
         _: &mut (),
         var_id: VarId,
@@ -555,5 +551,9 @@ impl Eval for EvalConst {
             Some(val) => Ok(val.clone()),
             None => Err(ShellError::NotAConstant(span)),
         }
+    }
+
+    fn value_as_string(_value: Value, _span: Span) -> Result<String, ShellError> {
+        todo!()
     }
 }

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli_error;
 pub mod config;
 mod did_you_mean;
 pub mod engine;
+pub mod eval_base;
 pub mod eval_const;
 mod example;
 mod exportable;


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR is for sharing code between `eval.rs` (normal runtime evaluation) and `eval_const.rs` (const evaluation). The two have a lot of the same logic, and when fixing a bug or something, it's easy to modify one and forget to modify the other. For example, when constructing records, `eval.rs` would check for duplicate columns, but `eval_const.rs` wouldn't, even though the behavior of both should have matched (#11144 made `eval_const.rs` check for duplicate columns too).

I figured the easiest way would be to make an `Eval` trait in nu-protocol, with two impls, one for runtime evaluation and one for const evaluation. The trait has an `eval` method acting like `eval_expression`/`eval_constant`. It has a huge match block for the expression being evaluated, and for cases that work differently between `eval.rs` and `eval_const.rs`, it dispatches to abstract methods (not sure what the Rust terminology here is).

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

<s>If there are any, something's gone wrong.</s>

Const eval has been modified (very slightly) to fit regular eval's behavior more closely:
- Const eval used to only allow strings as column names in records and tables. Now it also allows numbers, datetimes, etc., like regular eval. This makes Nushell more permissive, so hopefully it won't break anything.
- Error messages when const evaluating `FullCellPath` and `ValueWithUnit` now match regular eval (barely noticeable)
  - Errors encountered when evaluating the inner expression in `FullCellPath` are left as is, without converting to a generic error
  - For `ValueWithUnit`, if the value isn't an int, you now get a `CantConvert` rather than `NotAConstant`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Are tests necessary?

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
