### PR TITLE
Fix a panic when parsing empty file

### DIFF
--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -349,11 +349,10 @@ impl<'a> StateWorkingSet<'a> {
                     return &contents[begin..end];
                 }
             }
-        } else {
-            return self.permanent_state.get_span_contents(span);
         }
 
-        panic!("internal error: missing span contents in file cache")
+        // if no files with span were found, fall back on permanent ones
+        return self.permanent_state.get_span_contents(span);
     }
 
     pub fn enter_scope(&mut self) {

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -297,7 +297,7 @@ fn main_script_can_have_subcommands1() {
             r#"def "main foo" [x: int] {
                     print ($x + 100)
                   }
-                  
+
                   def "main" [] {
                     print "usage: script.nu <command name>"
                   }"#,
@@ -318,7 +318,7 @@ fn main_script_can_have_subcommands2() {
             r#"def "main foo" [x: int] {
                     print ($x + 100)
                   }
-                  
+
                   def "main" [] {
                     print "usage: script.nu <command name>"
                   }"#,
@@ -327,5 +327,16 @@ fn main_script_can_have_subcommands2() {
         let actual = nu!(cwd: dirs.test(), pipeline("nu script.nu"));
 
         assert!(actual.out.contains("usage: script.nu"));
+    })
+}
+
+#[test]
+fn source_empty_file() {
+    Playground::setup("source_empty_file", |dirs, sandbox| {
+        sandbox.mkdir("source_empty_file");
+        sandbox.with_files(vec![FileWithContent("empty.nu", "")]);
+
+        let actual = nu!(cwd: dirs.test(), pipeline("nu empty.nu"));
+        assert!(actual.out.is_empty());
     })
 }


### PR DESCRIPTION
The previous implementation presumed that if files were given, they had contents.  The change makes the fallback to permanent files uniform.

Fix #11256