### PR TITLE
Upgrade lsp-server Dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,8 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-server"
-version = "0.7.4"
-source = "git+https://github.com/schrieveslaach/rust-analyzer.git?branch=cancelable-initialization#81c2d3552e6d377bf0332523c1278b7e5723c27c"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb69ba934913ebf0ef3b3dd762f0149bf993decd571d094b646de09c2e456732"
 dependencies = [
  "crossbeam-channel",
  "log",

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -16,7 +16,7 @@ reedline = { version = "0.26" }
 
 crossbeam-channel = "0.5.8"
 lsp-types = "0.94.1"
-lsp-server = { version = "0.7.4", git = "https://github.com/schrieveslaach/rust-analyzer.git", branch = "cancelable-initialization" }
+lsp-server = "0.7.5"
 miette = "5.10"
 ropey = "1.6.1"
 serde = "1.0"


### PR DESCRIPTION
The lsp-server crate has been released and thus it is now possible to depend on this version rather on the git dependency of the crate.