### PR TITLE
Allow tables and records as input to math commands

### DIFF
--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -18,6 +18,9 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::Number)), Type::Number),
                 (Type::List(Box::new(Type::Duration)), Type::Duration),
                 (Type::List(Box::new(Type::Filesize)), Type::Filesize),
+                (Type::Range, Type::Number),
+                (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -2,8 +2,11 @@ use crate::math::reducers::{reducer_for, Reduce};
 use crate::math::utils::run_with_function;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+use nu_protocol::{
+    record, Category, Example, PipelineData, ShellError, Signature, Span, Type, Value,
+};
 
+const NS_PER_SEC: i64 = 1_000_000_000;
 #[derive(Clone)]
 pub struct SubCommand;
 
@@ -45,11 +48,26 @@ impl Command for SubCommand {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Compute the average of a list of numbers",
-            example: "[-50 100.0 25] | math avg",
-            result: Some(Value::test_float(25.0)),
-        }]
+        vec![
+            Example {
+                description: "Compute the average of a list of numbers",
+                example: "[-50 100.0 25] | math avg",
+                result: Some(Value::test_float(25.0)),
+            },
+            Example {
+                description: "Compute the average of a list of durations",
+                example: "[2sec 1min] | math avg",
+                result: Some(Value::test_duration(31 * NS_PER_SEC)),
+            },
+            Example {
+                description: "Compute the average of each column in a table",
+                example: "[[a b]; [1 2] [3 4]] | math avg",
+                result: Some(Value::test_record(record! {
+                    "a" => Value::test_int(2),
+                    "b" => Value::test_int(3),
+                })),
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -17,8 +17,12 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("math max")
             .input_output_types(vec![
-                (Type::List(Box::new(Type::Any)), Type::Any),
+                (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::List(Box::new(Type::Duration)), Type::Duration),
+                (Type::List(Box::new(Type::Filesize)), Type::Filesize),
+                (Type::Range, Type::Number),
                 (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -65,7 +65,9 @@ impl Command for SubCommand {
             Example {
                 description: "Find the maximum of a list of dates",
                 example: "[2022-02-02 2022-12-30 2012-12-12] | math max",
-                result: Some(Value::test_date("2022-12-30 00:00:00Z".parse().unwrap())),
+                result: Some(Value::test_date(
+                    "2022-12-30 00:00:00Z".parse().unwrap_or_default(),
+                )),
             },
         ]
     }

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -50,7 +50,7 @@ impl Command for SubCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Find the maximum of list of numbers",
+                description: "Find the maximum of a list of numbers",
                 example: "[-50 100 25] | math max",
                 result: Some(Value::test_int(100)),
             },
@@ -61,6 +61,11 @@ impl Command for SubCommand {
                     "a" => Value::test_int(2),
                     "b" => Value::test_int(3),
                 })),
+            },
+            Example {
+                description: "Find the maximum of a list of dates",
+                example: "[2022-02-02 2022-12-30 2012-12-12] | math max",
+                result: Some(Value::test_date("2022-12-30 00:00:00Z".parse().unwrap())),
             },
         ]
     }

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::Number)), Type::Number),
                 (Type::List(Box::new(Type::Duration)), Type::Duration),
                 (Type::List(Box::new(Type::Filesize)), Type::Filesize),
+                (Type::List(Box::new(Type::Any)), Type::Any),
                 (Type::Range, Type::Number),
                 (Type::Table(vec![]), Type::Record(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -63,6 +63,11 @@ impl Command for SubCommand {
                     "b" => Value::test_int(3),
                 })),
             },
+            Example {
+                description: "Find the median of a list of file sizes",
+                example: "[5KB 10MB 200B] | math median",
+                result: Some(Value::test_filesize(5 * 1_000)),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -22,7 +22,9 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::Number)), Type::Number),
                 (Type::List(Box::new(Type::Duration)), Type::Duration),
                 (Type::List(Box::new(Type::Filesize)), Type::Filesize),
+                (Type::Range, Type::Number),
                 (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -17,8 +17,12 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("math min")
             .input_output_types(vec![
-                (Type::List(Box::new(Type::Any)), Type::Any),
+                (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::List(Box::new(Type::Duration)), Type::Duration),
+                (Type::List(Box::new(Type::Filesize)), Type::Filesize),
+                (Type::Range, Type::Number),
                 (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -20,6 +20,7 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::Number)), Type::Number),
                 (Type::List(Box::new(Type::Duration)), Type::Duration),
                 (Type::List(Box::new(Type::Filesize)), Type::Filesize),
+                (Type::List(Box::new(Type::Any)), Type::Any),
                 (Type::Range, Type::Number),
                 (Type::Table(vec![]), Type::Record(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -2,7 +2,9 @@ use crate::math::reducers::{reducer_for, Reduce};
 use crate::math::utils::run_with_function;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+use nu_protocol::{
+    record, Category, Example, PipelineData, ShellError, Signature, Span, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -20,6 +22,7 @@ impl Command for SubCommand {
                 (Type::Table(vec![]), Type::Record(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),
             ])
+            .allow_variants_without_examples(true)
             .category(Category::Math)
     }
 
@@ -42,11 +45,21 @@ impl Command for SubCommand {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Compute the product of a list of numbers",
-            example: "[2 3 3 4] | math product",
-            result: Some(Value::test_int(72)),
-        }]
+        vec![
+            Example {
+                description: "Compute the product of a list of numbers",
+                example: "[2 3 3 4] | math product",
+                result: Some(Value::test_int(72)),
+            },
+            Example {
+                description: "Compute the product of each column in a table",
+                example: "[[a b]; [1 2] [3 4]] | math product",
+                result: Some(Value::test_record(record! {
+                    "a" => Value::test_int(3),
+                    "b" => Value::test_int(8),
+                })),
+            },
+        ]
     }
 }
 

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -14,7 +14,12 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math product")
-            .input_output_types(vec![(Type::List(Box::new(Type::Number)), Type::Number)])
+            .input_output_types(vec![
+                (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::Range, Type::Number),
+                (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
+            ])
             .category(Category::Math)
     }
 

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -24,6 +24,7 @@ impl Command for SubCommand {
                 "calculate sample standard deviation (i.e. using N-1 as the denominator)",
                 Some('s'),
             )
+            .allow_variants_without_examples(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -14,7 +14,11 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math stddev")
-            .input_output_types(vec![(Type::List(Box::new(Type::Number)), Type::Number)])
+            .input_output_types(vec![
+                (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
+            ])
             .switch(
                 "sample",
                 "calculate sample standard deviation (i.e. using N-1 as the denominator)",

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -2,7 +2,9 @@ use super::variance::compute_variance as variance;
 use crate::math::utils::run_with_function;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+use nu_protocol::{
+    record, Category, Example, PipelineData, ShellError, Signature, Span, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -65,6 +67,14 @@ impl Command for SubCommand {
                 description: "Compute the sample standard deviation of a list of numbers",
                 example: "[1 2 3 4 5] | math stddev --sample",
                 result: Some(Value::test_float(1.5811388300841898)),
+            },
+            Example {
+                description: "Compute the standard deviation of each column in a table",
+                example: "[[a b]; [1 2] [3 4]] | math stddev",
+                result: Some(Value::test_record(record! {
+                    "a" => Value::test_int(1),
+                    "b" => Value::test_int(1),
+                })),
             },
         ]
     }

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -2,7 +2,9 @@ use crate::math::reducers::{reducer_for, Reduce};
 use crate::math::utils::run_with_function;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+use nu_protocol::{
+    record, Category, Example, PipelineData, ShellError, Signature, Span, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -55,6 +57,14 @@ impl Command for SubCommand {
                 description: "Get the disk usage for the current directory",
                 example: "ls | get size | math sum",
                 result: None,
+            },
+            Example {
+                description: "Compute the sum of each column in a table",
+                example: "[[a b]; [1 2] [3 4]] | math sum",
+                result: Some(Value::test_record(record! {
+                    "a" => Value::test_int(4),
+                    "b" => Value::test_int(6),
+                })),
             },
         ]
     }

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -19,7 +19,8 @@ impl Command for SubCommand {
                 (Type::List(Box::new(Type::Duration)), Type::Duration),
                 (Type::List(Box::new(Type::Filesize)), Type::Filesize),
                 (Type::Range, Type::Number),
-                (Type::Table(vec![]), Type::Table(vec![])),
+                (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
             ])
             .allow_variants_without_examples(true)
             .category(Category::Math)

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -23,6 +23,7 @@ impl Command for SubCommand {
                 "calculate sample variance (i.e. using N-1 as the denominator)",
                 Some('s'),
             )
+            .allow_variants_without_examples(true)
             .category(Category::Math)
     }
 

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -1,7 +1,9 @@
 use crate::math::utils::run_with_function;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
-use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Span, Type, Value};
+use nu_protocol::{
+    record, Category, Example, PipelineData, ShellError, Signature, Span, Type, Value,
+};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -57,6 +59,14 @@ impl Command for SubCommand {
                 description: "Get the sample variance of a list of numbers",
                 example: "[1 2 3 4 5] | math variance --sample",
                 result: Some(Value::test_float(2.5)),
+            },
+            Example {
+                description: "Compute the variance of each column in a table",
+                example: "[[a b]; [1 2] [3 4]] | math variance",
+                result: Some(Value::test_record(record! {
+                    "a" => Value::test_int(1),
+                    "b" => Value::test_int(1),
+                })),
             },
         ]
     }

--- a/crates/nu-command/src/math/variance.rs
+++ b/crates/nu-command/src/math/variance.rs
@@ -13,7 +13,11 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("math variance")
-            .input_output_types(vec![(Type::List(Box::new(Type::Number)), Type::Number)])
+            .input_output_types(vec![
+                (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::Table(vec![]), Type::Record(vec![])),
+                (Type::Record(vec![]), Type::Record(vec![])),
+            ])
             .switch(
                 "sample",
                 "calculate sample variance (i.e. using N-1 as the denominator)",


### PR DESCRIPTION
# Description
The math functions `avg`, `max`, `median`, `min`, `product`, `stddev`, `sum` and `variance` all takes a list as input and return a number. <https://github.com/nushell/nushell/blob/main/crates/nu-command/src/math/utils.rs> contains code that makes these functions work for tables  (by running the function on each column), but this functionality has not been accessible because the input types are too strict. This PR remedies this.

The functions should also work on records, since a record is basically a one-row table.

Most of these functions also make sense for durations and file sizes, except `product` of course. There's an implementation issue with `stddev` and `variance` for durations and file sizes, but they could in principle support it.

# User-Facing Changes
This PR only adds supported types, and doesn't remove any, so there should be no breaking changes.