### PR TITLE
adjust some commansd input_output type

### DIFF
--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -23,10 +23,7 @@ impl Command for History {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("history")
-            .input_output_types(vec![
-                (Type::Nothing, Type::Table(vec![])),
-                (Type::Nothing, Type::Nothing),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .allow_variants_without_examples(true)
             .switch("clear", "Clears out the history entries", Some('c'))
             .switch(

--- a/crates/nu-cmd-extra/src/extra/filters/each_while.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/each_while.rs
@@ -24,13 +24,10 @@ impl Command for EachWhile {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build(self.name())
-            .input_output_types(vec![
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-                (Type::Table(vec![]), Type::List(Box::new(Type::Any))),
-            ])
+            .input_output_types(vec![(
+                Type::List(Box::new(Type::Any)),
+                Type::List(Box::new(Type::Any)),
+            )])
             .required(
                 "closure",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -19,10 +19,7 @@ impl Command for Describe {
 
     fn signature(&self) -> Signature {
         Signature::build("describe")
-            .input_output_types(vec![
-                (Type::Any, Type::String),
-                (Type::Any, Type::Record(vec![])),
-            ])
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .switch(
                 "no-collect",
                 "do not collect streams of structured data",

--- a/crates/nu-command/src/bytes/index_of.rs
+++ b/crates/nu-command/src/bytes/index_of.rs
@@ -30,8 +30,7 @@ impl Command for BytesIndexOf {
     fn signature(&self) -> Signature {
         Signature::build("bytes index-of")
             .input_output_types(vec![
-                (Type::Binary, Type::Int),
-                (Type::Binary, Type::List(Box::new(Type::Int))),
+                (Type::Binary, Type::Any),
                 // FIXME: this shouldn't be needed, cell paths should work with the two
                 // above
                 (Type::Table(vec![]), Type::Table(vec![])),

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -22,7 +22,6 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::Any)), Type::Record(vec![])),
                 (Type::Range, Type::Record(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
-                (Type::Table(vec![]), Type::Record(vec![])),
             ])
             .category(Category::Conversions)
     }

--- a/crates/nu-command/src/debug/debug_.rs
+++ b/crates/nu-command/src/debug/debug_.rs
@@ -21,7 +21,6 @@ impl Command for Debug {
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::String)),
                 ),
-                (Type::Table(vec![]), Type::List(Box::new(Type::String))),
                 (Type::Any, Type::String),
             ])
             .category(Category::Debug)

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -19,10 +19,7 @@ impl Command for ConfigEnv {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Env)
-            .input_output_types(vec![
-                (Type::Nothing, Type::Nothing),
-                (Type::Nothing, Type::String),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .switch("default", "Print default `env.nu` file instead.", Some('d'))
         // TODO: Signature narrower than what run actually supports theoretically
     }

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -19,10 +19,7 @@ impl Command for ConfigNu {
     fn signature(&self) -> Signature {
         Signature::build(self.name())
             .category(Category::Env)
-            .input_output_types(vec![
-                (Type::Nothing, Type::Nothing),
-                (Type::Nothing, Type::String),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .switch(
                 "default",
                 "Print default `config.nu` file instead.",

--- a/crates/nu-command/src/filters/all.rs
+++ b/crates/nu-command/src/filters/all.rs
@@ -16,10 +16,7 @@ impl Command for All {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![
-                (Type::List(Box::new(Type::Any)), Type::Bool),
-                (Type::Table(vec![]), Type::Bool),
-            ])
+            .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Bool)])
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),

--- a/crates/nu-command/src/filters/any.rs
+++ b/crates/nu-command/src/filters/any.rs
@@ -16,10 +16,7 @@ impl Command for Any {
 
     fn signature(&self) -> Signature {
         Signature::build(self.name())
-            .input_output_types(vec![
-                (Type::List(Box::new(Type::Any)), Type::Bool),
-                (Type::Table(vec![]), Type::Bool),
-            ])
+            .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Bool)])
             .required(
                 "predicate",
                 SyntaxShape::Closure(Some(vec![SyntaxShape::Any, SyntaxShape::Int])),

--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -14,19 +14,10 @@ impl Command for Compact {
 
     fn signature(&self) -> Signature {
         Signature::build("compact")
-            .input_output_types(vec![
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-                (Type::Table(vec![]), Type::Table(vec![])),
-                (
-                    // TODO: Should table be a subtype of List<Any>? If so then this
-                    // entry would be unnecessary.
-                    Type::Table(vec![]),
-                    Type::List(Box::new(Type::Any)),
-                ),
-            ])
+            .input_output_types(vec![(
+                Type::List(Box::new(Type::Any)),
+                Type::List(Box::new(Type::Any)),
+            )])
             .switch(
                 "empty",
                 "also compact empty items like \"\", {}, and []",

--- a/crates/nu-command/src/filters/filter.rs
+++ b/crates/nu-command/src/filters/filter.rs
@@ -31,7 +31,6 @@ a variable. On the other hand, the "row condition" syntax is not supported."#
                     Type::List(Box::new(Type::Any)),
                     Type::List(Box::new(Type::Any)),
                 ),
-                (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Range, Type::List(Box::new(Type::Any))),
             ])
             .required(

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -30,11 +30,6 @@ impl Command for Find {
                     Type::List(Box::new(Type::Any)),
                 ),
                 (Type::String, Type::Any),
-                (
-                    // For find -p
-                    Type::Table(vec![]),
-                    Type::Table(vec![]),
-                ),
             ])
             .named(
                 "regex",

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -18,15 +18,6 @@ impl Command for First {
         Signature::build("first")
             .input_output_types(vec![
                 (
-                    // TODO: This variant duplicates the functionality of
-                    // `take`. See #6611, #6611, #6893
-                    // TODO: This is too permissive; if we could express this
-                    // using a type parameter style it would be List<T> ->
-                    // List<T>.
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-                (
                     // TODO: This is too permissive; if we could express this
                     // using a type parameter it would be List<T> -> T.
                     Type::List(Box::new(Type::Any)),

--- a/crates/nu-command/src/filters/group_by.rs
+++ b/crates/nu-command/src/filters/group_by.rs
@@ -22,10 +22,7 @@ impl Command for GroupBy {
             // example. Perhaps Table should be a subtype of List, in which case
             // the current signature would suffice even when a Table example
             // exists.
-            .input_output_types(vec![
-                (Type::List(Box::new(Type::Any)), Type::Record(vec![])),
-                (Type::List(Box::new(Type::Any)), Type::Table(vec![])),
-            ])
+            .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Any)])
             .switch(
                 "to-table",
                 "Return a table with \"groups\" and \"items\" columns",

--- a/crates/nu-command/src/filters/length.rs
+++ b/crates/nu-command/src/filters/length.rs
@@ -18,10 +18,7 @@ impl Command for Length {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("length")
-            .input_output_types(vec![
-                (Type::List(Box::new(Type::Any)), Type::Int),
-                (Type::Table(vec![]), Type::Int),
-            ])
+            .input_output_types(vec![(Type::List(Box::new(Type::Any)), Type::Int)])
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/reverse.rs
+++ b/crates/nu-command/src/filters/reverse.rs
@@ -15,13 +15,10 @@ impl Command for Reverse {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("reverse")
-            .input_output_types(vec![
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-                (Type::Table(vec![]), Type::Table(vec![])),
-            ])
+            .input_output_types(vec![(
+                Type::List(Box::new(Type::Any)),
+                Type::List(Box::new(Type::Any)),
+            )])
             .category(Category::Filters)
     }
 

--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -20,17 +20,10 @@ impl Command for Uniq {
 
     fn signature(&self) -> Signature {
         Signature::build("uniq")
-            .input_output_types(vec![
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-                (
-                    // -c
-                    Type::List(Box::new(Type::Any)),
-                    Type::Table(vec![]),
-                ),
-            ])
+            .input_output_types(vec![(
+                Type::List(Box::new(Type::Any)),
+                Type::List(Box::new(Type::Any)),
+            )])
             .switch(
                 "count",
                 "Return a table containing the distinct input values together with their counts",

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -54,8 +54,7 @@ where
         Signature::build(self.name())
             .category(Category::Hash)
             .input_output_types(vec![
-                (Type::String, Type::String),
-                (Type::String, Type::Binary),
+                (Type::String, Type::Any),
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -21,10 +21,7 @@ impl Command for Help {
 
     fn signature(&self) -> Signature {
         Signature::build("help")
-            .input_output_types(vec![
-                (Type::Nothing, Type::String),
-                (Type::Nothing, Type::Table(vec![])),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .rest(
                 "rest",
                 SyntaxShape::String,

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -508,9 +508,7 @@ impl Command for AnsiCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("ansi")
-            .input_output_types(vec![
-                (Type::Nothing, Type::String),
-                (Type::Nothing, Type::Table(vec![]))])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .optional(
                 "code",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -34,10 +34,7 @@ impl Command for Input {
 
     fn signature(&self) -> Signature {
         Signature::build("input")
-            .input_output_types(vec![
-                (Type::Nothing, Type::String),
-                (Type::Nothing, Type::Binary),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .allow_variants_without_examples(true)
             .optional("prompt", SyntaxShape::String, "Prompt to show the user.")
             .named(

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -39,10 +39,6 @@ impl Command for InputList {
     fn signature(&self) -> Signature {
         Signature::build("input list")
             .input_output_types(vec![
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
                 (Type::List(Box::new(Type::Any)), Type::Any),
                 (Type::Range, Type::Int),
             ])

--- a/crates/nu-command/src/platform/ulimit.rs
+++ b/crates/nu-command/src/platform/ulimit.rs
@@ -503,10 +503,7 @@ impl Command for ULimit {
 
     fn signature(&self) -> Signature {
         let mut sig = Signature::build("ulimit")
-            .input_output_types(vec![
-                (Type::Nothing, Type::Table(vec![])),
-                (Type::Nothing, Type::Nothing),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .switch("soft", "Sets soft resource limit", Some('S'))
             .switch("hard", "Sets hard resource limit", Some('H'))
             .switch("all", "Prints all current limits", Some('a'))

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -158,10 +158,7 @@ impl Command for Char {
 
     fn signature(&self) -> Signature {
         Signature::build("char")
-            .input_output_types(vec![
-                (Type::Nothing, Type::String),
-                (Type::Nothing, Type::Table(vec![])),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .optional(
                 "character",
                 SyntaxShape::Any,

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -16,15 +16,10 @@ impl Command for DecodeBase64 {
     fn signature(&self) -> Signature {
         Signature::build("decode base64")
             .input_output_types(vec![
-                (Type::String, Type::String),
-                (Type::String, Type::Binary),
+                (Type::String, Type::Any),
                 (
                     Type::List(Box::new(Type::String)),
-                    Type::List(Box::new(Type::String)),
-                ),
-                (
-                    Type::List(Box::new(Type::String)),
-                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Any)),
                 ),
                 (Type::Table(vec![]), Type::Table(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -29,7 +29,6 @@ impl Command for Griddle {
             .input_output_types(vec![
                 (Type::List(Box::new(Type::Any)), Type::String),
                 (Type::Record(vec![]), Type::String),
-                (Type::Table(vec![]), Type::String),
             ])
             .named(
                 "width",

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -62,6 +62,7 @@ impl Type {
             (Type::Record(this), Type::Record(that)) | (Type::Table(this), Type::Table(that)) => {
                 is_subtype_collection(this, that)
             }
+            (Type::Table(_), Type::List(_)) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
# Description
1. Make table to be a subtype of `list<any>`, so some input_output_types of filter commands are unnecessary
2. Change some commands which accept an input type, but generates different output types.  In this case, delete duplicate entry, and change relative output type to `<any>`

Yeah it makes some commands more permissive, but I think it's better to run into strange issue that why my script runs to failed during parse time.

Fixes  #11193

# User-Facing Changes
NaN

# Tests + Formatting
NaN

# After Submitting
NaN