### PR TITLE
Shows Query Sub Commands : Issue #6844

### DIFF
--- a/crates/nu-command/src/database/commands/mod.rs
+++ b/crates/nu-command/src/database/commands/mod.rs
@@ -1,9 +1,11 @@
 mod into_sqlite;
+mod query;
 mod query_db;
 mod schema;
 
 use into_sqlite::IntoSqliteDb;
 use nu_protocol::engine::StateWorkingSet;
+use query::Query;
 use query_db::QueryDb;
 use schema::SchemaDb;
 
@@ -18,5 +20,5 @@ pub fn add_commands_decls(working_set: &mut StateWorkingSet) {
         }
 
     // Series commands
-    bind_command!(IntoSqliteDb, QueryDb, SchemaDb);
+    bind_command!(IntoSqliteDb, QueryDb, SchemaDb, Query);
 }

--- a/crates/nu-command/src/database/commands/query.rs
+++ b/crates/nu-command/src/database/commands/query.rs
@@ -1,7 +1,7 @@
 use nu_engine::get_full_help;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{IntoPipelineData, PipelineData, ShellError, Signature, Value};
+use nu_protocol::{IntoPipelineData, PipelineData, ShellError, Signature, Type, Value};
 
 #[derive(Clone)]
 pub struct Query;
@@ -12,7 +12,7 @@ impl Command for Query {
     }
 
     fn signature(&self) -> nu_protocol::Signature {
-        Signature::build(self.name())
+        Signature::build(self.name()).input_output_types(vec![(Type::Nothing, Type::Nothing)])
     }
 
     fn usage(&self) -> &str {

--- a/crates/nu-command/src/database/commands/query.rs
+++ b/crates/nu-command/src/database/commands/query.rs
@@ -1,0 +1,44 @@
+use nu_engine::get_full_help;
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{IntoPipelineData, PipelineData, ShellError, Signature, Value};
+
+#[derive(Clone)]
+pub struct Query;
+
+impl Command for Query {
+    fn name(&self) -> &str {
+        "query"
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build(self.name())
+    }
+
+    fn usage(&self) -> &str {
+        "Show all the query commands."
+    }
+
+    fn extra_usage(&self) -> &str {
+        "You must use one of the following subcommands. Using this command as-is will only produce this help message."
+    }
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(Value::string(
+            get_full_help(
+                &Query.signature(),
+                &Query.examples(),
+                engine_state,
+                stack,
+                self.is_parser_keyword(),
+            ),
+            call.head,
+        )
+        .into_pipeline_data())
+    }
+}


### PR DESCRIPTION
### Description
This PR resolves [Issue #6844](https://github.com/nushell/nushell/issues/6844) where entering ```query``` doesn't show any useful information. This PR semi resolves the issue,  but would need more ```query``` sub-command plugins to be registered.

# User-Facing Changes
User facing changes allow the user to enter ```query``` stand alone and see registered sub-commands

