### PR TITLE
Fix cross building for target x86_64-pc-windows-gnu on linux

### DIFF
--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -28,7 +28,7 @@ libproc = "0.14"
 mach2 = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ntapi = "0.4"
 once_cell = "1.18"
 windows = { version = "0.52", features = [


### PR DESCRIPTION
# Description

Cross build for target `x86_64-pc-windows-gnu` fails on linux.

```console
nushell on  main [?] is 📦 v0.88.2 via 🦀 v1.77.0-nightly
❯ cargo build --target x86_64-pc-windows-gnu -p nu-system
   Compiling nu-system v0.88.2 (/data/source/nushell/crates/nu-system)
error[E0432]: unresolved import `chrono::Local`
   --> crates/nu-system/src/windows.rs:5:14
    |
5   | use chrono::{Local, NaiveDate};
    |              ^^^^^ no `Local` in the root
    |
note: found an item that was configured out
   --> /path/to/home/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/chrono-0.4.31/src/lib.rs:537:17
    |
537 | pub use offset::Local;
    |                 ^^^^^
    = note: the item is gated behind the `clock` feature

error[E0412]: cannot find type `Local` in crate `chrono`
   --> crates/nu-system/src/windows.rs:68:46
    |
68  |     pub start_time: chrono::DateTime<chrono::Local>,
    |                                              ^^^^^ not found in `chrono`
    |
note: found an item that was configured out
   --> /path/to/home/.cargo/registry/src/rsproxy.cn-0dccff568467c15b/chrono-0.4.31/src/lib.rs:537:17
    |
537 | pub use offset::Local;
    |                 ^^^^^
    = note: the item is gated behind the `clock` feature

Some errors have detailed explanations: E0412, E0432.
For more information about an error, try `rustc --explain E0412`.
error: could not compile `nu-system` (lib) due to 2 previous errors
```