### PR TITLE
Simplify `SIGQUIT` handling

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -214,20 +214,6 @@ pub fn evaluate_repl(
         );
 
         start_time = std::time::Instant::now();
-        // Reset the SIGQUIT handler
-        if let Some(sig_quit) = engine_state.get_sig_quit() {
-            sig_quit.store(false, Ordering::SeqCst);
-        }
-        perf(
-            "reset sig_quit",
-            start_time,
-            file!(),
-            line!(),
-            column!(),
-            use_color,
-        );
-
-        start_time = std::time::Instant::now();
         let config = engine_state.get_config();
 
         let engine_reference = std::sync::Arc::new(engine_state.clone());

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -95,8 +95,6 @@ pub struct EngineState {
     pub table_decl_id: Option<usize>,
     #[cfg(feature = "plugin")]
     pub plugin_signatures: Option<PathBuf>,
-    #[cfg(not(windows))]
-    sig_quit: Option<Arc<AtomicBool>>,
     config_path: HashMap<String, PathBuf>,
     pub history_session_id: i64,
     // If Nushell was started, e.g., with `nu spam.nu`, the file's parent is stored here
@@ -152,8 +150,6 @@ impl EngineState {
             table_decl_id: None,
             #[cfg(feature = "plugin")]
             plugin_signatures: None,
-            #[cfg(not(windows))]
-            sig_quit: None,
             config_path: HashMap::new(),
             history_session_id: 0,
             currently_parsed_cwd: None,
@@ -860,21 +856,6 @@ impl EngineState {
         } else {
             None
         }
-    }
-
-    #[cfg(not(windows))]
-    pub fn get_sig_quit(&self) -> &Option<Arc<AtomicBool>> {
-        &self.sig_quit
-    }
-
-    #[cfg(windows)]
-    pub fn get_sig_quit(&self) -> &Option<Arc<AtomicBool>> {
-        &None
-    }
-
-    #[cfg(not(windows))]
-    pub fn set_sig_quit(&mut self, sig_quit: Arc<AtomicBool>) {
-        self.sig_quit = Some(sig_quit)
     }
 
     pub fn set_config_path(&mut self, key: &str, val: PathBuf) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use nu_protocol::{
 use nu_std::load_standard_library;
 use nu_utils::utils::perf;
 use run::{run_commands, run_file, run_repl};
-use signals::{ctrlc_protection, sigquit_protection};
+use signals::ctrlc_protection;
 use std::{
     io::BufReader,
     str::FromStr,
@@ -78,7 +78,6 @@ fn main() -> Result<()> {
     let ctrlc = Arc::new(AtomicBool::new(false));
     // TODO: make this conditional in the future
     ctrlc_protection(&mut engine_state, &ctrlc);
-    sigquit_protection(&mut engine_state);
 
     // Begin: Default NU_LIB_DIRS, NU_PLUGIN_DIRS
     // Set default NU_LIB_DIRS and NU_PLUGIN_DIRS here before the env.nu is processed. If

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -16,14 +16,3 @@ pub(crate) fn ctrlc_protection(engine_state: &mut EngineState, ctrlc: &Arc<Atomi
 
     engine_state.ctrlc = Some(engine_state_ctrlc);
 }
-
-#[cfg(not(windows))]
-pub(crate) fn sigquit_protection(engine_state: &mut EngineState) {
-    use signal_hook::consts::SIGQUIT;
-    let sig_quit = Arc::new(AtomicBool::new(false));
-    signal_hook::flag::register(SIGQUIT, sig_quit.clone()).expect("Error setting SIGQUIT flag");
-    engine_state.set_sig_quit(sig_quit);
-}
-
-#[cfg(windows)]
-pub(crate) fn sigquit_protection(_engine_state: &mut EngineState) {}

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -30,7 +30,8 @@ pub(crate) fn acquire_terminal(interactive: bool) {
                 std::process::exit(1);
             };
 
-            // SIGINT and SIGQUIT have special handling
+            // SIGINT has special handling
+            signal(Signal::SIGQUIT, SigHandler::SigIgn).expect("signal ignore");
             signal(Signal::SIGTSTP, SigHandler::SigIgn).expect("signal ignore");
             signal(Signal::SIGTTIN, SigHandler::SigIgn).expect("signal ignore");
             signal(Signal::SIGTTOU, SigHandler::SigIgn).expect("signal ignore");


### PR DESCRIPTION
# Description
Simplifies `SIGQUIT` protection to a single `signal` ignore system call.

# User-Facing Changes
`SIGQUIT` is no longer blocked if nushell is in non-interactive mode (signals should not be blocked in non-interactive mode).
Also a breaking API change for `nu_protocol`.

# Tests + Formatting
Should come after #11178 for testing.
