### PR TITLE
Send only absolute paths to uu_mv

### DIFF
--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -136,6 +136,15 @@ impl Command for UMv {
             }
             files.append(&mut app_vals);
         }
+
+        // Make sure to send absolute paths to avoid uu_cp looking for cwd in std::env which is not
+        // supported in Nushell
+        for src in files.iter_mut() {
+            if !src.is_absolute() {
+                *src = nu_path::expand_path_with(&src, &cwd);
+            }
+        }
+
         // Add back the target after globbing
         let spanned_target = paths.last().ok_or(ShellError::NushellFailedSpanned {
             msg: "Missing file operand".into(),

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -592,3 +592,18 @@ fn mv_files_with_glob_metachars(#[case] src_name: &str) {
 fn mv_files_with_glob_metachars_nw(#[case] src_name: &str) {
     mv_files_with_glob_metachars(src_name);
 }
+
+#[test]
+fn mv_with_cd() {
+    Playground::setup("umv_test_17", |_dirs, sandbox| {
+        sandbox
+            .mkdir("tmp_dir")
+            .with_files(vec![FileWithContent("tmp_dir/file.txt", "body")]);
+
+        let actual = nu!(
+            cwd: sandbox.cwd(),
+            r#"do { cd tmp_dir; let f = 'file.txt'; umv $f .. }; open file.txt"#,
+        );
+        assert!(actual.out.contains("body"));
+    });
+}


### PR DESCRIPTION
# Description
Fixes: #11127 

It's something similar to #11080, applying the same logic to `uu_mv`.

# User-Facing Changes

# After Submitting
