### PR TITLE
Remove `Expr::MatchPattern`

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -329,7 +329,6 @@ fn find_matching_block_end_in_expr(
             Expr::ImportPattern(_) => None,
             Expr::Overlay(_) => None,
             Expr::Signature(_) => None,
-            Expr::MatchPattern(_) => None,
             Expr::MatchBlock(_) => None,
             Expr::Nothing => None,
             Expr::Garbage => None,

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -242,12 +242,6 @@ fn convert_to_value(
             msg: "extra tokens in input file".into(),
             span: expr.span,
         }),
-        Expr::MatchPattern(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "extra tokens in input file".into(),
-            span: expr.span,
-        }),
         Expr::GlobPattern(val) => Ok(Value::string(val, span)),
         Expr::ImportPattern(..) => Err(ShellError::OutsideSpannedLabeledError {
             src: original_text.to_string(),

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -264,10 +264,6 @@ pub fn flatten_expression(
         Expr::Float(_) => {
             vec![(expr.span, FlatShape::Float)]
         }
-        Expr::MatchPattern(pattern) => {
-            // FIXME: do nicer flattening later
-            flatten_pattern(pattern)
-        }
         Expr::MatchBlock(matches) => {
             let mut output = vec![];
 

--- a/crates/nu-parser/src/parse_patterns.rs
+++ b/crates/nu-parser/src/parse_patterns.rs
@@ -1,5 +1,5 @@
 use nu_protocol::{
-    ast::{Expr, Expression, MatchPattern, Pattern},
+    ast::{MatchPattern, Pattern},
     engine::StateWorkingSet,
     ParseError, Span, SyntaxShape, Type, VarId,
 };
@@ -15,19 +15,6 @@ pub fn garbage(span: Span) -> MatchPattern {
         pattern: Pattern::Garbage,
         guard: None,
         span,
-    }
-}
-
-pub fn parse_match_pattern(working_set: &mut StateWorkingSet, span: Span) -> Expression {
-    working_set.enter_scope();
-    let output = parse_pattern(working_set, span);
-    working_set.exit_scope();
-
-    Expression {
-        expr: Expr::MatchPattern(Box::new(output)),
-        span,
-        ty: Type::Any,
-        custom_completion: None,
     }
 }
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2,7 +2,7 @@ use crate::{
     lex::{lex, lex_signature},
     lite_parser::{lite_parse, LiteCommand, LiteElement, LitePipeline},
     parse_mut,
-    parse_patterns::{parse_match_pattern, parse_pattern},
+    parse_patterns::parse_pattern,
     parse_shape_specs::{parse_shape_name, parse_type, ShapeDescriptorUse},
     type_check::{self, math_result_type, type_compatible},
     Token, TokenContents,
@@ -4447,10 +4447,6 @@ pub fn parse_value(
         _ => {}
     }
 
-    if matches!(shape, SyntaxShape::MatchPattern) {
-        return parse_match_pattern(working_set, span);
-    }
-
     match bytes[0] {
         b'$' => return parse_dollar_expr(working_set, span),
         b'(' => return parse_paren_expr(working_set, span, shape),
@@ -4488,7 +4484,6 @@ pub fn parse_value(
         SyntaxShape::GlobPattern => parse_glob_pattern(working_set, span),
         SyntaxShape::String => parse_string(working_set, span),
         SyntaxShape::Binary => parse_binary(working_set, span),
-        SyntaxShape::MatchPattern => parse_match_pattern(working_set, span),
         SyntaxShape::Signature => {
             if bytes.starts_with(b"[") {
                 parse_signature(working_set, span)
@@ -5932,7 +5927,6 @@ pub fn discover_captures_in_expr(
                 discover_captures_in_expr(working_set, expr, seen, seen_blocks, output)?;
             }
         }
-        Expr::MatchPattern(_) => {}
         Expr::MatchBlock(match_block) => {
             for match_ in match_block {
                 discover_captures_in_pattern(&match_.0, seen);

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -44,7 +44,6 @@ pub enum Expr {
     Overlay(Option<BlockId>), // block ID of the overlay's origin module
     Signature(Box<Signature>),
     StringInterpolation(Vec<Expression>),
-    MatchPattern(Box<MatchPattern>),
     Spread(Box<Expression>),
     Nothing,
     Garbage,

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -221,7 +221,6 @@ impl Expression {
                 }
                 false
             }
-            Expr::MatchPattern(_) => false,
             Expr::Operator(_) => false,
             Expr::MatchBlock(_) => false,
             Expr::Range(left, middle, right, ..) => {
@@ -407,7 +406,6 @@ impl Expression {
             Expr::Nothing => {}
             Expr::GlobPattern(_) => {}
             Expr::Int(_) => {}
-            Expr::MatchPattern(_) => {}
             Expr::MatchBlock(_) => {}
             Expr::Keyword(_, _, expr) => expr.replace_in_variable(working_set, new_var_id),
             Expr::List(list) => {
@@ -576,7 +574,6 @@ impl Expression {
             Expr::Garbage => {}
             Expr::Nothing => {}
             Expr::GlobPattern(_) => {}
-            Expr::MatchPattern(_) => {}
             Expr::MatchBlock(_) => {}
             Expr::Int(_) => {}
             Expr::Keyword(_, _, expr) => expr.replace_span(working_set, replaced, new_span),

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -277,8 +277,7 @@ pub trait Eval {
             Expr::GlobPattern(pattern) => {
                 Self::eval_glob_pattern(state, mut_state, pattern.clone(), expr.span)
             }
-            Expr::MatchPattern(_) // match patterns are handled directly by commands
-            | Expr::MatchBlock(_) // match blocks are handled by `match`
+            Expr::MatchBlock(_) // match blocks are handled by `match`
             | Expr::VarDecl(_)
             | Expr::ImportPattern(_)
             | Expr::Signature(_)

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -82,9 +82,6 @@ pub enum SyntaxShape {
     /// A block of matches, used by `match`
     MatchBlock,
 
-    /// A match pattern, eg `{a: $foo}`
-    MatchPattern,
-
     /// Nothing
     Nothing,
 
@@ -163,7 +160,6 @@ impl SyntaxShape {
             }
             SyntaxShape::Keyword(_, expr) => expr.to_type(),
             SyntaxShape::MatchBlock => Type::Any,
-            SyntaxShape::MatchPattern => Type::Any,
             SyntaxShape::MathExpression => Type::Any,
             SyntaxShape::Nothing => Type::Nothing,
             SyntaxShape::Number => Type::Number,
@@ -240,7 +236,6 @@ impl Display for SyntaxShape {
             SyntaxShape::MathExpression => write!(f, "variable"),
             SyntaxShape::VarWithOptType => write!(f, "vardecl"),
             SyntaxShape::Signature => write!(f, "signature"),
-            SyntaxShape::MatchPattern => write!(f, "match-pattern"),
             SyntaxShape::MatchBlock => write!(f, "match-block"),
             SyntaxShape::Expression => write!(f, "expression"),
             SyntaxShape::Boolean => write!(f, "bool"),

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -24,7 +24,6 @@ pub enum Type {
     Int,
     List(Box<Type>),
     ListStream,
-    MatchPattern,
     #[default]
     Nothing,
     Number,
@@ -110,7 +109,6 @@ impl Type {
             Type::Binary => SyntaxShape::Binary,
             Type::Custom(_) => SyntaxShape::Any,
             Type::Signature => SyntaxShape::Signature,
-            Type::MatchPattern => SyntaxShape::MatchPattern,
         }
     }
 
@@ -131,7 +129,6 @@ impl Type {
             Type::Record(_) => String::from("record"),
             Type::Table(_) => String::from("table"),
             Type::List(_) => String::from("list"),
-            Type::MatchPattern => String::from("match-pattern"),
             Type::Nothing => String::from("nothing"),
             Type::Number => String::from("number"),
             Type::String => String::from("string"),
@@ -198,7 +195,6 @@ impl Display for Type {
             Type::Binary => write!(f, "binary"),
             Type::Custom(custom) => write!(f, "{custom}"),
             Type::Signature => write!(f, "signature"),
-            Type::MatchPattern => write!(f, "match-pattern"),
         }
     }
 }


### PR DESCRIPTION
# Description
Following from #11356, it looks like `Expr::MatchPattern` is no longer used in any way. This PR removes `Expr::MatchPattern` alongside `Type::MatchPattern` and `SyntaxShape::MatchPattern`.

# User-Facing Changes
Breaking API change for `nu_protocol`.
