### PR TITLE
Do not create help for wrapped command

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -299,3 +299,9 @@ fn def_env_wrapped() {
     );
     assert_eq!(actual.out, "bacon");
 }
+
+#[test]
+fn def_env_wrapped_no_help() {
+    let actual = nu!("def --wrapped foo [...rest] { echo $rest }; foo -h | to json --raw");
+    assert_eq!(actual.out, r#"["-h"]"#);
+}

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -580,7 +580,9 @@ pub fn parse_def(
             let declaration = working_set.get_decl_mut(decl_id);
 
             signature.name = name.clone();
-            *signature = signature.add_help();
+            if !has_wrapped {
+                *signature = signature.add_help();
+            }
             signature.usage = usage;
             signature.extra_usage = extra_usage;
             signature.allows_unknown_args = has_wrapped;


### PR DESCRIPTION
Pretty self-explanatory.  The commit is only one `if`.

Fix #11096