### PR TITLE
Explicitly indicate duplicate flags

### DIFF
--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -469,7 +469,8 @@ impl Signature {
         let s = short.map(|c| {
             debug_assert!(
                 !self.get_shorts().contains(&c),
-                "There may be duplicate short flags, such as -h"
+                "There may be duplicate short flags for '-{}'",
+                c
             );
             c
         });
@@ -478,7 +479,8 @@ impl Signature {
             let name: String = name.into();
             debug_assert!(
                 !self.get_names().contains(&name.as_str()),
-                "There may be duplicate name flags, such as --help"
+                "There may be duplicate name flags for '--{}'",
+                name
             );
             name
         };

--- a/crates/nu-protocol/tests/test_signature.rs
+++ b/crates/nu-protocol/tests/test_signature.rs
@@ -96,7 +96,7 @@ fn test_signature_chained() {
 }
 
 #[test]
-#[should_panic(expected = "There may be duplicate short flags, such as -h")]
+#[should_panic(expected = "There may be duplicate short flags for '-n'")]
 fn test_signature_same_short() {
     // Creating signature with same short name should panic
     Signature::new("new_signature")
@@ -110,7 +110,7 @@ fn test_signature_same_short() {
 }
 
 #[test]
-#[should_panic(expected = "There may be duplicate name flags, such as --help")]
+#[should_panic(expected = "There may be duplicate name flags for '--name'")]
 fn test_signature_same_name() {
     // Creating signature with same short name should panic
     Signature::new("new-signature")


### PR DESCRIPTION
# Description
This PR adds an explicit indication for duplicate flags, which helps with debugging.

# User-Facing Changes
N/A

# Tests + Formatting
- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

# After Submitting
N/A