### PR TITLE
Add checks for ports

### DIFF
--- a/crates/nu-command/tests/commands/network/port.rs
+++ b/crates/nu-command/tests/commands/network/port.rs
@@ -47,3 +47,10 @@ fn port_from_system_given() {
     // check that we can get an integer port from system.
     assert!(actual.out.parse::<u16>().unwrap() > 0)
 }
+
+#[test]
+fn port_out_of_range() {
+    let actual = nu!("port 65536 99999");
+
+    assert!(actual.err.contains("can't convert usize to u16"));
+}


### PR DESCRIPTION
# Description
This PR adds checks for ports. This fixes unexpected output similar to the one in the comment https://github.com/nushell/nushell/pull/11210#issuecomment-1837152357.

* before

```console
/data/source/nushell> port 65536 99999                                                                                        
41233
```

* after

```console
/data/source/nushell> port 65536 99999                                                                                             
Error: nu::shell::cant_convert

  × Can't convert to u16.
   ╭─[entry #1:1:1]
 1 │ port 65536 99999
   ·      ──┬──
   ·        ╰── can't convert usize to u16
   ╰────
  help: out of range integral type conversion attempted (min: 0, max: 65535)
```

# User-Facing Changes
N/A

# Tests + Formatting
* [x] add `port_out_of_range` test

# After Submitting
N/A
