### PR TITLE
fix-`open`-is-ambiguous

### DIFF
--- a/crates/nu-command/src/stor/mod.rs
+++ b/crates/nu-command/src/stor/mod.rs
@@ -27,7 +27,7 @@ pub use import::StorImport;
 #[cfg(feature = "sqlite")]
 pub use insert::StorInsert;
 #[cfg(feature = "sqlite")]
-pub use open::StorOpen;
+pub use ::open::StorOpen;
 #[cfg(feature = "sqlite")]
 pub use reset::StorReset;
 pub use stor_::Stor;

--- a/crates/nu-command/src/stor/mod.rs
+++ b/crates/nu-command/src/stor/mod.rs
@@ -27,7 +27,7 @@ pub use import::StorImport;
 #[cfg(feature = "sqlite")]
 pub use insert::StorInsert;
 #[cfg(feature = "sqlite")]
-pub use ::open::StorOpen;
+pub use self::open::StorOpen;
 #[cfg(feature = "sqlite")]
 pub use reset::StorReset;
 pub use stor_::Stor;


### PR DESCRIPTION
# Description
Running `cargo install nu` on rustc 1.71.1 (eb26296b5 2023-08-03) produced the following error message when reaching `nu-command v0.88.0`:
```sh
error[E0659]: `open` is ambiguous
  --> /home/antoine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nu-command-0.88.0/src/stor/mod.rs:30:9
   |
30 | pub use open::StorOpen;
   |         ^^^^ ambiguous name
   |
   = note: ambiguous because of multiple potential import sources
   = note: `open` could refer to a crate passed with `--extern`
   = help: use `::open` to refer to this crate unambiguously
note: `open` could also refer to the module defined here
  --> /home/antoine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nu-command-0.88.0/src/stor/mod.rs:12:1
   |
12 | mod open;
   | ^^^^^^^^^
   = help: use `self::open` to refer to this module unambiguously

   Compiling nu-cli v0.88.0
   Compiling nu-lsp v0.88.0
For more information about this error, try `rustc --explain E0659`.
error: could not compile `nu-command` (lib) due to previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `nu v0.88.0`, intermediate artifacts can be found at `/tmp/cargo-installEUsfIr`
```

# User-Facing Changes
No user-facing changes.