### PR TITLE
Add OutOfBounds error

### DIFF
--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -173,7 +173,7 @@ fn action(
 
             if s.get(start_index..end_index).is_none() {
                 return Value::error(
-                    ShellError::InvalidRange {
+                    ShellError::OutOfBounds {
                         left_flank: start_index.to_string(),
                         right_flank: end_index.to_string(),
                         span: range_span,

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1236,6 +1236,22 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         #[label = "cannot spread value"]
         span: Span,
     },
+
+    /// Out of bounds.
+    ///
+    /// ## Resolution
+    ///
+    /// Make sure the range is within the bounds of the input.
+    #[error(
+        "The selected range {left_flank}..{right_flank} is out of the bounds of the provided input"
+    )]
+    #[diagnostic(code(nu::shell::out_of_bounds))]
+    OutOfBounds {
+        left_flank: String,
+        right_flank: String,
+        #[label = "byte index is not a char boundary or is out of bounds of the input"]
+        span: Span,
+    },
 }
 
 // TODO: Implement as From trait


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This is a continuation of #11190. Try to add `OutOfBounds` error. It seems that `OutOfBounds` is more accurate than `InvalidRange`.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
