### PR TITLE
Add CompletionKind to the LSP

### DIFF
--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -11,9 +11,10 @@ use std::{
 use lsp_server::{Connection, IoThreads, Message, Response, ResponseError};
 use lsp_types::{
     request::{Completion, GotoDefinition, HoverRequest, Request},
-    CompletionItem, CompletionParams, CompletionResponse, CompletionTextEdit, GotoDefinitionParams,
-    GotoDefinitionResponse, Hover, HoverContents, HoverParams, Location, MarkupContent, MarkupKind,
-    OneOf, Range, ServerCapabilities, TextDocumentSyncKind, TextEdit, Url, CompletionItemKind,
+    CompletionItem, CompletionItemKind, CompletionParams, CompletionResponse, CompletionTextEdit,
+    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents, HoverParams, Location,
+    MarkupContent, MarkupKind, OneOf, Range, ServerCapabilities, TextDocumentSyncKind, TextEdit,
+    Url,
 };
 use miette::{IntoDiagnostic, Result};
 use nu_cli::NuCompleter;

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -562,10 +562,9 @@ impl LanguageServer {
                         let mut start = params.text_document_position.position;
                         start.character -= (r.span.end - r.span.start) as u32;
 
-
-                        let completion_kind = if r.value.starts_with("$") {
+                        let completion_kind = if r.value.starts_with('$') {
                             Some(CompletionItemKind::VARIABLE)
-                        } else if r.value.starts_with("-") {
+                        } else if r.value.starts_with('-') {
                             Some(CompletionItemKind::FIELD)
                         } else {
                             None
@@ -1044,6 +1043,7 @@ mod tests {
             serde_json::json!([
                {
                   "label": "$greeting",
+                  "kind": 6,
                   "textEdit": {
                      "newText": "$greeting",
                      "range": {

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -13,7 +13,7 @@ use lsp_types::{
     request::{Completion, GotoDefinition, HoverRequest, Request},
     CompletionItem, CompletionParams, CompletionResponse, CompletionTextEdit, GotoDefinitionParams,
     GotoDefinitionResponse, Hover, HoverContents, HoverParams, Location, MarkupContent, MarkupKind,
-    OneOf, Range, ServerCapabilities, TextDocumentSyncKind, TextEdit, Url,
+    OneOf, Range, ServerCapabilities, TextDocumentSyncKind, TextEdit, Url, CompletionItemKind,
 };
 use miette::{IntoDiagnostic, Result};
 use nu_cli::NuCompleter;
@@ -561,9 +561,19 @@ impl LanguageServer {
                         let mut start = params.text_document_position.position;
                         start.character -= (r.span.end - r.span.start) as u32;
 
+
+                        let completion_kind = if r.value.starts_with("$") {
+                            Some(CompletionItemKind::VARIABLE)
+                        } else if r.value.starts_with("-") {
+                            Some(CompletionItemKind::FIELD)
+                        } else {
+                            None
+                        };
+
                         CompletionItem {
                             label: r.value.clone(),
                             detail: r.description,
+                            kind: completion_kind,
                             text_edit: Some(CompletionTextEdit::Edit(TextEdit {
                                 range: Range {
                                     start,


### PR DESCRIPTION
# Changes

This would add the little completion kind icons to the completions. Right now, all completions are marked as kind *text*, which was off putting to me when first using the LSP. 


# Note

I am new to the repo and to large scale rust, so I am sure this is not the best way to implement this. My motivation is simply to make this feature happen, and feedback/suggestions from others on how to impl this would be much appreciated. 

## Ideas

- It would be very nice if the Suggestion type gave some hint as to what Kind the completion is. Also, reading through the CLI code, I see that completions are always of the same Kind (variable, external, ...) so this may not be very hard
- I also tried (unsuccessfully) to create a tmp Rope of the file the completion added, then to parse the rope using the Find_ID to get the ID enum of the completion, then try to use this for the completion kind. This simply wasn't working and I thought it was too complicated any way so I gave up.

I would love some feedback and input on this.  

