### PR TITLE
Share the stack amongst CLI plugins instead of cloning it

### DIFF
--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -22,7 +22,7 @@ fn completer() -> NuCompleter {
     assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     // Instantiate a new completer
-    NuCompleter::new(std::sync::Arc::new(engine), stack)
+    NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable())
 }
 
 #[fixture]
@@ -36,7 +36,7 @@ fn completer_strings() -> NuCompleter {
     assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     // Instantiate a new completer
-    NuCompleter::new(std::sync::Arc::new(engine), stack)
+    NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable())
 }
 
 #[fixture]
@@ -56,7 +56,7 @@ fn extern_completer() -> NuCompleter {
     assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     // Instantiate a new completer
-    NuCompleter::new(std::sync::Arc::new(engine), stack)
+    NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable())
 }
 
 #[fixture]
@@ -79,14 +79,14 @@ fn custom_completer() -> NuCompleter {
     assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     // Instantiate a new completer
-    NuCompleter::new(std::sync::Arc::new(engine), stack)
+    NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable())
 }
 
 #[test]
 fn variables_dollar_sign_with_varialblecompletion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "$ ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -138,7 +138,7 @@ fn dotnu_completions() {
     let (_, _, engine, stack) = new_engine();
 
     // Instantiate a new completer
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     // Test source completion
     let completion_str = "source-env ".to_string();
@@ -198,7 +198,7 @@ fn file_completions() {
     let (dir, dir_str, engine, stack) = new_engine();
 
     // Instantiate a new completer
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     // Test completions for the current folder
     let target_dir = format!("cp {dir_str}");
@@ -235,7 +235,7 @@ fn partial_completions() {
     let (dir, _, engine, stack) = new_partial_engine();
 
     // Instantiate a new completer
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     // Test completions for a folder's name
     let target_dir = format!("cd {}", file(dir.join("pa")));
@@ -314,7 +314,7 @@ fn partial_completions() {
 fn command_ls_with_filecompletion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "ls ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -346,7 +346,7 @@ fn command_ls_with_filecompletion() {
 fn command_open_with_filecompletion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "open ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -379,7 +379,7 @@ fn command_open_with_filecompletion() {
 fn command_rm_with_globcompletion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "rm ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -412,7 +412,7 @@ fn command_rm_with_globcompletion() {
 fn command_cp_with_globcompletion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "cp ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -445,7 +445,7 @@ fn command_cp_with_globcompletion() {
 fn command_save_with_filecompletion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "save ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -478,7 +478,7 @@ fn command_save_with_filecompletion() {
 fn command_touch_with_filecompletion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "touch ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -511,7 +511,7 @@ fn command_touch_with_filecompletion() {
 fn command_watch_with_filecompletion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "watch ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -544,7 +544,7 @@ fn command_watch_with_filecompletion() {
 fn file_completion_quoted() {
     let (_, _, engine, stack) = new_quote_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "open ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -581,7 +581,7 @@ fn flag_completions() {
     let (_, _, engine, stack) = new_engine();
 
     // Instantiate a new completer
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
     // Test completions for the 'ls' flags
     let suggestions = completer.complete("ls -", 4);
 
@@ -616,7 +616,7 @@ fn folder_with_directorycompletions() {
     let (dir, dir_str, engine, stack) = new_engine();
 
     // Instantiate a new completer
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     // Test completions for the current folder
     let target_dir = format!("cd {dir_str}");
@@ -644,7 +644,7 @@ fn variables_completions() {
     assert!(support::merge_input(record.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
     // Instantiate a new completer
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
@@ -745,7 +745,7 @@ fn alias_of_command_and_flags() {
     let alias = r#"alias ll = ls -l"#;
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let suggestions = completer.complete("ll t", 4);
     #[cfg(windows)]
@@ -764,7 +764,7 @@ fn alias_of_basic_command() {
     let alias = r#"alias ll = ls "#;
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let suggestions = completer.complete("ll t", 4);
     #[cfg(windows)]
@@ -786,7 +786,7 @@ fn alias_of_another_alias() {
     let alias = r#"alias lf = ll -f"#;
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let suggestions = completer.complete("lf t", 4);
     #[cfg(windows)]
@@ -821,7 +821,7 @@ fn run_external_completion(block: &str, input: &str) -> Vec<Suggestion> {
     engine_state.set_config(config);
 
     // Instantiate a new completer
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine_state), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine_state), stack.into_shareable());
 
     completer.complete(input, input.len())
 }
@@ -830,7 +830,7 @@ fn run_external_completion(block: &str, input: &str) -> Vec<Suggestion> {
 fn unknown_command_completion() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let target_dir = "thiscommanddoesnotexist ";
     let suggestions = completer.complete(target_dir, target_dir.len());
@@ -891,7 +891,7 @@ fn flagcompletion_triggers_after_cursor_piped(mut completer: NuCompleter) {
 fn filecompletions_triggers_after_cursor() {
     let (_, _, engine, stack) = new_engine();
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     let suggestions = completer.complete("cp   test_c", 3);
 
@@ -998,7 +998,7 @@ fn alias_offset_bug_7648() {
     let alias = r#"alias ea = ^$env.EDITOR /tmp/test.s"#;
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     // Issue #7648
     // Nushell crashes when an alias name is shorter than the alias command
@@ -1017,7 +1017,7 @@ fn alias_offset_bug_7754() {
     let alias = r#"alias ll = ls -l"#;
     assert!(support::merge_input(alias.as_bytes(), &mut engine, &mut stack, dir).is_ok());
 
-    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack);
+    let mut completer = NuCompleter::new(std::sync::Arc::new(engine), stack.into_shareable());
 
     // Issue #7754
     // Nushell crashes when an alias name is shorter than the alias command

--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -99,7 +99,7 @@ fn get_editor_commandline(
 
 pub fn get_editor(
     engine_state: &EngineState,
-    stack: &mut Stack,
+    stack: &Stack,
     span: Span,
 ) -> Result<(String, Vec<String>), ShellError> {
     let config = engine_state.get_config();

--- a/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use nu_engine::{eval_block, CallExt};
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{Closure, Command, EngineState, Stack};
+use nu_protocol::engine::{Closure, Command, EngineState, ShareableStack, Stack};
 use nu_protocol::{
     Category, Example, IntoPipelineData, LazyRecord, PipelineData, ShellError, Signature, Span,
     SyntaxShape, Type, Value,
@@ -98,7 +98,7 @@ impl Command for LazyMake {
 #[derive(Clone)]
 struct NuLazyRecord {
     engine_state: EngineState,
-    stack: Arc<Mutex<Stack>>,
+    stack: ShareableStack,
     columns: Vec<String>,
     get_value: Closure,
     span: Span,

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -533,7 +533,7 @@ impl LanguageServer {
             &params.text_document_position.text_document.uri,
         )?;
 
-        let stack = Stack::new();
+        let stack = Stack::new().into_shareable();
         let mut completer = NuCompleter::new(Arc::new(engine_state.clone()), stack);
 
         let location =

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 
 use crate::engine::EngineState;
 use crate::engine::DEFAULT_OVERLAY_NAME;
@@ -38,6 +39,9 @@ pub struct Stack {
     pub recursion_count: u64,
 }
 
+/// A Stack wrapped in Arc and Mutex, for sharing between multiple code paths.
+pub type ShareableStack = Arc<Mutex<Stack>>;
+
 impl Stack {
     pub fn new() -> Stack {
         Stack {
@@ -47,6 +51,10 @@ impl Stack {
             active_overlays: vec![DEFAULT_OVERLAY_NAME.to_string()],
             recursion_count: 0,
         }
+    }
+
+    pub fn into_shareable(self) -> ShareableStack {
+        Arc::new(Mutex::from(self))
     }
 
     pub fn with_env(
@@ -191,6 +199,7 @@ impl Stack {
     }
 
     /// Flatten the env var scope frames into one frame
+    /// XXX this function is potentially extremely expensive
     pub fn get_env_vars(&self, engine_state: &EngineState) -> HashMap<String, Value> {
         let mut result = HashMap::new();
 
@@ -219,6 +228,7 @@ impl Stack {
     }
 
     /// Get flattened environment variables only from the stack
+    /// XXX this function is potentially extremely expensive
     pub fn get_stack_env_vars(&self) -> HashMap<String, Value> {
         let mut result = HashMap::new();
 

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -588,7 +588,7 @@ pub fn hover(engine_state: &mut EngineState, file_path: &str, location: &Value) 
 }
 
 pub fn complete(engine_reference: Arc<EngineState>, file_path: &str, location: &Value) {
-    let stack = Stack::new();
+    let stack = Stack::new().into_shareable();
     let mut completer = NuCompleter::new(engine_reference, stack);
 
     let file = std::fs::read(file_path)

--- a/src/run.rs
+++ b/src/run.rs
@@ -272,7 +272,7 @@ pub(crate) fn run_repl(
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_repl(
         engine_state,
-        &mut stack,
+        stack,
         config_files::NUSHELL_FOLDER,
         parsed_nu_cli_args.execute,
         parsed_nu_cli_args.no_std_lib,


### PR DESCRIPTION
 How to experience a huge slowdown on your machine:
 ```nushell
let $stuff = lsof | from ssv -m 1
```
 (This is routinely a 6-digit-length table)

After doing this, at least on my pretty beefy machine prompts take about 3 or 4 seconds to load instead of ~instant.
This shows up in `--log-level info`. This shows up in `perf` as a lot of activity on `Value::Clone` in particualr. 

Stack clones end up copying all the values inside of enviornment variables, which can be super costly if we have very large variables inside of the environment. Instead, we can pay some small costs to lock the environment (at least that's the theory), and share all of this.

I believe there's probably some subtle bugs that were present in `main` do to cloning of the stack instead of sharing (given that we were cloning to get a mutable copy, after all). I did not really try to find such bugs though, as here I mainly wanted to grasp where the initial performance issue was.

After this patch, the performance issue goes away entirely for me. To be seen whether there are other issues though.