### PR TITLE
Fix for alias issues: skip parser error for enclosed statements

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -913,19 +913,18 @@ pub fn parse_alias(
 
             let replacement_spans = &spans[(split_id + 2)..];
             let first_bytes = working_set.get_span_contents(replacement_spans[0]);
-
+            let b = first_bytes[0];
             if first_bytes != b"if"
                 && first_bytes != b"match"
-                && is_math_expression_like(working_set, replacement_spans[0])
+                && b != b'('
+                && is_math_expressions_like(working_set, replacement_spans[0])
             {
                 // TODO: Maybe we need to implement a Display trait for Expression?
                 let starting_error_count = working_set.parse_errors.len();
                 let expr = parse_expression(working_set, replacement_spans, false);
                 working_set.parse_errors.truncate(starting_error_count);
-
                 let msg = format!("{:?}", expr.expr);
                 let msg_parts: Vec<&str> = msg.split('(').collect();
-
                 working_set.error(ParseError::CantAliasExpression(
                     msg_parts[0].to_string(),
                     replacement_spans[0],


### PR DESCRIPTION
This PR should fix #10088

# Description
Fixes alias panic issue when enclosing multiple commands in parenthesis (i.e `alias eloc = (cd ~/.config/nvim; nvim)`).


# User-Facing Changes
Aliasing commands now supports enclosing multiple commands, original error is as follows:
```nushell
alias eloc = (cd ~/.config/nvim; nvim)
Error: nu::parser::cant_alias_expression

  × Can't create alias to expression.
   ╭─[entry #1:1:1]
 1 │ alias eloc = (cd ~/.config/nvim; nvim)
   ·              ────────────┬────────────
   ·                          ╰── aliasing FullCellPath is not supported
   ╰────
  help: Only command calls can be aliased.`
```
Now works as if you were aliasing 
```nushell
def eloc [] {
    cd ~/.config/nvim
    nvim
}
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
