### PR TITLE
Remove `--flag: bool` support

### DIFF
--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -173,19 +173,6 @@ fn def_default_value_should_restrict_implicit_type() {
 }
 
 #[test]
-fn def_boolean_flags() {
-    let actual = nu!("def foo [--x: bool] { $x }; foo --x");
-    assert!(actual.err.contains("flag missing bool argument"));
-    let actual = nu!("def foo [--x: bool = false] { $x }; foo");
-    assert_eq!(actual.out, "false");
-    let actual = nu!("def foo [--x: bool = false] { $x }; foo --x");
-    assert!(actual.err.contains("flag missing bool argument"));
-    // boolean flags' default value should be null
-    let actual = nu!("def foo [--x: bool] { $x == null }; foo");
-    assert_eq!(actual.out, "true");
-}
-
-#[test]
 fn def_wrapped_with_block() {
     let actual = nu!(
         "def --wrapped foo [...rest] { print ($rest | str join ',' ) }; foo --bar baz -- -q -u -x"

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3575,7 +3575,7 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         if syntax_shape == SyntaxShape::Boolean {
                                             working_set.error(ParseError::LabeledError(
                                                 "--flag: bool is not allowed".to_string(),
-                                                "remove this bool".to_string(),
+                                                "remove this `: bool`, more info: https://www.nushell.sh/book/custom_commands.html#flags".to_string(),
                                                 span,
                                             ));
                                         }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -18,8 +18,8 @@ use nu_protocol::{
     },
     engine::StateWorkingSet,
     eval_const::eval_constant,
-    span, BlockId, DidYouMean, Flag, ParseError, ParseWarning, PositionalArg, Signature, Span,
-    Spanned, SyntaxShape, Type, Unit, VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
+    span, BlockId, DidYouMean, Flag, ParseError, PositionalArg, Signature, Span, Spanned,
+    SyntaxShape, Type, Unit, VarId, ENV_VARIABLE_ID, IN_VARIABLE_ID,
 };
 
 use crate::parse_keywords::{
@@ -3573,9 +3573,9 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                     } => {
                                         working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), syntax_shape.to_type());
                                         if syntax_shape == SyntaxShape::Boolean {
-                                            working_set.warning(ParseWarning::DeprecatedWarning(
-                                                "--flag: bool".to_string(),
-                                                "--flag".to_string(),
+                                            working_set.error(ParseError::LabeledError(
+                                                "--flag: bool is not allowed".to_string(),
+                                                "remove this bool".to_string(),
                                                 span,
                                             ));
                                         }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3574,8 +3574,8 @@ pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> 
                                         working_set.set_variable_type(var_id.expect("internal error: all custom parameters must have var_ids"), syntax_shape.to_type());
                                         if syntax_shape == SyntaxShape::Boolean {
                                             working_set.error(ParseError::LabeledError(
-                                                "--flag: bool is not allowed".to_string(),
-                                                "remove this `: bool`, more info: https://www.nushell.sh/book/custom_commands.html#flags".to_string(),
+                                                "Type annotations are not allowed for boolean switches.".to_string(),
+                                                "Remove the `: bool` type annotation.".to_string(),
                                                 span,
                                             ));
                                         }

--- a/crates/nu-protocol/src/parse_warning.rs
+++ b/crates/nu-protocol/src/parse_warning.rs
@@ -3,7 +3,6 @@ use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
 pub enum ParseWarning {
     #[error("Deprecated: {0}")]

--- a/crates/nu-protocol/src/parse_warning.rs
+++ b/crates/nu-protocol/src/parse_warning.rs
@@ -3,6 +3,7 @@ use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+#[allow(dead_code)]
 #[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
 pub enum ParseWarning {
     #[error("Deprecated: {0}")]

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -149,8 +149,7 @@ fn custom_flag2() -> TestResult {
 #[test]
 fn deprecated_boolean_flag() {
     let actual = nu!(r#"def florb [--dry-run: bool, --another-flag] { "aaa" };  florb"#);
-    assert!(actual.err.contains("Deprecated"));
-    assert_eq!(actual.out, "aaa");
+    assert!(actual.err.contains("not allowed"));
 }
 
 #[test]


### PR DESCRIPTION
# Description
This is a follow up to: #11365

After this pr, `--flag: bool` is no longer allowed.

I think `ParseWarning::Deprecated` is useful when we want to deprecated something at syntax level, so I just leave it there for now.

# User-Facing Changes
## Before
```
❯ def foo [--b: bool] {}
Error:   × Deprecated: --flag: bool
   ╭─[entry #15:1:1]
 1 │ def foo [--b: bool] {}
   ·               ──┬─
   ·                 ╰── `--flag: bool` is deprecated and will be removed in 0.90. Please use `--flag` instead, more info: https://www.nushell.sh/book/custom_commands.html
   ╰────
```

## After
```
❯ def foo [--b: bool] {}
Error:   × --flag: bool is not allowed
   ╭─[entry #2:1:1]
 1 │ def foo [--b: bool] {}
   ·               ──┬─
   ·                 ╰── remove this `: bool`, more info: https://www.nushell.sh/book/custom_commands.html#flags
   ╰────
```
# Tests + Formatting
Done