### PR TITLE
Final changes, moved branch to fix build failure

### DIFF
--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -137,6 +137,12 @@ fn alias_match() {
     assert_eq!(actual.out, "yes!");
 }
 
+#[test]
+fn alias_parenthesis_enclosed() {
+    let actual = nu!(r#" alias spam = (match 3 { 1..10 => 'yes!' }); spam "#);
+    assert_eq!(actual.out, "yes!");
+}
+
 // Issue https://github.com/nushell/nushell/issues/8103
 #[test]
 fn alias_multiword_name() {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -931,9 +931,11 @@ pub fn parse_alias(
 
             let replacement_spans = &spans[(split_id + 2)..];
             let first_bytes = working_set.get_span_contents(replacement_spans[0]);
+            let b = first_bytes[0];
 
             if first_bytes != b"if"
                 && first_bytes != b"match"
+                && b != b'('
                 && is_math_expression_like(working_set, replacement_spans[0])
             {
                 // TODO: Maybe we need to implement a Display trait for Expression?


### PR DESCRIPTION
This PR should fix #10088


# Description
Fixes alias panic issue when enclosing multiple commands in parenthesis (i.e `alias eloc = (cd ~/.config/nvim; nvim)`).


# User-Facing Changes
Aliasing commands now supports enclosing multiple commands, original error is as follows:
```nushell
alias eloc = (cd ~/.config/nvim; nvim)
Error: nu::parser::cant_alias_expression

  × Can't create alias to expression.
   ╭─[entry #1:1:1]
 1 │ alias eloc = (cd ~/.config/nvim; nvim)
   ·              ────────────┬────────────
   ·                          ╰── aliasing FullCellPath is not supported
   ╰────
  help: Only command calls can be aliased.`
```
Now works as if you were aliasing 
```nushell
def eloc [] {
    cd ~/.config/nvim
    nvim
}
```

# Tests + Formatting
<!--
`#[test]
fn alias_parenthesis_enclosed() {
    let actual = nu!(r#" alias spam = (match 3 { 1..10 => 'yes!' }); spam "#);
    assert_eq!(actual.out, "yes!");
}`

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
