### PR TITLE
Replace htmlescape with v_htmlescape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,12 +1702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "htmlescape"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
-
-[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,7 +2725,6 @@ dependencies = [
  "ahash",
  "fancy-regex",
  "heck",
- "htmlescape",
  "nu-ansi-term",
  "nu-cmd-base",
  "nu-cmd-lang",
@@ -2747,6 +2740,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_urlencoded",
+ "v_htmlescape",
 ]
 
 [[package]]
@@ -2801,7 +2795,6 @@ dependencies = [
  "filesize",
  "filetime",
  "fs_extra",
- "htmlescape",
  "human-date-parser",
  "indexmap",
  "indicatif",
@@ -2874,6 +2867,7 @@ dependencies = [
  "uu_mv",
  "uu_whoami",
  "uuid",
+ "v_htmlescape",
  "wax",
  "which 5.0.0",
  "windows 0.52.0",
@@ -5877,6 +5871,12 @@ checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "v_htmlescape"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
 
 [[package]]
 name = "value-trait"

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1.0.164"
 nu-pretty-hex = { version = "0.89.1", path = "../nu-pretty-hex" }
 nu-json = { version = "0.89.1", path = "../nu-json" }
 serde_urlencoded = "0.7.1"
-htmlescape = "0.3.1"
+v_htmlescape = "0.15.0"
 
 [features]
 extra = ["default"]

--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -396,7 +396,7 @@ fn html_table(table: Vec<Value>, headers: Vec<String>, config: &Config) -> Strin
     output_string.push_str("<thead><tr>");
     for header in &headers {
         output_string.push_str("<th>");
-        output_string.push_str(&htmlescape::encode_minimal(header));
+        output_string.push_str(&v_htmlescape::escape(header).to_string());
         output_string.push_str("</th>");
     }
     output_string.push_str("</tr></thead><tbody>");
@@ -432,7 +432,8 @@ fn html_value(value: Value, config: &Config) -> String {
             output_string.push_str("</pre>");
         }
         other => output_string.push_str(
-            &htmlescape::encode_minimal(&other.into_abbreviated_string(config))
+            &v_htmlescape::escape(&other.into_abbreviated_string(config))
+                .to_string()
                 .replace('\n', "<br>"),
         ),
     }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -46,7 +46,6 @@ fancy-regex = "0.12"
 filesize = "0.2"
 filetime = "0.2"
 fs_extra = "1.3"
-htmlescape = "0.3"
 human-date-parser = "0.1.1"
 indexmap = "2.1"
 indicatif = "0.17"
@@ -94,6 +93,7 @@ uu_whoami = "0.0.23"
 uu_mkdir = "0.0.23"
 uu_mktemp = "0.0.23"
 uuid = { version = "1.6", features = ["v4"] }
+v_htmlescape = "0.15.0"
 wax = { version = "0.6" }
 which = { version = "5.0", optional = true }
 bracoxide = "0.1.2"

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -138,7 +138,7 @@ fn collect_headers(headers: &[String]) -> (Vec<String>, Vec<usize>) {
 
     if !headers.is_empty() && (headers.len() > 1 || !headers[0].is_empty()) {
         for header in headers {
-            let escaped_header_string = htmlescape::encode_minimal(header);
+            let escaped_header_string = v_htmlescape::escape(header).to_string();
             column_widths.push(escaped_header_string.len());
             escaped_headers.push(escaped_header_string);
         }
@@ -179,7 +179,8 @@ fn table(input: PipelineData, pretty: bool, config: &Config) -> String {
                 }
             }
             p => {
-                let value_string = htmlescape::encode_minimal(&p.into_abbreviated_string(config));
+                let value_string =
+                    v_htmlescape::escape(&p.into_abbreviated_string(config)).to_string();
                 escaped_row.push(value_string);
             }
         }


### PR DESCRIPTION
# Description

`htmlescape` is unmaintained: https://crates.io/crates/htmlescape

while `v_htmlescape` is: https://crates.io/crates/v_htmlescape

and is used by two popular crates (`actix-files` and `minijinja`)

Let's use this instead - I'm packaging `nu` in Fedora and there is understandable reluctance in bringing in an unmaintained crate if we can avoid it.

# User-Facing Changes
Should not be any; drop-in replacement

# Tests + Formatting
Tested using:
- `cargo build` in the root folder (needed by some `nu-command` tests)
- `cargo test --features sqlite` in `crates/nu-command` (`tests/commands/database/into_sqlite.rs` needs `rusqlite`)
- `cargo test` in `crates/nu-cmd-extra`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
N/A