### PR TITLE
Remove `into_string_parsable`

### DIFF
--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -57,7 +57,7 @@ impl NuHelpCompleter {
 
                 if !sig.named.is_empty() {
                     long_desc.push_str(&get_flags_section(Some(&*self.0.clone()), sig, |v| {
-                        v.into_string_parsable(", ", &self.0.config)
+                        v.into_string(", ", &self.0.config)
                     }))
                 }
 
@@ -72,8 +72,8 @@ impl NuHelpCompleter {
                     for positional in &sig.optional_positional {
                         let opt_suffix = if let Some(value) = &positional.default_value {
                             format!(
-                                " (optional, default: {})",
-                                &value.into_string_parsable(", ", &self.0.config),
+                                " (optional, default: `{}`)",
+                                &value.into_string(", ", &self.0.config),
                             )
                         } else {
                             (" (optional)").to_string()

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -139,7 +139,7 @@ fn get_documentation(
     if !sig.named.is_empty() {
         long_desc.push_str(&get_flags_section(Some(engine_state), sig, |v| {
             nu_highlight_string(
-                &v.into_string_parsable(", ", &engine_state.config),
+                &v.into_string(", ", &engine_state.config),
                 engine_state,
                 stack,
             )
@@ -185,9 +185,9 @@ fn get_documentation(
                 _ => {
                     let opt_suffix = if let Some(value) = &positional.default_value {
                         format!(
-                            " (optional, default: {})",
+                            " (optional, default: `{}`)",
                             nu_highlight_string(
-                                &value.into_string_parsable(", ", &engine_state.config),
+                                &value.into_string(", ", &engine_state.config),
                                 engine_state,
                                 stack
                             )

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -819,35 +819,6 @@ impl Value {
         format!("{self:#?}")
     }
 
-    /// Convert Value into a parsable string (quote strings)
-    /// bugbug other, rarer types not handled
-
-    pub fn into_string_parsable(&self, separator: &str, config: &Config) -> String {
-        match self {
-            // give special treatment to the simple types to make them parsable
-            Value::String { val, .. } => format!("'{}'", val),
-
-            // recurse back into this function for recursive formatting
-            Value::List { vals: val, .. } => format!(
-                "[{}]",
-                val.iter()
-                    .map(|x| x.into_string_parsable(", ", config))
-                    .collect::<Vec<_>>()
-                    .join(separator)
-            ),
-            Value::Record { val, .. } => format!(
-                "{{{}}}",
-                val.iter()
-                    .map(|(x, y)| format!("{}: {}", x, y.into_string_parsable(", ", config)))
-                    .collect::<Vec<_>>()
-                    .join(separator)
-            ),
-
-            // defer to standard handling for types where standard representation is parsable
-            _ => self.into_string(separator, config),
-        }
-    }
-
     /// Convert Value into string. Note that Streams will be consumed.
     pub fn debug_string(&self, separator: &str, config: &Config) -> String {
         match self {

--- a/src/tests/test_help.rs
+++ b/src/tests/test_help.rs
@@ -5,7 +5,7 @@ use rstest::rstest;
 // avoid feeding strings containing parens to regex.  Does not end well.
 #[case(": arga help")]
 #[case("argb help")]
-#[case("optional, default: 20")]
+#[case("optional, default: `20`")]
 #[case("- f1 switch")]
 #[case("- f2 named no default")]
 #[case("- f3 named default 3")]


### PR DESCRIPTION
The function's only difference from `into_string` was in adding single quotes around string.  It was only used for help, for default options/arguments.

I replaced it with `into_string` and backticks around default argument options.

Resolve #11291