### PR TITLE
`--` "flag" in commands

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -394,101 +394,116 @@ fn parse_long_flag(
     let arg_contents = working_set.get_span_contents(arg_span);
 
     if arg_contents.starts_with(b"--") {
-        // FIXME: only use the first flag you find?
-        let split: Vec<_> = arg_contents.split(|x| *x == b'=').collect();
-        let long_name = String::from_utf8(split[0].into());
-        if let Ok(long_name) = long_name {
-            let long_name = long_name[2..].to_string();
-            if let Some(flag) = sig.get_long_flag(&long_name) {
-                if let Some(arg_shape) = &flag.arg {
-                    if split.len() > 1 {
-                        // and we also have the argument
-                        let long_name_len = long_name.len();
-                        let mut span = arg_span;
-                        span.start += long_name_len + 3; //offset by long flag and '='
+        if arg_contents.len() == 2 {
+            (
+                Some(Spanned {
+                    item: "--".to_string(),
+                    span: arg_span,
+                }),
+                None,
+            )
+        } else {
+            // FIXME: only use the first flag you find?
+            let split: Vec<_> = arg_contents.split(|x| *x == b'=').collect();
+            let long_name = String::from_utf8(split[0].into());
+            if let Ok(long_name) = long_name {
+                let long_name = long_name[2..].to_string();
+                if let Some(flag) = sig.get_long_flag(&long_name) {
+                    if let Some(arg_shape) = &flag.arg {
+                        if split.len() > 1 {
+                            // and we also have the argument
+                            let long_name_len = long_name.len();
+                            let mut span = arg_span;
+                            span.start += long_name_len + 3; //offset by long flag and '='
 
-                        let arg = parse_value(working_set, span, arg_shape);
-                        let (arg_name, val_expression) = ensure_flag_arg_type(
-                            working_set,
-                            long_name,
-                            arg,
-                            arg_shape,
-                            Span::new(arg_span.start, arg_span.start + long_name_len + 2),
-                        );
-                        (Some(arg_name), Some(val_expression))
-                    } else if let Some(arg) = spans.get(*spans_idx + 1) {
-                        let arg = parse_value(working_set, *arg, arg_shape);
+                            let arg = parse_value(working_set, span, arg_shape);
+                            let (arg_name, val_expression) = ensure_flag_arg_type(
+                                working_set,
+                                long_name,
+                                arg,
+                                arg_shape,
+                                Span::new(arg_span.start, arg_span.start + long_name_len + 2),
+                            );
+                            (Some(arg_name), Some(val_expression))
+                        } else if let Some(arg) = spans.get(*spans_idx + 1) {
+                            let arg = parse_value(working_set, *arg, arg_shape);
 
-                        *spans_idx += 1;
-                        let (arg_name, val_expression) =
-                            ensure_flag_arg_type(working_set, long_name, arg, arg_shape, arg_span);
-                        (Some(arg_name), Some(val_expression))
+                            *spans_idx += 1;
+                            let (arg_name, val_expression) = ensure_flag_arg_type(
+                                working_set,
+                                long_name,
+                                arg,
+                                arg_shape,
+                                arg_span,
+                            );
+                            (Some(arg_name), Some(val_expression))
+                        } else {
+                            working_set.error(ParseError::MissingFlagParam(
+                                arg_shape.to_string(),
+                                arg_span,
+                            ));
+                            (
+                                Some(Spanned {
+                                    item: long_name,
+                                    span: arg_span,
+                                }),
+                                None,
+                            )
+                        }
                     } else {
-                        working_set.error(ParseError::MissingFlagParam(
-                            arg_shape.to_string(),
-                            arg_span,
-                        ));
-                        (
-                            Some(Spanned {
-                                item: long_name,
-                                span: arg_span,
-                            }),
-                            None,
-                        )
+                        // A flag with no argument
+                        // It can also takes a boolean value like --x=true
+                        if split.len() > 1 {
+                            // and we also have the argument
+                            let long_name_len = long_name.len();
+                            let mut span = arg_span;
+                            span.start += long_name_len + 3; //offset by long flag and '='
+
+                            let arg = parse_value(working_set, span, &SyntaxShape::Boolean);
+
+                            let (arg_name, val_expression) = ensure_flag_arg_type(
+                                working_set,
+                                long_name,
+                                arg,
+                                &SyntaxShape::Boolean,
+                                Span::new(arg_span.start, arg_span.start + long_name_len + 2),
+                            );
+                            (Some(arg_name), Some(val_expression))
+                        } else {
+                            (
+                                Some(Spanned {
+                                    item: long_name,
+                                    span: arg_span,
+                                }),
+                                None,
+                            )
+                        }
                     }
                 } else {
-                    // A flag with no argument
-                    // It can also takes a boolean value like --x=true
-                    if split.len() > 1 {
-                        // and we also have the argument
-                        let long_name_len = long_name.len();
-                        let mut span = arg_span;
-                        span.start += long_name_len + 3; //offset by long flag and '='
-
-                        let arg = parse_value(working_set, span, &SyntaxShape::Boolean);
-
-                        let (arg_name, val_expression) = ensure_flag_arg_type(
-                            working_set,
-                            long_name,
-                            arg,
-                            &SyntaxShape::Boolean,
-                            Span::new(arg_span.start, arg_span.start + long_name_len + 2),
-                        );
-                        (Some(arg_name), Some(val_expression))
-                    } else {
-                        (
-                            Some(Spanned {
-                                item: long_name,
-                                span: arg_span,
-                            }),
-                            None,
-                        )
-                    }
+                    working_set.error(ParseError::UnknownFlag(
+                        sig.name.clone(),
+                        long_name.clone(),
+                        arg_span,
+                        sig.clone().formatted_flags(),
+                    ));
+                    (
+                        Some(Spanned {
+                            item: long_name.clone(),
+                            span: arg_span,
+                        }),
+                        None,
+                    )
                 }
             } else {
-                working_set.error(ParseError::UnknownFlag(
-                    sig.name.clone(),
-                    long_name.clone(),
-                    arg_span,
-                    sig.clone().formatted_flags(),
-                ));
+                working_set.error(ParseError::NonUtf8(arg_span));
                 (
                     Some(Spanned {
-                        item: long_name.clone(),
+                        item: "--".into(),
                         span: arg_span,
                     }),
                     None,
                 )
             }
-        } else {
-            working_set.error(ParseError::NonUtf8(arg_span));
-            (
-                Some(Spanned {
-                    item: "--".into(),
-                    span: arg_span,
-                }),
-                None,
-            )
         }
     } else {
         (None, None)
@@ -815,7 +830,6 @@ pub fn parse_internal_call(
 
     let mut call = Call::new(command_span);
     call.decl_id = decl_id;
-    call.head = command_span;
 
     let decl = working_set.get_decl(decl_id);
     let signature = decl.signature();
@@ -859,132 +873,146 @@ pub fn parse_internal_call(
         working_set.enter_scope();
     }
 
+    let mut only_positional = false;
     while spans_idx < spans.len() {
         let arg_span = spans[spans_idx];
 
         let starting_error_count = working_set.parse_errors.len();
         // Check if we're on a long flag, if so, parse
-        let (long_name, arg) = parse_long_flag(working_set, spans, &mut spans_idx, &signature);
 
-        if let Some(long_name) = long_name {
-            // We found a long flag, like --bar
-            if working_set.parse_errors[starting_error_count..]
-                .iter()
-                .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
-                && signature.allows_unknown_args
-            {
-                working_set.parse_errors.truncate(starting_error_count);
-                let arg = parse_value(working_set, arg_span, &SyntaxShape::Any);
+        if !only_positional {
+            let (long_name, arg) = parse_long_flag(working_set, spans, &mut spans_idx, &signature);
+            if let Some(long_name) = long_name {
+                // We found a long flag, like --bar
+                if working_set.parse_errors[starting_error_count..]
+                    .iter()
+                    .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
+                    && signature.allows_unknown_args
+                {
+                    working_set.parse_errors.truncate(starting_error_count);
+                    let arg = parse_value(working_set, arg_span, &SyntaxShape::Any);
 
-                call.add_unknown(arg);
-            } else {
-                call.add_named((long_name, None, arg));
+                    call.add_unknown(arg);
+                } else if long_name.item == "--" {
+                    if signature.allows_unknown_args {
+                        call.add_positional(Expression {
+                            expr: Expr::String("--".to_string()),
+                            span: arg_span,
+                            ty: Type::String,
+                            custom_completion: None,
+                        });
+                    } else {
+                        only_positional = true;
+                    }
+                } else {
+                    call.add_named((long_name, None, arg));
+                }
+
+                spans_idx += 1;
+                continue;
             }
 
-            spans_idx += 1;
-            continue;
-        }
+            let starting_error_count = working_set.parse_errors.len();
 
-        let starting_error_count = working_set.parse_errors.len();
+            // Check if we're on a short flag or group of short flags, if so, parse
+            let short_flags = parse_short_flags(
+                working_set,
+                spans,
+                &mut spans_idx,
+                positional_idx,
+                &signature,
+            );
 
-        // Check if we're on a short flag or group of short flags, if so, parse
-        let short_flags = parse_short_flags(
-            working_set,
-            spans,
-            &mut spans_idx,
-            positional_idx,
-            &signature,
-        );
+            if let Some(mut short_flags) = short_flags {
+                if short_flags.is_empty() {
+                    // workaround for completions (PR #6067)
+                    short_flags.push(Flag {
+                        long: "".to_string(),
+                        short: Some('a'),
+                        arg: None,
+                        required: false,
+                        desc: "".to_string(),
+                        var_id: None,
+                        default_value: None,
+                    })
+                }
 
-        if let Some(mut short_flags) = short_flags {
-            if short_flags.is_empty() {
-                // workaround for completions (PR #6067)
-                short_flags.push(Flag {
-                    long: "".to_string(),
-                    short: Some('a'),
-                    arg: None,
-                    required: false,
-                    desc: "".to_string(),
-                    var_id: None,
-                    default_value: None,
-                })
-            }
+                if working_set.parse_errors[starting_error_count..]
+                    .iter()
+                    .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
+                    && signature.allows_unknown_args
+                {
+                    working_set.parse_errors.truncate(starting_error_count);
+                    let arg = parse_value(working_set, arg_span, &SyntaxShape::Any);
 
-            if working_set.parse_errors[starting_error_count..]
-                .iter()
-                .any(|x| matches!(x, ParseError::UnknownFlag(_, _, _, _)))
-                && signature.allows_unknown_args
-            {
-                working_set.parse_errors.truncate(starting_error_count);
-                let arg = parse_value(working_set, arg_span, &SyntaxShape::Any);
+                    call.add_unknown(arg);
+                } else {
+                    for flag in short_flags {
+                        if let Some(arg_shape) = flag.arg {
+                            if let Some(arg) = spans.get(spans_idx + 1) {
+                                let arg = parse_value(working_set, *arg, &arg_shape);
 
-                call.add_unknown(arg);
-            } else {
-                for flag in short_flags {
-                    if let Some(arg_shape) = flag.arg {
-                        if let Some(arg) = spans.get(spans_idx + 1) {
-                            let arg = parse_value(working_set, *arg, &arg_shape);
-
-                            if flag.long.is_empty() {
-                                if let Some(short) = flag.short {
+                                if flag.long.is_empty() {
+                                    if let Some(short) = flag.short {
+                                        call.add_named((
+                                            Spanned {
+                                                item: String::new(),
+                                                span: spans[spans_idx],
+                                            },
+                                            Some(Spanned {
+                                                item: short.to_string(),
+                                                span: spans[spans_idx],
+                                            }),
+                                            Some(arg),
+                                        ));
+                                    }
+                                } else {
                                     call.add_named((
                                         Spanned {
-                                            item: String::new(),
+                                            item: flag.long.clone(),
                                             span: spans[spans_idx],
                                         },
-                                        Some(Spanned {
-                                            item: short.to_string(),
-                                            span: spans[spans_idx],
-                                        }),
+                                        None,
                                         Some(arg),
                                     ));
                                 }
+                                spans_idx += 1;
                             } else {
+                                working_set.error(ParseError::MissingFlagParam(
+                                    arg_shape.to_string(),
+                                    arg_span,
+                                ))
+                            }
+                        } else if flag.long.is_empty() {
+                            if let Some(short) = flag.short {
                                 call.add_named((
                                     Spanned {
-                                        item: flag.long.clone(),
+                                        item: String::new(),
                                         span: spans[spans_idx],
                                     },
+                                    Some(Spanned {
+                                        item: short.to_string(),
+                                        span: spans[spans_idx],
+                                    }),
                                     None,
-                                    Some(arg),
                                 ));
                             }
-                            spans_idx += 1;
                         } else {
-                            working_set.error(ParseError::MissingFlagParam(
-                                arg_shape.to_string(),
-                                arg_span,
-                            ))
-                        }
-                    } else if flag.long.is_empty() {
-                        if let Some(short) = flag.short {
                             call.add_named((
                                 Spanned {
-                                    item: String::new(),
+                                    item: flag.long.clone(),
                                     span: spans[spans_idx],
                                 },
-                                Some(Spanned {
-                                    item: short.to_string(),
-                                    span: spans[spans_idx],
-                                }),
+                                None,
                                 None,
                             ));
                         }
-                    } else {
-                        call.add_named((
-                            Spanned {
-                                item: flag.long.clone(),
-                                span: spans[spans_idx],
-                            },
-                            None,
-                            None,
-                        ));
                     }
                 }
-            }
 
-            spans_idx += 1;
-            continue;
+                spans_idx += 1;
+                continue;
+            }
         }
 
         {


### PR DESCRIPTION
fixes #10939, #8323

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Half-fixes #7898. May also relate to #5445, as it seems to be the same issue (quoting/escaping flags)

#7898 covers both commands within nushell and `nu` itself, and this PR doesn't relate to `nu`'s arg parsing

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
- **breaking:** unless `--wrapped` is specified for `def`, or `allow_unknown_arg` is set, `--` will stop flags parsing, and anything afterwards will be processed only as positional arguments

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
