### PR TITLE
Fix the test which fails on windows

### DIFF
--- a/crates/nu-command/tests/commands/complete.rs
+++ b/crates/nu-command/tests/commands/complete.rs
@@ -1,12 +1,24 @@
 use nu_test_support::nu;
 
 #[test]
-fn basic() {
-    let actual = nu!(r#"
-        (^echo a | complete) == {stdout: "a\n", exit_code: 0}
+fn basic_stdout() {
+    let without_complete = nu!(r#"
+        ^echo a
+    "#);
+    let with_complete = nu!(r#"
+        (^echo a | complete).stdout
     "#);
 
-    assert_eq!(actual.out, "true");
+    assert_eq!(with_complete.out, without_complete.out);
+}
+
+#[test]
+fn basic_exit_code() {
+    let with_complete = nu!(r#"
+        (^echo a | complete).exit_code
+    "#);
+
+    assert_eq!(with_complete.out, "0");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/complete.rs
+++ b/crates/nu-command/tests/commands/complete.rs
@@ -3,10 +3,10 @@ use nu_test_support::nu;
 #[test]
 fn basic_stdout() {
     let without_complete = nu!(r#"
-        ^echo a
+        nu --testbin cococo test
     "#);
     let with_complete = nu!(r#"
-        (^echo a | complete).stdout
+        (nu --testbin cococo test | complete).stdout
     "#);
 
     assert_eq!(with_complete.out, without_complete.out);
@@ -15,7 +15,7 @@ fn basic_stdout() {
 #[test]
 fn basic_exit_code() {
     let with_complete = nu!(r#"
-        (^echo a | complete).exit_code
+        (nu --testbin cococo test | complete).exit_code
     "#);
 
     assert_eq!(with_complete.out, "0");


### PR DESCRIPTION

- related PR: #11463

# Description

Currently, `commands::complete::basic` fails on Windows without git bash.
This pr fixes it.

# User-Facing Changes

(none)

# Tests + Formatting

- [x] (on Windows) `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] (on Windows) `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] (on Windows without git bash, Windows with git bash and Ubuntu) `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
   - on my Windows with Japanese lang pack: 1 test still fails. (see #11463)
- [x] (on Windows and Ubuntu) `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

# After Submitting

(none)
