### PR TITLE
Ensure that command usage starts uppercase and ends period

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/expressions_macro.rs
@@ -319,7 +319,7 @@ macro_rules! lazy_expr_command {
 expr_command!(
     ExprList,
     "dfr implode",
-    "Aggregates a group to a Series",
+    "Aggregates a group to a Series.",
     vec![Example {
         description: "",
         example: "",
@@ -334,7 +334,7 @@ expr_command!(
 expr_command!(
     ExprAggGroups,
     "dfr agg-groups",
-    "creates an agg_groups expression",
+    "Creates an agg_groups expression.",
     vec![Example {
         description: "",
         example: "",
@@ -349,7 +349,7 @@ expr_command!(
 expr_command!(
     ExprCount,
     "dfr count",
-    "creates a count expression",
+    "Creates a count expression.",
     vec![Example {
         description: "",
         example: "",
@@ -364,7 +364,7 @@ expr_command!(
 expr_command!(
     ExprNot,
     "dfr expr-not",
-    "creates a not expression",
+    "Creates a not expression.",
     vec![Example {
         description: "Creates a not expression",
         example: "(dfr col a) > 2) | dfr expr-not",
@@ -379,7 +379,7 @@ expr_command!(
 lazy_expr_command!(
     ExprMax,
     "dfr max",
-    "Creates a max expression or aggregates columns to their max value",
+    "Creates a max expression or aggregates columns to their max value.",
     vec![
         Example {
             description: "Max value from columns in a dataframe",
@@ -424,7 +424,7 @@ lazy_expr_command!(
 lazy_expr_command!(
     ExprMin,
     "dfr min",
-    "Creates a min expression or aggregates columns to their min value",
+    "Creates a min expression or aggregates columns to their min value.",
     vec![
         Example {
             description: "Min value from columns in a dataframe",
@@ -469,7 +469,7 @@ lazy_expr_command!(
 lazy_expr_command!(
     ExprSum,
     "dfr sum",
-    "Creates a sum expression for an aggregation or aggregates columns to their sum value",
+    "Creates a sum expression for an aggregation or aggregates columns to their sum value.",
     vec![
         Example {
             description: "Sums all columns in a dataframe",
@@ -514,7 +514,7 @@ lazy_expr_command!(
 lazy_expr_command!(
     ExprMean,
     "dfr mean",
-    "Creates a mean expression for an aggregation or aggregates columns to their mean value",
+    "Creates a mean expression for an aggregation or aggregates columns to their mean value.",
     vec![
         Example {
             description: "Mean value from columns in a dataframe",
@@ -559,7 +559,7 @@ lazy_expr_command!(
 expr_command!(
     ExprMedian,
     "dfr median",
-    "Creates a median expression for an aggregation",
+    "Creates a median expression for an aggregation.",
     vec![Example {
         description: "Median aggregation for a group-by",
         example: r#"[[a b]; [one 2] [one 4] [two 1]]
@@ -590,7 +590,7 @@ expr_command!(
 lazy_expr_command!(
     ExprStd,
     "dfr std",
-    "Creates a std expression for an aggregation of std value from columns in a dataframe",
+    "Creates a std expression for an aggregation of std value from columns in a dataframe.",
     vec![
         Example {
             description: "Std value from columns in a dataframe",
@@ -636,7 +636,7 @@ lazy_expr_command!(
 lazy_expr_command!(
     ExprVar,
     "dfr var",
-    "Create a var expression for an aggregation",
+    "Create a var expression for an aggregation.",
     vec![
         Example {
             description:

--- a/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/expressions/otherwise.rs
@@ -15,7 +15,7 @@ impl Command for ExprOtherwise {
     }
 
     fn usage(&self) -> &str {
-        "completes a when expression."
+        "Completes a when expression."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/fetch.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/fetch.rs
@@ -16,7 +16,7 @@ impl Command for LazyFetch {
     }
 
     fn usage(&self) -> &str {
-        "collects the lazyframe to the selected rows."
+        "Collects the lazyframe to the selected rows."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/flatten.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/flatten.rs
@@ -17,7 +17,7 @@ impl Command for LazyFlatten {
     }
 
     fn usage(&self) -> &str {
-        "An alias for dfr explode"
+        "An alias for dfr explode."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/macro_commands.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/macro_commands.rs
@@ -121,7 +121,7 @@ lazy_command!(
     "dfr reverse",
     "Reverses the LazyFrame",
     vec![Example {
-        description: "Reverses the dataframe",
+        description: "Reverses the dataframe.",
         example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr reverse",
         result: Some(
             NuDataFrame::try_from_columns(vec![
@@ -147,7 +147,7 @@ lazy_command!(
 lazy_command!(
     LazyCache,
     "dfr cache",
-    "Caches operations in a new LazyFrame",
+    "Caches operations in a new LazyFrame.",
     vec![Example {
         description: "Caches the result into a new LazyFrame",
         example: "[[a b]; [6 2] [4 2] [2 2]] | dfr into-df | dfr reverse | dfr cache",

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/sort_by_expr.rs
@@ -16,7 +16,7 @@ impl Command for LazySortBy {
     }
 
     fn usage(&self) -> &str {
-        "sorts a lazy dataframe based on expression(s)."
+        "Sorts a lazy dataframe based on expression(s)."
     }
 
     fn signature(&self) -> Signature {

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -57,7 +57,7 @@ impl Command for BytesAt {
     }
 
     fn usage(&self) -> &str {
-        "Get bytes defined by a range"
+        "Get bytes defined by a range."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -54,7 +54,7 @@ impl Command for Join {
     }
 
     fn usage(&self) -> &str {
-        "Join two tables"
+        "Join two tables."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -23,7 +23,7 @@ impl Command for SplitBy {
     }
 
     fn usage(&self) -> &str {
-        "Split a record into groups"
+        "Split a record into groups."
     }
 
     fn run(

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -24,7 +24,7 @@ impl<D: HashDigest> Default for GenericDigest<D> {
     fn default() -> Self {
         Self {
             name: format!("hash {}", D::name()),
-            usage: format!("Hash a value using the {} hash algorithm", D::name()),
+            usage: format!("Hash a value using the {} hash algorithm.", D::name()),
             phantom: PhantomData,
         }
     }

--- a/crates/nu-command/src/platform/input/input_listen.rs
+++ b/crates/nu-command/src/platform/input/input_listen.rs
@@ -49,7 +49,7 @@ impl Command for InputListen {
     }
 
     fn usage(&self) -> &str {
-        "Listen for user interface event"
+        "Listen for user interface event."
     }
 
     fn extra_usage(&self) -> &str {

--- a/crates/nu-command/src/platform/is_terminal.rs
+++ b/crates/nu-command/src/platform/is_terminal.rs
@@ -23,7 +23,7 @@ impl Command for IsTerminal {
     }
 
     fn usage(&self) -> &str {
-        "Check if stdin, stdout, or stderr is a terminal"
+        "Check if stdin, stdout, or stderr is a terminal."
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/removed/format.rs
+++ b/crates/nu-command/src/removed/format.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Removed command: use `format date` instead"
+        "Removed command: use `format date` instead."
     }
 
     fn run(

--- a/crates/nu-command/src/stor/create.rs
+++ b/crates/nu-command/src/stor/create.rs
@@ -35,7 +35,7 @@ impl Command for StorCreate {
     }
 
     fn usage(&self) -> &str {
-        "Create a table in the in-memory sqlite database"
+        "Create a table in the in-memory sqlite database."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/stor/delete.rs
+++ b/crates/nu-command/src/stor/delete.rs
@@ -35,7 +35,7 @@ impl Command for StorDelete {
     }
 
     fn usage(&self) -> &str {
-        "Delete a table or specified rows in the in-memory sqlite database"
+        "Delete a table or specified rows in the in-memory sqlite database."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/stor/export.rs
+++ b/crates/nu-command/src/stor/export.rs
@@ -29,7 +29,7 @@ impl Command for StorExport {
     }
 
     fn usage(&self) -> &str {
-        "Export the in-memory sqlite database to a sqlite database file"
+        "Export the in-memory sqlite database to a sqlite database file."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/stor/import.rs
+++ b/crates/nu-command/src/stor/import.rs
@@ -29,7 +29,7 @@ impl Command for StorImport {
     }
 
     fn usage(&self) -> &str {
-        "Import a sqlite database file into the in-memory sqlite database"
+        "Import a sqlite database file into the in-memory sqlite database."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/stor/insert.rs
+++ b/crates/nu-command/src/stor/insert.rs
@@ -35,7 +35,7 @@ impl Command for StorInsert {
     }
 
     fn usage(&self) -> &str {
-        "Insert information into a specified table in the in-memory sqlite database"
+        "Insert information into a specified table in the in-memory sqlite database."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/stor/open.rs
+++ b/crates/nu-command/src/stor/open.rs
@@ -24,7 +24,7 @@ impl Command for StorOpen {
     }
 
     fn usage(&self) -> &str {
-        "Opens the in-memory sqlite database"
+        "Opens the in-memory sqlite database."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/stor/reset.rs
+++ b/crates/nu-command/src/stor/reset.rs
@@ -21,7 +21,7 @@ impl Command for StorReset {
     }
 
     fn usage(&self) -> &str {
-        "Reset the in-memory database by dropping all tables"
+        "Reset the in-memory database by dropping all tables."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/stor/update.rs
+++ b/crates/nu-command/src/stor/update.rs
@@ -41,7 +41,7 @@ impl Command for StorUpdate {
     }
 
     fn usage(&self) -> &str {
-        "Update information in a specified table in the in-memory sqlite database"
+        "Update information in a specified table in the in-memory sqlite database."
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -110,3 +110,52 @@ fn no_search_term_duplicates() {
         failures.join("\n")
     );
 }
+
+#[test]
+fn usage_end_period() {
+    let ctx = crate::create_default_context();
+    let decls = ctx.get_decls_sorted(true);
+    let mut failures = Vec::new();
+
+    for (name_bytes, decl_id) in decls {
+        let cmd = ctx.get_decl(decl_id);
+        let cmd_name = String::from_utf8_lossy(&name_bytes);
+        let usage = cmd.usage();
+
+        if !usage.ends_with('.') {
+            failures.push(format!("{cmd_name}: \"{usage}\""));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Command usage does not end with a period:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn usage_start_uppercase() {
+    let ctx = crate::create_default_context();
+    let decls = ctx.get_decls_sorted(true);
+    let mut failures = Vec::new();
+
+    for (name_bytes, decl_id) in decls {
+        let cmd = ctx.get_decl(decl_id);
+        let cmd_name = String::from_utf8_lossy(&name_bytes);
+        let usage = cmd.usage();
+
+        // Check lowercase to allow usage to contain removed syntax like:
+        //
+        // "`let-env FOO = ...` …"
+        if usage.starts_with(|u: char| u.is_lowercase()) {
+            failures.push(format!("{cmd_name}: \"{usage}\""));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Command usage does not start with an uppercase letter:\n{}",
+        failures.join("\n")
+    );
+}


### PR DESCRIPTION
# Description

This repeats #8268 to make all command usage strings start with an uppercase letter and end with a period per #5056

Adds a test to ensure that commands won't regress

Part of #5066

# User-Facing Changes

Command usage is now consistent

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Automatic documentation updates