### PR TITLE
:bug: Fixes markdown formatting on LSP hover

### DIFF
--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -371,7 +371,7 @@ impl LanguageServer {
                     let mut first = true;
                     for required_arg in &signature.required_positional {
                         if !first {
-                            description.push_str("\n");
+                            description.push('\n');
                         } else {
                             first = false;
                         }

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -371,7 +371,7 @@ impl LanguageServer {
                     let mut first = true;
                     for required_arg in &signature.required_positional {
                         if !first {
-                            description.push_str("\\\n");
+                            description.push_str("\n");
                         } else {
                             first = false;
                         }
@@ -957,7 +957,7 @@ mod tests {
             serde_json::json!({
                 "contents": {
                     "kind": "markdown",
-                    "value": "```\n### Signature\n```\n  hello {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n### Usage\n  Renders some greeting message\n"
+                    "value": "\n### Signature\n```\n  hello {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n### Usage\n  Renders some greeting message\n"
                 }
             })
         );

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -347,7 +347,7 @@ impl LanguageServer {
             Id::Declaration(decl_id) => {
                 let decl = working_set.get_decl(decl_id);
 
-                let mut description = "```\n### Signature\n```\n".to_string();
+                let mut description = "\n### Signature\n```\n".to_string();
                 let signature = decl.signature();
                 description.push_str(&format!("  {}", signature.name));
                 if !signature.named.is_empty() {
@@ -450,7 +450,7 @@ impl LanguageServer {
                     description.push_str("\n```\n");
                     for input_output in &signature.input_output_types {
                         description
-                            .push_str(&format!("  {} | {}\n", input_output.0, input_output.1));
+                            .push_str(&format!(" {} | {}\n", input_output.0, input_output.1));
                     }
                     description.push_str("\n```\n");
                 }
@@ -463,10 +463,10 @@ impl LanguageServer {
                         .push_str(&format!("\n### Extra usage:\n  {}\n", decl.extra_usage()));
                 }
                 if !decl.examples().is_empty() {
-                    description.push_str("### Example(s)\n```\n");
+                    description.push_str("### Example(s)\n");
                     for example in decl.examples() {
                         description.push_str(&format!(
-                            "```\n  {}\n```\n  {}\n\n",
+                            "  {}\n```\n  {}\n```\n",
                             example.description, example.example
                         ));
                     }

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -387,7 +387,7 @@ impl LanguageServer {
                     }
                     for optional_arg in &signature.optional_positional {
                         if !first {
-                            description.push_str("\\\n");
+                            description.push('\n');
                         } else {
                             first = false;
                         }
@@ -403,7 +403,7 @@ impl LanguageServer {
                     }
                     if let Some(arg) = &signature.rest_positional {
                         if !first {
-                            description.push_str("\\\n");
+                            description.push('\n');
                         }
                         description.push_str(&format!(
                             " `...{}: {}`",
@@ -422,7 +422,7 @@ impl LanguageServer {
                     let mut first = true;
                     for named in &signature.named {
                         if !first {
-                            description.push_str("\\\n");
+                            description.push('\n');
                         } else {
                             first = false;
                         }

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -98,6 +98,36 @@ mod tests {
     use crate::tests::{hover, initialize_language_server, open, update};
 
     #[test]
+    fn hover_correct_documentation_on_let() {
+        let (client_connection, _recv) = initialize_language_server();
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("hover");
+        script.push("var.nu");
+        let script = Url::from_file_path(script).unwrap();
+
+        open(&client_connection, script.clone());
+
+        let resp = hover(&client_connection, script.clone(), 0, 0);
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!({
+                "contents": {
+                    "kind": "markdown",
+                    "value": "\n### Signature\n```\n  let {flags} <var_name> <initial_value>\n```\n\n### Parameters\n\n  `var_name: any` - variable name\n\n  `initial_value: any` - equals sign followed by value\n\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n### Input/output\n\n```\n any | nothing\n\n```\n### Usage\n  Create a variable and give it a value.\n\n### Extra usage:\n  This command is a parser keyword. For details, check:\n  https://www.nushell.sh/book/thinking_in_nu.html\n### Example(s)\n  Set a variable to a value\n```\n  let x = 10\n```\n  Set a variable to the result of an expression\n```\n  let x = 10 + 100\n```\n  Set a variable based on the condition\n```\n  let x = if false { -1 } else { 1 }\n```\n"
+                }
+            })
+        );
+    }
+
+    #[test]
     fn hover_on_command_after_full_content_change() {
         let (client_connection, _recv) = initialize_language_server();
 
@@ -132,7 +162,7 @@ hello"#,
             serde_json::json!({
                 "contents": {
                     "kind": "markdown",
-                    "value": "```\n### Signature\n```\n  hello {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n### Usage\n  Renders some updated greeting message\n"
+                    "value": "\n### Signature\n```\n  hello {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n### Usage\n  Renders some updated greeting message\n"
                 }
             })
         );
@@ -177,7 +207,7 @@ hello"#,
             serde_json::json!({
                 "contents": {
                     "kind": "markdown",
-                    "value": "```\n### Signature\n```\n  hello {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n### Usage\n  Renders some updated greeting message\n"
+                    "value": "\n### Signature\n```\n  hello {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n### Usage\n  Renders some updated greeting message\n"
                 }
             })
         );


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Hi! I was playing around and I fixed the formatting in the LSP hover. 
I _only tested in VS Code using Windows_, if anyone is capable, can you test it on nvim or linux if it works properly? I think markdown shouldn't have any problem

The link of the LSP meta issue just for reference #10941 
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
Now the LSP hovers markdown properly
![image](https://github.com/nushell/nushell/assets/30557287/7e824331-d9b1-40dd-957f-da77a21e97a2)

<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
