### PR TITLE
Don't panic when `http_client` fails

### DIFF
--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -26,17 +26,21 @@ pub enum BodyType {
     Unknown,
 }
 
-// Only panics if the user agent is invalid but we define it statically so either
-// it always or never fails
 pub fn http_client(
     allow_insecure: bool,
     engine_state: &EngineState,
     stack: &mut Stack,
-) -> ureq::Agent {
+) -> Result<ureq::Agent, ShellError> {
     let tls = native_tls::TlsConnector::builder()
         .danger_accept_invalid_certs(allow_insecure)
         .build()
-        .expect("Failed to build network tls");
+        .map_err(|e| ShellError::GenericError {
+            error: format!("Failed to build network tls: {}", e),
+            msg: String::new(),
+            span: None,
+            help: None,
+            inner: vec![],
+        })?;
 
     let mut agent_builder = ureq::builder()
         .user_agent("nushell")
@@ -48,7 +52,7 @@ pub fn http_client(
         }
     };
 
-    agent_builder.build()
+    Ok(agent_builder.build())
 }
 
 pub fn http_parse_url(

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -187,7 +187,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure, engine_state, stack);
+    let client = http_client(args.insecure, engine_state, stack)?;
     let mut request = client.delete(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -171,7 +171,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure, engine_state, stack);
+    let client = http_client(args.insecure, engine_state, stack)?;
     let mut request = client.get(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -147,7 +147,7 @@ fn helper(
     let span = args.url.span();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure, engine_state, stack);
+    let client = http_client(args.insecure, engine_state, stack)?;
     let mut request = client.head(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -160,7 +160,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure, engine_state, stack);
+    let client = http_client(args.insecure, engine_state, stack)?;
     let mut request = client.request("OPTIONS", &requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -179,7 +179,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure, engine_state, stack);
+    let client = http_client(args.insecure, engine_state, stack)?;
     let mut request = client.patch(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -177,7 +177,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure, engine_state, stack);
+    let client = http_client(args.insecure, engine_state, stack)?;
     let mut request = client.post(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -177,7 +177,7 @@ fn helper(
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
-    let client = http_client(args.insecure, engine_state, stack);
+    let client = http_client(args.insecure, engine_state, stack)?;
     let mut request = client.put(&requested_url);
 
     request = request_set_timeout(args.timeout, request)?;


### PR DESCRIPTION
# Description

This PR makes `http_client` return `Result<ureq::Agent, ShellError>`, so errors can be propagated to the caller.