### PR TITLE
Fix tarpaulin skip attribute to latest

### DIFF
--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -27,7 +27,7 @@ pub struct ProcessInfo {
     pub interval: Duration,
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();
@@ -116,7 +116,7 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
     ret
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_arg_max() -> size_t {
     let mut mib: [c_int; 2] = [libc::CTL_KERN, libc::KERN_ARGMAX];
     let mut arg_max = 0i32;
@@ -144,7 +144,7 @@ pub struct PathInfo {
     pub cwd: PathBuf,
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 unsafe fn get_unchecked_str(cp: *mut u8, start: *mut u8) -> String {
     let len = cp as usize - start as usize;
     let part = Vec::from_raw_parts(start, len, len);
@@ -153,7 +153,7 @@ unsafe fn get_unchecked_str(cp: *mut u8, start: *mut u8) -> String {
     tmp
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_path_info(pid: i32, mut size: size_t) -> Option<PathInfo> {
     let mut proc_args = Vec::with_capacity(size);
     let ptr: *mut u8 = proc_args.as_mut_slice().as_mut_ptr();
@@ -254,7 +254,7 @@ fn get_path_info(pid: i32, mut size: size_t) -> Option<PathInfo> {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn clone_task_all_info(src: &TaskAllInfo) -> TaskAllInfo {
     let pbsd = BSDInfo {
         pbi_flags: src.pbsd.pbi_flags,

--- a/crates/nu-system/src/windows.rs
+++ b/crates/nu-system/src/windows.rs
@@ -109,7 +109,7 @@ pub struct CpuInfo {
     pub curr_user: u64,
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();
@@ -255,7 +255,7 @@ pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> 
     ret
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn set_privilege() -> bool {
     unsafe {
         let handle = GetCurrentProcess();
@@ -282,7 +282,7 @@ fn set_privilege() -> bool {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_pids() -> Vec<i32> {
     let dword_size = size_of::<u32>();
     let mut pids: Vec<u32> = Vec::with_capacity(10192);
@@ -305,7 +305,7 @@ fn get_pids() -> Vec<i32> {
     pids.iter().map(|x| *x as i32).collect()
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_ppid_threads() -> (HashMap<i32, i32>, HashMap<i32, i32>) {
     let mut ppids = HashMap::new();
     let mut threads = HashMap::new();
@@ -330,7 +330,7 @@ fn get_ppid_threads() -> (HashMap<i32, i32>, HashMap<i32, i32>) {
     (ppids, threads)
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_handle(pid: i32) -> Option<HANDLE> {
     if pid == 0 {
         return None;
@@ -351,7 +351,7 @@ fn get_handle(pid: i32) -> Option<HANDLE> {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_times(handle: HANDLE) -> Option<(u64, u64, u64, u64)> {
     unsafe {
         let mut start: FILETIME = zeroed();
@@ -380,7 +380,7 @@ fn get_times(handle: HANDLE) -> Option<(u64, u64, u64, u64)> {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_memory_info(handle: HANDLE) -> Option<MemoryInfo> {
     unsafe {
         let mut pmc: PROCESS_MEMORY_COUNTERS_EX = zeroed();
@@ -411,7 +411,7 @@ fn get_memory_info(handle: HANDLE) -> Option<MemoryInfo> {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_command(handle: HANDLE) -> Option<String> {
     unsafe {
         let mut exe_buf = [0u16; MAX_PATH as usize + 1];
@@ -778,7 +778,7 @@ fn get_cwd<T: RtlUserProcessParameters>(params: &T, handle: HANDLE) -> PathBuf {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_io(handle: HANDLE) -> Option<(u64, u64)> {
     unsafe {
         let mut io: IO_COUNTERS = zeroed();
@@ -799,7 +799,7 @@ pub struct SidName {
     pub domainname: Option<String>,
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_user(handle: HANDLE) -> Option<SidName> {
     unsafe {
         let mut token: HANDLE = zeroed();
@@ -852,7 +852,7 @@ fn get_user(handle: HANDLE) -> Option<SidName> {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
     unsafe {
         let mut token: HANDLE = zeroed();
@@ -912,7 +912,7 @@ fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_sid(psid: PSID) -> Vec<u64> {
     unsafe {
         let mut ret = Vec::new();
@@ -943,7 +943,7 @@ thread_local!(
         RefCell::new(HashMap::new());
 );
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_name_cached(psid: PSID) -> Option<(String, String)> {
     NAME_CACHE.with(|c| {
         let mut c = c.borrow_mut();
@@ -957,7 +957,7 @@ fn get_name_cached(psid: PSID) -> Option<(String, String)> {
     })
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_name(psid: PSID) -> Option<(String, String)> {
     unsafe {
         let mut cc_name = 0;
@@ -1001,7 +1001,7 @@ fn get_name(psid: PSID) -> Option<(String, String)> {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn from_wide_ptr(ptr: *const u16) -> String {
     unsafe {
         assert!(!ptr.is_null());
@@ -1013,7 +1013,7 @@ fn from_wide_ptr(ptr: *const u16) -> String {
     }
 }
 
-#[cfg_attr(tarpaulin, skip)]
+#[cfg_attr(tarpaulin, ignore)]
 fn get_priority(handle: HANDLE) -> u32 {
     unsafe { GetPriorityClass(handle) }
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Updated the attribute as per the latest version of [tarpaulin](https://github.com/xd009642/tarpaulin) to fix compilation error when used as library with latest tarpaulin.
https://github.com/xd009642/tarpaulin/tree/develop?tab=readme-ov-file#ignoring-code-in-files

# User-Facing Changes
None

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
