### PR TITLE
hide `std testing`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: cargo install --path . --locked --no-default-features
 
       - name: Standard library tests
-        run: nu -c 'use std crates/nu-std/testing.nu; testing run-tests --path crates/nu-std'
+        run: nu -c 'use crates/nu-std/testing.nu; testing run-tests --path crates/nu-std'
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: cargo install --path . --locked --no-default-features
 
       - name: Standard library tests
-        run: nu -c 'use std testing; testing run-tests --path crates/nu-std'
+        run: nu -c 'use std crates/nu-std/testing.nu; testing run-tests --path crates/nu-std'
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -18,7 +18,6 @@ pub fn load_standard_library(
 
         let mut std_files = vec![
             ("mod.nu", include_str!("../std/mod.nu")),
-            ("testing.nu", include_str!("../std/testing.nu")),
             ("dirs.nu", include_str!("../std/dirs.nu")),
             ("dt.nu", include_str!("../std/dt.nu")),
             ("help.nu", include_str!("../std/help.nu")),

--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -1,4 +1,4 @@
-use log.nu
+use std/log.nu
 
 def "nu-complete threads" [] {
     seq 1 (sys|get cpu|length)
@@ -287,16 +287,6 @@ export def run-tests [
     --list,                               # list the selected tests without running them.
     --threads: int@"nu-complete threads", # Amount of threads to use for parallel execution. Default: All threads are utilized
 ] {
-    print $"Warning:   (char -u 26a0) (ansi yellow_bold)deprecated_module(ansi reset)"
-    print "| the `std testing run-tests` command is deprecated and will be removed in Nushell 0.90"
-    print ""
-    print $"(ansi cyan)help(ansi reset): please use (ansi {fg: cyan, attr: du})[`nushell/nupm`]\(https://github.com/nushell/nupm\)(ansi reset)"
-    print ""
-    print $"(ansi default_dimmed)|(ansi reset) (ansi {fg: 'cyan', attr: 'b'})Note(ansi reset)"
-    print $"(ansi default_dimmed)| Nupm is still a work in progress and is NOT production-ready, just as `run-tests` is.(ansi reset)"
-    print $"(ansi default_dimmed)| Please keep in mind that Nupm will change a lot in the near future and we can't recommend it for now.(ansi reset)"
-    print $"(ansi default_dimmed)| However, if you like bleeding edge software and want to give it a spin, we would welcome feedbacks and ideas :pray:(ansi reset)"
-
     let available_threads = (sys | get cpu | length)
 
     # Can't use pattern matching here due to https://github.com/nushell/nushell/issues/9198

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -107,7 +107,10 @@ export def test [
 export def "test stdlib" [
     --extra-args: string = ''
 ] {
-    cargo run -- -c $"use std testing; testing run-tests --path crates/nu-std ($extra_args)"
+    cargo run -- -c $"
+        use crates/nu-std/testing.nu
+        testing run-tests --path crates/nu-std ($extra_args)
+    "
 }
 
 # formats the pipe input inside backticks, dimmed and italic, as a pretty command


### PR DESCRIPTION
follow-up to
- https://github.com/nushell/nushell/pull/11151

> **Important**
> land only between 0.89 and 0.90

# Description
this PR hides the `std testing` module from the outside.
- moves `nu-std/std/testing.nu` to `nu-std/testing.nu`
- removes the module from the standard library list of modules to parse
- fixes `toolkit.nu` and the CI

# User-Facing Changes
`std testing` won't be part of the standard library anymore.
# Tests + Formatting

# After Submitting