### PR TITLE
expose argv[0] as `$env.PROCESS_PATH`

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -99,7 +99,7 @@ pub fn evaluate_file(
         Value::string(file_path.to_string_lossy(), Span::unknown()),
     );
     stack.add_env_var(
-        "ORIGINAL_CMDLINE".to_string(),
+        "PROCESS_PATH".to_string(),
         Value::string(path, Span::unknown()),
     );
 

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -98,6 +98,10 @@ pub fn evaluate_file(
         "CURRENT_FILE".to_string(),
         Value::string(file_path.to_string_lossy(), Span::unknown()),
     );
+    stack.add_env_var(
+        "ORIGINAL_CMDLINE".to_string(),
+        Value::string(path, Span::unknown()),
+    );
 
     let source_filename = file_path
         .file_name()


### PR DESCRIPTION
closes #11059 

# Description
I'm not sure what the consensus was after discussing this in discord, so I'm creating a PR as suggested

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
TBD
# Tests + Formatting
TBD
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
TBD
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->


