### PR TITLE
Check for clean repo after tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,17 @@ jobs:
         run: nu scripts/test_virtualenv.nu
         shell: bash
 
+      - name: Check for clean repo
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "there are changes";
+            git status --porcelain
+            exit 1
+          else
+            echo "no changes in working directory";
+          fi
+
   plugins:
     strategy:
       fail-fast: true
@@ -161,3 +172,14 @@ jobs:
 
       - name: Tests
         run: cargo test --profile ci --package nu_plugin_*
+
+      - name: Check for clean repo
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "there are changes";
+            git status --porcelain
+            exit 1
+          else
+            echo "no changes in working directory";
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,17 @@ jobs:
       - name: Tests
         run: cargo test --workspace --profile ci --exclude nu_plugin_* ${{ matrix.flags }}
 
+      - name: Check for clean repo
+        shell: bash
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "there are changes";
+            git status --porcelain
+            exit 1
+          else
+            echo "no changes in working directory";
+          fi
+
   std-lib-and-python-virtualenv:
     strategy:
       fail-fast: true

--- a/scripts/test_virtualenv.nu
+++ b/scripts/test_virtualenv.nu
@@ -53,4 +53,5 @@ def main [] {
         let msg = $"OUTPUT:\n($o)\n\nEXPECTED:\n($e)"
         error make {msg: $"Output does not match the expected value:\n($msg)"}
     }
+    rm script.nu
 }


### PR DESCRIPTION
Goal: detect problems like adressed by #11407 or missing `Cargo.lock`
update early

Try to fail when there is a non clear `git status` message
