### PR TITLE
Remove unnecessary boxing of `Stack::recursion_count`

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -611,14 +611,14 @@ pub fn eval_block(
         // picked 50 arbitrarily, should work on all architectures
         const RECURSION_LIMIT: u64 = 50;
         if recursive {
-            if *stack.recursion_count >= RECURSION_LIMIT {
-                stack.recursion_count = Box::new(0);
+            if stack.recursion_count >= RECURSION_LIMIT {
+                stack.recursion_count = 0;
                 return Err(ShellError::RecursionLimitReached {
                     recursion_limit: RECURSION_LIMIT,
                     span: block.span,
                 });
             }
-            *stack.recursion_count += 1;
+            stack.recursion_count += 1;
         }
     }
 

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -35,7 +35,7 @@ pub struct Stack {
     pub env_hidden: HashMap<String, HashSet<String>>,
     /// List of active overlays
     pub active_overlays: Vec<String>,
-    pub recursion_count: Box<u64>,
+    pub recursion_count: u64,
 }
 
 impl Stack {
@@ -45,7 +45,7 @@ impl Stack {
             env_vars: vec![],
             env_hidden: HashMap::new(),
             active_overlays: vec![DEFAULT_OVERLAY_NAME.to_string()],
-            recursion_count: Box::new(0),
+            recursion_count: 0,
         }
     }
 
@@ -159,7 +159,7 @@ impl Stack {
             env_vars,
             env_hidden: self.env_hidden.clone(),
             active_overlays: self.active_overlays.clone(),
-            recursion_count: self.recursion_count.to_owned(),
+            recursion_count: self.recursion_count,
         }
     }
 
@@ -186,7 +186,7 @@ impl Stack {
             env_vars,
             env_hidden: self.env_hidden.clone(),
             active_overlays: self.active_overlays.clone(),
-            recursion_count: self.recursion_count.to_owned(),
+            recursion_count: self.recursion_count,
         }
     }
 


### PR DESCRIPTION
# Description
Changes the type of `Stack::recursion_count` from `Box<u64>` to `u64`.

# User-Facing Changes
Technically a breaking change for `nu_protocol` crate.