### PR TITLE
Do not block signals for child processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,7 +2654,6 @@ dependencies = [
  "rstest",
  "serde_json",
  "serial_test",
- "signal-hook",
  "simplelog",
  "tempfile",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ time = "0.3"
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Our dependencies don't use OpenSSL on Windows
 openssl = { version = "0.10", features = ["vendored"], optional = true }
-signal-hook = { version = "0.3", default-features = false }
 
 [target.'cfg(windows)'.build-dependencies]
 winresource = "0.1"

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -8,7 +8,7 @@ use nu_protocol::{
     Category, Example, ListStream, PipelineData, RawStream, ShellError, Signature, Span, Spanned,
     SyntaxShape, Type, Value,
 };
-use nu_system::ForegroundProcess;
+use nu_system::ForegroundChild;
 use nu_utils::IgnoreCaseExt;
 use os_pipe::PipeReader;
 use pathdiff::diff_paths;
@@ -198,82 +198,69 @@ impl ExternalCommand {
 
         #[allow(unused_mut)]
         let (cmd, mut reader) = self.create_process(&input, false, head)?;
-        let mut fg_process =
-            ForegroundProcess::new(cmd, engine_state.pipeline_externals_state.clone());
-        // mut is used in the windows branch only, suppress warning on other platforms
-        #[allow(unused_mut)]
-        let mut child;
+
+        #[cfg(all(not(unix), not(windows)))] // are there any systems like this?
+        let child = ForegroundChild::spawn(cmd);
 
         #[cfg(windows)]
-        {
-            // Running external commands on Windows has 2 points of complication:
-            // 1. Some common Windows commands are actually built in to cmd.exe, not executables in their own right.
-            // 2. We need to let users run batch scripts etc. (.bat, .cmd) without typing their extension
+        let child = match ForegroundChild::spawn(cmd) {
+            Ok(child) => Ok(child),
+            Err(err) => {
+                // Running external commands on Windows has 2 points of complication:
+                // 1. Some common Windows commands are actually built in to cmd.exe, not executables in their own right.
+                // 2. We need to let users run batch scripts etc. (.bat, .cmd) without typing their extension
 
-            // To support these situations, we have a fallback path that gets run if a command
-            // fails to be run as a normal executable:
-            // 1. "shell out" to cmd.exe if the command is a known cmd.exe internal command
-            // 2. Otherwise, use `which-rs` to look for batch files etc. then run those in cmd.exe
-            match fg_process.spawn(engine_state.is_interactive) {
-                Err(err) => {
-                    // set the default value, maybe we'll override it later
-                    child = Err(err);
+                // To support these situations, we have a fallback path that gets run if a command
+                // fails to be run as a normal executable:
+                // 1. "shell out" to cmd.exe if the command is a known cmd.exe internal command
+                // 2. Otherwise, use `which-rs` to look for batch files etc. then run those in cmd.exe
 
-                    // This has the full list of cmd.exe "internal" commands: https://ss64.com/nt/syntax-internal.html
-                    // I (Reilly) went through the full list and whittled it down to ones that are potentially useful:
-                    const CMD_INTERNAL_COMMANDS: [&str; 9] = [
-                        "ASSOC", "CLS", "ECHO", "FTYPE", "MKLINK", "PAUSE", "START", "VER", "VOL",
-                    ];
-                    let command_name = &self.name.item;
-                    let looks_like_cmd_internal = CMD_INTERNAL_COMMANDS
-                        .iter()
-                        .any(|&cmd| command_name.eq_ignore_ascii_case(cmd));
+                // set the default value, maybe we'll override it later
+                let mut child = Err(err);
 
-                    if looks_like_cmd_internal {
-                        let (cmd, new_reader) = self.create_process(&input, true, head)?;
-                        reader = new_reader;
-                        let mut cmd_process = ForegroundProcess::new(
-                            cmd,
-                            engine_state.pipeline_externals_state.clone(),
-                        );
-                        child = cmd_process.spawn(engine_state.is_interactive);
-                    } else {
-                        #[cfg(feature = "which-support")]
+                // This has the full list of cmd.exe "internal" commands: https://ss64.com/nt/syntax-internal.html
+                // I (Reilly) went through the full list and whittled it down to ones that are potentially useful:
+                const CMD_INTERNAL_COMMANDS: [&str; 9] = [
+                    "ASSOC", "CLS", "ECHO", "FTYPE", "MKLINK", "PAUSE", "START", "VER", "VOL",
+                ];
+                let command_name = &self.name.item;
+                let looks_like_cmd_internal = CMD_INTERNAL_COMMANDS
+                    .iter()
+                    .any(|&cmd| command_name.eq_ignore_ascii_case(cmd));
+
+                if looks_like_cmd_internal {
+                    let (cmd, new_reader) = self.create_process(&input, true, head)?;
+                    reader = new_reader;
+                    child = ForegroundChild::spawn(cmd);
+                } else {
+                    #[cfg(feature = "which-support")]
+                    {
+                        // maybe it's a batch file (foo.cmd) and the user typed `foo`. Try to find it with `which-rs`
+                        // TODO: clean this up with an if-let chain once those are stable
+                        if let Ok(path) =
+                            nu_engine::env::path_str(engine_state, stack, self.name.span)
                         {
-                            // maybe it's a batch file (foo.cmd) and the user typed `foo`. Try to find it with `which-rs`
-                            // TODO: clean this up with an if-let chain once those are stable
-                            if let Ok(path) =
-                                nu_engine::env::path_str(engine_state, stack, self.name.span)
-                            {
-                                if let Some(cwd) = self.env_vars.get("PWD") {
-                                    // append cwd to PATH so `which-rs` looks in the cwd too.
-                                    // this approximates what cmd.exe does.
-                                    let path_with_cwd = format!("{};{}", cwd, path);
-                                    if let Ok(which_path) =
-                                        which::which_in(&self.name.item, Some(path_with_cwd), cwd)
-                                    {
-                                        if let Some(file_name) = which_path.file_name() {
-                                            if !file_name
-                                                .to_string_lossy()
-                                                .eq_ignore_case(command_name)
-                                            {
-                                                // which-rs found an executable file with a slightly different name
-                                                // than the one the user tried. Let's try running it
-                                                let mut new_command = self.clone();
-                                                new_command.name = Spanned {
-                                                    item: file_name.to_string_lossy().to_string(),
-                                                    span: self.name.span,
-                                                };
-                                                let (cmd, new_reader) = new_command
-                                                    .create_process(&input, true, head)?;
-                                                reader = new_reader;
-                                                let mut cmd_process = ForegroundProcess::new(
-                                                    cmd,
-                                                    engine_state.pipeline_externals_state.clone(),
-                                                );
-                                                child =
-                                                    cmd_process.spawn(engine_state.is_interactive);
-                                            }
+                            if let Some(cwd) = self.env_vars.get("PWD") {
+                                // append cwd to PATH so `which-rs` looks in the cwd too.
+                                // this approximates what cmd.exe does.
+                                let path_with_cwd = format!("{};{}", cwd, path);
+                                if let Ok(which_path) =
+                                    which::which_in(&self.name.item, Some(path_with_cwd), cwd)
+                                {
+                                    if let Some(file_name) = which_path.file_name() {
+                                        if !file_name.to_string_lossy().eq_ignore_case(command_name)
+                                        {
+                                            // which-rs found an executable file with a slightly different name
+                                            // than the one the user tried. Let's try running it
+                                            let mut new_command = self.clone();
+                                            new_command.name = Spanned {
+                                                item: file_name.to_string_lossy().to_string(),
+                                                span: self.name.span,
+                                            };
+                                            let (cmd, new_reader) =
+                                                new_command.create_process(&input, true, head)?;
+                                            reader = new_reader;
+                                            child = ForegroundChild::spawn(cmd);
                                         }
                                     }
                                 }
@@ -281,16 +268,17 @@ impl ExternalCommand {
                         }
                     }
                 }
-                Ok(process) => {
-                    child = Ok(process);
-                }
-            }
-        }
 
-        #[cfg(not(windows))]
-        {
-            child = fg_process.spawn(engine_state.is_interactive)
-        }
+                child
+            }
+        };
+
+        #[cfg(unix)]
+        let child = ForegroundChild::spawn(
+            cmd,
+            engine_state.is_interactive,
+            &engine_state.pipeline_externals_state,
+        );
 
         match child {
             Err(err) => {

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -126,12 +126,12 @@ mod foreground_pgroup {
                 // Reset signal handlers for child, sync with `terminal.rs`
                 let default = SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty());
                 // SIGINT has special handling
-                sigaction(Signal::SIGQUIT, &default).expect("signal default");
+                let _ = sigaction(Signal::SIGQUIT, &default);
                 // We don't support background jobs, so keep some signals blocked for now
-                // sigaction(Signal::SIGTSTP, &default).expect("signal default");
-                // sigaction(Signal::SIGTTIN, &default).expect("signal default");
-                // sigaction(Signal::SIGTTOU, &default).expect("signal default");
-                sigaction(Signal::SIGTERM, &default).expect("signal default");
+                // let _ = sigaction(Signal::SIGTSTP, &default);
+                // let _ = sigaction(Signal::SIGTTIN, &default);
+                // let _ = sigaction(Signal::SIGTTOU, &default);
+                let _ = sigaction(Signal::SIGTERM, &default);
 
                 Ok(())
             });

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -160,7 +160,7 @@ mod foreground_pgroup {
     /// Reset the foreground process group to the shell
     pub fn reset() {
         if let Err(e) = unistd::tcsetpgrp(libc::STDIN_FILENO, unistd::getpgrp()) {
-            println!("ERROR: reset foreground id failed, tcsetpgrp result: {e:?}");
+            eprintln!("ERROR: reset foreground id failed, tcsetpgrp result: {e:?}");
         }
     }
 }

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -128,7 +128,7 @@ mod foreground_pgroup {
         unsafe {
             // Safety:
             // POSIX only allows async-signal-safe functions to be called.
-            // `sigprocmask`, `setpgid` and `tcsetpgrp` are async-signal-safe according to:
+            // `sigaction`, `getpid`, `setpgid`, and `tcsetpgrp` are async-signal-safe according to:
             // https://manpages.ubuntu.com/manpages/bionic/man7/signal-safety.7.html
             external_command.pre_exec(move || {
                 // When this callback is run, std::process has already done:

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -6,8 +6,10 @@ use std::{
 #[cfg(unix)]
 use std::{
     io::IsTerminal,
-    sync::atomic::Ordering,
-    sync::{atomic::AtomicU32, Arc},
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc,
+    },
 };
 
 /// A simple wrapper for [`std::process::Child`]
@@ -129,10 +131,6 @@ mod foreground_pgroup {
                 // sigaction(Signal::SIGTSTP, &default).expect("signal default");
                 sigaction(Signal::SIGTTIN, &default).expect("signal default");
                 sigaction(Signal::SIGTTOU, &default).expect("signal default");
-
-                // TODO: determine if this is necessary or not, since this breaks `rm` on macOS
-                // sigaction(Signal::SIGCHLD, &ignore).expect("signal default");
-
                 sigaction(Signal::SIGTERM, &default).expect("signal default");
 
                 Ok(())

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -1,11 +1,11 @@
 use std::{
     io,
     process::{Child, Command},
-    sync::{
-        atomic::{AtomicU32, Ordering},
-        Arc,
-    },
+    sync::{atomic::AtomicU32, Arc},
 };
+
+#[cfg(unix)]
+use std::{io::IsTerminal, sync::atomic::Ordering};
 
 /// A simple wrapper for `std::process::Command`
 ///
@@ -56,8 +56,6 @@ impl ForegroundProcess {
 
     #[cfg(unix)]
     pub fn spawn(&mut self, interactive: bool) -> io::Result<ForegroundChild> {
-        use std::io::IsTerminal;
-
         if interactive && io::stdin().is_terminal() {
             let (ref pgrp, ref pcnt) = *self._pipeline_state;
             let existing_pgrp = pgrp.load(Ordering::SeqCst);

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -113,16 +113,7 @@ mod fg_process_setup {
             // https://manpages.ubuntu.com/manpages/bionic/man7/signal-safety.7.html
             external_command.pre_exec(move || {
                 // When this callback is run, std::process has already done:
-                // - pthread_sigmask(SIG_SETMASK) with an empty sigset
                 // - signal(SIGPIPE, SIG_DFL)
-                // However, we do need TTOU/TTIN blocked again during this setup.
-                let mut sigset = signal::SigSet::empty();
-                sigset.add(signal::Signal::SIGTSTP);
-                sigset.add(signal::Signal::SIGTTOU);
-                sigset.add(signal::Signal::SIGTTIN);
-                sigset.add(signal::Signal::SIGCHLD);
-                signal::sigprocmask(signal::SigmaskHow::SIG_BLOCK, Some(&sigset), None)
-                    .expect("signal mask");
 
                 // According to glibc's job control manual:
                 // https://www.gnu.org/software/libc/manual/html_node/Launching-Jobs.html

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -31,7 +31,7 @@ pub struct ForegroundProcess {
 /// It can only be created by `ForegroundProcess::spawn`.
 pub struct ForegroundChild {
     inner: Child,
-    pipeline_state: Option<Arc<(AtomicU32, AtomicU32)>>,
+    _pipeline_state: Option<Arc<(AtomicU32, AtomicU32)>>,
 }
 
 impl ForegroundProcess {
@@ -45,7 +45,7 @@ impl ForegroundProcess {
     fn spawn_simple(&mut self) -> io::Result<ForegroundChild> {
         self.inner.spawn().map(|child| ForegroundChild {
             inner: child,
-            pipeline_state: None,
+            _pipeline_state: None,
         })
     }
 
@@ -70,7 +70,7 @@ impl ForegroundProcess {
                     }
                     ForegroundChild {
                         inner: child,
-                        pipeline_state: Some(self.pipeline_state.clone()),
+                        _pipeline_state: Some(self.pipeline_state.clone()),
                     }
                 })
                 .map_err(|e| {
@@ -92,7 +92,7 @@ impl AsMut<Child> for ForegroundChild {
 #[cfg(unix)]
 impl Drop for ForegroundChild {
     fn drop(&mut self) {
-        if let Some((pgrp, pcnt)) = self.pipeline_state.as_deref() {
+        if let Some((pgrp, pcnt)) = self._pipeline_state.as_deref() {
             if pcnt.fetch_sub(1, Ordering::SeqCst) == 1 {
                 pgrp.store(0, Ordering::SeqCst);
                 foreground_pgroup::reset()

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -127,10 +127,10 @@ mod foreground_pgroup {
                 let default = SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty());
                 // SIGINT has special handling
                 sigaction(Signal::SIGQUIT, &default).expect("signal default");
-                // We don't support background jobs, so keep SIGTSTP blocked?
+                // We don't support background jobs, so keep some signals blocked for now
                 // sigaction(Signal::SIGTSTP, &default).expect("signal default");
-                sigaction(Signal::SIGTTIN, &default).expect("signal default");
-                sigaction(Signal::SIGTTOU, &default).expect("signal default");
+                // sigaction(Signal::SIGTTIN, &default).expect("signal default");
+                // sigaction(Signal::SIGTTOU, &default).expect("signal default");
                 sigaction(Signal::SIGTERM, &default).expect("signal default");
 
                 Ok(())

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -119,7 +119,7 @@ mod foreground_pgroup {
                 // According to glibc's job control manual:
                 // https://www.gnu.org/software/libc/manual/html_node/Launching-Jobs.html
                 // This has to be done *both* in the parent and here in the child due to race conditions.
-                set_foreground_pid(unistd::getpid(), existing_pgrp);
+                set_foreground_pid(Pid::this(), existing_pgrp);
 
                 // Reset signal handlers for child, sync with `terminal.rs`
                 let default = SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty());

--- a/crates/nu-system/src/lib.rs
+++ b/crates/nu-system/src/lib.rs
@@ -7,7 +7,7 @@ pub mod os_info;
 #[cfg(target_os = "windows")]
 mod windows;
 
-pub use self::foreground::{ForegroundChild, ForegroundProcess};
+pub use self::foreground::ForegroundChild;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 pub use self::linux::*;
 #[cfg(target_os = "macos")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod ide;
 mod logger;
 mod run;
 mod signals;
+#[cfg(unix)]
 mod terminal;
 mod test_bins;
 #[cfg(test)]
@@ -17,7 +18,6 @@ use crate::{
     command::parse_commandline_args,
     config_files::set_config_path,
     logger::{configure, logger},
-    terminal::acquire_terminal,
 };
 use command::gather_commandline_args;
 use log::Level;
@@ -185,16 +185,19 @@ fn main() -> Result<()> {
         use_color,
     );
 
-    start_time = std::time::Instant::now();
-    acquire_terminal(engine_state.is_interactive);
-    perf(
-        "acquire_terminal",
-        start_time,
-        file!(),
-        line!(),
-        column!(),
-        use_color,
-    );
+    #[cfg(unix)]
+    {
+        start_time = std::time::Instant::now();
+        terminal::acquire(engine_state.is_interactive);
+        perf(
+            "acquire_terminal",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
+    }
 
     if let Some(include_path) = &parsed_nu_cli_args.include_path {
         let span = include_path.span;

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,10 +1,8 @@
-#[cfg(unix)]
 use std::{
     io::IsTerminal,
     sync::atomic::{AtomicI32, Ordering},
 };
 
-#[cfg(unix)]
 use nix::{
     errno::Errno,
     libc,
@@ -12,11 +10,9 @@ use nix::{
     unistd::{self, Pid},
 };
 
-#[cfg(unix)]
 static INITIAL_PGID: AtomicI32 = AtomicI32::new(-1);
 
-#[cfg(unix)]
-pub(crate) fn acquire_terminal(interactive: bool) {
+pub(crate) fn acquire(interactive: bool) {
     if interactive && std::io::stdin().is_terminal() {
         // see also: https://www.gnu.org/software/libc/manual/html_node/Initializing-the-Shell.html
 
@@ -65,12 +61,8 @@ pub(crate) fn acquire_terminal(interactive: bool) {
     }
 }
 
-#[cfg(not(unix))]
-pub(crate) fn acquire_terminal(_: bool) {}
-
 // Inspired by fish's acquire_tty_or_exit
 // Returns our original pgid
-#[cfg(unix)]
 fn take_control() -> Pid {
     let shell_pgid = unistd::getpgrp();
 
@@ -126,7 +118,6 @@ fn take_control() -> Pid {
     std::process::exit(1);
 }
 
-#[cfg(unix)]
 extern "C" fn restore_terminal() {
     // Safety: can only call async-signal-safe functions here
     // `tcsetpgrp` and `getpgrp` are async-signal-safe
@@ -136,7 +127,6 @@ extern "C" fn restore_terminal() {
     }
 }
 
-#[cfg(unix)]
 extern "C" fn sigterm_handler(_signum: libc::c_int) {
     // Safety: can only call async-signal-safe functions here
     // `restore_terminal`, `sigaction`, `raise`, and `_exit` are all async-signal-safe

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -139,7 +139,7 @@ extern "C" fn restore_terminal() {
 #[cfg(unix)]
 extern "C" fn sigterm_handler(_signum: libc::c_int) {
     // Safety: can only call async-signal-safe functions here
-    // `restore_terminal`, `sigaction`, and `raise` are all async-signal-safe
+    // `restore_terminal`, `sigaction`, `raise`, and `_exit` are all async-signal-safe
 
     restore_terminal();
 
@@ -149,10 +149,10 @@ extern "C" fn sigterm_handler(_signum: libc::c_int) {
         // This should not be possible, but if it does happen,
         // then this could result in an infinite loop due to the raise below.
         // So, we'll just exit immediately if this happens.
-        std::process::exit(1);
+        unsafe { libc::_exit(1) };
     };
 
     if raise(Signal::SIGTERM).is_err() {
-        std::process::exit(1);
+        unsafe { libc::_exit(1) };
     };
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -151,7 +151,7 @@ extern "C" fn sigterm_handler(_signum: libc::c_int) {
     if unsafe { sigaction(Signal::SIGTERM, &default) }.is_err() {
         // Failed to set signal handler to default.
         // This should not be possible, but if it does happen,
-        // then this could result in an infitite loop due to the raise below.
+        // then this could result in an infinite loop due to the raise below.
         // So, we'll just exit immediately if this happens.
         std::process::exit(1);
     };

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -36,10 +36,6 @@ pub(crate) fn acquire_terminal(interactive: bool) {
             sigaction(Signal::SIGTSTP, &ignore).expect("signal ignore");
             sigaction(Signal::SIGTTIN, &ignore).expect("signal ignore");
             sigaction(Signal::SIGTTOU, &ignore).expect("signal ignore");
-
-            // TODO: determine if this is necessary or not, since this breaks `rm` on macOS
-            // sigaction(Signal::SIGCHLD, &ignore).expect("signal ignore");
-
             sigaction(
                 Signal::SIGTERM,
                 &SigAction::new(


### PR DESCRIPTION
# Description / User-Facing Changes
Signals are no longer blocked for child processes launched from both interactive and non-interactive mode. The only exception is that `SIGTSTP`, `SIGTTIN`, and `SIGTTOU` remain blocked for child processes launched only from **interactive** mode. This is to help prevent nushell from getting into an unrecoverable state, since we don't support background jobs. Anyways, this fully fixes #9026.

# Other Notes
- Needs Rust version `>= 1.66` for a fix in `std::process::Command::spawn`, but it looks our current Rust version is way above this.
- Uses `sigaction` instead of `signal`, since the behavior of `signal` can apparently differ across systems. Also, the `sigaction` man page says:
  > The sigaction() function supersedes the signal() function, and should be used in preference.

  Additionally, using both `sigaction` and `signal` is not recommended. Since we were already using `sigaction` in some places (and possibly some of our dependencies as well), this PR replaces all usages of `signal`.

# Tests
Might want to wait for #11178 for testing.
