### PR TITLE
Fix highlighting of spread subexpressions in records

### DIFF
--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -443,8 +443,15 @@ pub fn flatten_expression(
                             output.push((Span::new(last_end, op_span.start), FlatShape::Record));
                         }
                         output.push((*op_span, FlatShape::Operator));
+                        last_end = op_span.end;
 
                         let flattened_inner = flatten_expression(working_set, record);
+                        if let Some(first) = flattened_inner.first() {
+                            if first.0.start > last_end {
+                                output
+                                    .push((Span::new(last_end, first.0.start), FlatShape::Record));
+                            }
+                        }
                         if let Some(last) = flattened_inner.last() {
                             last_end = last.0.end;
                         }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

It turns out that I left a bug in [#11144](https://github.com/nushell/nushell/pull/11144/), which introduced a spread operator in record literals. When highlighting subexpressions that are spread inside records, the spread operator and the token before it are insert twice. Currently, when you type `{ ...() }`, this is what you'll see:

![image](https://github.com/nushell/nushell/assets/45539777/9a76647a-6bbe-426e-95bc-50becf2fa537)

With the PR, the behavior is as expected:

![image](https://github.com/nushell/nushell/assets/45539777/36bdab23-3252-4500-8317-51278da0e869)

I'm still not sure how `FlatShape` works, I just copied the existing logic for flattening key-value pairs in records, so it's possible there's still issues, but I haven't found any yet (tried spreading subexpressions, variables, and records).

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Highlighting for subexpressions spread inside records should no longer be screwed up.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Is there any way to test flattening/syntax highlighting?

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
