### PR TITLE
allow users to access `$env.path` in a case-insensitive manner

### DIFF
--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -718,9 +718,9 @@ fn variables_completions() {
 
     assert_eq!(3, suggestions.len());
 
-    // #[cfg(windows)]
-    // let expected: Vec<String> = vec!["PWD".into(), "Path".into(), "TEST".into()];
-    // #[cfg(not(windows))]
+    #[cfg(windows)]
+    let expected: Vec<String> = vec!["PWD".into(), "Path".into(), "TEST".into()];
+    #[cfg(not(windows))]
     let expected: Vec<String> = vec!["PATH".into(), "PWD".into(), "TEST".into()];
 
     // Match results

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -66,7 +66,7 @@ fn custom_completer() -> NuCompleter {
 
     // Add record value as example
     let record = r#"
-        let external_completer = {|spans| 
+        let external_completer = {|spans|
             $spans
         }
 
@@ -718,9 +718,9 @@ fn variables_completions() {
 
     assert_eq!(3, suggestions.len());
 
-    #[cfg(windows)]
-    let expected: Vec<String> = vec!["PWD".into(), "Path".into(), "TEST".into()];
-    #[cfg(not(windows))]
+    // #[cfg(windows)]
+    // let expected: Vec<String> = vec!["PWD".into(), "Path".into(), "TEST".into()];
+    // #[cfg(not(windows))]
     let expected: Vec<String> = vec!["PATH".into(), "PWD".into(), "TEST".into()];
 
     // Match results

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -13,6 +13,11 @@ use nu_protocol::{
 use std::collections::HashMap;
 use std::thread::{self, JoinHandle};
 
+#[cfg(windows)]
+const ENV_PATH_NAME: &str = "Path";
+#[cfg(not(windows))]
+const ENV_PATH_NAME: &str = "PATH";
+
 pub fn eval_call(
     engine_state: &EngineState,
     caller_stack: &mut Stack,
@@ -774,7 +779,13 @@ pub fn eval_variable(
             let env_values = env_vars.values();
 
             let mut pairs = env_columns
-                .map(|x| x.to_string())
+                .map(|x| {
+                    if x.to_ascii_lowercase() == "path" {
+                        ENV_PATH_NAME.to_string()
+                    } else {
+                        x.to_string()
+                    }
+                })
                 .zip(env_values.cloned())
                 .collect::<Vec<(String, Value)>>();
 

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -8,6 +8,11 @@ use crate::{ENV_VARIABLE_ID, NU_VARIABLE_ID};
 /// Environment variables per overlay
 pub type EnvVars = HashMap<String, HashMap<String, Value>>;
 
+#[cfg(windows)]
+const ENV_PATH_NAME: &str = "Path";
+#[cfg(not(windows))]
+const ENV_PATH_NAME: &str = "PATH";
+
 /// A runtime value stack used during evaluation
 ///
 /// A note on implementation:
@@ -117,7 +122,7 @@ impl Stack {
     pub fn add_env_var(&mut self, var: String, value: Value) {
         // When dealing with Path/PATH always make it PATH
         let checked_var = if &var.to_ascii_lowercase() == "path" {
-            "PATH"
+            ENV_PATH_NAME
         } else {
             &var
         };
@@ -223,7 +228,7 @@ impl Stack {
                         .map(|(k, v)| {
                             // No matter the case, always return PATH as uppercase
                             if k.to_ascii_lowercase() == "path" {
-                                ("PATH".into(), v.clone())
+                                (ENV_PATH_NAME.into(), v.clone())
                             } else {
                                 (k.clone(), v.clone())
                             }
@@ -252,7 +257,7 @@ impl Stack {
                             .map(|(k, v)| {
                                 // No matter the case, always return PATH as uppercase
                                 if k.to_ascii_lowercase() == "path" {
-                                    ("PATH".into(), v.clone())
+                                    (ENV_PATH_NAME.into(), v.clone())
                                 } else {
                                     (k.clone(), v.clone())
                                 }
@@ -280,7 +285,7 @@ impl Stack {
                             .map(|(k, v)| {
                                 // No matter the case, always return PATH as uppercase
                                 if k.to_ascii_lowercase() == "path" {
-                                    ("PATH".into(), v.clone())
+                                    (ENV_PATH_NAME.into(), v.clone())
                                 } else {
                                     (k.clone(), v.clone())
                                 }
@@ -314,7 +319,7 @@ impl Stack {
                         .map(|k| {
                             // No matter the case, always return PATH as uppercase
                             if k.to_ascii_lowercase() == "path" {
-                                "PATH".into()
+                                ENV_PATH_NAME.into()
                             } else {
                                 k.clone()
                             }
@@ -333,7 +338,7 @@ impl Stack {
                             .map(|k| {
                                 // No matter the case, always return PATH as uppercase
                                 if k.to_ascii_lowercase() == "path" {
-                                    "PATH".into()
+                                    ENV_PATH_NAME.into()
                                 } else {
                                     k.clone()
                                 }
@@ -350,7 +355,7 @@ impl Stack {
     pub fn get_env_var(&self, engine_state: &EngineState, name: &str) -> Option<Value> {
         // When dealing with Path/PATH always make it PATH
         let checked_name = if &name.to_ascii_lowercase() == "path" {
-            "PATH"
+            ENV_PATH_NAME
         } else {
             name
         };
@@ -387,7 +392,7 @@ impl Stack {
     pub fn has_env_var(&self, engine_state: &EngineState, name: &str) -> bool {
         // When dealing with Path/PATH always make it PATH
         let checked_name = if &name.to_ascii_lowercase() == "path" {
-            "PATH"
+            ENV_PATH_NAME
         } else {
             name
         };
@@ -424,7 +429,7 @@ impl Stack {
     pub fn remove_env_var(&mut self, engine_state: &EngineState, name: &str) -> bool {
         // When dealing with Path/PATH always make it PATH
         let checked_name = if &name.to_ascii_lowercase() == "path" {
-            "PATH"
+            ENV_PATH_NAME
         } else {
             name
         };
@@ -462,7 +467,7 @@ impl Stack {
     pub fn has_env_overlay(&self, name: &str, engine_state: &EngineState) -> bool {
         // When dealing with Path/PATH always make it PATH
         let checked_name = if &name.to_ascii_lowercase() == "path" {
-            "PATH"
+            ENV_PATH_NAME
         } else {
             name
         };

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -207,7 +207,14 @@ impl Stack {
                                 true
                             }
                         })
-                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .map(|(k, v)| {
+                            // No matter the case, always return PATH as uppercase
+                            if k.to_ascii_lowercase() == "path" {
+                                ("PATH".into(), v.clone())
+                            } else {
+                                (k.clone(), v.clone())
+                            }
+                        })
                         .collect::<HashMap<String, Value>>(),
                 );
             }
@@ -225,7 +232,20 @@ impl Stack {
         for scope in &self.env_vars {
             for active_overlay in self.active_overlays.iter() {
                 if let Some(env_vars) = scope.get(active_overlay) {
-                    result.extend(env_vars.clone());
+                    result.extend(
+                        env_vars
+                            .clone()
+                            .iter()
+                            .map(|(k, v)| {
+                                // No matter the case, always return PATH as uppercase
+                                if k.to_ascii_lowercase() == "path" {
+                                    ("PATH".into(), v.clone())
+                                } else {
+                                    (k.clone(), v.clone())
+                                }
+                            })
+                            .collect::<HashMap<String, Value>>(),
+                    );
                 }
             }
         }

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -352,7 +352,7 @@ impl Stack {
         let checked_name = if &name.to_ascii_lowercase() == "path" {
             "PATH"
         } else {
-            &name
+            name
         };
 
         for scope in self.env_vars.iter().rev() {
@@ -389,7 +389,7 @@ impl Stack {
         let checked_name = if &name.to_ascii_lowercase() == "path" {
             "PATH"
         } else {
-            &name
+            name
         };
 
         for scope in self.env_vars.iter().rev() {
@@ -426,7 +426,7 @@ impl Stack {
         let checked_name = if &name.to_ascii_lowercase() == "path" {
             "PATH"
         } else {
-            &name
+            name
         };
 
         for scope in self.env_vars.iter_mut().rev() {
@@ -464,7 +464,7 @@ impl Stack {
         let checked_name = if &name.to_ascii_lowercase() == "path" {
             "PATH"
         } else {
-            &name
+            name
         };
 
         for scope in self.env_vars.iter().rev() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,6 +35,7 @@ use tempfile::NamedTempFile;
 
 pub type TestResult = Result<(), Box<dyn std::error::Error>>;
 
+#[cfg(test)]
 pub fn run_test_with_env(input: &str, expected: &str, env: &HashMap<&str, &str>) -> TestResult {
     let mut file = NamedTempFile::new()?;
     let name = file.path();


### PR DESCRIPTION
# Description

Nushell has never been able to handle `PATH` on Windows or `Path` on *nix, because in those two use cases, they do not exist and it's actually reversed. Windows (most) always wants to see `$env.Path` and MacOS and Linux want to see `$env.PATH`. This lead to a bunch of scripts checking the OS to determine if they should look at `PATH` or `Path`. This change allows you to `$env.Path`, `$env.PATH`, `$env.path`, `$env.PaTh` on any OS, effectively making this access case-insensitive.

![image](https://github.com/nushell/nushell/assets/343840/04fc6b15-43ec-402b-a236-12969ef9eec0)

I'm not sure this change is in the right place, but it works. I'm looking for reviewers to point out what's wrong with this or a better way to do it. It seems a little hack-ish to me.

I initially tried to hard code anything to `PATH` but that ended up breaking things an giving me two `PATH` env variables on Windows. It was very weird to have 2 of the same name env var. To top it off, they had slightly different data as well. So, I took the path of least resistance, which means Windows is always really stored as `Path` and MacOS/Linux is always stored as `PATH`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
