### PR TITLE
Support global and local vendor completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,8 +2997,10 @@ name = "nu-path"
 version = "0.88.2"
 dependencies = [
  "dirs-next",
+ "dirs-sys-next",
  "omnipath",
  "pwd",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -16,6 +16,8 @@ dirs-next = "2.0"
 
 [target.'cfg(windows)'.dependencies]
 omnipath = "0.1"
+winapi = "0.3"
+dirs-sys-next = "0.1"
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android")))'.dependencies]
 pwd = "1.3"

--- a/crates/nu-path/src/helpers.rs
+++ b/crates/nu-path/src/helpers.rs
@@ -10,6 +10,43 @@ pub fn config_dir() -> Option<PathBuf> {
     dirs_next::config_dir()
 }
 
+pub fn vendor_completions_dirs() -> Vec<PathBuf> {
+    let vendor_completions_fn = |mut path: PathBuf| {
+        path.push("nushell");
+        path.push("completions");
+        path
+    };
+    let mut dirs = Vec::new();
+
+    // default global directory
+    #[cfg(not(target_os = "windows"))]
+    let global_default = Some(PathBuf::from("/usr/share"));
+    #[cfg(target_os = "windows")]
+    let global_default =
+        dirs_sys_next::known_folder(&winapi::um::knownfolders::FOLDERID_ProgramData);
+
+    // global directory
+    if let Some(global) = std::env::var("NU_VENDOR_COMPLETIONS_DIR")
+        .ok()
+        .or(option_env!("NU_VENDOR_COMPLETIONS_DIR").map(String::from))
+        .map(PathBuf::from)
+        .or(global_default.map(vendor_completions_fn))
+    {
+        dirs.push(global);
+    }
+
+    // local directory of the current user
+    if let Some(data_dir) = std::env::var("NU_COMPLETIONS_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs_next::data_dir().map(vendor_completions_fn))
+    {
+        dirs.push(data_dir);
+    }
+
+    dirs
+}
+
 #[cfg(windows)]
 pub fn canonicalize(path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
     path.canonicalize()?.to_winuser_path()

--- a/crates/nu-path/src/lib.rs
+++ b/crates/nu-path/src/lib.rs
@@ -5,6 +5,6 @@ mod tilde;
 mod util;
 
 pub use expansions::{canonicalize_with, expand_path_with, expand_to_real_path};
-pub use helpers::{config_dir, home_dir};
+pub use helpers::{config_dir, home_dir, vendor_completions_dirs};
 pub use tilde::expand_tilde;
 pub use util::trim_trailing_slash;

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -85,6 +85,25 @@ $env.ENV_CONVERSIONS = {
     }
 }
 
+# Completions distributed by package managers are sourced from a global vendor
+# completions directory If you want to override the default, you can do so like
+# this:
+#
+# $env.NU_VENDOR_COMPLETIONS_DIR = ...
+#
+# The default is /usr/share/nushell/completions on Linux and MacOS, and
+# %ProgramData%\nushell\completions on Windows
+#
+# There's a similar path for completions installed by the user, which can be
+# overridden like so:
+#
+# $env.NU_COMPLETIONS_DIR = ...
+#
+# The default here is $XDG_DATA_HOME/nushell/completions on Linux, falling back
+# to $HOME/.local/share for $XDG_DATA_HOME if it's not set,
+# $HOME/Library/Application Support/nushell/completions on MacOS, and
+# %RoamingAppData%\nushell\completions on Windows.
+
 # Directories to search for scripts when calling source or use
 # The default for this is $nu.default-config-dir/scripts
 $env.NU_LIB_DIRS = [


### PR DESCRIPTION

# Description
This adds both a global/system vendor completions dir, and a local one. The global one is primarily meant for the use with system package managers, such as the ones used by Linux distributions. The local one is specific to the user, and can be used for automatically including completions installed locally by the user.

The global/system vendor completions dir can be overridden at both compile time and run time, the local user one only at run time, as I don't see why a distribution would want to override that.

Fixes #11337

# User-Facing Changes
Not sure how much users should see of this at all. This is primarily so that completions magically work when packages ship with them. If anyone has any ideas of how to document this properly for users, please, contribute that bit as well.

# Tests + Formatting
I haven't added any new tests here, and I don't want to either. I've got quite limited time at the moment and spent way too much of it on this already, so if someone else could take over this bit, I'd be happy about that as well.

I have run `toolkit check pr` on my changes though, and that was happy.
