### PR TITLE
Allow `int` type as a valid limit value

### DIFF
--- a/crates/nu-command/src/platform/ulimit.rs
+++ b/crates/nu-command/src/platform/ulimit.rs
@@ -444,14 +444,10 @@ fn parse_limit(
 
             let (limit, overflow) = value.overflowing_mul(multiplier);
             if overflow {
-                return Err(ShellError::OperatorOverflow {
-                    msg: "Multiple overflow".into(),
-                    span: *internal_span,
-                    help: String::new(),
-                });
+                Ok(RLIM_INFINITY)
+            } else {
+                Ok(limit)
             }
-
-            Ok(limit)
         }
         Value::String { val, internal_span } => {
             if val == "unlimited" {

--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -123,6 +123,7 @@ fn limit_set_invalid3() {
             .contains("Only unlimited, soft and hard are supported for strings"));
     });
 }
+
 #[test]
 fn limit_set_invalid4() {
     Playground::setup("limit_set_invalid4", |dirs, _sandbox| {

--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -139,12 +139,14 @@ fn limit_set_invalid4() {
 
 #[test]
 fn limit_set_invalid5() {
+    use nix::sys::resource::rlim_t;
+
+    let max = (rlim_t::MAX / 1024) + 1;
+
     Playground::setup("limit_set_invalid5", |dirs, _sandbox| {
         let actual = nu!(
             cwd: dirs.test(),
-            "
-                ulimit -c 20000000000000000
-            "
+            format!("ulimit -c {max}")
         );
 
         assert!(actual.err.contains("Multiple overflow"));

--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -7,9 +7,9 @@ fn limit_set_soft1() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             "
-                let soft = (ulimit -s | first | get soft | into string);
+                let soft = (ulimit -s | first | get soft);
                 ulimit -s -H $soft;
-                let hard = (ulimit -s | first | get hard | into string);
+                let hard = (ulimit -s | first | get hard);
                 $soft == $hard
             "
         ));
@@ -24,9 +24,9 @@ fn limit_set_soft2() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             "
-                let soft = (ulimit -s | first | get soft | into string);
+                let soft = (ulimit -s | first | get soft);
                 ulimit -s -H soft;
-                let hard = (ulimit -s | first | get hard | into string);
+                let hard = (ulimit -s | first | get hard);
                 $soft == $hard
             "
         ));
@@ -41,9 +41,9 @@ fn limit_set_hard1() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             "
-                let hard = (ulimit -s | first | get hard | into string);
+                let hard = (ulimit -s | first | get hard);
                 ulimit -s $hard;
-                let soft = (ulimit -s | first | get soft | into string);
+                let soft = (ulimit -s | first | get soft);
                 $soft == $hard
            "
         ));
@@ -58,9 +58,9 @@ fn limit_set_hard2() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             "
-                let hard = (ulimit -s | first | get hard | into string);
+                let hard = (ulimit -s | first | get hard);
                 ulimit -s hard;
-                let soft = (ulimit -s | first | get soft | into string);
+                let soft = (ulimit -s | first | get soft);
                 $soft == $hard
             "
         ));
@@ -79,7 +79,7 @@ fn limit_set_invalid1() {
             match $hard {
                 \"unlimited\" => { echo \"unlimited\" },
                 $x => {
-                    let new = ($x + 1 | into string);
+                    let new = $x + 1;
                     ulimit -s $new
                 }
             }
@@ -99,10 +99,54 @@ fn limit_set_invalid2() {
         let actual = nu!(
             cwd: dirs.test(),
             "
+                let val = -100;
+                ulimit -c $val
+            "
+        );
+
+        assert!(actual.err.contains("can't convert i64 to rlim_t"));
+    });
+}
+
+#[test]
+fn limit_set_invalid3() {
+    Playground::setup("limit_set_invalid3", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            "
                 ulimit -c abcd
             "
         );
 
-        assert!(actual.err.contains("Can't convert to rlim_t."));
+        assert!(actual
+            .err
+            .contains("Only unlimited, soft and hard are supported for strings"));
+    });
+}
+#[test]
+fn limit_set_invalid4() {
+    Playground::setup("limit_set_invalid4", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            "
+                ulimit -c 100.0
+            "
+        );
+
+        assert!(actual.err.contains("string or int required"));
+    });
+}
+
+#[test]
+fn limit_set_invalid5() {
+    Playground::setup("limit_set_invalid5", |dirs, _sandbox| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            "
+                ulimit -c 20000000000000000
+            "
+        );
+
+        assert!(actual.err.contains("Multiple overflow"));
     });
 }

--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -146,10 +146,25 @@ fn limit_set_invalid5() {
 
     Playground::setup("limit_set_invalid5", |dirs, _sandbox| {
         let actual = nu!(
-            cwd: dirs.test(),
-            format!("ulimit -c {max}")
-        );
+            cwd: dirs.test(), pipeline(
+                format!(
+                "
+                    let hard = (ulimit -c | first | get hard)
+                    match hard {
+                        \"unlimited\" => {
+                            ulimit -c -S 0;
+                            ulimit -c {max};
+                            ulimit -c
+                            | first
+                            | get soft
+                        },
+                        _ => {
+                            echo \"unlimited\"
+                        }
+                    }
+                ").as_str()
+        ));
 
-        assert!(actual.err.contains("Multiple overflow"));
+        assert!(actual.out.eq("unlimited"));
     });
 }

--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -149,19 +149,19 @@ fn limit_set_invalid5() {
             cwd: dirs.test(), pipeline(
                 format!(
                 "
-                    let hard = (ulimit -c | first | get hard)
-                    match hard {
-                        \"unlimited\" => {
+                    let hard = (ulimit -c | first | get hard);
+                    match $hard {{
+                        \"unlimited\" => {{
                             ulimit -c -S 0;
                             ulimit -c {max};
                             ulimit -c
                             | first
                             | get soft
-                        },
-                        _ => {
+                        }},
+                        _ => {{
                             echo \"unlimited\"
-                        }
-                    }
+                        }}
+                    }}
                 ").as_str()
         ));
 


### PR DESCRIPTION
# Description
This PR allows `int` type as a valid limit value for `ulimit`, so there is no need to use `into string` to convert limit values in the tests.

# User-Facing Changes
N/A

# Tests + Formatting
Make sure you've run and fixed any issues with these commands:
- [x] add `commands::ulimit::limit_set_invalid3`
- [x] add `commands::ulimit::limit_set_invalid4`
- [x] add `commands::ulimit::limit_set_invalid5`
- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library