### PR TITLE
Bump windows from 0.48.0 to 0.52.0 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.51.1",
 ]
 
 [[package]]
@@ -2893,7 +2893,7 @@ dependencies = [
  "uuid",
  "wax",
  "which 5.0.0",
- "windows 0.48.0",
+ "windows 0.52.0",
  "winreg",
 ]
 
@@ -6137,11 +6137,12 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-core 0.52.0",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -6151,6 +6152,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -122,7 +122,7 @@ features = [
 	"Win32_Security",
 	"Win32_System_Threading",
 ]
-version = "0.48"
+version = "0.52"
 
 [features]
 plugin = ["nu-parser/plugin"]

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -66,14 +66,15 @@ fn is_root_impl() -> bool {
         System::Threading::{GetCurrentProcess, OpenProcessToken},
     };
 
-    let mut handle = HANDLE::default();
     let mut elevated = false;
 
     // Checks whether the access token associated with the current process has elevated privileges.
     // SAFETY: `elevated` only touched by safe code.
-    // `handle` lives long enough, initialized, mutated as out param, used, closed with validity check.
+    // `handle` lives long enough, initialized, mutated, used and closed with validity check.
     // `elevation` only read on success and passed with correct `size`.
     unsafe {
+        let mut handle = HANDLE::default();
+
         // Opens the access token associated with the current process.
         if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle).is_ok() {
             let mut elevation = TOKEN_ELEVATION::default();

--- a/crates/nu-command/src/experimental/is_admin.rs
+++ b/crates/nu-command/src/experimental/is_admin.rs
@@ -75,7 +75,7 @@ fn is_root_impl() -> bool {
     // `elevation` only read on success and passed with correct `size`.
     unsafe {
         // Opens the access token associated with the current process.
-        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle).as_bool() {
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut handle).is_ok() {
             let mut elevation = TOKEN_ELEVATION::default();
             let mut size = std::mem::size_of::<TOKEN_ELEVATION>() as u32;
 
@@ -89,7 +89,7 @@ fn is_root_impl() -> bool {
                 size,
                 &mut size,
             )
-            .as_bool()
+            .is_ok()
             {
                 // Whether the token has elevated privileges.
                 // Safe to read as `GetTokenInformation` will not write outside `elevation` and it succeeded
@@ -100,7 +100,7 @@ fn is_root_impl() -> bool {
 
         if !handle.is_invalid() {
             // Closes the object handle.
-            CloseHandle(handle);
+            let _ = CloseHandle(handle);
         }
     }
 


### PR DESCRIPTION
# Description
Bump `windows` to 0.52.0 and fix `is_admin`

https://github.com/microsoft/windows-rs/pull/2476

# User-Facing Changes
N/A

# Tests + Formatting
- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

