### PR TITLE
Don't create a thread if stderr_stream is None

### DIFF
--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -861,10 +861,13 @@ pub fn print_if_stream(
     // NOTE: currently we don't need anything from stderr
     // so we just consume and throw away `stderr_stream` to make sure the pipe doesn't fill up
 
-    thread::Builder::new()
-        .name("stderr consumer".to_string())
-        .spawn(move || stderr_stream.map(|x| x.into_bytes()))
-        .expect("could not create thread");
+    if let Some(stderr_stream) = stderr_stream {
+        thread::Builder::new()
+            .name("stderr consumer".to_string())
+            .spawn(move || stderr_stream.into_bytes())
+            .expect("could not create thread");
+    }
+
     if let Some(stream) = stream {
         for s in stream {
             let s_live = s?;


### PR DESCRIPTION
# Description

There is no need to create a thread if `stderr_stream` is `None`.
