### PR TITLE
Deprecate `--flag: bool` in custom command

### DIFF
--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -35,6 +35,10 @@ pub fn evaluate_commands(
         let mut working_set = StateWorkingSet::new(engine_state);
 
         let output = parse(&mut working_set, None, commands.item.as_bytes(), false);
+        if let Some(warning) = working_set.parse_warnings.first() {
+            report_error(&working_set, warning);
+        }
+
         if let Some(err) = working_set.parse_errors.first() {
             report_error(&working_set, err);
 

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -220,6 +220,10 @@ pub fn eval_source(
             source,
             false,
         );
+        if let Some(warning) = working_set.parse_warnings.first() {
+            report_error(&working_set, warning);
+        }
+
         if let Some(err) = working_set.parse_errors.first() {
             set_last_exit_code(stack, 1);
             report_error(&working_set, err);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3495,7 +3495,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         if syntax_shape == SyntaxShape::Boolean {
                                             working_set.warning(ParseWarning::DeprecatedWarning(
                                                 "--flag: bool".to_string(),
-                                                "barely --flag".to_string(),
+                                                "--flag".to_string(),
                                                 span,
                                             ));
                                         }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -18,8 +18,8 @@ use nu_protocol::{
     },
     engine::StateWorkingSet,
     eval_const::eval_constant,
-    span, BlockId, DidYouMean, Flag, ParseError, PositionalArg, Signature, Span, Spanned,
-    SyntaxShape, Type, Unit, VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
+    span, BlockId, DidYouMean, Flag, ParseError, ParseWarning, PositionalArg, Signature, Span,
+    Spanned, SyntaxShape, Type, Unit, VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
 };
 
 use crate::parse_keywords::{
@@ -3492,6 +3492,13 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         type_annotated,
                                     } => {
                                         working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), syntax_shape.to_type());
+                                        if syntax_shape == SyntaxShape::Boolean {
+                                            working_set.warning(ParseWarning::DeprecatedWarning(
+                                                "--flag: bool".to_string(),
+                                                "barely --flag".to_string(),
+                                                span,
+                                            ));
+                                        }
                                         *arg = Some(syntax_shape);
                                         *type_annotated = true;
                                     }

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -6,7 +6,7 @@ use crate::ast::Block;
 use crate::{
     BlockId, Config, DeclId, FileId, Module, ModuleId, Span, Type, VarId, Variable, VirtualPathId,
 };
-use crate::{Category, ParseError, Value};
+use crate::{Category, ParseError, ParseWarning, Value};
 use core::panic;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -27,6 +27,7 @@ pub struct StateWorkingSet<'a> {
     /// Whether or not predeclarations are searched when looking up a command (used with aliases)
     pub search_predecls: bool,
     pub parse_errors: Vec<ParseError>,
+    pub parse_warnings: Vec<ParseWarning>,
 }
 
 impl<'a> StateWorkingSet<'a> {
@@ -39,6 +40,7 @@ impl<'a> StateWorkingSet<'a> {
             parsed_module_files: vec![],
             search_predecls: true,
             parse_errors: vec![],
+            parse_warnings: vec![],
         }
     }
 
@@ -48,6 +50,10 @@ impl<'a> StateWorkingSet<'a> {
 
     pub fn error(&mut self, parse_error: ParseError) {
         self.parse_errors.push(parse_error)
+    }
+
+    pub fn warning(&mut self, parse_warning: ParseWarning) {
+        self.parse_warnings.push(parse_warning)
     }
 
     pub fn num_files(&self) -> usize {

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -12,6 +12,7 @@ mod id;
 mod lev_distance;
 mod module;
 mod parse_error;
+mod parse_warning;
 mod pipeline_data;
 #[cfg(feature = "plugin")]
 mod plugin_signature;
@@ -35,6 +36,7 @@ pub use id::*;
 pub use lev_distance::levenshtein_distance;
 pub use module::*;
 pub use parse_error::{DidYouMean, ParseError};
+pub use parse_warning::ParseWarning;
 pub use pipeline_data::*;
 #[cfg(feature = "plugin")]
 pub use plugin_signature::*;

--- a/crates/nu-protocol/src/parse_warning.rs
+++ b/crates/nu-protocol/src/parse_warning.rs
@@ -9,7 +9,7 @@ pub enum ParseWarning {
     DeprecatedWarning(
         String,
         String,
-        #[label = "`{0}` is deprecated. Please use `{1}` instead, more info: https://www.nushell.sh/book/custom_commands.html"]
+        #[label = "`{0}` is deprecated and will be removed in 0.90. Please use `{1}` instead, more info: https://www.nushell.sh/book/custom_commands.html"]
         Span,
     ),
 }

--- a/crates/nu-protocol/src/parse_warning.rs
+++ b/crates/nu-protocol/src/parse_warning.rs
@@ -1,0 +1,17 @@
+use crate::Span;
+use miette::Diagnostic;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
+pub enum ParseWarning {
+    #[error("{0} is deprecated, use {1} instead")]
+    DeprecatedWarning(String, String, #[label = "deprecated"] Span),
+}
+impl ParseWarning {
+    pub fn span(&self) -> Span {
+        match self {
+            ParseWarning::DeprecatedWarning(_, _, s) => *s,
+        }
+    }
+}

--- a/crates/nu-protocol/src/parse_warning.rs
+++ b/crates/nu-protocol/src/parse_warning.rs
@@ -5,9 +5,15 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
 pub enum ParseWarning {
-    #[error("{0} is deprecated, use {1} instead")]
-    DeprecatedWarning(String, String, #[label = "deprecated"] Span),
+    #[error("Deprecated: {0}")]
+    DeprecatedWarning(
+        String,
+        String,
+        #[label = "`{0}` is deprecated. Please use `{1}` instead, more info: https://www.nushell.sh/book/custom_commands.html"]
+        Span,
+    ),
 }
+
 impl ParseWarning {
     pub fn span(&self) -> Span {
         match self {

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -139,6 +139,13 @@ fn custom_flag2() -> TestResult {
 }
 
 #[test]
+fn deprecated_boolean_flag() {
+    let actual = nu!(r#"def florb [--dry-run: bool, --another-flag] { "aaa" };  florb"#);
+    assert!(actual.err.contains("Deprecated"));
+    assert_eq!(actual.out, "aaa");
+}
+
+#[test]
 fn simple_var_closing() -> TestResult {
     run_test("let $x = 10; def foo [] { $x }; foo", "10")
 }


### PR DESCRIPTION
# Description
While #11057 is merged, it's hard to tell the difference between `--flag: bool` and `--flag`, and it makes user hard to read custom commands' signature, and hard to use them correctly.

After discussion, I think we can deprecate `--flag: bool` usage, and encourage using `--flag` instead.

# User-Facing Changes
The following code will raise warning message, but don't stop from running.
```nushell
❯ def florb [--dry-run: bool, --another-flag] { "aaa" };  florb
Error:   × Deprecated: --flag: bool
   ╭─[entry #7:1:1]
 1 │ def florb [--dry-run: bool, --another-flag] { "aaa" };  florb
   ·                       ──┬─
   ·                         ╰── `--flag: bool` is deprecated. Please use `--flag` instead, more info: https://www.nushell.sh/book/custom_commands.html
   ╰────

aaa
```

cc @kubouch 

# Tests + Formatting
Done

# After Submitting
- [ ] Add more information under https://www.nushell.sh/book/custom_commands.html to indicate `--dry-run: bool` is not allowed, 
- [ ] remove `: bool` from custom commands between 0.89 and 0.90