### PR TITLE
add special emoji handling for debug --raw

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -20,7 +20,9 @@ pub use custom_value::CustomValue;
 use fancy_regex::Regex;
 pub use from_value::FromValue;
 pub use lazy_record::LazyRecord;
-use nu_utils::{get_system_locale, is_emoji, locale::get_system_locale_string, IgnoreCaseExt};
+use nu_utils::{
+    contains_emoji, get_system_locale, locale::get_system_locale_string, IgnoreCaseExt,
+};
 use num_format::ToFormattedString;
 pub use range::*;
 pub use record::Record;
@@ -790,7 +792,7 @@ impl Value {
     pub fn debug_value(&self) -> String {
         match self {
             Value::String { val, .. } => {
-                if is_emoji(val) {
+                if contains_emoji(val) {
                     // This has to be an emoji, so let's display the code points that make it up.
                     format!(
                         "{:#?}",

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -789,7 +789,34 @@ impl Value {
 
     /// Convert Value into a debug string
     pub fn debug_value(&self) -> String {
-        format!("{self:#?}")
+        // Let's do some special handling for emojis
+        const ZERO_WIDTH_JOINER: &str = "\u{200d}";
+        const VARIATION_SELECTOR_16: &str = "\u{fe0f}";
+        const SKIN_TONES: [&str; 5] = [
+            "\u{1f3fb}", // Light Skin Tone
+            "\u{1f3fc}", // Medium-Light Skin Tone
+            "\u{1f3fd}", // Medium Skin Tone
+            "\u{1f3fe}", // Medium-Dark Skin Tone
+            "\u{1f3ff}", // Dark Skin Tone
+        ];
+
+        match self {
+            Value::String { val, .. } => {
+                if val.contains(ZERO_WIDTH_JOINER)
+                    || val.contains(VARIATION_SELECTOR_16)
+                    || SKIN_TONES.iter().any(|skin_tone| val.contains(skin_tone))
+                {
+                    // This has to be an emoji, so let's display the code points that make it up.
+                    format!(
+                        "{:#?}",
+                        Value::test_string(val.escape_unicode().to_string())
+                    )
+                } else {
+                    format!("{self:#?}")
+                }
+            }
+            _ => format!("{self:#?}"),
+        }
     }
 
     /// Convert Value into a parsable string (quote strings)

--- a/crates/nu-utils/src/emoji.rs
+++ b/crates/nu-utils/src/emoji.rs
@@ -1,4 +1,4 @@
-pub fn is_emoji(val: &str) -> bool {
+pub fn contains_emoji(val: &str) -> bool {
     // Let's do some special handling for emojis
     const ZERO_WIDTH_JOINER: &str = "\u{200d}";
     const VARIATION_SELECTOR_16: &str = "\u{fe0f}";

--- a/crates/nu-utils/src/emoji.rs
+++ b/crates/nu-utils/src/emoji.rs
@@ -1,0 +1,16 @@
+pub fn is_emoji(val: &str) -> bool {
+    // Let's do some special handling for emojis
+    const ZERO_WIDTH_JOINER: &str = "\u{200d}";
+    const VARIATION_SELECTOR_16: &str = "\u{fe0f}";
+    const SKIN_TONES: [&str; 5] = [
+        "\u{1f3fb}", // Light Skin Tone
+        "\u{1f3fc}", // Medium-Light Skin Tone
+        "\u{1f3fd}", // Medium Skin Tone
+        "\u{1f3fe}", // Medium-Dark Skin Tone
+        "\u{1f3ff}", // Dark Skin Tone
+    ];
+
+    val.contains(ZERO_WIDTH_JOINER)
+        || val.contains(VARIATION_SELECTOR_16)
+        || SKIN_TONES.iter().any(|skin_tone| val.contains(skin_tone))
+}

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -15,4 +15,4 @@ pub use casing::IgnoreCaseExt;
 pub use deansi::{
     strip_ansi_likely, strip_ansi_string_likely, strip_ansi_string_unlikely, strip_ansi_unlikely,
 };
-pub use emoji::is_emoji;
+pub use emoji::contains_emoji;

--- a/crates/nu-utils/src/lib.rs
+++ b/crates/nu-utils/src/lib.rs
@@ -1,6 +1,7 @@
 mod casing;
 pub mod ctrl_c;
 mod deansi;
+pub mod emoji;
 pub mod locale;
 pub mod utils;
 
@@ -14,3 +15,4 @@ pub use casing::IgnoreCaseExt;
 pub use deansi::{
     strip_ansi_likely, strip_ansi_string_likely, strip_ansi_string_unlikely, strip_ansi_unlikely,
 };
+pub use emoji::is_emoji;


### PR DESCRIPTION
# Description

This PR add special handling in `debug -r` for emoji's so that it prints the code points.

### Before
```nushell
❯ emoji --list | where name =~ farmer | reject utf8_bytes | get 0.emoji | debug -r
String {
    val: "🧑\u{200d}🌾",
    internal_span: Span {
        start: 0,
        end: 0,
    },
}
```

### After
```nushell
❯ emoji --list | where name =~ farmer | reject utf8_bytes | get 0.emoji | debug -r
String {
    val: "\\u{1f9d1}\\u{200d}\\u{1f33e}",
    internal_span: Span {
        start: 0,
        end: 0,
    },
}
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
