### PR TITLE
Enforce required, optional, and rest positional arguments start with an uppercase and end with a period.

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/alias.rs
@@ -19,11 +19,11 @@ impl Command for Alias {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("alias")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("name", SyntaxShape::String, "name of the alias")
+            .required("name", SyntaxShape::String, "Name of the alias.")
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::Expression)),
-                "equals sign followed by value",
+                "Equals sign followed by value.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/collect.rs
+++ b/crates/nu-cmd-lang/src/core_commands/collect.rs
@@ -20,7 +20,7 @@ impl Command for Collect {
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
-                "the closure to run once the stream is collected.",
+                "The closure to run once the stream is collected.",
             )
             .switch(
                 "keep-env",

--- a/crates/nu-cmd-lang/src/core_commands/collect.rs
+++ b/crates/nu-cmd-lang/src/core_commands/collect.rs
@@ -20,7 +20,7 @@ impl Command for Collect {
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
-                "the closure to run once the stream is collected",
+                "the closure to run once the stream is collected.",
             )
             .switch(
                 "keep-env",

--- a/crates/nu-cmd-lang/src/core_commands/const_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/const_.rs
@@ -18,11 +18,11 @@ impl Command for Const {
         Signature::build("const")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("const_name", SyntaxShape::VarWithOptType, "constant name.")
+            .required("const_name", SyntaxShape::VarWithOptType, "Constant name.")
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
-                "equals sign followed by constant value.",
+                "Equals sign followed by constant value.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/const_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/const_.rs
@@ -18,11 +18,11 @@ impl Command for Const {
         Signature::build("const")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("const_name", SyntaxShape::VarWithOptType, "constant name")
+            .required("const_name", SyntaxShape::VarWithOptType, "constant name.")
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
-                "equals sign followed by constant value",
+                "equals sign followed by constant value.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -19,9 +19,9 @@ impl Command for Def {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("def")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "command name")
-            .required("params", SyntaxShape::Signature, "parameters")
-            .required("block", SyntaxShape::Closure(None), "body of the definition")
+            .required("def_name", SyntaxShape::String, "Command name.")
+            .required("params", SyntaxShape::Signature, "Parameters.")
+            .required("block", SyntaxShape::Closure(None), "Body of the definition.")
             .switch("env", "keep the environment defined inside the command", None)
             .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -53,7 +53,11 @@ impl Command for Do {
                 "keep the environment defined inside the command",
                 None,
             )
-            .rest("rest", SyntaxShape::Any, "the parameter(s) for the closure")
+            .rest(
+                "rest",
+                SyntaxShape::Any,
+                "The parameter(s) for the closure.",
+            )
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -25,7 +25,7 @@ impl Command for Do {
             .required(
                 "closure",
                 SyntaxShape::OneOf(vec![SyntaxShape::Closure(None), SyntaxShape::Any]),
-                "the closure to run",
+                "The closure to run.",
             )
             .input_output_types(vec![(Type::Any, Type::Any)])
             .switch(

--- a/crates/nu-cmd-lang/src/core_commands/echo.rs
+++ b/crates/nu-cmd-lang/src/core_commands/echo.rs
@@ -21,7 +21,7 @@ impl Command for Echo {
     fn signature(&self) -> Signature {
         Signature::build("echo")
             .input_output_types(vec![(Type::Nothing, Type::Any)])
-            .rest("rest", SyntaxShape::Any, "the values to echo")
+            .rest("rest", SyntaxShape::Any, "The values to echo.")
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -19,7 +19,7 @@ impl Command for ErrorMake {
             .required(
                 "error_struct",
                 SyntaxShape::Record(vec![]),
-                "the error to create",
+                "The error to create.",
             )
             .switch(
                 "unspanned",

--- a/crates/nu-cmd-lang/src/core_commands/export_alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_alias.rs
@@ -19,11 +19,11 @@ impl Command for ExportAlias {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export alias")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("name", SyntaxShape::String, "name of the alias")
+            .required("name", SyntaxShape::String, "name of the alias.")
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::Expression)),
-                "equals sign followed by value",
+                "equals sign followed by value.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/export_alias.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_alias.rs
@@ -19,11 +19,11 @@ impl Command for ExportAlias {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export alias")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("name", SyntaxShape::String, "name of the alias.")
+            .required("name", SyntaxShape::String, "Name of the alias.")
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::Expression)),
-                "equals sign followed by value.",
+                "Equals sign followed by value.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/export_const.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_const.rs
@@ -20,11 +20,11 @@ impl Command for ExportConst {
         Signature::build("export const")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("const_name", SyntaxShape::VarWithOptType, "constant name")
+            .required("const_name", SyntaxShape::VarWithOptType, "Constant name.")
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
-                "equals sign followed by constant value",
+                "Equals sign followed by constant value.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/export_def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_def.rs
@@ -19,9 +19,9 @@ impl Command for ExportDef {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export def")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "command name")
-            .required("params", SyntaxShape::Signature, "parameters")
-            .required("block", SyntaxShape::Block, "body of the definition")
+            .required("def_name", SyntaxShape::String, "Command name.")
+            .required("params", SyntaxShape::Signature, "Parameters.")
+            .required("block", SyntaxShape::Block, "Body of the definition.")
             .switch("env", "keep the environment defined inside the command", None)
             .switch("wrapped", "treat unknown flags and arguments as strings (requires ...rest-like parameter in signature)", None)
             .category(Category::Core)

--- a/crates/nu-cmd-lang/src/core_commands/export_extern.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_extern.rs
@@ -17,8 +17,8 @@ impl Command for ExportExtern {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export extern")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "definition name")
-            .required("params", SyntaxShape::Signature, "parameters")
+            .required("def_name", SyntaxShape::String, "Definition name.")
+            .required("params", SyntaxShape::Signature, "Parameters.")
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/export_module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_module.rs
@@ -24,7 +24,7 @@ impl Command for ExportModule {
             .optional(
                 "block",
                 SyntaxShape::Block,
-                "body of the module if 'module' parameter is not a path",
+                "Body of the module if 'module' parameter is not a path.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/export_module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_module.rs
@@ -20,7 +20,7 @@ impl Command for ExportModule {
         Signature::build("export module")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("module", SyntaxShape::String, "module name or module path")
+            .required("module", SyntaxShape::String, "Module name or module path.")
             .optional(
                 "block",
                 SyntaxShape::Block,

--- a/crates/nu-cmd-lang/src/core_commands/export_use.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_use.rs
@@ -19,7 +19,7 @@ impl Command for ExportUse {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("export use")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("module", SyntaxShape::String, "Module or module file")
+            .required("module", SyntaxShape::String, "Module or module file.")
             .optional(
                 "members",
                 SyntaxShape::Any,

--- a/crates/nu-cmd-lang/src/core_commands/export_use.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_use.rs
@@ -23,7 +23,7 @@ impl Command for ExportUse {
             .optional(
                 "members",
                 SyntaxShape::Any,
-                "Which members of the module to import",
+                "Which members of the module to import.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/extern_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/extern_.rs
@@ -17,8 +17,8 @@ impl Command for Extern {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("extern")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("def_name", SyntaxShape::String, "definition name")
-            .required("params", SyntaxShape::Signature, "parameters")
+            .required("def_name", SyntaxShape::String, "Definition name.")
+            .required("params", SyntaxShape::Signature, "Parameters.")
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -25,14 +25,14 @@ impl Command for For {
             .required(
                 "var_name",
                 SyntaxShape::VarWithOptType,
-                "name of the looping variable",
+                "Name of the looping variable.",
             )
             .required(
                 "range",
                 SyntaxShape::Keyword(b"in".to_vec(), Box::new(SyntaxShape::Any)),
-                "range of the loop",
+                "Range of the loop.",
             )
-            .required("block", SyntaxShape::Block, "the block to run")
+            .required("block", SyntaxShape::Block, "The block to run.")
             .switch(
                 "numbered",
                 "return a numbered item ($it.index and $it.item)",

--- a/crates/nu-cmd-lang/src/core_commands/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide.rs
@@ -13,7 +13,7 @@ impl Command for Hide {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("hide")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("module", SyntaxShape::String, "Module or module file")
+            .required("module", SyntaxShape::String, "Module or module file.")
             .optional(
                 "members",
                 SyntaxShape::Any,

--- a/crates/nu-cmd-lang/src/core_commands/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide.rs
@@ -17,7 +17,7 @@ impl Command for Hide {
             .optional(
                 "members",
                 SyntaxShape::Any,
-                "Which members of the module to import",
+                "Which members of the module to import.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -20,7 +20,7 @@ impl Command for HideEnv {
             .rest(
                 "name",
                 SyntaxShape::String,
-                "environment variable names to hide",
+                "Environment variable names to hide.",
             )
             .switch(
                 "ignore-errors",

--- a/crates/nu-cmd-lang/src/core_commands/if_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/if_.rs
@@ -21,11 +21,11 @@ impl Command for If {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("if")
             .input_output_types(vec![(Type::Any, Type::Any)])
-            .required("cond", SyntaxShape::MathExpression, "condition to check")
+            .required("cond", SyntaxShape::MathExpression, "Condition to check.")
             .required(
                 "then_block",
                 SyntaxShape::Block,
-                "block to run if check succeeds",
+                "Block to run if check succeeds.",
             )
             .optional(
                 "else_expression",

--- a/crates/nu-cmd-lang/src/core_commands/if_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/if_.rs
@@ -36,7 +36,7 @@ impl Command for If {
                         SyntaxShape::Expression,
                     ])),
                 ),
-                "expression or block to run if check fails",
+                "Expression or block to run when the condition is false.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/let_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/let_.rs
@@ -19,11 +19,11 @@ impl Command for Let {
         Signature::build("let")
             .input_output_types(vec![(Type::Any, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("var_name", SyntaxShape::VarWithOptType, "variable name")
+            .required("var_name", SyntaxShape::VarWithOptType, "Variable name.")
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
-                "equals sign followed by value",
+                "Equals sign followed by value.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -21,7 +21,7 @@ impl Command for Loop {
         Signature::build("loop")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("block", SyntaxShape::Block, "block to loop")
+            .required("block", SyntaxShape::Block, "Block to loop.")
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/match_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/match_.rs
@@ -20,11 +20,11 @@ impl Command for Match {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("match")
             .input_output_types(vec![(Type::Any, Type::Any)])
-            .required("value", SyntaxShape::Any, "value to check")
+            .required("value", SyntaxShape::Any, "Value to check.")
             .required(
                 "match_block",
                 SyntaxShape::MatchBlock,
-                "block to run if check succeeds",
+                "Block to run if check succeeds.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/module.rs
@@ -24,7 +24,7 @@ impl Command for Module {
             .optional(
                 "block",
                 SyntaxShape::Block,
-                "body of the module if 'module' parameter is not a module path",
+                "Body of the module if 'module' parameter is not a module path.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/module.rs
+++ b/crates/nu-cmd-lang/src/core_commands/module.rs
@@ -20,7 +20,7 @@ impl Command for Module {
         Signature::build("module")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("module", SyntaxShape::String, "module name or module path")
+            .required("module", SyntaxShape::String, "Module name or module path.")
             .optional(
                 "block",
                 SyntaxShape::Block,

--- a/crates/nu-cmd-lang/src/core_commands/mut_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/mut_.rs
@@ -19,11 +19,11 @@ impl Command for Mut {
         Signature::build("mut")
             .input_output_types(vec![(Type::Any, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("var_name", SyntaxShape::VarWithOptType, "variable name")
+            .required("var_name", SyntaxShape::VarWithOptType, "Variable name.")
             .required(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
-                "equals sign followed by value",
+                "Equals sign followed by value.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -20,10 +20,10 @@ impl Command for OverlayHide {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("overlay hide")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .optional("name", SyntaxShape::String, "Overlay to hide")
+            .optional("name", SyntaxShape::String, "Overlay to hide.")
             .switch(
                 "keep-custom",
-                "Keep all newly added commands and aliases in the next activated overlay",
+                "Keep all newly added commands and aliases in the next activated overlay.",
                 Some('k'),
             )
             .named(

--- a/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
@@ -21,7 +21,7 @@ impl Command for OverlayNew {
         Signature::build("overlay new")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("name", SyntaxShape::String, "Name of the overlay")
+            .required("name", SyntaxShape::String, "Name of the overlay.")
             // TODO:
             // .switch(
             //     "prefix",

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -32,7 +32,7 @@ impl Command for OverlayUse {
             .optional(
                 "as",
                 SyntaxShape::Keyword(b"as".to_vec(), Box::new(SyntaxShape::String)),
-                "as keyword followed by a new name",
+                "`as` keyword followed by a new name.",
             )
             .switch(
                 "prefix",

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -27,7 +27,7 @@ impl Command for OverlayUse {
             .required(
                 "name",
                 SyntaxShape::String,
-                "Module name to use overlay for",
+                "Module name to use overlay for.",
             )
             .optional(
                 "as",

--- a/crates/nu-cmd-lang/src/core_commands/register.rs
+++ b/crates/nu-cmd-lang/src/core_commands/register.rs
@@ -20,7 +20,7 @@ impl Command for Register {
             .required(
                 "plugin",
                 SyntaxShape::Filepath,
-                "path of executable for plugin",
+                "Path of executable for plugin.",
             )
             .optional(
                 "signature",

--- a/crates/nu-cmd-lang/src/core_commands/register.rs
+++ b/crates/nu-cmd-lang/src/core_commands/register.rs
@@ -25,7 +25,7 @@ impl Command for Register {
             .optional(
                 "signature",
                 SyntaxShape::Any,
-                "Block with signature description as json object",
+                "Block with signature description as json object.",
             )
             .named(
                 "shell",

--- a/crates/nu-cmd-lang/src/core_commands/return_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/return_.rs
@@ -20,7 +20,11 @@ impl Command for Return {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("return")
             .input_output_types(vec![(Type::Nothing, Type::Any)])
-            .optional("return_value", SyntaxShape::Any, "optional value to return")
+            .optional(
+                "return_value",
+                SyntaxShape::Any,
+                "Optional value to return.",
+            )
             .category(Category::Core)
     }
 

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -31,7 +31,7 @@ impl Command for Try {
                         SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                     ])),
                 ),
-                "block to run if try block fails",
+                "Block to run if try block fails.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -21,7 +21,7 @@ impl Command for Try {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("try")
             .input_output_types(vec![(Type::Any, Type::Any)])
-            .required("try_block", SyntaxShape::Block, "block to run")
+            .required("try_block", SyntaxShape::Block, "Block to run.")
             .optional(
                 "catch_block",
                 SyntaxShape::Keyword(

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -25,7 +25,7 @@ impl Command for Use {
             .rest(
                 "members",
                 SyntaxShape::Any,
-                "Which members of the module to import",
+                "Which members of the module to import.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -21,7 +21,7 @@ impl Command for Use {
         Signature::build("use")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("module", SyntaxShape::String, "Module or module file")
+            .required("module", SyntaxShape::String, "Module or module file.")
             .rest(
                 "members",
                 SyntaxShape::Any,

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -21,11 +21,11 @@ impl Command for While {
         Signature::build("while")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .required("cond", SyntaxShape::MathExpression, "condition to check")
+            .required("cond", SyntaxShape::MathExpression, "Condition to check.")
             .required(
                 "block",
                 SyntaxShape::Block,
-                "block to loop if check succeeds",
+                "Block to loop if check succeeds.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -40,7 +40,7 @@ impl Command for BytesAdd {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("data", SyntaxShape::Binary, "the binary to add")
+            .required("data", SyntaxShape::Binary, "the binary to add.")
             .named(
                 "index",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -51,7 +51,7 @@ impl Command for BytesAdd {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, add bytes to the data at the given cell paths",
+                "For a data structure input, add bytes to the data at the given cell paths.",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/add.rs
+++ b/crates/nu-command/src/bytes/add.rs
@@ -40,7 +40,7 @@ impl Command for BytesAdd {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("data", SyntaxShape::Binary, "the binary to add.")
+            .required("data", SyntaxShape::Binary, "The binary to add.")
             .named(
                 "index",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -47,7 +47,7 @@ impl Command for BytesAt {
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
-            .required("range", SyntaxShape::Range, "the range to get bytes")
+            .required("range", SyntaxShape::Range, "the range to get bytes.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -47,7 +47,7 @@ impl Command for BytesAt {
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
-            .required("range", SyntaxShape::Range, "the range to get bytes.")
+            .required("range", SyntaxShape::Range, "The range to get bytes.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -51,7 +51,7 @@ impl Command for BytesAt {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, get bytes from data at the given cell paths",
+                "For a data structure input, get bytes from data at the given cell paths.",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/build_.rs
+++ b/crates/nu-command/src/bytes/build_.rs
@@ -25,7 +25,7 @@ impl Command for BytesBuild {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("bytes build")
             .input_output_types(vec![(Type::Nothing, Type::Binary)])
-            .rest("rest", SyntaxShape::Any, "list of bytes")
+            .rest("rest", SyntaxShape::Any, "List of bytes.")
             .category(Category::Bytes)
     }
 

--- a/crates/nu-command/src/bytes/collect.rs
+++ b/crates/nu-command/src/bytes/collect.rs
@@ -20,7 +20,7 @@ impl Command for BytesCollect {
             .optional(
                 "separator",
                 SyntaxShape::Binary,
-                "optional separator to use when creating binary",
+                "Optional separator to use when creating binary.",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -37,7 +37,7 @@ impl Command for BytesEndsWith {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, check if bytes at the given cell paths end with the pattern",
+                "For a data structure input, check if bytes at the given cell paths end with the pattern.",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -33,7 +33,7 @@ impl Command for BytesEndsWith {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("pattern", SyntaxShape::Binary, "the pattern to match")
+            .required("pattern", SyntaxShape::Binary, "the pattern to match.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -33,7 +33,7 @@ impl Command for BytesEndsWith {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("pattern", SyntaxShape::Binary, "the pattern to match.")
+            .required("pattern", SyntaxShape::Binary, "The pattern to match.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -41,7 +41,7 @@ impl Command for BytesIndexOf {
             .required(
                 "pattern",
                 SyntaxShape::Binary,
-                "the pattern to find index of",
+                "the pattern to find index of.",
             )
             .rest(
                 "rest",

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -46,7 +46,7 @@ impl Command for BytesIndexOf {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, find the indexes at the given cell paths",
+                "For a data structure input, find the indexes at the given cell paths.",
             )
             .switch("all", "returns all matched index", Some('a'))
             .switch("end", "search from the end of the binary", Some('e'))

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -41,7 +41,7 @@ impl Command for BytesIndexOf {
             .required(
                 "pattern",
                 SyntaxShape::Binary,
-                "the pattern to find index of.",
+                "The pattern to find index of.",
             )
             .rest(
                 "rest",

--- a/crates/nu-command/src/bytes/length.rs
+++ b/crates/nu-command/src/bytes/length.rs
@@ -29,7 +29,7 @@ impl Command for BytesLen {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, find the length of data at the given cell paths",
+                "For a data structure input, find the length of data at the given cell paths.",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -39,7 +39,7 @@ impl Command for BytesRemove {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, remove bytes from data at the given cell paths",
+                "For a data structure input, remove bytes from data at the given cell paths.",
             )
             .switch("end", "remove from end of binary", Some('e'))
             .switch("all", "remove occurrences of finding binary", Some('a'))

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -35,7 +35,7 @@ impl Command for BytesRemove {
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
-            .required("pattern", SyntaxShape::Binary, "the pattern to find")
+            .required("pattern", SyntaxShape::Binary, "the pattern to find.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/remove.rs
+++ b/crates/nu-command/src/bytes/remove.rs
@@ -35,7 +35,7 @@ impl Command for BytesRemove {
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
-            .required("pattern", SyntaxShape::Binary, "the pattern to find.")
+            .required("pattern", SyntaxShape::Binary, "The pattern to find.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -41,7 +41,7 @@ impl Command for BytesReplace {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, replace bytes in data at the given cell paths",
+                "For a data structure input, replace bytes in data at the given cell paths.",
             )
             .switch("all", "replace all occurrences of find binary", Some('a'))
             .category(Category::Bytes)

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -36,8 +36,8 @@ impl Command for BytesReplace {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("find", SyntaxShape::Binary, "the pattern to find")
-            .required("replace", SyntaxShape::Binary, "the replacement pattern")
+            .required("find", SyntaxShape::Binary, "the pattern to find.")
+            .required("replace", SyntaxShape::Binary, "the replacement pattern.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/replace.rs
+++ b/crates/nu-command/src/bytes/replace.rs
@@ -36,8 +36,8 @@ impl Command for BytesReplace {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("find", SyntaxShape::Binary, "the pattern to find.")
-            .required("replace", SyntaxShape::Binary, "the replacement pattern.")
+            .required("find", SyntaxShape::Binary, "The pattern to find.")
+            .required("replace", SyntaxShape::Binary, "The replacement pattern.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/reverse.rs
+++ b/crates/nu-command/src/bytes/reverse.rs
@@ -26,7 +26,7 @@ impl Command for BytesReverse {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, reverse data at the given cell paths",
+                "For a data structure input, reverse data at the given cell paths.",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -35,7 +35,7 @@ impl Command for BytesStartsWith {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("pattern", SyntaxShape::Binary, "the pattern to match.")
+            .required("pattern", SyntaxShape::Binary, "The pattern to match.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -39,7 +39,7 @@ impl Command for BytesStartsWith {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, check if bytes at the given cell paths start with the pattern",
+                "For a data structure input, check if bytes at the given cell paths start with the pattern.",
             )
             .category(Category::Bytes)
     }

--- a/crates/nu-command/src/bytes/starts_with.rs
+++ b/crates/nu-command/src/bytes/starts_with.rs
@@ -35,7 +35,7 @@ impl Command for BytesStartsWith {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("pattern", SyntaxShape::Binary, "the pattern to match")
+            .required("pattern", SyntaxShape::Binary, "the pattern to match.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -25,8 +25,8 @@ impl Command for Histogram {
     fn signature(&self) -> Signature {
         Signature::build("histogram")
             .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Table(vec![])),])
-            .optional("column-name", SyntaxShape::String, "column name to calc frequency, no need to provide if input is just a list")
-            .optional("frequency-column-name", SyntaxShape::String, "histogram's frequency column, default to be frequency column output")
+            .optional("column-name", SyntaxShape::String, "Column name to calc frequency, no need to provide if input is a list.")
+            .optional("frequency-column-name", SyntaxShape::String, "Histogram's frequency column, default to be frequency column output.")
             .named("percentage-type", SyntaxShape::String, "percentage calculate method, can be 'normalize' or 'relative', in 'normalize', defaults to be 'normalize'", Some('t'))
             .category(Category::Chart)
     }

--- a/crates/nu-command/src/conversions/into/binary.rs
+++ b/crates/nu-command/src/conversions/into/binary.rs
@@ -44,7 +44,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, convert data at the given cell paths",
+                "For a data structure input, convert data at the given cell paths.",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/bool.rs
+++ b/crates/nu-command/src/conversions/into/bool.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, convert data at the given cell paths",
+                "For a data structure input, convert data at the given cell paths.",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -104,7 +104,7 @@ impl Command for SubCommand {
             .rest(
             "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, convert data at the given cell paths",
+                "For a data structure input, convert data at the given cell paths.",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, convert data at the given cell paths",
+                "For a data structure input, convert data at the given cell paths.",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -49,7 +49,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, convert data at the given cell paths",
+                "For a data structure input, convert data at the given cell paths.",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/float.rs
+++ b/crates/nu-command/src/conversions/into/float.rs
@@ -31,7 +31,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, convert data at the given cell paths",
+                "For a data structure input, convert data at the given cell paths.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Conversions)

--- a/crates/nu-command/src/conversions/into/int.rs
+++ b/crates/nu-command/src/conversions/into/int.rs
@@ -81,7 +81,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, convert data at the given cell paths",
+                "For a data structure input, convert data at the given cell paths.",
             )
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -52,7 +52,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "for a data structure input, convert data at the given cell paths",
+                "For a data structure input, convert data at the given cell paths.",
             )
             .named(
                 "decimals",

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -25,7 +25,7 @@ impl Command for IntoSqliteDb {
             .required(
                 "file_name",
                 SyntaxShape::String,
-                "Specify the filename to save the database to",
+                "Specify the filename to save the database to.",
             )
             .named(
                 "table_name",

--- a/crates/nu-command/src/database/commands/query_db.rs
+++ b/crates/nu-command/src/database/commands/query_db.rs
@@ -22,7 +22,7 @@ impl Command for QueryDb {
             .required(
                 "SQL",
                 SyntaxShape::String,
-                "SQL to execute against the database",
+                "SQL to execute against the database.",
             )
             .category(Category::Custom("database".into()))
     }

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
         Signature::build("date to-timezone")
             .input_output_types(vec![(Type::Date, Type::Date), (Type::String, Type::Date)])
             .allow_variants_without_examples(true) // https://github.com/nushell/nushell/issues/7032
-            .required("time zone", SyntaxShape::String, "time zone description.")
+            .required("time zone", SyntaxShape::String, "Time zone description.")
             .category(Category::Date)
     }
 

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -22,7 +22,7 @@ impl Command for SubCommand {
         Signature::build("date to-timezone")
             .input_output_types(vec![(Type::Date, Type::Date), (Type::String, Type::Date)])
             .allow_variants_without_examples(true) // https://github.com/nushell/nushell/issues/7032
-            .required("time zone", SyntaxShape::String, "time zone description")
+            .required("time zone", SyntaxShape::String, "time zone description.")
             .category(Category::Date)
     }
 

--- a/crates/nu-command/src/debug/ast.rs
+++ b/crates/nu-command/src/debug/ast.rs
@@ -25,7 +25,7 @@ impl Command for Ast {
             .required(
                 "pipeline",
                 SyntaxShape::String,
-                "the pipeline to print the ast for",
+                "the pipeline to print the ast for.",
             )
             .switch("json", "serialize to json", Some('j'))
             .switch("minify", "minify the nuon or json output", Some('m'))

--- a/crates/nu-command/src/debug/ast.rs
+++ b/crates/nu-command/src/debug/ast.rs
@@ -25,7 +25,7 @@ impl Command for Ast {
             .required(
                 "pipeline",
                 SyntaxShape::String,
-                "the pipeline to print the ast for.",
+                "The pipeline to print the ast for.",
             )
             .switch("json", "serialize to json", Some('j'))
             .switch("minify", "minify the nuon or json output", Some('m'))

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -23,7 +23,7 @@ impl Command for Explain {
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
-                "the closure to run",
+                "The closure to run.",
             )
             .input_output_types(vec![(Type::Any, Type::Any), (Type::Nothing, Type::Any)])
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -25,7 +25,7 @@ impl Command for Metadata {
             .optional(
                 "expression",
                 SyntaxShape::Any,
-                "the expression you want metadata for",
+                "The expression you want metadata for.",
             )
             .category(Category::Debug)
     }

--- a/crates/nu-command/src/debug/timeit.rs
+++ b/crates/nu-command/src/debug/timeit.rs
@@ -24,7 +24,7 @@ impl Command for TimeIt {
             .required(
                 "command",
                 SyntaxShape::OneOf(vec![SyntaxShape::Block, SyntaxShape::Expression]),
-                "the command or block to run",
+                "The command or block to run.",
             )
             .input_output_types(vec![
                 (Type::Any, Type::Duration),

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -22,7 +22,7 @@ impl Command for ViewSource {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("view source")
             .input_output_types(vec![(Type::Nothing, Type::String)])
-            .required("item", SyntaxShape::Any, "name or block to view")
+            .required("item", SyntaxShape::Any, "Name or block to view.")
             .category(Category::Debug)
     }
 

--- a/crates/nu-command/src/debug/view_span.rs
+++ b/crates/nu-command/src/debug/view_span.rs
@@ -25,8 +25,8 @@ impl Command for ViewSpan {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("view span")
             .input_output_types(vec![(Type::Nothing, Type::String)])
-            .required("start", SyntaxShape::Int, "start of the span")
-            .required("end", SyntaxShape::Int, "end of the span")
+            .required("start", SyntaxShape::Int, "Start of the span.")
+            .required("end", SyntaxShape::Int, "End of the span.")
             .category(Category::Debug)
     }
 

--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -19,7 +19,7 @@ impl Command for ExportEnv {
             .required(
                 "block",
                 SyntaxShape::Block,
-                "the block to run to set the environment",
+                "The block to run to set the environment.",
             )
             .category(Category::Env)
     }

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -27,7 +27,7 @@ impl Command for LoadEnv {
             .optional(
                 "update",
                 SyntaxShape::Record(vec![]),
-                "the record to use for updates",
+                "The record to use for updates.",
             )
             .category(Category::FileSystem)
     }

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -24,7 +24,7 @@ impl Command for SourceEnv {
             .required(
                 "filename",
                 SyntaxShape::String, // type is string to avoid automatically canonicalizing the path
-                "the filepath to the script file to source the environment from",
+                "The filepath to the script file to source the environment from.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -21,12 +21,12 @@ impl Command for WithEnv {
             .required(
                 "variable",
                 SyntaxShape::Any,
-                "the environment variable to temporarily set",
+                "The environment variable to temporarily set.",
             )
             .required(
                 "block",
                 SyntaxShape::Closure(None),
-                "the block to run once the variable is set",
+                "The block to run once the variable is set.",
             )
             .category(Category::Env)
     }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -43,7 +43,7 @@ impl Command for Cd {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("cd")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .optional("path", SyntaxShape::Directory, "the path to change to")
+            .optional("path", SyntaxShape::Directory, "The path to change to.")
             .input_output_types(vec![
                 (Type::Nothing, Type::Nothing),
                 (Type::String, Type::Nothing),

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -39,8 +39,8 @@ impl Command for Cp {
     fn signature(&self) -> Signature {
         Signature::build("cp-old")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("source", SyntaxShape::GlobPattern, "the place to copy from")
-            .required("destination", SyntaxShape::Filepath, "the place to copy to")
+            .required("source", SyntaxShape::GlobPattern, "the place to copy from.")
+            .required("destination", SyntaxShape::Filepath, "the place to copy to.")
             .switch(
                 "recursive",
                 "copy recursively through subdirectories",

--- a/crates/nu-command/src/filesystem/cp.rs
+++ b/crates/nu-command/src/filesystem/cp.rs
@@ -39,8 +39,8 @@ impl Command for Cp {
     fn signature(&self) -> Signature {
         Signature::build("cp-old")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("source", SyntaxShape::GlobPattern, "the place to copy from.")
-            .required("destination", SyntaxShape::Filepath, "the place to copy to.")
+            .required("source", SyntaxShape::GlobPattern, "The place to copy from.")
+            .required("destination", SyntaxShape::Filepath, "The place to copy to.")
             .switch(
                 "recursive",
                 "copy recursively through subdirectories",

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -21,7 +21,7 @@ impl Command for Glob {
     fn signature(&self) -> Signature {
         Signature::build("glob")
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::String)))])
-            .required("glob", SyntaxShape::String, "the glob expression")
+            .required("glob", SyntaxShape::String, "The glob expression.")
             .named(
                 "depth",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -39,7 +39,7 @@ impl Command for Ls {
         Signature::build("ls")
             .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             // Using a string instead of a glob pattern shape so it won't auto-expand
-            .optional("pattern", SyntaxShape::String, "the glob pattern to use")
+            .optional("pattern", SyntaxShape::String, "The glob pattern to use.")
             .switch("all", "Show hidden files", Some('a'))
             .switch(
                 "long",

--- a/crates/nu-command/src/filesystem/mkdir.rs
+++ b/crates/nu-command/src/filesystem/mkdir.rs
@@ -23,7 +23,7 @@ impl Command for Mkdir {
             .rest(
                 "rest",
                 SyntaxShape::Directory,
-                "the name(s) of the path(s) to create",
+                "The name(s) of the path(s) to create.",
             )
             .switch("verbose", "print created path(s).", Some('v'))
             .category(Category::FileSystem)

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -33,12 +33,12 @@ impl Command for Mv {
             .required(
                 "source",
                 SyntaxShape::GlobPattern,
-                "the location to move files/directories from",
+                "The location to move files/directories from.",
             )
             .required(
                 "destination",
                 SyntaxShape::Filepath,
-                "the location to move files/directories to",
+                "The location to move files/directories to.",
             )
             .switch(
                 "verbose",

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -41,7 +41,7 @@ impl Command for Open {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("open")
             .input_output_types(vec![(Type::Nothing, Type::Any), (Type::String, Type::Any)])
-            .optional("filename", SyntaxShape::Filepath, "the filename to use")
+            .optional("filename", SyntaxShape::Filepath, "The filename to use.")
             .rest(
                 "filenames",
                 SyntaxShape::Filepath,

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -45,7 +45,7 @@ impl Command for Open {
             .rest(
                 "filenames",
                 SyntaxShape::Filepath,
-                "optional additional files to open",
+                "Optional additional files to open.",
             )
             .switch("raw", "open file as raw binary", Some('r'))
             .category(Category::FileSystem)

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -68,7 +68,7 @@ impl Command for Rm {
             .rest(
                 "rest",
                 SyntaxShape::GlobPattern,
-                "additional file path(s) to remove",
+                "Additional file path(s) to remove.",
             )
             .category(Category::FileSystem)
     }

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -44,7 +44,7 @@ impl Command for Rm {
             .required(
                 "filename",
                 SyntaxShape::GlobPattern,
-                "the file or files you want to remove",
+                "The file or files you want to remove.",
             )
             .switch(
                 "trash",

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -42,7 +42,7 @@ impl Command for Save {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("save")
             .input_output_types(vec![(Type::Any, Type::Nothing)])
-            .required("filename", SyntaxShape::Filepath, "the filename to use")
+            .required("filename", SyntaxShape::Filepath, "The filename to use.")
             .named(
                 "stderr",
                 SyntaxShape::Filepath,

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -30,7 +30,7 @@ impl Command for Start {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("start")
             .input_output_types(vec![(Type::Nothing, Type::Any), (Type::String, Type::Any)])
-            .required("path", SyntaxShape::String, "path to open")
+            .required("path", SyntaxShape::String, "Path to open.")
             .category(Category::FileSystem)
     }
 

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -29,7 +29,7 @@ impl Command for Touch {
             .required(
                 "filename",
                 SyntaxShape::Filepath,
-                "the path of the file you want to create",
+                "The path of the file you want to create.",
             )
             .named(
                 "reference",

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -52,7 +52,7 @@ impl Command for Touch {
                 "do not create the file if it does not exist",
                 Some('c'),
             )
-            .rest("rest", SyntaxShape::Filepath, "additional files to create")
+            .rest("rest", SyntaxShape::Filepath, "Additional files to create.")
             .category(Category::FileSystem)
     }
 

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -54,7 +54,7 @@ impl Command for UCp {
             .switch("progress", "display a progress bar", Some('p'))
             .switch("no-clobber", "do not overwrite an existing file", Some('n'))
             .switch("debug", "explain how a file is copied. Implies -v", None)
-            .rest("paths", SyntaxShape::Filepath, "Copy SRC file/s to DEST")
+            .rest("paths", SyntaxShape::Filepath, "Copy SRC file/s to DEST.")
             .allow_variants_without_examples(true)
             .category(Category::FileSystem)
     }

--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -33,7 +33,7 @@ impl Command for UMkdir {
             .rest(
                 "rest",
                 SyntaxShape::Directory,
-                "the name(s) of the path(s) to create",
+                "The name(s) of the path(s) to create.",
             )
             .switch(
                 "verbose",

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -40,10 +40,10 @@ impl Command for Watch {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("watch")
         .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
-            .required("path", SyntaxShape::Filepath, "the path to watch. Can be a file or directory")
+            .required("path", SyntaxShape::Filepath, "The path to watch. Can be a file or directory.")
             .required("closure",
             SyntaxShape::Closure(Some(vec![SyntaxShape::String, SyntaxShape::String, SyntaxShape::String])),
-                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order")
+                "Some Nu code to run whenever a file changes. The closure will be passed `operation`, `path`, and `new_path` (for renames only) arguments in that order.")
             .named(
                 "debounce-ms",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -23,7 +23,7 @@ impl Command for All {
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "a closure that must evaluate to a boolean",
+                "a closure that must evaluate to a boolean.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -23,7 +23,7 @@ impl Command for All {
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "a closure that must evaluate to a boolean.",
+                "A closure that must evaluate to a boolean.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -23,7 +23,7 @@ impl Command for Any {
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "a closure that must evaluate to a boolean",
+                "a closure that must evaluate to a boolean.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -23,7 +23,7 @@ impl Command for Any {
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "a closure that must evaluate to a boolean.",
+                "A closure that must evaluate to a boolean.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -20,7 +20,7 @@ impl Command for Append {
             .required(
                 "row",
                 SyntaxShape::Any,
-                "the row, list, or table to append.",
+                "The row, list, or table to append.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/append.rs
+++ b/crates/nu-command/src/filters/append.rs
@@ -17,7 +17,11 @@ impl Command for Append {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("append")
             .input_output_types(vec![(Type::Any, Type::List(Box::new(Type::Any)))])
-            .required("row", SyntaxShape::Any, "the row, list, or table to append")
+            .required(
+                "row",
+                SyntaxShape::Any,
+                "the row, list, or table to append.",
+            )
             .allow_variants_without_examples(true)
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -35,7 +35,7 @@ impl Command for Compact {
             .rest(
                 "columns",
                 SyntaxShape::Any,
-                "the columns to compact from the table",
+                "The columns to compact from the table.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -22,7 +22,7 @@ impl Command for Default {
             .required(
                 "default value",
                 SyntaxShape::Any,
-                "the value to use as a default",
+                "The value to use as a default.",
             )
             .optional("column name", SyntaxShape::String, "the name of the column")
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -24,7 +24,11 @@ impl Command for Default {
                 SyntaxShape::Any,
                 "The value to use as a default.",
             )
-            .optional("column name", SyntaxShape::String, "the name of the column")
+            .optional(
+                "column name",
+                SyntaxShape::String,
+                "The name of the column.",
+            )
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -25,7 +25,7 @@ impl Command for DropColumn {
             .optional(
                 "columns",
                 SyntaxShape::Int,
-                "starting from the end, the number of columns to remove",
+                "Starting from the end, the number of columns to remove.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/drop/drop_.rs
+++ b/crates/nu-command/src/filters/drop/drop_.rs
@@ -24,7 +24,7 @@ impl Command for Drop {
                     Type::List(Box::new(Type::Any)),
                 ),
             ])
-            .optional("rows", SyntaxShape::Int, "The number of items to remove")
+            .optional("rows", SyntaxShape::Int, "The number of items to remove.")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -25,7 +25,7 @@ impl Command for DropNth {
                 "row number or row range",
                 // FIXME: we can make this accept either Int or Range when we can compose SyntaxShapes
                 SyntaxShape::Any,
-                "the number of the row to drop or a range to drop consecutive rows",
+                "The number of the row to drop or a range to drop consecutive rows.",
             )
             .rest("rest", SyntaxShape::Any, "the number of the row to drop")
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -27,7 +27,7 @@ impl Command for DropNth {
                 SyntaxShape::Any,
                 "The number of the row to drop or a range to drop consecutive rows.",
             )
-            .rest("rest", SyntaxShape::Any, "the number of the row to drop")
+            .rest("rest", SyntaxShape::Any, "The number of the row to drop.")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/each.rs
+++ b/crates/nu-command/src/filters/each.rs
@@ -46,7 +46,7 @@ with 'transpose' first."#
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "the closure to run",
+                "The closure to run.",
             )
             .switch("keep-empty", "keep empty result cells", Some('k'))
             .allow_variants_without_examples(true)

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -20,7 +20,7 @@ impl Command for Empty {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "the names of the columns to check emptiness",
+                "The names of the columns to check emptiness.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/every.rs
+++ b/crates/nu-command/src/filters/every.rs
@@ -24,7 +24,7 @@ impl Command for Every {
             .required(
                 "stride",
                 SyntaxShape::Int,
-                "how many rows to skip between (and including) each row returned",
+                "How many rows to skip between (and including) each row returned.",
             )
             .switch(
                 "skip",

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -37,7 +37,7 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "Predicate closure",
+                "Predicate closure.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -64,7 +64,7 @@ impl Command for Find {
                 Some('c'),
             )
             .switch("invert", "invert the match", Some('v'))
-            .rest("rest", SyntaxShape::Any, "terms to search")
+            .rest("rest", SyntaxShape::Any, "Terms to search.")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -38,7 +38,7 @@ impl Command for First {
             .optional(
                 "rows",
                 SyntaxShape::Int,
-                "starting from the front, the number of rows to return",
+                "Starting from the front, the number of rows to return.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -28,7 +28,7 @@ impl Command for Flatten {
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "optionally flatten data by column",
+                "Optionally flatten data by column.",
             )
             .switch("all", "flatten inner table one level out", Some('a'))
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -41,7 +41,7 @@ If multiple cell paths are given, this will produce a list of values."#
                 SyntaxShape::CellPath,
                 "The cell path to the data.",
             )
-            .rest("rest", SyntaxShape::CellPath, "additional cell paths")
+            .rest("rest", SyntaxShape::CellPath, "Additional cell paths.")
             .switch(
                 "ignore-errors",
                 "ignore missing data (make all cell path members optional)",

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -39,7 +39,7 @@ If multiple cell paths are given, this will produce a list of values."#
             .required(
                 "cell_path",
                 SyntaxShape::CellPath,
-                "the cell path to the data",
+                "The cell path to the data.",
             )
             .rest("rest", SyntaxShape::CellPath, "additional cell paths")
             .switch(

--- a/crates/nu-command/src/filters/group.rs
+++ b/crates/nu-command/src/filters/group.rs
@@ -24,7 +24,7 @@ impl Command for Group {
                 Type::List(Box::new(Type::Any)),
                 Type::List(Box::new(Type::List(Box::new(Type::Any)))),
             )])
-            .required("group_size", SyntaxShape::Int, "the size of each group")
+            .required("group_size", SyntaxShape::Int, "The size of each group.")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -39,7 +39,7 @@ impl Command for GroupBy {
                     SyntaxShape::Closure(None),
                     SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                 ]),
-                "the path to the column to group on",
+                "The path to the column to group on.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/insert.rs
+++ b/crates/nu-command/src/filters/insert.rs
@@ -27,12 +27,12 @@ impl Command for Insert {
             .required(
                 "field",
                 SyntaxShape::CellPath,
-                "the name of the column to insert",
+                "The name of the column to insert.",
             )
             .required(
                 "new value",
                 SyntaxShape::Any,
-                "the new value to give the cell(s)",
+                "The new value to give the cell(s).",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -22,7 +22,7 @@ impl Command for Items {
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Any])),
-                "the closure to run",
+                "The closure to run.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/join.rs
+++ b/crates/nu-command/src/filters/join.rs
@@ -33,12 +33,12 @@ impl Command for Join {
             .required(
                 "right-table",
                 SyntaxShape::List(Box::new(SyntaxShape::Any)),
-                "The right table in the join",
+                "The right table in the join.",
             )
             .required(
                 "left-on",
                 SyntaxShape::String,
-                "Name of column in input (left) table to join on",
+                "Name of column in input (left) table to join on.",
             )
             .optional(
                 "right-on",

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -31,7 +31,7 @@ impl Command for Last {
             .optional(
                 "rows",
                 SyntaxShape::Int,
-                "starting from the back, the number of rows to return",
+                "Starting from the back, the number of rows to return.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/merge.rs
+++ b/crates/nu-command/src/filters/merge.rs
@@ -36,7 +36,7 @@ repeating this process with row 1, and so on."#
                 "value",
                 // Both this and `update` should have a shape more like <record> | <table> than just <any>. -Leon 2022-10-27
                 SyntaxShape::Any,
-                "the new value to merge with",
+                "The new value to merge with.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -30,7 +30,7 @@ impl Command for Move {
                 (Type::Record(vec![]), Type::Record(vec![])),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .rest("columns", SyntaxShape::String, "the columns to move")
+            .rest("columns", SyntaxShape::String, "The columns to move.")
             .named(
                 "after",
                 SyntaxShape::String,

--- a/crates/nu-command/src/filters/par_each.rs
+++ b/crates/nu-command/src/filters/par_each.rs
@@ -45,7 +45,7 @@ impl Command for ParEach {
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "the closure to run",
+                "The closure to run.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/prepend.rs
+++ b/crates/nu-command/src/filters/prepend.rs
@@ -20,7 +20,7 @@ impl Command for Prepend {
             .required(
                 "row",
                 SyntaxShape::Any,
-                "the row, list, or table to prepend",
+                "The row, list, or table to prepend.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/range.rs
+++ b/crates/nu-command/src/filters/range.rs
@@ -21,11 +21,7 @@ impl Command for Range {
                 Type::List(Box::new(Type::Any)),
                 Type::List(Box::new(Type::Any)),
             )])
-            .required(
-                "rows",
-                SyntaxShape::Range,
-                "range of rows to return: Eg) 4..7 (=> from 4 to 7)",
-            )
+            .required("rows", SyntaxShape::Range, "Range of rows to return.")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/reduce.rs
+++ b/crates/nu-command/src/filters/reduce.rs
@@ -35,7 +35,7 @@ impl Command for Reduce {
                     SyntaxShape::Any,
                     SyntaxShape::Int,
                 ])),
-                "reducing function",
+                "Reducing function.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -33,7 +33,7 @@ impl Command for Reject {
                     SyntaxShape::CellPath,
                     SyntaxShape::List(Box::new(SyntaxShape::CellPath)),
                 ]),
-                "the names of columns to remove from the table",
+                "The names of columns to remove from the table.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -34,7 +34,11 @@ impl Command for Rename {
                 "A closure to apply changes on each column",
                 Some('b'),
             )
-            .rest("rest", SyntaxShape::String, "the new names for the columns")
+            .rest(
+                "rest",
+                SyntaxShape::String,
+                "The new names for the columns.",
+            )
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -34,7 +34,7 @@ impl Command for Select {
                     SyntaxShape::CellPath,
                     SyntaxShape::List(Box::new(SyntaxShape::CellPath)),
                 ]),
-                "the columns to select from the table",
+                "The columns to select from the table.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -25,7 +25,7 @@ impl Command for Skip {
                     Type::List(Box::new(Type::Any)),
                 ),
             ])
-            .optional("n", SyntaxShape::Int, "the number of elements to skip")
+            .optional("n", SyntaxShape::Int, "The number of elements to skip.")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/skip/skip_until.rs
+++ b/crates/nu-command/src/filters/skip/skip_until.rs
@@ -26,7 +26,7 @@ impl Command for SkipUntil {
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "the predicate that skipped element must not match",
+                "The predicate that skipped element must not match.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/skip/skip_while.rs
+++ b/crates/nu-command/src/filters/skip/skip_while.rs
@@ -26,7 +26,7 @@ impl Command for SkipWhile {
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "the predicate that skipped element must match",
+                "The predicate that skipped element must match.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/sort_by.rs
+++ b/crates/nu-command/src/filters/sort_by.rs
@@ -24,7 +24,7 @@ impl Command for SortBy {
                 (Type::Record(vec![]), Type::Table(vec![])),
                 (Type::Table(vec![]), Type::Table(vec![])),
             ])
-            .rest("columns", SyntaxShape::Any, "the column(s) to sort by")
+            .rest("columns", SyntaxShape::Any, "The column(s) to sort by.")
             .switch("reverse", "Sort in reverse order", Some('r'))
             .switch(
                 "ignore-case",

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -18,7 +18,7 @@ impl Command for SplitBy {
     fn signature(&self) -> Signature {
         Signature::build("split-by")
             .input_output_types(vec![(Type::Record(vec![]), Type::Record(vec![]))])
-            .optional("splitter", SyntaxShape::Any, "the splitter value to use")
+            .optional("splitter", SyntaxShape::Any, "The splitter value to use.")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/take/take_.rs
+++ b/crates/nu-command/src/filters/take/take_.rs
@@ -28,7 +28,7 @@ impl Command for Take {
             .required(
                 "n",
                 SyntaxShape::Int,
-                "starting from the front, the number of elements to return",
+                "Starting from the front, the number of elements to return.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/take/take_until.rs
+++ b/crates/nu-command/src/filters/take/take_until.rs
@@ -26,7 +26,7 @@ impl Command for TakeUntil {
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "the predicate that element(s) must not match",
+                "The predicate that element(s) must not match.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/take/take_while.rs
+++ b/crates/nu-command/src/filters/take/take_while.rs
@@ -26,7 +26,7 @@ impl Command for TakeWhile {
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),
-                "the predicate that element(s) must match",
+                "The predicate that element(s) must match.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/transpose.rs
+++ b/crates/nu-command/src/filters/transpose.rs
@@ -59,7 +59,7 @@ impl Command for Transpose {
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "the names to give columns once transposed",
+                "The names to give columns once transposed.",
             )
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/uniq_by.rs
+++ b/crates/nu-command/src/filters/uniq_by.rs
@@ -24,7 +24,7 @@ impl Command for UniqBy {
                     Type::List(Box::new(Type::Any)),
                 ),
             ])
-            .rest("columns", SyntaxShape::Any, "the column(s) to filter by")
+            .rest("columns", SyntaxShape::Any, "The column(s) to filter by.")
             .switch(
                 "count",
                 "Return a table containing the distinct input values together with their counts",

--- a/crates/nu-command/src/filters/update.rs
+++ b/crates/nu-command/src/filters/update.rs
@@ -27,12 +27,12 @@ impl Command for Update {
             .required(
                 "field",
                 SyntaxShape::CellPath,
-                "the name of the column to update",
+                "The name of the column to update.",
             )
             .required(
                 "replacement value",
                 SyntaxShape::Any,
-                "the new value to give the cell(s), or a closure to create the value",
+                "The new value to give the cell(s), or a closure to create the value.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -27,12 +27,12 @@ impl Command for Upsert {
             .required(
                 "field",
                 SyntaxShape::CellPath,
-                "the name of the column to update or insert",
+                "The name of the column to update or insert.",
             )
             .required(
                 "replacement value",
                 SyntaxShape::Any,
-                "the new value to give the cell(s), or a closure to create the value",
+                "The new value to give the cell(s), or a closure to create the value.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -37,7 +37,7 @@ not supported."#
             .required(
                 "row_condition",
                 SyntaxShape::RowCondition,
-                "Filter condition",
+                "Filter condition.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Filters)

--- a/crates/nu-command/src/filters/window.rs
+++ b/crates/nu-command/src/filters/window.rs
@@ -20,7 +20,7 @@ impl Command for Window {
                 Type::List(Box::new(Type::Any)),
                 Type::List(Box::new(Type::List(Box::new(Type::Any)))),
             )])
-            .required("window_size", SyntaxShape::Int, "the size of each window")
+            .required("window_size", SyntaxShape::Int, "The size of each window.")
             .named(
                 "stride",
                 SyntaxShape::Int,

--- a/crates/nu-command/src/filters/wrap.rs
+++ b/crates/nu-command/src/filters/wrap.rs
@@ -25,7 +25,7 @@ impl Command for Wrap {
                 (Type::Range, Type::Table(vec![])),
                 (Type::Any, Type::Record(vec![])),
             ])
-            .required("name", SyntaxShape::String, "the name of the column")
+            .required("name", SyntaxShape::String, "The name of the column.")
             .allow_variants_without_examples(true)
             .category(Category::Filters)
     }

--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -30,7 +30,7 @@ impl Command for Zip {
                     Type::List(Box::new(Type::List(Box::new(Type::Any)))),
                 ),
             ])
-            .required("other", SyntaxShape::Any, "the other input")
+            .required("other", SyntaxShape::Any, "The other input.")
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -24,11 +24,11 @@ impl Command for Generate {
                     Type::List(Box::new(Type::Any)),
                 ),
             ])
-            .required("initial", SyntaxShape::Any, "initial value")
+            .required("initial", SyntaxShape::Any, "Initial value.")
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
-                "generator function",
+                "Generator function.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Generators)

--- a/crates/nu-command/src/generators/seq.rs
+++ b/crates/nu-command/src/generators/seq.rs
@@ -17,7 +17,7 @@ impl Command for Seq {
     fn signature(&self) -> Signature {
         Signature::build("seq")
             .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::Number)))])
-            .rest("rest", SyntaxShape::Number, "sequence values")
+            .rest("rest", SyntaxShape::Number, "Sequence values.")
             .category(Category::Generators)
     }
 

--- a/crates/nu-command/src/generators/seq_char.rs
+++ b/crates/nu-command/src/generators/seq_char.rs
@@ -23,12 +23,12 @@ impl Command for SeqChar {
             .required(
                 "start",
                 SyntaxShape::String,
-                "start of character sequence (inclusive)",
+                "Start of character sequence (inclusive).",
             )
             .required(
                 "end",
                 SyntaxShape::String,
-                "end of character sequence (inclusive)",
+                "End of character sequence (inclusive).",
             )
             .category(Category::Generators)
     }

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -68,7 +68,7 @@ where
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                format!("optionally {} hash data by cell path", D::name()),
+                format!("Optionally {} hash data by cell path.", D::name()),
             )
     }
 

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -28,7 +28,7 @@ impl Command for Help {
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "the name of command, alias or module to get help on",
+                "The name of command, alias or module to get help on.",
             )
             .named(
                 "find",

--- a/crates/nu-command/src/help/help_aliases.rs
+++ b/crates/nu-command/src/help/help_aliases.rs
@@ -26,7 +26,7 @@ impl Command for HelpAliases {
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "the name of alias to get help on",
+                "The name of alias to get help on.",
             )
             .named(
                 "find",

--- a/crates/nu-command/src/help/help_commands.rs
+++ b/crates/nu-command/src/help/help_commands.rs
@@ -27,7 +27,7 @@ impl Command for HelpCommands {
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "the name of command to get help on",
+                "The name of command to get help on.",
             )
             .named(
                 "find",

--- a/crates/nu-command/src/help/help_externs.rs
+++ b/crates/nu-command/src/help/help_externs.rs
@@ -26,7 +26,7 @@ impl Command for HelpExterns {
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "the name of extern to get help on",
+                "The name of extern to get help on.",
             )
             .named(
                 "find",

--- a/crates/nu-command/src/help/help_modules.rs
+++ b/crates/nu-command/src/help/help_modules.rs
@@ -32,7 +32,7 @@ are also available in the current scope. Commands/aliases that were imported und
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "the name of module to get help on",
+                "The name of module to get help on.",
             )
             .named(
                 "find",

--- a/crates/nu-command/src/math/log.rs
+++ b/crates/nu-command/src/math/log.rs
@@ -18,7 +18,7 @@ impl Command for SubCommand {
             .required(
                 "base",
                 SyntaxShape::Number,
-                "Base for which the logarithm should be computed",
+                "Base for which the logarithm should be computed.",
             )
             .input_output_types(vec![
                 (Type::Number, Type::Float),

--- a/crates/nu-command/src/misc/source.rs
+++ b/crates/nu-command/src/misc/source.rs
@@ -18,7 +18,7 @@ impl Command for Source {
             .required(
                 "filename",
                 SyntaxShape::Filepath,
-                "the filepath to the script file to source",
+                "The filepath to the script file to source.",
             )
             .category(Category::Core)
     }

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -22,7 +22,7 @@ impl Command for Tutor {
             .optional(
                 "search",
                 SyntaxShape::String,
-                "item to search for, or 'list' to list available tutorials",
+                "Item to search for, or 'list' to list available tutorials.",
             )
             .named(
                 "find",

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
             .required(
                 "URL",
                 SyntaxShape::String,
-                "the URL to fetch the contents from",
+                "The URL to fetch the contents from.",
             )
             .named(
                 "user",

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
             .required(
                 "URL",
                 SyntaxShape::String,
-                "the URL to fetch the contents from",
+                "The URL to fetch the contents from.",
             )
             .named(
                 "user",

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
             .required(
                 "URL",
                 SyntaxShape::String,
-                "the URL to fetch the contents from",
+                "The URL to fetch the contents from.",
             )
             .named(
                 "user",

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
             .required(
                 "URL",
                 SyntaxShape::String,
-                "the URL to fetch the options from",
+                "The URL to fetch the options from.",
             )
             .named(
                 "user",

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -24,8 +24,8 @@ impl Command for SubCommand {
         Signature::build("http patch")
             .input_output_types(vec![(Type::Nothing, Type::Any)])
             .allow_variants_without_examples(true)
-            .required("URL", SyntaxShape::String, "the URL to post to")
-            .required("data", SyntaxShape::Any, "the contents of the post body")
+            .required("URL", SyntaxShape::String, "The URL to post to.")
+            .required("data", SyntaxShape::Any, "The contents of the post body.")
             .named(
                 "user",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -24,8 +24,8 @@ impl Command for SubCommand {
         Signature::build("http post")
             .input_output_types(vec![(Type::Nothing, Type::Any)])
             .allow_variants_without_examples(true)
-            .required("URL", SyntaxShape::String, "the URL to post to")
-            .required("data", SyntaxShape::Any, "the contents of the post body")
+            .required("URL", SyntaxShape::String, "The URL to post to.")
+            .required("data", SyntaxShape::Any, "The contents of the post body.")
             .named(
                 "user",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -24,8 +24,8 @@ impl Command for SubCommand {
         Signature::build("http put")
             .input_output_types(vec![(Type::Nothing, Type::Any)])
             .allow_variants_without_examples(true)
-            .required("URL", SyntaxShape::String, "the URL to post to")
-            .required("data", SyntaxShape::Any, "the contents of the post body")
+            .required("URL", SyntaxShape::String, "The URL to post to.")
+            .required("data", SyntaxShape::Any, "The contents of the post body.")
             .named(
                 "user",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/network/port.rs
+++ b/crates/nu-command/src/network/port.rs
@@ -22,9 +22,9 @@ impl Command for SubCommand {
             .optional(
                 "start",
                 SyntaxShape::Int,
-                "The start port to scan (inclusive)",
+                "The start port to scan (inclusive).",
             )
-            .optional("end", SyntaxShape::Int, "The end port to scan (inclusive)")
+            .optional("end", SyntaxShape::Int, "The end port to scan (inclusive).")
             .category(Category::Network)
     }
 

--- a/crates/nu-command/src/network/url/decode.rs
+++ b/crates/nu-command/src/network/url/decode.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, url decode strings at the given cell paths",
+                "For a data structure input, url decode strings at the given cell paths.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -31,7 +31,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, check strings at the given cell paths, and replace with result",
+                "For a data structure input, check strings at the given cell paths, and replace with result.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/network/url/parse.rs
+++ b/crates/nu-command/src/network/url/parse.rs
@@ -26,7 +26,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "optionally operate by cell path",
+                "Optionally operate by cell path.",
             )
             .category(Category::Network)
     }

--- a/crates/nu-command/src/path/join.rs
+++ b/crates/nu-command/src/path/join.rs
@@ -32,7 +32,11 @@ impl Command for SubCommand {
                 (Type::Record(vec![]), Type::String),
                 (Type::Table(vec![]), Type::List(Box::new(Type::String))),
             ])
-            .rest("append", SyntaxShape::String, "Path to append to the input")
+            .rest(
+                "append",
+                SyntaxShape::String,
+                "Path to append to the input.",
+            )
             .category(Category::Path)
     }
 

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
             .required(
                 "path",
                 SyntaxShape::String,
-                "Parent shared with the input path",
+                "Parent shared with the input path.",
             )
             .category(Category::Path)
     }

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -514,7 +514,7 @@ impl Command for AnsiCommand {
             .optional(
                 "code",
                 SyntaxShape::Any,
-                "the name of the code to use like 'green' or 'reset' to reset the color",
+                "The name of the code to use (from `ansi -l`).",
             )
             .switch(
                 "escape", // \x1b[

--- a/crates/nu-command/src/platform/ansi/link.rs
+++ b/crates/nu-command/src/platform/ansi/link.rs
@@ -37,7 +37,7 @@ impl Command for SubCommand {
             .rest(
                 "cell path",
                 SyntaxShape::CellPath,
-                "for a data structure input, add links to all strings at the given cell paths",
+                "For a data structure input, add links to all strings at the given cell paths.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Platform)

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -24,7 +24,7 @@ impl Command for SubCommand {
             .rest(
                 "cell path",
                 SyntaxShape::CellPath,
-                "for a data structure input, remove ANSI sequences from strings at the given cell paths",
+                "For a data structure input, remove ANSI sequences from strings at the given cell paths.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Platform)

--- a/crates/nu-command/src/platform/du.rs
+++ b/crates/nu-command/src/platform/du.rs
@@ -38,7 +38,7 @@ impl Command for Du {
         Signature::build("du")
             .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
-            .optional("path", SyntaxShape::GlobPattern, "starting directory")
+            .optional("path", SyntaxShape::GlobPattern, "Starting directory.")
             .switch(
                 "all",
                 "Output file sizes as well as directory sizes",

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -39,7 +39,7 @@ impl Command for Input {
                 (Type::Nothing, Type::Binary),
             ])
             .allow_variants_without_examples(true)
-            .optional("prompt", SyntaxShape::String, "prompt to show the user")
+            .optional("prompt", SyntaxShape::String, "Prompt to show the user.")
             .named(
                 "bytes-until-any",
                 SyntaxShape::String,

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -46,7 +46,7 @@ impl Command for InputList {
                 (Type::List(Box::new(Type::Any)), Type::Any),
                 (Type::Range, Type::Int),
             ])
-            .optional("prompt", SyntaxShape::String, "the prompt to display")
+            .optional("prompt", SyntaxShape::String, "The prompt to display.")
             .switch(
                 "multi",
                 "Use multiple results, you can press a to toggle all options on/off",

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -28,7 +28,7 @@ impl Command for Kill {
                 SyntaxShape::Int,
                 "Process id of process that is to be killed.",
             )
-            .rest("rest", SyntaxShape::Int, "rest of processes to kill")
+            .rest("rest", SyntaxShape::Int, "Rest of processes to kill.")
             .switch("force", "forcefully kill the process", Some('f'))
             .switch("quiet", "won't print anything to the console", Some('q'))
             .category(Category::Platform);

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -26,7 +26,7 @@ impl Command for Kill {
             .required(
                 "pid",
                 SyntaxShape::Int,
-                "process id of process that is to be killed",
+                "Process id of process that is to be killed.",
             )
             .rest("rest", SyntaxShape::Int, "rest of processes to kill")
             .switch("force", "forcefully kill the process", Some('f'))

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -27,7 +27,7 @@ impl Command for Sleep {
     fn signature(&self) -> Signature {
         Signature::build("sleep")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
-            .required("duration", SyntaxShape::Duration, "time to sleep")
+            .required("duration", SyntaxShape::Duration, "Time to sleep.")
             .rest("rest", SyntaxShape::Duration, "additional time")
             .category(Category::Platform)
     }

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -28,7 +28,7 @@ impl Command for Sleep {
         Signature::build("sleep")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("duration", SyntaxShape::Duration, "Time to sleep.")
-            .rest("rest", SyntaxShape::Duration, "additional time")
+            .rest("rest", SyntaxShape::Duration, "Additional time.")
             .category(Category::Platform)
     }
 

--- a/crates/nu-command/src/random/float.rs
+++ b/crates/nu-command/src/random/float.rs
@@ -20,7 +20,7 @@ impl Command for SubCommand {
         Signature::build("random float")
             .input_output_types(vec![(Type::Nothing, Type::Float)])
             .allow_variants_without_examples(true)
-            .optional("range", SyntaxShape::Range, "Range of values")
+            .optional("range", SyntaxShape::Range, "Range of values.")
             .category(Category::Random)
     }
 

--- a/crates/nu-command/src/random/int.rs
+++ b/crates/nu-command/src/random/int.rs
@@ -20,7 +20,7 @@ impl Command for SubCommand {
         Signature::build("random int")
             .input_output_types(vec![(Type::Nothing, Type::Int)])
             .allow_variants_without_examples(true)
-            .optional("range", SyntaxShape::Range, "Range of values")
+            .optional("range", SyntaxShape::Range, "Range of values.")
             .category(Category::Random)
     }
 

--- a/crates/nu-command/src/removed/format.rs
+++ b/crates/nu-command/src/removed/format.rs
@@ -21,7 +21,7 @@ impl Command for SubCommand {
             .optional(
                 "format string",
                 SyntaxShape::String,
-                "the desired date format",
+                "The desired date format.",
             )
             .category(Category::Removed)
     }

--- a/crates/nu-command/src/removed/let_env.rs
+++ b/crates/nu-command/src/removed/let_env.rs
@@ -14,11 +14,11 @@ impl Command for LetEnv {
         Signature::build(self.name())
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .allow_variants_without_examples(true)
-            .optional("var_name", SyntaxShape::String, "variable name")
+            .optional("var_name", SyntaxShape::String, "Variable name.")
             .optional(
                 "initial_value",
                 SyntaxShape::Keyword(b"=".to_vec(), Box::new(SyntaxShape::MathExpression)),
-                "equals sign followed by value",
+                "Equals sign followed by value.",
             )
             .category(Category::Removed)
     }

--- a/crates/nu-command/src/shells/exit.rs
+++ b/crates/nu-command/src/shells/exit.rs
@@ -17,7 +17,7 @@ impl Command for Exit {
             .optional(
                 "exit_code",
                 SyntaxShape::Int,
-                "Exit code to return immediately with",
+                "Exit code to return immediately with.",
             )
             .category(Category::Shells)
     }

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -165,7 +165,7 @@ impl Command for Char {
             .optional(
                 "character",
                 SyntaxShape::Any,
-                "the name of the character to output",
+                "The name of the character to output.",
             )
             .rest("rest", SyntaxShape::Any, "multiple Unicode bytes")
             .switch("list", "List all supported character names", Some('l'))

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -167,7 +167,7 @@ impl Command for Char {
                 SyntaxShape::Any,
                 "The name of the character to output.",
             )
-            .rest("rest", SyntaxShape::Any, "multiple Unicode bytes")
+            .rest("rest", SyntaxShape::Any, "Multiple Unicode bytes.")
             .switch("list", "List all supported character names", Some('l'))
             .switch("unicode", "Unicode string i.e. 1f378", Some('u'))
             .switch("integer", "Create a codepoint from an integer", Some('i'))

--- a/crates/nu-command/src/strings/encode_decode/decode.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode.rs
@@ -25,7 +25,7 @@ impl Command for Decode {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("decode")
             .input_output_types(vec![(Type::Binary, Type::String)])
-            .optional("encoding", SyntaxShape::String, "the text encoding to use")
+            .optional("encoding", SyntaxShape::String, "The text encoding to use.")
             .category(Category::Strings)
     }
 

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -44,7 +44,7 @@ impl Command for DecodeBase64 {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, decode data at the given cell paths",
+                "For a data structure input, decode data at the given cell paths.",
             )
             .category(Category::Hash)
     }

--- a/crates/nu-command/src/strings/encode_decode/encode.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode.rs
@@ -29,7 +29,7 @@ impl Command for Encode {
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("encode")
             .input_output_types(vec![(Type::String, Type::Binary)])
-            .required("encoding", SyntaxShape::String, "the text encoding to use")
+            .required("encoding", SyntaxShape::String, "The text encoding to use.")
             .switch(
                 "ignore-errors",
                 "when a character isn't in the given encoding, replace with a HTML entity (like `&#127880;`)",

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -45,7 +45,7 @@ impl Command for EncodeBase64 {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, encode data at the given cell paths",
+                "For a data structure input, encode data at the given cell paths.",
             )
             .category(Category::Hash)
     }

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -31,7 +31,7 @@ impl Command for FormatDate {
             .optional(
                 "format string",
                 SyntaxShape::String,
-                "the desired format date",
+                "The desired format date.",
             )
             .category(Category::Date)
     }

--- a/crates/nu-command/src/strings/format/duration.rs
+++ b/crates/nu-command/src/strings/format/duration.rs
@@ -40,7 +40,7 @@ impl Command for FormatDuration {
             .required(
                 "format value",
                 SyntaxShape::String,
-                "the unit in which to display the duration",
+                "The unit in which to display the duration.",
             )
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/format/duration.rs
+++ b/crates/nu-command/src/strings/format/duration.rs
@@ -45,7 +45,7 @@ impl Command for FormatDuration {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, format duration at the given cell paths",
+                "For a data structure input, format duration at the given cell paths.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -37,7 +37,7 @@ impl Command for FormatFilesize {
             .required(
                 "format value",
                 SyntaxShape::String,
-                "the format into which convert the file sizes",
+                "The format into which convert the file sizes.",
             )
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -42,7 +42,7 @@ impl Command for FormatFilesize {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, format filesizes at the given cell paths",
+                "For a data structure input, format filesizes at the given cell paths.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -28,11 +28,7 @@ impl Command for Parse {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("parse")
-            .required(
-                "pattern",
-                SyntaxShape::String,
-                "the pattern to match. Eg) \"{foo}: {bar}\"",
-            )
+            .required("pattern", SyntaxShape::String, "The pattern to match.")
             .input_output_types(vec![
                 (Type::String, Type::Table(vec![])),
                 (Type::List(Box::new(Type::Any)), Type::Table(vec![])),

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "column names to give the new columns",
+                "column names to give the new columns.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
             .required(
                 "separator",
                 SyntaxShape::String,
-                "the character or string that denotes what separates columns",
+                "The character or string that denotes what separates columns.",
             )
             .switch("collapse-empty", "remove empty columns", Some('c'))
             .switch("regex", "separator is a regular expression", Some('r'))

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -35,7 +35,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::String,
-                "column names to give the new columns.",
+                "Column names to give the new columns.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -24,7 +24,7 @@ impl Command for SubCommand {
             .required(
                 "separator",
                 SyntaxShape::Any,
-                "the value that denotes what separates the list",
+                "The value that denotes what separates the list.",
             )
             .switch(
                 "regex", 

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -27,7 +27,7 @@ impl Command for SubCommand {
             .required(
                 "separator",
                 SyntaxShape::String,
-                "a character or regex that denotes what separates rows",
+                "A character or regex that denotes what separates rows.",
             )
             .named(
                 "number",

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, convert strings at the given cell paths",
+                "For a data structure input, convert strings at the given cell paths.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, convert strings at the given cell paths",
+                "For a data structure input, convert strings at the given cell paths.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -28,7 +28,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, convert strings at the given cell paths",
+                "For a data structure input, convert strings at the given cell paths.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -39,7 +39,7 @@ impl Command for SubCommand {
                 (Type::Record(vec![]), Type::Record(vec![])),
                 (Type::List(Box::new(Type::String)), Type::List(Box::new(Type::Bool)))
             ])
-            .required("string", SyntaxShape::String, "the substring to find")
+            .required("string", SyntaxShape::String, "The substring to find.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -43,7 +43,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, check strings at the given cell paths, and replace with result",
+                "For a data structure input, check strings at the given cell paths, and replace with result.",
             )
             .switch("ignore-case", "search is case insensitive", Some('i'))
             .switch("not", "does not contain", Some('n'))

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -41,7 +41,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, check strings at the given cell paths, and replace with result",
+                "For a data structure input, check strings at the given cell paths, and replace with result.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
             .required(
                 "compare-string",
                 SyntaxShape::String,
-                "the first string to compare",
+                "The first string to compare.",
             )
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -40,7 +40,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, check strings at the given cell paths, and replace with result",
+                "For a data structure input, check strings at the given cell paths, and replace with result.",
             )
             .switch("ignore-case", "search is case insensitive", Some('i'))
             .category(Category::Strings)

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -36,7 +36,7 @@ impl Command for SubCommand {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("string", SyntaxShape::String, "the string to match")
+            .required("string", SyntaxShape::String, "The string to match.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -44,7 +44,7 @@ impl Command for SubCommand {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("string", SyntaxShape::String, "the string to find in the input")
+            .required("string", SyntaxShape::String, "The string to find in the input.")
             .switch(
                 "grapheme-clusters",
                 "count indexes using grapheme clusters (all visible chars have length 1)",

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -58,7 +58,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, search strings at the given cell paths, and replace with result",
+                "For a data structure input, search strings at the given cell paths, and replace with result.",
             )
             .named(
                 "range",

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -23,7 +23,7 @@ impl Command for StrJoin {
             .optional(
                 "separator",
                 SyntaxShape::String,
-                "optional separator to use when creating string",
+                "Optional separator to use when creating string.",
             )
             .allow_variants_without_examples(true)
             .category(Category::Strings)

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -49,7 +49,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, replace strings at the given cell paths with their length",
+                "For a data structure input, replace strings at the given cell paths with their length.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -44,8 +44,8 @@ impl Command for SubCommand {
                     Type::List(Box::new(Type::String)),
                 ),
             ])
-            .required("find", SyntaxShape::String, "the pattern to find")
-            .required("replace", SyntaxShape::String, "the replacement string")
+            .required("find", SyntaxShape::String, "The pattern to find.")
+            .required("replace", SyntaxShape::String, "The replacement string.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -49,7 +49,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, operate on strings at the given cell paths",
+                "For a data structure input, operate on strings at the given cell paths.",
             )
             .switch("all", "replace all occurrences of the pattern", Some('a'))
             .switch(

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -29,7 +29,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, reverse strings at the given cell paths",
+                "For a data structure input, reverse strings at the given cell paths.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -38,7 +38,7 @@ impl Command for SubCommand {
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
-            .required("string", SyntaxShape::String, "the string to match")
+            .required("string", SyntaxShape::String, "The string to match.")
             .rest(
                 "rest",
                 SyntaxShape::CellPath,

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -42,7 +42,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, check strings at the given cell paths, and replace with result",
+                "For a data structure input, check strings at the given cell paths, and replace with result.",
             )
             .switch("ignore-case", "search is case insensitive", Some('i'))
             .category(Category::Strings)

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -63,7 +63,7 @@ impl Command for SubCommand {
             .required(
                 "range",
                 SyntaxShape::Any,
-                "the indexes to substring [start end]",
+                "The indexes to substring [start end].",
             )
             .rest(
                 "rest",

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -68,7 +68,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, turn strings at the given cell paths into substrings",
+                "For a data structure input, turn strings at the given cell paths into substrings.",
             )
             .category(Category::Strings)
     }

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -49,7 +49,7 @@ impl Command for SubCommand {
             .rest(
                 "rest",
                 SyntaxShape::CellPath,
-                "For a data structure input, trim strings at the given cell paths",
+                "For a data structure input, trim strings at the given cell paths.",
             )
             .named(
                 "char",

--- a/crates/nu-command/src/system/exec.rs
+++ b/crates/nu-command/src/system/exec.rs
@@ -17,7 +17,7 @@ impl Command for Exec {
     fn signature(&self) -> Signature {
         Signature::build("exec")
             .input_output_types(vec![(Type::Nothing, Type::Any)])
-            .required("command", SyntaxShape::String, "the command to execute")
+            .required("command", SyntaxShape::String, "The command to execute.")
             .allows_unknown_args()
             .category(Category::System)
     }

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -20,7 +20,7 @@ impl Command for NuCheck {
             (Type::ListStream, Type::Bool),
             (Type::List(Box::new(Type::Any)), Type::Bool)])
             // type is string to avoid automatically canonicalizing the path
-            .optional("path", SyntaxShape::String, "File path to parse")
+            .optional("path", SyntaxShape::String, "File path to parse.")
             .switch("as-module", "Parse content as module", Some('m'))
             .switch("debug", "Show error messages", Some('d'))
             .switch("all", "Parse content as script first, returns result if success, otherwise, try with module", Some('a'))

--- a/crates/nu-command/src/system/registry_query.rs
+++ b/crates/nu-command/src/system/registry_query.rs
@@ -38,11 +38,11 @@ impl Command for RegistryQuery {
                 "do not expand %ENV% placeholders in REG_EXPAND_SZ",
                 Some('u'),
             )
-            .required("key", SyntaxShape::String, "registry key to query")
+            .required("key", SyntaxShape::String, "Registry key to query.")
             .optional(
                 "value",
                 SyntaxShape::String,
-                "optionally supply a registry value to query",
+                "Optionally supply a registry value to query.",
             )
             .category(Category::System)
     }

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -48,7 +48,7 @@ impl Command for External {
             )
             .switch("trim-end-newline", "trimming end newlines", None)
             .required("command", SyntaxShape::String, "External command to run.")
-            .rest("args", SyntaxShape::Any, "arguments for external command")
+            .rest("args", SyntaxShape::Any, "Arguments for external command.")
             .category(Category::System)
     }
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -47,7 +47,7 @@ impl Command for External {
                 None,
             )
             .switch("trim-end-newline", "trimming end newlines", None)
-            .required("command", SyntaxShape::String, "external command to run")
+            .required("command", SyntaxShape::String, "External command to run.")
             .rest("args", SyntaxShape::Any, "arguments for external command")
             .category(Category::System)
     }

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -24,7 +24,7 @@ impl Command for Which {
         Signature::build("which")
             .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
-            .required("application", SyntaxShape::String, "application")
+            .required("application", SyntaxShape::String, "Application.")
             .rest("rest", SyntaxShape::String, "additional applications")
             .switch("all", "list all executables", Some('a'))
             .category(Category::System)

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -25,7 +25,7 @@ impl Command for Which {
             .input_output_types(vec![(Type::Nothing, Type::Table(vec![]))])
             .allow_variants_without_examples(true)
             .required("application", SyntaxShape::String, "Application.")
-            .rest("rest", SyntaxShape::String, "additional applications")
+            .rest("rest", SyntaxShape::String, "Additional applications.")
             .switch("all", "list all executables", Some('a'))
             .category(Category::System)
     }

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -43,7 +43,39 @@ fn arguments_end_period() {
             let arg_name = arg.name;
             let desc = arg.desc;
             if !desc.ends_with('.') {
-                failures.push(format!("{cmd_name} argument \"{arg_name}\": \"{desc}\""));
+                failures.push(format!(
+                    "{cmd_name} required argument \"{arg_name}\": \"{desc}\""
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Command argument description does not end with a period:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn arguments_start_uppercase() {
+    let ctx = crate::create_default_context();
+    let decls = ctx.get_decls_sorted(true);
+    let mut failures = Vec::new();
+
+    for (name_bytes, decl_id) in decls {
+        let cmd = ctx.get_decl(decl_id);
+        let cmd_name = String::from_utf8_lossy(&name_bytes);
+        let signature = cmd.signature();
+
+        for arg in signature.required_positional {
+            let arg_name = arg.name;
+            let desc = arg.desc;
+
+            if !desc.starts_with(|u: char| u.is_uppercase()) {
+                failures.push(format!(
+                    "{cmd_name} required argument \"{arg_name}\": \"{desc}\""
+                ));
             }
         }
     }

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -48,6 +48,16 @@ fn arguments_end_period() {
                 ));
             }
         }
+
+        for arg in signature.optional_positional {
+            let arg_name = arg.name;
+            let desc = arg.desc;
+            if !desc.ends_with('.') {
+                failures.push(format!(
+                    "{cmd_name} optional argument \"{arg_name}\": \"{desc}\""
+                ));
+            }
+        }
     }
 
     assert!(

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -29,6 +29,33 @@ fn quickcheck_parse(data: String) -> bool {
 }
 
 #[test]
+fn arguments_end_period() {
+    let ctx = crate::create_default_context();
+    let decls = ctx.get_decls_sorted(true);
+    let mut failures = Vec::new();
+
+    for (name_bytes, decl_id) in decls {
+        let cmd = ctx.get_decl(decl_id);
+        let cmd_name = String::from_utf8_lossy(&name_bytes);
+        let signature = cmd.signature();
+
+        for arg in signature.required_positional {
+            let arg_name = arg.name;
+            let desc = arg.desc;
+            if !desc.ends_with('.') {
+                failures.push(format!("{cmd_name} argument \"{arg_name}\": \"{desc}\""));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "Command argument description does not end with a period:\n{}",
+        failures.join("\n")
+    );
+}
+
+#[test]
 fn signature_name_matches_command_name() {
     let ctx = create_default_context();
     let decls = ctx.get_decls_sorted(true);

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -71,6 +71,20 @@ fn arguments_end_period() {
 
 #[test]
 fn arguments_start_uppercase() {
+    fn starts_uppercase(cmd_name: &str, ty: &str, arg: PositionalArg, failures: &mut Vec<String>) {
+        let arg_name = arg.name;
+        let desc = arg.desc;
+
+        // Check lowercase to allow usage to contain syntax like:
+        //
+        // "`as` keyword …"
+        if desc.starts_with(|u: char| u.is_lowercase()) {
+            failures.push(format!(
+                "{cmd_name} {ty} argument \"{arg_name}\": \"{desc}\""
+            ));
+        }
+    }
+
     let ctx = crate::create_default_context();
     let decls = ctx.get_decls_sorted(true);
     let mut failures = Vec::new();
@@ -81,28 +95,15 @@ fn arguments_start_uppercase() {
         let signature = cmd.signature();
 
         for arg in signature.required_positional {
-            let arg_name = arg.name;
-            let desc = arg.desc;
-
-            // Check lowercase to allow usage to contain syntax like:
-            //
-            // "`as` keyword …"
-            if !desc.starts_with(|u: char| u.is_uppercase()) {
-                failures.push(format!(
-                    "{cmd_name} required argument \"{arg_name}\": \"{desc}\""
-                ));
-            }
+            starts_uppercase(&cmd_name, "required", arg, &mut failures);
         }
 
         for arg in signature.optional_positional {
-            let arg_name = arg.name;
-            let desc = arg.desc;
+            starts_uppercase(&cmd_name, "optional", arg, &mut failures);
+        }
 
-            if desc.starts_with(|u: char| u.is_lowercase()) {
-                failures.push(format!(
-                    "{cmd_name} optional argument \"{arg_name}\": \"{desc}\""
-                ));
-            }
+        if let Some(arg) = signature.rest_positional {
+            starts_uppercase(&cmd_name, "rest", arg, &mut failures);
         }
     }
 

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -72,9 +72,23 @@ fn arguments_start_uppercase() {
             let arg_name = arg.name;
             let desc = arg.desc;
 
+            // Check lowercase to allow usage to contain syntax like:
+            //
+            // "`as` keyword …"
             if !desc.starts_with(|u: char| u.is_uppercase()) {
                 failures.push(format!(
                     "{cmd_name} required argument \"{arg_name}\": \"{desc}\""
+                ));
+            }
+        }
+
+        for arg in signature.optional_positional {
+            let arg_name = arg.name;
+            let desc = arg.desc;
+
+            if desc.starts_with(|u: char| u.is_lowercase()) {
+                failures.push(format!(
+                    "{cmd_name} optional argument \"{arg_name}\": \"{desc}\""
                 ));
             }
         }
@@ -204,7 +218,7 @@ fn usage_start_uppercase() {
         let cmd_name = String::from_utf8_lossy(&name_bytes);
         let usage = cmd.usage();
 
-        // Check lowercase to allow usage to contain removed syntax like:
+        // Check lowercase to allow usage to contain syntax like:
         //
         // "`let-env FOO = ...` …"
         if usage.starts_with(|u: char| u.is_lowercase()) {

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -1,6 +1,6 @@
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
-    Category, Span,
+    Category, PositionalArg, Span,
 };
 use quickcheck_macros::quickcheck;
 
@@ -30,6 +30,16 @@ fn quickcheck_parse(data: String) -> bool {
 
 #[test]
 fn arguments_end_period() {
+    fn ends_period(cmd_name: &str, ty: &str, arg: PositionalArg, failures: &mut Vec<String>) {
+        let arg_name = arg.name;
+        let desc = arg.desc;
+        if !desc.ends_with('.') {
+            failures.push(format!(
+                "{cmd_name} {ty} argument \"{arg_name}\": \"{desc}\""
+            ));
+        }
+    }
+
     let ctx = crate::create_default_context();
     let decls = ctx.get_decls_sorted(true);
     let mut failures = Vec::new();
@@ -40,23 +50,15 @@ fn arguments_end_period() {
         let signature = cmd.signature();
 
         for arg in signature.required_positional {
-            let arg_name = arg.name;
-            let desc = arg.desc;
-            if !desc.ends_with('.') {
-                failures.push(format!(
-                    "{cmd_name} required argument \"{arg_name}\": \"{desc}\""
-                ));
-            }
+            ends_period(&cmd_name, "required", arg, &mut failures);
         }
 
         for arg in signature.optional_positional {
-            let arg_name = arg.name;
-            let desc = arg.desc;
-            if !desc.ends_with('.') {
-                failures.push(format!(
-                    "{cmd_name} optional argument \"{arg_name}\": \"{desc}\""
-                ));
-            }
+            ends_period(&cmd_name, "optional", arg, &mut failures);
+        }
+
+        if let Some(arg) = signature.rest_positional {
+            ends_period(&cmd_name, "rest", arg, &mut failures);
         }
     }
 

--- a/crates/nu-lsp/src/notification.rs
+++ b/crates/nu-lsp/src/notification.rs
@@ -121,7 +121,7 @@ mod tests {
             serde_json::json!({
                 "contents": {
                     "kind": "markdown",
-                    "value": "\n### Signature\n```\n  let {flags} <var_name> <initial_value>\n```\n\n### Parameters\n\n  `var_name: any` - variable name\n\n  `initial_value: any` - equals sign followed by value\n\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n### Input/output\n\n```\n any | nothing\n\n```\n### Usage\n  Create a variable and give it a value.\n\n### Extra usage:\n  This command is a parser keyword. For details, check:\n  https://www.nushell.sh/book/thinking_in_nu.html\n### Example(s)\n  Set a variable to a value\n```\n  let x = 10\n```\n  Set a variable to the result of an expression\n```\n  let x = 10 + 100\n```\n  Set a variable based on the condition\n```\n  let x = if false { -1 } else { 1 }\n```\n"
+                    "value": "\n### Signature\n```\n  let {flags} <var_name> <initial_value>\n```\n\n### Parameters\n\n  `var_name: any` - Variable name.\n\n  `initial_value: any` - Equals sign followed by value.\n\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n### Input/output\n\n```\n any | nothing\n\n```\n### Usage\n  Create a variable and give it a value.\n\n### Extra usage:\n  This command is a parser keyword. For details, check:\n  https://www.nushell.sh/book/thinking_in_nu.html\n### Example(s)\n  Set a variable to a value\n```\n  let x = 10\n```\n  Set a variable to the result of an expression\n```\n  let x = 10 + 100\n```\n  Set a variable based on the condition\n```\n  let x = if false { -1 } else { 1 }\n```\n"
                 }
             })
         );


### PR DESCRIPTION
# Description

This updates all the positional arguments (except with `--features=dataframe` or `--features=extra`) to start with an uppercase letter and end with a period.

Part of #5066, specifically [this comment](/nushell/nushell/issues/5066#issuecomment-1421528910)

Some arguments had example data removed from them because it also appears in the examples.

There are other inconsistencies in positional arguments I noticed while making the tests pass which I will bring up in #5066.

# User-Facing Changes

Positional arguments are now consistent

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Automatic documentation updates