### PR TITLE
Only run $env.PROMPT_COMMAND once per prompt (copy of #10986)

### DIFF
--- a/crates/nu-cli/src/prompt_update.rs
+++ b/crates/nu-cli/src/prompt_update.rs
@@ -147,26 +147,26 @@ pub(crate) fn update_prompt(
     trace!("update_prompt {}:{}:{}", file!(), line!(), column!());
 }
 
-/// Construct the transient prompt
+/// Construct the transient prompt based on the normal nu_prompt
 pub(crate) fn make_transient_prompt(
-    nu_prompt: &NushellPrompt,
+    config: &Config,
     engine_state: &EngineState,
     stack: &mut Stack,
+    nu_prompt: &NushellPrompt,
 ) -> Box<dyn Prompt> {
-    let mut prompt = nu_prompt.clone();
-    let config = engine_state.get_config();
+    let mut nu_prompt = nu_prompt.clone();
 
     if let Some(s) = get_prompt_string(TRANSIENT_PROMPT_COMMAND, config, engine_state, stack) {
-        prompt.update_prompt_left(Some(s))
+        nu_prompt.update_prompt_left(Some(s))
     }
 
     if let Some(s) = get_prompt_string(TRANSIENT_PROMPT_COMMAND_RIGHT, config, engine_state, stack)
     {
-        prompt.update_prompt_right(Some(s), config.render_right_prompt_on_last_line)
+        nu_prompt.update_prompt_right(Some(s), config.render_right_prompt_on_last_line)
     }
 
     if let Some(s) = get_prompt_string(TRANSIENT_PROMPT_INDICATOR, config, engine_state, stack) {
-        prompt.update_prompt_indicator(Some(s))
+        nu_prompt.update_prompt_indicator(Some(s))
     }
     if let Some(s) = get_prompt_string(
         TRANSIENT_PROMPT_INDICATOR_VI_INSERT,
@@ -174,7 +174,7 @@ pub(crate) fn make_transient_prompt(
         engine_state,
         stack,
     ) {
-        prompt.update_prompt_vi_insert(Some(s))
+        nu_prompt.update_prompt_vi_insert(Some(s))
     }
     if let Some(s) = get_prompt_string(
         TRANSIENT_PROMPT_INDICATOR_VI_NORMAL,
@@ -182,7 +182,7 @@ pub(crate) fn make_transient_prompt(
         engine_state,
         stack,
     ) {
-        prompt.update_prompt_vi_normal(Some(s))
+        nu_prompt.update_prompt_vi_normal(Some(s))
     }
 
     if let Some(s) = get_prompt_string(
@@ -191,8 +191,8 @@ pub(crate) fn make_transient_prompt(
         engine_state,
         stack,
     ) {
-        prompt.update_prompt_multiline(Some(s))
+        nu_prompt.update_prompt_multiline(Some(s))
     }
 
-    Box::new(prompt)
+    Box::new(nu_prompt)
 }

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -29,7 +29,7 @@ use std::{
     env::temp_dir,
     io::{self, IsTerminal, Write},
     path::Path,
-    sync::{atomic::Ordering, Arc, RwLock},
+    sync::atomic::Ordering,
     time::Instant,
 };
 use sysinfo::SystemExt;
@@ -68,7 +68,7 @@ pub fn evaluate_repl(
 
     let mut entry_num = 0;
 
-    let nu_prompt = Arc::new(RwLock::new(NushellPrompt::new()));
+    let mut nu_prompt = NushellPrompt::new();
 
     let start_time = std::time::Instant::now();
     // Translate environment variables from Strings to Values
@@ -267,12 +267,7 @@ pub fn evaluate_repl(
             .with_quick_completions(config.quick_completions)
             .with_partial_completions(config.partial_completions)
             .with_ansi_colors(config.use_ansi_coloring)
-            .with_cursor_config(cursor_config)
-            .with_transient_prompt(prompt_update::transient_prompt(
-                Arc::clone(&nu_prompt),
-                engine_reference.clone(),
-                stack,
-            ));
+            .with_cursor_config(cursor_config);
         perf(
             "reedline builder",
             start_time,
@@ -425,7 +420,7 @@ pub fn evaluate_repl(
 
         start_time = std::time::Instant::now();
         let config = &engine_state.get_config().clone();
-        prompt_update::update_prompt(config, engine_state, stack, Arc::clone(&nu_prompt));
+        prompt_update::update_prompt(config, engine_state, stack, &mut nu_prompt);
         perf(
             "update_prompt",
             start_time,
@@ -438,14 +433,13 @@ pub fn evaluate_repl(
         entry_num += 1;
 
         start_time = std::time::Instant::now();
-        let input = {
-            line_editor.read_line(
-                &nu_prompt
-                    .read()
-                    .expect("Could not lock on prompt to pass to read_line")
-                    .to_owned(),
-            )
-        };
+        let input =
+            {
+                line_editor = line_editor.with_transient_prompt(
+                    prompt_update::make_transient_prompt(&nu_prompt, engine_state, stack),
+                );
+                line_editor.read_line(&nu_prompt)
+            };
         let shell_integration = config.shell_integration;
 
         match input {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -69,7 +69,7 @@ pub fn evaluate_repl(
 
     let mut entry_num = 0;
 
-    let mut nu_prompt = NushellPrompt::new();
+    let mut nu_prompt = NushellPrompt::new(config.shell_integration);
 
     let start_time = std::time::Instant::now();
     // Translate environment variables from Strings to Values

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -421,6 +421,8 @@ pub fn evaluate_repl(
         start_time = std::time::Instant::now();
         let config = &engine_state.get_config().clone();
         prompt_update::update_prompt(config, engine_state, stack, &mut nu_prompt);
+        let transient_prompt =
+            prompt_update::make_transient_prompt(config, engine_state, stack, &nu_prompt);
         perf(
             "update_prompt",
             start_time,
@@ -433,13 +435,8 @@ pub fn evaluate_repl(
         entry_num += 1;
 
         start_time = std::time::Instant::now();
-        let input =
-            {
-                line_editor = line_editor.with_transient_prompt(
-                    prompt_update::make_transient_prompt(&nu_prompt, engine_state, stack),
-                );
-                line_editor.read_line(&nu_prompt)
-            };
+        line_editor = line_editor.with_transient_prompt(transient_prompt);
+        let input = line_editor.read_line(&nu_prompt);
         let shell_integration = config.shell_integration;
 
         match input {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR is basically a copy of #10986 by @CAD97, which made `$env.PROMPT_COMMAND` only run once per prompt, but @fdncred found an issue where hitting Enter would make the transient prompt appear and be immediately overwritten by the regular prompt, so it was [reverted](https://github.com/nushell/nushell/pull/11340). https://github.com/nushell/nushell/pull/10788 was also made to do the same thing as #10986 but that ended up having the same issue. For some reason, this branch doesn't have that problem, although I haven't figured out why yet.

@CAD97, if you have any inputs or want to make your own PR, let me know.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

When hitting enter, the prompt shouldn't blink in place anymore.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
