### PR TITLE
Add self-closed tag support for `to xml`

### DIFF
--- a/crates/nu-command/tests/format_conversions/xml.rs
+++ b/crates/nu-command/tests/format_conversions/xml.rs
@@ -91,3 +91,22 @@ fn to_xml_pi_comment_not_escaped() {
     ));
     assert_eq!(actual.out, r#"<a><?qwe "'<>&?><!--"'<>&--></a>"#);
 }
+
+#[test]
+fn to_xml_self_closed() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+        r#"
+            {
+                tag: root
+                content: [
+                    [tag attributes content];
+                    [a null null]
+                    [b {e: r} null]
+                    [c {t: y} []]
+                ]
+            } | to xml --self-closed
+        "#
+    ));
+    assert_eq!(actual.out, r#"<root><a/><b e="r"/><c t="y"/></root>"#);
+}


### PR DESCRIPTION
# Description
This PR closes #11524
Add `to xml --self-closed` flag to output empty tags as self close.
For example:
![image](https://github.com/nushell/nushell/assets/17511668/bdf040f7-8ac1-4e8b-80bb-0043d7cec7f9)


# User-Facing Changes
New `to xml` flag `--self-closed`.

# Tests + Formatting
Added new example for `to xml` command and new test for self-closed tags.
