### PR TITLE
Lock out new direct construction of `Record`

### DIFF
--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -6,8 +6,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Record {
+    /// Don't use this field publicly!
+    ///
+    /// Only public as command `rename` is not reimplemented in a sane way yet
+    /// Using it or making `vals` public will draw shaming by @sholderbach
     pub cols: Vec<String>,
-    pub vals: Vec<Value>,
+    vals: Vec<Value>,
 }
 
 impl Record {


### PR DESCRIPTION
# Description
With #11386 we don't have any nushell-internal code directly accessing the `vals` field of `Record`, so let's make it private so everyone in the future uses the checked ways guaranteeing matching cols/vals.

The `cols` feel has to remain pub for now as `rename` still directly mutates this field. See #11020 for challenges for this refactor.

# Plugin-Author-Facing Changes
This is a breaking change for outside plugins that relied on the `pub` fields.
