### PR TITLE
Fix completion on folders.

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -143,7 +143,9 @@ pub fn complete_item(
         }
     }
 
-    let options = if isdir {
+    let mut target_pathbuf = cwd.clone();
+    target_pathbuf.extend(partial.clone());
+    let options = if isdir && target_pathbuf.exists() {
         CompletionOptions {
             match_algorithm: MatchAlgorithm::Exact,
             ..options.clone()

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -1,4 +1,4 @@
-use crate::completions::{matches, CompletionOptions};
+use crate::completions::{matches, CompletionOptions, MatchAlgorithm};
 use nu_path::home_dir;
 use nu_protocol::{engine::StateWorkingSet, Span};
 use std::path::{is_separator, Component, Path, PathBuf, MAIN_SEPARATOR as SEP};
@@ -143,7 +143,16 @@ pub fn complete_item(
         }
     }
 
-    complete_rec(partial.as_slice(), &cwd, options, want_directory, isdir)
+    let options = if isdir {
+        CompletionOptions {
+            match_algorithm: MatchAlgorithm::Exact,
+            ..options.clone()
+        }
+    } else {
+        options.clone()
+    };
+
+    complete_rec(partial.as_slice(), &cwd, &options, want_directory, isdir)
         .into_iter()
         .map(|p| (span, escape_path(original_cwd.apply(&p), want_directory)))
         .collect()

--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -14,6 +14,11 @@ pub enum SortBy {
 /// Describes how suggestions should be matched.
 #[derive(Copy, Clone, Debug)]
 pub enum MatchAlgorithm {
+    /// Only show suggestions which match exactly the given input
+    ///
+    /// Example:
+    /// "git switch" is matched by "git switch"
+    Exact,
     /// Only show suggestions which begin with the given input
     ///
     /// Example:
@@ -33,6 +38,7 @@ impl MatchAlgorithm {
         let haystack = trim_quotes_str(haystack);
         let needle = trim_quotes_str(needle);
         match *self {
+            MatchAlgorithm::Exact => haystack == needle,
             MatchAlgorithm::Prefix => haystack.starts_with(needle),
             MatchAlgorithm::Fuzzy => {
                 let matcher = SkimMatcherV2::default();
@@ -44,6 +50,7 @@ impl MatchAlgorithm {
     /// Returns whether the `needle` search text matches the given `haystack`.
     pub fn matches_u8(&self, haystack: &[u8], needle: &[u8]) -> bool {
         match *self {
+            MatchAlgorithm::Exact => haystack == needle,
             MatchAlgorithm::Prefix => haystack.starts_with(needle),
             MatchAlgorithm::Fuzzy => {
                 let haystack_str = String::from_utf8_lossy(haystack);

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -163,6 +163,9 @@ fn filter(prefix: &[u8], items: Vec<Suggestion>, options: &CompletionOptions) ->
                     }
                 }
             },
+            MatchAlgorithm::Exact => options
+                .match_algorithm
+                .matches_u8(it.value.as_bytes(), prefix),
             MatchAlgorithm::Fuzzy => options
                 .match_algorithm
                 .matches_u8(it.value.as_bytes(), prefix),


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx
you can also mention related issues, PRs or discussions!
-->

fixes #11396 

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
This PR introduces a new strategy for exact matching. This strategy is only activated when the user specifically selects the target folder.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Given the folder structure like this:
```
.
├── dir
│   ├── license
│   └── readme.md
├── dir_one
│   ├── license
│   └── readme.md
├── dir_three
│   ├── license
│   └── readme.md
└── dir_two
    ├── license
    └── readme.md
```

Before this PR, completion on `ls dir/` returns:
```
dir/license          dir/readme.md        dir_one/license      dir_one/readme.md    
dir_three/license    dir_three/readme.md  dir_two/license      dir_two/readme.md
```
After this PR, completion on `ls dir/` will return:
```
dir/license         dir/readme.md 
```
However,  for now completion on `ls dir/r` still returns:
```
dir/readme.md        dir_one/readme.md    dir_three/readme.md  dir_two/readme.md
```
instead of 
```
dir/readme.md
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
