### PR TITLE
Remove `expect` for thread related functions

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -255,7 +255,7 @@ fn send_cancellable_request(
             let ret = request_fn();
             let _ = tx.send(ret); // may fail if the user has cancelled the operation
         })
-        .expect("Failed to create thread");
+        .map_err(|e| ShellErrorOrRequestError::ShellError(e.into()))?;
 
     // ...and poll the channel for responses
     loop {

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -64,8 +64,7 @@ impl Command for Complete {
                                 } else {
                                     Ok::<_, ShellError>(Value::binary(stderr.item, stderr.span))
                                 }
-                            })
-                            .expect("failed to create thread"),
+                            }),
                         stderr_span,
                     )
                 });
@@ -83,11 +82,13 @@ impl Command for Complete {
                 }
 
                 if let Some((handler, stderr_span)) = stderr_handler {
-                    let res = handler.join().map_err(|err| ShellError::ExternalCommand {
-                        label: "Fail to receive external commands stderr message".to_string(),
-                        help: format!("{err:?}"),
-                        span: stderr_span,
-                    })??;
+                    let res = handler?
+                        .join()
+                        .map_err(|err| ShellError::ExternalCommand {
+                            label: "Fail to receive external commands stderr message".to_string(),
+                            help: format!("{err:?}"),
+                            span: stderr_span,
+                        })??;
                     record.push("stderr", res)
                 };
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -436,8 +436,7 @@ impl ExternalCommand {
                                 }
 
                                 Ok(())
-                            })
-                            .expect("Failed to create thread");
+                            })?;
                     }
                 }
 
@@ -525,7 +524,7 @@ impl ExternalCommand {
                             Ok(())
                         }
                     }
-                }).expect("Failed to create thread");
+                })?;
 
                 let (stderr_tx, stderr_rx) = mpsc::sync_channel(OUTPUT_BUFFERS_IN_FLIGHT);
                 if redirect_stderr {
@@ -541,8 +540,7 @@ impl ExternalCommand {
 
                             read_and_redirect_message(stderr, stderr_tx, stderr_ctrlc);
                             Ok::<(), ShellError>(())
-                        })
-                        .expect("Failed to create thread");
+                        })?;
                 }
 
                 let stdout_receiver = ChannelReceiver::new(stdout_rx);

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -436,7 +436,8 @@ impl ExternalCommand {
                                 }
 
                                 Ok(())
-                            })?;
+                            })
+                            .expect("Failed to create thread");
                     }
                 }
 
@@ -524,7 +525,7 @@ impl ExternalCommand {
                             Ok(())
                         }
                     }
-                })?;
+                }).expect("Failed to create thread");
 
                 let (stderr_tx, stderr_rx) = mpsc::sync_channel(OUTPUT_BUFFERS_IN_FLIGHT);
                 if redirect_stderr {
@@ -540,7 +541,8 @@ impl ExternalCommand {
 
                             read_and_redirect_message(stderr, stderr_tx, stderr_ctrlc);
                             Ok::<(), ShellError>(())
-                        })?;
+                        })
+                        .expect("Failed to create thread");
                 }
 
                 let stdout_receiver = ChannelReceiver::new(stdout_rx);

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -439,7 +439,7 @@ fn eval_element_with_input(
                                     stderr_stack,
                                     save_call,
                                     input,
-                                ));
+                                )?);
 
                                 Ok(might_consume_external_result(
                                     PipelineData::ExternalStream {
@@ -870,8 +870,8 @@ impl DataSaveJob {
         mut stack: Stack,
         save_call: Call,
         input: PipelineData,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, ShellError> {
+        let job = Self {
             inner: thread::Builder::new()
                 .name("stderr saver".to_string())
                 .spawn(move || {
@@ -879,9 +879,10 @@ impl DataSaveJob {
                     if let Err(err) = result {
                         eprintln!("WARNING: error occurred when redirect to stderr: {:?}", err);
                     }
-                })
-                .expect("Failed to create thread"),
-        }
+                })?,
+        };
+
+        Ok(job)
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -861,8 +861,7 @@ pub fn print_if_stream(
 
     thread::Builder::new()
         .name("stderr consumer".to_string())
-        .spawn(move || stderr_stream.map(|x| x.into_bytes()))
-        .expect("could not create thread");
+        .spawn(move || stderr_stream.map(|x| x.into_bytes()))?;
     if let Some(stream) = stream {
         for s in stream {
             let s_live = s?;


### PR DESCRIPTION
# Description
Remove some `expect` functions from the code base, which should make Nushell more reliable.

# User-Facing Changes

* before
```nu
/data/source/nushell> ulimit -v 10                                                                                       
/data/source/nushell> ls                                                                                                         
thread 'main' panicked at crates/nu-protocol/src/pipeline_data.rs:865:10:
could not create thread: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

* after
```
/data/source/nushell> ulimit -v 10                               
/data/source/nushell> ls                                        
Error: nu::shell::io_error

  × I/O error
  help: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
```
# Tests + Formatting
Make sure you've run and fixed any issues with these commands:

-  [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
-  [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
-  [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library
