### PR TITLE
Make env var names case insensitive on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "simplelog",
  "tempfile",
  "time",
+ "unicase",
  "winresource",
 ]
 
@@ -3035,6 +3036,7 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "typetag",
+ "unicase",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ time = "0.3"
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 signal-hook = { version = "0.3", default-features = false }
 
+[target.'cfg(windows)'.dependencies]
+unicase = "2.7"
+
 [target.'cfg(windows)'.build-dependencies]
 winresource = "0.1"
 

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -69,7 +69,7 @@ impl Completer for VariableCompletion {
                     let nested_levels: Vec<Vec<u8>> =
                         self.var_context.1.clone().into_iter().skip(1).collect();
 
-                    if let Some(val) = env_vars.get(&target_var_str) {
+                    if let Some(val) = env_vars.get(&target_var_str.into()) {
                         for suggestion in
                             nested_suggestions(val.clone(), nested_levels, current_span)
                         {
@@ -93,7 +93,7 @@ impl Completer for VariableCompletion {
                             &prefix,
                         ) {
                             output.push(Suggestion {
-                                value: env_var.0,
+                                value: env_var.0.into(),
                                 description: None,
                                 extra: None,
                                 span: current_span,

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -91,15 +91,15 @@ pub fn evaluate_file(
     });
 
     stack.add_env_var(
-        "FILE_PWD".to_string(),
+        "FILE_PWD".into(),
         Value::string(parent.to_string_lossy(), Span::unknown()),
     );
     stack.add_env_var(
-        "CURRENT_FILE".to_string(),
+        "CURRENT_FILE".into(),
         Value::string(file_path.to_string_lossy(), Span::unknown()),
     );
     stack.add_env_var(
-        "PROCESS_PATH".to_string(),
+        "PROCESS_PATH".into(),
         Value::string(path, Span::unknown()),
     );
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -309,7 +309,7 @@ pub fn evaluate_repl(
                 engine_state
                     .render_env_vars()
                     .into_iter()
-                    .filter_map(|(k, v)| v.as_string().ok().map(|v| (k, v))),
+                    .filter_map(|(k, v)| v.as_string().ok().map(|v| (k.as_str(), v))),
             );
             line_editor.with_buffer_editor(command, temp_file.clone())
         } else {

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -197,7 +197,7 @@ fn gather_env_vars(
             };
 
             // stack.add_env_var(name, value);
-            engine_state.add_env_var(name, value);
+            engine_state.add_env_var(name.into(), value);
         }
     }
 }
@@ -320,7 +320,7 @@ pub fn eval_source(
 
 fn set_last_exit_code(stack: &mut Stack, exit_code: i64) {
     stack.add_env_var(
-        "LAST_EXIT_CODE".to_string(),
+        "LAST_EXIT_CODE".into(),
         Value::int(exit_code, Span::unknown()),
     );
 }
@@ -348,15 +348,15 @@ mod test {
         let env = engine_state.render_env_vars();
 
         assert!(
-            matches!(env.get(&"FOO".to_string()), Some(&Value::String { val, .. }) if val == "foo")
+            matches!(env.get(&"FOO".to_owned().into()), Some(&Value::String { val, .. }) if val == "foo")
         );
         assert!(
-            matches!(env.get(&"SYMBOLS".to_string()), Some(&Value::String { val, .. }) if val == symbols)
+            matches!(env.get(&"SYMBOLS".to_owned().into()), Some(&Value::String { val, .. }) if val == symbols)
         );
         assert!(
-            matches!(env.get(&symbols.to_string()), Some(&Value::String { val, .. }) if val == "symbols")
+            matches!(env.get(&symbols.to_owned().into()), Some(&Value::String { val, .. }) if val == "symbols")
         );
-        assert!(env.get(&"PWD".to_string()).is_some());
+        assert!(env.get(&"PWD".to_owned().into()).is_some());
         assert_eq!(env.len(), 4);
     }
 }

--- a/crates/nu-cli/tests/support/completions_helpers.rs
+++ b/crates/nu-cli/tests/support/completions_helpers.rs
@@ -39,11 +39,11 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
 
     // Add pwd as env var
     stack.add_env_var(
-        "PWD".to_string(),
+        "PWD".into(),
         Value::string(dir_str.clone(), nu_protocol::Span::new(0, dir_str.len())),
     );
     stack.add_env_var(
-        "TEST".to_string(),
+        "TEST".into(),
         Value::string(
             "NUSHELL".to_string(),
             nu_protocol::Span::new(0, dir_str.len()),
@@ -51,7 +51,7 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
     );
     #[cfg(windows)]
     stack.add_env_var(
-        "Path".to_string(),
+        "Path".into(),
         Value::string(
             "c:\\some\\path;c:\\some\\other\\path".to_string(),
             nu_protocol::Span::new(0, dir_str.len()),
@@ -59,7 +59,7 @@ pub fn new_engine() -> (PathBuf, String, EngineState, Stack) {
     );
     #[cfg(not(windows))]
     stack.add_env_var(
-        "PATH".to_string(),
+        "PATH".into(),
         Value::string(
             "/some/path:/some/other/path".to_string(),
             nu_protocol::Span::new(0, dir_str.len()),
@@ -91,11 +91,11 @@ pub fn new_quote_engine() -> (PathBuf, String, EngineState, Stack) {
 
     // Add pwd as env var
     stack.add_env_var(
-        "PWD".to_string(),
+        "PWD".into(),
         Value::string(dir_str.clone(), nu_protocol::Span::new(0, dir_str.len())),
     );
     stack.add_env_var(
-        "TEST".to_string(),
+        "TEST".into(),
         Value::string(
             "NUSHELL".to_string(),
             nu_protocol::Span::new(0, dir_str.len()),
@@ -127,11 +127,11 @@ pub fn new_partial_engine() -> (PathBuf, String, EngineState, Stack) {
 
     // Add pwd as env var
     stack.add_env_var(
-        "PWD".to_string(),
+        "PWD".into(),
         Value::string(dir_str.clone(), nu_protocol::Span::new(0, dir_str.len())),
     );
     stack.add_env_var(
-        "TEST".to_string(),
+        "TEST".into(),
         Value::string(
             "NUSHELL".to_string(),
             nu_protocol::Span::new(0, dir_str.len()),

--- a/crates/nu-cmd-base/src/hook.rs
+++ b/crates/nu-cmd-base/src/hook.rs
@@ -3,7 +3,7 @@ use miette::Result;
 use nu_engine::{eval_block, eval_block_with_early_return};
 use nu_parser::parse;
 use nu_protocol::cli_error::{report_error, report_error_new};
-use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
+use nu_protocol::engine::{EngineState, EnvVarName, Stack, StateWorkingSet};
 use nu_protocol::{BlockId, PipelineData, PositionalArg, ShellError, Span, Type, Value, VarId};
 
 pub fn eval_env_change_hook(
@@ -17,7 +17,7 @@ pub fn eval_env_change_hook(
                 for (env_name, hook_value) in &val {
                     let before = engine_state
                         .previous_env_vars
-                        .get(env_name)
+                        .get(&EnvVarName::from(env_name.to_owned()))
                         .cloned()
                         .unwrap_or_default();
 
@@ -37,7 +37,7 @@ pub fn eval_env_change_hook(
 
                         engine_state
                             .previous_env_vars
-                            .insert(env_name.to_string(), after);
+                            .insert(env_name.to_owned().into(), after);
                     }
                 }
             }

--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -109,9 +109,9 @@ pub fn get_editor(
         get_editor_commandline(&config.buffer_editor, "$env.config.buffer_editor")
     {
         Ok(buff_editor)
-    } else if let Some(value) = env_vars.get("EDITOR") {
+    } else if let Some(value) = env_vars.get(&"EDITOR".into()) {
         get_editor_commandline(value, "$env.EDITOR")
-    } else if let Some(value) = env_vars.get("VISUAL") {
+    } else if let Some(value) = env_vars.get(&"VISUAL".into()) {
         get_editor_commandline(value, "$env.VISUAL")
     } else {
         Err(ShellError::GenericError {

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -1,6 +1,6 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::engine::{Command, EngineState, EnvVarName, Stack};
 use nu_protocol::{
     did_you_mean, Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape,
     Type, Value,
@@ -46,7 +46,7 @@ impl Command for HideEnv {
 
         for name in env_var_names {
             if !stack.remove_env_var(engine_state, &name.item) && !ignore_errors {
-                let all_names: Vec<String> = stack
+                let all_names: Vec<EnvVarName> = stack
                     .get_env_var_names(engine_state)
                     .iter()
                     .cloned()

--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -1,6 +1,6 @@
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::engine::{Command, EngineState, EnvVarName, Stack};
 use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Spanned, SyntaxShape, Type,
 };
@@ -55,14 +55,14 @@ impl Command for OverlayHide {
             name
         } else {
             Spanned {
-                item: stack.last_overlay_name()?,
+                item: stack.last_overlay_name()?.to_string(),
                 span: call.head,
             }
         };
 
         if !stack.is_overlay_active(&overlay_name.item) {
             return Err(ShellError::OverlayNotFoundAtRuntime {
-                overlay_name: overlay_name.item,
+                overlay_name: overlay_name.item.into(),
                 span: overlay_name.span,
             });
         }
@@ -93,7 +93,7 @@ impl Command for OverlayHide {
         stack.remove_overlay(&overlay_name.item);
 
         for (name, val) in env_vars_to_keep {
-            stack.add_env_var(name, val);
+            stack.add_env_var(EnvVarName::from(name), val);
         }
 
         Ok(PipelineData::empty())

--- a/crates/nu-cmd-lang/src/core_commands/overlay/list.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/list.rs
@@ -36,7 +36,7 @@ impl Command for OverlayList {
         let active_overlays_engine: Vec<Value> = stack
             .active_overlays
             .iter()
-            .map(|s| Value::string(s, call.head))
+            .map(|s| Value::string(s.to_string(), call.head))
             .collect();
 
         Ok(Value::list(active_overlays_engine, call.head).into_pipeline_data())

--- a/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/new.rs
@@ -51,7 +51,7 @@ This command is a parser keyword. For details, check:
     ) -> Result<PipelineData, ShellError> {
         let name_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
 
-        stack.add_overlay(name_arg.item);
+        stack.add_overlay(&*name_arg.item);
 
         Ok(PipelineData::empty())
     }

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -133,12 +133,12 @@ impl Command for OverlayUse {
 
                     let file_pwd = Value::string(parent.to_string_lossy(), call.head);
 
-                    callee_stack.add_env_var("FILE_PWD".to_string(), file_pwd);
+                    callee_stack.add_env_var("FILE_PWD".into(), file_pwd);
                 }
 
                 if let Some(file_path) = &maybe_path {
                     let file_path = Value::string(file_path.to_string_lossy(), call.head);
-                    callee_stack.add_env_var("CURRENT_FILE".to_string(), file_path);
+                    callee_stack.add_env_var("CURRENT_FILE".into(), file_path);
                 }
 
                 let _ = eval_block(
@@ -151,15 +151,15 @@ impl Command for OverlayUse {
                 );
 
                 // The export-env block should see the env vars *before* activating this overlay
-                caller_stack.add_overlay(overlay_name);
+                caller_stack.add_overlay(&*overlay_name);
 
                 // Merge the block's environment to the current stack
                 redirect_env(engine_state, caller_stack, &callee_stack);
             } else {
-                caller_stack.add_overlay(overlay_name);
+                caller_stack.add_overlay(&*overlay_name);
             }
         } else {
-            caller_stack.add_overlay(overlay_name);
+            caller_stack.add_overlay(&*overlay_name);
         }
 
         Ok(PipelineData::empty())

--- a/crates/nu-cmd-lang/src/core_commands/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/use_.rs
@@ -109,12 +109,12 @@ This command is a parser keyword. For details, check:
                 // If so, set the currently evaluated directory (file-relative PWD)
                 if let Some(parent) = maybe_parent {
                     let file_pwd = Value::string(parent.to_string_lossy(), call.head);
-                    callee_stack.add_env_var("FILE_PWD".to_string(), file_pwd);
+                    callee_stack.add_env_var("FILE_PWD".into(), file_pwd);
                 }
 
                 if let Some(file_path) = maybe_file_path {
                     let file_path = Value::string(file_path.to_string_lossy(), call.head);
-                    callee_stack.add_env_var("CURRENT_FILE".to_string(), file_path);
+                    callee_stack.add_env_var("CURRENT_FILE".into(), file_path);
                 }
 
                 // Run the block (discard the result)

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -113,7 +113,7 @@ pub fn eval_block(
 
     let mut stack = Stack::new();
 
-    stack.add_env_var("PWD".to_string(), Value::test_string(cwd.to_string_lossy()));
+    stack.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
     match nu_engine::eval_block(engine_state, &mut stack, &block, input, true, true) {
         Err(err) => panic!("test eval error in `{}`: {:?}", "TODO", err),
@@ -129,7 +129,7 @@ pub fn check_example_evaluates_to_expected_output(
     let mut stack = Stack::new();
 
     // Set up PWD
-    stack.add_env_var("PWD".to_string(), Value::test_string(cwd.to_string_lossy()));
+    stack.add_env_var("PWD".into(), Value::test_string(cwd.to_string_lossy()));
 
     engine_state
         .merge_env(&mut stack, cwd)

--- a/crates/nu-cmd-lang/src/example_test.rs
+++ b/crates/nu-cmd-lang/src/example_test.rs
@@ -59,7 +59,7 @@ mod test_examples {
             .expect("Could not get current working directory.")
             .to_string_lossy()
             .to_string();
-        engine_state.add_env_var("PWD".to_string(), Value::test_string(cwd));
+        engine_state.add_env_var("PWD".into(), Value::test_string(cwd));
 
         let delta = {
             // Base functions that are needed for testing
@@ -84,7 +84,7 @@ mod test_examples {
             working_set.render()
         };
 
-        engine_state.add_env_var("PWD".to_string(), Value::test_string("."));
+        engine_state.add_env_var("PWD".into(), Value::test_string("."));
 
         engine_state
             .merge_delta(delta)

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -52,7 +52,7 @@ impl Command for LoadEnv {
                             span: call.head,
                         });
                     }
-                    stack.add_env_var(env_var, rhs);
+                    stack.add_env_var(env_var.into(), rhs);
                 }
                 Ok(PipelineData::empty())
             }
@@ -72,11 +72,11 @@ impl Command for LoadEnv {
                             let rhs = rhs.as_string()?;
                             let rhs = nu_path::expand_path_with(rhs, cwd);
                             stack.add_env_var(
-                                env_var,
+                                env_var.into(),
                                 Value::string(rhs.to_string_lossy(), call.head),
                             );
                         } else {
-                            stack.add_env_var(env_var, rhs);
+                            stack.add_env_var(env_var.into(), rhs);
                         }
                     }
                     Ok(PipelineData::empty())

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -63,11 +63,11 @@ impl Command for SourceEnv {
         if let Some(parent) = file_path.parent() {
             let file_pwd = Value::string(parent.to_string_lossy(), call.head);
 
-            caller_stack.add_env_var("FILE_PWD".to_string(), file_pwd);
+            caller_stack.add_env_var("FILE_PWD".into(), file_pwd);
         }
 
         caller_stack.add_env_var(
-            "CURRENT_FILE".to_string(),
+            "CURRENT_FILE".into(),
             Value::string(file_path.to_string_lossy(), call.head),
         );
 

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -141,7 +141,7 @@ fn with_env(
     };
 
     for (k, v) in env {
-        stack.add_env_var(k, v);
+        stack.add_env_var(k.into(), v);
     }
 
     eval_block(

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1069,12 +1069,12 @@ impl Eval for EvalRuntime {
                                                 span: *span,
                                             });
                                         } else {
-                                            stack.add_env_var(val.to_string(), vardata);
+                                            stack.add_env_var(val.to_string().into(), vardata);
                                         }
                                     }
                                     // In case someone really wants an integer env-var
                                     PathMember::Int { val, .. } => {
-                                        stack.add_env_var(val.to_string(), vardata);
+                                        stack.add_env_var(val.to_string().into(), vardata);
                                     }
                                 }
                             } else {

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -30,6 +30,9 @@ serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
 typetag = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+unicase = "2.7"
+
 [features]
 plugin = ["serde_json"]
 

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1,5 +1,5 @@
 use super::{
-    usage::build_usage, Command, EngineState, OverlayFrame, StateDelta, VirtualPath, Visibility,
+    usage::build_usage, Command, EngineState, EnvVarName, OverlayFrame, StateDelta, VirtualPath, Visibility,
     PWD_ENV,
 };
 use crate::ast::Block;
@@ -597,7 +597,7 @@ impl<'a> StateWorkingSet<'a> {
         &self.permanent_state.config
     }
 
-    pub fn list_env(&self) -> Vec<String> {
+    pub fn list_env(&self) -> Vec<EnvVarName> {
         let mut env_vars = vec![];
 
         for env_var in self.permanent_state.env_vars.clone().into_iter() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,14 +94,14 @@ fn main() -> Result<()> {
     let mut default_nu_lib_dirs_path = nushell_config_path.clone();
     default_nu_lib_dirs_path.push("scripts");
     engine_state.add_env_var(
-        "NU_LIB_DIRS".to_string(),
+        "NU_LIB_DIRS".into(),
         Value::test_string(default_nu_lib_dirs_path.to_string_lossy()),
     );
 
     let mut default_nu_plugin_dirs_path = nushell_config_path;
     default_nu_plugin_dirs_path.push("plugins");
     engine_state.add_env_var(
-        "NU_PLUGIN_DIRS".to_string(),
+        "NU_PLUGIN_DIRS".into(),
         Value::test_string(default_nu_plugin_dirs_path.to_string_lossy()),
     );
     // End: Default NU_LIB_DIRS, NU_PLUGIN_DIRS
@@ -220,7 +220,7 @@ fn main() -> Result<()> {
     );
 
     engine_state.add_env_var(
-        "NU_VERSION".to_string(),
+        "NU_VERSION".into(),
         Value::string(env!("CARGO_PKG_VERSION"), Span::unknown()),
     );
 


### PR DESCRIPTION
The Windows `getenv`/`putenv` functions are case-insensitive, so when built for Windows nushell should also act this way to avoid many complicated conflicts. A full description of the problem is in #11154.

Fixes #11154

# User-Facing Changes

On Windows systems, environment variable names are now case-insensitive. Reading from / writing to `PATH` and `Path` and `path` are the same.

# Tests + Formatting

Old special case implementation switcheroo from `Path` and `PATH` is removed, but the test cases are not and still pass.

New tests should likely be added, but sending the PR as-is for initial evaluation.

# After Submitting

- [ ] Doc updates are indeed required.
- [ ] Example config needs updating to remove the vague language around `Path`.
