### PR TITLE
Fix overlay_use_main_not_exported hanging when an external spam command exists

### DIFF
--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -1243,9 +1243,9 @@ fn overlay_use_main_def_known_external() {
 #[test]
 fn overlay_use_main_not_exported() {
     let inp = &[
-        r#"module spam { def main [] { "spam" } }"#,
-        "overlay use spam",
-        "spam",
+        r#"module foo { def main [] { "foo" } }"#,
+        "overlay use foo",
+        "foo",
     ];
 
     let actual = nu!(&inp.join("; "));


### PR DESCRIPTION
# Description
The `spam` command is provided by [opensp](https://openjade.sourceforge.net/) which causes `overlay_use_main_not_exported` to hang. `opensp`  is pulled by `gnome-control-center` on my system.

[opensp package list](https://archlinux.org/packages/extra/x86_64/opensp/files/)

```
opensp 1.5.2-10 File List

Package has 224 files and 14 directories.

[Back to Package](https://archlinux.org/packages/extra/x86_64/opensp/)

    usr/
    usr/bin/
    usr/bin/nsgmls
    usr/bin/onsgmls
    usr/bin/osgmlnorm
    usr/bin/ospam
    usr/bin/ospcat
    usr/bin/ospent
    usr/bin/osx
    usr/bin/sgml2xml
    usr/bin/sgmlnorm
    usr/bin/spam
    ...snip...
```

`cargo test` output
```
...snip...
test shell::pipeline::commands::internal::unlet_variable_in_parent_scope ... ok
test shell::pipeline::commands::internal::unlet_env_variable ... ok
test shell::pipeline::doesnt_break_on_utf8 ... ok
test shell::run_export_extern ... ok
test shell::run_script_that_looks_like_module ... ok
test shell::pipeline::commands::internal::can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external ... ok
test shell::pipeline::commands::internal::variable_scoping::access_variables_in_scopes ... ok
test shell::run_in_login_mode ... ok
test shell::run_in_interactive_mode ... ok
test shell::run_in_noninteractive_mode ... ok
test shell::run_in_not_login_mode ... ok
test shell::pipeline::commands::internal::subexpression_properly_redirects ... ok
test shell::pipeline::commands::internal::subexpression_handles_dot ... ok
test shell::pipeline::commands::internal::takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external ... ok
test overlays::overlay_use_main_not_exported has been running for over 60 seconds
```
# User-Facing Changes
N/A

# Tests + Formatting
Make sure you've run and fixed any issues with these commands:

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library



# After Submitting
N/A