### PR TITLE
Simplify the feature gates for `stor` commands

### DIFF
--- a/crates/nu-command/src/lib.rs
+++ b/crates/nu-command/src/lib.rs
@@ -23,6 +23,7 @@ mod random;
 mod removed;
 mod shells;
 mod sort_utils;
+#[cfg(feature = "sqlite")]
 mod stor;
 mod strings;
 mod system;

--- a/crates/nu-command/src/stor/mod.rs
+++ b/crates/nu-command/src/stor/mod.rs
@@ -1,35 +1,19 @@
-#[cfg(feature = "sqlite")]
 mod create;
-#[cfg(feature = "sqlite")]
 mod delete;
-#[cfg(feature = "sqlite")]
 mod export;
-#[cfg(feature = "sqlite")]
 mod import;
-#[cfg(feature = "sqlite")]
 mod insert;
-#[cfg(feature = "sqlite")]
 mod open;
-#[cfg(feature = "sqlite")]
 mod reset;
 mod stor_;
-#[cfg(feature = "sqlite")]
 mod update;
 
-#[cfg(feature = "sqlite")]
 pub use create::StorCreate;
-#[cfg(feature = "sqlite")]
 pub use delete::StorDelete;
-#[cfg(feature = "sqlite")]
 pub use export::StorExport;
-#[cfg(feature = "sqlite")]
 pub use import::StorImport;
-#[cfg(feature = "sqlite")]
 pub use insert::StorInsert;
-#[cfg(feature = "sqlite")]
 pub use open::StorOpen;
-#[cfg(feature = "sqlite")]
 pub use reset::StorReset;
 pub use stor_::Stor;
-#[cfg(feature = "sqlite")]
 pub use update::StorUpdate;


### PR DESCRIPTION
All of them depend on feature `sqlite` so just conditionally `use` the
parent module.
