### PR TITLE
external completer: support style

### DIFF
--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -2,6 +2,7 @@ use crate::completions::{
     CommandCompletion, Completer, CompletionOptions, CustomCompletion, DirectoryCompletion,
     DotNuCompletion, FileCompletion, FlagCompletion, VariableCompletion,
 };
+use nu_color_config::{color_record_to_nustyle, lookup_ansi_color_style};
 use nu_engine::eval_block;
 use nu_parser::{flatten_expression, parse, FlatShape};
 use nu_protocol::{
@@ -507,6 +508,16 @@ pub fn map_value_completions<'a>(
                         // Update the suggestion value
                         suggestion.description = Some(desc_str);
                     }
+                }
+
+                // Match `style` column
+                if it.0 == "style" {
+                    // Convert the value to string
+                    suggestion.style = match it.1 {
+                        Value::String { val, .. } => Some(lookup_ansi_color_style(val)),
+                        Value::Record { .. } => Some(color_record_to_nustyle(it.1)),
+                        _ => None,
+                    };
                 }
             });
 

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -265,7 +265,7 @@ $env.config = {
             }
             style: {
                 text: green
-                selected_text: green_reverse
+                selected_text: {attr: r}
                 description_text: yellow
             }
         }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

Adds style support.

Reverse highlighting is recommended for the [completion-menu](https://www.nushell.sh/book/line_editor.html#completion-menu):
```nushell
style: {
    text: white
    selected_text: {
        attr: r
    }
    description_text: white_dimmed
}
```

needs https://github.com/nushell/reedline/pull/691
related https://github.com/nushell/nushell/issues/5292
fix https://github.com/rsteube/carapace/issues/967

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes

Style support for values during completion:

![image](https://github.com/nushell/nushell/assets/9090290/f5e4440e-61db-4eeb-87b3-f887b6918c50)

![image](https://github.com/nushell/nushell/assets/9090290/e59065a6-58c2-4f5f-82ea-e2b9c2464b9a)

<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
