### PR TITLE
Revert "Bump reedline development version"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4392,7 +4392,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.27.1"
-source = "git+https://github.com/nushell/reedline.git?branch=main#e097b88dab538705c7b165cf3a1f5cf3a74a23bb"
+source = "git+https://github.com/nushell/reedline.git?branch=main#a4bfaa512be8b7214b80c63327930155da86978a"
 dependencies = [
  "chrono",
  "crossterm",


### PR DESCRIPTION
Reverts nushell/nushell#11406

This PR https://github.com/nushell/reedline/pull/688 is causing clear screens to happen at strange times. Documented here https://github.com/nushell/nushell/pull/11406#issuecomment-1869591405