### PR TITLE
Convert Shellerror::GenericError to named fields

### DIFF
--- a/crates/nu-cli/src/commands/keybindings_listen.rs
+++ b/crates/nu-cli/src/commands/keybindings_listen.rs
@@ -45,13 +45,13 @@ impl Command for KeybindingsListen {
             Ok(v) => Ok(v.into_pipeline_data()),
             Err(e) => {
                 terminal::disable_raw_mode()?;
-                Err(ShellError::GenericError(
-                    "Error with input".to_string(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                ))
+                Err(ShellError::GenericError {
+                    error: "Error with input".into(),
+                    msg: "".into(),
+                    span: None,
+                    help: Some(e.to_string()),
+                    inner: vec![],
+                })
             }
         }
     }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -773,23 +773,21 @@ pub fn get_command_finished_marker(stack: &Stack, engine_state: &EngineState) ->
 }
 
 fn run_ansi_sequence(seq: &str) -> Result<(), ShellError> {
-    io::stdout().write_all(seq.as_bytes()).map_err(|e| {
-        ShellError::GenericError(
-            "Error writing ansi sequence".into(),
-            e.to_string(),
-            Some(Span::unknown()),
-            None,
-            Vec::new(),
-        )
-    })?;
-    io::stdout().flush().map_err(|e| {
-        ShellError::GenericError(
-            "Error flushing stdio".into(),
-            e.to_string(),
-            Some(Span::unknown()),
-            None,
-            Vec::new(),
-        )
+    io::stdout()
+        .write_all(seq.as_bytes())
+        .map_err(|e| ShellError::GenericError {
+            error: "Error writing ansi sequence".into(),
+            msg: e.to_string(),
+            span: Some(Span::unknown()),
+            help: None,
+            inner: vec![],
+        })?;
+    io::stdout().flush().map_err(|e| ShellError::GenericError {
+        error: "Error flushing stdio".into(),
+        msg: e.to_string(),
+        span: Some(Span::unknown()),
+        help: None,
+        inner: vec![],
     })
 }
 

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -43,13 +43,13 @@ fn gather_env_vars(
         let working_set = StateWorkingSet::new(engine_state);
         report_error(
             &working_set,
-            &ShellError::GenericError(
-                format!("Environment variable was not captured: {env_str}"),
-                "".to_string(),
-                None,
-                Some(msg.into()),
-                Vec::new(),
-            ),
+            &ShellError::GenericError {
+                error: format!("Environment variable was not captured: {env_str}"),
+                msg: "".into(),
+                span: None,
+                help: Some(msg.into()),
+                inner: vec![],
+            },
         );
     }
 
@@ -75,15 +75,15 @@ fn gather_env_vars(
             let working_set = StateWorkingSet::new(engine_state);
             report_error(
                 &working_set,
-                &ShellError::GenericError(
-                    "Current directory is not a valid utf-8 path".to_string(),
-                    "".to_string(),
-                    None,
-                    Some(format!(
+                &ShellError::GenericError {
+                    error: "Current directory is not a valid utf-8 path".into(),
+                    msg: "".into(),
+                    span: None,
+                    help: Some(format!(
                         "Retrieving current directory failed: {init_cwd:?} not a valid utf-8 path"
                     )),
-                    Vec::new(),
-                ),
+                    inner: vec![],
+                },
             );
         }
     }

--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -72,22 +72,22 @@ fn get_editor_commandline(
                     let params = editor_cmd.collect::<Result<_, ShellError>>()?;
                     Ok((editor, params))
                 }
-                _ => Err(ShellError::GenericError(
-                    "Editor executable is missing".into(),
-                    "Set the first element to an executable".into(),
-                    Some(value.span()),
-                    Some(HELP_MSG.into()),
-                    vec![],
-                )),
+                _ => Err(ShellError::GenericError {
+                    error: "Editor executable is missing".into(),
+                    msg: "Set the first element to an executable".into(),
+                    span: Some(value.span()),
+                    help: Some(HELP_MSG.into()),
+                    inner: vec![],
+                }),
             }
         }
-        Value::String { .. } | Value::List { .. } => Err(ShellError::GenericError(
-            format!("{var_name} should be a non-empty string or list<String>"),
-            "Specify an executable here".into(),
-            Some(value.span()),
-            Some(HELP_MSG.into()),
-            vec![],
-        )),
+        Value::String { .. } | Value::List { .. } => Err(ShellError::GenericError {
+            error: format!("{var_name} should be a non-empty string or list<String>"),
+            msg: "Specify an executable here".into(),
+            span: Some(value.span()),
+            help: Some(HELP_MSG.into()),
+            inner: vec![],
+        }),
         x => Err(ShellError::CantConvert {
             to_type: "string or list<string>".into(),
             from_type: x.get_type().to_string(),
@@ -114,13 +114,14 @@ pub fn get_editor(
     } else if let Some(value) = env_vars.get("VISUAL") {
         get_editor_commandline(value, "$env.VISUAL")
     } else {
-        Err(ShellError::GenericError(
-            "No editor configured".into(),
-            "Please specify one via `$env.config.buffer_editor` or `$env.EDITOR`/`$env.VISUAL`"
-                .into(),
-            Some(span),
-            Some(HELP_MSG.into()),
-            vec![],
-        ))
+        Err(ShellError::GenericError {
+            error: "No editor configured".into(),
+            msg:
+                "Please specify one via `$env.config.buffer_editor` or `$env.EDITOR`/`$env.VISUAL`"
+                    .into(),
+            span: Some(span),
+            help: Some(HELP_MSG.into()),
+            inner: vec![],
+        })
     }
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/drop.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/drop.rs
@@ -69,25 +69,23 @@ fn command(
 
     let new_df = col_string
         .first()
-        .ok_or_else(|| {
-            ShellError::GenericError(
-                "Empty names list".into(),
-                "No column names were found".into(),
-                Some(col_span),
-                None,
-                Vec::new(),
-            )
+        .ok_or_else(|| ShellError::GenericError {
+            error: "Empty names list".into(),
+            msg: "No column names were found".into(),
+            span: Some(col_span),
+            help: None,
+            inner: vec![],
         })
         .and_then(|col| {
-            df.as_ref().drop(&col.item).map_err(|e| {
-                ShellError::GenericError(
-                    "Error dropping column".into(),
-                    e.to_string(),
-                    Some(col.span),
-                    None,
-                    Vec::new(),
-                )
-            })
+            df.as_ref()
+                .drop(&col.item)
+                .map_err(|e| ShellError::GenericError {
+                    error: "Error dropping column".into(),
+                    msg: e.into(),
+                    span: Some(col.span),
+                    help: None,
+                    inner: vec![],
+                })
         })?;
 
     // If there are more columns in the drop selection list, these
@@ -96,15 +94,15 @@ fn command(
         .iter()
         .skip(1)
         .try_fold(new_df, |new_df, col| {
-            new_df.drop(&col.item).map_err(|e| {
-                ShellError::GenericError(
-                    "Error dropping column".into(),
-                    e.to_string(),
-                    Some(col.span),
-                    None,
-                    Vec::new(),
-                )
-            })
+            new_df
+                .drop(&col.item)
+                .map_err(|e| ShellError::GenericError {
+                    error: "Error dropping column".into(),
+                    msg: e.into(),
+                    span: Some(col.span),
+                    help: None,
+                    inner: vec![],
+                })
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/drop_duplicates.rs
@@ -100,14 +100,12 @@ fn command(
 
     df.as_ref()
         .unique(subset_slice, keep_strategy, None)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error dropping duplicates".into(),
-                e.to_string(),
-                Some(col_span),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error dropping duplicates".into(),
+            msg: e.into(),
+            span: Some(col_span),
+            help: None,
+            inner: vec![],
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/drop_nulls.rs
@@ -115,14 +115,12 @@ fn command(
 
     df.as_ref()
         .drop_nulls(subset_slice)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error dropping nulls".into(),
-                e.to_string(),
-                Some(col_span),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error dropping nulls".into(),
+            msg: e.into(),
+            span: Some(col_span),
+            help: None,
+            inner: vec![],
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/dummies.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/dummies.rs
@@ -88,14 +88,12 @@ fn command(
 
     df.as_ref()
         .to_dummies(None, drop_first)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error calculating dummies".into(),
-                e.to_string(),
-                Some(call.head),
-                Some("The only allowed column types for dummies are String or Int".into()),
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error calculating dummies".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: Some("The only allowed column types for dummies are String or Int".into()),
+            inner: vec![],
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/filter_with.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/filter_with.rs
@@ -105,26 +105,22 @@ fn command_eager(
         ))
     } else {
         let mask = NuDataFrame::try_from_value(mask_value)?.as_series(mask_span)?;
-        let mask = mask.bool().map_err(|e| {
-            ShellError::GenericError(
-                "Error casting to bool".into(),
-                e.to_string(),
-                Some(mask_span),
-                Some("Perhaps you want to use a series with booleans as mask".into()),
-                Vec::new(),
-            )
+        let mask = mask.bool().map_err(|e| ShellError::GenericError {
+            error: "Error casting to bool".into(),
+            msg: e.into(),
+            span: Some(mask_span),
+            help: Some("Perhaps you want to use a series with booleans as mask".into()),
+            inner: vec![],
         })?;
 
         df.as_ref()
             .filter(mask)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error filtering dataframe".into(),
-                    e.to_string(),
-                    Some(call.head),
-                    Some("The only allowed column types for dummies are String or Int".into()),
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Error filtering dataframe".into(),
+                msg: e.into(),
+                span: Some(call.head),
+                help: Some("The only allowed column types for dummies are String or Int".into()),
+                inner: vec![],
             })
             .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
     }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/get.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/get.rs
@@ -70,14 +70,12 @@ fn command(
 
     df.as_ref()
         .select(col_string)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error selecting columns".into(),
-                e.to_string(),
-                Some(col_span),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error selecting columns".into(),
+            msg: e.into(),
+            span: Some(col_span),
+            help: None,
+            inner: vec![],
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/melt.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/melt.rs
@@ -152,38 +152,34 @@ fn command(
     let mut res = df
         .as_ref()
         .melt(&id_col_string, &val_col_string)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error calculating melt".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error calculating melt".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?;
 
     if let Some(name) = &variable_name {
-        res.rename("variable", &name.item).map_err(|e| {
-            ShellError::GenericError(
-                "Error renaming column".into(),
-                e.to_string(),
-                Some(name.span),
-                None,
-                Vec::new(),
-            )
-        })?;
+        res.rename("variable", &name.item)
+            .map_err(|e| ShellError::GenericError {
+                error: "Error renaming column".into(),
+                msg: e.into(),
+                span: Some(name.span),
+                help: None,
+                inner: vec![],
+            })?;
     }
 
     if let Some(name) = &value_name {
-        res.rename("value", &name.item).map_err(|e| {
-            ShellError::GenericError(
-                "Error renaming column".into(),
-                e.to_string(),
-                Some(name.span),
-                None,
-                Vec::new(),
-            )
-        })?;
+        res.rename("value", &name.item)
+            .map_err(|e| ShellError::GenericError {
+                error: "Error renaming column".into(),
+                msg: e.into(),
+                span: Some(name.span),
+                help: None,
+                inner: vec![],
+            })?;
     }
 
     Ok(PipelineData::Value(
@@ -198,50 +194,50 @@ fn check_column_datatypes<T: AsRef<str>>(
     col_span: Span,
 ) -> Result<(), ShellError> {
     if cols.is_empty() {
-        return Err(ShellError::GenericError(
-            "Merge error".into(),
-            "empty column list".into(),
-            Some(col_span),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "Merge error".into(),
+            msg: "empty column list".into(),
+            span: Some(col_span),
+            help: None,
+            inner: vec![],
+        });
     }
 
     // Checking if they are same type
     if cols.len() > 1 {
         for w in cols.windows(2) {
-            let l_series = df.column(w[0].as_ref()).map_err(|e| {
-                ShellError::GenericError(
-                    "Error selecting columns".into(),
-                    e.to_string(),
-                    Some(col_span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
+            let l_series = df
+                .column(w[0].as_ref())
+                .map_err(|e| ShellError::GenericError {
+                    error: "Error selecting columns".into(),
+                    msg: e.into(),
+                    span: Some(col_span),
+                    help: None,
+                    inner: vec![],
+                })?;
 
-            let r_series = df.column(w[1].as_ref()).map_err(|e| {
-                ShellError::GenericError(
-                    "Error selecting columns".into(),
-                    e.to_string(),
-                    Some(col_span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
+            let r_series = df
+                .column(w[1].as_ref())
+                .map_err(|e| ShellError::GenericError {
+                    error: "Error selecting columns".into(),
+                    msg: e.into(),
+                    span: Some(col_span),
+                    help: None,
+                    inner: vec![],
+                })?;
 
             if l_series.dtype() != r_series.dtype() {
-                return Err(ShellError::GenericError(
-                    "Merge error".into(),
-                    "found different column types in list".into(),
-                    Some(col_span),
-                    Some(format!(
+                return Err(ShellError::GenericError {
+                    error: "Merge error".into(),
+                    msg: "found different column types in list".into(),
+                    span: Some(col_span),
+                    help: Some(format!(
                         "datatypes {} and {} are incompatible",
                         l_series.dtype(),
                         r_series.dtype()
                     )),
-                    Vec::new(),
-                ));
+                    inner: vec![],
+                });
             }
         }
     }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/open.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/open.rs
@@ -153,14 +153,12 @@ fn from_parquet(
         };
 
         let df: NuLazyFrame = LazyFrame::scan_parquet(file, args)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Parquet reader error".into(),
-                    format!("{e:?}"),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Parquet reader error".into(),
+                mesg: format!("{e:?}"),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             })?
             .into();
 
@@ -169,14 +167,12 @@ fn from_parquet(
         let file: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
         let columns: Option<Vec<String>> = call.get_flag(engine_state, stack, "columns")?;
 
-        let r = File::open(&file.item).map_err(|e| {
-            ShellError::GenericError(
-                "Error opening file".into(),
-                e.to_string(),
-                Some(file.span),
-                None,
-                Vec::new(),
-            )
+        let r = File::open(&file.item).map_err(|e| ShellError::GenericError {
+            error: "Error opening file".into(),
+            msg: e.into(),
+            span: Some(file.span),
+            help: None,
+            inner: vec![],
         })?;
         let reader = ParquetReader::new(r);
 
@@ -187,14 +183,12 @@ fn from_parquet(
 
         let df: NuDataFrame = reader
             .finish()
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Parquet reader error".into(),
-                    format!("{e:?}"),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Parquet reader error".into(),
+                msg: format!("{e:?}"),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             })?
             .into();
 
@@ -210,14 +204,12 @@ fn from_avro(
     let file: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
     let columns: Option<Vec<String>> = call.get_flag(engine_state, stack, "columns")?;
 
-    let r = File::open(&file.item).map_err(|e| {
-        ShellError::GenericError(
-            "Error opening file".into(),
-            e.to_string(),
-            Some(file.span),
-            None,
-            Vec::new(),
-        )
+    let r = File::open(&file.item).map_err(|e| ShellError::GenericError {
+        error: "Error opening file".into(),
+        msg: e.into(),
+        span: Some(file.span),
+        help: None,
+        inner: vec![],
     })?;
     let reader = AvroReader::new(r);
 
@@ -228,14 +220,12 @@ fn from_avro(
 
     let df: NuDataFrame = reader
         .finish()
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Avro reader error".into(),
-                format!("{e:?}"),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Avro reader error".into(),
+            msg: format!("{e:?}"),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into();
 
@@ -258,14 +248,12 @@ fn from_ipc(
         };
 
         let df: NuLazyFrame = LazyFrame::scan_ipc(file, args)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "IPC reader error".into(),
-                    format!("{e:?}"),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "IPC reader error".into(),
+                msg: format!("{e:?}"),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             })?
             .into();
 
@@ -274,14 +262,12 @@ fn from_ipc(
         let file: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
         let columns: Option<Vec<String>> = call.get_flag(engine_state, stack, "columns")?;
 
-        let r = File::open(&file.item).map_err(|e| {
-            ShellError::GenericError(
-                "Error opening file".into(),
-                e.to_string(),
-                Some(file.span),
-                None,
-                Vec::new(),
-            )
+        let r = File::open(&file.item).map_err(|e| ShellError::GenericError {
+            error: "Error opening file".into(),
+            msg: e.into(),
+            span: Some(file.span),
+            help: None,
+            inner: vec![],
         })?;
         let reader = IpcReader::new(r);
 
@@ -292,14 +278,12 @@ fn from_ipc(
 
         let df: NuDataFrame = reader
             .finish()
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "IPC reader error".into(),
-                    format!("{e:?}"),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "IPC reader error".into(),
+                msg: format!("{e:?}"),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             })?
             .into();
 
@@ -313,14 +297,12 @@ fn from_json(
     call: &Call,
 ) -> Result<Value, ShellError> {
     let file: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
-    let file = File::open(&file.item).map_err(|e| {
-        ShellError::GenericError(
-            "Error opening file".into(),
-            e.to_string(),
-            Some(file.span),
-            None,
-            Vec::new(),
-        )
+    let file = File::open(&file.item).map_err(|e| ShellError::GenericError {
+        error: "Error opening file".into(),
+        msg: e.into(),
+        span: Some(file.span),
+        help: None,
+        inner: vec![],
     })?;
 
     let buf_reader = BufReader::new(file);
@@ -328,14 +310,12 @@ fn from_json(
 
     let df: NuDataFrame = reader
         .finish()
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Json reader error".into(),
-                format!("{e:?}"),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Json reader error".into(),
+            msg: format!("{e:?}"),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into();
 
@@ -349,14 +329,12 @@ fn from_jsonl(
 ) -> Result<Value, ShellError> {
     let infer_schema: Option<usize> = call.get_flag(engine_state, stack, "infer-schema")?;
     let file: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
-    let file = File::open(&file.item).map_err(|e| {
-        ShellError::GenericError(
-            "Error opening file".into(),
-            e.to_string(),
-            Some(file.span),
-            None,
-            Vec::new(),
-        )
+    let file = File::open(&file.item).map_err(|e| ShellError::GenericError {
+        error: "Error opening file".into(),
+        msg: e.into(),
+        span: Some(file.span),
+        help: None,
+        inner: vec![],
     })?;
 
     let buf_reader = BufReader::new(file);
@@ -366,14 +344,12 @@ fn from_jsonl(
 
     let df: NuDataFrame = reader
         .finish()
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Json lines reader error".into(),
-                format!("{e:?}"),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Json lines reader error".into(),
+            msg: format!("{e:?}"),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into();
 
@@ -399,13 +375,13 @@ fn from_csv(
             None => csv_reader,
             Some(d) => {
                 if d.item.len() != 1 {
-                    return Err(ShellError::GenericError(
-                        "Incorrect delimiter".into(),
-                        "Delimiter has to be one character".into(),
-                        Some(d.span),
-                        None,
-                        Vec::new(),
-                    ));
+                    return Err(ShellError::GenericError {
+                        error: "Incorrect delimiter".into(),
+                        msg: "Delimiter has to be one character".into(),
+                        span: Some(d.span),
+                        help: None,
+                        inner: vec![],
+                    });
                 } else {
                     let delimiter = match d.item.chars().next() {
                         Some(d) => d as u8,
@@ -430,14 +406,12 @@ fn from_csv(
 
         let df: NuLazyFrame = csv_reader
             .finish()
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Parquet reader error".into(),
-                    format!("{e:?}"),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Parquet reader error".into(),
+                msg: format!("{e:?}"),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             })?
             .into();
 
@@ -445,14 +419,12 @@ fn from_csv(
     } else {
         let file: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
         let csv_reader = CsvReader::from_path(&file.item)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error creating CSV reader".into(),
-                    e.to_string(),
-                    Some(file.span),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Error creating CSV reader".into(),
+                msg: e.into(),
+                span: Some(file.span),
+                help: None,
+                inner: vec![],
             })?
             .with_encoding(CsvEncoding::LossyUtf8);
 
@@ -460,13 +432,13 @@ fn from_csv(
             None => csv_reader,
             Some(d) => {
                 if d.item.len() != 1 {
-                    return Err(ShellError::GenericError(
-                        "Incorrect delimiter".into(),
-                        "Delimiter has to be one character".into(),
-                        Some(d.span),
-                        None,
-                        Vec::new(),
-                    ));
+                    return Err(ShellError::GenericError {
+                        error: "Incorrect delimiter".into(),
+                        msg: "Delimiter has to be one character".into(),
+                        span: Some(d.span),
+                        help: None,
+                        inner: vec![],
+                    });
                 } else {
                     let delimiter = match d.item.chars().next() {
                         Some(d) => d as u8,
@@ -496,14 +468,12 @@ fn from_csv(
 
         let df: NuDataFrame = csv_reader
             .finish()
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Parquet reader error".into(),
-                    format!("{e:?}"),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Parquet reader error".into(),
+                msg: format!("{e:?}"),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             })?
             .into();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/query_df.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/query_df.rs
@@ -76,15 +76,15 @@ fn command(
 
     let mut ctx = SQLContext::new();
     ctx.register("df", &df.df);
-    let df_sql = ctx.execute(&sql_query).map_err(|e| {
-        ShellError::GenericError(
-            "Dataframe Error".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let df_sql = ctx
+        .execute(&sql_query)
+        .map_err(|e| ShellError::GenericError {
+            error: "Dataframe Error".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        })?;
     let lazy = NuLazyFrame::new(false, df_sql);
 
     let eager = lazy.collect(call.head)?;

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/rename.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/rename.rs
@@ -130,15 +130,15 @@ fn command_eager(
     let new_names = extract_strings(new_names)?;
 
     for (from, to) in columns.iter().zip(new_names.iter()) {
-        df.as_mut().rename(from, to).map_err(|e| {
-            ShellError::GenericError(
-                "Error renaming".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
-        })?;
+        df.as_mut()
+            .rename(from, to)
+            .map_err(|e| ShellError::GenericError {
+                error: "Error renaming".into(),
+                msg: e.into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            })?;
     }
 
     Ok(PipelineData::Value(df.into_value(call.head), None))

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/sample.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/sample.rs
@@ -95,41 +95,37 @@ fn command(
         (Some(rows), None) => df
             .as_ref()
             .sample_n(rows.item, replace, shuffle, seed)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error creating sample".into(),
-                    e.to_string(),
-                    Some(rows.span),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Error creating sample".into(),
+                msg: e.into(),
+                span: Some(rows.span),
+                help: None,
+                inner: vec![],
             }),
         (None, Some(frac)) => df
             .as_ref()
             .sample_frac(frac.item, replace, shuffle, seed)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error creating sample".into(),
-                    e.to_string(),
-                    Some(frac.span),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Error creating sample".into(),
+                msg: e.into(),
+                span: Some(frac.span),
+                help: None,
+                inner: vec![],
             }),
-        (Some(_), Some(_)) => Err(ShellError::GenericError(
-            "Incompatible flags".into(),
-            "Only one selection criterion allowed".into(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )),
-        (None, None) => Err(ShellError::GenericError(
-            "No selection".into(),
-            "No selection criterion was found".into(),
-            Some(call.head),
-            Some("Perhaps you want to use the flag -n or -f".into()),
-            Vec::new(),
-        )),
+        (Some(_), Some(_)) => Err(ShellError::GenericError {
+            error: "Incompatible flags".into(),
+            msg: "Only one selection criterion allowed".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        }),
+        (None, None) => Err(ShellError::GenericError {
+            error: "No selection".into(),
+            msg: "No selection criterion was found".into(),
+            span: Some(call.head),
+            help: Some("Perhaps you want to use the flag -n or -f".into()),
+            inner: vec![],
+        }),
     }
     .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/summary.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/summary.rs
@@ -127,23 +127,23 @@ fn command(
                         if (&0.0..=&1.0).contains(&val) {
                             Ok(*val)
                         } else {
-                            Err(ShellError::GenericError(
-                                "Incorrect value for quantile".to_string(),
-                                "value should be between 0 and 1".to_string(),
-                                Some(span),
-                                None,
-                                Vec::new(),
-                            ))
+                            Err(ShellError::GenericError {
+                                error: "Incorrect value for quantile".into(),
+                                msg: "value should be between 0 and 1".into(),
+                                span: Some(span),
+                                help: None,
+                                inner: vec![],
+                            })
                         }
                     }
                     Value::Error { error, .. } => Err(*error.clone()),
-                    _ => Err(ShellError::GenericError(
-                        "Incorrect value for quantile".to_string(),
-                        "value should be a float".to_string(),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    )),
+                    _ => Err(ShellError::GenericError {
+                        error: "Incorrect value for quantile".into(),
+                        msg: "value should be a float".into(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    }),
                 }
             })
             .collect::<Result<Vec<f64>, ShellError>>()
@@ -250,14 +250,12 @@ fn command(
     let res = head.chain(tail).collect::<Vec<Series>>();
 
     DataFrame::new(res)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Dataframe Error".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Dataframe Error".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })
         .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/take.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/take.rs
@@ -97,47 +97,41 @@ fn command(
     let index = NuDataFrame::try_from_value(index_value)?.as_series(index_span)?;
 
     let casted = match index.dtype() {
-        DataType::UInt32 | DataType::UInt64 | DataType::Int32 | DataType::Int64 => {
-            index.cast(&DataType::UInt32).map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting index list".into(),
-                    e.to_string(),
-                    Some(index_span),
-                    None,
-                    Vec::new(),
-                )
-            })
-        }
-        _ => Err(ShellError::GenericError(
-            "Incorrect type".into(),
-            "Series with incorrect type".into(),
-            Some(call.head),
-            Some("Consider using a Series with type int type".into()),
-            Vec::new(),
-        )),
+        DataType::UInt32 | DataType::UInt64 | DataType::Int32 | DataType::Int64 => index
+            .cast(&DataType::UInt32)
+            .map_err(|e| ShellError::GenericError {
+                error: "Error casting index list".into(),
+                msg: e.into(),
+                span: Some(index_span),
+                help: None,
+                inner: vec![],
+            }),
+        _ => Err(ShellError::GenericError {
+            error: "Incorrect type".into(),
+            msg: "Series with incorrect type".into(),
+            span: Some(call.head),
+            help: Some("Consider using a Series with type int type".into()),
+            inner: vec![],
+        }),
     }?;
 
-    let indices = casted.u32().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting index list".into(),
-            e.to_string(),
-            Some(index_span),
-            None,
-            Vec::new(),
-        )
+    let indices = casted.u32().map_err(|e| ShellError::GenericError {
+        error: "Error casting index list".into(),
+        msg: e.into(),
+        span: Some(index_span),
+        help: None,
+        inner: vec![],
     })?;
 
     NuDataFrame::try_from_pipeline(input, call.head).and_then(|df| {
         df.as_ref()
             .take(indices)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error taking values".into(),
-                    e.to_string(),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Error taking values".into(),
+                msg: e.into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             })
             .map(|df| PipelineData::Value(NuDataFrame::dataframe_into_value(df, call.head), None))
     })

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_arrow.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_arrow.rs
@@ -58,25 +58,23 @@ fn command(
 
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
-    let mut file = File::create(&file_name.item).map_err(|e| {
-        ShellError::GenericError(
-            "Error with file name".into(),
-            e.to_string(),
-            Some(file_name.span),
-            None,
-            Vec::new(),
-        )
+    let mut file = File::create(&file_name.item).map_err(|e| ShellError::GenericError {
+        error: "Error with file name".into(),
+        msg: e.into(),
+        span: Some(file_name.span),
+        help: None,
+        inner: vec![],
     })?;
 
-    IpcWriter::new(&mut file).finish(df.as_mut()).map_err(|e| {
-        ShellError::GenericError(
-            "Error saving file".into(),
-            e.to_string(),
-            Some(file_name.span),
-            None,
-            Vec::new(),
-        )
-    })?;
+    IpcWriter::new(&mut file)
+        .finish(df.as_mut())
+        .map_err(|e| ShellError::GenericError {
+            error: "Error saving file".into(),
+            msg: e.into(),
+            span: Some(file_name.span),
+            help: None,
+            inner: vec![],
+        })?;
 
     let file_value = Value::string(format!("saved {:?}", &file_name.item), file_name.span);
 

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_avro.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_avro.rs
@@ -85,27 +85,23 @@ fn command(
 
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
-    let file = File::create(&file_name.item).map_err(|e| {
-        ShellError::GenericError(
-            "Error with file name".into(),
-            e.to_string(),
-            Some(file_name.span),
-            None,
-            Vec::new(),
-        )
+    let file = File::create(&file_name.item).map_err(|e| ShellError::GenericError {
+        error: "Error with file name".into(),
+        msg: e.into(),
+        span: Some(file_name.span),
+        help: None,
+        inner: vec![],
     })?;
 
     AvroWriter::new(file)
         .with_compression(compression)
         .finish(df.as_mut())
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error saving file".into(),
-                e.to_string(),
-                Some(file_name.span),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error saving file".into(),
+            msg: e.into(),
+            span: Some(file_name.span),
+            help: None,
+            inner: vec![],
         })?;
 
     let file_value = Value::string(format!("saved {:?}", &file_name.item), file_name.span);

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_csv.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_csv.rs
@@ -74,14 +74,12 @@ fn command(
 
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
-    let mut file = File::create(&file_name.item).map_err(|e| {
-        ShellError::GenericError(
-            "Error with file name".into(),
-            e.to_string(),
-            Some(file_name.span),
-            None,
-            Vec::new(),
-        )
+    let mut file = File::create(&file_name.item).map_err(|e| ShellError::GenericError {
+        error: "Error with file name".into(),
+        msg: e.into(),
+        span: Some(file_name.span),
+        help: None,
+        inner: vec![],
     })?;
 
     let writer = CsvWriter::new(&mut file);
@@ -96,13 +94,13 @@ fn command(
         None => writer,
         Some(d) => {
             if d.item.len() != 1 {
-                return Err(ShellError::GenericError(
-                    "Incorrect delimiter".into(),
-                    "Delimiter has to be one char".into(),
-                    Some(d.span),
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "Incorrect delimiter".into(),
+                    msg: "Delimiter has to be one char".into(),
+                    span: Some(d.span),
+                    help: None,
+                    inner: vec![],
+                });
             } else {
                 let delimiter = match d.item.chars().next() {
                     Some(d) => d as u8,
@@ -114,15 +112,15 @@ fn command(
         }
     };
 
-    writer.finish(df.as_mut()).map_err(|e| {
-        ShellError::GenericError(
-            "Error writing to file".into(),
-            e.to_string(),
-            Some(file_name.span),
-            None,
-            Vec::new(),
-        )
-    })?;
+    writer
+        .finish(df.as_mut())
+        .map_err(|e| ShellError::GenericError {
+            error: "Error writing to file".into(),
+            msg: e.into(),
+            span: Some(file_name.span),
+            help: None,
+            inner: vec![],
+        })?;
 
     let file_value = Value::string(format!("saved {:?}", &file_name.item), file_name.span);
 

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_json_lines.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_json_lines.rs
@@ -58,27 +58,23 @@ fn command(
 
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
-    let file = File::create(&file_name.item).map_err(|e| {
-        ShellError::GenericError(
-            "Error with file name".into(),
-            e.to_string(),
-            Some(file_name.span),
-            None,
-            Vec::new(),
-        )
+    let file = File::create(&file_name.item).map_err(|e| ShellError::GenericError {
+        error: "Error with file name".into(),
+        msg: e.into(),
+        span: Some(file_name.span),
+        help: None,
+        inner: vec![],
     })?;
     let buf_writer = BufWriter::new(file);
 
     JsonWriter::new(buf_writer)
         .finish(df.as_mut())
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error saving file".into(),
-                e.to_string(),
-                Some(file_name.span),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error saving file".into(),
+            msg: e.into(),
+            span: Some(file_name.span),
+            help: None,
+            inner: vec![],
         })?;
 
     let file_value = Value::string(format!("saved {:?}", &file_name.item), file_name.span);

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_parquet.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_parquet.rs
@@ -58,25 +58,23 @@ fn command(
 
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
-    let file = File::create(&file_name.item).map_err(|e| {
-        ShellError::GenericError(
-            "Error with file name".into(),
-            e.to_string(),
-            Some(file_name.span),
-            None,
-            Vec::new(),
-        )
+    let file = File::create(&file_name.item).map_err(|e| ShellError::GenericError {
+        error: "Error with file name".into(),
+        msg: e.into(),
+        span: Some(file_name.span),
+        help: None,
+        inner: vec![],
     })?;
 
-    ParquetWriter::new(file).finish(df.as_mut()).map_err(|e| {
-        ShellError::GenericError(
-            "Error saving file".into(),
-            e.to_string(),
-            Some(file_name.span),
-            None,
-            Vec::new(),
-        )
-    })?;
+    ParquetWriter::new(file)
+        .finish(df.as_mut())
+        .map_err(|e| ShellError::GenericError {
+            error: "Error saving file".into(),
+            msg: e.into(),
+            span: Some(file_name.span),
+            help: None,
+            inner: vec![],
+        })?;
 
     let file_value = Value::string(format!("saved {:?}", &file_name.item), file_name.span);
 

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/with_column.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/with_column.rs
@@ -151,14 +151,12 @@ fn command_eager(
 
         df.as_mut()
             .with_column(series)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error adding column to dataframe".into(),
-                    e.to_string(),
-                    Some(column_span),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Error adding column to dataframe".into(),
+                msg: e.into(),
+                span: Some(column_span),
+                help: None,
+                inner: vec![],
             })
             .map(|df| {
                 PipelineData::Value(

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/aggregate.rs
@@ -125,13 +125,13 @@ impl Command for LazyAggregate {
                     let dtype = schema.get(name.as_str());
 
                     if matches!(dtype, Some(DataType::Object(..))) {
-                        return Err(ShellError::GenericError(
-                            "Object type column not supported for aggregation".into(),
-                            format!("Column '{name}' is type Object"),
-                            Some(call.head),
-                            Some("Aggregations cannot be performed on Object type columns. Use dtype command to check column types".into()),
-                            Vec::new(),
-                        ));
+                        return Err(ShellError::GenericError {
+                            error: "Object type column not supported for aggregation".into(),
+                            msg: format!("Column '{name}' is type Object"),
+                            span: Some(call.head),
+                            help: Some("Aggregations cannot be performed on Object type columns. Use dtype command to check column types".into()),
+                            inner: vec![],
+                        });
                     }
                 }
             }

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/fetch.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/fetch.rs
@@ -67,14 +67,12 @@ impl Command for LazyFetch {
         let eager: NuDataFrame = lazy
             .into_polars()
             .fetch(rows as usize)
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error fetching rows".into(),
-                    e.to_string(),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Error fetching rows".into(),
+                msg: e.into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
             })?
             .into();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/sort_by_expr.rs
@@ -118,13 +118,13 @@ impl Command for LazySortBy {
                         .get_flag::<Value>(engine_state, stack, "reverse")?
                         .expect("already checked and it exists")
                         .span();
-                    return Err(ShellError::GenericError(
-                        "Incorrect list size".into(),
-                        "Size doesn't match expression list".into(),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    ));
+                    return Err(ShellError::GenericError {
+                        error: "Incorrect list size".into(),
+                        msg: "Size doesn't match expression list".into(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    });
                 } else {
                     list
                 }

--- a/crates/nu-cmd-dataframe/src/dataframe/series/all_false.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/all_false.rs
@@ -78,14 +78,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     let series = df.as_series(call.head)?;
-    let bool = series.bool().map_err(|_| {
-        ShellError::GenericError(
-            "Error converting to bool".into(),
-            "all-false only works with series of type bool".into(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let bool = series.bool().map_err(|_| ShellError::GenericError {
+        error: "Error converting to bool".into(),
+        msg: "all-false only works with series of type bool".into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let value = Value::bool(!bool.any(), call.head);

--- a/crates/nu-cmd-dataframe/src/dataframe/series/all_true.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/all_true.rs
@@ -78,14 +78,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
 
     let series = df.as_series(call.head)?;
-    let bool = series.bool().map_err(|_| {
-        ShellError::GenericError(
-            "Error converting to bool".into(),
-            "all-false only works with series of type bool".into(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let bool = series.bool().map_err(|_| ShellError::GenericError {
+        error: "Error converting to bool".into(),
+        msg: "all-false only works with series of type bool".into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let value = Value::bool(bool.all(), call.head);

--- a/crates/nu-cmd-dataframe/src/dataframe/series/cumulative.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/cumulative.rs
@@ -21,13 +21,13 @@ impl CumType {
             "min" => Ok(Self::Min),
             "max" => Ok(Self::Max),
             "sum" => Ok(Self::Sum),
-            _ => Err(ShellError::GenericError(
-                "Wrong operation".into(),
-                "Operation not valid for cumulative".into(),
-                Some(span),
-                Some("Allowed values: max, min, sum".into()),
-                Vec::new(),
-            )),
+            _ => Err(ShellError::GenericError {
+                error: "Wrong operation".into(),
+                msg: "Operation not valid for cumulative".into(),
+                span: Some(span),
+                help: Some("Allowed values: max, min, sum".into()),
+                inner: vec![],
+            }),
         }
     }
 
@@ -108,13 +108,13 @@ fn command(
     let series = df.as_series(call.head)?;
 
     if let DataType::Object(_) = series.dtype() {
-        return Err(ShellError::GenericError(
-            "Found object series".into(),
-            "Series of type object cannot be used for cumulative operation".into(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "Found object series".into(),
+            msg: "Series of type object cannot be used for cumulative operation".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
     }
 
     let cum_type = CumType::from_str(&cum_type.item, cum_type.span)?;

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/as_date.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/as_date.rs
@@ -68,14 +68,12 @@ fn command(
 
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
-    let casted = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to string".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "Error casting to string".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = if not_exact {
@@ -85,14 +83,12 @@ fn command(
     };
 
     let mut res = res
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error creating datetime".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error creating datetime".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into_series();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/as_datetime.rs
@@ -132,14 +132,12 @@ fn command(
 
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
-    let casted = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to string".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "Error casting to string".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = if not_exact {
@@ -162,14 +160,12 @@ fn command(
     };
 
     let mut res = res
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error creating datetime".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error creating datetime".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into_series();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_day.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_day.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.day().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_hour.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.hour().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_minute.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.minute().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_month.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_month.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.month().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_nanosecond.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.nanosecond().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_ordinal.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.ordinal().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_second.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_second.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.second().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_week.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_week.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.week().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_weekday.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.weekday().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/date/get_year.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/date/get_year.rs
@@ -65,14 +65,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to datetime type".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to datetime type".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = casted.year().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/indexes/arg_true.rs
@@ -67,13 +67,13 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let columns = df.as_ref().get_column_names();
     if columns.len() > 1 {
-        return Err(ShellError::GenericError(
-            "Error using as series".into(),
-            "dataframe has more than one column".into(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "Error using as series".into(),
+            msg: "dataframe has more than one column".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
     }
 
     match columns.first() {
@@ -85,14 +85,12 @@ fn command(
                 .lazy()
                 .select(&[expression])
                 .collect()
-                .map_err(|err| {
-                    ShellError::GenericError(
-                        "Error creating index column".into(),
-                        err.to_string(),
-                        Some(call.head),
-                        None,
-                        Vec::new(),
-                    )
+                .map_err(|err| ShellError::GenericError {
+                    error: "Error creating index column".into(),
+                    msg: err.into(),
+                    span: Some(call.head),
+                    help: None,
+                    inner: vec![],
                 })?;
 
             let value = NuDataFrame::dataframe_into_value(res, call.head);

--- a/crates/nu-cmd-dataframe/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/indexes/arg_unique.rs
@@ -69,14 +69,12 @@ fn command(
     let mut res = df
         .as_series(call.head)?
         .arg_unique()
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error extracting unique values".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error extracting unique values".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into_series();
     res.rename("arg_unique");

--- a/crates/nu-cmd-dataframe/src/dataframe/series/indexes/set_with_idx.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/indexes/set_with_idx.rs
@@ -86,36 +86,33 @@ fn command(
     let indices = NuDataFrame::try_from_value(indices_value)?.as_series(indices_span)?;
 
     let casted = match indices.dtype() {
-        DataType::UInt32 | DataType::UInt64 | DataType::Int32 | DataType::Int64 => {
-            indices.as_ref().cast(&DataType::UInt32).map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting indices".into(),
-                    e.to_string(),
-                    Some(indices_span),
-                    None,
-                    Vec::new(),
-                )
-            })
-        }
-        _ => Err(ShellError::GenericError(
-            "Incorrect type".into(),
-            "Series with incorrect type".into(),
-            Some(indices_span),
-            Some("Consider using a Series with type int type".into()),
-            Vec::new(),
-        )),
+        DataType::UInt32 | DataType::UInt64 | DataType::Int32 | DataType::Int64 => indices
+            .as_ref()
+            .cast(&DataType::UInt32)
+            .map_err(|e| ShellError::GenericError {
+                error: "Error casting indices".into(),
+                msg: e.into(),
+                span: Some(indices_span),
+                help: None,
+                inner: vec![],
+            }),
+        _ => Err(ShellError::GenericError {
+            error: "Incorrect type".into(),
+            msg: "Series with incorrect type".into(),
+            span: Some(indices_span),
+            help: Some("Consider using a Series with type int type".into()),
+            inner: vec![],
+        }),
     }?;
 
     let indices = casted
         .u32()
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error casting indices".into(),
-                e.to_string(),
-                Some(indices_span),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error casting indices".into(),
+            msg: e.into(),
+            span: Some(indices_span),
+            help: None,
+            inner: vec![],
         })?
         .into_iter()
         .flatten();
@@ -124,92 +121,85 @@ fn command(
     let series = df.as_series(call.head)?;
 
     let span = value.span();
-    let res = match value {
-        Value::Int { val, .. } => {
-            let chunked = series.i64().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting to i64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
-
-            let res = chunked.set_at_idx(indices, Some(val)).map_err(|e| {
-                ShellError::GenericError(
-                    "Error setting value".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
-
-            NuDataFrame::try_from_series(vec![res.into_series()], call.head)
-        }
-        Value::Float { val, .. } => {
-            let chunked = series.f64().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting to f64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
-
-            let res = chunked.set_at_idx(indices, Some(val)).map_err(|e| {
-                ShellError::GenericError(
-                    "Error setting value".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
-
-            NuDataFrame::try_from_series(vec![res.into_series()], call.head)
-        }
-        Value::String { val, .. } => {
-            let chunked = series.utf8().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting to string".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
-
-            let res = chunked
-                .set_at_idx(indices, Some(val.as_ref()))
-                .map_err(|e| {
-                    ShellError::GenericError(
-                        "Error setting value".into(),
-                        e.to_string(),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    )
+    let res =
+        match value {
+            Value::Int { val, .. } => {
+                let chunked = series.i64().map_err(|e| ShellError::GenericError {
+                    error: "Error casting to i64".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
                 })?;
 
-            let mut res = res.into_series();
-            res.rename("string");
+                let res = chunked.set_at_idx(indices, Some(val)).map_err(|e| {
+                    ShellError::GenericError {
+                        error: "Error setting value".into(),
+                        msg: e.into(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    }
+                })?;
 
-            NuDataFrame::try_from_series(vec![res.into_series()], call.head)
-        }
-        _ => Err(ShellError::GenericError(
-            "Incorrect value type".into(),
-            format!(
-                "this value cannot be set in a series of type '{}'",
-                series.dtype()
-            ),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
-    };
+                NuDataFrame::try_from_series(vec![res.into_series()], call.head)
+            }
+            Value::Float { val, .. } => {
+                let chunked = series.f64().map_err(|e| ShellError::GenericError {
+                    error: "Error casting to f64".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                })?;
+
+                let res = chunked.set_at_idx(indices, Some(val)).map_err(|e| {
+                    ShellError::GenericError {
+                        error: "Error setting value".into(),
+                        msg: e.into(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    }
+                })?;
+
+                NuDataFrame::try_from_series(vec![res.into_series()], call.head)
+            }
+            Value::String { val, .. } => {
+                let chunked = series.utf8().map_err(|e| ShellError::GenericError {
+                    error: "Error casting to string".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                })?;
+
+                let res = chunked
+                    .set_at_idx(indices, Some(val.as_ref()))
+                    .map_err(|e| ShellError::GenericError {
+                        error: "Error setting value".into(),
+                        msg: e.into(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    })?;
+
+                let mut res = res.into_series();
+                res.rename("string");
+
+                NuDataFrame::try_from_series(vec![res.into_series()], call.head)
+            }
+            _ => Err(ShellError::GenericError {
+                error: "Incorrect value type".into(),
+                msg: format!(
+                    "this value cannot be set in a series of type '{}'",
+                    series.dtype()
+                ),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            }),
+        };
 
     res.map(|df| PipelineData::Value(NuDataFrame::into_value(df, call.head), None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/masks/is_duplicated.rs
@@ -94,14 +94,12 @@ fn command(
     let mut res = df
         .as_ref()
         .is_duplicated()
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error finding duplicates".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error finding duplicates".into(),
+            msg: e.to_string(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into_series();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/masks/is_in.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/masks/is_in.rs
@@ -79,14 +79,12 @@ fn command(
     let other = other_df.as_series(other_span)?;
 
     let mut res = is_in(&df, &other)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error finding in other".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error finding in other".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into_series();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/masks/is_unique.rs
@@ -93,14 +93,12 @@ fn command(
     let mut res = df
         .as_ref()
         .is_unique()
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error finding unique values".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error finding unique values".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into_series();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/masks/not.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/masks/not.rs
@@ -68,14 +68,12 @@ fn command(
 ) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
-    let bool = series.bool().map_err(|e| {
-        ShellError::GenericError(
-            "Error inverting mask".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let bool = series.bool().map_err(|e| ShellError::GenericError {
+        error: "Error inverting mask".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let res = bool.not();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/masks/set.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/masks/set.rs
@@ -85,22 +85,20 @@ fn command(
     let mask = NuDataFrame::try_from_value(mask_value)?.as_series(mask_span)?;
 
     let bool_mask = match mask.dtype() {
-        DataType::Boolean => mask.bool().map_err(|e| {
-            ShellError::GenericError(
-                "Error casting to bool".into(),
-                e.to_string(),
-                Some(mask_span),
-                None,
-                Vec::new(),
-            )
+        DataType::Boolean => mask.bool().map_err(|e| ShellError::GenericError {
+            error: "Error casting to bool".into(),
+            msg: e.into(),
+            span: Some(mask_span),
+            help: None,
+            inner: vec![],
         }),
-        _ => Err(ShellError::GenericError(
-            "Incorrect type".into(),
-            "can only use bool series as mask".into(),
-            Some(mask_span),
-            None,
-            Vec::new(),
-        )),
+        _ => Err(ShellError::GenericError {
+            error: "Incorrect type".into(),
+            msg: "can only use bool series as mask".into(),
+            span: Some(mask_span),
+            help: None,
+            inner: vec![],
+        }),
     }?;
 
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
@@ -108,70 +106,64 @@ fn command(
     let span = value.span();
     let res = match value {
         Value::Int { val, .. } => {
-            let chunked = series.i64().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting to i64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
+            let chunked = series.i64().map_err(|e| ShellError::GenericError {
+                error: "Error casting to i64".into(),
+                msg: e.into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
             })?;
 
-            let res = chunked.set(bool_mask, Some(val)).map_err(|e| {
-                ShellError::GenericError(
-                    "Error setting value".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
+            let res = chunked
+                .set(bool_mask, Some(val))
+                .map_err(|e| ShellError::GenericError {
+                    error: "Error setting value".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                })?;
 
             NuDataFrame::try_from_series(vec![res.into_series()], call.head)
         }
         Value::Float { val, .. } => {
-            let chunked = series.f64().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting to f64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
+            let chunked = series.f64().map_err(|e| ShellError::GenericError {
+                error: "Error casting to f64".into(),
+                msg: e.into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
             })?;
 
-            let res = chunked.set(bool_mask, Some(val)).map_err(|e| {
-                ShellError::GenericError(
-                    "Error setting value".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
+            let res = chunked
+                .set(bool_mask, Some(val))
+                .map_err(|e| ShellError::GenericError {
+                    error: "Error setting value".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                })?;
 
             NuDataFrame::try_from_series(vec![res.into_series()], call.head)
         }
         Value::String { val, .. } => {
-            let chunked = series.utf8().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting to string".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
+            let chunked = series.utf8().map_err(|e| ShellError::GenericError {
+                error: "Error casting to string".into(),
+                msg: e.into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
             })?;
 
             let res = chunked.set(bool_mask, Some(val.as_ref())).map_err(|e| {
-                ShellError::GenericError(
-                    "Error setting value".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
+                ShellError::GenericError {
+                    error: "Error setting value".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }
             })?;
 
             let mut res = res.into_series();
@@ -179,16 +171,16 @@ fn command(
 
             NuDataFrame::try_from_series(vec![res.into_series()], call.head)
         }
-        _ => Err(ShellError::GenericError(
-            "Incorrect value type".into(),
-            format!(
+        _ => Err(ShellError::GenericError {
+            error: "Incorrect value type".into(),
+            msg: format!(
                 "this value cannot be set in a series of type '{}'",
                 series.dtype()
             ),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     };
 
     res.map(|df| PipelineData::Value(NuDataFrame::into_value(df, call.head), None))

--- a/crates/nu-cmd-dataframe/src/dataframe/series/n_unique.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/n_unique.rs
@@ -83,15 +83,16 @@ fn command(
     call: &Call,
     df: NuDataFrame,
 ) -> Result<PipelineData, ShellError> {
-    let res = df.as_series(call.head)?.n_unique().map_err(|e| {
-        ShellError::GenericError(
-            "Error counting unique values".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let res = df
+        .as_series(call.head)?
+        .n_unique()
+        .map_err(|e| ShellError::GenericError {
+            error: "Error counting unique values".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        })?;
 
     let value = Value::int(res as i64, call.head);
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/rolling.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/rolling.rs
@@ -23,13 +23,13 @@ impl RollType {
             "max" => Ok(Self::Max),
             "sum" => Ok(Self::Sum),
             "mean" => Ok(Self::Mean),
-            _ => Err(ShellError::GenericError(
-                "Wrong operation".into(),
-                "Operation not valid for cumulative".into(),
-                Some(span),
-                Some("Allowed values: min, max, sum, mean".into()),
-                Vec::new(),
-            )),
+            _ => Err(ShellError::GenericError {
+                error: "Wrong operation".into(),
+                msg: "Operation not valid for cumulative".into(),
+                span: Some(span),
+                help: Some("Allowed values: min, max, sum, mean".into()),
+                inner: vec![],
+            }),
         }
     }
 
@@ -129,13 +129,13 @@ fn command(
     let series = df.as_series(call.head)?;
 
     if let DataType::Object(_) = series.dtype() {
-        return Err(ShellError::GenericError(
-            "Found object series".into(),
-            "Series of type object cannot be used for rolling operation".into(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "Found object series".into(),
+            msg: "Series of type object cannot be used for rolling operation".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
     }
 
     let roll_type = RollType::from_str(&roll_type.item, roll_type.span)?;
@@ -158,14 +158,12 @@ fn command(
         RollType::Mean => series.rolling_mean(rolling_opts),
     };
 
-    let mut res = res.map_err(|e| {
-        ShellError::GenericError(
-            "Error calculating rolling values".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let mut res = res.map_err(|e| ShellError::GenericError {
+        error: "Error calculating rolling values".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let name = format!("{}_{}", series.name(), roll_type.to_str());

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/concatenate.rs
@@ -78,25 +78,21 @@ fn command(
     let other_df = NuDataFrame::try_from_value(other)?;
 
     let other_series = other_df.as_series(other_span)?;
-    let other_chunked = other_series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "The concatenate only with string columns".into(),
-            e.to_string(),
-            Some(other_span),
-            None,
-            Vec::new(),
-        )
+    let other_chunked = other_series.utf8().map_err(|e| ShellError::GenericError {
+        error: "The concatenate only with string columns".into(),
+        msg: e.into(),
+        span: Some(other_span),
+        help: None,
+        inner: vec![],
     })?;
 
     let series = df.as_series(call.head)?;
-    let chunked = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "The concatenate only with string columns".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let chunked = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "The concatenate only with string columns".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
     let mut res = chunked.concat(other_chunked);

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/contains.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/contains.rs
@@ -74,25 +74,23 @@ fn command(
     let pattern: String = call.req(engine_state, stack, 0)?;
 
     let series = df.as_series(call.head)?;
-    let chunked = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "The contains command only with string columns".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let chunked = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "The contains command only with string columns".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
-    let res = chunked.contains(&pattern, false).map_err(|e| {
-        ShellError::GenericError(
-            "Error searching in series".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let res = chunked
+        .contains(&pattern, false)
+        .map_err(|e| ShellError::GenericError {
+            error: "Error searching in series".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        })?;
 
     NuDataFrame::try_from_series(vec![res.into_series()], call.head)
         .map(|df| PipelineData::Value(NuDataFrame::into_value(df, call.head), None))

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/replace.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/replace.rs
@@ -86,25 +86,23 @@ fn command(
 
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
-    let chunked = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "Error conversion to string".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let chunked = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "Error conversion to string".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
-    let mut res = chunked.replace(&pattern, &replace).map_err(|e| {
-        ShellError::GenericError(
-            "Error finding pattern other".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let mut res = chunked
+        .replace(&pattern, &replace)
+        .map_err(|e| ShellError::GenericError {
+            error: "Error finding pattern other".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        })?;
 
     res.rename(series.name());
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/replace_all.rs
@@ -86,25 +86,24 @@ fn command(
 
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
-    let chunked = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "Error conversion to string".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
+    let chunked = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "Error conversion to string".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: None,
+        inner: vec![],
     })?;
 
-    let mut res = chunked.replace_all(&pattern, &replace).map_err(|e| {
-        ShellError::GenericError(
-            "Error finding pattern other".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let mut res =
+        chunked
+            .replace_all(&pattern, &replace)
+            .map_err(|e| ShellError::GenericError {
+                error: "Error finding pattern other".into(),
+                msg: e.into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            })?;
 
     res.rename(series.name());
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/str_lengths.rs
@@ -63,14 +63,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let chunked = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to string".into(),
-            e.to_string(),
-            Some(call.head),
-            Some("The str-lengths command can only be used with string columns".into()),
-            Vec::new(),
-        )
+    let chunked = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "Error casting to string".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: Some("The str-lengths command can only be used with string columns".into()),
+        inner: vec![],
     })?;
 
     let res = chunked.as_ref().str_lengths().into_series();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/str_slice.rs
@@ -75,25 +75,23 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let chunked = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to string".into(),
-            e.to_string(),
-            Some(call.head),
-            Some("The str-slice command can only be used with string columns".into()),
-            Vec::new(),
-        )
+    let chunked = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "Error casting to string".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: Some("The str-slice command can only be used with string columns".into()),
+        inner: vec![],
     })?;
 
-    let mut res = chunked.str_slice(start, length).map_err(|e| {
-        ShellError::GenericError(
-            "Error slicing series".into(),
-            e.to_string(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let mut res = chunked
+        .str_slice(start, length)
+        .map_err(|e| ShellError::GenericError {
+            error: "Error slicing series".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        })?;
     res.rename(series.name());
 
     NuDataFrame::try_from_series(vec![res.into_series()], call.head)

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/strftime.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/strftime.rs
@@ -72,26 +72,22 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.datetime().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to date".into(),
-            e.to_string(),
-            Some(call.head),
-            Some("The str-slice command can only be used with string columns".into()),
-            Vec::new(),
-        )
+    let casted = series.datetime().map_err(|e| ShellError::GenericError {
+        error: "Error casting to date".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: Some("The str-slice command can only be used with string columns".into()),
+        inner: vec![],
     })?;
 
     let res = casted
         .strftime(&fmt)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error formatting datetime".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error formatting datetime".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?
         .into_series();
 

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/to_lowercase.rs
@@ -67,14 +67,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to string".into(),
-            e.to_string(),
-            Some(call.head),
-            Some("The str-slice command can only be used with string columns".into()),
-            Vec::new(),
-        )
+    let casted = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "Error casting to string".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: Some("The str-slice command can only be used with string columns".into()),
+        inner: vec![],
     })?;
 
     let mut res = casted.to_lowercase();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/string/to_uppercase.rs
@@ -71,14 +71,12 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let casted = series.utf8().map_err(|e| {
-        ShellError::GenericError(
-            "Error casting to string".into(),
-            e.to_string(),
-            Some(call.head),
-            Some("The str-slice command can only be used with string columns".into()),
-            Vec::new(),
-        )
+    let casted = series.utf8().map_err(|e| ShellError::GenericError {
+        error: "Error casting to string".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: Some("The str-slice command can only be used with string columns".into()),
+        inner: vec![],
     })?;
 
     let mut res = casted.to_uppercase();

--- a/crates/nu-cmd-dataframe/src/dataframe/series/unique.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/unique.rs
@@ -96,14 +96,12 @@ fn command_eager(
 ) -> Result<PipelineData, ShellError> {
     let series = df.as_series(call.head)?;
 
-    let res = series.unique().map_err(|e| {
-        ShellError::GenericError(
-            "Error calculating unique values".into(),
-            e.to_string(),
-            Some(call.head),
-            Some("The str-slice command can only be used with string columns".into()),
-            Vec::new(),
-        )
+    let res = series.unique().map_err(|e| ShellError::GenericError {
+        error: "Error calculating unique values".into(),
+        msg: e.into(),
+        span: Some(call.head),
+        help: Some("The str-slice command can only be used with string columns".into()),
+        inner: vec![],
     })?;
 
     NuDataFrame::try_from_series(vec![res.into_series()], call.head)

--- a/crates/nu-cmd-dataframe/src/dataframe/series/value_counts.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/value_counts.rs
@@ -70,15 +70,15 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(input, call.head)?;
     let series = df.as_series(call.head)?;
 
-    let res = series.value_counts(false, false).map_err(|e| {
-        ShellError::GenericError(
-            "Error calculating value counts values".into(),
-            e.to_string(),
-            Some(call.head),
-            Some("The str-slice command can only be used with string columns".into()),
-            Vec::new(),
-        )
-    })?;
+    let res = series
+        .value_counts(false, false)
+        .map_err(|e| ShellError::GenericError {
+            error: "Error calculating value counts values".into(),
+            msg: e.into(),
+            span: Some(call.head),
+            help: Some("The str-slice command can only be used with string columns".into()),
+            inner: vec![],
+        })?;
 
     Ok(PipelineData::Value(
         NuDataFrame::dataframe_into_value(res, call.head),

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/between_values.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/between_values.rs
@@ -68,13 +68,13 @@ pub(super) fn compute_between_series(
                     res.rename(&name);
                     NuDataFrame::series_to_value(res, operation_span)
                 }
-                Err(e) => Err(ShellError::GenericError(
-                    "Division error".into(),
-                    e.to_string(),
-                    Some(right.span()),
-                    None,
-                    Vec::new(),
-                )),
+                Err(e) => Err(ShellError::GenericError {
+                    error: "Division error".into(),
+                    msg: e.into(),
+                    span: Some(right.span()),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         }
         Operator::Comparison(Comparison::Equal) => {
@@ -119,13 +119,13 @@ pub(super) fn compute_between_series(
                         res.rename(&name);
                         NuDataFrame::series_to_value(res, operation_span)
                     }
-                    _ => Err(ShellError::GenericError(
-                        "Incompatible types".into(),
-                        "unable to cast to boolean".into(),
-                        Some(right.span()),
-                        None,
-                        Vec::new(),
-                    )),
+                    _ => Err(ShellError::GenericError {
+                        error: "Incompatible types".into(),
+                        msg: "unable to cast to boolean".into(),
+                        span: Some(right.span()),
+                        help: None,
+                        inner: vec![],
+                    }),
                 }
             }
             _ => Err(ShellError::IncompatibleParametersSingle {
@@ -148,13 +148,13 @@ pub(super) fn compute_between_series(
                         res.rename(&name);
                         NuDataFrame::series_to_value(res, operation_span)
                     }
-                    _ => Err(ShellError::GenericError(
-                        "Incompatible types".into(),
-                        "unable to cast to boolean".into(),
-                        Some(right.span()),
-                        None,
-                        Vec::new(),
-                    )),
+                    _ => Err(ShellError::GenericError {
+                        error: "Incompatible types".into(),
+                        msg: "unable to cast to boolean".into(),
+                        span: Some(right.span()),
+                        help: None,
+                        inner: vec![],
+                    }),
                 }
             }
             _ => Err(ShellError::IncompatibleParametersSingle {
@@ -186,14 +186,12 @@ where
     F: Fn(&'s Series, &'s Series) -> Result<ChunkedArray<BooleanType>, PolarsError>,
 {
     let mut res = f(lhs, rhs)
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Equality error".into(),
-                e.to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Equality error".into(),
+            msg: e.into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         })?
         .into_series();
 
@@ -458,29 +456,29 @@ where
                     let casted = series.i64();
                     compute_casted_i64(casted, val, f, span)
                 }
-                Err(e) => Err(ShellError::GenericError(
-                    "Unable to cast to i64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                Err(e) => Err(ShellError::GenericError {
+                    error: "Unable to cast to i64".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         }
         DataType::Int64 => {
             let casted = series.i64();
             compute_casted_i64(casted, val, f, span)
         }
-        _ => Err(ShellError::GenericError(
-            "Incorrect type".into(),
-            format!(
+        _ => Err(ShellError::GenericError {
+            error: "Incorrect type".into(),
+            msg: format!(
                 "Series of type {} can not be used for operations with an i64 value",
                 series.dtype()
             ),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -499,13 +497,13 @@ where
             let res = res.into_series();
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::GenericError(
-            "Unable to cast to i64".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+        Err(e) => Err(ShellError::GenericError {
+            error: "Unable to cast to i64".into(),
+            msg: e.into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -522,29 +520,29 @@ where
                     let casted = series.f64();
                     compute_casted_f64(casted, val, f, span)
                 }
-                Err(e) => Err(ShellError::GenericError(
-                    "Unable to cast to f64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                Err(e) => Err(ShellError::GenericError {
+                    error: "Unable to cast to f64".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         }
         DataType::Float64 => {
             let casted = series.f64();
             compute_casted_f64(casted, val, f, span)
         }
-        _ => Err(ShellError::GenericError(
-            "Incorrect type".into(),
-            format!(
+        _ => Err(ShellError::GenericError {
+            error: "Incorrect type".into(),
+            msg: format!(
                 "Series of type {} can not be used for operations with a float value",
                 series.dtype()
             ),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -563,13 +561,13 @@ where
             let res = res.into_series();
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::GenericError(
-            "Unable to cast to f64".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+        Err(e) => Err(ShellError::GenericError {
+            error: "Unable to cast to f64".into(),
+            msg: e.into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -586,13 +584,13 @@ where
                     let casted = series.i64();
                     compare_casted_i64(casted, val, f, span)
                 }
-                Err(e) => Err(ShellError::GenericError(
-                    "Unable to cast to f64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                Err(e) => Err(ShellError::GenericError {
+                    error: "Unable to cast to f64".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         }
         DataType::Date => {
@@ -607,29 +605,29 @@ where
                         .expect("already checked for casting");
                     compare_casted_i64(Ok(&casted), val, f, span)
                 }
-                Err(e) => Err(ShellError::GenericError(
-                    "Unable to cast to f64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                Err(e) => Err(ShellError::GenericError {
+                    error: "Unable to cast to f64".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         }
         DataType::Int64 => {
             let casted = series.i64();
             compare_casted_i64(casted, val, f, span)
         }
-        _ => Err(ShellError::GenericError(
-            "Incorrect type".into(),
-            format!(
+        _ => Err(ShellError::GenericError {
+            error: "Incorrect type".into(),
+            msg: format!(
                 "Series of type {} can not be used for operations with an i64 value",
                 series.dtype()
             ),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -648,13 +646,13 @@ where
             let res = res.into_series();
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::GenericError(
-            "Unable to cast to i64".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+        Err(e) => Err(ShellError::GenericError {
+            error: "Unable to cast to i64".into(),
+            msg: e.into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -671,29 +669,29 @@ where
                     let casted = series.f64();
                     compare_casted_f64(casted, val, f, span)
                 }
-                Err(e) => Err(ShellError::GenericError(
-                    "Unable to cast to i64".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                Err(e) => Err(ShellError::GenericError {
+                    error: "Unable to cast to i64".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         }
         DataType::Float64 => {
             let casted = series.f64();
             compare_casted_f64(casted, val, f, span)
         }
-        _ => Err(ShellError::GenericError(
-            "Incorrect type".into(),
-            format!(
+        _ => Err(ShellError::GenericError {
+            error: "Incorrect type".into(),
+            msg: format!(
                 "Series of type {} can not be used for operations with a float value",
                 series.dtype()
             ),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -712,13 +710,13 @@ where
             let res = res.into_series();
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::GenericError(
-            "Unable to cast to f64".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+        Err(e) => Err(ShellError::GenericError {
+            error: "Unable to cast to f64".into(),
+            msg: e.into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -733,22 +731,22 @@ fn contains_series_pat(series: &Series, pat: &str, span: Span) -> Result<Value, 
                     let res = res.into_series();
                     NuDataFrame::series_to_value(res, span)
                 }
-                Err(e) => Err(ShellError::GenericError(
-                    "Error using contains".into(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                Err(e) => Err(ShellError::GenericError {
+                    error: "Error using contains".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         }
-        Err(e) => Err(ShellError::GenericError(
-            "Unable to cast to string".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+        Err(e) => Err(ShellError::GenericError {
+            error: "Unable to cast to string".into(),
+            msg: e.into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 
@@ -761,12 +759,12 @@ fn add_string_to_series(series: &Series, pat: &str, span: Span) -> Result<Value,
 
             NuDataFrame::series_to_value(res, span)
         }
-        Err(e) => Err(ShellError::GenericError(
-            "Unable to cast to string".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )),
+        Err(e) => Err(ShellError::GenericError {
+            error: "Unable to cast to string".into(),
+            msg: e.into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }),
     }
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
@@ -287,14 +287,12 @@ pub fn from_parsed_columns(column_values: ColumnMap) -> Result<NuDataFrame, Shel
 
     DataFrame::new(df_series)
         .map(|df| NuDataFrame::new(false, df))
-        .map_err(|e| {
-            ShellError::GenericError(
-                "Error creating dataframe".into(),
-                "".to_string(),
-                None,
-                Some(e.to_string()),
-                Vec::new(),
-            )
+        .map_err(|e| ShellError::GenericError {
+            error: "Error creating dataframe".into(),
+            msg: "".into(),
+            span: None,
+            help: Some(e.into()),
+            inner: vec![],
         })
 }
 
@@ -314,16 +312,14 @@ fn input_type_list_to_series(
     list_type: &InputType,
     values: &[Value],
 ) -> Result<Series, ShellError> {
-    let inconsistent_error = |_| {
-        ShellError::GenericError(
-            format!(
-                "column {name} contains a list with inconsistent types: Expecting: {list_type:?}"
-            ),
-            "".to_string(),
-            None,
-            None,
-            Vec::new(),
-        )
+    let inconsistent_error = |_| ShellError::GenericError {
+        error: format!(
+            "column {name} contains a list with inconsistent types: Expecting: {list_type:?}"
+        ),
+        msg: "".into(),
+        span: None,
+        help: None,
+        inner: vec![],
     };
     match *list_type {
         // list of boolean values
@@ -423,14 +419,12 @@ fn input_type_list_to_series(
 
                 builder
                     .append_series(&dt_chunked.into_series())
-                    .map_err(|e| {
-                        ShellError::GenericError(
-                            "Error appending to series".into(),
-                            "".to_string(),
-                            None,
-                            Some(e.to_string()),
-                            Vec::new(),
-                        )
+                    .map_err(|e| ShellError::GenericError {
+                        error: "Error appending to series".into(),
+                        msg: "".into(),
+                        span: None,
+                        help: Some(e.into()),
+                        inner: vec![],
                     })?
             }
             let res = builder.finish();
@@ -463,14 +457,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::UInt8 => {
-            let casted = series.u8().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to u8".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.u8().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to u8".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -488,14 +480,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::UInt16 => {
-            let casted = series.u16().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to u16".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.u16().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to u16".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -513,14 +503,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::UInt32 => {
-            let casted = series.u32().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to u32".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.u32().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to u32".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -538,14 +526,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::UInt64 => {
-            let casted = series.u64().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to u64".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.u64().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to u64".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -563,14 +549,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Int8 => {
-            let casted = series.i8().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to i8".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.i8().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to i8".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -588,14 +572,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Int16 => {
-            let casted = series.i16().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to i16".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.i16().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to i16".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -613,14 +595,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Int32 => {
-            let casted = series.i32().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to i32".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.i32().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to i32".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -638,14 +618,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Int64 => {
-            let casted = series.i64().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to i64".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.i64().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to i64".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -663,14 +641,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Float32 => {
-            let casted = series.f32().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to f32".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.f32().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to f32".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -688,14 +664,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Float64 => {
-            let casted = series.f64().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to f64".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.f64().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to f64".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -713,14 +687,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Boolean => {
-            let casted = series.bool().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to bool".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.bool().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to bool".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -738,14 +710,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Utf8 => {
-            let casted = series.utf8().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to string".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.utf8().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to string".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -768,13 +738,13 @@ fn series_to_values(
                 .downcast_ref::<ChunkedArray<ObjectType<DataFrameValue>>>();
 
             match casted {
-                None => Err(ShellError::GenericError(
-                    "Error casting object from series".into(),
-                    "".to_string(),
-                    None,
-                    Some(format!("Object not supported for conversion: {x}")),
-                    Vec::new(),
-                )),
+                None => Err(ShellError::GenericError {
+                    error: "Error casting object from series".into(),
+                    msg: "".into(),
+                    span: None,
+                    help: Some(format!("Object not supported for conversion: {x}")),
+                    inner: vec![],
+                }),
                 Some(ca) => {
                     let it = ca.into_iter();
                     let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row)
@@ -796,13 +766,13 @@ fn series_to_values(
         DataType::List(x) => {
             let casted = series.as_any().downcast_ref::<ChunkedArray<ListType>>();
             match casted {
-                None => Err(ShellError::GenericError(
-                    "Error casting list from series".into(),
-                    "".to_string(),
-                    None,
-                    Some(format!("List not supported for conversion: {x}")),
-                    Vec::new(),
-                )),
+                None => Err(ShellError::GenericError {
+                    error: "Error casting list from series".into(),
+                    msg: "".into(),
+                    span: None,
+                    help: Some(format!("List not supported for conversion: {x}")),
+                    inner: vec![],
+                }),
                 Some(ca) => {
                     let it = ca.into_iter();
                     let values: Vec<Value> =
@@ -831,14 +801,12 @@ fn series_to_values(
             }
         }
         DataType::Date => {
-            let casted = series.date().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to date".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.date().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to date".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -894,14 +862,12 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Datetime(time_unit, _) => {
-            let casted = series.datetime().map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to datetime".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
+            let casted = series.datetime().map_err(|e| ShellError::GenericError {
+                error: "Error casting column to datetime".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(e.into()),
+                inner: vec![],
             })?;
 
             let it = casted.into_iter();
@@ -962,15 +928,16 @@ fn series_to_values(
             Ok(values)
         }
         DataType::Time => {
-            let casted = series.timestamp(TimeUnit::Nanoseconds).map_err(|e| {
-                ShellError::GenericError(
-                    "Error casting column to time".into(),
-                    "".to_string(),
-                    None,
-                    Some(e.to_string()),
-                    Vec::new(),
-                )
-            })?;
+            let casted =
+                series
+                    .timestamp(TimeUnit::Nanoseconds)
+                    .map_err(|e| ShellError::GenericError {
+                        error: "Error casting column to time".into(),
+                        msg: "".into(),
+                        span: None,
+                        help: Some(e.into()),
+                        inner: vec![],
+                    })?;
 
             let it = casted.into_iter();
             let values = if let (Some(size), Some(from_row)) = (maybe_size, maybe_from_row) {
@@ -986,13 +953,13 @@ fn series_to_values(
 
             Ok(values)
         }
-        e => Err(ShellError::GenericError(
-            "Error creating Dataframe".into(),
-            "".to_string(),
-            None,
-            Some(format!("Value not supported in nushell: {e}")),
-            Vec::new(),
-        )),
+        e => Err(ShellError::GenericError {
+            error: "Error creating Dataframe".into(),
+            msg: "".to_string(),
+            span: None,
+            help: Some(format!("Value not supported in nushell: {e}")),
+            inner: vec![],
+        }),
     }
 }
 

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
@@ -124,13 +124,13 @@ impl NuDataFrame {
     pub fn series_to_value(series: Series, span: Span) -> Result<Value, ShellError> {
         match DataFrame::new(vec![series]) {
             Ok(dataframe) => Ok(NuDataFrame::dataframe_into_value(dataframe, span)),
-            Err(e) => Err(ShellError::GenericError(
-                "Error creating dataframe".into(),
-                e.to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            )),
+            Err(e) => Err(ShellError::GenericError {
+                error: "Error creating dataframe".into(),
+                msg: e.into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            }),
         }
     }
 
@@ -167,14 +167,12 @@ impl NuDataFrame {
     }
 
     pub fn try_from_series(columns: Vec<Series>, span: Span) -> Result<Self, ShellError> {
-        let dataframe = DataFrame::new(columns).map_err(|e| {
-            ShellError::GenericError(
-                "Error creating dataframe".into(),
-                format!("Unable to create DataFrame: {e}"),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+        let dataframe = DataFrame::new(columns).map_err(|e| ShellError::GenericError {
+            error: "Error creating dataframe".into(),
+            msg: format!("Unable to create DataFrame: {e}"),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         })?;
 
         Ok(Self::new(false, dataframe))
@@ -294,14 +292,12 @@ impl NuDataFrame {
             }
         })?;
 
-        let df = DataFrame::new(vec![s.clone()]).map_err(|e| {
-            ShellError::GenericError(
-                "Error creating dataframe".into(),
-                e.to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+        let df = DataFrame::new(vec![s.clone()]).map_err(|e| ShellError::GenericError {
+            error: "Error creating dataframe".into(),
+            msg: e.into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         })?;
 
         Ok(Self {
@@ -316,13 +312,13 @@ impl NuDataFrame {
 
     pub fn as_series(&self, span: Span) -> Result<Series, ShellError> {
         if !self.is_series() {
-            return Err(ShellError::GenericError(
-                "Error using as series".into(),
-                "dataframe has more than one column".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Error using as series".into(),
+                msg: "dataframe has more than one column".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            });
         }
 
         let series = self

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/operations.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/operations.rs
@@ -135,14 +135,12 @@ impl NuDataFrame {
                     })
                     .collect::<Vec<Series>>();
 
-                let df_new = DataFrame::new(new_cols).map_err(|e| {
-                    ShellError::GenericError(
-                        "Error creating dataframe".into(),
-                        e.to_string(),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    )
+                let df_new = DataFrame::new(new_cols).map_err(|e| ShellError::GenericError {
+                    error: "Error creating dataframe".into(),
+                    msg: e.into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
                 })?;
 
                 Ok(NuDataFrame::new(false, df_new))
@@ -183,26 +181,24 @@ impl NuDataFrame {
                         match res {
                             Ok(s) => Ok(s.clone()),
                             Err(e) => Err({
-                                ShellError::GenericError(
-                                    "Error appending dataframe".into(),
-                                    format!("Unable to append: {e}"),
-                                    Some(span),
-                                    None,
-                                    Vec::new(),
-                                )
+                                ShellError::GenericError {
+                                    error: "Error appending dataframe".into(),
+                                    msg: format!("Unable to append: {e}"),
+                                    span: Some(span),
+                                    help: None,
+                                    inner: vec![],
+                                }
                             }),
                         }
                     })
                     .collect::<Result<Vec<Series>, ShellError>>()?;
 
-                let df_new = DataFrame::new(new_cols).map_err(|e| {
-                    ShellError::GenericError(
-                        "Error appending dataframe".into(),
-                        format!("Unable to append dataframes: {e}"),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    )
+                let df_new = DataFrame::new(new_cols).map_err(|e| ShellError::GenericError {
+                    error: "Error appending dataframe".into(),
+                    msg: format!("Unable to append dataframes: {e}"),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
                 })?;
 
                 Ok(NuDataFrame::new(false, df_new))

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/mod.rs
@@ -104,14 +104,12 @@ impl NuLazyFrame {
         self.lazy
             .expect("No empty lazy for collect")
             .collect()
-            .map_err(|e| {
-                ShellError::GenericError(
-                    "Error collecting lazy frame".to_string(),
-                    e.to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
+            .map_err(|e| ShellError::GenericError {
+                error: "Error collecting lazy frame".into(),
+                msg: e.into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
             })
             .map(|df| NuDataFrame {
                 df,

--- a/crates/nu-cmd-dataframe/src/dataframe/values/utils.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/utils.rs
@@ -12,14 +12,12 @@ pub(crate) fn convert_columns(
     // First column span
     let mut col_span = columns
         .first()
-        .ok_or_else(|| {
-            ShellError::GenericError(
-                "Empty column list".into(),
-                "Empty list found for command".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+        .ok_or_else(|| ShellError::GenericError {
+            error: "Empty column list".into(),
+            msg: "Empty list found for command".into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         })
         .map(|v| v.span())?;
 
@@ -32,13 +30,13 @@ pub(crate) fn convert_columns(
                     col_span = span_join(&[col_span, span]);
                     Ok(Spanned { item: val, span })
                 }
-                _ => Err(ShellError::GenericError(
-                    "Incorrect column format".into(),
-                    "Only string as column name".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                _ => Err(ShellError::GenericError {
+                    error: "Incorrect column format".into(),
+                    msg: "Only string as column name".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         })
         .collect::<Result<Vec<Spanned<String>>, _>>()?;
@@ -55,14 +53,12 @@ pub(crate) fn convert_columns_string(
     // First column span
     let mut col_span = columns
         .first()
-        .ok_or_else(|| {
-            ShellError::GenericError(
-                "Empty column list".into(),
-                "Empty list found for command".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+        .ok_or_else(|| ShellError::GenericError {
+            error: "Empty column list".into(),
+            msg: "Empty list found for command".into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         })
         .map(|v| v.span())?;
 
@@ -75,13 +71,13 @@ pub(crate) fn convert_columns_string(
                     col_span = span_join(&[col_span, span]);
                     Ok(val)
                 }
-                _ => Err(ShellError::GenericError(
-                    "Incorrect column format".into(),
-                    "Only string as column name".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                _ => Err(ShellError::GenericError {
+                    error: "Incorrect column format".into(),
+                    msg: "Only string as column name".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             }
         })
         .collect::<Result<Vec<String>, _>>()?;

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -108,15 +108,15 @@ where
     match rotate_result {
         Ok(val) => Value::int(val, span),
         Err(_) => Value::error(
-            ShellError::GenericError(
-                "Rotate left result beyond the range of 64 bit signed number".to_string(),
-                format!(
+            ShellError::GenericError {
+                error: "Rotate left result beyond the range of 64 bit signed number".into(),
+                msg: format!(
                     "{val} of the specified number of bytes rotate left {bits} bits exceed limit"
                 ),
-                Some(span),
-                None,
-                Vec::new(),
-            ),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            },
             span,
         ),
     }

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -112,15 +112,15 @@ where
     match rotate_result {
         Ok(val) => Value::int(val, span),
         Err(_) => Value::error(
-            ShellError::GenericError(
-                "Rotate right result beyond the range of 64 bit signed number".to_string(),
-                format!(
+            ShellError::GenericError {
+                error: "Rotate right result beyond the range of 64 bit signed number".into(),
+                msg: format!(
                     "{val} of the specified number of bytes rotate right {bits} bits exceed limit"
                 ),
-                Some(span),
-                None,
-                Vec::new(),
-            ),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            },
             span,
         ),
     }

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -120,27 +120,27 @@ where
             match shift_result {
                 Ok(val) => Value::int( val, span ),
                 Err(_) => Value::error(
-                    ShellError::GenericError(
-                        "Shift left result beyond the range of 64 bit signed number".to_string(),
-                        format!(
+                    ShellError::GenericError {
+                        error:"Shift left result beyond the range of 64 bit signed number".into(),
+                        msg: format!(
                             "{val} of the specified number of bytes shift left {bits} bits exceed limit"
                         ),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    ),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    },
                     span,
                 ),
             }
         }
         None => Value::error(
-            ShellError::GenericError(
-                "Shift left failed".to_string(),
-                format!("{val} shift left {bits} bits failed, you may shift too many bits"),
-                Some(span),
-                None,
-                Vec::new(),
-            ),
+            ShellError::GenericError {
+                error: "Shift left failed".into(),
+                msg: format!("{val} shift left {bits} bits failed, you may shift too many bits"),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            },
             span,
         ),
     }

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -110,27 +110,27 @@ where
             match shift_result {
                 Ok(val) => Value::int( val, span ),
                 Err(_) => Value::error(
-                    ShellError::GenericError(
-                        "Shift right result beyond the range of 64 bit signed number".to_string(),
-                        format!(
+                    ShellError::GenericError {
+                        error: "Shift right result beyond the range of 64 bit signed number".into(),
+                        msg: format!(
                             "{val} of the specified number of bytes shift right {bits} bits exceed limit"
                         ),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    ),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    },
                     span,
                 ),
             }
         }
         None => Value::error(
-            ShellError::GenericError(
-                "Shift right failed".to_string(),
-                format!("{val} shift right {bits} bits failed, you may shift too many bits"),
-                Some(span),
-                None,
-                Vec::new(),
-            ),
+            ShellError::GenericError {
+                error: "Shift right failed".into(),
+                msg: format!("{val} shift right {bits} bits failed, you may shift too many bits"),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            },
             span,
         ),
     }

--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -304,13 +304,13 @@ fn to_html(
         let color_hm = match color_hm {
             Ok(c) => c,
             _ => {
-                return Err(ShellError::GenericError(
-                    "Error finding theme name".to_string(),
-                    "Error finding theme name".to_string(),
-                    Some(theme_span),
-                    None,
-                    Vec::new(),
-                ))
+                return Err(ShellError::GenericError {
+                    error: "Error finding theme name".into(),
+                    msg: "Error finding theme name".into(),
+                    span: Some(theme_span),
+                    help: None,
+                    inner: vec![],
+                })
             }
         };
 

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/hex.rs
@@ -121,22 +121,22 @@ fn action(
 
                 ActionType::Decode => match hex_decode(val.as_ref()) {
                     Ok(decoded_value) => Value::binary(decoded_value, command_span),
-                    Err(HexDecodingError::InvalidLength(len)) => Value::error(ShellError::GenericError(
-                            "value could not be hex decoded".to_string(),
-                            format!("invalid hex input length: {len}. The length should be even"),
-                            Some(command_span),
-                            None,
-                            Vec::new(),
-                        ),
+                    Err(HexDecodingError::InvalidLength(len)) => Value::error(ShellError::GenericError {
+                            error: "value could not be hex decoded".into(),
+                            msg: format!("invalid hex input length: {len}. The length should be even"),
+                            span: Some(command_span),
+                            help: None,
+                            inner: vec![],
+                        },
                         command_span,
                     ),
-                    Err(HexDecodingError::InvalidDigit(index, digit)) => Value::error(ShellError::GenericError(
-                            "value could not be hex decoded".to_string(),
-                            format!("invalid hex digit: '{digit}' at index {index}. Only 0-9, A-F, a-f are allowed in hex encoding"),
-                            Some(command_span),
-                            None,
-                            Vec::new(),
-                        ),
+                    Err(HexDecodingError::InvalidDigit(index, digit)) => Value::error(ShellError::GenericError {
+                            error: "value could not be hex decoded".into(),
+                            msg: format!("invalid hex digit: '{digit}' at index {index}. Only 0-9, A-F, a-f are allowed in hex encoding"),
+                            span: Some(command_span),
+                            help: None,
+                            inner: vec![],
+                        },
                         command_span,
                     ),
                 },

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -58,13 +58,13 @@ This command is a parser keyword. For details, check:
             ..
         }) = call.get_parser_info("import_pattern")
         else {
-            return Err(ShellError::GenericError(
-                "Unexpected import".into(),
-                "import pattern not supported".into(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Unexpected import".into(),
+                msg: "import pattern not supported".into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            });
         };
 
         if let Some(module_id) = import_pattern.head.id {
@@ -131,16 +131,16 @@ This command is a parser keyword. For details, check:
                 redirect_env(engine_state, caller_stack, &callee_stack);
             }
         } else {
-            return Err(ShellError::GenericError(
-                format!(
+            return Err(ShellError::GenericError {
+                error: format!(
                     "Could not import from '{}'",
                     String::from_utf8_lossy(&import_pattern.head.name)
                 ),
-                "module does not exist".to_string(),
-                Some(import_pattern.head.span),
-                None,
-                Vec::new(),
-            ));
+                msg: "module does not exist".to_string(),
+                span: Some(import_pattern.head.span),
+                help: None,
+                inner: vec![],
+            });
         }
 
         Ok(PipelineData::empty())

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -155,25 +155,23 @@ fn action(
                 format!("CREATE TABLE IF NOT EXISTS [{table_name}] ({table_columns_creation})");
 
             // prepare the string as a sqlite statement
-            let mut stmt = conn.prepare(&create_statement).map_err(|e| {
-                ShellError::GenericError(
-                    "Failed to prepare SQLite statement".into(),
-                    e.to_string(),
-                    Some(file.span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
+            let mut stmt =
+                conn.prepare(&create_statement)
+                    .map_err(|e| ShellError::GenericError {
+                        error: "Failed to prepare SQLite statement".into(),
+                        msg: e.to_string(),
+                        span: Some(file.span),
+                        help: None,
+                        inner: vec![],
+                    })?;
 
             // execute the statement
-            stmt.execute([]).map_err(|e| {
-                ShellError::GenericError(
-                    "Failed to execute SQLite statement".into(),
-                    e.to_string(),
-                    Some(file.span),
-                    None,
-                    Vec::new(),
-                )
+            stmt.execute([]).map_err(|e| ShellError::GenericError {
+                error: "Failed to execute SQLite statement".into(),
+                msg: e.to_string(),
+                span: Some(file.span),
+                help: None,
+                inner: vec![],
             })?;
 
             // use normal sql to create the table
@@ -187,25 +185,23 @@ fn action(
             let insert_statement = format!("INSERT INTO [{table_name}] VALUES {table_values}");
 
             // prepare the string as a sqlite statement
-            let mut stmt = conn.prepare(&insert_statement).map_err(|e| {
-                ShellError::GenericError(
-                    "Failed to prepare SQLite statement".into(),
-                    e.to_string(),
-                    Some(file.span),
-                    None,
-                    Vec::new(),
-                )
-            })?;
+            let mut stmt =
+                conn.prepare(&insert_statement)
+                    .map_err(|e| ShellError::GenericError {
+                        error: "Failed to prepare SQLite statement".into(),
+                        msg: e.to_string(),
+                        span: Some(file.span),
+                        help: None,
+                        inner: vec![],
+                    })?;
 
             // execute the statement
-            stmt.execute([]).map_err(|e| {
-                ShellError::GenericError(
-                    "Failed to execute SQLite statement".into(),
-                    e.to_string(),
-                    Some(file.span),
-                    None,
-                    Vec::new(),
-                )
+            stmt.execute([]).map_err(|e| ShellError::GenericError {
+                error: "Failed to execute SQLite statement".into(),
+                msg: e.to_string(),
+                span: Some(file.span),
+                help: None,
+                inner: vec![],
             })?;
 
             // and we're done

--- a/crates/nu-command/src/database/commands/schema.rs
+++ b/crates/nu-command/src/database/commands/schema.rs
@@ -47,15 +47,15 @@ impl Command for SchemaDb {
 
         let sqlite_db = SQLiteDatabase::try_from_pipeline(input, span)?;
         let conn = open_sqlite_db_connection(&sqlite_db, span)?;
-        let tables = sqlite_db.get_tables(&conn).map_err(|e| {
-            ShellError::GenericError(
-                "Error reading tables".into(),
-                e.to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
-        })?;
+        let tables = sqlite_db
+            .get_tables(&conn)
+            .map_err(|e| ShellError::GenericError {
+                error: "Error reading tables".into(),
+                msg: e.to_string(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            })?;
 
         let mut tables_record = Record::new();
         for table in tables {
@@ -87,14 +87,12 @@ impl Command for SchemaDb {
 }
 
 fn open_sqlite_db_connection(db: &SQLiteDatabase, span: Span) -> Result<Connection, ShellError> {
-    db.open_connection().map_err(|e| {
-        ShellError::GenericError(
-            "Error opening file".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )
+    db.open_connection().map_err(|e| ShellError::GenericError {
+        error: "Error opening file".into(),
+        msg: e.to_string(),
+        span: Some(span),
+        help: None,
+        inner: vec![],
     })
 }
 
@@ -104,15 +102,15 @@ fn get_table_columns(
     table: &DbTable,
     span: Span,
 ) -> Result<Vec<Value>, ShellError> {
-    let columns = db.get_columns(conn, table).map_err(|e| {
-        ShellError::GenericError(
-            "Error getting database columns".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let columns = db
+        .get_columns(conn, table)
+        .map_err(|e| ShellError::GenericError {
+            error: "Error getting database columns".into(),
+            msg: e.to_string(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        })?;
 
     // a record of column name = column value
     let mut column_info = vec![];
@@ -136,15 +134,15 @@ fn get_table_constraints(
     table: &DbTable,
     span: Span,
 ) -> Result<Vec<Value>, ShellError> {
-    let constraints = db.get_constraints(conn, table).map_err(|e| {
-        ShellError::GenericError(
-            "Error getting DB constraints".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let constraints = db
+        .get_constraints(conn, table)
+        .map_err(|e| ShellError::GenericError {
+            error: "Error getting DB constraints".into(),
+            msg: e.to_string(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        })?;
     let mut constraint_info = vec![];
     for constraint in constraints {
         constraint_info.push(Value::record(
@@ -167,15 +165,15 @@ fn get_table_foreign_keys(
     table: &DbTable,
     span: Span,
 ) -> Result<Vec<Value>, ShellError> {
-    let foreign_keys = db.get_foreign_keys(conn, table).map_err(|e| {
-        ShellError::GenericError(
-            "Error getting DB Foreign Keys".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let foreign_keys = db
+        .get_foreign_keys(conn, table)
+        .map_err(|e| ShellError::GenericError {
+            error: "Error getting DB Foreign Keys".into(),
+            msg: e.to_string(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        })?;
     let mut foreign_key_info = vec![];
     for fk in foreign_keys {
         foreign_key_info.push(Value::record(
@@ -197,15 +195,15 @@ fn get_table_indexes(
     table: &DbTable,
     span: Span,
 ) -> Result<Vec<Value>, ShellError> {
-    let indexes = db.get_indexes(conn, table).map_err(|e| {
-        ShellError::GenericError(
-            "Error getting DB Indexes".into(),
-            e.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )
-    })?;
+    let indexes = db
+        .get_indexes(conn, table)
+        .map_err(|e| ShellError::GenericError {
+            error: "Error getting DB Indexes".into(),
+            msg: e.to_string(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        })?;
     let mut index_info = vec![];
     for index in indexes {
         index_info.push(Value::record(

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -102,15 +102,14 @@ impl SQLiteDatabase {
     pub fn query(&self, sql: &Spanned<String>, call_span: Span) -> Result<Value, ShellError> {
         let conn = open_sqlite_db(&self.path, call_span)?;
 
-        let stream = run_sql_query(conn, sql, self.ctrlc.clone()).map_err(|e| {
-            ShellError::GenericError(
-                "Failed to query SQLite database".into(),
-                e.to_string(),
-                Some(sql.span),
-                None,
-                Vec::new(),
-            )
-        })?;
+        let stream =
+            run_sql_query(conn, sql, self.ctrlc.clone()).map_err(|e| ShellError::GenericError {
+                error: "Failed to query SQLite database".into(),
+                msg: e.to_string(),
+                span: Some(sql.span),
+                help: None,
+                inner: vec![],
+            })?;
 
         Ok(stream)
     }
@@ -119,14 +118,12 @@ impl SQLiteDatabase {
         if self.path == PathBuf::from(MEMORY_DB) {
             open_connection_in_memory_custom()
         } else {
-            Connection::open(&self.path).map_err(|e| {
-                ShellError::GenericError(
-                    "Failed to open SQLite database from open_connection".into(),
-                    e.to_string(),
-                    None,
-                    None,
-                    Vec::new(),
-                )
+            Connection::open(&self.path).map_err(|e| ShellError::GenericError {
+                error: "Failed to open SQLite database from open_connection".into(),
+                msg: e.to_string(),
+                span: None,
+                help: None,
+                inner: vec![],
             })
         }
     }
@@ -362,14 +359,12 @@ impl CustomValue for SQLiteDatabase {
 
     fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
         let db = open_sqlite_db(&self.path, span)?;
-        read_entire_sqlite_db(db, span, self.ctrlc.clone()).map_err(|e| {
-            ShellError::GenericError(
-                "Failed to read from SQLite database".into(),
-                e.to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+        read_entire_sqlite_db(db, span, self.ctrlc.clone()).map_err(|e| ShellError::GenericError {
+            error: "Failed to read from SQLite database".into(),
+            msg: e.to_string(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         })
     }
 
@@ -386,13 +381,13 @@ impl CustomValue for SQLiteDatabase {
         let db = open_sqlite_db(&self.path, span)?;
 
         read_single_table(db, _column_name, span, self.ctrlc.clone()).map_err(|e| {
-            ShellError::GenericError(
-                "Failed to read from SQLite database".into(),
-                e.to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+            ShellError::GenericError {
+                error: "Failed to read from SQLite database".into(),
+                msg: e.to_string(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            }
         })
     }
 
@@ -410,14 +405,12 @@ pub fn open_sqlite_db(path: &Path, call_span: Span) -> Result<Connection, ShellE
         open_connection_in_memory_custom()
     } else {
         let path = path.to_string_lossy().to_string();
-        Connection::open(path).map_err(|e| {
-            ShellError::GenericError(
-                "Failed to open SQLite database".into(),
-                e.to_string(),
-                Some(call_span),
-                None,
-                Vec::new(),
-            )
+        Connection::open(path).map_err(|e| ShellError::GenericError {
+            error: "Failed to open SQLite database".into(),
+            msg: e.to_string(),
+            span: Some(call_span),
+            help: None,
+            inner: vec![],
         })
     }
 }
@@ -611,25 +604,21 @@ mod test {
 
 pub fn open_connection_in_memory_custom() -> Result<Connection, ShellError> {
     let flags = OpenFlags::default();
-    Connection::open_with_flags(MEMORY_DB, flags).map_err(|err| {
-        ShellError::GenericError(
-            "Failed to open SQLite custom connection in memory".into(),
-            err.to_string(),
-            Some(Span::test_data()),
-            None,
-            Vec::new(),
-        )
+    Connection::open_with_flags(MEMORY_DB, flags).map_err(|e| ShellError::GenericError {
+        error: "Failed to open SQLite custom connection in memory".into(),
+        msg: e.to_string(),
+        span: Some(Span::test_data()),
+        help: None,
+        inner: vec![],
     })
 }
 
 pub fn open_connection_in_memory() -> Result<Connection, ShellError> {
-    Connection::open_in_memory().map_err(|err| {
-        ShellError::GenericError(
-            "Failed to open SQLite standard connection in memory".into(),
-            err.to_string(),
-            Some(Span::test_data()),
-            None,
-            Vec::new(),
-        )
+    Connection::open_in_memory().map_err(|e| ShellError::GenericError {
+        error: "Failed to open SQLite standard connection in memory".into(),
+        msg: e.to_string(),
+        span: Some(Span::test_data()),
+        help: None,
+        inner: vec![],
     })
 }

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -85,22 +85,22 @@ impl Command for ViewSource {
                             final_contents.push_str(&String::from_utf8_lossy(contents));
                             Ok(Value::string(final_contents, call.head).into_pipeline_data())
                         } else {
-                            Err(ShellError::GenericError(
-                                "Cannot view value".to_string(),
-                                "the command does not have a viewable block".to_string(),
-                                Some(arg_span),
-                                None,
-                                Vec::new(),
-                            ))
+                            Err(ShellError::GenericError {
+                                error: "Cannot view value".to_string(),
+                                msg: "the command does not have a viewable block".to_string(),
+                                span: Some(arg_span),
+                                help: None,
+                                inner: vec![],
+                            })
                         }
                     } else {
-                        Err(ShellError::GenericError(
-                            "Cannot view value".to_string(),
-                            "the command does not have a viewable block".to_string(),
-                            Some(arg_span),
-                            None,
-                            Vec::new(),
-                        ))
+                        Err(ShellError::GenericError {
+                            error: "Cannot view value".to_string(),
+                            msg: "the command does not have a viewable block".to_string(),
+                            span: Some(arg_span),
+                            help: None,
+                            inner: vec![],
+                        })
                     }
                 } else if let Some(module_id) = engine_state.find_module(val.as_bytes(), &[]) {
                     // arg is a module
@@ -110,22 +110,22 @@ impl Command for ViewSource {
                         Ok(Value::string(String::from_utf8_lossy(contents), call.head)
                             .into_pipeline_data())
                     } else {
-                        Err(ShellError::GenericError(
-                            "Cannot view value".to_string(),
-                            "the module does not have a viewable block".to_string(),
-                            Some(arg_span),
-                            None,
-                            Vec::new(),
-                        ))
+                        Err(ShellError::GenericError {
+                            error: "Cannot view value".to_string(),
+                            msg: "the module does not have a viewable block".to_string(),
+                            span: Some(arg_span),
+                            help: None,
+                            inner: vec![],
+                        })
                     }
                 } else {
-                    Err(ShellError::GenericError(
-                        "Cannot view value".to_string(),
-                        "this name does not correspond to a viewable value".to_string(),
-                        Some(arg_span),
-                        None,
-                        Vec::new(),
-                    ))
+                    Err(ShellError::GenericError {
+                        error: "Cannot view value".to_string(),
+                        msg: "this name does not correspond to a viewable value".to_string(),
+                        span: Some(arg_span),
+                        help: None,
+                        inner: vec![],
+                    })
                 }
             }
             value => {
@@ -140,13 +140,13 @@ impl Command for ViewSource {
                         Ok(Value::string("<internal command>", call.head).into_pipeline_data())
                     }
                 } else {
-                    Err(ShellError::GenericError(
-                        "Cannot view value".to_string(),
-                        "this value cannot be viewed".to_string(),
-                        Some(arg_span),
-                        None,
-                        Vec::new(),
-                    ))
+                    Err(ShellError::GenericError {
+                        error: "Cannot view value".to_string(),
+                        msg: "this value cannot be viewed".to_string(),
+                        span: Some(arg_span),
+                        help: None,
+                        inner: vec![],
+                    })
                 }
             }
         }

--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -48,13 +48,13 @@ impl Command for ViewSpan {
                     .into_pipeline_data(),
             )
         } else {
-            Err(ShellError::GenericError(
-                "Cannot view span".to_string(),
-                "this start and end does not correspond to a viewable value".to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            ))
+            Err(ShellError::GenericError {
+                error: "Cannot view span".to_string(),
+                msg: "this start and end does not correspond to a viewable value".to_string(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            })
         }
     }
 

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -68,13 +68,13 @@ impl Command for ConfigEnv {
         let nu_config = match engine_state.get_config_path("env-path") {
             Some(path) => path.clone(),
             None => {
-                return Err(ShellError::GenericError(
-                    "Could not find $nu.env-path".to_string(),
-                    "Could not find $nu.env-path".to_string(),
-                    None,
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "Could not find $nu.env-path".into(),
+                    msg: "Could not find $nu.env-path".into(),
+                    span: None,
+                    help: None,
+                    inner: vec![],
+                });
             }
         };
 

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -72,13 +72,13 @@ impl Command for ConfigNu {
         let nu_config = match engine_state.get_config_path("config-path") {
             Some(path) => path.clone(),
             None => {
-                return Err(ShellError::GenericError(
-                    "Could not find $nu.config-path".to_string(),
-                    "Could not find $nu.config-path".to_string(),
-                    None,
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "Could not find $nu.config-path".into(),
+                    msg: "Could not find $nu.config-path".into(),
+                    span: None,
+                    help: None,
+                    inner: vec![],
+                });
             }
         };
 

--- a/crates/nu-command/src/env/config/config_reset.rs
+++ b/crates/nu-command/src/env/config/config_reset.rs
@@ -51,13 +51,13 @@ impl Command for ConfigReset {
         let mut config_path = match nu_path::config_dir() {
             Some(path) => path,
             None => {
-                return Err(ShellError::GenericError(
-                    "Could not find config path".to_string(),
-                    "Could not find config path".to_string(),
-                    None,
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "Could not find config path".into(),
+                    msg: "Could not find config path".into(),
+                    span: None,
+                    help: None,
+                    inner: vec![],
+                });
             }
         };
         config_path.push("nushell");

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -158,13 +158,13 @@ impl Command for Glob {
         };
 
         if glob_pattern.item.is_empty() {
-            return Err(ShellError::GenericError(
-                "glob pattern must not be empty".to_string(),
-                "glob pattern is empty".to_string(),
-                Some(glob_pattern.span),
-                Some("add characters to the glob pattern".to_string()),
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "glob pattern must not be empty".into(),
+                msg: "glob pattern is empty".into(),
+                span: Some(glob_pattern.span),
+                help: Some("add characters to the glob pattern".into()),
+                inner: vec![],
+            });
         }
 
         let folder_depth = if let Some(depth) = depth {
@@ -176,13 +176,13 @@ impl Command for Glob {
         let (prefix, glob) = match WaxGlob::new(&glob_pattern.item) {
             Ok(p) => p.partition(),
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    "error with glob pattern".to_string(),
-                    format!("{e}"),
-                    Some(glob_pattern.span),
-                    None,
-                    Vec::new(),
-                ))
+                return Err(ShellError::GenericError {
+                    error: "error with glob pattern".into(),
+                    msg: format!("{e}"),
+                    span: Some(glob_pattern.span),
+                    help: None,
+                    inner: vec![],
+                })
             }
         };
 
@@ -195,13 +195,13 @@ impl Command for Glob {
                 std::path::PathBuf::new() // user should get empty list not an error
             }
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    "error in canonicalize".to_string(),
-                    format!("{e}"),
-                    Some(glob_pattern.span),
-                    None,
-                    Vec::new(),
-                ))
+                return Err(ShellError::GenericError {
+                    error: "error in canonicalize".into(),
+                    msg: format!("{e}"),
+                    span: Some(glob_pattern.span),
+                    help: None,
+                    inner: vec![],
+                })
             }
         };
 
@@ -216,14 +216,12 @@ impl Command for Glob {
                     },
                 )
                 .not(np)
-                .map_err(|err| {
-                    ShellError::GenericError(
-                        "error with glob's not pattern".to_string(),
-                        format!("{err}"),
-                        Some(not_pattern_span),
-                        None,
-                        Vec::new(),
-                    )
+                .map_err(|err| ShellError::GenericError {
+                    error: "error with glob's not pattern".into(),
+                    msg: format!("{err}"),
+                    span: Some(not_pattern_span),
+                    help: None,
+                    inner: vec![],
                 })?
                 .flatten();
             let result = glob_to_value(ctrlc, glob_results, no_dirs, no_files, no_symlinks, span)?;

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -120,13 +120,13 @@ impl Command for Ls {
                         );
                         #[cfg(not(unix))]
                         let error_msg = String::from("Permission denied");
-                        return Err(ShellError::GenericError(
-                            "Permission denied".to_string(),
-                            error_msg,
-                            Some(p_tag),
-                            None,
-                            Vec::new(),
-                        ));
+                        return Err(ShellError::GenericError {
+                            error: "Permission denied".into(),
+                            msg: error_msg,
+                            span: Some(p_tag),
+                            help: None,
+                            inner: vec![],
+                        });
                     }
                     if is_empty_dir(&expanded) {
                         return Ok(Value::list(vec![], call_span).into_pipeline_data());
@@ -168,13 +168,13 @@ impl Command for Ls {
 
         let mut paths_peek = paths.peekable();
         if paths_peek.peek().is_none() {
-            return Err(ShellError::GenericError(
-                format!("No matches found for {}", &path.display().to_string()),
-                "Pattern, file or folder not found".to_string(),
-                Some(p_tag),
-                Some("no matches found".to_string()),
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: format!("No matches found for {}", &path.display().to_string()),
+                msg: "Pattern, file or folder not found".into(),
+                span: Some(p_tag),
+                help: Some("no matches found".into()),
+                inner: vec![],
+            });
         }
 
         let mut hidden_dirs = vec![];
@@ -233,14 +233,12 @@ impl Command for Ls {
                     } else {
                         Some(path.to_string_lossy().to_string())
                     }
-                    .ok_or_else(|| {
-                        ShellError::GenericError(
-                            format!("Invalid file name: {:}", path.to_string_lossy()),
-                            "invalid file name".into(),
-                            Some(call_span),
-                            None,
-                            Vec::new(),
-                        )
+                    .ok_or_else(|| ShellError::GenericError {
+                        error: format!("Invalid file name: {:}", path.to_string_lossy()),
+                        msg: "invalid file name".into(),
+                        span: Some(call_span),
+                        help: None,
+                        inner: vec![],
                     });
 
                     match display_name {

--- a/crates/nu-command/src/filesystem/mktemp.rs
+++ b/crates/nu-command/src/filesystem/mktemp.rs
@@ -119,13 +119,13 @@ impl Command for Mktemp {
                     })?
             }
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    format!("{}", e),
-                    format!("{}", e),
-                    None,
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: format!("{}", e),
+                    msg: format!("{}", e),
+                    span: None,
+                    help: None,
+                    inner: vec![],
+                });
             }
         };
         Ok(PipelineData::Value(Value::string(res, span), None))

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -96,31 +96,31 @@ impl Command for Mv {
         // it's an error.
 
         if destination.exists() && !force && !destination.is_dir() && !source.is_dir() {
-            return Err(ShellError::GenericError(
-                "Destination file already exists".into(),
+            return Err(ShellError::GenericError {
+                error: "Destination file already exists".into(),
                 // These messages all use to_string_lossy() because
                 // showing the full path reduces misinterpretation of the message.
                 // Also, this is preferable to {:?} because that renders Windows paths incorrectly.
-                format!(
+                msg: format!(
                     "Destination file '{}' already exists",
                     destination.to_string_lossy()
                 ),
-                Some(spanned_destination.span),
-                Some("you can use -f, --force to force overwriting the destination".into()),
-                Vec::new(),
-            ));
+                span: Some(spanned_destination.span),
+                help: Some("you can use -f, --force to force overwriting the destination".into()),
+                inner: vec![],
+            });
         }
 
         if (destination.exists() && !destination.is_dir() && sources.len() > 1)
             || (!destination.exists() && sources.len() > 1)
         {
-            return Err(ShellError::GenericError(
-                "Can only move multiple sources if destination is a directory".into(),
-                "destination must be a directory when moving multiple sources".into(),
-                Some(spanned_destination.span),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Can only move multiple sources if destination is a directory".into(),
+                msg: "destination must be a directory when moving multiple sources".into(),
+                span: Some(spanned_destination.span),
+                help: None,
+                inner: vec![],
+            });
         }
 
         // This is the case where you move a directory A to the interior of directory B, but directory B
@@ -129,17 +129,17 @@ impl Command for Mv {
             if let Some(name) = source.file_name() {
                 let dst = destination.join(name);
                 if dst.is_dir() {
-                    return Err(ShellError::GenericError(
-                        format!(
+                    return Err(ShellError::GenericError {
+                        error: format!(
                             "Can't move '{}' to '{}'",
                             source.to_string_lossy(),
                             dst.to_string_lossy()
                         ),
-                        format!("Directory '{}' is not empty", destination.to_string_lossy()),
-                        Some(spanned_destination.span),
-                        None,
-                        Vec::new(),
-                    ));
+                        msg: format!("Directory '{}' is not empty", destination.to_string_lossy()),
+                        span: Some(spanned_destination.span),
+                        help: None,
+                        inner: vec![],
+                    });
                 }
             }
         }
@@ -149,16 +149,16 @@ impl Command for Mv {
             .find(|f| matches!(f, Ok(f) if destination.starts_with(f)));
         if destination.exists() && destination.is_dir() && sources.len() == 1 {
             if let Some(Ok(filename)) = some_if_source_is_destination {
-                return Err(ShellError::GenericError(
-                    format!(
+                return Err(ShellError::GenericError {
+                    error: format!(
                         "Not possible to move '{}' to itself",
                         filename.to_string_lossy()
                     ),
-                    "cannot move to itself".into(),
-                    Some(spanned_destination.span),
-                    None,
-                    Vec::new(),
-                ));
+                    msg: "cannot move to itself".into(),
+                    span: Some(spanned_destination.span),
+                    help: None,
+                    inner: vec![],
+                });
             }
         }
 
@@ -291,13 +291,13 @@ fn move_file(
             format!("mv: overwrite '{}'? ", to.to_string_lossy()),
         );
         if let Err(e) = interaction {
-            return Err(ShellError::GenericError(
-                format!("Error during interaction: {e:}"),
-                "could not move".into(),
-                None,
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: format!("Error during interaction: {e:}"),
+                msg: "could not move".into(),
+                span: None,
+                help: None,
+                inner: vec![],
+            });
         } else if !confirmed {
             return Ok(false);
         }
@@ -341,13 +341,13 @@ fn move_item(from: &Path, from_span: Span, to: &Path) -> Result<(), ShellError> 
                     }
                     _ => e.to_string(),
                 };
-                Err(ShellError::GenericError(
-                    format!("Could not move {from:?} to {to:?}. Error Kind: {error_kind}"),
-                    "could not move".into(),
-                    Some(from_span),
-                    None,
-                    Vec::new(),
-                ))
+                Err(ShellError::GenericError {
+                    error: format!("Could not move {from:?} to {to:?}. Error Kind: {error_kind}"),
+                    msg: "could not move".into(),
+                    span: Some(from_span),
+                    help: None,
+                    inner: vec![],
+                })
             }
         }
     })

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -125,13 +125,13 @@ impl Command for Open {
 
                     #[cfg(not(unix))]
                     let error_msg = String::from("Permission denied");
-                    return Err(ShellError::GenericError(
-                        "Permission denied".into(),
-                        error_msg,
-                        Some(arg_span),
-                        None,
-                        Vec::new(),
-                    ));
+                    return Err(ShellError::GenericError {
+                        error: "Permission denied".into(),
+                        msg: error_msg,
+                        span: Some(arg_span),
+                        help: None,
+                        inner: vec![],
+                    });
                 } else {
                     #[cfg(feature = "sqlite")]
                     if !raw {
@@ -146,13 +146,13 @@ impl Command for Open {
                     let file = match std::fs::File::open(path) {
                         Ok(file) => file,
                         Err(err) => {
-                            return Err(ShellError::GenericError(
-                                "Permission denied".into(),
-                                err.to_string(),
-                                Some(arg_span),
-                                None,
-                                Vec::new(),
-                            ));
+                            return Err(ShellError::GenericError {
+                                error: "Permission denied".into(),
+                                msg: err.to_string(),
+                                span: Some(arg_span),
+                                help: None,
+                                inner: vec![],
+                            });
                         }
                     };
 
@@ -200,13 +200,13 @@ impl Command for Open {
                                 decl.run(engine_state, stack, &Call::new(call_span), file_contents)
                             };
                             output.push(command_output.map_err(|inner| {
-                                    ShellError::GenericError(
-                                        format!("Error while parsing as {ext}"),
-                                        format!("Could not parse '{}' with `from {}`", path.display(), ext),
-                                        Some(arg_span),
-                                        Some(format!("Check out `help from {}` or `help from` for more options or open raw data with `open --raw '{}'`", ext, path.display())),
-                                        vec![inner],
-                                    )
+                                    ShellError::GenericError{
+                                        error: format!("Error while parsing as {ext}"),
+                                        msg: format!("Could not parse '{}' with `from {}`", path.display(), ext),
+                                        span: Some(arg_span),
+                                        help: Some(format!("Check out `help from {}` or `help from` for more options or open raw data with `open --raw '{}'`", ext, path.display())),
+                                        inner: vec![inner],
+                                }
                                 })?);
                         }
                         None => output.push(file_contents),

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -173,47 +173,47 @@ fn rm(
 
     if !TRASH_SUPPORTED {
         if rm_always_trash {
-            return Err(ShellError::GenericError(
-                "Cannot execute `rm`; the current configuration specifies \
+            return Err(ShellError::GenericError {
+                error: "Cannot execute `rm`; the current configuration specifies \
                     `always_trash = true`, but the current nu executable was not \
                     built with feature `trash_support`."
                     .into(),
-                "trash required to be true but not supported".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            ));
+                msg: "trash required to be true but not supported".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            });
         } else if trash {
-            return Err(ShellError::GenericError(
-                "Cannot execute `rm` with option `--trash`; feature `trash-support` not enabled or on an unsupported platform"
+            return Err(ShellError::GenericError{
+                error: "Cannot execute `rm` with option `--trash`; feature `trash-support` not enabled or on an unsupported platform"
                     .into(),
-                "this option is only available if nu is built with the `trash-support` feature and the platform supports trash"
+                msg: "this option is only available if nu is built with the `trash-support` feature and the platform supports trash"
                     .into(),
-                Some(span),
-                None,
-                Vec::new(),
-            ));
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            });
         }
     }
 
     if targets.is_empty() {
-        return Err(ShellError::GenericError(
-            "rm requires target paths".into(),
-            "needs parameter".into(),
-            Some(span),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "rm requires target paths".into(),
+            msg: "needs parameter".into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        });
     }
 
     if unique_argument_check.is_some() && !(interactive_once || interactive) {
-        return Err(ShellError::GenericError(
-            "You are trying to remove your home dir".into(),
-            "If you really want to remove your home dir, please use -I or -i".into(),
-            unique_argument_check,
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "You are trying to remove your home dir".into(),
+            msg: "If you really want to remove your home dir, please use -I or -i".into(),
+            span: unique_argument_check,
+            help: None,
+            inner: vec![],
+        });
     }
 
     let targets_span = Span::new(
@@ -236,13 +236,13 @@ fn rm(
         if currentdir_path.to_string_lossy() == target.item
             || currentdir_path.starts_with(format!("{}{}", target.item, std::path::MAIN_SEPARATOR))
         {
-            return Err(ShellError::GenericError(
-                "Cannot remove any parent directory".into(),
-                "cannot remove any parent directory".into(),
-                Some(target.span),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Cannot remove any parent directory".into(),
+                msg: "cannot remove any parent directory".into(),
+                span: Some(target.span),
+                help: None,
+                inner: vec![],
+            });
         }
 
         let path = currentdir_path.join(&target.item);
@@ -268,13 +268,13 @@ fn rm(
                                 .or_insert_with(|| target.span);
                         }
                         Err(e) => {
-                            return Err(ShellError::GenericError(
-                                format!("Could not remove {:}", path.to_string_lossy()),
-                                e.to_string(),
-                                Some(target.span),
-                                None,
-                                Vec::new(),
-                            ));
+                            return Err(ShellError::GenericError {
+                                error: format!("Could not remove {:}", path.to_string_lossy()),
+                                msg: e.to_string(),
+                                span: Some(target.span),
+                                help: None,
+                                inner: vec![],
+                            });
                         }
                     }
                 }
@@ -285,25 +285,25 @@ fn rm(
                 }
             }
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    e.to_string(),
-                    e.to_string(),
-                    Some(target.span),
-                    None,
-                    Vec::new(),
-                ))
+                return Err(ShellError::GenericError {
+                    error: e.to_string(),
+                    msg: e.to_string(),
+                    span: Some(target.span),
+                    help: None,
+                    inner: vec![],
+                })
             }
         };
     }
 
     if all_targets.is_empty() && !force {
-        return Err(ShellError::GenericError(
-            "File(s) not found".into(),
-            "File(s) not found".into(),
-            Some(targets_span),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "File(s) not found".into(),
+            msg: "File(s) not found".into(),
+            span: Some(targets_span),
+            help: None,
+            inner: vec![],
+        });
     }
 
     if interactive_once {
@@ -312,13 +312,13 @@ fn rm(
             format!("rm: remove {} files? ", all_targets.len()),
         );
         if let Err(e) = interaction {
-            return Err(ShellError::GenericError(
-                format!("Error during interaction: {e:}"),
-                "could not move".into(),
-                None,
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: format!("Error during interaction: {e:}"),
+                msg: "could not move".into(),
+                span: None,
+                help: None,
+                inner: vec![],
+            });
         } else if !confirmed {
             return Ok(PipelineData::Empty);
         }
@@ -406,28 +406,28 @@ fn rm(
                         Value::nothing(span)
                     }
                 } else {
-                    let msg = format!("Cannot remove {:}. try --recursive", f.to_string_lossy());
+                    let error = format!("Cannot remove {:}. try --recursive", f.to_string_lossy());
                     Value::error(
-                        ShellError::GenericError(
-                            msg,
-                            "cannot remove non-empty directory".into(),
-                            Some(span),
-                            None,
-                            Vec::new(),
-                        ),
+                        ShellError::GenericError {
+                            error,
+                            msg: "cannot remove non-empty directory".into(),
+                            span: Some(span),
+                            help: None,
+                            inner: vec![],
+                        },
                         span,
                     )
                 }
             } else {
-                let msg = format!("no such file or directory: {:}", f.to_string_lossy());
+                let error = format!("no such file or directory: {:}", f.to_string_lossy());
                 Value::error(
-                    ShellError::GenericError(
-                        msg,
-                        "no such file or directory".into(),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    ),
+                    ShellError::GenericError {
+                        error,
+                        msg: "no such file or directory".into(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    },
                     span,
                 )
             }

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -323,16 +323,16 @@ fn prepare_path(
     let path = &path.item;
 
     if !(force || append) && path.exists() {
-        Err(ShellError::GenericError(
-            "Destination file already exists".into(),
-            format!(
+        Err(ShellError::GenericError {
+            error: "Destination file already exists".into(),
+            msg: format!(
                 "Destination file '{}' already exists",
                 path.to_string_lossy()
             ),
-            Some(span),
-            Some("you can use -f, --force to force overwriting the destination".into()),
-            Vec::new(),
-        ))
+            span: Some(span),
+            help: Some("you can use -f, --force to force overwriting the destination".into()),
+            inner: vec![],
+        })
     } else {
         Ok((path, span))
     }
@@ -347,14 +347,12 @@ fn open_file(path: &Path, span: Span, append: bool) -> Result<File, ShellError> 
         _ => std::fs::File::create(path),
     };
 
-    file.map_err(|err| {
-        ShellError::GenericError(
-            "Permission denied".into(),
-            err.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )
+    file.map_err(|e| ShellError::GenericError {
+        error: "Permission denied".into(),
+        msg: e.to_string(),
+        span: Some(span),
+        help: None,
+        inner: vec![],
     })
 }
 
@@ -380,13 +378,13 @@ fn get_files(
     let stderr_file = stderr_path_and_span
         .map(|(stderr_path, stderr_path_span)| {
             if path == stderr_path {
-                Err(ShellError::GenericError(
-                    "input and stderr input to same file".to_string(),
-                    "can't save both input and stderr input to the same file".to_string(),
-                    Some(stderr_path_span),
-                    Some("you should use `o+e> file` instead".to_string()),
-                    vec![],
-                ))
+                Err(ShellError::GenericError {
+                    error: "input and stderr input to same file".into(),
+                    msg: "can't save both input and stderr input to the same file".into(),
+                    span: Some(stderr_path_span),
+                    help: Some("you should use `o+e> file` instead".into()),
+                    inner: vec![],
+                })
             } else {
                 open_file(stderr_path, stderr_path_span, append || err_append)
             }

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -52,14 +52,12 @@ impl Command for Start {
         if file_path.exists() {
             open_path(path_no_whitespace, engine_state, stack, path.span)?;
         } else if file_path.starts_with("https://") || file_path.starts_with("http://") {
-            let url = url::Url::parse(&path.item).map_err(|_| {
-                ShellError::GenericError(
-                    format!("Cannot parse url: {}", &path.item),
-                    "".to_string(),
-                    Some(path.span),
-                    Some("cannot parse".to_string()),
-                    Vec::new(),
-                )
+            let url = url::Url::parse(&path.item).map_err(|_| ShellError::GenericError {
+                error: format!("Cannot parse url: {}", &path.item),
+                msg: "".to_string(),
+                span: Some(path.span),
+                help: Some("cannot parse".to_string()),
+                inner: vec![],
             })?;
             open_path(url.as_str(), engine_state, stack, path.span)?;
         } else {
@@ -73,14 +71,12 @@ impl Command for Start {
                 let path_with_prefix = Path::new("https://").join(&path.item);
                 let common_domains = ["com", "net", "org", "edu", "sh"];
                 if let Some(url) = path_with_prefix.to_str() {
-                    let url = url::Url::parse(url).map_err(|_| {
-                        ShellError::GenericError(
-                            format!("Cannot parse url: {}", &path.item),
-                            "".to_string(),
-                            Some(path.span),
-                            Some("cannot parse".to_string()),
-                            Vec::new(),
-                        )
+                    let url = url::Url::parse(url).map_err(|_| ShellError::GenericError {
+                        error: format!("Cannot parse url: {}", &path.item),
+                        msg: "".into(),
+                        span: Some(path.span),
+                        help: Some("cannot parse".into()),
+                        inner: vec![],
                     })?;
                     if let Some(domain) = url.host() {
                         let domain = domain.to_string();
@@ -91,13 +87,13 @@ impl Command for Start {
                             }
                         }
                     }
-                    return Err(ShellError::GenericError(
-                        format!("Cannot find file or url: {}", &path.item),
-                        "".to_string(),
-                        Some(path.span),
-                        Some("Use prefix https:// to disambiguate URLs from files".to_string()),
-                        Vec::new(),
-                    ));
+                    return Err(ShellError::GenericError {
+                        error: format!("Cannot find file or url: {}", &path.item),
+                        msg: "".into(),
+                        span: Some(path.span),
+                        help: Some("Use prefix https:// to disambiguate URLs from files".into()),
+                        inner: vec![],
+                    });
                 }
             };
         }

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -135,34 +135,34 @@ impl Command for UCp {
             })
             .collect();
         if paths.is_empty() {
-            return Err(ShellError::GenericError(
-                "Missing file operand".into(),
-                "Missing file operand".into(),
-                Some(call.head),
-                Some("Please provide source and destination paths".into()),
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Missing file operand".into(),
+                msg: "Missing file operand".into(),
+                span: Some(call.head),
+                help: Some("Please provide source and destination paths".into()),
+                inner: vec![],
+            });
         }
 
         if paths.len() == 1 {
-            return Err(ShellError::GenericError(
-                "Missing destination path".into(),
-                format!("Missing destination path operand after {}", paths[0].item),
-                Some(paths[0].span),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Missing destination path".into(),
+                msg: format!("Missing destination path operand after {}", paths[0].item),
+                span: Some(paths[0].span),
+                help: None,
+                inner: vec![],
+            });
         }
         let target = paths.pop().expect("Should not be reached?");
         let target_path = PathBuf::from(&target.item);
         if target.item.ends_with(PATH_SEPARATOR) && !target_path.is_dir() {
-            return Err(ShellError::GenericError(
-                "is not a directory".into(),
-                "is not a directory".into(),
-                Some(target.span),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "is not a directory".into(),
+                msg: "is not a directory".into(),
+                span: Some(target.span),
+                help: None,
+                inner: vec![],
+            });
         };
 
         // paths now contains the sources
@@ -180,13 +180,15 @@ impl Command for UCp {
                 match v {
                     Ok(path) => {
                         if !recursive && path.is_dir() {
-                            return Err(ShellError::GenericError(
-                                "could_not_copy_directory".into(),
-                                "resolves to a directory (not copied)".into(),
-                                Some(p.span),
-                                Some("Directories must be copied using \"--recursive\"".into()),
-                                Vec::new(),
-                            ));
+                            return Err(ShellError::GenericError {
+                                error: "could_not_copy_directory".into(),
+                                msg: "resolves to a directory (not copied)".into(),
+                                span: Some(p.span),
+                                help: Some(
+                                    "Directories must be copied using \"--recursive\"".into(),
+                                ),
+                                inner: vec![],
+                            });
                         };
                         app_vals.push(path)
                     }
@@ -240,13 +242,13 @@ impl Command for UCp {
                 // code should still be EXIT_ERR as does GNU cp
                 uu_cp::Error::NotAllFilesCopied => {}
                 _ => {
-                    return Err(ShellError::GenericError(
-                        format!("{}", error),
-                        format!("{}", error),
-                        None,
-                        None,
-                        Vec::new(),
-                    ))
+                    return Err(ShellError::GenericError {
+                        error: format!("{}", error),
+                        msg: format!("{}", error),
+                        span: None,
+                        help: None,
+                        inner: vec![],
+                    })
                 }
             };
             // TODO: What should we do in place of set_exit_code?

--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -68,13 +68,13 @@ impl Command for UMkdir {
 
         for dir in directories {
             if let Err(error) = mkdir(&dir, IS_RECURSIVE, DEFAULT_MODE, is_verbose) {
-                return Err(ShellError::GenericError(
-                    format!("{}", error),
-                    format!("{}", error),
-                    None,
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: format!("{}", error),
+                    msg: format!("{}", error),
+                    span: None,
+                    help: None,
+                    inner: vec![],
+                });
             }
         }
 

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -262,13 +262,13 @@ fn group_closure(
                     let collection: Vec<Value> = s.into_iter().collect();
 
                     if collection.len() > 1 {
-                        return Err(ShellError::GenericError(
-                            "expected one value from the block".into(),
-                            "requires a table with one value for grouping".into(),
-                            Some(span),
-                            None,
-                            Vec::new(),
-                        ));
+                        return Err(ShellError::GenericError {
+                            error: "expected one value from the block".into(),
+                            msg: "requires a table with one value for grouping".into(),
+                            span: Some(span),
+                            help: None,
+                            inner: vec![],
+                        });
                     }
 
                     let value = match collection.first() {

--- a/crates/nu-command/src/filters/headers.rs
+++ b/crates/nu-command/src/filters/headers.rs
@@ -159,14 +159,12 @@ fn extract_headers(
             .iter()
             .map(|value| extract_headers(value, config))
             .next()
-            .ok_or_else(|| {
-                ShellError::GenericError(
-                    "Found empty list".to_string(),
-                    "unable to extract headers".to_string(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
+            .ok_or_else(|| ShellError::GenericError {
+                error: "Found empty list".into(),
+                msg: "unable to extract headers".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
             })?,
         _ => Err(ShellError::TypeMismatch {
             err_message: "record".to_string(),

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -129,22 +129,22 @@ impl Command for Move {
                 span: v.span(),
             },
             (Some(_), Some(_)) => {
-                return Err(ShellError::GenericError(
-                    "Cannot move columns".to_string(),
-                    "Use either --after, or --before, not both".to_string(),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                ))
+                return Err(ShellError::GenericError {
+                    error: "Cannot move columns".into(),
+                    msg: "Use either --after, or --before, not both".into(),
+                    span: Some(call.head),
+                    help: None,
+                    inner: vec![],
+                })
             }
             (None, None) => {
-                return Err(ShellError::GenericError(
-                    "Cannot move columns".to_string(),
-                    "Missing --after or --before flag".to_string(),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                ))
+                return Err(ShellError::GenericError {
+                    error: "Cannot move columns".into(),
+                    msg: "Missing --after or --before flag".into(),
+                    span: Some(call.head),
+                    help: None,
+                    inner: vec![],
+                })
             }
         };
 
@@ -198,24 +198,24 @@ fn move_record_columns(
     match &before_or_after.item {
         BeforeOrAfter::After(after) => {
             if !record.contains(after) {
-                return Err(ShellError::GenericError(
-                    "Cannot move columns".to_string(),
-                    "column does not exist".to_string(),
-                    Some(before_or_after.span),
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "Cannot move columns".into(),
+                    msg: "column does not exist".into(),
+                    span: Some(before_or_after.span),
+                    help: None,
+                    inner: vec![],
+                });
             }
         }
         BeforeOrAfter::Before(before) => {
             if !record.contains(before) {
-                return Err(ShellError::GenericError(
-                    "Cannot move columns".to_string(),
-                    "column does not exist".to_string(),
-                    Some(before_or_after.span),
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "Cannot move columns".into(),
+                    msg: "column does not exist".into(),
+                    span: Some(before_or_after.span),
+                    help: None,
+                    inner: vec![],
+                });
             }
         }
     }
@@ -227,13 +227,13 @@ fn move_record_columns(
         if let Some(idx) = record.index_of(&column_str) {
             column_idx.push(idx);
         } else {
-            return Err(ShellError::GenericError(
-                "Cannot move columns".to_string(),
-                "column does not exist".to_string(),
-                Some(column.span()),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Cannot move columns".into(),
+                msg: "column does not exist".into(),
+                span: Some(column.span()),
+                help: None,
+                inner: vec![],
+            });
         }
     }
 

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -107,14 +107,12 @@ impl Command for ParEach {
                 .num_threads(num_threads)
                 .build()
             {
-                Err(e) => Err(e).map_err(|e| {
-                    ShellError::GenericError(
-                        "Error creating thread pool".into(),
-                        e.to_string(),
-                        Some(Span::unknown()),
-                        None,
-                        Vec::new(),
-                    )
+                Err(e) => Err(e).map_err(|e| ShellError::GenericError {
+                    error: "Error creating thread pool".into(),
+                    msg: e.to_string(),
+                    span: Some(Span::unknown()),
+                    help: None,
+                    inner: vec![],
                 }),
                 Ok(pool) => Ok(pool),
             }

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -117,13 +117,13 @@ impl Command for Reduce {
         } else if let Some(val) = input_iter.next() {
             val
         } else {
-            return Err(ShellError::GenericError(
-                "Expected input".to_string(),
-                "needs input".to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Expected input".into(),
+                msg: "needs input".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            });
         };
 
         let mut acc = start_val;

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -225,13 +225,13 @@ fn reject(
         match members.first() {
             Some(PathMember::Int { val, span, .. }) => {
                 if members.len() > 1 {
-                    return Err(ShellError::GenericError(
-                        "Reject only allows row numbers for rows".into(),
-                        "extra after row number".into(),
-                        Some(*span),
-                        None,
-                        Vec::new(),
-                    ));
+                    return Err(ShellError::GenericError {
+                        error: "Reject only allows row numbers for rows".into(),
+                        msg: "extra after row number".into(),
+                        span: Some(*span),
+                        help: None,
+                        inner: vec![],
+                    });
                 }
                 if !unique_rows.contains(val) {
                     unique_rows.insert(*val);

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -215,13 +215,13 @@ fn select(
         match members.first() {
             Some(PathMember::Int { val, span, .. }) => {
                 if members.len() > 1 {
-                    return Err(ShellError::GenericError(
-                        "Select only allows row numbers for rows".into(),
-                        "extra after row number".into(),
-                        Some(*span),
-                        None,
-                        Vec::new(),
-                    ));
+                    return Err(ShellError::GenericError {
+                        error: "Select only allows row numbers for rows".into(),
+                        msg: "extra after row number".into(),
+                        span: Some(*span),
+                        help: None,
+                        inner: vec![],
+                    });
                 }
                 unique_rows.insert(*val);
             }

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -102,13 +102,13 @@ pub fn split_by(
             Ok(split(splitter.as_ref(), input, name)?)
         }
         // This uses the same format as the 'requires a column name' error in sort_utils.rs
-        None => Err(ShellError::GenericError(
-            "expected name".into(),
-            "requires a column name for splitting".into(),
-            Some(name),
-            None,
-            Vec::new(),
-        )),
+        None => Err(ShellError::GenericError {
+            error: "expected name".into(),
+            msg: "requires a column name for splitting".into(),
+            span: Some(name),
+            help: None,
+            inner: vec![],
+        }),
     }
 }
 

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -196,33 +196,33 @@ pub fn transpose(
                         if let Ok(s) = x.as_string() {
                             headers.push(s.to_string());
                         } else {
-                            return Err(ShellError::GenericError(
-                                "Header row needs string headers".into(),
-                                "used non-string headers".into(),
-                                Some(name),
-                                None,
-                                Vec::new(),
-                            ));
+                            return Err(ShellError::GenericError {
+                                error: "Header row needs string headers".into(),
+                                msg: "used non-string headers".into(),
+                                span: Some(name),
+                                help: None,
+                                inner: vec![],
+                            });
                         }
                     }
                     _ => {
-                        return Err(ShellError::GenericError(
-                            "Header row is incomplete and can't be used".into(),
-                            "using incomplete header row".into(),
-                            Some(name),
-                            None,
-                            Vec::new(),
-                        ));
+                        return Err(ShellError::GenericError {
+                            error: "Header row is incomplete and can't be used".into(),
+                            msg: "using incomplete header row".into(),
+                            span: Some(name),
+                            help: None,
+                            inner: vec![],
+                        });
                     }
                 }
             } else {
-                return Err(ShellError::GenericError(
-                    "Header row is incomplete and can't be used".into(),
-                    "using incomplete header row".into(),
-                    Some(name),
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "Header row is incomplete and can't be used".into(),
+                    msg: "using incomplete header row".into(),
+                    span: Some(name),
+                    help: None,
+                    inner: vec![],
+                });
             }
         }
     } else {

--- a/crates/nu-command/src/filters/uniq_by.rs
+++ b/crates/nu-command/src/filters/uniq_by.rs
@@ -117,13 +117,13 @@ fn validate(vec: &[Value], columns: &[String], span: Span) -> Result<(), ShellEr
         if let Value::Record { val: record, .. } = &v {
             if columns.is_empty() {
                 // This uses the same format as the 'requires a column name' error in split_by.rs
-                return Err(ShellError::GenericError(
-                    "expected name".into(),
-                    "requires a column name to filter table data".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "expected name".into(),
+                    msg: "requires a column name to filter table data".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                });
             }
 
             if let Some(nonexistent) = nonexistent_column(columns, record.columns()) {

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -150,18 +150,18 @@ fn convert_string_to_value(string_input: String, span: Span) -> Result<Value, Sh
             nu_json::Error::Syntax(_, row, col) => {
                 let label = x.to_string();
                 let label_span = convert_row_column_to_span(row, col, &string_input);
-                Err(ShellError::GenericError(
-                    "Error while parsing JSON text".into(),
-                    "error parsing JSON text".into(),
-                    Some(span),
-                    None,
-                    vec![ShellError::OutsideSpannedLabeledError(
+                Err(ShellError::GenericError {
+                    error: "Error while parsing JSON text".into(),
+                    msg: "error parsing JSON text".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![ShellError::OutsideSpannedLabeledError(
                         string_input,
                         "Error while parsing JSON text".into(),
                         label,
                         label_span,
                     )],
-                ))
+                })
             }
             x => Err(ShellError::CantConvert {
                 to_type: format!("structured json data ({x})"),

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -60,32 +60,32 @@ impl Command for FromNuon {
 
         if let Some(pipeline) = block.pipelines.get(1) {
             if let Some(element) = pipeline.elements.first() {
-                return Err(ShellError::GenericError(
-                    "error when loading nuon text".into(),
-                    "could not load nuon text".into(),
-                    Some(head),
-                    None,
-                    vec![ShellError::OutsideSpannedLabeledError(
+                return Err(ShellError::GenericError {
+                    error: "error when loading nuon text".into(),
+                    msg: "could not load nuon text".into(),
+                    span: Some(head),
+                    help: None,
+                    inner: vec![ShellError::OutsideSpannedLabeledError(
                         string_input,
                         "error when loading".into(),
                         "excess values when loading".into(),
                         element.span(),
                     )],
-                ));
+                });
             } else {
-                return Err(ShellError::GenericError(
-                    "error when loading nuon text".into(),
-                    "could not load nuon text".into(),
-                    Some(head),
-                    None,
-                    vec![ShellError::GenericError(
-                        "error when loading".into(),
-                        "excess values when loading".into(),
-                        Some(head),
-                        None,
-                        Vec::new(),
-                    )],
-                ));
+                return Err(ShellError::GenericError {
+                    error: "error when loading nuon text".into(),
+                    msg: "could not load nuon text".into(),
+                    span: Some(head),
+                    help: None,
+                    inner: vec![ShellError::GenericError {
+                        error: "error when loading".into(),
+                        msg: "excess values when loading".into(),
+                        span: Some(head),
+                        help: None,
+                        inner: vec![],
+                    }],
+                });
             }
         }
 
@@ -100,18 +100,18 @@ impl Command for FromNuon {
             let mut pipeline = block.pipelines.remove(0);
 
             if let Some(expr) = pipeline.elements.get(1) {
-                return Err(ShellError::GenericError(
-                    "error when loading nuon text".into(),
-                    "could not load nuon text".into(),
-                    Some(head),
-                    None,
-                    vec![ShellError::OutsideSpannedLabeledError(
+                return Err(ShellError::GenericError {
+                    error: "error when loading nuon text".into(),
+                    msg: "could not load nuon text".into(),
+                    span: Some(head),
+                    help: None,
+                    inner: vec![ShellError::OutsideSpannedLabeledError(
                         string_input,
                         "error when loading".into(),
                         "detected a pipeline in nuon file".into(),
                         expr.span(),
                     )],
-                ));
+                });
             }
 
             if pipeline.elements.is_empty() {
@@ -140,31 +140,31 @@ impl Command for FromNuon {
         };
 
         if let Some(err) = working_set.parse_errors.first() {
-            return Err(ShellError::GenericError(
-                "error when parsing nuon text".into(),
-                "could not parse nuon text".into(),
-                Some(head),
-                None,
-                vec![ShellError::OutsideSpannedLabeledError(
+            return Err(ShellError::GenericError {
+                error: "error when parsing nuon text".into(),
+                msg: "could not parse nuon text".into(),
+                span: Some(head),
+                help: None,
+                inner: vec![ShellError::OutsideSpannedLabeledError(
                     string_input,
                     "error when parsing".into(),
                     err.to_string(),
                     err.span(),
                 )],
-            ));
+            });
         }
 
         let result = convert_to_value(expr, head, &string_input);
 
         match result {
             Ok(result) => Ok(result.into_pipeline_data_with_metadata(metadata)),
-            Err(err) => Err(ShellError::GenericError(
-                "error when loading nuon text".into(),
-                "could not load nuon text".into(),
-                Some(head),
-                None,
-                vec![err],
-            )),
+            Err(err) => Err(ShellError::GenericError {
+                error: "error when loading nuon text".into(),
+                msg: "could not load nuon text".into(),
+                span: Some(head),
+                help: None,
+                inner: vec![err],
+            }),
         }
     }
 }

--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -155,13 +155,13 @@ used as the next argument to the closure, otherwise generation stops.
                                 } else if k.eq_ignore_ascii_case("next") {
                                     next = Some(v);
                                 } else {
-                                    let error = ShellError::GenericError(
-                                        "Invalid block return".to_string(),
-                                        format!("Unexpected record key '{}'", k),
-                                        Some(span),
-                                        None,
-                                        Vec::new(),
-                                    );
+                                    let error = ShellError::GenericError {
+                                        error: "Invalid block return".into(),
+                                        msg: format!("Unexpected record key '{}'", k),
+                                        span: Some(span),
+                                        help: None,
+                                        inner: vec![],
+                                    };
                                     err = Some(Value::error(error, block_span));
                                     break;
                                 }
@@ -176,13 +176,13 @@ used as the next argument to the closure, otherwise generation stops.
 
                         // some other value -> error and stop
                         _ => {
-                            let error = ShellError::GenericError(
-                                "Invalid block return".to_string(),
-                                format!("Expected record, found {}", value.get_type()),
-                                Some(span),
-                                None,
-                                Vec::new(),
-                            );
+                            let error = ShellError::GenericError {
+                                error: "Invalid block return".into(),
+                                msg: format!("Expected record, found {}", value.get_type()),
+                                span: Some(span),
+                                help: None,
+                                inner: vec![],
+                            };
 
                             (Some(Value::error(error, block_span)), None)
                         }
@@ -191,13 +191,13 @@ used as the next argument to the closure, otherwise generation stops.
 
                 Ok(other) => {
                     let val = other.into_value(block_span);
-                    let error = ShellError::GenericError(
-                        "Invalid block return".to_string(),
-                        format!("Expected record, found {}", val.get_type()),
-                        Some(val.span()),
-                        None,
-                        Vec::new(),
-                    );
+                    let error = ShellError::GenericError {
+                        error: "Invalid block return".into(),
+                        msg: format!("Expected record, found {}", val.get_type()),
+                        span: Some(val.span()),
+                        help: None,
+                        inner: vec![],
+                    };
 
                     (Some(Value::error(error, block_span)), None)
                 }

--- a/crates/nu-command/src/generators/seq.rs
+++ b/crates/nu-command/src/generators/seq.rs
@@ -101,13 +101,13 @@ fn seq(
     let contains_decimals = rest_nums_check.is_err();
 
     if rest_nums.is_empty() {
-        return Err(ShellError::GenericError(
-            "seq requires some parameters".into(),
-            "needs parameter".into(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "seq requires some parameters".into(),
+            msg: "needs parameter".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
     }
 
     let rest_nums: Vec<f64> = rest_nums.iter().map(|n| n.item).collect();

--- a/crates/nu-command/src/generators/seq_char.rs
+++ b/crates/nu-command/src/generators/seq_char.rs
@@ -82,23 +82,23 @@ fn seq_char(
     let end: Spanned<String> = call.req(engine_state, stack, 1)?;
 
     if !is_single_character(&start.item) {
-        return Err(ShellError::GenericError(
-            "seq char only accepts individual ASCII characters as parameters".into(),
-            "should be 1 character long".into(),
-            Some(start.span),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "seq char only accepts individual ASCII characters as parameters".into(),
+            msg: "should be 1 character long".into(),
+            span: Some(start.span),
+            help: None,
+            inner: vec![],
+        });
     }
 
     if !is_single_character(&end.item) {
-        return Err(ShellError::GenericError(
-            "seq char only accepts individual ASCII characters as parameters".into(),
-            "should be 1 character long".into(),
-            Some(end.span),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "seq char only accepts individual ASCII characters as parameters".into(),
+            msg: "should be 1 character long".into(),
+            span: Some(end.span),
+            help: None,
+            inner: vec![],
+        });
     }
 
     let start = start

--- a/crates/nu-command/src/generators/seq_date.rs
+++ b/crates/nu-command/src/generators/seq_date.rs
@@ -194,26 +194,26 @@ pub fn run_seq_dates(
     let mut step_size: i64 = increment.as_i64()?;
 
     if step_size == 0 {
-        return Err(ShellError::GenericError(
-            "increment cannot be 0".to_string(),
-            "increment cannot be 0".to_string(),
-            Some(increment.span()),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "increment cannot be 0".into(),
+            msg: "increment cannot be 0".into(),
+            span: Some(increment.span()),
+            help: None,
+            inner: vec![],
+        });
     }
 
     let in_format = match input_format {
         Some(i) => match i.as_string() {
             Ok(v) => v,
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    e.to_string(),
-                    "".to_string(),
-                    None,
-                    Some("error with input_format as_string".to_string()),
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: e.to_string(),
+                    msg: "".into(),
+                    span: None,
+                    help: Some("error with input_format as_string".into()),
+                    inner: vec![],
+                });
             }
         },
         _ => "%Y-%m-%d".to_string(),
@@ -223,13 +223,13 @@ pub fn run_seq_dates(
         Some(i) => match i.as_string() {
             Ok(v) => v,
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    e.to_string(),
-                    "".to_string(),
-                    None,
-                    Some("error with output_format as_string".to_string()),
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: e.to_string(),
+                    msg: "".into(),
+                    span: None,
+                    help: Some("error with output_format as_string".into()),
+                    inner: vec![],
+                });
             }
         },
         _ => "%Y-%m-%d".to_string(),
@@ -239,13 +239,13 @@ pub fn run_seq_dates(
         Some(d) => match parse_date_string(&d, &in_format) {
             Ok(nd) => nd,
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    e.to_string(),
-                    "Failed to parse date".to_string(),
-                    Some(call_span),
-                    None,
-                    Vec::new(),
-                ))
+                return Err(ShellError::GenericError {
+                    error: e.to_string(),
+                    msg: "Failed to parse date".into(),
+                    span: Some(call_span),
+                    help: None,
+                    inner: vec![],
+                })
             }
         },
         _ => today,
@@ -255,13 +255,13 @@ pub fn run_seq_dates(
         Some(d) => match parse_date_string(&d, &in_format) {
             Ok(nd) => nd,
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    e.to_string(),
-                    "Failed to parse date".to_string(),
-                    Some(call_span),
-                    None,
-                    Vec::new(),
-                ))
+                return Err(ShellError::GenericError {
+                    error: e.to_string(),
+                    msg: "Failed to parse date".into(),
+                    span: Some(call_span),
+                    help: None,
+                    inner: vec![],
+                })
             }
         },
         _ => today,
@@ -282,13 +282,13 @@ pub fn run_seq_dates(
         end_date = match start_date.checked_add_signed(Duration::days(days_to_output)) {
             Some(date) => date,
             None => {
-                return Err(ShellError::GenericError(
-                    "int value too large".to_string(),
-                    "int value too large".to_string(),
-                    Some(call_span),
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "int value too large".into(),
+                    msg: "int value too large".into(),
+                    span: Some(call_span),
+                    help: None,
+                    inner: vec![],
+                });
             }
         }
     }
@@ -304,13 +304,13 @@ pub fn run_seq_dates(
 
     let mut next = start_date;
     if is_out_of_range(next) {
-        return Err(ShellError::GenericError(
-            "date is out of range".to_string(),
-            "date is out of range".to_string(),
-            Some(call_span),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "date is out of range".into(),
+            msg: "date is out of range".into(),
+            span: Some(call_span),
+            help: None,
+            inner: vec![],
+        });
     }
 
     let mut ret = vec![];

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -207,13 +207,13 @@ pub fn highlight_search_string(
     let regex = match Regex::new(&regex_string) {
         Ok(regex) => regex,
         Err(err) => {
-            return Err(ShellError::GenericError(
-                "Could not compile regex".into(),
-                err.to_string(),
-                Some(Span::test_data()),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Could not compile regex".into(),
+                msg: err.to_string(),
+                span: Some(Span::test_data()),
+                help: None,
+                inner: vec![],
+            });
         }
     };
     // strip haystack to remove existing ansi style
@@ -245,13 +245,13 @@ pub fn highlight_search_string(
                 last_match_end = end;
             }
             Err(e) => {
-                return Err(ShellError::GenericError(
-                    "Error with regular expression capture".into(),
-                    e.to_string(),
-                    None,
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "Error with regular expression capture".into(),
+                    msg: e.to_string(),
+                    span: None,
+                    help: None,
+                    inner: vec![],
+                });
             }
         }
     }

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -403,26 +403,23 @@ fn transform_response_using_content_type(
     resp: Response,
     content_type: &str,
 ) -> Result<PipelineData, ShellError> {
-    let content_type = mime::Mime::from_str(content_type).map_err(|_| {
-        ShellError::GenericError(
-            format!("MIME type unknown: {content_type}"),
-            "".to_string(),
-            None,
-            Some("given unknown MIME type".to_string()),
-            Vec::new(),
-        )
-    })?;
+    let content_type =
+        mime::Mime::from_str(content_type).map_err(|_| ShellError::GenericError {
+            error: format!("MIME type unknown: {content_type}"),
+            msg: "".into(),
+            span: None,
+            help: Some("given unknown MIME type".into()),
+            inner: vec![],
+        })?;
     let ext = match (content_type.type_(), content_type.subtype()) {
         (mime::TEXT, mime::PLAIN) => {
             let path_extension = url::Url::parse(requested_url)
-                .map_err(|_| {
-                    ShellError::GenericError(
-                        format!("Cannot parse URL: {requested_url}"),
-                        "".to_string(),
-                        None,
-                        Some("cannot parse".to_string()),
-                        Vec::new(),
-                    )
+                .map_err(|_| ShellError::GenericError {
+                    error: format!("Cannot parse URL: {requested_url}"),
+                    msg: "".into(),
+                    span: None,
+                    help: Some("cannot parse".into()),
+                    inner: vec![],
                 })?
                 .path_segments()
                 .and_then(|segments| segments.last())

--- a/crates/nu-command/src/network/url/decode.rs
+++ b/crates/nu-command/src/network/url/decode.rs
@@ -85,13 +85,13 @@ fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
             match val {
                 Ok(val) => Value::string(val, head),
                 Err(e) => Value::error(
-                    ShellError::GenericError(
-                        "Failed to decode string".into(),
-                        e.to_string(),
-                        Some(input_span),
-                        None,
-                        Vec::new(),
-                    ),
+                    ShellError::GenericError {
+                        error: "Failed to decode string".into(),
+                        msg: e.to_string(),
+                        span: Some(input_span),
+                        help: None,
+                        inner: vec![],
+                    },
                     head,
                 ),
             }

--- a/crates/nu-command/src/network/url/join.rs
+++ b/crates/nu-command/src/network/url/join.rs
@@ -283,13 +283,13 @@ impl UrlComponents {
             _ => {
                 nu_protocol::report_error_new(
                     engine_state,
-                    &ShellError::GenericError(
-                        format!("'{key}' is not a valid URL field"),
-                        format!("remove '{key}' col from input record"),
-                        Some(span),
-                        None,
-                        vec![],
-                    ),
+                    &ShellError::GenericError {
+                        error: format!("'{key}' is not a valid URL field"),
+                        msg: format!("remove '{key}' col from input record"),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    },
                 );
                 Ok(self)
             }

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -157,15 +157,15 @@ fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
                 }
             }
             Err(_) => Value::error(
-                ShellError::GenericError(
-                    "Could not expand path".into(),
-                    "could not be expanded (path might not exist, non-final \
+                ShellError::GenericError {
+                    error: "Could not expand path".into(),
+                    msg: "could not be expanded (path might not exist, non-final \
                             component is not a directory, or other cause)"
                         .into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                ),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                },
                 span,
             ),
         }

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -732,13 +732,13 @@ Operating system commands:
                         None => Color::White.prefix().to_string(),
                     },
                     Err(err) => {
-                        return Err(ShellError::GenericError(
-                            "error parsing hex color".to_string(),
-                            format!("{err}"),
-                            Some(code.span()),
-                            None,
-                            Vec::new(),
-                        ));
+                        return Err(ShellError::GenericError {
+                            error: "error parsing hex color".into(),
+                            msg: format!("{err}"),
+                            span: Some(code.span()),
+                            help: None,
+                            inner: vec![],
+                        });
                     }
                 }
             } else {

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -90,14 +90,12 @@ There are 4 `key_type` variants:
         terminal::enable_raw_mode()?;
         let console_state = event_type_filter.enable_events()?;
         loop {
-            let event = crossterm::event::read().map_err(|_| {
-                ShellError::GenericError(
-                    "Error with user input".to_string(),
-                    "".to_string(),
-                    Some(head),
-                    None,
-                    Vec::new(),
-                )
+            let event = crossterm::event::read().map_err(|_| ShellError::GenericError {
+                error: "Error with user input".into(),
+                msg: "".into(),
+                span: Some(head),
+                help: None,
+                inner: vec![],
             })?;
             let event = parse_event(head, &event, &event_type_filter, add_raw);
             if let Some(event) = event {

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -92,27 +92,23 @@ impl Command for Kill {
                         left_message: "force".to_string(),
                         left_span: call
                             .get_named_arg("force")
-                            .ok_or_else(|| {
-                                ShellError::GenericError(
-                                    "Flag error".into(),
-                                    "flag force not found".into(),
-                                    Some(call.head),
-                                    None,
-                                    Vec::new(),
-                                )
+                            .ok_or_else(|| ShellError::GenericError {
+                                error: "Flag error".into(),
+                                msg: "flag force not found".into(),
+                                span: Some(call.head),
+                                help: None,
+                                inner: vec![],
                             })?
                             .span,
                         right_message: "signal".to_string(),
                         right_span: span(&[
                             call.get_named_arg("signal")
-                                .ok_or_else(|| {
-                                    ShellError::GenericError(
-                                        "Flag error".into(),
-                                        "flag signal not found".into(),
-                                        Some(call.head),
-                                        None,
-                                        Vec::new(),
-                                    )
+                                .ok_or_else(|| ShellError::GenericError {
+                                    error: "Flag error".into(),
+                                    msg: "flag signal not found".into(),
+                                    span: Some(call.head),
+                                    help: None,
+                                    inner: vec![],
                                 })?
                                 .span,
                             signal_span,
@@ -138,36 +134,32 @@ impl Command for Kill {
                 .stderr(Stdio::null());
         }
 
-        let output = cmd.output().map_err(|e| {
-            ShellError::GenericError(
-                "failed to execute shell command".into(),
-                e.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+        let output = cmd.output().map_err(|e| ShellError::GenericError {
+            error: "failed to execute shell command".into(),
+            msg: e.to_string(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
         })?;
 
         if !quiet && !output.status.success() {
-            return Err(ShellError::GenericError(
-                "process didn't terminate successfully".into(),
-                String::from_utf8(output.stderr).unwrap_or_default(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "process didn't terminate successfully".into(),
+                msg: String::from_utf8(output.stderr).unwrap_or_default(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            });
         }
 
         let val = String::from(
             String::from_utf8(output.stdout)
-                .map_err(|e| {
-                    ShellError::GenericError(
-                        "failed to convert output to string".into(),
-                        e.to_string(),
-                        Some(call.head),
-                        None,
-                        Vec::new(),
-                    )
+                .map_err(|e| ShellError::GenericError {
+                    error: "failed to convert output to string".into(),
+                    msg: e.to_string(),
+                    span: Some(call.head),
+                    help: None,
+                    inner: vec![],
                 })?
                 .trim_end(),
         );

--- a/crates/nu-command/src/platform/whoami.rs
+++ b/crates/nu-command/src/platform/whoami.rs
@@ -36,14 +36,14 @@ impl Command for Whoami {
     ) -> Result<PipelineData, ShellError> {
         let output = match uu_whoami::whoami() {
             Ok(username) => username.to_string_lossy().to_string(),
-            Err(err) => {
-                return Err(ShellError::GenericError(
-                    "Failed to get username".into(),
-                    err.to_string(),
-                    Some(call.head),
-                    None,
-                    Vec::new(),
-                ))
+            Err(e) => {
+                return Err(ShellError::GenericError {
+                    error: "Failed to get username".into(),
+                    msg: e.to_string(),
+                    span: Some(call.head),
+                    help: None,
+                    inner: vec![],
+                })
             }
         };
 

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -69,13 +69,13 @@ pub fn sort(
         Some(Value::Record { val: record, .. }) => {
             if sort_columns.is_empty() {
                 // This uses the same format as the 'requires a column name' error in split_by.rs
-                return Err(ShellError::GenericError(
-                    "expected name".into(),
-                    "requires a column name to sort table data".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                ));
+                return Err(ShellError::GenericError {
+                    error: "expected name".into(),
+                    msg: "requires a column name to sort table data".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                });
             }
 
             if let Some(nonexistent) = nonexistent_column(&sort_columns, record.columns()) {

--- a/crates/nu-command/src/stor/create.rs
+++ b/crates/nu-command/src/stor/create.rs
@@ -128,15 +128,14 @@ fn process(
 
                 // dbg!(&create_stmt);
 
-                conn.execute(&create_stmt, []).map_err(|err| {
-                    ShellError::GenericError(
-                        "Failed to open SQLite connection in memory from create".into(),
-                        err.to_string(),
-                        Some(Span::test_data()),
-                        None,
-                        Vec::new(),
-                    )
-                })?;
+                conn.execute(&create_stmt, [])
+                    .map_err(|err| ShellError::GenericError {
+                        error: "Failed to open SQLite connection in memory from create".into(),
+                        msg: err.to_string(),
+                        span: Some(Span::test_data()),
+                        help: None,
+                        inner: vec![],
+                    })?;
             }
             None => {
                 return Err(ShellError::MissingParameter {

--- a/crates/nu-command/src/stor/delete.rs
+++ b/crates/nu-command/src/stor/delete.rs
@@ -112,15 +112,14 @@ impl Command for StorDelete {
                 };
 
                 // dbg!(&sql_stmt);
-                conn.execute(&sql_stmt, []).map_err(|err| {
-                    ShellError::GenericError(
-                        "Failed to open SQLite connection in memory from delete".into(),
-                        err.to_string(),
-                        Some(Span::test_data()),
-                        None,
-                        Vec::new(),
-                    )
-                })?;
+                conn.execute(&sql_stmt, [])
+                    .map_err(|err| ShellError::GenericError {
+                        error: "Failed to open SQLite connection in memory from delete".into(),
+                        msg: err.to_string(),
+                        span: Some(Span::test_data()),
+                        help: None,
+                        inner: vec![],
+                    })?;
             }
         }
         // dbg!(db.clone());

--- a/crates/nu-command/src/stor/export.rs
+++ b/crates/nu-command/src/stor/export.rs
@@ -70,14 +70,12 @@ impl Command for StorExport {
             // This uses vacuum. I'm not really sure if this is the best way to do this.
             // I also added backup in the sqlitedatabase impl. If we have problems, we could switch to that.
             db.export_in_memory_database_to_file(&conn, file_name)
-                .map_err(|err| {
-                    ShellError::GenericError(
-                        "Failed to open SQLite connection in memory from export".into(),
-                        err.to_string(),
-                        Some(Span::test_data()),
-                        None,
-                        Vec::new(),
-                    )
+                .map_err(|err| ShellError::GenericError {
+                    error: "Failed to open SQLite connection in memory from export".into(),
+                    msg: err.to_string(),
+                    span: Some(Span::test_data()),
+                    help: None,
+                    inner: vec![],
                 })?;
         }
         // dbg!(db.clone());

--- a/crates/nu-command/src/stor/import.rs
+++ b/crates/nu-command/src/stor/import.rs
@@ -68,14 +68,12 @@ impl Command for StorImport {
 
         if let Ok(mut conn) = db.open_connection() {
             db.restore_database_from_file(&mut conn, file_name)
-                .map_err(|err| {
-                    ShellError::GenericError(
-                        "Failed to open SQLite connection in memory from import".into(),
-                        err.to_string(),
-                        Some(Span::test_data()),
-                        None,
-                        Vec::new(),
-                    )
+                .map_err(|err| ShellError::GenericError {
+                    error: "Failed to open SQLite connection in memory from import".into(),
+                    msg: err.to_string(),
+                    span: Some(Span::test_data()),
+                    help: None,
+                    inner: vec![],
                 })?;
         }
         // dbg!(db.clone());

--- a/crates/nu-command/src/stor/insert.rs
+++ b/crates/nu-command/src/stor/insert.rs
@@ -119,15 +119,14 @@ impl Command for StorInsert {
 
                     // dbg!(&create_stmt);
 
-                    conn.execute(&create_stmt, []).map_err(|err| {
-                        ShellError::GenericError(
-                            "Failed to open SQLite connection in memory from insert".into(),
-                            err.to_string(),
-                            Some(Span::test_data()),
-                            None,
-                            Vec::new(),
-                        )
-                    })?;
+                    conn.execute(&create_stmt, [])
+                        .map_err(|err| ShellError::GenericError {
+                            error: "Failed to open SQLite connection in memory from insert".into(),
+                            msg: err.to_string(),
+                            span: Some(Span::test_data()),
+                            help: None,
+                            inner: vec![],
+                        })?;
                 }
                 None => {
                     return Err(ShellError::MissingParameter {

--- a/crates/nu-command/src/stor/reset.rs
+++ b/crates/nu-command/src/stor/reset.rs
@@ -49,15 +49,14 @@ impl Command for StorReset {
         let db = Box::new(SQLiteDatabase::new(std::path::Path::new(MEMORY_DB), None));
 
         if let Ok(conn) = db.open_connection() {
-            db.drop_all_tables(&conn).map_err(|err| {
-                ShellError::GenericError(
-                    "Failed to open SQLite connection in memory from reset".into(),
-                    err.to_string(),
-                    Some(Span::test_data()),
-                    None,
-                    Vec::new(),
-                )
-            })?;
+            db.drop_all_tables(&conn)
+                .map_err(|err| ShellError::GenericError {
+                    error: "Failed to open SQLite connection in memory from reset".into(),
+                    msg: err.to_string(),
+                    span: Some(Span::test_data()),
+                    help: None,
+                    inner: vec![],
+                })?;
         }
         // dbg!(db.clone());
         Ok(Value::custom_value(db, span).into_pipeline_data())

--- a/crates/nu-command/src/stor/update.rs
+++ b/crates/nu-command/src/stor/update.rs
@@ -131,15 +131,14 @@ impl Command for StorUpdate {
                     }
                     // dbg!(&update_stmt);
 
-                    conn.execute(&update_stmt, []).map_err(|err| {
-                        ShellError::GenericError(
-                            "Failed to open SQLite connection in memory from update".into(),
-                            err.to_string(),
-                            Some(Span::test_data()),
-                            None,
-                            Vec::new(),
-                        )
-                    })?;
+                    conn.execute(&update_stmt, [])
+                        .map_err(|err| ShellError::GenericError {
+                            error: "Failed to open SQLite connection in memory from update".into(),
+                            msg: err.to_string(),
+                            span: Some(Span::test_data()),
+                            help: None,
+                            inner: vec![],
+                        })?;
                 }
                 None => {
                     return Err(ShellError::MissingParameter {

--- a/crates/nu-command/src/strings/encode_decode/base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/base64.rs
@@ -91,15 +91,15 @@ fn action(
         "crypt" => GeneralPurpose::new(&alphabet::CRYPT, NO_PAD),
         "mutf7" => GeneralPurpose::new(&alphabet::IMAP_MUTF7, NO_PAD),
         not_valid => return Value::error (
-            ShellError::GenericError(
-            "value is not an accepted character set".to_string(),
-            format!(
+            ShellError::GenericError {
+            error: "value is not an accepted character set".into(),
+            msg: format!(
                 "{not_valid} is not a valid character-set.\nPlease use `help encode base64` to see a list of valid character sets."
             ),
-            Some(config_character_set.span),
-            None,
-            Vec::new(),
-        ), config_character_set.span)
+            span: Some(config_character_set.span),
+            help: None,
+            inner: vec![],
+        }, config_character_set.span)
     };
     let value_span = input.span();
     match input {
@@ -110,15 +110,15 @@ fn action(
                 let mut enc_vec = vec![0; val.len() * 4 / 3 + 4];
                 let bytes_written = match base64_engine.encode_slice(val, &mut enc_vec) {
                     Ok(bytes_written) => bytes_written,
-                    Err(err) => {
+                    Err(e) => {
                         return Value::error(
-                            ShellError::GenericError(
-                                "Error encoding data".into(),
-                                err.to_string(),
-                                Some(value_span),
-                                None,
-                                Vec::new(),
-                            ),
+                            ShellError::GenericError {
+                                error: "Error encoding data".into(),
+                                msg: e.to_string(),
+                                span: Some(value_span),
+                                help: None,
+                                inner: vec![],
+                            },
                             value_span,
                         )
                     }
@@ -157,30 +157,32 @@ fn action(
                                 match String::from_utf8(decoded_value) {
                                     Ok(string_value) => Value::string(string_value, command_span),
                                     Err(e) => Value::error(
-                                        ShellError::GenericError(
-                                            "base64 payload isn't a valid utf-8 sequence"
-                                                .to_owned(),
-                                            e.to_string(),
-                                            Some(value_span),
-                                            Some("consider using the `--binary` flag".to_owned()),
-                                            Vec::new(),
-                                        ),
+                                        ShellError::GenericError {
+                                            error: "base64 payload isn't a valid utf-8 sequence"
+                                                .into(),
+                                            msg: e.to_string(),
+                                            span: Some(value_span),
+                                            help: Some(
+                                                "consider using the `--binary` flag".to_owned(),
+                                            ),
+                                            inner: vec![],
+                                        },
                                         value_span,
                                     ),
                                 }
                             }
                         }
                         Err(_) => Value::error(
-                            ShellError::GenericError(
-                                "value could not be base64 decoded".to_string(),
-                                format!(
+                            ShellError::GenericError {
+                                error: "value could not be base64 decoded".into(),
+                                msg: format!(
                                     "invalid base64 input for character set {}",
                                     &config_character_set.item
                                 ),
-                                Some(command_span),
-                                None,
-                                Vec::new(),
-                            ),
+                                span: Some(command_span),
+                                help: None,
+                                inner: vec![],
+                            },
                             command_span,
                         ),
                     }

--- a/crates/nu-command/src/strings/encode_decode/encoding.rs
+++ b/crates/nu-command/src/strings/encode_decode/encoding.rs
@@ -55,13 +55,13 @@ pub fn encode(
     // This behaviour can be enabled with -i. Otherwise, it becomes an error.
     if replacements && !ignore_errors {
         // TODO: make GenericError accept two spans (including head)
-        Err(ShellError::GenericError(
-            "error while encoding string".into(),
-            format!("string contained characters not in {}", &encoding_name.item),
-            Some(s_span),
-            None,
-            vec![],
-        ))
+        Err(ShellError::GenericError {
+            error: "error while encoding string".into(),
+            msg: format!("string contained characters not in {}", &encoding_name.item),
+            span: Some(s_span),
+            help: None,
+            inner: vec![],
+        })
     } else {
         Ok(Value::binary(result.into_owned(), head))
     }
@@ -75,15 +75,15 @@ fn parse_encoding(span: Span, label: &str) -> Result<&'static Encoding, ShellErr
         label
     };
     match Encoding::for_label_no_replacement(label.as_bytes()) {
-        None => Err(ShellError::GenericError(
-            format!(
+        None => Err(ShellError::GenericError{
+            error: format!(
                 r#"{label} is not a valid encoding"#
             ),
-            "invalid encoding".into(),
-            Some(span),
-            Some("refer to https://docs.rs/encoding_rs/latest/encoding_rs/index.html#statics for a valid list of encodings".into()),
-            vec![],
-        )),
+            msg: "invalid encoding".into(),
+            span: Some(span),
+            help: Some("refer to https://docs.rs/encoding_rs/latest/encoding_rs/index.html#statics for a valid list of encodings".into()),
+            inner: vec![],
+        }),
         Some(encoding) => Ok(encoding),
     }
 }

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -138,14 +138,12 @@ fn operate(
         build_regex(&pattern_item, pattern_span)?
     };
 
-    let regex_pattern = Regex::new(&item_to_parse).map_err(|err| {
-        ShellError::GenericError(
-            "Error with regular expression".into(),
-            err.to_string(),
-            Some(pattern_span),
-            None,
-            Vec::new(),
-        )
+    let regex_pattern = Regex::new(&item_to_parse).map_err(|e| ShellError::GenericError {
+        error: "Error with regular expression".into(),
+        msg: e.to_string(),
+        span: Some(pattern_span),
+        help: None,
+        inner: vec![],
     })?;
 
     let columns = column_names(&regex_pattern);
@@ -164,13 +162,13 @@ fn operate(
                             let captures = match c {
                                 Ok(c) => c,
                                 Err(e) => {
-                                    return Err(ShellError::GenericError(
-                                        "Error with regular expression captures".into(),
-                                        e.to_string(),
-                                        None,
-                                        None,
-                                        Vec::new(),
-                                    ))
+                                    return Err(ShellError::GenericError {
+                                        error: "Error with regular expression captures".into(),
+                                        msg: e.to_string(),
+                                        span: None,
+                                        help: None,
+                                        inner: vec![],
+                                    })
                                 }
                             };
 
@@ -430,13 +428,13 @@ fn stream_helper(
             Ok(c) => c,
             Err(e) => {
                 return Some(Value::error(
-                    ShellError::GenericError(
-                        "Error with regular expression captures".into(),
-                        e.to_string(),
-                        Some(span),
-                        Some(e.to_string()),
-                        Vec::new(),
-                    ),
+                    ShellError::GenericError {
+                        error: "Error with regular expression captures".into(),
+                        msg: e.to_string(),
+                        span: Some(span),
+                        help: Some(e.to_string()),
+                        inner: vec![],
+                    },
                     span,
                 ))
             }

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -127,14 +127,12 @@ fn split_column(
         let escaped = regex::escape(&separator.item);
         Regex::new(&escaped)
     }
-    .map_err(|err| {
-        ShellError::GenericError(
-            "Error with regular expression".into(),
-            err.to_string(),
-            Some(separator.span),
-            None,
-            Vec::new(),
-        )
+    .map_err(|e| ShellError::GenericError {
+        error: "Error with regular expression".into(),
+        msg: e.to_string(),
+        span: Some(separator.span),
+        help: None,
+        inner: vec![],
     })?;
 
     input.flat_map(

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -161,17 +161,15 @@ impl Matcher {
     pub fn new(regex: bool, lhs: Value) -> Result<Self, ShellError> {
         if regex {
             Ok(Matcher::Regex(Regex::new(&lhs.as_string()?).map_err(
-                |err| {
-                    ShellError::GenericError(
-                        "Error with regular expression".into(),
-                        err.to_string(),
-                        match lhs {
-                            Value::Error { .. } => None,
-                            _ => Some(lhs.span()),
-                        },
-                        None,
-                        Vec::new(),
-                    )
+                |e| ShellError::GenericError {
+                    error: "Error with regular expression".into(),
+                    msg: e.to_string(),
+                    span: match lhs {
+                        Value::Error { .. } => None,
+                        _ => Some(lhs.span()),
+                    },
+                    help: None,
+                    inner: vec![],
                 },
             )?))
         } else {

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -129,14 +129,12 @@ fn split_row(
         let escaped = regex::escape(&separator.item);
         Regex::new(&escaped)
     }
-    .map_err(|err| {
-        ShellError::GenericError(
-            "Error with regular expression".into(),
-            err.to_string(),
-            Some(separator.span),
-            None,
-            Vec::new(),
-        )
+    .map_err(|e| ShellError::GenericError {
+        error: "Error with regular expression".into(),
+        msg: e.to_string(),
+        span: Some(separator.span),
+        help: None,
+        inner: vec![],
     })?;
     let max_split: Option<usize> = call.get_flag(engine_state, stack, "number")?;
     input.flat_map(

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -234,7 +234,7 @@ fn str_expand(contents: &str, span: Span, value_span: Span) -> Value {
                         },
                         Err(e) => match e {
                             bracoxide::ExpansionError::NumConversionFailed(s) => Value::error(
-                                ShellError::GenericError("Number Conversion Failed".to_owned(), format!("Number conversion failed at {s}."), Some(value_span), Some("Expected number, found text. Range format is `{M..N}`, where M and N are numeric values representing the starting and ending limits.".to_owned()), vec![]),
+                                ShellError::GenericError{error: "Number Conversion Failed".into(), msg: format!("Number conversion failed at {s}."), span: Some(value_span), help: Some("Expected number, found text. Range format is `{M..N}`, where M and N are numeric values representing the starting and ending limits.".into()), inner: vec![]},
                             span,
                         ),
                         },
@@ -243,17 +243,17 @@ fn str_expand(contents: &str, span: Span, value_span: Span) -> Value {
                 Err(e) => Value::error(
                     match e {
                         ParsingError::NoTokens => ShellError::PipelineEmpty { dst_span: value_span },
-                        ParsingError::OBraExpected(s) => ShellError::GenericError("Opening Brace Expected".to_owned(), format!("Opening brace is expected at {s}."), Some(value_span), Some("In brace syntax, we use equal amount of opening (`{`) and closing (`}`). Please, take a look at the examples.".to_owned()), vec![]),
-                        ParsingError::CBraExpected(s) => ShellError::GenericError("Closing Brace Expected".to_owned(), format!("Closing brace is expected at {s}."), Some(value_span), Some("In brace syntax, we use equal amount of opening (`{`) and closing (`}`). Please, see the examples.".to_owned()), vec![]),
-                        ParsingError::RangeStartLimitExpected(s) => ShellError::GenericError("Range Start Expected".to_owned(), format!("Range start limit is missing, expected at {s}."), Some(value_span), Some("In brace syntax, Range is defined like `{X..Y}`, where X and Y are a number. X is the start, Y is the end. Please, inspect the examples for more information.".to_owned()), vec![]),
-                        ParsingError::RangeEndLimitExpected(s) => ShellError::GenericError("Range Start Expected".to_owned(), format!("Range start limit is missing, expected at {s}."), Some(value_span), Some("In brace syntax, Range is defined like `{X..Y}`, where X and Y are a number. X is the start, Y is the end. Please see the examples, for more information.".to_owned()), vec![]),
-                        ParsingError::ExpectedText(s) => ShellError::GenericError("Expected Text".to_owned(), format!("Expected text at {s}."), Some(value_span), Some("Texts are only allowed before opening brace (`{`), after closing brace (`}`), or inside `{}`. Please take a look at the examples.".to_owned()), vec![]),
-                        ParsingError::InvalidCommaUsage(s) => ShellError::GenericError("Invalid Comma Usage".to_owned(), format!("Found comma at {s}. Commas are only valid inside collection (`{{X,Y}}`)."), Some(value_span), Some("To escape comma use backslash `\\,`.".to_owned()), vec![]),
-                        ParsingError::RangeCantHaveText(s) => ShellError::GenericError("Range Can not Have Text".to_owned(), format!("Expecting, brace, number, or range operator, but found text at {s}."), Some(value_span), Some("Please use the format {M..N} for ranges in brace expansion, where M and N are numeric values representing the starting and ending limits of the sequence, respectively.".to_owned()), vec![]),
-                        ParsingError::ExtraRangeOperator(s) => ShellError::GenericError("Extra Range Operator".to_owned(), format!("Found additional, range operator at {s}."), Some(value_span), Some("Please, use the format `{M..N}` where M and N are numeric values representing the starting and ending limits of the range.".to_owned()), vec![]),
-                        ParsingError::ExtraCBra(s) => ShellError::GenericError("Extra Closing Brace".to_owned(), format!("Used extra closing brace at {s}."), Some(value_span), Some("To escape closing brace use backslash, e.g. `\\}`".to_owned()), vec![]),
-                        ParsingError::ExtraOBra(s) => ShellError::GenericError("Extra Opening Brace".to_owned(), format!("Used extra opening brace at {s}."), Some(value_span), Some("To escape opening brace use backslash, e.g. `\\{`".to_owned()), vec![]),
-                        ParsingError::NothingInBraces(s) => ShellError::GenericError("Nothing In Braces".to_owned(), format!("Nothing found inside braces at {s}."), Some(value_span), Some("Please provide valid content within the braces. Additionally, you can safely remove it, not needed.".to_owned()), vec![]),
+                        ParsingError::OBraExpected(s) => ShellError::GenericError{ error: "Opening Brace Expected".into(), msg: format!("Opening brace is expected at {s}."), span: Some(value_span), help: Some("In brace syntax, we use equal amount of opening (`{`) and closing (`}`). Please, take a look at the examples.".into()), inner: vec![]},
+                        ParsingError::CBraExpected(s) => ShellError::GenericError{ error: "Closing Brace Expected".into(), msg: format!("Closing brace is expected at {s}."), span: Some(value_span), help: Some("In brace syntax, we use equal amount of opening (`{`) and closing (`}`). Please, see the examples.".into()), inner: vec![]},
+                        ParsingError::RangeStartLimitExpected(s) => ShellError::GenericError{error: "Range Start Expected".into(), msg: format!("Range start limit is missing, expected at {s}."), span: Some(value_span), help: Some("In brace syntax, Range is defined like `{X..Y}`, where X and Y are a number. X is the start, Y is the end. Please, inspect the examples for more information.".into()), inner: vec![]},
+                        ParsingError::RangeEndLimitExpected(s) => ShellError::GenericError{ error: "Range Start Expected".into(), msg: format!("Range start limit is missing, expected at {s}."),span:  Some(value_span), help: Some("In brace syntax, Range is defined like `{X..Y}`, where X and Y are a number. X is the start, Y is the end. Please see the examples, for more information.".into()), inner: vec![]},
+                        ParsingError::ExpectedText(s) => ShellError::GenericError { error: "Expected Text".into(), msg: format!("Expected text at {s}."), span: Some(value_span), help: Some("Texts are only allowed before opening brace (`{`), after closing brace (`}`), or inside `{}`. Please take a look at the examples.".into()), inner: vec![] },
+                        ParsingError::InvalidCommaUsage(s) => ShellError::GenericError { error: "Invalid Comma Usage".into(), msg: format!("Found comma at {s}. Commas are only valid inside collection (`{{X,Y}}`)."),span:  Some(value_span), help: Some("To escape comma use backslash `\\,`.".into()), inner: vec![] },
+                        ParsingError::RangeCantHaveText(s) => ShellError::GenericError { error: "Range Can not Have Text".into(), msg: format!("Expecting, brace, number, or range operator, but found text at {s}."), span: Some(value_span), help: Some("Please use the format {M..N} for ranges in brace expansion, where M and N are numeric values representing the starting and ending limits of the sequence, respectively.".into()), inner: vec![]},
+                        ParsingError::ExtraRangeOperator(s) => ShellError::GenericError { error: "Extra Range Operator".into(), msg: format!("Found additional, range operator at {s}."), span: Some(value_span), help: Some("Please, use the format `{M..N}` where M and N are numeric values representing the starting and ending limits of the range.".into()), inner: vec![] },
+                        ParsingError::ExtraCBra(s) => ShellError::GenericError { error: "Extra Closing Brace".into(), msg: format!("Used extra closing brace at {s}."), span: Some(value_span), help: Some("To escape closing brace use backslash, e.g. `\\}`".into()), inner: vec![] },
+                        ParsingError::ExtraOBra(s) => ShellError::GenericError { error: "Extra Opening Brace".into(), msg: format!("Used extra opening brace at {s}."), span: Some(value_span), help: Some("To escape opening brace use backslash, e.g. `\\{`".into()), inner: vec![] },
+                        ParsingError::NothingInBraces(s) => ShellError::GenericError { error: "Nothing In Braces".into(), msg: format!("Nothing found inside braces at {s}."), span: Some(value_span), help: Some("Please provide valid content within the braces. Additionally, you can safely remove it, not needed.".into()), inner: vec![] },
                     }
                 ,
                 span,
@@ -267,17 +267,17 @@ fn str_expand(contents: &str, span: Span, value_span: Span) -> Value {
             ),
             TokenizationError::FormatNotSupported => Value::error(
 
-                    ShellError::GenericError(
-                        "Format Not Supported".to_owned(),
-                        "Usage of only `{` or `}`. Brace Expansion syntax, needs to have equal amount of opening (`{`) and closing (`}`)".to_owned(),
-                        Some(value_span),
-                        Some("In brace expansion syntax, it is important to have an equal number of opening (`{`) and closing (`}`) braces. Please ensure that you provide a balanced pair of braces in your brace expansion pattern.".to_owned()),
-                        vec![]
-                ),
+                    ShellError::GenericError {
+                        error: "Format Not Supported".into(),
+                        msg: "Usage of only `{` or `}`. Brace Expansion syntax, needs to have equal amount of opening (`{`) and closing (`}`)".into(),
+                        span: Some(value_span),
+                        help: Some("In brace expansion syntax, it is important to have an equal number of opening (`{`) and closing (`}`) braces. Please ensure that you provide a balanced pair of braces in your brace expansion pattern.".into()),
+                        inner: vec![]
+                },
                  value_span,
             ),
             TokenizationError::NoBraces => Value::error(
-                ShellError::GenericError("No Braces".to_owned(), "At least one `{}` brace expansion expected.".to_owned(), Some(value_span), Some("Please, examine the examples.".to_owned()), vec![]),
+                ShellError::GenericError { error: "No Braces".into(), msg: "At least one `{}` brace expansion expected.".into(), span: Some(value_span), help: Some("Please, examine the examples.".into()), inner: vec![] },
                 value_span,
             )
         },

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -88,13 +88,13 @@ impl Command for SubCommand {
         let to_trim = match character.as_ref() {
             Some(v) => {
                 if v.item.chars().count() > 1 {
-                    return Err(ShellError::GenericError(
-                        "Trim only works with single character".into(),
-                        "needs single character".into(),
-                        Some(v.span),
-                        None,
-                        Vec::new(),
-                    ));
+                    return Err(ShellError::GenericError {
+                        error: "Trim only works with single character".into(),
+                        msg: "needs single character".into(),
+                        span: Some(v.span),
+                        help: None,
+                        inner: vec![],
+                    });
                 }
                 v.item.chars().next()
             }

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -101,13 +101,13 @@ impl Command for Complete {
 
                 Ok(Value::record(record, call.head).into_pipeline_data())
             }
-            _ => Err(ShellError::GenericError(
-                "Complete only works with external streams".to_string(),
-                "complete only works on external streams".to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )),
+            _ => Err(ShellError::GenericError {
+                error: "Complete only works with external streams".into(),
+                msg: "complete only works on external streams".into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            }),
         }
     }
 

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -81,13 +81,13 @@ fn exec_impl(mut command: std::process::Command, span: Span) -> Result<PipelineD
 
     let error = command.exec();
 
-    Err(ShellError::GenericError(
-        "Error on exec".into(),
-        error.to_string(),
-        Some(span),
-        None,
-        Vec::new(),
-    ))
+    Err(ShellError::GenericError {
+        error: "Error on exec".into(),
+        msg: error.to_string(),
+        span: Some(span),
+        help: None,
+        inner: vec![],
+    })
 }
 
 #[cfg(windows)]

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -53,11 +53,13 @@ impl Command for NuCheck {
         let mut working_set = StateWorkingSet::new(engine_state);
 
         if is_all && is_module {
-            return Err(ShellError::GenericError(
-                "Detected command flags conflict".to_string(),
-                "You cannot have both `--all` and `--as-module` on the same command line, please refer to `nu-check --help` for more details".to_string(),
-                Some(call.head),
-                None, vec![]));
+            return Err(ShellError::GenericError {
+                error: "Detected command flags conflict".into(),
+                msg: "You cannot have both `--all` and `--as-module` on the same command line, please refer to `nu-check --help` for more details".into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![]
+            });
         }
 
         let span = input.span().unwrap_or(call.head);
@@ -130,13 +132,13 @@ impl Command for NuCheck {
 
                     let ext: Vec<_> = path_str.rsplitn(2, '.').collect();
                     if ext[0] != "nu" {
-                        return Err(ShellError::GenericError(
-                            "Cannot parse input".to_string(),
-                            "File extension must be the type of .nu".to_string(),
-                            Some(call.head),
-                            None,
-                            Vec::new(),
-                        ));
+                        return Err(ShellError::GenericError {
+                            error: "Cannot parse input".into(),
+                            msg: "File extension must be the type of .nu".into(),
+                            span: Some(call.head),
+                            help: None,
+                            inner: vec![],
+                        });
                     }
 
                     // Change currently parsed directory
@@ -163,13 +165,13 @@ impl Command for NuCheck {
 
                     result
                 } else {
-                    Err(ShellError::GenericError(
-                        "Failed to execute command".to_string(),
-                        "Please run 'nu-check --help' for more details".to_string(),
-                        Some(call.head),
-                        None,
-                        Vec::new(),
-                    ))
+                    Err(ShellError::GenericError {
+                        error: "Failed to execute command".into(),
+                        msg: "Please run 'nu-check --help' for more details".into(),
+                        span: Some(call.head),
+                        help: None,
+                        inner: vec![],
+                    })
                 }
             }
         }
@@ -241,13 +243,13 @@ fn heuristic_parse(
                 Ok(v) => Ok(v),
                 Err(_) => {
                     if is_debug {
-                        Err(ShellError::GenericError(
-                            "Failed to parse content,tried both script and module".to_string(),
-                            "syntax error".to_string(),
-                            Some(span),
-                            Some("Run `nu-check --help` for more details".to_string()),
-                            Vec::new(),
-                        ))
+                        Err(ShellError::GenericError {
+                            error: "Failed to parse content,tried both script and module".into(),
+                            msg: "syntax error".into(),
+                            span: Some(span),
+                            help: Some("Run `nu-check --help` for more details".into()),
+                            inner: vec![],
+                        })
                     } else {
                         Ok(PipelineData::Value(Value::bool(false, span), None))
                     }
@@ -285,14 +287,14 @@ fn heuristic_parse_file(
                         Ok(v) => Ok(v),
                         Err(_) => {
                             if is_debug {
-                                Err(ShellError::GenericError(
-                                    "Failed to parse content,tried both script and module"
-                                        .to_string(),
-                                    "syntax error".to_string(),
-                                    Some(call.head),
-                                    Some("Run `nu-check --help` for more details".to_string()),
-                                    Vec::new(),
-                                ))
+                                Err(ShellError::GenericError {
+                                    error: "Failed to parse content,tried both script and module"
+                                        .into(),
+                                    msg: "syntax error".into(),
+                                    span: Some(call.head),
+                                    help: Some("Run `nu-check --help` for more details".into()),
+                                    inner: vec![],
+                                })
                             } else {
                                 Ok(PipelineData::Value(Value::bool(false, call.head), None))
                             }
@@ -334,13 +336,13 @@ fn parse_module(
                     .first()
                     .expect("Unable to parse content as module")
             );
-            Err(ShellError::GenericError(
-                "Failed to parse content".to_string(),
+            Err(ShellError::GenericError {
+                error: "Failed to parse content".into(),
                 msg,
-                Some(span),
-                Some("If the content is intended to be a script, please try to remove `--as-module` flag ".to_string()),
-                Vec::new(),
-            ))
+                span: Some(span),
+                help: Some("If the content is intended to be a script, please try to remove `--as-module` flag ".into()),
+                inner: vec![],
+            })
         } else {
             Ok(PipelineData::Value(Value::bool(false, new_span), None))
         }
@@ -367,13 +369,13 @@ fn parse_script(
                 .expect("Unable to parse content")
         );
         if is_debug {
-            Err(ShellError::GenericError(
-                "Failed to parse content".to_string(),
+            Err(ShellError::GenericError {
+                error: "Failed to parse content".into(),
                 msg,
-                Some(span),
-                Some("If the content is intended to be a module, please consider flag of `--as-module` ".to_string()),
-                Vec::new(),
-            ))
+                span: Some(span),
+                help: Some("If the content is intended to be a module, please consider flag of `--as-module` ".into()),
+                inner: vec![],
+            })
         } else {
             Ok(PipelineData::Value(Value::bool(false, span), None))
         }

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -126,15 +126,16 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
                 not(target_os = "ios")
             ))]
             {
-                let proc_stat = proc.curr_proc.stat().map_err(|e| {
-                    ShellError::GenericError(
-                        "Error getting process stat".into(),
-                        e.to_string(),
-                        Some(Span::unknown()),
-                        None,
-                        Vec::new(),
-                    )
-                })?;
+                let proc_stat = proc
+                    .curr_proc
+                    .stat()
+                    .map_err(|e| ShellError::GenericError {
+                        error: "Error getting process stat".into(),
+                        msg: e.to_string(),
+                        span: Some(Span::unknown()),
+                        help: None,
+                        inner: vec![],
+                    })?;
                 // If we can't get the start time, just use the current time
                 let proc_start = proc_stat
                     .starttime()

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -130,13 +130,13 @@ fn registry_query(
                         )
                         .into_pipeline_data())
                     }
-                    Err(_) => Err(ShellError::GenericError(
-                        "Unable to find registry key/value".to_string(),
-                        format!("Registry value: {} was not found", value.item),
-                        Some(value.span),
-                        None,
-                        Vec::new(),
-                    )),
+                    Err(_) => Err(ShellError::GenericError {
+                        error: "Unable to find registry key/value".into(),
+                        msg: format!("Registry value: {} was not found", value.item),
+                        span: Some(value.span),
+                        help: None,
+                        inner: vec![],
+                    }),
                 }
             }
             None => Ok(Value::nothing(call_span).into_pipeline_data()),
@@ -153,13 +153,13 @@ fn get_reg_hive(call: &Call) -> Result<RegKey, ShellError> {
     .filter(|flag| call.has_flag(flag))
     .collect();
     if flags.len() > 1 {
-        return Err(ShellError::GenericError(
-            "Only one registry key can be specified".into(),
-            "Only one registry key can be specified".into(),
-            Some(call.head),
-            None,
-            Vec::new(),
-        ));
+        return Err(ShellError::GenericError {
+            error: "Only one registry key can be specified".into(),
+            msg: "Only one registry key can be specified".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
     }
     let hive = flags.first().copied().unwrap_or("hkcu");
     let hkey = match hive {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -601,16 +601,16 @@ impl ExternalCommand {
             }
             process
         } else {
-            return Err(ShellError::GenericError(
-                "Current directory not found".to_string(),
-                "did not find PWD environment variable".to_string(),
-                Some(span),
-                Some(concat!(
+            return Err(ShellError::GenericError{
+                error: "Current directory not found".into(),
+                msg: "did not find PWD environment variable".into(),
+                span: Some(span),
+                help: Some(concat!(
                     "The environment variable 'PWD' was not found. ",
                     "It is required to define the current directory when running an external command."
-                ).to_string()),
-                Vec::new(),
-            ));
+                ).into()),
+                inner:Vec::new(),
+            });
         };
 
         process.envs(&self.env_vars);

--- a/crates/nu-command/src/viewers/icons.rs
+++ b/crates/nu-command/src/viewers/icons.rs
@@ -143,24 +143,20 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
     } else if file_path.is_dir() {
         let str = file_path
             .file_name()
-            .ok_or_else(|| {
-                ShellError::GenericError(
-                    "File name error".into(),
-                    "Unable to get file name".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
+            .ok_or_else(|| ShellError::GenericError {
+                error: "File name error".into(),
+                msg: "Unable to get file name".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
             })?
             .to_str()
-            .ok_or_else(|| {
-                ShellError::GenericError(
-                    "Unable to get str error".into(),
-                    "Unable to convert to str file name".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )
+            .ok_or_else(|| ShellError::GenericError {
+                error: "Unable to get str error".into(),
+                msg: "Unable to convert to str file name".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
             })?;
         Ok(match str {
             "bin" => '\u{e5fc}',   // 
@@ -171,14 +167,12 @@ pub fn icon_for_file(file_path: &Path, span: Span) -> Result<char, ShellError> {
     } else if let Some(icon) = extensions.icon_file(file_path) {
         Ok(icon)
     } else if let Some(ext) = file_path.extension().as_ref() {
-        let str = ext.to_str().ok_or_else(|| {
-            ShellError::GenericError(
-                "Unable to get str error".into(),
-                "Unable to convert to str file name".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+        let str = ext.to_str().ok_or_else(|| ShellError::GenericError {
+            error: "Unable to get str error".into(),
+            msg: "Unable to convert to str file name".into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         })?;
         Ok(match str {
             "a" => '\u{f17c}',              // 

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -166,25 +166,25 @@ pub fn current_dir_str(engine_state: &EngineState, stack: &Stack) -> Result<Stri
                 if Path::new(&cwd).is_absolute() {
                     Ok(cwd)
                 } else {
-                    Err(ShellError::GenericError(
-                            "Invalid current directory".to_string(),
-                            format!("The 'PWD' environment variable must be set to an absolute path. Found: '{cwd}'"),
-                            Some(pwd.span()),
-                            None,
-                            Vec::new()
-                    ))
+                    Err(ShellError::GenericError {
+                            error: "Invalid current directory".into(),
+                            msg: format!("The 'PWD' environment variable must be set to an absolute path. Found: '{cwd}'"),
+                            span: Some(pwd.span()),
+                            help: None,
+                            inner: vec![]
+                    })
                 }
             }
             Err(e) => Err(e),
         }
     } else {
-        Err(ShellError::GenericError(
-                "Current directory not found".to_string(),
-                "".to_string(),
-                None,
-                Some("The environment variable 'PWD' was not found. It is required to define the current directory.".to_string()),
-                Vec::new(),
-        ))
+        Err(ShellError::GenericError {
+                error: "Current directory not found".into(),
+                msg: "".into(),
+                span: None,
+                help: Some("The environment variable 'PWD' was not found. It is required to define the current directory.".into()),
+                inner: vec![],
+        })
     }
 }
 
@@ -197,34 +197,34 @@ pub fn current_dir_str_const(working_set: &StateWorkingSet) -> Result<String, Sh
                 if Path::new(val).is_absolute() {
                     Ok(val.clone())
                 } else {
-                    Err(ShellError::GenericError(
-                            "Invalid current directory".to_string(),
-                            format!("The 'PWD' environment variable must be set to an absolute path. Found: '{val}'"),
-                            Some(span),
-                            None,
-                            Vec::new()
-                    ))
+                    Err(ShellError::GenericError {
+                            error: "Invalid current directory".into(),
+                            msg: format!("The 'PWD' environment variable must be set to an absolute path. Found: '{val}'"),
+                            span: Some(span),
+                            help: None,
+                            inner: vec![]
+                    })
                 }
             }
-            _ => Err(ShellError::GenericError(
-                "PWD is not a string".to_string(),
-                "".to_string(),
-                None,
-                Some(
+            _ => Err(ShellError::GenericError {
+                error: "PWD is not a string".into(),
+                msg: "".into(),
+                span: None,
+                help: Some(
                     "Cusrrent working directory environment variable 'PWD' must be a string."
-                        .to_string(),
+                        .into(),
                 ),
-                Vec::new(),
-            )),
+                inner: vec![],
+            }),
         }
     } else {
-        Err(ShellError::GenericError(
-                "Current directory not found".to_string(),
-                "".to_string(),
-                None,
-                Some("The environment variable 'PWD' was not found. It is required to define the current directory.".to_string()),
-                Vec::new(),
-        ))
+        Err(ShellError::GenericError{
+                error: "Current directory not found".into(),
+                msg: "".into(),
+                span: None,
+                help: Some("The environment variable 'PWD' was not found. It is required to define the current directory.".into()),
+                inner: vec![],
+        })
     }
 }
 
@@ -304,13 +304,13 @@ pub fn find_in_dirs_env(
                 if Path::new(&cwd).is_absolute() {
                     cwd
                 } else {
-                    return Err(ShellError::GenericError(
-                            "Invalid current directory".to_string(),
-                            format!("The 'FILE_PWD' environment variable must be set to an absolute path. Found: '{cwd}'"),
-                            Some(pwd.span()),
-                            None,
-                            Vec::new()
-                    ));
+                    return Err(ShellError::GenericError {
+                            error: "Invalid current directory".into(),
+                            msg: format!("The 'FILE_PWD' environment variable must be set to an absolute path. Found: '{cwd}'"),
+                            span: Some(pwd.span()),
+                            help: None,
+                            inner: vec![]
+                    });
                 }
             }
             Err(e) => return Err(e),
@@ -434,13 +434,13 @@ fn ensure_path(scope: &mut HashMap<String, Value>, env_path_name: &str) -> Optio
                 // Must be a list of strings
                 if !vals.iter().all(|v| matches!(v, Value::String { .. })) {
                     error = error.or_else(|| {
-                        Some(ShellError::GenericError(
-                            format!("Wrong {env_path_name} environment variable value"),
-                            format!("{env_path_name} must be a list of strings"),
-                            Some(span),
-                            None,
-                            Vec::new(),
-                        ))
+                        Some(ShellError::GenericError {
+                            error: format!("Wrong {env_path_name} environment variable value"),
+                            msg: format!("{env_path_name} must be a list of strings"),
+                            span: Some(span),
+                            help: None,
+                            inner: vec![],
+                        })
                     });
                 }
             }
@@ -450,13 +450,13 @@ fn ensure_path(scope: &mut HashMap<String, Value>, env_path_name: &str) -> Optio
                 let span = val.span();
 
                 error = error.or_else(|| {
-                    Some(ShellError::GenericError(
-                        format!("Wrong {env_path_name} environment variable value"),
-                        format!("{env_path_name} must be a list of strings"),
-                        Some(span),
-                        None,
-                        Vec::new(),
-                    ))
+                    Some(ShellError::GenericError {
+                        error: format!("Wrong {env_path_name} environment variable value"),
+                        msg: format!("{env_path_name} must be a list of strings"),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    })
                 });
             }
         }

--- a/crates/nu-engine/src/glob_from.rs
+++ b/crates/nu-engine/src/glob_from.rs
@@ -84,27 +84,27 @@ pub fn glob_from(
     let pattern = pattern.to_string_lossy().to_string();
     let glob_options = options.unwrap_or_default();
 
-    let glob = nu_glob::glob_with(&pattern, glob_options).map_err(|err| {
-        nu_protocol::ShellError::GenericError(
-            "Error extracting glob pattern".into(),
-            err.to_string(),
-            Some(span),
-            None,
-            Vec::new(),
-        )
+    let glob = nu_glob::glob_with(&pattern, glob_options).map_err(|e| {
+        nu_protocol::ShellError::GenericError {
+            error: "Error extracting glob pattern".into(),
+            msg: e.to_string(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        }
     })?;
 
     Ok((
         prefix,
         Box::new(glob.map(move |x| match x {
             Ok(v) => Ok(v),
-            Err(err) => Err(nu_protocol::ShellError::GenericError(
-                "Error extracting glob pattern".into(),
-                err.to_string(),
-                Some(span),
-                None,
-                Vec::new(),
-            )),
+            Err(e) => Err(nu_protocol::ShellError::GenericError {
+                error: "Error extracting glob pattern".into(),
+                msg: e.to_string(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            }),
         })),
     ))
 }

--- a/crates/nu-explore/src/views/util.rs
+++ b/crates/nu-explore/src/views/util.rs
@@ -157,13 +157,13 @@ fn convert_with_precision(val: &str, precision: usize) -> Result<String, ShellEr
     let val_float = match val.trim().parse::<f64>() {
         Ok(f) => f,
         Err(e) => {
-            return Err(ShellError::GenericError(
-                format!("error converting string [{}] to f64", &val),
-                "".to_string(),
-                None,
-                Some(e.to_string()),
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: format!("error converting string [{}] to f64", &val),
+                msg: "".into(),
+                span: None,
+                help: Some(e.to_string()),
+                inner: vec![],
+            });
         }
     };
     Ok(format!("{val_float:.precision$}"))

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -87,13 +87,13 @@ impl Command for PluginDeclaration {
 
         let mut child = plugin_cmd.spawn().map_err(|err| {
             let decl = engine_state.get_decl(call.decl_id);
-            ShellError::GenericError(
-                format!("Unable to spawn plugin for {}", decl.name()),
-                format!("{err}"),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+            ShellError::GenericError {
+                error: format!("Unable to spawn plugin for {}", decl.name()),
+                msg: format!("{err}"),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            }
         })?;
 
         let input = input.into_value(call.head);
@@ -109,16 +109,16 @@ impl Command for PluginDeclaration {
                     }
                     _ => {
                         let custom_value_name = val.value_string();
-                        return Err(ShellError::GenericError(
-                            format!(
+                        return Err(ShellError::GenericError {
+                            error: format!(
                                 "Plugin {} can not handle the custom value {}",
                                 self.name, custom_value_name
                             ),
-                            format!("custom value {custom_value_name}"),
-                            Some(span),
-                            None,
-                            Vec::new(),
-                        ));
+                            msg: format!("custom value {custom_value_name}"),
+                            span: Some(span),
+                            help: None,
+                            inner: vec![],
+                        });
                     }
                 }
             }
@@ -145,13 +145,13 @@ impl Command for PluginDeclaration {
         };
         let response = call_plugin(&mut child, plugin_call, &encoding, call.head).map_err(|err| {
             let decl = engine_state.get_decl(call.decl_id);
-            ShellError::GenericError(
-                format!("Unable to decode call for {}", decl.name()),
-                err.to_string(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )
+            ShellError::GenericError {
+                error: format!("Unable to decode call for {}", decl.name()),
+                msg: err.to_string(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            }
         });
 
         let pipeline_data = match response {
@@ -172,13 +172,13 @@ impl Command for PluginDeclaration {
                 None,
             )),
             Ok(PluginResponse::Error(err)) => Err(err.into()),
-            Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError(
-                "Plugin missing value".into(),
-                "Received a signature from plugin instead of value".into(),
-                Some(call.head),
-                None,
-                Vec::new(),
-            )),
+            Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError {
+                error: "Plugin missing value".into(),
+                msg: "Received a signature from plugin instead of value".into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            }),
             Err(err) => Err(err),
         };
 

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -111,13 +111,13 @@ pub(crate) fn call_plugin(
 
         encoding.decode_response(&mut buf_read)
     } else {
-        Err(ShellError::GenericError(
-            "Error with stdout reader".into(),
-            "no stdout reader".into(),
-            Some(span),
-            None,
-            Vec::new(),
-        ))
+        Err(ShellError::GenericError {
+            error: "Error with stdout reader".into(),
+            msg: "no stdout reader".into(),
+            span: Some(span),
+            help: None,
+            inner: vec![],
+        })
     }
 }
 

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -48,16 +48,20 @@ pub struct LabeledError {
 impl From<LabeledError> for ShellError {
     fn from(error: LabeledError) -> Self {
         match error.span {
-            Some(span) => {
-                ShellError::GenericError(error.label, error.msg, Some(span), None, Vec::new())
-            }
-            None => ShellError::GenericError(
-                error.label,
-                "".to_string(),
-                None,
-                Some(error.msg),
-                Vec::new(),
-            ),
+            Some(span) => ShellError::GenericError {
+                error: error.label,
+                msg: error.msg,
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            },
+            None => ShellError::GenericError {
+                error: error.label,
+                msg: "".into(),
+                span: None,
+                help: Some(error.msg),
+                inner: vec![],
+            },
         }
     }
 }
@@ -65,9 +69,12 @@ impl From<LabeledError> for ShellError {
 impl From<ShellError> for LabeledError {
     fn from(error: ShellError) -> Self {
         match error {
-            ShellError::GenericError(label, msg, span, _help, _related) => {
-                LabeledError { label, msg, span }
-            }
+            ShellError::GenericError {
+                error: label,
+                msg,
+                span,
+                ..
+            } => LabeledError { label, msg, span },
             ShellError::CantConvert {
                 to_type: expected,
                 from_type: input,

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -47,17 +47,15 @@ impl CustomValue for PluginCustomValue {
     ) -> Result<nu_protocol::Value, nu_protocol::ShellError> {
         let mut plugin_cmd = create_command(&self.filename, self.shell.as_deref());
 
-        let mut child = plugin_cmd.spawn().map_err(|err| {
-            ShellError::GenericError(
-                format!(
-                    "Unable to spawn plugin for {} to get base value",
-                    self.source
-                ),
-                format!("{err}"),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+        let mut child = plugin_cmd.spawn().map_err(|err| ShellError::GenericError {
+            error: format!(
+                "Unable to spawn plugin for {} to get base value",
+                self.source
+            ),
+            msg: format!("{err}"),
+            span: Some(span),
+            help: None,
+            inner: vec![],
         })?;
 
         let plugin_call = PluginCall::CollapseCustomValue(PluginData {
@@ -77,35 +75,35 @@ impl CustomValue for PluginCustomValue {
         };
 
         let response = call_plugin(&mut child, plugin_call, &encoding, span).map_err(|err| {
-            ShellError::GenericError(
-                format!(
+            ShellError::GenericError {
+                error: format!(
                     "Unable to decode call for {} to get base value",
                     self.source
                 ),
-                format!("{err}"),
-                Some(span),
-                None,
-                Vec::new(),
-            )
+                msg: format!("{err}"),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            }
         });
 
         let value = match response {
             Ok(PluginResponse::Value(value)) => Ok(*value),
-            Ok(PluginResponse::PluginData(..)) => Err(ShellError::GenericError(
-                "Plugin misbehaving".into(),
-                "Plugin returned custom data as a response to a collapse call".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            )),
+            Ok(PluginResponse::PluginData(..)) => Err(ShellError::GenericError {
+                error: "Plugin misbehaving".into(),
+                msg: "Plugin returned custom data as a response to a collapse call".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            }),
             Ok(PluginResponse::Error(err)) => Err(err.into()),
-            Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError(
-                "Plugin missing value".into(),
-                "Received a signature from plugin instead of value".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            )),
+            Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError {
+                error: "Plugin missing value".into(),
+                msg: "Received a signature from plugin instead of value".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            }),
             Err(err) => Err(err),
         };
 

--- a/crates/nu-protocol/src/config/helper.rs
+++ b/crates/nu-protocol/src/config/helper.rs
@@ -21,28 +21,28 @@ pub(super) fn process_string_enum<T, E>(
                 *config_point = format;
             }
             Err(err) => {
-                errors.push(ShellError::GenericError(
-                    "Error while applying config changes".into(),
-                    format!(
+                errors.push(ShellError::GenericError {
+                    error: "Error while applying config changes".into(),
+                    msg: format!(
                         "unrecognized $env.config.{} option '{v}'",
                         config_path.join(".")
                     ),
-                    Some(span),
-                    Some(err.to_string()),
-                    vec![],
-                ));
+                    span: Some(span),
+                    help: Some(err.to_string()),
+                    inner: vec![],
+                });
                 // Reconstruct
                 *value = config_point.reconstruct_value(span);
             }
         }
     } else {
-        errors.push(ShellError::GenericError(
-            "Error while applying config changes".into(),
-            format!("$env.config.{} should be a string", config_path.join(".")),
-            Some(span),
-            Some("This value will be ignored.".into()),
-            vec![],
-        ));
+        errors.push(ShellError::GenericError {
+            error: "Error while applying config changes".into(),
+            msg: format!("$env.config.{} should be a string", config_path.join(".")),
+            span: Some(span),
+            help: Some("This value will be ignored.".into()),
+            inner: vec![],
+        });
         // Reconstruct
         *value = config_point.reconstruct_value(span);
     }
@@ -56,13 +56,13 @@ pub(super) fn process_bool_config(
     if let Ok(b) = value.as_bool() {
         *config_point = b;
     } else {
-        errors.push(ShellError::GenericError(
-            "Error while applying config changes".into(),
-            "should be a bool".to_string(),
-            Some(value.span()),
-            Some("This value will be ignored.".into()),
-            vec![],
-        ));
+        errors.push(ShellError::GenericError {
+            error: "Error while applying config changes".into(),
+            msg: "should be a bool".to_string(),
+            span: Some(value.span()),
+            help: Some("This value will be ignored.".into()),
+            inner: vec![],
+        });
         // Reconstruct
         *value = Value::bool(*config_point, value.span());
     }
@@ -76,13 +76,13 @@ pub(super) fn process_int_config(
     if let Ok(b) = value.as_int() {
         *config_point = b;
     } else {
-        errors.push(ShellError::GenericError(
-            "Error while applying config changes".into(),
-            "should be an int".to_string(),
-            Some(value.span()),
-            Some("This value will be ignored.".into()),
-            vec![],
-        ));
+        errors.push(ShellError::GenericError {
+            error: "Error while applying config changes".into(),
+            msg: "should be an int".into(),
+            span: Some(value.span()),
+            help: Some("This value will be ignored.".into()),
+            inner: vec![],
+        });
         // Reconstruct
         *value = Value::int(*config_point, value.span());
     }
@@ -92,26 +92,26 @@ pub(super) fn report_invalid_key(keys: &[&str], span: Span, errors: &mut Vec<She
     // Because Value::Record discards all of the spans of its
     // column names (by storing them as Strings), the key name cannot be provided
     // as a value, even in key errors.
-    errors.push(ShellError::GenericError(
-        "Error while applying config changes".into(),
-        format!(
+    errors.push(ShellError::GenericError {
+        error: "Error while applying config changes".into(),
+        msg: format!(
             "$env.config.{} is an unknown config setting",
             keys.join(".")
         ),
-        Some(span),
-        Some("This value will not appear in your $env.config record.".into()),
-        vec![],
-    ));
+        span: Some(span),
+        help: Some("This value will not appear in your $env.config record.".into()),
+        inner: vec![],
+    });
 }
 
 pub(super) fn report_invalid_value(msg: &str, span: Span, errors: &mut Vec<ShellError>) {
-    errors.push(ShellError::GenericError(
-        "Error while applying config changes".into(),
-        msg.into(),
-        Some(span),
-        Some("This value will be ignored.".into()),
-        vec![],
-    ));
+    errors.push(ShellError::GenericError {
+        error: "Error while applying config changes".into(),
+        msg: msg.into(),
+        span: Some(span),
+        help: Some("This value will be ignored.".into()),
+        inner: vec![],
+    });
 }
 
 pub(super) fn create_map(value: &Value) -> Result<HashMap<String, Value>, ShellError> {

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -705,13 +705,13 @@ impl Value {
         } else {
             return (
                 config,
-                Some(ShellError::GenericError(
-                    "Error while applying config changes".into(),
-                    "$env.config is not a record".into(),
-                    Some(self.span()),
-                    None,
-                    vec![],
-                )),
+                Some(ShellError::GenericError {
+                    error: "Error while applying config changes".into(),
+                    msg: "$env.config is not a record".into(),
+                    span: Some(self.span()),
+                    help: None,
+                    inner: vec![],
+                }),
             );
         }
 
@@ -719,14 +719,13 @@ impl Value {
         (
             config,
             if !errors.is_empty() {
-                Some(ShellError::GenericError(
-                    "Config record contains invalid values or unknown settings".into(),
-                    // Without a span, this second string is ignored.
-                    "".into(),
-                    None,
-                    None,
-                    errors,
-                ))
+                Some(ShellError::GenericError {
+                    error: "Config record contains invalid values or unknown settings".into(),
+                    msg: "".into(),
+                    span: None,
+                    help: None,
+                    inner: errors,
+                })
             } else {
                 None
             },

--- a/crates/nu-protocol/src/config/table.rs
+++ b/crates/nu-protocol/src/config/table.rs
@@ -206,14 +206,12 @@ pub(super) fn try_parse_trim_strategy(
     value: &Value,
     errors: &mut Vec<ShellError>,
 ) -> Result<TrimStrategy, ShellError> {
-    let map = value.as_record().map_err(|e| {
-        ShellError::GenericError(
-            "Error while applying config changes".into(),
-            "$env.config.table.trim is not a record".into(),
-            Some(value.span()),
-            Some("Please consult the documentation for configuring Nushell.".into()),
-            vec![e],
-        )
+    let map = value.as_record().map_err(|e| ShellError::GenericError {
+        error: "Error while applying config changes".into(),
+        msg: "$env.config.table.trim is not a record".into(),
+        span: Some(value.span()),
+        help: Some("Please consult the documentation for configuring Nushell.".into()),
+        inner: vec![e],
     })?;
 
     let mut methodology = match map.get("methodology") {
@@ -222,13 +220,13 @@ pub(super) fn try_parse_trim_strategy(
             None => return Ok(TrimStrategy::default()),
         },
         None => {
-            errors.push(ShellError::GenericError(
-                "Error while applying config changes".into(),
-                "$env.config.table.trim.methodology was not provided".into(),
-                Some(value.span()),
-                Some("Please consult the documentation for configuring Nushell.".into()),
-                vec![],
-            ));
+            errors.push(ShellError::GenericError {
+                error: "Error while applying config changes".into(),
+                msg: "$env.config.table.trim.methodology was not provided".into(),
+                span: Some(value.span()),
+                help: Some("Please consult the documentation for configuring Nushell.".into()),
+                inner: vec![],
+            });
             return Ok(TrimStrategy::default());
         }
     };
@@ -239,13 +237,15 @@ pub(super) fn try_parse_trim_strategy(
                 if let Ok(b) = value.as_bool() {
                     *try_to_keep_words = b;
                 } else {
-                    errors.push(ShellError::GenericError(
-                        "Error while applying config changes".into(),
-                        "$env.config.table.trim.wrapping_try_keep_words is not a bool".into(),
-                        Some(value.span()),
-                        Some("Please consult the documentation for configuring Nushell.".into()),
-                        vec![],
-                    ));
+                    errors.push(ShellError::GenericError {
+                        error: "Error while applying config changes".into(),
+                        msg: "$env.config.table.trim.wrapping_try_keep_words is not a bool".into(),
+                        span: Some(value.span()),
+                        help: Some(
+                            "Please consult the documentation for configuring Nushell.".into(),
+                        ),
+                        inner: vec![],
+                    });
                 }
             }
         }
@@ -254,13 +254,15 @@ pub(super) fn try_parse_trim_strategy(
                 if let Ok(v) = value.as_string() {
                     *suffix = Some(v);
                 } else {
-                    errors.push(ShellError::GenericError(
-                        "Error while applying config changes".into(),
-                        "$env.config.table.trim.truncating_suffix is not a string".into(),
-                        Some(value.span()),
-                        Some("Please consult the documentation for configuring Nushell.".into()),
-                        vec![],
-                    ));
+                    errors.push(ShellError::GenericError {
+                        error: "Error while applying config changes".into(),
+                        msg: "$env.config.table.trim.truncating_suffix is not a string".into(),
+                        span: Some(value.span()),
+                        help: Some(
+                            "Please consult the documentation for configuring Nushell.".into(),
+                        ),
+                        inner: vec![],
+                    });
                 }
             }
         }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -526,14 +526,12 @@ impl EngineState {
                             })
                         })
                         .and_then(|_| {
-                            plugin_file.flush().map_err(|err| {
-                                ShellError::GenericError(
-                                    "Error flushing plugin file".to_string(),
-                                    format! {"{err}"},
-                                    None,
-                                    None,
-                                    Vec::new(),
-                                )
+                            plugin_file.flush().map_err(|err| ShellError::GenericError {
+                                error: "Error flushing plugin file".into(),
+                                msg: format! {"{err}"},
+                                span: None,
+                                help: None,
+                                inner: vec![],
                             })
                         })
                 })

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -82,13 +82,13 @@ impl Stack {
         }
 
         if var_id == NU_VARIABLE_ID || var_id == ENV_VARIABLE_ID {
-            return Err(ShellError::GenericError(
-                "Built-in variables `$env` and `$nu` have no metadata".into(),
-                "no metadata available".into(),
-                Some(span),
-                None,
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: "Built-in variables `$env` and `$nu` have no metadata".into(),
+                msg: "no metadata available".into(),
+                span: Some(span),
+                help: None,
+                inner: vec![],
+            });
         }
 
         Err(ShellError::VariableNotFoundAtRuntime { span })

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -666,28 +666,28 @@ impl PipelineData {
                     match (&val.to, &val.from) {
                         (Value::Float { val, .. }, _) | (_, Value::Float { val, .. }) => {
                             if *val == f64::INFINITY || *val == f64::NEG_INFINITY {
-                                return Err(ShellError::GenericError(
-                                    "Cannot create range".into(),
-                                    "Infinity is not allowed when converting to json".into(),
-                                    Some(span),
-                                    Some("Consider removing infinity".into()),
-                                    vec![],
-                                ));
+                                return Err(ShellError::GenericError {
+                                    error: "Cannot create range".into(),
+                                    msg: "Infinity is not allowed when converting to json".into(),
+                                    span: Some(span),
+                                    help: Some("Consider removing infinity".into()),
+                                    inner: vec![],
+                                });
                             }
                         }
                         (Value::Int { val, .. }, _) => {
                             if *val == i64::MAX || *val == i64::MIN {
-                                return Err(ShellError::GenericError(
-                                    "Cannot create range".into(),
-                                    "Unbounded ranges are not allowed when converting to json"
+                                return Err(ShellError::GenericError {
+                                    error: "Cannot create range".into(),
+                                    msg: "Unbounded ranges are not allowed when converting to json"
                                         .into(),
-                                    Some(span),
-                                    Some(
+                                    span: Some(span),
+                                    help: Some(
                                         "Consider using ranges with valid start and end point."
                                             .into(),
                                     ),
-                                    vec![],
-                                ));
+                                    inner: vec![],
+                                });
                             }
                         }
                         _ => (),

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1070,15 +1070,18 @@ pub enum ShellError {
     },
 
     /// This is a generic error type used for different situations.
-    #[error("{0}")]
+    #[error("{error}")]
     #[diagnostic()]
-    GenericError(
-        String,
-        String,
-        #[label("{1}")] Option<Span>,
-        #[help] Option<String>,
-        #[related] Vec<ShellError>,
-    ),
+    GenericError {
+        error: String,
+        msg: String,
+        #[label("{msg}")]
+        span: Option<Span>,
+        #[help]
+        help: Option<String>,
+        #[related]
+        inner: Vec<ShellError>,
+    },
 
     /// This is a generic error type used for different situations.
     #[error("{1}")]

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -696,13 +696,13 @@ impl Command for BlockCommand {
         _call: &Call,
         _input: PipelineData,
     ) -> Result<crate::PipelineData, crate::ShellError> {
-        Err(ShellError::GenericError(
-            "Internal error: can't run custom command with 'run', use block_id".to_string(),
-            "".to_string(),
-            None,
-            None,
-            Vec::new(),
-        ))
+        Err(ShellError::GenericError {
+            error: "Internal error: can't run custom command with 'run', use block_id".into(),
+            msg: "".into(),
+            span: None,
+            help: None,
+            inner: vec![],
+        })
     }
 
     fn get_block_id(&self) -> Option<BlockId> {

--- a/crates/nu-protocol/src/value/unit.rs
+++ b/crates/nu-protocol/src/value/unit.rs
@@ -67,43 +67,43 @@ impl Unit {
             Unit::Second => Ok(Value::duration(size * 1000 * 1000 * 1000, span)),
             Unit::Minute => match size.checked_mul(1000 * 1000 * 1000 * 60) {
                 Some(val) => Ok(Value::duration(val, span)),
-                None => Err(ShellError::GenericError(
-                    "duration too large".into(),
-                    "duration too large".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                None => Err(ShellError::GenericError {
+                    error: "duration too large".into(),
+                    msg: "duration too large".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             },
             Unit::Hour => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60) {
                 Some(val) => Ok(Value::duration(val, span)),
-                None => Err(ShellError::GenericError(
-                    "duration too large".into(),
-                    "duration too large".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                None => Err(ShellError::GenericError {
+                    error: "duration too large".into(),
+                    msg: "duration too large".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             },
             Unit::Day => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24) {
                 Some(val) => Ok(Value::duration(val, span)),
-                None => Err(ShellError::GenericError(
-                    "duration too large".into(),
-                    "duration too large".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                None => Err(ShellError::GenericError {
+                    error: "duration too large".into(),
+                    msg: "duration too large".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             },
             Unit::Week => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 7) {
                 Some(val) => Ok(Value::duration(val, span)),
-                None => Err(ShellError::GenericError(
-                    "duration too large".into(),
-                    "duration too large".into(),
-                    Some(span),
-                    None,
-                    Vec::new(),
-                )),
+                None => Err(ShellError::GenericError {
+                    error: "duration too large".into(),
+                    msg: "duration too large".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                }),
             },
         }
     }

--- a/crates/nu-table/src/common.rs
+++ b/crates/nu-table/src/common.rs
@@ -153,13 +153,13 @@ fn convert_with_precision(val: &str, precision: usize) -> Result<String, ShellEr
     let val_float = match val.trim().parse::<f64>() {
         Ok(f) => f,
         Err(e) => {
-            return Err(ShellError::GenericError(
-                format!("error converting string [{}] to f64", &val),
-                "".to_string(),
-                None,
-                Some(e.to_string()),
-                Vec::new(),
-            ));
+            return Err(ShellError::GenericError {
+                error: format!("error converting string [{}] to f64", &val),
+                msg: "".into(),
+                span: None,
+                help: Some(e.to_string()),
+                inner: vec![],
+            });
         }
     };
     Ok(format!("{val_float:.precision$}"))


### PR DESCRIPTION
# Description

Replace .to_string() used in GenericError with .into() as .into() seems more popular

Replace Vec::new() used in GenericError with vec![] as vec![] seems more popular

(There are so, so many)

# User-Facing Changes

None

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A