### PR TITLE
Evaluate string interpolation at parse time

### DIFF
--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -7,8 +7,8 @@ use nu_protocol::{
     },
     engine::{Closure, EngineState, Stack},
     eval_base::Eval,
-    DeclId, IntoInterruptiblePipelineData, IntoPipelineData, PipelineData, ShellError, Span,
-    Spanned, Type, Value, VarId, ENV_VARIABLE_ID,
+    Config, DeclId, IntoPipelineData, PipelineData, ShellError, Span, Spanned, Type, Value, VarId,
+    ENV_VARIABLE_ID,
 };
 use std::collections::HashMap;
 use std::thread::{self, JoinHandle};
@@ -913,6 +913,10 @@ impl Eval for EvalRuntime {
 
     type MutState = Stack;
 
+    fn get_config(state: Self::State<'_>) -> &Config {
+        state.get_config()
+    }
+
     fn eval_filepath(
         engine_state: Self::State<'_>,
         stack: &mut Self::MutState,
@@ -1131,26 +1135,6 @@ impl Eval for EvalRuntime {
             .collect::<Result<_, _>>()?;
 
         Ok(Value::closure(Closure { block_id, captures }, span))
-    }
-
-    fn eval_string_interpolation(
-        engine_state: &EngineState,
-        stack: &mut Stack,
-        exprs: &[Expression],
-        span: Span,
-    ) -> Result<Value, ShellError> {
-        let mut parts = vec![];
-        for expr in exprs {
-            parts.push(eval_expression(engine_state, stack, expr)?);
-        }
-
-        let config = engine_state.get_config();
-
-        parts
-            .into_iter()
-            .into_pipeline_data(None)
-            .collect_string("", config)
-            .map(|x| Value::string(x, span))
     }
 
     fn eval_overlay(engine_state: &EngineState, span: Span) -> Result<Value, ShellError> {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -1,4 +1,4 @@
-use crate::{current_dir_str, get_full_help};
+use crate::{current_dir_str, get_config, get_full_help};
 use nu_path::expand_path_with;
 use nu_protocol::{
     ast::{
@@ -913,8 +913,8 @@ impl Eval for EvalRuntime {
 
     type MutState = Stack;
 
-    fn get_config(state: Self::State<'_>) -> &Config {
-        state.get_config()
+    fn get_config(engine_state: &EngineState, stack: &mut Stack) -> Config {
+        get_config(engine_state, stack)
     }
 
     fn eval_filepath(

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -10,8 +10,8 @@ use nu_protocol::{
     Config, DeclId, IntoPipelineData, PipelineData, ShellError, Span, Spanned, Type, Value, VarId,
     ENV_VARIABLE_ID,
 };
-use std::collections::HashMap;
 use std::thread::{self, JoinHandle};
+use std::{borrow::Cow, collections::HashMap};
 
 pub fn eval_call(
     engine_state: &EngineState,
@@ -913,13 +913,13 @@ impl Eval for EvalRuntime {
 
     type MutState = Stack;
 
-    fn get_config(engine_state: &EngineState, stack: &mut Stack) -> Config {
-        get_config(engine_state, stack)
+    fn get_config<'a>(engine_state: Self::State<'a>, stack: &mut Stack) -> Cow<'a, Config> {
+        Cow::Owned(get_config(engine_state, stack))
     }
 
     fn eval_filepath(
-        engine_state: Self::State<'_>,
-        stack: &mut Self::MutState,
+        engine_state: &EngineState,
+        stack: &mut Stack,
         path: String,
         span: Span,
     ) -> Result<Value, ShellError> {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1969,14 +1969,20 @@ fn parse_module_file(
     } else if let Some(stem) = path.file_stem() {
         stem.to_string_lossy().to_string()
     } else {
-        working_set.error(ParseError::ModuleNotFound(path_span));
+        working_set.error(ParseError::ModuleNotFound(
+            path_span,
+            path.path().to_string_lossy().to_string(),
+        ));
         return None;
     };
 
     let contents = if let Some(contents) = path.read(working_set) {
         contents
     } else {
-        working_set.error(ParseError::ModuleNotFound(path_span));
+        working_set.error(ParseError::ModuleNotFound(
+            path_span,
+            path.path().to_string_lossy().to_string(),
+        ));
         return None;
     };
 
@@ -2031,20 +2037,26 @@ pub fn parse_module_file_or_dir(
         if let Some(path) = find_in_dirs(&module_path_str, working_set, &cwd, LIB_DIRS_VAR) {
             path
         } else {
-            working_set.error(ParseError::ModuleNotFound(path_span));
+            working_set.error(ParseError::ModuleNotFound(path_span, module_path_str));
             return None;
         };
 
     if module_path.is_dir() {
         if module_path.read_dir().is_none() {
-            working_set.error(ParseError::ModuleNotFound(path_span));
+            working_set.error(ParseError::ModuleNotFound(
+                path_span,
+                module_path.path().to_string_lossy().to_string(),
+            ));
             return None;
         };
 
         let module_name = if let Some(stem) = module_path.file_stem() {
             stem.to_string_lossy().to_string()
         } else {
-            working_set.error(ParseError::ModuleNotFound(path_span));
+            working_set.error(ParseError::ModuleNotFound(
+                path_span,
+                module_path.path().to_string_lossy().to_string(),
+            ));
             return None;
         };
 
@@ -2084,7 +2096,10 @@ pub fn parse_module_file_or_dir(
     } else if module_path.is_file() {
         parse_module_file(working_set, module_path, path_span, name_override)
     } else {
-        working_set.error(ParseError::ModuleNotFound(path_span));
+        working_set.error(ParseError::ModuleNotFound(
+            path_span,
+            module_path.path().to_string_lossy().to_string(),
+        ));
         None
     }
 }
@@ -2200,7 +2215,10 @@ pub fn parse_module(
         ) {
             return (pipeline, Some(module_id));
         } else {
-            working_set.error(ParseError::ModuleNotFound(module_name_or_path_span));
+            working_set.error(ParseError::ModuleNotFound(
+                module_name_or_path_span,
+                module_name_or_path,
+            ));
             return (pipeline, None);
         }
     }
@@ -2397,7 +2415,10 @@ pub fn parse_use(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeline
             module_id,
         )
     } else {
-        working_set.error(ParseError::ModuleNotFound(import_pattern.head.span));
+        working_set.error(ParseError::ModuleNotFound(
+            import_pattern.head.span,
+            String::from_utf8_lossy(&import_pattern.head.name).to_string(),
+        ));
         return (
             Pipeline::from_vec(vec![Expression {
                 expr: Expr::Call(call),
@@ -2567,7 +2588,10 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline
                     (false, Module::new(b"tmp".to_vec()))
                 }
             } else {
-                working_set.error(ParseError::ModuleNotFound(spans[1]));
+                working_set.error(ParseError::ModuleNotFound(
+                    spans[1],
+                    String::from_utf8_lossy(&import_pattern.head.name).to_string(),
+                ));
                 return garbage_pipeline(spans);
             };
 

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     Config, IntoInterruptiblePipelineData, Range, Record, ShellError, Span, Value, VarId,
 };
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 /// To share implementations for regular eval and const eval
 pub trait Eval {
@@ -298,7 +298,7 @@ pub trait Eval {
         }
     }
 
-    fn get_config(state: Self::State<'_>, mut_state: &mut Self::MutState) -> Config;
+    fn get_config<'a>(state: Self::State<'a>, mut_state: &mut Self::MutState) -> Cow<'a, Config>;
 
     fn eval_filepath(
         state: Self::State<'_>,

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -276,12 +276,12 @@ pub trait Eval {
                     parts.push(Self::eval(state, mut_state, expr)?);
                 }
 
-                let config = Self::get_config(state);
+                let config = Self::get_config(state, mut_state);
 
                 parts
                     .into_iter()
                     .into_pipeline_data(None)
-                    .collect_string("", config)
+                    .collect_string("", &config)
                     .map(|x| Value::string(x, expr.span))
             }
             Expr::Overlay(_) => Self::eval_overlay(state, expr.span),
@@ -298,7 +298,7 @@ pub trait Eval {
         }
     }
 
-    fn get_config(state: Self::State<'_>) -> &Config;
+    fn get_config(state: Self::State<'_>, mut_state: &mut Self::MutState) -> Config;
 
     fn eval_filepath(
         state: Self::State<'_>,

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument, PipelineElement},
     engine::{EngineState, StateWorkingSet},
     eval_base::Eval,
-    record, HistoryFileFormat, PipelineData, Record, ShellError, Span, Value, VarId,
+    record, Config, HistoryFileFormat, PipelineData, Record, ShellError, Span, Value, VarId,
 };
 use nu_system::os_info::{get_kernel_version, get_os_arch, get_os_family, get_os_name};
 use std::path::{Path, PathBuf};
@@ -278,6 +278,10 @@ impl Eval for EvalConst {
 
     type MutState = ();
 
+    fn get_config(state: Self::State<'_>) -> &Config {
+        state.get_config()
+    }
+
     fn eval_filepath(
         _: &StateWorkingSet,
         _: &mut (),
@@ -370,15 +374,6 @@ impl Eval for EvalConst {
         _: &StateWorkingSet,
         _: &mut (),
         _: usize,
-        span: Span,
-    ) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant { span })
-    }
-
-    fn eval_string_interpolation(
-        _: &StateWorkingSet,
-        _: &mut (),
-        _: &[Expression],
         span: Span,
     ) -> Result<Value, ShellError> {
         Err(ShellError::NotAConstant { span })

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -5,7 +5,10 @@ use crate::{
     record, Config, HistoryFileFormat, PipelineData, Record, ShellError, Span, Value, VarId,
 };
 use nu_system::os_info::{get_kernel_version, get_os_arch, get_os_family, get_os_name};
-use std::path::{Path, PathBuf};
+use std::{
+    borrow::Cow,
+    path::{Path, PathBuf},
+};
 
 pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Value, ShellError> {
     fn canonicalize_path(engine_state: &EngineState, path: &Path) -> PathBuf {
@@ -278,8 +281,8 @@ impl Eval for EvalConst {
 
     type MutState = ();
 
-    fn get_config(state: Self::State<'_>, _: &mut ()) -> Config {
-        state.get_config().clone()
+    fn get_config<'a>(state: Self::State<'a>, _: &mut ()) -> Cow<'a, Config> {
+        Cow::Borrowed(state.get_config())
     }
 
     fn eval_filepath(

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -278,8 +278,8 @@ impl Eval for EvalConst {
 
     type MutState = ();
 
-    fn get_config(state: Self::State<'_>) -> &Config {
-        state.get_config()
+    fn get_config(state: Self::State<'_>, _: &mut ()) -> Config {
+        state.get_config().clone()
     }
 
     fn eval_filepath(

--- a/crates/nu-protocol/src/parse_error.rs
+++ b/crates/nu-protocol/src/parse_error.rs
@@ -207,7 +207,7 @@ pub enum ParseError {
         code(nu::parser::module_not_found),
         help("module files and their paths must be available before your script is run as parsing occurs before anything is evaluated")
     )]
-    ModuleNotFound(#[label = "module not found"] Span),
+    ModuleNotFound(#[label = "module {1} not found"] Span, String),
 
     #[error("Missing mod.nu file.")]
     #[diagnostic(
@@ -520,7 +520,7 @@ impl ParseError {
             ParseError::VariableNotValid(s) => *s,
             ParseError::AliasNotValid(s) => *s,
             ParseError::CommandDefNotValid(s) => *s,
-            ParseError::ModuleNotFound(s) => *s,
+            ParseError::ModuleNotFound(s, _) => *s,
             ParseError::ModuleMissingModNuFile(_, s) => *s,
             ParseError::NamedAsModule(_, _, _, s) => *s,
             ParseError::ModuleDoubleMain(_, s) => *s,

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -109,6 +109,19 @@ fn const_string() {
 }
 
 #[test]
+fn const_string_interpolation() {
+    let actual = nu!(r#"
+        const x = 2
+        const s = $"var: ($x), date: (2021-02-27T13:55:40+00:00), file size: (2kb)"
+        $s
+    "#);
+    assert_eq!(
+        actual.out,
+        "var: 2, date: Sat, 27 Feb 2021 13:55:40 +0000 (2 years ago), file size: 2.0 KiB"
+    );
+}
+
+#[test]
 fn const_nothing() {
     let inp = &["const x = null", "$x | describe"];
 

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -357,7 +357,7 @@ fn module_cyclical_imports_0() {
 
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
 
-        assert!(actual.err.contains("module not found"));
+        assert!(actual.err.contains("Module not found"));
     })
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

Closes #11561

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR will allow string interpolation at parse time.

Since the actual config hasn't been loaded at parse time, this uses the `get_config()` method on `StateWorkingSet`. So file sizes and datetimes (I think those are the only things whose string representations depend on the config) may be formatted differently from how users have configured things, which may come as a surprise to some. It does seem unlikely that anyone would be formatting file sizes or date times at parse time. Still, something to think about if/before this PR merged.

Also, I changed the `ModuleNotFound` error to include the name of the module.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Users will be able to do stuff like:

```nu
const x = [1 2 3]
const y = $"foo($x)" // foo[1, 2, 3]
```

The main use case is `use`-ing and `source`-ing files at parse time:

```nu
const file = "foo.nu"
use $"($file)"
```

If the module isn't found, you'll see an error like this:
```
Error: nu::parser::module_not_found

  × Module not found.
   ╭─[entry #3:1:1]
 1 │  use $"($file)"
   ·      ─────┬────
   ·           ╰── module foo.nu not found
   ╰────
  help: module files and their paths must be available before your script is run as parsing occurs before anything is evaluated
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Although there's user-facing changes, there's probably no need to change the docs since people probably already expect string interpolation to work at parse time.

Edit: @kubouch pointed out that we'd need to document the fact that stuff like file sizes and datetimes won't get formatted according to user's runtime configs, so I'll make a PR to nushell.github.io after this one