### PR TITLE
Remove `Value::MatchPattern`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -290,7 +290,6 @@ fn describe_value(
         | Value::Date { .. }
         | Value::Range { .. }
         | Value::String { .. }
-        | Value::MatchPattern { .. }
         | Value::Nothing { .. } => Value::record(
             record!(
                 "type" => Value::string(value.get_type().to_string(), head),

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -278,9 +278,6 @@ impl<'a> std::fmt::Debug for DebuggableValue<'a> {
                 let rec = val.collect().map_err(|_| std::fmt::Error)?;
                 write!(f, "LazyRecord({:?})", DebuggableValue(&rec))
             }
-            Value::MatchPattern { val, .. } => {
-                write!(f, "MatchPattern({:?})", val)
-            }
         }
     }
 }

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -131,8 +131,7 @@ impl<'a> StyleComputer<'a> {
             Value::Closure { .. }
             | Value::CustomValue { .. }
             | Value::Error { .. }
-            | Value::LazyRecord { .. }
-            | Value::MatchPattern { .. } => TextStyle::basic_left(),
+            | Value::LazyRecord { .. } => TextStyle::basic_left(),
         }
     }
 

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -260,7 +260,6 @@ fn nu_value_to_string(value: Value, separator: &str) -> String {
         Value::Binary { val, .. } => format!("{val:?}"),
         Value::CellPath { val, .. } => val.to_string(),
         Value::CustomValue { val, .. } => val.value_string(),
-        Value::MatchPattern { val, .. } => format!("{:?}", val),
     }
 }
 

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -259,6 +259,5 @@ pub fn debug_string_without_formatting(value: &Value) -> String {
         Value::Binary { val, .. } => format!("{val:?}"),
         Value::CellPath { val, .. } => val.to_string(),
         Value::CustomValue { val, .. } => val.value_string(),
-        Value::MatchPattern { val, .. } => format!("{:?}", val),
     }
 }

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -516,7 +516,6 @@ fn value_should_be_printed(
             Err(_) => false,
         },
         Value::Binary { .. } => false,
-        Value::MatchPattern { .. } => false,
     });
     if invert {
         match_found = !match_found;

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -127,10 +127,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
 
         Value::List { vals, .. } => nu_json::Value::Array(json_list(vals)?),
         Value::Error { error, .. } => return Err(*error.clone()),
-        Value::Closure { .. }
-        | Value::Block { .. }
-        | Value::Range { .. }
-        | Value::MatchPattern { .. } => nu_json::Value::Null,
+        Value::Closure { .. } | Value::Block { .. } | Value::Range { .. } => nu_json::Value::Null,
         Value::Binary { val, .. } => {
             nu_json::Value::Array(val.iter().map(|x| nu_json::Value::U64(*x as u64)).collect())
         }

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -241,12 +241,6 @@ pub fn value_to_string(
                 ))
             }
         }
-        Value::MatchPattern { .. } => Err(ShellError::UnsupportedInput {
-            msg: "match patterns are currently not nuon-compatible".to_string(),
-            input: "value originates from here".into(),
-            msg_span: span,
-            input_span: v.span(),
-        }),
         Value::Nothing { .. } => Ok("null".to_string()),
         Value::Range { val, .. } => Ok(format!(
             "{}..{}{}",

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -148,7 +148,6 @@ fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
         Value::Binary { val, .. } => format!("{val:?}"),
         Value::CellPath { val, .. } => val.to_string(),
         Value::CustomValue { val, .. } => val.value_string(),
-        Value::MatchPattern { val, .. } => format!("{:?}", val),
     }
 }
 

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -94,7 +94,6 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
                 .collect::<Result<Vec<toml::Value>, ShellError>>()?,
         ),
         Value::CustomValue { .. } => toml::Value::String("<Custom Value>".to_string()),
-        Value::MatchPattern { .. } => toml::Value::String("<Match Pattern>".to_string()),
     })
 }
 

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -97,7 +97,6 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
                 .collect::<Result<Vec<serde_yaml::Value>, ShellError>>()?,
         ),
         Value::CustomValue { .. } => serde_yaml::Value::Null,
-        Value::MatchPattern { .. } => serde_yaml::Value::Null,
     })
 }
 

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -277,8 +277,8 @@ pub trait Eval {
             Expr::GlobPattern(pattern) => {
                 Self::eval_glob_pattern(state, mut_state, pattern.clone(), expr.span)
             }
-            Expr::MatchPattern(pattern) => Ok(Value::match_pattern(*pattern.clone(), expr.span)),
-            Expr::MatchBlock(_) // match blocks are handled by `match`
+            Expr::MatchPattern(_) // match patterns are handled directly by commands
+            | Expr::MatchBlock(_) // match blocks are handled by `match`
             | Expr::VarDecl(_)
             | Expr::ImportPattern(_)
             | Expr::Signature(_)

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::ast::{CellPath, MatchPattern, PathMember};
+use crate::ast::{CellPath, PathMember};
 use crate::engine::{Block, Closure};
 use crate::{Range, Record, ShellError, Spanned, Value};
 use chrono::{DateTime, FixedOffset};
@@ -528,35 +528,6 @@ impl FromValue for Spanned<Closure> {
             Value::Closure { val, .. } => Ok(Spanned { item: val, span }),
             v => Err(ShellError::CantConvert {
                 to_type: "Closure".into(),
-                from_type: v.get_type().to_string(),
-                span: v.span(),
-                help: None,
-            }),
-        }
-    }
-}
-
-impl FromValue for Spanned<MatchPattern> {
-    fn from_value(v: Value) -> Result<Self, ShellError> {
-        let span = v.span();
-        match v {
-            Value::MatchPattern { val, .. } => Ok(Spanned { item: *val, span }),
-            v => Err(ShellError::CantConvert {
-                to_type: "Match pattern".into(),
-                from_type: v.get_type().to_string(),
-                span: v.span(),
-                help: None,
-            }),
-        }
-    }
-}
-
-impl FromValue for MatchPattern {
-    fn from_value(v: Value) -> Result<Self, ShellError> {
-        match v {
-            Value::MatchPattern { val, .. } => Ok(*val),
-            v => Err(ShellError::CantConvert {
-                to_type: "Match pattern".into(),
                 from_type: v.get_type().to_string(),
                 span: v.span(),
                 help: None,


### PR DESCRIPTION
# Description
`Value::MatchPattern` implies that `MatchPattern`s are first-class values. This PR removes this case, and commands must now instead use `Expr::MatchPattern` to extract `MatchPattern`s just like how the `match` command does using `Expr::MatchBlock`.

# User-Facing Changes
Breaking API change for `nu_protocol` crate.