### PR TITLE
Fix build for BSDs

### DIFF
--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -106,7 +106,7 @@ libc = "0.2"
 umask = "2.1"
 nix = { version = "0.27", default-features = false, features = ["user", "resource"] }
 
-[target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android"), not(target_os = "ios"), not(target_os = "netbsd")))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs = "0.16.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]

--- a/crates/nu-command/src/platform/ulimit.rs
+++ b/crates/nu-command/src/platform/ulimit.rs
@@ -233,7 +233,7 @@ static RESOURCE_ARRAY: Lazy<Vec<ResourceInfo>> = Lazy::new(|| {
             "Maximum number of pseudo-terminals",
             'P',
             1,
-            Resource::RLIMIT_NPTY,
+            Resource::RLIMIT_NPTS,
         ),
     ];
 

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -5,8 +5,6 @@ use itertools::Itertools;
     not(target_os = "macos"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "ios"),
-    not(target_os = "netbsd")
 ))]
 use nu_protocol::Span;
 use nu_protocol::{
@@ -20,8 +18,6 @@ use nu_protocol::{
     not(target_os = "macos"),
     not(target_os = "windows"),
     not(target_os = "android"),
-    not(target_os = "ios"),
-    not(target_os = "netbsd")
 ))]
 use procfs::WithCurrentSystemInfo;
 
@@ -125,8 +121,6 @@ fn run_ps(engine_state: &EngineState, call: &Call) -> Result<PipelineData, Shell
                 not(target_os = "macos"),
                 not(target_os = "windows"),
                 not(target_os = "android"),
-                not(target_os = "ios"),
-                not(target_os = "netbsd")
             ))]
             {
                 let proc_stat = proc

--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -93,6 +93,7 @@ fn limit_set_invalid1() {
     });
 }
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 #[test]
 fn limit_set_invalid2() {
     Playground::setup("limit_set_invalid2", |dirs, _sandbox| {


### PR DESCRIPTION
# Description
This PR fixes build for BSD variants (including FreeBSD and NetBSD). 

Currently, `procfs` only support linux, android and l4re, and 0cba269d80953bc391070bdc8e878d276ecd1180 only adds support for NetBSD, this PR should work on all BSD variants.

https://github.com/eminence/procfs/blob/b153b782a5957aa619ed744d0ac8bbe4734601ed/procfs/build.rs#L4-L8

Fixes #11373 

# User-Facing Changes
* before

```console
nibon7@fbsd /d/s/nushell ((70f7db14))> cargo build
   Compiling tempfile v3.8.1
   Compiling procfs v0.16.0
   Compiling toml_edit v0.21.0
   Compiling native-tls v0.2.11
error: failed to run custom build command for `procfs v0.16.0`

Caused by:
  process didn't exit successfully: `/data/source/nushell/target/debug/build/procfs-d59599f40f32f0d5/build-script-build` (exit status: 1)
  --- stderr
  Building procfs on an for a unsupported platform. Currently only linux and android are supported
  (Your current target_os is freebsd)
warning: build failed, waiting for other jobs to finish...
```

* after

```console
nushell on  bsd [✘!?] is 📦 v0.88.2 via 🦀 v1.74.1
❯ version
╭────────────────────┬───────────────────────────────────────────╮
│ version            │ 0.88.2                                    │
│ branch             │ bsd                                       │
│ commit_hash        │ 151edef186470e454367ac6e4b2178188062c1f9  │
│ build_os           │ freebsd-x86_64                            │
│ build_target       │ x86_64-unknown-freebsd                    │
│ rust_version       │ rustc 1.74.1 (a28077b28 2023-12-04)       │
│ rust_channel       │ stable-x86_64-unknown-freebsd             │
│ cargo_version      │ cargo 1.74.1 (ecb9851af 2023-10-18)       │
│ build_time         │ 2023-12-19 10:12:15 +00:00                │
│ build_rust_channel │ debug                                     │
│ allocator          │ mimalloc                                  │
│ features           │ default, extra, sqlite, trash, which, zip │
│ installed_plugins  │                                           │
╰────────────────────┴───────────────────────────────────────────╯
nushell on  bsd [✘!?] is 📦 v0.88.2 via 🦀 v1.74.1
❯ cargo test --workspace commands::ulimit e>> /dev/null | rg ulimit
test commands::ulimit::limit_set_filesize2 ... ok
test commands::ulimit::limit_set_filesize1 ... ok
test commands::ulimit::limit_set_hard1 ... ok
test commands::ulimit::limit_set_hard2 ... ok
test commands::ulimit::limit_set_invalid1 ... ok
test commands::ulimit::limit_set_invalid3 ... ok
test commands::ulimit::limit_set_invalid4 ... ok
test commands::ulimit::limit_set_invalid5 ... ok
test commands::ulimit::limit_set_soft2 ... ok
test commands::ulimit::limit_set_soft1 ... ok
nushell on  bsd [✘!?] is 📦 v0.88.2 via 🦀 v1.74.1
```


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
