### PR TITLE
`ansi --csi` (first part of #11546)

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -516,17 +516,17 @@ impl Command for AnsiCommand {
             )
             .switch(
                 "escape", // \x1b[
-                r"Control Sequence Introducer (CSI) sequence without the escape character(s) ('\x1b[' is not required); NOTE: this flag is deprecated, use --csi for CSI sequence instead",
+                r"Control Sequence Introducer (CSI) sequence without the escape character(s) ('\e[' is not required); NOTE: this flag is deprecated, use --csi for CSI sequence instead",
                 Some('e'),
             )
             .switch(
                 "csi", // \x1b[
-                r"Control Sequence Introducer (CSI) sequence without the escape character(s) ('\x1b[' is not required)",
+                r"Control Sequence Introducer (CSI) sequence without the escape character(s) ('\e[' is not required)",
                 Some('c'),
             )
             .switch(
                 "osc", // \x1b]
-                r"Operating System Command (OSC) escape sequence without the escape character(s) ('\x1b]' is not required)",
+                r"Operating System Command (OSC) escape sequence without the escape character(s) ('\e]' is not required)",
                 Some('o'),
             )
             .switch("list", "list available ansi code names", Some('l'))
@@ -626,7 +626,7 @@ Operating system commands:
                 )),
             },
             Example {
-                description: "Use escape codes, without the '\\x1b['",
+                description: "Use escape codes, without the '\\e['",
                 example: r#"$"(ansi --csi '3;93;41m')Hello(ansi reset)"  # italic bright yellow on red background"#,
                 result: Some(Value::test_string("\u{1b}[3;93;41mHello\u{1b}[0m")),
             },
@@ -731,7 +731,7 @@ Operating system commands:
                     error: "Using --escape for CSI sequence is deprecated".into(),
                     msg: "Using --escape for CSI sequence is deprecated".into(), // TODO
                     span: call.get_flag_expr("escape").map(|e| e.span),
-                    help: Some("Use the --csi flag for CSI sequence (\\x1b[)".into()),
+                    help: Some("Use the --csi flag for CSI sequence (\\e[)".into()),
                     inner: vec![],
                 },
             );


### PR DESCRIPTION
Completes the first part of #11546, that is, without changing the functionality of `--escape`.

# Description
See #11546 

Not quite sure about how to include deprecation warnings.

Also includes a second commit that changes user visible `\x1b` into `\e` (since they don't actually work in nushell)

# User-Facing Changes
- Using `--escape`/`-e` for CSI sequences (`\e[`) is deprecated; please use `--csi`/`-c`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
