### PR TITLE
Rename extra's `format` to `format pattern`

### DIFF
--- a/crates/nu-cmd-extra/src/extra/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/mod.rs
@@ -65,7 +65,7 @@ pub fn add_extra_command_context(mut engine_state: EngineState) -> EngineState {
         bind_command!(platform::ansi::Gradient);
 
         bind_command!(
-            strings::format::Format,
+            strings::format::FormatPattern,
             strings::encode_decode::EncodeHex,
             strings::encode_decode::DecodeHex,
             strings::str_::case::Str,

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -10,15 +10,15 @@ use nu_protocol::{
 };
 
 #[derive(Clone)]
-pub struct Format;
+pub struct FormatPattern;
 
-impl Command for Format {
+impl Command for FormatPattern {
     fn name(&self) -> &str {
-        "format"
+        "format pattern"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("format")
+        Signature::build("format pattern")
             .input_output_types(vec![
                 (Type::Table(vec![]), Type::List(Box::new(Type::String))),
                 (Type::Record(vec![]), Type::Any),
@@ -80,12 +80,12 @@ impl Command for Format {
         vec![
             Example {
                 description: "Print filenames with their sizes",
-                example: "ls | format '{name}: {size}'",
+                example: "ls | format pattern '{name}: {size}'",
                 result: None,
             },
             Example {
                 description: "Print elements from some columns of a table",
-                example: "[[col1, col2]; [v1, v2] [v3, v4]] | format '{col2}'",
+                example: "[[col1, col2]; [v1, v2] [v3, v4]] | format pattern '{col2}'",
                 result: Some(Value::list(
                     vec![Value::test_string("v2"), Value::test_string("v4")],
                     Span::test_data(),
@@ -318,8 +318,8 @@ fn format_record(
 mod test {
     #[test]
     fn test_examples() {
-        use super::Format;
+        use super::FormatPattern;
         use crate::test_examples;
-        test_examples(Format {})
+        test_examples(FormatPattern {})
     }
 }

--- a/crates/nu-cmd-extra/src/extra/strings/format/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/mod.rs
@@ -1,3 +1,3 @@
 mod command;
 
-pub(crate) use command::Format;
+pub(crate) use command::FormatPattern;


### PR DESCRIPTION
This removes the naming conflict, introduced by `fd77114` (#11334), when the `extra` feature is enabled.