### PR TITLE
improve completions of `use` and `overlay use`

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -250,7 +250,9 @@ impl NuCompleter {
                                             working_set.get_span_contents(previous_expr.0).to_vec();
 
                                         // Completion for .nu files
-                                        if prev_expr_str == b"use" || prev_expr_str == b"source-env"
+                                        if prev_expr_str == b"use"
+                                            || prev_expr_str == b"overlay use"
+                                            || prev_expr_str == b"source-env"
                                         {
                                             let mut completer =
                                                 DotNuCompletion::new(self.engine_state.clone());

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
 };
 use reedline::Suggestion;
 use std::{
-    path::{is_separator, MAIN_SEPARATOR as SEP, MAIN_SEPARATOR_STR},
+    path::{is_separator, MAIN_SEPARATOR as SEP, MAIN_SEPARATOR_STR, Path},
     sync::Arc,
 };
 
@@ -91,16 +91,21 @@ impl Completer for DotNuCompletion {
         // and transform them into suggestions
         let output: Vec<Suggestion> = search_dirs
             .into_iter()
-            .flat_map(|it| {
-                file_path_completion(span, &partial, &it, options)
+            .flat_map(|search_dir| {
+                let completions = file_path_completion(span, &partial, &search_dir, options);
+                completions
                     .into_iter()
-                    .filter(|it| {
+                    .filter(move |it| {
                         // Different base dir, so we list the .nu files or folders
                         if !is_current_folder {
                             it.1.ends_with(".nu") || it.1.ends_with(SEP)
                         } else {
-                            // Lib dirs, so we filter only the .nu files
-                            it.1.ends_with(".nu")
+                            // Lib dirs, so we filter only the .nu files or directory modules
+                            if it.1.ends_with(SEP) {
+                                Path::new(&search_dir).join(&it.1).join("mod.nu").exists()
+                            } else {
+                                it.1.ends_with(".nu")
+                            }
                         }
                     })
                     .map(move |x| Suggestion {

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
 };
 use reedline::Suggestion;
 use std::{
-    path::{is_separator, MAIN_SEPARATOR as SEP, MAIN_SEPARATOR_STR, Path},
+    path::{is_separator, Path, MAIN_SEPARATOR as SEP, MAIN_SEPARATOR_STR},
     sync::Arc,
 };
 

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -91,7 +91,7 @@ fn variables_dollar_sign_with_varialblecompletion() {
     let target_dir = "$ ";
     let suggestions = completer.complete(target_dir, target_dir.len());
 
-    assert_eq!(7, suggestions.len());
+    assert_eq!(8, suggestions.len());
 }
 
 #[rstest]
@@ -218,6 +218,7 @@ fn file_completions() {
     let expected_paths: Vec<String> = vec![
         folder(dir.join("another")),
         file(dir.join("custom_completion.nu")),
+        folder(dir.join("directory_completion")),
         file(dir.join("nushell")),
         folder(dir.join("test_a")),
         folder(dir.join("test_b")),
@@ -333,6 +334,7 @@ fn command_ls_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -343,6 +345,7 @@ fn command_ls_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),
@@ -365,6 +368,7 @@ fn command_open_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -375,6 +379,7 @@ fn command_open_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),
@@ -398,6 +403,7 @@ fn command_rm_with_globcompletion() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -408,6 +414,7 @@ fn command_rm_with_globcompletion() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),
@@ -431,6 +438,7 @@ fn command_cp_with_globcompletion() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -441,6 +449,7 @@ fn command_cp_with_globcompletion() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),
@@ -464,6 +473,7 @@ fn command_save_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -474,6 +484,7 @@ fn command_save_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),
@@ -497,6 +508,7 @@ fn command_touch_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -507,6 +519,7 @@ fn command_touch_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),
@@ -530,6 +543,7 @@ fn command_watch_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -540,6 +554,7 @@ fn command_watch_with_filecompletion() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),
@@ -635,6 +650,7 @@ fn folder_with_directorycompletions() {
     // Create the expected values
     let expected_paths: Vec<String> = vec![
         folder(dir.join("another")),
+        folder(dir.join("directory_completion")),
         folder(dir.join("test_a")),
         folder(dir.join("test_b")),
         folder(dir.join(".hidden_folder")),
@@ -849,6 +865,7 @@ fn unknown_command_completion() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -859,6 +876,7 @@ fn unknown_command_completion() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),
@@ -909,6 +927,7 @@ fn filecompletions_triggers_after_cursor() {
     let expected_paths: Vec<String> = vec![
         "another\\".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion\\".to_string(),
         "nushell".to_string(),
         "test_a\\".to_string(),
         "test_b\\".to_string(),
@@ -919,6 +938,7 @@ fn filecompletions_triggers_after_cursor() {
     let expected_paths: Vec<String> = vec![
         "another/".to_string(),
         "custom_completion.nu".to_string(),
+        "directory_completion/".to_string(),
         "nushell".to_string(),
         "test_a/".to_string(),
         "test_b/".to_string(),

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -146,6 +146,9 @@ fn dotnu_completions() {
 
     assert_eq!(2, suggestions.len());
     assert_eq!("custom_completion.nu", suggestions.first().unwrap().value);
+    #[cfg(windows)]
+    assert_eq!("directory_completion\\", suggestions.get(1).unwrap().value);
+    #[cfg(not(windows))]
     assert_eq!("directory_completion/", suggestions.get(1).unwrap().value);
 
     // Test use completion
@@ -154,6 +157,9 @@ fn dotnu_completions() {
 
     assert_eq!(2, suggestions.len());
     assert_eq!("custom_completion.nu", suggestions.first().unwrap().value);
+    #[cfg(windows)]
+    assert_eq!("directory_completion\\", suggestions.get(1).unwrap().value);
+    #[cfg(not(windows))]
     assert_eq!("directory_completion/", suggestions.get(1).unwrap().value);
 
     // Test overlay use completion
@@ -162,6 +168,9 @@ fn dotnu_completions() {
 
     assert_eq!(2, suggestions.len());
     assert_eq!("custom_completion.nu", suggestions.first().unwrap().value);
+    #[cfg(windows)]
+    assert_eq!("directory_completion\\", suggestions.get(1).unwrap().value);
+    #[cfg(not(windows))]
     assert_eq!("directory_completion/", suggestions.get(1).unwrap().value);
 }
 

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -144,22 +144,25 @@ fn dotnu_completions() {
     let completion_str = "source-env ".to_string();
     let suggestions = completer.complete(&completion_str, completion_str.len());
 
-    assert_eq!(1, suggestions.len());
+    assert_eq!(2, suggestions.len());
     assert_eq!("custom_completion.nu", suggestions.first().unwrap().value);
+    assert_eq!("directory_completion/", suggestions.get(1).unwrap().value);
 
     // Test use completion
     let completion_str = "use ".to_string();
     let suggestions = completer.complete(&completion_str, completion_str.len());
 
-    assert_eq!(1, suggestions.len());
+    assert_eq!(2, suggestions.len());
     assert_eq!("custom_completion.nu", suggestions.first().unwrap().value);
+    assert_eq!("directory_completion/", suggestions.get(1).unwrap().value);
 
     // Test overlay use completion
     let completion_str = "overlay use ".to_string();
     let suggestions = completer.complete(&completion_str, completion_str.len());
 
-    assert_eq!(1, suggestions.len());
+    assert_eq!(2, suggestions.len());
     assert_eq!("custom_completion.nu", suggestions.first().unwrap().value);
+    assert_eq!("directory_completion/", suggestions.get(1).unwrap().value);
 }
 
 #[test]

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -153,6 +153,13 @@ fn dotnu_completions() {
 
     assert_eq!(1, suggestions.len());
     assert_eq!("custom_completion.nu", suggestions.first().unwrap().value);
+
+    // Test overlay use completion
+    let completion_str = "overlay use ".to_string();
+    let suggestions = completer.complete(&completion_str, completion_str.len());
+
+    assert_eq!(1, suggestions.len());
+    assert_eq!("custom_completion.nu", suggestions.first().unwrap().value);
 }
 
 #[test]


### PR DESCRIPTION
# Description
this PR is two-fold
- make `use` and `overlay use` use the same completion algorithm in 48f29b633
- list directory modules in completions of both with 402acde5c

# User-Facing Changes
i currently have the following in my `NU_LIB_DIRS`
<details>
<summary>click to see the script</summary>

```nushell
for dir in $env.NU_LIB_DIRS {
    print $dir
    print (ls $dir --short-names | select name type)
}
```
</details>

```
/home/amtoine/.local/share/nupm/modules
#┬────────name────────┬type
0│nu-git-manager      │dir
1│nu-git-manager-sugar│dir
2│nu-hooks            │dir
3│nu-scripts          │dir
4│nu-themes           │dir
5│nupm                │dir
─┴────────────────────┴────

/home/amtoine/.config/nushell/overlays
#┬──name──┬type
0│ocaml.nu│file
─┴────────┴────
```

> **Note**
> all the samples below are run from the Nushell repo, i.e. a directory with a `toolkit.nu` module

## before the changes
- `use` would give me `["ocaml.nu", "toolkit.nu"]` 
- `overlay use` would give me `[]` 

## after the changes
both commands give me
```nushell
[
    "nupm/",
    "ocaml.nu",
    "toolkit.nu",
    "nu-scripts/",
    "nu-git-manager/",
    "nu-git-manager-sugar/",
]
```

# Tests + Formatting
- adds a new `directory_completion/mod.nu` to the completion fixtures
- make sure `source-env`, `use` and `overlay-use` are all tested in the _dotnu_ test
- fix all the other tests that use completions in the fixtures directory for completions

# After Submitting
