### PR TITLE
Bump `fancy-regex` to single `0.12.0` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,16 +1254,6 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
-name = "fancy-regex"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
@@ -2686,7 +2676,7 @@ version = "0.88.2"
 dependencies = [
  "chrono",
  "crossterm",
- "fancy-regex 0.11.0",
+ "fancy-regex",
  "fuzzy-matcher",
  "is_executable",
  "log",
@@ -2735,7 +2725,7 @@ version = "0.88.2"
 dependencies = [
  "chrono",
  "chrono-tz",
- "fancy-regex 0.12.0",
+ "fancy-regex",
  "indexmap",
  "nu-cmd-lang",
  "nu-engine",
@@ -2757,7 +2747,7 @@ name = "nu-cmd-extra"
 version = "0.88.2"
 dependencies = [
  "ahash",
- "fancy-regex 0.11.0",
+ "fancy-regex",
  "heck",
  "htmlescape",
  "nu-ansi-term",
@@ -2781,7 +2771,7 @@ dependencies = [
 name = "nu-cmd-lang"
 version = "0.88.2"
 dependencies = [
- "fancy-regex 0.11.0",
+ "fancy-regex",
  "itertools 0.12.0",
  "nu-ansi-term",
  "nu-engine",
@@ -2825,7 +2815,7 @@ dependencies = [
  "dirs-next",
  "dtparse",
  "encoding_rs",
- "fancy-regex 0.11.0",
+ "fancy-regex",
  "filesize",
  "filetime",
  "fs_extra",
@@ -3029,7 +3019,7 @@ dependencies = [
  "byte-unit",
  "chrono",
  "chrono-humanize",
- "fancy-regex 0.11.0",
+ "fancy-regex",
  "indexmap",
  "lru",
  "miette",
@@ -3078,7 +3068,7 @@ dependencies = [
 name = "nu-table"
 version = "0.88.2"
 dependencies = [
- "fancy-regex 0.11.0",
+ "fancy-regex",
  "nu-ansi-term",
  "nu-color-config",
  "nu-engine",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -29,7 +29,7 @@ reedline = { version = "0.27.0", features = ["bashisms", "sqlite"] }
 
 chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.27"
-fancy-regex = "0.11"
+fancy-regex = "0.12"
 fuzzy-matcher = "0.3"
 is_executable = "1.0"
 log = "0.4"

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -24,7 +24,7 @@ heck = "0.4.1"
 num-traits = "0.2"
 ahash = "0.8.3"
 nu-ansi-term = "0.49.0"
-fancy-regex = "0.11.0"
+fancy-regex = "0.12.0"
 rust-embed = "8.0.0"
 serde = "1.0.164"
 nu-pretty-hex = { version = "0.88.2", path = "../nu-pretty-hex" }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -18,7 +18,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.88.2" }
 nu-utils = { path = "../nu-utils", version = "0.88.2" }
 nu-ansi-term = "0.49.0"
 
-fancy-regex = "0.11"
+fancy-regex = "0.12"
 itertools = "0.12"
 shadow-rs = { version = "0.25", default-features = false }
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -42,7 +42,7 @@ dialoguer = { default-features = false, features = ["fuzzy-select"], version = "
 digest = { default-features = false, version = "0.10" }
 dtparse = "2.0"
 encoding_rs = "0.8"
-fancy-regex = "0.11"
+fancy-regex = "0.12"
 filesize = "0.2"
 filetime = "0.2"
 fs_extra = "1.3"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -20,7 +20,7 @@ nu-system = { path = "../nu-system", version = "0.88.2" }
 byte-unit = "4.0"
 chrono = { version = "0.4", features = [ "serde", "std", "unstable-locales" ], default-features = false }
 chrono-humanize = "0.2"
-fancy-regex = "0.11"
+fancy-regex = "0.12"
 indexmap = "2.1"
 lru = "0.12"
 miette = { version = "5.10", features = ["fancy-no-backtrace"] }

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -17,7 +17,7 @@ nu-engine = { path = "../nu-engine", version = "0.88.2" }
 nu-color-config = { path = "../nu-color-config", version = "0.88.2" }
 nu-ansi-term = "0.49.0"
 once_cell = "1.18"
-fancy-regex = "0.11"
+fancy-regex = "0.12"
 tabled = { version = "0.14.0", features = ["color"], default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
Supersedes #11039 that was broken due to dependabot not correctly taking
the workspace into account (this bug has been worked around in #11387)
