### PR TITLE
Fix `get -i` ignoring errors for only the first cellpath

### DIFF
--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -65,7 +65,7 @@ If multiple cell paths are given, this will produce a list of values."#
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
         let mut cell_path: CellPath = call.req(engine_state, stack, 0)?;
-        let rest: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
+        let mut rest: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
         let ignore_errors = call.has_flag("ignore-errors");
         let sensitive = call.has_flag("sensitive");
         let ctrlc = engine_state.ctrlc.clone();
@@ -73,6 +73,9 @@ If multiple cell paths are given, this will produce a list of values."#
 
         if ignore_errors {
             cell_path.make_optional();
+            for path in &mut rest {
+                path.make_optional();
+            }
         }
 
         if rest.is_empty() {

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -200,3 +200,10 @@ fn ignore_errors_works() {
 
     assert_eq!(actual.out, "null");
 }
+
+#[test]
+fn ignore_multiple() {
+    let actual = nu!(r#"[[a];[b]] | get -i c d | to nuon"#);
+
+    assert_eq!(actual.out, "[[null], [null]]");
+}


### PR DESCRIPTION
# Description
Fixes issue #11212 where only the first cellpath supplied to `get -i` is treated as optional, and the rest of the cell paths are treated as non-optional.

# Tests
Added one test.