### PR TITLE
external completer: support display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4665,8 +4665,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e01ebfbdb1a88963121d3c928c97be7f10fec7795bec8b918c8cda1db7c29e6"
+source = "git+https://github.com/rsteube/reedline?branch=suggestion-display#4949025ad826530407aacabbdcc1720484a48182"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,8 @@ bench = false
 
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
-#[patch.crates-io]
+[patch.crates-io]
+reedline = { git = "https://github.com/rsteube/reedline", branch = "suggestion-display" }
 #reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 # uu_cp = { git = "https://github.com/uutils/coreutils.git", branch = "main" }

--- a/crates/nu-cli/src/completions/command_completions.rs
+++ b/crates/nu-cli/src/completions/command_completions.rs
@@ -93,6 +93,7 @@ impl CommandCompletion {
             .into_iter()
             .map(move |x| Suggestion {
                 value: String::from_utf8_lossy(&x.0).to_string(),
+                display: None,
                 description: x.1,
                 style: None,
                 extra: None,
@@ -110,6 +111,7 @@ impl CommandCompletion {
                 .into_iter()
                 .map(move |x| Suggestion {
                     value: x,
+                    display: None,
                     description: None,
                     style: None,
                     extra: None,
@@ -124,6 +126,7 @@ impl CommandCompletion {
                 if results_strings.contains(&external.value) {
                     results.push(Suggestion {
                         value: format!("^{}", external.value),
+                        display: None,
                         description: None,
                         style: None,
                         extra: None,

--- a/crates/nu-cli/src/completions/completer.rs
+++ b/crates/nu-cli/src/completions/completer.rs
@@ -477,6 +477,7 @@ pub fn map_value_completions<'a>(
         if let Ok(s) = x.as_string() {
             return Some(Suggestion {
                 value: s,
+                display: None,
                 description: None,
                 style: None,
                 extra: None,
@@ -492,6 +493,7 @@ pub fn map_value_completions<'a>(
         if let Ok(record) = x.as_record() {
             let mut suggestion = Suggestion {
                 value: String::from(""), // Initialize with empty string
+                display: None,
                 description: None,
                 style: None,
                 extra: None,
@@ -510,6 +512,15 @@ pub fn map_value_completions<'a>(
                     if let Ok(val_str) = it.1.as_string() {
                         // Update the suggestion value
                         suggestion.value = val_str;
+                    }
+                }
+
+                // Match `display` column
+                if it.0 == "display" {
+                    // Convert the value to string
+                    if let Ok(display_str) = it.1.as_string() {
+                        // Update the suggestion value
+                        suggestion.display = Some(display_str);
                     }
                 }
 

--- a/crates/nu-cli/src/completions/directory_completions.rs
+++ b/crates/nu-cli/src/completions/directory_completions.rs
@@ -50,6 +50,7 @@ impl Completer for DirectoryCompletion {
         .into_iter()
         .map(move |x| Suggestion {
             value: x.1,
+            display: None,
             description: None,
             style: x.2,
             extra: None,

--- a/crates/nu-cli/src/completions/dotnu_completions.rs
+++ b/crates/nu-cli/src/completions/dotnu_completions.rs
@@ -121,6 +121,7 @@ impl Completer for DotNuCompletion {
                     })
                     .map(move |x| Suggestion {
                         value: x.1,
+                        display: None,
                         description: None,
                         style: x.2,
                         extra: None,

--- a/crates/nu-cli/src/completions/file_completions.rs
+++ b/crates/nu-cli/src/completions/file_completions.rs
@@ -55,6 +55,7 @@ impl Completer for FileCompletion {
         .into_iter()
         .map(move |x| Suggestion {
             value: x.1,
+            display: None,
             description: None,
             style: x.2,
             extra: None,

--- a/crates/nu-cli/src/completions/flag_completions.rs
+++ b/crates/nu-cli/src/completions/flag_completions.rs
@@ -45,6 +45,7 @@ impl Completer for FlagCompletion {
                     if options.match_algorithm.matches_u8(&named, &prefix) {
                         output.push(Suggestion {
                             value: String::from_utf8_lossy(&named).to_string(),
+                            display: None,
                             description: Some(flag_desc.to_string()),
                             style: None,
                             extra: None,
@@ -68,6 +69,7 @@ impl Completer for FlagCompletion {
                 if options.match_algorithm.matches_u8(&named, &prefix) {
                     output.push(Suggestion {
                         value: String::from_utf8_lossy(&named).to_string(),
+                        display: None,
                         description: Some(flag_desc.to_string()),
                         style: None,
                         extra: None,

--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -94,6 +94,7 @@ impl Completer for VariableCompletion {
                         ) {
                             output.push(Suggestion {
                                 value: env_var.0,
+                                display: None,
                                 description: None,
                                 style: None,
                                 extra: None,
@@ -165,6 +166,7 @@ impl Completer for VariableCompletion {
             ) {
                 output.push(Suggestion {
                     value: builtin.to_string(),
+                    display: None,
                     description: None,
                     style: None,
                     extra: None,
@@ -188,6 +190,7 @@ impl Completer for VariableCompletion {
                     ) {
                         output.push(Suggestion {
                             value: String::from_utf8_lossy(v.0).to_string(),
+                            display: None,
                             description: None,
                             style: None,
                             extra: None,
@@ -210,6 +213,7 @@ impl Completer for VariableCompletion {
                 ) {
                     output.push(Suggestion {
                         value: String::from_utf8_lossy(v.0).to_string(),
+                        display: None,
                         description: None,
                         style: None,
                         extra: None,
@@ -242,6 +246,7 @@ fn nested_suggestions(
             for (col, _) in val.into_iter() {
                 output.push(Suggestion {
                     value: col,
+                    display: None,
                     description: None,
                     style: None,
                     extra: None,
@@ -257,6 +262,7 @@ fn nested_suggestions(
             for column_name in val.column_names() {
                 output.push(Suggestion {
                     value: column_name.to_string(),
+                    display: None,
                     description: None,
                     style: None,
                     extra: None,
@@ -271,6 +277,7 @@ fn nested_suggestions(
             for column_name in get_columns(vals.as_slice()) {
                 output.push(Suggestion {
                     value: column_name,
+                    display: None,
                     description: None,
                     style: None,
                     extra: None,

--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -101,6 +101,7 @@ impl NuHelpCompleter {
 
                 Suggestion {
                     value: sig.name.clone(),
+                    display: None,
                     description: Some(long_desc),
                     style: None,
                     extra: Some(extra),

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -145,6 +145,7 @@ fn convert_to_suggestions(
 
             vec![Suggestion {
                 value: text,
+                display: None,
                 description,
                 style: None,
                 extra,
@@ -158,6 +159,7 @@ fn convert_to_suggestions(
             .collect(),
         _ => vec![Suggestion {
             value: format!("Not a record: {value:?}"),
+            display: None,
             description: None,
             style: None,
             extra: None,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Adds display support.

needs https://github.com/nushell/nushell/pull/11442
needs https://github.com/nushell/reedline/pull/692
fix https://github.com/nushell/nushell/issues/5292

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Full inserted value:
![image](https://github.com/nushell/nushell/assets/9090290/7b5a2de9-89bd-445a-887f-27661b54b747)

Display value:
![image](https://github.com/nushell/nushell/assets/9090290/f04229ce-f8e2-46e1-b96a-73c24e65eff8)


# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
