### PR TITLE
Downgrade openssl-src to fix riscv64 build target, close #11345

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3414,9 +3414,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "300.1.6+3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Downgrade `openssl-src` to fix `riscv64gc-unknown-linux-gnu` build target: https://github.com/nushell/nightly/actions/runs/7231785373/job/19705342169, Related issue: https://github.com/alexcrichton/openssl-src-rs/issues/222