### PR TITLE
Bubble up errors passed to `complete`

### DIFF
--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -101,6 +101,8 @@ impl Command for Complete {
 
                 Ok(Value::record(record, call.head).into_pipeline_data())
             }
+            // bubble up errors from the previous command
+            PipelineData::Value(Value::Error { error, .. }, _) => Err(*error),
             _ => Err(ShellError::GenericError {
                 error: "Complete only works with external streams".into(),
                 msg: "complete only works on external streams".into(),

--- a/crates/nu-command/tests/commands/complete.rs
+++ b/crates/nu-command/tests/commands/complete.rs
@@ -1,0 +1,17 @@
+use nu_test_support::nu;
+
+#[test]
+fn basic() {
+    let actual = nu!(r#"
+        (^echo a | complete) == {stdout: "a\n", exit_code: 0}
+    "#);
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn error() {
+    let actual = nu!("do { not-found } | complete");
+
+    assert!(actual.err.contains("executable was not found"));
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -7,6 +7,7 @@ mod break_;
 mod cal;
 mod cd;
 mod compact;
+mod complete;
 mod config_env_default;
 mod config_nu_default;
 mod continue_;


### PR DESCRIPTION
Errors passed in `PipelineData::Value` get thrown in `complete` now.

Also added two simple tests for the command.

Fix #11187
Fix #10204
