### PR TITLE
Fix piping output logic

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -603,8 +603,8 @@ pub fn eval_block(
     stack: &mut Stack,
     block: &Block,
     mut input: PipelineData,
-    mut redirect_stdout: bool,
-    mut redirect_stderr: bool,
+    redirect_stdout: bool,
+    redirect_stderr: bool,
 ) -> Result<PipelineData, ShellError> {
     // if Block contains recursion, make sure we don't recurse too deeply (to avoid stack overflow)
     if let Some(recursive) = block.recursive {
@@ -629,6 +629,8 @@ pub fn eval_block(
         let elements = &pipeline.elements;
         let elements_length = elements.len();
         for (idx, element) in elements.iter().enumerate() {
+            let mut redirect_stdout = redirect_stdout;
+            let mut redirect_stderr = redirect_stderr;
             if !redirect_stderr && idx < elements_length - 1 {
                 let next_element = &elements[idx + 1];
                 if matches!(


### PR DESCRIPTION
# Description
Fixes: #11295

Sorry for introducing such issue.
The issue is caused by we wrongly set `redirect_stdout` and `redirect_stderr` during eval, take the following as example:
```nushell
ls | bat --paging always
```
When running `bat --paging always`, `redirect_stdout` should be `false`.
But before this pr, it's set to true due to `ls` command, and then the `true` value will go to all remaining commands.

# User-Facing Changes
NaN

# Tests + Formatting
Sorry I don't think we have a way to test it.  Because it needs to be tested on interactive command like `nvim`.

# After Submitting
NaN