### PR TITLE
add `nothing -> table` to `format date`

### DIFF
--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -25,6 +25,7 @@ impl Command for FormatDate {
             .input_output_types(vec![
                 (Type::Date, Type::String),
                 (Type::String, Type::String),
+                (Type::Nothing, Type::Table(vec![])),
             ])
             .allow_variants_without_examples(true) // https://github.com/nushell/nushell/issues/7032
             .switch("list", "lists strftime cheatsheet", Some('l'))


### PR DESCRIPTION
this will allow to run
```nushell
format date --list | get 0
```
and get
```
─────────────┬───────────────────────────────────────────────────────────
Specification│%Y
Example      │2023
Description  │The full proleptic Gregorian year, zero-padded to 4 digits.
─────────────┴───────────────────────────────────────────────────────────
```
instead of currently
```
Error: nu::parser::input_type_mismatch

  × Command does not support string input.
   ╭─[entry #2:1:1]
 1 │ format date --list | get 0
   ·                      ─┬─
   ·                       ╰── command doesn't support string input
   ╰────
```