### PR TITLE
Fix `Option<&str> == Option<&String>` build error when using rust_decimal/rkyv feature

### DIFF
--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -364,7 +364,7 @@ fn merge_records(left: &Record, right: &Record, shared_key: Option<&str>) -> Rec
 
     for (k, v) in right {
         let k_seen = seen.contains(k);
-        let k_shared = shared_key == Some(k);
+        let k_shared = shared_key == Some(k.as_str());
         // Do not output shared join key twice
         if !(k_seen && k_shared) {
             record.push(


### PR DESCRIPTION
Without this change, projects which depend on both nu-command and rust_decimal's "rkyv" feature cause nu-command to fail to compile.

```toml
[dependencies]
nu-command = { path = "../nushell/crates/nu-command" }
rust_decimal = { version = "1", features = ["rkyv"] }
```

```console
error[E0277]: can't compare `std::option::Option<&str>` with `std::option::Option<&std::string::String>`
   --> nushell/crates/nu-command/src/filters/join.rs:367:35
    |
367 |         let k_shared = shared_key == Some(k);
    |                                   ^^ no implementation for `std::option::Option<&str> == std::option::Option<&std::string::String>`
    |
    = help: the trait `PartialEq<std::option::Option<&std::string::String>>` is not implemented for `std::option::Option<&str>`
    = help: the following other types implement trait `PartialEq<Rhs>`:
              <std::option::Option<Box<U>> as PartialEq<rkyv::niche::option_box::ArchivedOptionBox<T>>>
              <std::option::Option<T> as PartialEq>
              <std::option::Option<U> as PartialEq<rkyv::option::ArchivedOption<T>>>

For more information about this error, try `rustc --explain E0277`.
warning: `nu-command` (lib) generated 1 warning
error: could not compile `nu-command` (lib) due to previous error; 1 warning emitted
```