### PR TITLE
Convert remainder of ShellError variants to named fields

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -139,7 +139,7 @@ pub fn evaluate_file(
             false,
         );
         let pipeline_data = match pipeline_data {
-            Err(ShellError::Return(_, _)) => {
+            Err(ShellError::Return { .. }) => {
                 // allows early exists before `main` is run.
                 return Ok(());
             }

--- a/crates/nu-cmd-base/src/arg_glob.rs
+++ b/crates/nu-cmd-base/src/arg_glob.rs
@@ -64,12 +64,10 @@ fn arg_glob_opt(
     // user wasn't referring to a specific thing in filesystem, try to glob it.
     match glob_with_parent(&pattern.item, options, cwd) {
         Ok(p) => Ok(p),
-        Err(pat_err) => {
-            Err(ShellError::InvalidGlobPattern(
-                pat_err.msg.into(),
-                pattern.span, // improve specificity
-            ))
-        }
+        Err(pat_err) => Err(ShellError::InvalidGlobPattern {
+            msg: pat_err.msg.into(),
+            span: pattern.span,
+        }),
     }
 }
 

--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -27,7 +27,7 @@ impl Command for Break {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Err(ShellError::Break(call.head))
+        Err(ShellError::Break { span: call.head })
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -27,7 +27,7 @@ impl Command for Continue {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Err(ShellError::Continue(call.head))
+        Err(ShellError::Continue { span: call.head })
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -116,7 +116,7 @@ impl Command for For {
                         Err(ShellError::Break { .. }) => {
                             break;
                         }
-                        Err(ShellError::Continue(_)) => {
+                        Err(ShellError::Continue { .. }) => {
                             continue;
                         }
                         Err(err) => {
@@ -162,7 +162,7 @@ impl Command for For {
                         Err(ShellError::Break { .. }) => {
                             break;
                         }
-                        Err(ShellError::Continue(_)) => {
+                        Err(ShellError::Continue { .. }) => {
                             continue;
                         }
                         Err(err) => {

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -113,7 +113,7 @@ impl Command for For {
                         redirect_stdout,
                         redirect_stderr,
                     ) {
-                        Err(ShellError::Break(_)) => {
+                        Err(ShellError::Break { .. }) => {
                             break;
                         }
                         Err(ShellError::Continue(_)) => {
@@ -159,7 +159,7 @@ impl Command for For {
                         redirect_stdout,
                         redirect_stderr,
                     ) {
-                        Err(ShellError::Break(_)) => {
+                        Err(ShellError::Break { .. }) => {
                             break;
                         }
                         Err(ShellError::Continue(_)) => {

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -48,7 +48,7 @@ impl Command for Loop {
                 call.redirect_stdout,
                 call.redirect_stderr,
             ) {
-                Err(ShellError::Break(_)) => {
+                Err(ShellError::Break { .. }) => {
                     break;
                 }
                 Err(ShellError::Continue(_)) => {

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -51,7 +51,7 @@ impl Command for Loop {
                 Err(ShellError::Break { .. }) => {
                     break;
                 }
-                Err(ShellError::Continue(_)) => {
+                Err(ShellError::Continue { .. }) => {
                     continue;
                 }
                 Err(err) => {

--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -42,12 +42,15 @@ impl Command for Return {
     ) -> Result<PipelineData, ShellError> {
         let return_value: Option<Value> = call.opt(engine_state, stack, 0)?;
         if let Some(value) = return_value {
-            Err(ShellError::Return(call.head, Box::new(value)))
+            Err(ShellError::Return {
+                span: call.head,
+                value: Box::new(value),
+            })
         } else {
-            Err(ShellError::Return(
-                call.head,
-                Box::new(Value::nothing(call.head)),
-            ))
+            Err(ShellError::Return {
+                span: call.head,
+                value: Box::new(Value::nothing(call.head)),
+            })
         }
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -128,7 +128,7 @@ fn handle_catch(
 /// `Err` when flow control to bubble up with `?`
 fn intercept_block_control(error: ShellError) -> Result<ShellError, ShellError> {
     match error {
-        nu_protocol::ShellError::Break(_) => Err(error),
+        nu_protocol::ShellError::Break { .. } => Err(error),
         nu_protocol::ShellError::Continue(_) => Err(error),
         nu_protocol::ShellError::Return(_, _) => Err(error),
         _ => Ok(error),

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -130,7 +130,7 @@ fn intercept_block_control(error: ShellError) -> Result<ShellError, ShellError> 
     match error {
         nu_protocol::ShellError::Break { .. } => Err(error),
         nu_protocol::ShellError::Continue { .. } => Err(error),
-        nu_protocol::ShellError::Return(_, _) => Err(error),
+        nu_protocol::ShellError::Return { .. } => Err(error),
         _ => Ok(error),
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -129,7 +129,7 @@ fn handle_catch(
 fn intercept_block_control(error: ShellError) -> Result<ShellError, ShellError> {
     match error {
         nu_protocol::ShellError::Break { .. } => Err(error),
-        nu_protocol::ShellError::Continue(_) => Err(error),
+        nu_protocol::ShellError::Continue { .. } => Err(error),
         nu_protocol::ShellError::Return(_, _) => Err(error),
         _ => Ok(error),
     }

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -65,7 +65,7 @@ impl Command for While {
                             Err(ShellError::Break { .. }) => {
                                 break;
                             }
-                            Err(ShellError::Continue(_)) => {
+                            Err(ShellError::Continue { .. }) => {
                                 continue;
                             }
                             Err(err) => {

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -62,7 +62,7 @@ impl Command for While {
                             call.redirect_stdout,
                             call.redirect_stderr,
                         ) {
-                            Err(ShellError::Break(_)) => {
+                            Err(ShellError::Break { .. }) => {
                                 break;
                             }
                             Err(ShellError::Continue(_)) => {

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -193,10 +193,10 @@ impl Command for UCp {
                         app_vals.push(path)
                     }
                     Err(e) => {
-                        return Err(ShellError::ErrorExpandingGlob(
-                            format!("error {} in path {}", e.error(), e.path().display()),
-                            p.span,
-                        ));
+                        return Err(ShellError::ErrorExpandingGlob {
+                            msg: format!("error {} in path {}", e.error(), e.path().display()),
+                            span: p.span,
+                        });
                     }
                 }
             }

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -157,7 +157,7 @@ with 'transpose' first."#
                         redirect_stderr,
                     ) {
                         Ok(v) => Some(v.into_value(span)),
-                        Err(ShellError::Continue(v)) => Some(Value::nothing(v)),
+                        Err(ShellError::Continue { span }) => Some(Value::nothing(span)),
                         Err(ShellError::Break { .. }) => None,
                         Err(error) => {
                             let error = chain_error_with_input(error, x_is_error, input_span);
@@ -180,7 +180,7 @@ with 'transpose' first."#
 
                     let x = match x {
                         Ok(x) => x,
-                        Err(ShellError::Continue(v)) => return Some(Value::nothing(v)),
+                        Err(ShellError::Continue { span }) => return Some(Value::nothing(span)),
                         Err(ShellError::Break { .. }) => return None,
                         Err(err) => return Some(Value::error(err, span)),
                     };
@@ -203,7 +203,7 @@ with 'transpose' first."#
                         redirect_stderr,
                     ) {
                         Ok(v) => Some(v.into_value(span)),
-                        Err(ShellError::Continue(v)) => Some(Value::nothing(v)),
+                        Err(ShellError::Continue { span }) => Some(Value::nothing(span)),
                         Err(ShellError::Break { .. }) => None,
                         Err(error) => {
                             let error = chain_error_with_input(error, x_is_error, input_span);

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -158,7 +158,7 @@ with 'transpose' first."#
                     ) {
                         Ok(v) => Some(v.into_value(span)),
                         Err(ShellError::Continue(v)) => Some(Value::nothing(v)),
-                        Err(ShellError::Break(_)) => None,
+                        Err(ShellError::Break { .. }) => None,
                         Err(error) => {
                             let error = chain_error_with_input(error, x_is_error, input_span);
                             Some(Value::error(error, input_span))
@@ -181,7 +181,7 @@ with 'transpose' first."#
                     let x = match x {
                         Ok(x) => x,
                         Err(ShellError::Continue(v)) => return Some(Value::nothing(v)),
-                        Err(ShellError::Break(_)) => return None,
+                        Err(ShellError::Break { .. }) => return None,
                         Err(err) => return Some(Value::error(err, span)),
                     };
 
@@ -204,7 +204,7 @@ with 'transpose' first."#
                     ) {
                         Ok(v) => Some(v.into_value(span)),
                         Err(ShellError::Continue(v)) => Some(Value::nothing(v)),
-                        Err(ShellError::Break(_)) => None,
+                        Err(ShellError::Break { .. }) => None,
                         Err(error) => {
                             let error = chain_error_with_input(error, x_is_error, input_span);
                             Some(Value::error(error, input_span))

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -83,7 +83,7 @@ impl Command for Items {
                 redirect_stderr,
             ) {
                 Ok(v) => Some(v.into_value(span)),
-                Err(ShellError::Break(_)) => None,
+                Err(ShellError::Break { .. }) => None,
                 Err(error) => {
                     let error = chain_error_with_input(error, false, input_span);
                     Some(Value::error(error, span))

--- a/crates/nu-command/src/filters/utils.rs
+++ b/crates/nu-command/src/filters/utils.rs
@@ -11,7 +11,10 @@ pub fn chain_error_with_input(
     span: Span,
 ) -> ShellError {
     if !input_is_error {
-        return ShellError::EvalBlockWithInput(span, vec![error_source]);
+        return ShellError::EvalBlockWithInput {
+            span,
+            sources: vec![error_source],
+        };
     }
     error_source
 }

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -155,12 +155,12 @@ fn convert_string_to_value(string_input: String, span: Span) -> Result<Value, Sh
                     msg: "error parsing JSON text".into(),
                     span: Some(span),
                     help: None,
-                    inner: vec![ShellError::OutsideSpannedLabeledError(
-                        string_input,
-                        "Error while parsing JSON text".into(),
-                        label,
-                        label_span,
-                    )],
+                    inner: vec![ShellError::OutsideSpannedLabeledError {
+                        src: string_input,
+                        error: "Error while parsing JSON text".into(),
+                        msg: label,
+                        span: label_span,
+                    }],
                 })
             }
             x => Err(ShellError::CantConvert {

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -65,12 +65,12 @@ impl Command for FromNuon {
                     msg: "could not load nuon text".into(),
                     span: Some(head),
                     help: None,
-                    inner: vec![ShellError::OutsideSpannedLabeledError(
-                        string_input,
-                        "error when loading".into(),
-                        "excess values when loading".into(),
-                        element.span(),
-                    )],
+                    inner: vec![ShellError::OutsideSpannedLabeledError {
+                        src: string_input,
+                        error: "error when loading".into(),
+                        msg: "excess values when loading".into(),
+                        span: element.span(),
+                    }],
                 });
             } else {
                 return Err(ShellError::GenericError {
@@ -105,12 +105,12 @@ impl Command for FromNuon {
                     msg: "could not load nuon text".into(),
                     span: Some(head),
                     help: None,
-                    inner: vec![ShellError::OutsideSpannedLabeledError(
-                        string_input,
-                        "error when loading".into(),
-                        "detected a pipeline in nuon file".into(),
-                        expr.span(),
-                    )],
+                    inner: vec![ShellError::OutsideSpannedLabeledError {
+                        src: string_input,
+                        error: "error when loading".into(),
+                        msg: "detected a pipeline in nuon file".into(),
+                        span: expr.span(),
+                    }],
                 });
             }
 
@@ -145,12 +145,12 @@ impl Command for FromNuon {
                 msg: "could not parse nuon text".into(),
                 span: Some(head),
                 help: None,
-                inner: vec![ShellError::OutsideSpannedLabeledError(
-                    string_input,
-                    "error when parsing".into(),
-                    err.to_string(),
-                    err.span(),
-                )],
+                inner: vec![ShellError::OutsideSpannedLabeledError {
+                    src: string_input,
+                    error: "error when parsing".into(),
+                    msg: err.to_string(),
+                    span: err.span(),
+                }],
             });
         }
 
@@ -175,99 +175,99 @@ fn convert_to_value(
     original_text: &str,
 ) -> Result<Value, ShellError> {
     match expr.expr {
-        Expr::BinaryOp(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "binary operators not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::UnaryNot(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "unary operators not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::Block(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "blocks not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::Closure(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "closures not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::BinaryOp(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "binary operators not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::UnaryNot(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "unary operators not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::Block(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "blocks not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::Closure(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "closures not supported in nuon".into(),
+            span: expr.span,
+        }),
         Expr::Binary(val) => Ok(Value::binary(val, span)),
         Expr::Bool(val) => Ok(Value::bool(val, span)),
-        Expr::Call(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "calls not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::CellPath(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "subexpressions and cellpaths not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::Call(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "calls not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::CellPath(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "subexpressions and cellpaths not supported in nuon".into(),
+            span: expr.span,
+        }),
         Expr::DateTime(dt) => Ok(Value::date(dt, span)),
-        Expr::ExternalCall(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "calls not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::ExternalCall(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "calls not supported in nuon".into(),
+            span: expr.span,
+        }),
         Expr::Filepath(val) => Ok(Value::string(val, span)),
         Expr::Directory(val) => Ok(Value::string(val, span)),
         Expr::Float(val) => Ok(Value::float(val, span)),
         Expr::FullCellPath(full_cell_path) => {
             if !full_cell_path.tail.is_empty() {
-                Err(ShellError::OutsideSpannedLabeledError(
-                    original_text.to_string(),
-                    "Error when loading".into(),
-                    "subexpressions and cellpaths not supported in nuon".into(),
-                    expr.span,
-                ))
+                Err(ShellError::OutsideSpannedLabeledError {
+                    src: original_text.to_string(),
+                    error: "Error when loading".into(),
+                    msg: "subexpressions and cellpaths not supported in nuon".into(),
+                    span: expr.span,
+                })
             } else {
                 convert_to_value(full_cell_path.head, span, original_text)
             }
         }
 
-        Expr::Garbage => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "extra tokens in input file".into(),
-            expr.span,
-        )),
-        Expr::MatchPattern(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "extra tokens in input file".into(),
-            expr.span,
-        )),
+        Expr::Garbage => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "extra tokens in input file".into(),
+            span: expr.span,
+        }),
+        Expr::MatchPattern(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "extra tokens in input file".into(),
+            span: expr.span,
+        }),
         Expr::GlobPattern(val) => Ok(Value::string(val, span)),
-        Expr::ImportPattern(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "imports not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::Overlay(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "overlays not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::ImportPattern(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "imports not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::Overlay(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "overlays not supported in nuon".into(),
+            span: expr.span,
+        }),
         Expr::Int(val) => Ok(Value::int(val, span)),
-        Expr::Keyword(kw, ..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            format!("{} not supported in nuon", String::from_utf8_lossy(&kw)),
-            expr.span,
-        )),
+        Expr::Keyword(kw, ..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: format!("{} not supported in nuon", String::from_utf8_lossy(&kw)),
+            span: expr.span,
+        }),
         Expr::List(vals) => {
             let mut output = vec![];
             for val in vals {
@@ -276,19 +276,19 @@ fn convert_to_value(
 
             Ok(Value::list(output, span))
         }
-        Expr::MatchBlock(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "match blocks not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::MatchBlock(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "match blocks not supported in nuon".into(),
+            span: expr.span,
+        }),
         Expr::Nothing => Ok(Value::nothing(span)),
-        Expr::Operator(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "operators not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::Operator(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "operators not supported in nuon".into(),
+            span: expr.span,
+        }),
         Expr::Range(from, next, to, operator) => {
             let from = if let Some(f) = from {
                 convert_to_value(*f, span, original_text)?
@@ -322,12 +322,12 @@ fn convert_to_value(
                         let key_str = match key.expr {
                             Expr::String(key_str) => key_str,
                             _ => {
-                                return Err(ShellError::OutsideSpannedLabeledError(
-                                    original_text.to_string(),
-                                    "Error when loading".into(),
-                                    "only strings can be keys".into(),
-                                    key.span,
-                                ))
+                                return Err(ShellError::OutsideSpannedLabeledError {
+                                    src: original_text.to_string(),
+                                    error: "Error when loading".into(),
+                                    msg: "only strings can be keys".into(),
+                                    span: key.span,
+                                })
                             }
                         };
 
@@ -336,49 +336,49 @@ fn convert_to_value(
                         record.push(key_str, value);
                     }
                     RecordItem::Spread(_, inner) => {
-                        return Err(ShellError::OutsideSpannedLabeledError(
-                            original_text.to_string(),
-                            "Error when loading".into(),
-                            "spread operator not supported in nuon".into(),
-                            inner.span,
-                        ));
+                        return Err(ShellError::OutsideSpannedLabeledError {
+                            src: original_text.to_string(),
+                            error: "Error when loading".into(),
+                            msg: "spread operator not supported in nuon".into(),
+                            span: inner.span,
+                        });
                     }
                 }
             }
 
             Ok(Value::record(record, span))
         }
-        Expr::RowCondition(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "row conditions not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::Signature(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "signatures not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::Spread(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "spread operator not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::RowCondition(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "row conditions not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::Signature(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "signatures not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::Spread(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "spread operator not supported in nuon".into(),
+            span: expr.span,
+        }),
         Expr::String(s) => Ok(Value::string(s, span)),
-        Expr::StringInterpolation(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "string interpolation not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::Subexpression(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "subexpressions not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::StringInterpolation(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "string interpolation not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::Subexpression(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "subexpressions not supported in nuon".into(),
+            span: expr.span,
+        }),
         Expr::Table(mut headers, cells) => {
             let mut cols = vec![];
 
@@ -388,12 +388,12 @@ fn convert_to_value(
                 let key_str = match &mut key.expr {
                     Expr::String(key_str) => key_str,
                     _ => {
-                        return Err(ShellError::OutsideSpannedLabeledError(
-                            original_text.to_string(),
-                            "Error when loading".into(),
-                            "only strings can be keys".into(),
-                            expr.span,
-                        ))
+                        return Err(ShellError::OutsideSpannedLabeledError {
+                            src: original_text.to_string(),
+                            error: "Error when loading".into(),
+                            msg: "only strings can be keys".into(),
+                            span: expr.span,
+                        })
                     }
                 };
 
@@ -416,12 +416,12 @@ fn convert_to_value(
                 }
 
                 if cols.len() != vals.len() {
-                    return Err(ShellError::OutsideSpannedLabeledError(
-                        original_text.to_string(),
-                        "Error when loading".into(),
-                        "table has mismatched columns".into(),
-                        expr.span,
-                    ));
+                    return Err(ShellError::OutsideSpannedLabeledError {
+                        src: original_text.to_string(),
+                        error: "Error when loading".into(),
+                        msg: "table has mismatched columns".into(),
+                        span: expr.span,
+                    });
                 }
 
                 output.push(Value::record(
@@ -439,12 +439,12 @@ fn convert_to_value(
             let size = match val.expr {
                 Expr::Int(val) => val,
                 _ => {
-                    return Err(ShellError::OutsideSpannedLabeledError(
-                        original_text.to_string(),
-                        "Error when loading".into(),
-                        "non-integer unit value".into(),
-                        expr.span,
-                    ))
+                    return Err(ShellError::OutsideSpannedLabeledError {
+                        src: original_text.to_string(),
+                        error: "Error when loading".into(),
+                        msg: "non-integer unit value".into(),
+                        span: expr.span,
+                    })
                 }
             };
 
@@ -484,37 +484,37 @@ fn convert_to_value(
                 Unit::Hour => Ok(Value::duration(size * 1000 * 1000 * 1000 * 60 * 60, span)),
                 Unit::Day => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24) {
                     Some(val) => Ok(Value::duration(val, span)),
-                    None => Err(ShellError::OutsideSpannedLabeledError(
-                        original_text.to_string(),
-                        "day duration too large".into(),
-                        "day duration too large".into(),
-                        expr.span,
-                    )),
+                    None => Err(ShellError::OutsideSpannedLabeledError {
+                        src: original_text.to_string(),
+                        error: "day duration too large".into(),
+                        msg: "day duration too large".into(),
+                        span: expr.span,
+                    }),
                 },
 
                 Unit::Week => match size.checked_mul(1000 * 1000 * 1000 * 60 * 60 * 24 * 7) {
                     Some(val) => Ok(Value::duration(val, span)),
-                    None => Err(ShellError::OutsideSpannedLabeledError(
-                        original_text.to_string(),
-                        "week duration too large".into(),
-                        "week duration too large".into(),
-                        expr.span,
-                    )),
+                    None => Err(ShellError::OutsideSpannedLabeledError {
+                        src: original_text.to_string(),
+                        error: "week duration too large".into(),
+                        msg: "week duration too large".into(),
+                        span: expr.span,
+                    }),
                 },
             }
         }
-        Expr::Var(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "variables not supported in nuon".into(),
-            expr.span,
-        )),
-        Expr::VarDecl(..) => Err(ShellError::OutsideSpannedLabeledError(
-            original_text.to_string(),
-            "Error when loading".into(),
-            "variable declarations not supported in nuon".into(),
-            expr.span,
-        )),
+        Expr::Var(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "variables not supported in nuon".into(),
+            span: expr.span,
+        }),
+        Expr::VarDecl(..) => Err(ShellError::OutsideSpannedLabeledError {
+            src: original_text.to_string(),
+            error: "Error when loading".into(),
+            msg: "variable declarations not supported in nuon".into(),
+            span: expr.span,
+        }),
     }
 }
 

--- a/crates/nu-command/src/platform/du.rs
+++ b/crates/nu-command/src/platform/du.rs
@@ -108,7 +108,10 @@ impl Command for Du {
         let exclude = args.exclude.map_or(Ok(None), move |x| {
             Pattern::new(&x.item)
                 .map(Some)
-                .map_err(|e| ShellError::InvalidGlobPattern(e.msg.to_string(), x.span))
+                .map_err(|e| ShellError::InvalidGlobPattern {
+                    msg: e.msg.into(),
+                    span: x.span,
+                })
         })?;
 
         let include_files = args.all;

--- a/crates/nu-command/src/removed/format.rs
+++ b/crates/nu-command/src/removed/format.rs
@@ -37,10 +37,10 @@ impl Command for SubCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Err(nu_protocol::ShellError::RemovedCommand(
-            self.name().to_string(),
-            "format date".to_owned(),
-            call.head,
-        ))
+        Err(nu_protocol::ShellError::RemovedCommand {
+            removed: self.name().to_string(),
+            replacement: "format date".to_owned(),
+            span: call.head,
+        })
     }
 }

--- a/crates/nu-command/src/removed/let_env.rs
+++ b/crates/nu-command/src/removed/let_env.rs
@@ -34,10 +34,10 @@ impl Command for LetEnv {
         call: &Call,
         _: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Err(nu_protocol::ShellError::RemovedCommand(
-            self.name().to_string(),
-            "$env.<environment variable> = ...".to_owned(),
-            call.head,
-        ))
+        Err(nu_protocol::ShellError::RemovedCommand {
+            removed: self.name().to_string(),
+            replacement: "$env.<environment variable> = ...".to_owned(),
+            span: call.head,
+        })
     }
 }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -305,11 +305,11 @@ impl ExternalCommand {
                                 Some(s) => s.clone(),
                                 None => "".to_string(),
                             };
-                            return Err(ShellError::RemovedCommand(
-                                command_name_lower,
+                            return Err(ShellError::RemovedCommand {
+                                removed: command_name_lower,
                                 replacement,
-                                self.name.span,
-                            ));
+                                span: self.name.span,
+                            });
                         }
 
                         let suggestion = suggest_command(&self.name.item, engine_state);

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -593,7 +593,7 @@ pub fn eval_block_with_early_return(
         redirect_stdout,
         redirect_stderr,
     ) {
-        Err(ShellError::Return(_, value)) => Ok(PipelineData::Value(*value, None)),
+        Err(ShellError::Return { span: _, value }) => Ok(PipelineData::Value(*value, None)),
         x => x,
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -233,7 +233,7 @@ pub fn eval_const_subexpression(
     for pipeline in block.pipelines.iter() {
         for element in pipeline.elements.iter() {
             let PipelineElement::Expression(_, expr) = element else {
-                return Err(ShellError::NotAConstant(span));
+                return Err(ShellError::NotAConstant { span });
             };
 
             input = eval_constant_with_input(working_set, expr, input)?
@@ -288,7 +288,7 @@ impl Eval for EvalConst {
         _: String,
         span: Span,
     ) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant(span))
+        Err(ShellError::NotAConstant { span })
     }
 
     fn eval_var(
@@ -299,7 +299,7 @@ impl Eval for EvalConst {
     ) -> Result<Value, ShellError> {
         match working_set.get_variable(var_id).const_val.as_ref() {
             Some(val) => Ok(val.clone()),
-            None => Err(ShellError::NotAConstant(span)),
+            None => Err(ShellError::NotAConstant { span }),
         }
     }
 
@@ -322,7 +322,7 @@ impl Eval for EvalConst {
         span: Span,
     ) -> Result<Value, ShellError> {
         // TODO: It may be more helpful to give not_a_const_command error
-        Err(ShellError::NotAConstant(span))
+        Err(ShellError::NotAConstant { span })
     }
 
     fn eval_subexpression(
@@ -346,7 +346,7 @@ impl Eval for EvalConst {
         _: bool,
         expr_span: Span,
     ) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant(expr_span))
+        Err(ShellError::NotAConstant { span: expr_span })
     }
 
     fn eval_assignment(
@@ -358,7 +358,7 @@ impl Eval for EvalConst {
         _op_span: Span,
         expr_span: Span,
     ) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant(expr_span))
+        Err(ShellError::NotAConstant { span: expr_span })
     }
 
     fn eval_row_condition_or_closure(
@@ -367,7 +367,7 @@ impl Eval for EvalConst {
         _: usize,
         span: Span,
     ) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant(span))
+        Err(ShellError::NotAConstant { span })
     }
 
     fn eval_string_interpolation(
@@ -376,11 +376,11 @@ impl Eval for EvalConst {
         _: &[Expression],
         span: Span,
     ) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant(span))
+        Err(ShellError::NotAConstant { span })
     }
 
     fn eval_overlay(_: &StateWorkingSet, span: Span) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant(span))
+        Err(ShellError::NotAConstant { span })
     }
 
     fn eval_glob_pattern(
@@ -389,10 +389,10 @@ impl Eval for EvalConst {
         _: String,
         span: Span,
     ) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant(span))
+        Err(ShellError::NotAConstant { span })
     }
 
     fn unreachable(expr: &Expression) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant(expr.span))
+        Err(ShellError::NotAConstant { span: expr.span })
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -218,7 +218,7 @@ fn eval_const_call(
     if !decl.is_known_external() && call.named_iter().any(|(flag, _, _)| flag.item == "help") {
         // It would require re-implementing get_full_help() for const evaluation. Assuming that
         // getting help messages at parse-time is rare enough, we can simply disallow it.
-        return Err(ShellError::NotAConstHelp(call.head));
+        return Err(ShellError::NotAConstHelp { span: call.head });
     }
 
     decl.run_const(working_set, call, input)

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -212,7 +212,7 @@ fn eval_const_call(
     let decl = working_set.get_decl(call.decl_id);
 
     if !decl.is_const() {
-        return Err(ShellError::NotAConstCommand(call.head));
+        return Err(ShellError::NotAConstCommand { span: call.head });
     }
 
     if !decl.is_known_external() && call.named_iter().any(|(flag, _, _)| flag.item == "help") {

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1212,7 +1212,10 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         code(nu::shell::not_a_constant),
         help("Only a subset of expressions are allowed constants during parsing. Try using the 'const' command or typing the value literally.")
     )]
-    NotAConstant(#[label = "Value is not a parse-time constant"] Span),
+    NotAConstant {
+        #[label("Value is not a parse-time constant")]
+        span: Span,
+    },
 
     /// Tried running a command that is not const-compatible
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -944,14 +944,6 @@ pub enum ShellError {
         span: Span,
     },
 
-    // These three are unused. Remove?
-    #[error("No file to be removed")]
-    NoFileToBeRemoved(),
-    #[error("No file to be moved")]
-    NoFileToBeMoved(),
-    #[error("No file to be copied")]
-    NoFileToBeCopied(),
-
     /// Error while trying to read a file
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1114,7 +1114,12 @@ pub enum ShellError {
     /// Failed to eval block with specific pipeline input.
     #[error("Eval block failed with pipeline input")]
     #[diagnostic(code(nu::shell::eval_block_with_input))]
-    EvalBlockWithInput(#[label("source value")] Span, #[related] Vec<ShellError>),
+    EvalBlockWithInput {
+        #[label("source value")]
+        span: Span,
+        #[related]
+        sources: Vec<ShellError>,
+    },
 
     /// Break event, which may become an error if used outside of a loop
     #[error("Break used outside of loop")]

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1123,7 +1123,10 @@ pub enum ShellError {
 
     /// Break event, which may become an error if used outside of a loop
     #[error("Break used outside of loop")]
-    Break(#[label = "used outside of loop"] Span),
+    Break {
+        #[label("used outside of loop")]
+        span: Span,
+    },
 
     /// Continue event, which may become an error if used outside of a loop
     #[error("Continue used outside of loop")]

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1130,7 +1130,10 @@ pub enum ShellError {
 
     /// Continue event, which may become an error if used outside of a loop
     #[error("Continue used outside of loop")]
-    Continue(#[label = "used outside of loop"] Span),
+    Continue {
+        #[label("used outside of loop")]
+        span: Span,
+    },
 
     /// Return event, which may become an error if used outside of a function
     #[error("Return used outside of function")]

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1137,7 +1137,11 @@ pub enum ShellError {
 
     /// Return event, which may become an error if used outside of a function
     #[error("Return used outside of function")]
-    Return(#[label = "used outside of function"] Span, Box<Value>),
+    Return {
+        #[label("used outside of function")]
+        span: Span,
+        value: Box<Value>,
+    },
 
     /// The code being executed called itself too many times.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1092,13 +1092,14 @@ pub enum ShellError {
     /// ## Resolution
     ///
     /// Check the help for the new suggested command and update your script accordingly.
-    #[error("Removed command: {0}")]
+    #[error("Removed command: {removed}")]
     #[diagnostic(code(nu::shell::removed_command))]
-    RemovedCommand(
-        String,
-        String,
-        #[label = "'{0}' has been removed from Nushell. Please use '{1}' instead."] Span,
-    ),
+    RemovedCommand {
+        removed: String,
+        replacement: String,
+        #[label("'{removed}' has been removed from Nushell. Please use '{replacement}' instead.")]
+        span: Span,
+    },
 
     /// Non-Unicode input received.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1076,9 +1076,16 @@ pub enum ShellError {
     },
 
     /// This is a generic error type used for different situations.
-    #[error("{1}")]
+    #[error("{error}")]
     #[diagnostic()]
-    OutsideSpannedLabeledError(#[source_code] String, String, String, #[label("{2}")] Span),
+    OutsideSpannedLabeledError {
+        #[source_code]
+        src: String,
+        error: String,
+        msg: String,
+        #[label("{msg}")]
+        span: Span,
+    },
 
     /// Attempted to use a command that has been removed from Nushell.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1275,7 +1275,11 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         help("Correct glob pattern or file access issue")
     )]
     //todo: add error detail
-    ErrorExpandingGlob(String, #[label = "{0}"] Span),
+    ErrorExpandingGlob {
+        msg: String,
+        #[label("{msg}")]
+        span: Span,
+    },
 
     /// Tried spreading a non-list inside a list.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1243,7 +1243,10 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         code(nu::shell::not_a_const_help),
         help("Help messages are currently not supported to be constants.")
     )]
-    NotAConstHelp(#[label = "Cannot get help message at parse time."] Span),
+    NotAConstHelp {
+        #[label("This command cannot run at parse time.")]
+        span: Span,
+    },
 
     /// Invalid glob pattern
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1228,7 +1228,10 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         code(nu::shell::not_a_const_command),
         help("Only a subset of builtin commands, and custom commands built only from those commands, can run at parse time.")
     )]
-    NotAConstCommand(#[label = "This command cannot run at parse time."] Span),
+    NotAConstCommand {
+        #[label("This command cannot run at parse time.")]
+        span: Span,
+    },
 
     /// Tried getting a help message at parse time.
     ///

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1110,15 +1110,6 @@ pub enum ShellError {
     #[diagnostic(code(nu::shell::non_unicode_input))]
     NonUnicodeInput,
 
-    /// Unexpected abbr component.
-    ///
-    /// ## Resolution
-    ///
-    /// Check the path abbreviation to ensure that it is valid.
-    #[error("Unexpected abbr component `{0}`.")]
-    #[diagnostic(code(nu::shell::unexpected_path_abbreviateion))]
-    UnexpectedAbbrComponent(String),
-
     // It should be only used by commands accepts block, and accept inputs from pipeline.
     /// Failed to eval block with specific pipeline input.
     #[error("Eval block failed with pipeline input")]

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1258,7 +1258,11 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         code(nu::shell::invalid_glob_pattern),
         help("Refer to xxx for help on nushell glob patterns.")
     )]
-    InvalidGlobPattern(String, #[label = "{0}"] Span),
+    InvalidGlobPattern {
+        msg: String,
+        #[label("{msg}")]
+        span: Span,
+    },
 
     /// Error expanding glob pattern
     ///


### PR DESCRIPTION
# Description

Removed variants that are no longer in use:
* `NoFile*`
* `UnexpectedAbbrComponent`

Converted:
* `OutsideSpannedLabeledError`
* `EvalBlockWithInput`
* `Break`
* `Continue`
* `Return`
* `NotAConstant`
* `NotAConstCommand`
* `NotAConstHelp`
* `InvalidGlobPattern`
* `ErrorExpandingGlob`

Fixes #10700 

# User-Facing Changes

None

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A