### PR TITLE
Command "ls"

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -347,8 +347,9 @@ fn is_hidden_dir(dir: impl AsRef<Path>) -> bool {
         } else {
             return false;
         }
-        // hidden_attribute have to be checked because it determines if the file is hidden or not
-        // in Windows, while Linux software use the dot prefix to determine if the file is hidden
+        // Besides checking the hidden attribute, also check if the file name starts
+        // with "." (dot), because many Linux programs, when used on Windows,
+        //  still use the Linux convention of the dot file.
         hidden_attributes
             || dir
                 .as_ref()

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -338,14 +338,22 @@ fn is_hidden_dir(dir: impl AsRef<Path>) -> bool {
     #[cfg(windows)]
     {
         use std::os::windows::fs::MetadataExt;
+        let hidden_attributes: bool;
 
         if let Ok(metadata) = dir.as_ref().metadata() {
             let attributes = metadata.file_attributes();
             // https://docs.microsoft.com/en-us/windows/win32/fileio/file-attribute-constants
-            (attributes & 0x2) != 0
+            hidden_attributes = (attributes & 0x2) != 0;
         } else {
-            false
+            return false;
         }
+
+        hidden_attributes
+            || dir
+                .as_ref()
+                .file_name()
+                .map(|name| name.to_string_lossy().starts_with('.'))
+                .unwrap_or(false)
     }
 
     #[cfg(not(windows))]

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -347,7 +347,8 @@ fn is_hidden_dir(dir: impl AsRef<Path>) -> bool {
         } else {
             return false;
         }
-
+        // hidden_attribute have to be checked because it determines if the file is hidden or not
+        // in Windows, while Linux software use the dot prefix to determine if the file is hidden
         hidden_attributes
             || dir
                 .as_ref()


### PR DESCRIPTION
Partial fixed https://github.com/nushell/nushell/issues/11148


# Description
The ls command shows hidden files (e.g .example), it should normally show them only when it is called with the "-a/-all" argument.


# User-Facing Changes
ls doesn't show .files anymore.

# Tests + Formatting
![image](https://github.com/nushell/nushell/assets/119429832/fc0bee52-400b-46ee-ac83-f07d5ba59b19)
![image](https://github.com/nushell/nushell/assets/119429832/d260fdc3-3d4a-4fe5-a7cf-ae035a27fbb9)


