### PR TITLE
Added --index flag to input list

### DIFF
--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -49,6 +49,7 @@ impl Command for InputList {
                 Some('m'),
             )
             .switch("fuzzy", "Use a fuzzy select.", Some('f'))
+            .switch("index", "Returns list indexes.", Some('i'))
             .allow_variants_without_examples(true)
             .category(Category::Platform)
     }
@@ -76,6 +77,7 @@ impl Command for InputList {
         let prompt: Option<String> = call.opt(engine_state, stack, 0)?;
         let multi = call.has_flag(engine_state, stack, "multi")?;
         let fuzzy = call.has_flag(engine_state, stack, "fuzzy")?;
+        let index = call.has_flag(engine_state, stack, "index")?;
 
         let options: Vec<Options> = match input {
             PipelineData::Value(Value::Range { .. }, ..)
@@ -168,16 +170,35 @@ impl Command for InputList {
         };
 
         Ok(match ans {
-            InteractMode::Multi(res) => match res {
-                Some(opts) => Value::list(
-                    opts.iter().map(|s| options[*s].value.clone()).collect(),
-                    head,
-                ),
-                None => Value::nothing(head),
+            InteractMode::Multi(res) => {
+                if index {
+                    match res {
+                        Some(opts) => Value::list(
+                            opts.into_iter().map(|s| Value::int(s as i64, head)).collect(), head),
+                        None => Value::nothing(head),
+                    }
+                } else {
+                    match res {
+                        Some(opts) => Value::list(
+                            opts.iter().map(|s| options[*s].value.clone()).collect(),
+                            head,
+                        ),
+                        None => Value::nothing(head),
+                    }
+                }
             },
-            InteractMode::Single(res) => match res {
-                Some(opt) => options[opt].value.clone(),
-                None => Value::nothing(head),
+            InteractMode::Single(res) => {
+                if index {
+                    match res {
+                        Some(opt) => Value::int(opt as i64, head),
+                        None => Value::nothing(head),
+                    }
+                } else {
+                    match res {
+                        Some(opt) => options[opt].value.clone(),
+                        None => Value::nothing(head),
+                    }
+                }
             },
         }
         .into_pipeline_data())
@@ -203,6 +224,11 @@ impl Command for InputList {
             Example {
                 description: "Choose an item from a range",
                 example: r#"1..10 | input list"#,
+                result: None,
+            },
+            Example {
+                description: "Return the index of a selected item",
+                example: r#"[Banana Kiwi Pear Peach Strawberry] | input list --index"#,
                 result: None,
             },
         ]

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -174,7 +174,11 @@ impl Command for InputList {
                 if index {
                     match res {
                         Some(opts) => Value::list(
-                            opts.into_iter().map(|s| Value::int(s as i64, head)).collect(), head),
+                            opts.into_iter()
+                                .map(|s| Value::int(s as i64, head))
+                                .collect(),
+                            head,
+                        ),
                         None => Value::nothing(head),
                     }
                 } else {
@@ -186,7 +190,7 @@ impl Command for InputList {
                         None => Value::nothing(head),
                     }
                 }
-            },
+            }
             InteractMode::Single(res) => {
                 if index {
                     match res {
@@ -199,7 +203,7 @@ impl Command for InputList {
                         None => Value::nothing(head),
                     }
                 }
-            },
+            }
         }
         .into_pipeline_data())
     }


### PR DESCRIPTION
# Description
This PR closes #11571 

Add `--index` flag to input list.

For example:
 ![image](https://github.com/nushell/nushell/assets/72006223/19efb011-1ff8-4916-b2bd-6f73e89cb186))
 
# Tests + Formatting
 Added new example for `--index` flag.
