### PR TITLE
Refactor tests (using cococo instead of ^echo)

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -197,7 +197,7 @@ fn def_wrapped_with_block() {
 #[test]
 fn def_wrapped_from_module() {
     let actual = nu!(r#"module spam {
-            export def --wrapped my-echo [...rest] { ^echo ...$rest }
+            export def --wrapped my-echo [...rest] { nu --testbin cococo ...$rest }
         }
 
         use spam

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -139,7 +139,6 @@ fn failed_command_with_semicolon_will_not_execute_following_cmds() {
     })
 }
 
-#[cfg(not(windows))]
 #[test]
 fn external_args_with_quoted() {
     Playground::setup("external failed command with semicolon", |dirs, _| {
@@ -187,7 +186,6 @@ fn external_arg_with_variable_name() {
     })
 }
 
-#[cfg(not(windows))]
 #[test]
 fn external_command_escape_args() {
     Playground::setup("external failed command with semicolon", |dirs, _| {
@@ -308,7 +306,6 @@ fn can_run_batch_files_without_bat_extension() {
     );
 }
 
-#[cfg(windows)]
 #[test]
 fn quotes_trimmed_when_shelling_out() {
     // regression test for a bug where we weren't trimming quotes around string args before shelling out to cmd.exe

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -146,7 +146,7 @@ fn external_args_with_quoted() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                ^echo "foo=bar 'hi'"
+                nu --testbin cococo "foo=bar 'hi'"
             "#
         ));
 
@@ -161,7 +161,7 @@ fn external_arg_with_long_flag_value_quoted() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                ^echo --foo='bar'
+                nu --testbin cococo --foo='bar'
             "#
         ));
 
@@ -194,7 +194,7 @@ fn external_command_escape_args() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                ^echo "\"abcd"
+                nu --testbin cococo "\"abcd"
             "#
         ));
 
@@ -314,7 +314,7 @@ fn quotes_trimmed_when_shelling_out() {
     // regression test for a bug where we weren't trimming quotes around string args before shelling out to cmd.exe
     let actual = nu!(pipeline(
         r#"
-            ^echo "foo"
+            nu --testbin cococo "foo"
         "#
     ));
 

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -161,7 +161,7 @@ fn external_arg_with_long_flag_value_quoted() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu --testbin cococo --foo='bar'
+                ^echo --foo='bar'
             "#
         ));
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -501,7 +501,6 @@ mod external_command_arguments {
         assert_eq!(actual.out, "a;b");
     }
 
-    #[cfg(not(windows))]
     #[test]
     fn ampersands_are_sanitized_before_passing_to_subshell() {
         let actual = nu!("nu --testbin cococo \"a&b\"");
@@ -509,7 +508,6 @@ mod external_command_arguments {
         assert_eq!(actual.out, "a&b");
     }
 
-    #[cfg(not(windows))]
     #[test]
     fn subcommands_are_sanitized_before_passing_to_subshell() {
         let actual = nu!("nu --testbin cococo \"$(ls)\"");

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -493,7 +493,6 @@ mod external_command_arguments {
         )
     }
 
-    #[cfg(not(windows))]
     #[test]
     fn semicolons_are_sanitized_before_passing_to_subshell() {
         let actual = nu!("nu --testbin cococo \"a;b\"");
@@ -508,6 +507,7 @@ mod external_command_arguments {
         assert_eq!(actual.out, "a&b");
     }
 
+    #[cfg(not(windows))]
     #[test]
     fn subcommands_are_sanitized_before_passing_to_subshell() {
         let actual = nu!("nu --testbin cococo \"$(ls)\"");

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -85,7 +85,7 @@ fn execute_binary_in_string() {
 
 #[test]
 fn single_quote_dollar_external() {
-    let actual = nu!("let author = 'JT'; ^echo $'foo=($author)'");
+    let actual = nu!("let author = 'JT'; nu --testbin cococo $'foo=($author)'");
 
     assert_eq!(actual.out, "foo=JT");
 }
@@ -496,7 +496,7 @@ mod external_command_arguments {
     #[cfg(not(windows))]
     #[test]
     fn semicolons_are_sanitized_before_passing_to_subshell() {
-        let actual = nu!("^echo \"a;b\"");
+        let actual = nu!("nu --testbin cococo \"a;b\"");
 
         assert_eq!(actual.out, "a;b");
     }
@@ -504,7 +504,7 @@ mod external_command_arguments {
     #[cfg(not(windows))]
     #[test]
     fn ampersands_are_sanitized_before_passing_to_subshell() {
-        let actual = nu!("^echo \"a&b\"");
+        let actual = nu!("nu --testbin cococo \"a&b\"");
 
         assert_eq!(actual.out, "a&b");
     }


### PR DESCRIPTION
- related PR: #11478 

# Description

Now we can use `nu --testbin cococo` instead of `^echo` to echo messages to stdout in tests.

But `nu` treats parameters as its own flags when parameter starts with `-`. So `^echo --foo='bar'` still use `^echo`.

# User-Facing Changes

(none)

# Tests + Formatting

- [x] `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- [x] `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- [x] `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- [x] `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library


# After Submitting

(none)