### PR TITLE
:memo: Update `str trim` CLI help doc

### DIFF
--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -134,7 +134,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Trim a specific character",
-                example: "'=== Nu shell ===' | str trim --char '=' | str trim",
+                example: "'=== Nu shell ===' | str trim --char '='",
                 result: Some(Value::test_string("Nu shell")),
             },
             Example {
@@ -143,17 +143,12 @@ impl Command for SubCommand {
                 result: Some(Value::test_string("Nu shell ")),
             },
             Example {
-                description: "Trim a specific character",
-                example: "'=== Nu shell ===' | str trim --char '='",
-                result: Some(Value::test_string(" Nu shell ")),
-            },
-            Example {
                 description: "Trim whitespace from the end of string",
                 example: "' Nu shell ' | str trim --right",
                 result: Some(Value::test_string(" Nu shell")),
             },
             Example {
-                description: "Trim a specific character",
+                description: "Trim a specific character only from the end of the string",
                 example: "'=== Nu shell ===' | str trim --right --char '='",
                 result: Some(Value::test_string("=== Nu shell ")),
             },

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -133,9 +133,9 @@ impl Command for SubCommand {
                 result: Some(Value::test_string("Nu shell")),
             },
             Example {
-                description: "Trim a specific character",
+                description: "Trim a specific character (not the whitespace)",
                 example: "'=== Nu shell ===' | str trim --char '='",
-                result: Some(Value::test_string("Nu shell")),
+                result: Some(Value::test_string(" Nu shell ")),
             },
             Example {
                 description: "Trim whitespace from the beginning of string",


### PR DESCRIPTION
# Description
Hi! I updated the samples of `str trim` because there were repeated and clarified the explanations

# User-Facing Changes
Yes! I send the details here:

![image](https://github.com/nushell/nushell/assets/30557287/e30a5612-4214-4365-8b83-7aefbc0ee825)

(`old` is version `88.1` not the latest main)

# Tests + Formatting
~~I ran `toolkit check pr` successfully~~

There was a tiny problem, a test I never touched now it's failing

```nu
(^echo a | complete) == {stdout: "a\n", exit_code: 0}
```
should output `true` but outputs `false`, both in my running `nu` version and in my PR version
This make the test `nu-command::main commands::complete::basic` fail
located in `crates\nu-command\tests\commands\complete.rs`

# After Submitting
I'm not sure if I need to update nushell.github.io, some of the help is auto-generated, but maybe not all?
I can file a PR if needed

