### PR TITLE
Fix deprecation in default_config.nu

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -138,7 +138,7 @@ let light_theme = {
 
 # External completer example
 # let carapace_completer = {|spans|
-#     carapace $spans.0 nushell $spans | from json
+#     carapace $spans.0 nushell ...$spans | from json
 # }
 
 # The default config record. This is where much of your global configuration is setup.


### PR DESCRIPTION
# Description
in https://github.com/nushell/nushell/pull/11289, spreading lists into command invocations was made possible and its implicit version was deprecated, but not everything was updated accordingly.

# User-Facing Changes
A commented part of the default config no longer throws a deprecation warning when uncommented


# After Submitting
After https://github.com/nushell/nushell/pull/11289, the mention of carapace in the documentation wasn’t updated. See https://github.com/nushell/nushell.github.io/pull/1211