### PR TITLE
More specific errors for missing values in records

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5272,15 +5272,46 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
 
             idx += 1;
             if idx == tokens.len() {
-                working_set.error(ParseError::Expected("record", span));
-                return garbage(span);
+                working_set.error(ParseError::Expected(
+                    "':'",
+                    Span::new(curr_span.end, curr_span.end),
+                ));
+                output.push(RecordItem::Pair(
+                    garbage(curr_span),
+                    garbage(Span::new(curr_span.end, curr_span.end)),
+                ));
+                break;
             }
-            let colon = working_set.get_span_contents(tokens[idx].span);
+            let colon_span = tokens[idx].span;
+            let colon = working_set.get_span_contents(colon_span);
             idx += 1;
-            if idx == tokens.len() || colon != b":" {
-                //FIXME: need better error
-                working_set.error(ParseError::Expected("record", span));
-                return garbage(span);
+            if colon != b":" {
+                working_set.error(ParseError::Expected(
+                    "':'",
+                    Span::new(colon_span.start, colon_span.start),
+                ));
+                output.push(RecordItem::Pair(
+                    field,
+                    garbage(Span::new(
+                        colon_span.start,
+                        tokens[tokens.len() - 1].span.end,
+                    )),
+                ));
+                break;
+            }
+            if idx == tokens.len() {
+                working_set.error(ParseError::Expected(
+                    "value for record field",
+                    Span::new(colon_span.end, colon_span.end),
+                ));
+                output.push(RecordItem::Pair(
+                    garbage(curr_span),
+                    garbage(Span::new(
+                        colon_span.start,
+                        tokens[tokens.len() - 1].span.end,
+                    )),
+                ));
+                break;
             }
             let value = parse_value(working_set, tokens[idx].span, &SyntaxShape::Any);
             idx += 1;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5305,11 +5305,8 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
                     Span::new(colon_span.end, colon_span.end),
                 ));
                 output.push(RecordItem::Pair(
-                    garbage(curr_span),
-                    garbage(Span::new(
-                        colon_span.start,
-                        tokens[tokens.len() - 1].span.end,
-                    )),
+                    garbage(Span::new(curr_span.start, colon_span.end)),
+                    garbage(Span::new(colon_span.end, tokens[tokens.len() - 1].span.end)),
                 ));
                 break;
             }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -763,3 +763,14 @@ fn properly_typecheck_rest_param() -> TestResult {
 fn implied_collect_has_compatible_type() -> TestResult {
     run_test(r#"let idx = 3 | $in; $idx < 1"#, "false")
 }
+
+#[test]
+fn record_expected_colon() -> TestResult {
+    fail_test(r#"{ a: 2 b }"#, "expected ':'")?;
+    fail_test(r#"{ a: 2 b 3 }"#, "expected ':'")
+}
+
+#[test]
+fn record_missing_value() -> TestResult {
+    fail_test(r#"{ a: 2 b: }"#, "expected value for record field")
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Currently, when writing a record, if you don't give the value for a field, the syntax error highlights the entire record instead of pinpointing the issue. Here's some examples:

```nushell
> { a: 2, 3 } # Missing colon (and value)
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
   ╭─[entry #2:1:1]
 1 │  { a: 2, 3 }
   ·  ─────┬─────
   ·       ╰── expected record
   ╰────

> { a: 2, 3: } # Missing value
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
   ╭─[entry #3:1:1]
 1 │  { a: 2, 3: }
   ·  ──────┬─────
   ·        ╰── expected record
   ╰────

> { a: 2, 3 4 } # Missing colon
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
   ╭─[entry #4:1:1]
 1 │  { a: 2, 3 4 }
   ·  ──────┬──────
   ·        ╰── expected record
   ╰────
```

In all of them, the entire record is highlighted red because an `Expr::Garbage` is returned covering that whole span:

![image](https://github.com/nushell/nushell/assets/45539777/36660b50-23be-4353-b180-3f84eff3c220)

This PR is for highlighting only the part inside the record that could not be parsed. If the record literal is big, an error message pointing to the start of where the parser thinks things went wrong should help people fix their code.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Below are screenshots of the new errors:

If there's a stray record key right before the record ends, it highlights only that key and tells the user it expected a colon after it:

![image](https://github.com/nushell/nushell/assets/45539777/94503256-8ea2-47dd-b69a-4b520c66f7b6)

If the record ends before the value for the last field was given, it highlights the key and colon of that field and tells the user it expected a value after the colon:

![image](https://github.com/nushell/nushell/assets/45539777/2f3837ec-3b35-4b81-8c57-706f8056ac04)

If there are two consecutive expressions without a colon between them, it highlights everything from the second expression to the end of the record and tells the user it expected a colon. I was tempted to add a help message suggesting adding a colon in between, but that may not always be the right thing to do.

![image](https://github.com/nushell/nushell/assets/45539777/1abaaaa8-1896-4909-bbb7-9a38cece5250)

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
