### PR TITLE
add support for repeated flags in custom commands

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -896,6 +896,7 @@ pub fn parse_internal_call(
                     arg: None,
                     required: false,
                     desc: "".to_string(),
+                    multiple: false,
                     var_id: None,
                     default_value: None,
                 })
@@ -3221,6 +3222,13 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                         }
                     }
                 } else {
+                    let (contents, multiple) = if let Some(stripped) = contents.strip_prefix(b"...")
+                    {
+                        (stripped, true)
+                    } else {
+                        (contents.as_slice(), false)
+                    };
+
                     match parse_mode {
                         ParseMode::ArgMode | ParseMode::AfterCommaArgMode => {
                             // Long flag with optional short form following with no whitespace, e.g. --output, --age(-a)
@@ -3259,6 +3267,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                             short: None,
                                             required: false,
                                             var_id: Some(var_id),
+                                            multiple,
                                             default_value: None,
                                         },
                                         type_annotated: false,
@@ -3320,6 +3329,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                                 short: Some(chars[0]),
                                                 required: false,
                                                 var_id: Some(var_id),
+                                                multiple,
                                                 default_value: None,
                                             },
                                             type_annotated: false,
@@ -3362,6 +3372,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         short: Some(chars[0]),
                                         required: false,
                                         var_id: Some(var_id),
+                                        multiple,
                                         default_value: None,
                                     },
                                     type_annotated: false,
@@ -3371,7 +3382,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                             // Short flag alias for long flag, e.g. --b (-a)
                             // This is the same as the short flag in --b(-a)
                             else if contents.starts_with(b"(-") {
-                                if matches!(parse_mode, ParseMode::AfterCommaArgMode) {
+                                if multiple || matches!(parse_mode, ParseMode::AfterCommaArgMode) {
                                     working_set
                                         .error(ParseError::Expected("parameter or flag", span));
                                 }
@@ -3410,6 +3421,12 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                             }
                             // Positional arg, optional
                             else if contents.ends_with(b"?") {
+                                if multiple {
+                                    working_set.error(ParseError::Expected(
+                                        "no '?' for a rest parameter",
+                                        span,
+                                    ))
+                                }
                                 let contents: Vec<_> = contents[..(contents.len() - 1)].into();
                                 let name = String::from_utf8_lossy(&contents).to_string();
 
@@ -3436,38 +3453,18 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                 });
                                 parse_mode = ParseMode::ArgMode;
                             }
-                            // Rest param
-                            else if let Some(contents) = contents.strip_prefix(b"...") {
-                                let name = String::from_utf8_lossy(contents).to_string();
-                                let contents_vec: Vec<u8> = contents.to_vec();
-
-                                if !is_variable(&contents_vec) {
-                                    working_set.error(ParseError::Expected(
-                                        "valid variable name for this rest parameter",
-                                        span,
-                                    ))
-                                }
-
-                                let var_id =
-                                    working_set.add_variable(contents_vec, span, Type::Any, false);
-
-                                args.push(Arg::RestPositional(PositionalArg {
-                                    desc: String::new(),
-                                    name,
-                                    shape: SyntaxShape::Any,
-                                    var_id: Some(var_id),
-                                    default_value: None,
-                                }));
-                                parse_mode = ParseMode::ArgMode;
-                            }
-                            // Normal param
+                            // Rest & Normal param
                             else {
-                                let name = String::from_utf8_lossy(&contents).to_string();
+                                let name = String::from_utf8_lossy(contents).to_string();
                                 let contents_vec = contents.to_vec();
 
                                 if !is_variable(&contents_vec) {
                                     working_set.error(ParseError::Expected(
-                                        "valid variable name for this parameter",
+                                        if multiple {
+                                            "valid variable name for this rest parameter"
+                                        } else {
+                                            "valid variable name for this parameter"
+                                        },
                                         span,
                                     ))
                                 }
@@ -3476,16 +3473,21 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     working_set.add_variable(contents_vec, span, Type::Any, false);
 
                                 // Positional arg, required
-                                args.push(Arg::Positional {
-                                    arg: PositionalArg {
-                                        desc: String::new(),
-                                        name,
-                                        shape: SyntaxShape::Any,
-                                        var_id: Some(var_id),
-                                        default_value: None,
-                                    },
-                                    required: true,
-                                    type_annotated: false,
+                                let arg = PositionalArg {
+                                    desc: String::new(),
+                                    name,
+                                    shape: SyntaxShape::Any,
+                                    var_id: Some(var_id),
+                                    default_value: None,
+                                };
+                                args.push(if multiple {
+                                    Arg::RestPositional(arg)
+                                } else {
+                                    Arg::Positional {
+                                        arg,
+                                        required: true,
+                                        type_annotated: false,
+                                    }
                                 });
                                 parse_mode = ParseMode::ArgMode;
                             }
@@ -3494,7 +3496,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                             if let Some(last) = args.last_mut() {
                                 let syntax_shape = parse_shape_name(
                                     working_set,
-                                    &contents,
+                                    contents,
                                     span,
                                     ShapeDescriptorUse::Argument,
                                 );

--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -20,6 +20,7 @@ pub struct Flag {
     pub short: Option<char>,
     pub arg: Option<SyntaxShape>,
     pub required: bool,
+    pub multiple: bool,
     pub desc: String,
 
     // For custom commands
@@ -210,6 +211,7 @@ impl Signature {
             arg: None,
             desc: "Display the help message for this command".into(),
             required: false,
+            multiple: false,
             var_id: None,
             default_value: None,
         };
@@ -342,6 +344,31 @@ impl Signature {
             short: s,
             arg: Some(shape.into()),
             required: false,
+            multiple: false,
+            desc: desc.into(),
+            var_id: None,
+            default_value: None,
+        });
+
+        self
+    }
+
+    /// Add an optional named flag argument to the signature
+    pub fn multiple_named(
+        mut self,
+        name: impl Into<String>,
+        shape: impl Into<SyntaxShape>,
+        desc: impl Into<String>,
+        short: Option<char>,
+    ) -> Signature {
+        let (name, s) = self.check_names(name, short);
+
+        self.named.push(Flag {
+            long: name,
+            short: s,
+            arg: Some(shape.into()),
+            required: false,
+            multiple: true,
             desc: desc.into(),
             var_id: None,
             default_value: None,
@@ -365,6 +392,7 @@ impl Signature {
             short: s,
             arg: Some(shape.into()),
             required: true,
+            multiple: false,
             desc: desc.into(),
             var_id: None,
             default_value: None,
@@ -387,6 +415,7 @@ impl Signature {
             short: s,
             arg: None,
             required: false,
+            multiple: false,
             desc: desc.into(),
             var_id: None,
             default_value: None,

--- a/crates/nu-protocol/tests/test_signature.rs
+++ b/crates/nu-protocol/tests/test_signature.rs
@@ -25,16 +25,25 @@ fn test_signature_chained() {
             "required named description",
             Some('r'),
         )
+        .multiple_named(
+            "mult-named",
+            SyntaxShape::String,
+            "multiple named description",
+            Some('m'),
+        )
         .named("named", SyntaxShape::String, "named description", Some('n'))
         .switch("switch", "switch description", None)
         .rest("rest", SyntaxShape::String, "rest description");
 
     assert_eq!(signature.required_positional.len(), 1);
     assert_eq!(signature.optional_positional.len(), 1);
-    assert_eq!(signature.named.len(), 3);
+    assert_eq!(signature.named.len(), 4);
     assert!(signature.rest_positional.is_some());
-    assert_eq!(signature.get_shorts(), vec!['r', 'n']);
-    assert_eq!(signature.get_names(), vec!["req-named", "named", "switch"]);
+    assert_eq!(signature.get_shorts(), vec!['r', 'm', 'n']);
+    assert_eq!(
+        signature.get_names(),
+        vec!["req-named", "mult-named", "named", "switch"]
+    );
     assert_eq!(signature.num_positionals(), 2);
 
     assert_eq!(
@@ -76,6 +85,7 @@ fn test_signature_chained() {
             arg: Some(SyntaxShape::String),
             required: true,
             desc: "required named description".to_string(),
+            multiple: false,
             var_id: None,
             default_value: None,
         })
@@ -89,6 +99,35 @@ fn test_signature_chained() {
             arg: Some(SyntaxShape::String),
             required: true,
             desc: "required named description".to_string(),
+            multiple: false,
+            var_id: None,
+            default_value: None,
+        })
+    );
+
+    assert_eq!(
+        signature.get_long_flag("mult-named"),
+        Some(Flag {
+            long: "mult-named".to_string(),
+            short: Some('m'),
+            arg: Some(SyntaxShape::String),
+            required: false,
+            desc: "multiple named description".to_string(),
+            multiple: true,
+            var_id: None,
+            default_value: None,
+        })
+    );
+
+    assert_eq!(
+        signature.get_short_flag('m'),
+        Some(Flag {
+            long: "mult-named".to_string(),
+            short: Some('m'),
+            arg: Some(SyntaxShape::String),
+            required: false,
+            desc: "multiple named description".to_string(),
+            multiple: true,
             var_id: None,
             default_value: None,
         })


### PR DESCRIPTION
fix #10789 

# Description

# User-Facing Changes
- Flags in custom commands (`--long`, `-s`, `--short (-s)`) can now have a prepending `...` (i.e. `...--long` etc.). When multiple (non-bool) values are specified when calling the command, the values will now be collected into a list, just like (positional) rest parameters. When no flags are provided, an empty list is passed (just like rest parameters).

# Tests + Formatting
`toolkit check pr` run, though I can't actually finish them (there are a bunch that are just hung for no reason)
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :red_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`

# After Submitting
