### PR TITLE
Add an option to enable or disable ansi coloring automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,9 @@ dependencies = [
  "log",
  "lscolors",
  "num-format",
+ "serde",
  "strip-ansi-escapes",
+ "supports-color",
  "sys-locale",
  "unicase",
 ]

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -4,7 +4,7 @@ use nu_engine::env_to_string;
 use nu_path::home_dir;
 use nu_protocol::engine::{EngineState, Stack};
 use nu_protocol::{engine::StateWorkingSet, Span};
-use nu_utils::get_ls_colors;
+use nu_utils::{get_ls_colors, utils::supports_color};
 use std::ffi::OsStr;
 use std::path::{is_separator, Component, Path, PathBuf, MAIN_SEPARATOR as SEP};
 
@@ -104,14 +104,14 @@ pub fn complete_item(
     let isdir = partial.ends_with(is_separator);
     let cwd_pathbuf = Path::new(cwd).to_path_buf();
     let ls_colors = (engine_state.config.use_ls_colors_completions
-        && engine_state.config.use_ansi_coloring)
-        .then(|| {
-            let ls_colors_env_str = match stack.get_env_var(engine_state, "LS_COLORS") {
-                Some(v) => env_to_string("LS_COLORS", &v, engine_state, stack).ok(),
-                None => None,
-            };
-            get_ls_colors(ls_colors_env_str)
-        });
+        && supports_color(engine_state.config.ansi_coloring, true))
+    .then(|| {
+        let ls_colors_env_str = match stack.get_env_var(engine_state, "LS_COLORS") {
+            Some(v) => env_to_string("LS_COLORS", &v, engine_state, stack).ok(),
+            None => None,
+        };
+        get_ls_colors(ls_colors_env_str)
+    });
     let mut original_cwd = OriginalCwd::None;
     let mut components_vec: Vec<Component> = Path::new(&partial).components().collect();
 

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -23,6 +23,8 @@ pub fn read_plugin_file(
     plugin_file: Option<Spanned<String>>,
     storage_path: &str,
 ) {
+    use nu_utils::utils::supports_color;
+
     let start_time = std::time::Instant::now();
     let mut plug_path = String::new();
     // Reading signatures from signature file
@@ -51,7 +53,7 @@ pub fn read_plugin_file(
         file!(),
         line!(),
         column!(),
-        engine_state.get_config().use_ansi_coloring,
+        supports_color(engine_state.get_config().ansi_coloring, true),
     );
 }
 

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -10,7 +10,7 @@ use nu_protocol::{
 use nu_protocol::{report_error, report_error_new};
 #[cfg(windows)]
 use nu_utils::enable_vt_processing;
-use nu_utils::utils::perf;
+use nu_utils::utils::{perf, supports_color};
 use std::path::Path;
 
 // This will collect environment variables from std::env and adds them to a stack.
@@ -313,7 +313,7 @@ pub fn eval_source(
         file!(),
         line!(),
         column!(),
-        engine_state.get_config().use_ansi_coloring,
+        supports_color(engine_state.get_config().ansi_coloring, true),
     );
 
     true

--- a/crates/nu-command/src/help/help_aliases.rs
+++ b/crates/nu-command/src/help/help_aliases.rs
@@ -7,6 +7,7 @@ use nu_protocol::{
     span, Category, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
     ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
 };
+use nu_utils::utils::supports_color;
 
 #[derive(Clone)]
 pub struct HelpAliases;
@@ -155,7 +156,7 @@ pub fn help_aliases(
         long_desc.push_str(&format!("{G}Expansion{RESET}:\n  {alias_expansion}"));
 
         let config = engine_state.get_config();
-        if !config.use_ansi_coloring {
+        if !supports_color(config.ansi_coloring, true) {
             long_desc = nu_utils::strip_ansi_string_likely(long_desc);
         }
 

--- a/crates/nu-command/src/help/help_modules.rs
+++ b/crates/nu-command/src/help/help_modules.rs
@@ -7,6 +7,7 @@ use nu_protocol::{
     span, Category, DeclId, Example, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData,
     ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
 };
+use nu_utils::utils::supports_color;
 
 #[derive(Clone)]
 pub struct HelpModules;
@@ -239,7 +240,7 @@ pub fn help_modules(
         }
 
         let config = engine_state.get_config();
-        if !config.use_ansi_coloring {
+        if !supports_color(config.ansi_coloring, true) {
             long_desc = nu_utils::strip_ansi_string_likely(long_desc);
         }
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -10,6 +10,7 @@ use nu_protocol::{
     ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
 };
 use nu_system::ForegroundChild;
+use nu_utils::utils::AnsiColoring;
 use nu_utils::IgnoreCaseExt;
 use os_pipe::PipeReader;
 use pathdiff::diff_paths;
@@ -459,7 +460,7 @@ impl ExternalCommand {
                     let mut stack = stack.clone();
 
                     // Turn off color as we pass data through
-                    Arc::make_mut(&mut engine_state.config).use_ansi_coloring = false;
+                    Arc::make_mut(&mut engine_state.config).ansi_coloring = AnsiColoring::False;
 
                     // Pipe input into the external command's stdin
                     if let Some(mut stdin_write) = child.as_mut().stdin.take() {

--- a/crates/nu-command/src/viewers/griddle.rs
+++ b/crates/nu-command/src/viewers/griddle.rs
@@ -11,6 +11,7 @@ use nu_protocol::{
 };
 use nu_term_grid::grid::{Alignment, Cell, Direction, Filling, Grid, GridOptions};
 use nu_utils::get_ls_colors;
+use nu_utils::utils::supports_color;
 use terminal_size::{Height, Width};
 #[derive(Clone)]
 pub struct Griddle;
@@ -71,7 +72,7 @@ prints out the list properly."#
             None => None,
         };
         let use_grid_icons = config.use_grid_icons;
-        let use_color: bool = color_param && config.use_ansi_coloring;
+        let use_color: bool = color_param && supports_color(config.ansi_coloring, true);
 
         match input {
             PipelineData::Value(Value::List { vals, .. }, ..) => {

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -18,7 +18,7 @@ use nu_table::{
     CollapsedTable, ExpandedTable, JustTable, NuTable, NuTableCell, StringResult, TableOpts,
     TableOutput,
 };
-use nu_utils::get_ls_colors;
+use nu_utils::{get_ls_colors, utils::supports_color};
 use std::collections::VecDeque;
 use std::io::IsTerminal;
 use std::str::FromStr;
@@ -994,7 +994,7 @@ enum TableView {
 
 fn maybe_strip_color(output: String, config: &Config) -> String {
     // the terminal is for when people do ls from vim, there should be no coloring there
-    if !config.use_ansi_coloring || !std::io::stdout().is_terminal() {
+    if !supports_color(config.ansi_coloring, true) || !std::io::stdout().is_terminal() {
         // Draw the table without ansi colors
         nu_utils::strip_ansi_string_likely(output)
     } else {

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -6,6 +6,7 @@ use nu_protocol::{
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
     Value,
 };
+use nu_utils::utils::supports_color;
 use std::{collections::HashMap, fmt::Write};
 
 use crate::eval_call;
@@ -20,7 +21,7 @@ pub fn get_full_help(
     let config = engine_state.get_config();
     let doc_config = DocumentationConfig {
         no_subcommands: false,
-        no_color: !config.use_ansi_coloring,
+        no_color: !supports_color(config.ansi_coloring, true),
         brief: false,
     };
 

--- a/crates/nu-protocol/src/errors/cli_error.rs
+++ b/crates/nu-protocol/src/errors/cli_error.rs
@@ -6,6 +6,7 @@ use miette::{
     LabeledSpan, MietteHandlerOpts, NarratableReportHandler, ReportHandler, RgbColors, Severity,
     SourceCode,
 };
+use nu_utils::utils::supports_color;
 use thiserror::Error;
 
 /// This error exists so that we can defer SourceCode handling. It simply
@@ -49,7 +50,7 @@ impl std::fmt::Debug for CliError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let config = self.1.get_config();
 
-        let ansi_support = config.use_ansi_coloring;
+        let ansi_support = supports_color(config.ansi_coloring, false);
 
         let error_style = &config.error_style;
 

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -23,6 +23,8 @@ num-format = { workspace = true }
 strip-ansi-escapes = { workspace = true }
 sys-locale = "0.3"
 unicase = "2.7.0"
+supports-color = "3.0.0"
+serde = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 crossterm_winapi = "0.9"

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -231,7 +231,7 @@ $env.config = {
     footer_mode: "25" # always, never, number_of_rows, auto
     float_precision: 2 # the precision for displaying floats in tables
     buffer_editor: "" # command that will be used to edit the current line buffer with ctrl+o, if unset fallback to $env.EDITOR and $env.VISUAL
-    use_ansi_coloring: true
+    ansi_coloring: true # true, false or auto
     bracketed_paste: true # enable bracketed paste, currently useless on windows
     edit_mode: emacs # emacs, vi
     shell_integration: false # enables terminal shell integration. Off by default, as some terminals have issues with this.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ use nu_protocol::{
     PipelineData, RawStream, ShellError, Span, Value, NU_VARIABLE_ID,
 };
 use nu_std::load_standard_library;
-use nu_utils::utils::perf;
+use nu_utils::utils::{perf, supports_color};
 use run::{run_commands, run_file, run_repl};
 use signals::ctrlc_protection;
 use std::{
@@ -162,7 +162,7 @@ fn main() -> Result<()> {
 
     engine_state.history_enabled = parsed_nu_cli_args.no_history.is_none();
 
-    let use_color = engine_state.get_config().use_ansi_coloring;
+    let use_color = supports_color(engine_state.get_config().ansi_coloring, true);
     if let Some(level) = parsed_nu_cli_args
         .log_level
         .as_ref()

--- a/src/run.rs
+++ b/src/run.rs
@@ -9,7 +9,7 @@ use nu_cli::read_plugin_file;
 use nu_cli::{evaluate_commands, evaluate_file, evaluate_repl};
 use nu_protocol::eval_const::create_nu_constant;
 use nu_protocol::{PipelineData, Span, NU_VARIABLE_ID};
-use nu_utils::utils::perf;
+use nu_utils::utils::{perf, supports_color};
 
 pub(crate) fn run_commands(
     engine_state: &mut nu_protocol::engine::EngineState,
@@ -259,7 +259,7 @@ pub(crate) fn run_repl(
     }
 
     // Reload use_color from config in case it's different from the default value
-    let use_color = engine_state.get_config().use_ansi_coloring;
+    let use_color = supports_color(engine_state.get_config().ansi_coloring, true);
     perf(
         "setup_config",
         start_time,


### PR DESCRIPTION
# Description

This PR provides an option to enable or disable ansi coloring automatically, which changes `config.use_ansi_coloring` to `config.ansi_coloring`. The new config option could be set to `true`, `false` or `auto`.

* `config.ansi_coloring = true` is equivalent to the original `config.use_ansi_coloring = true`
* `config.ansi_coloring = false` is equivalent to the original `config.use_ansi_coloring = false`
* `config.ansi_coloring = auto` makes nushell to detect whether the terminal supports color, and then enable or disable ansi coloring automatically.

For external programs that use `sh -c` to run shell commands, we should also pass `-l` along with `-c` to make it work when we set `config.ansi_coloring = auto`.

Related #11464 #11847

# User-Facing Changes

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
