### PR TITLE
Strict JSON parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4771,6 +4771,7 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -76,7 +76,7 @@ roxmltree = "0.18"
 rusqlite = { version = "0.29", features = ["bundled", "backup", "chrono"], optional = true }
 same-file = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_urlencoded = "0.7"
 serde_yaml = "0.9"
 sha2 = "0.10"

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -143,12 +143,12 @@ fn convert_nujson_to_value(value: nu_json::Value, span: Span) -> Value {
 // Converts row+column to a Span, assuming bytes (1-based rows)
 fn convert_row_column_to_span(row: usize, col: usize, contents: &str) -> Span {
     let mut cur_row = 1;
-    let mut cur_col = 0;
+    let mut cur_col = 1;
 
     for (offset, curr_byte) in contents.bytes().enumerate() {
         if curr_byte == b'\n' {
             cur_row += 1;
-            cur_col = 0;
+            cur_col = 1;
         }
         if cur_row >= row && cur_col >= col {
             return Span::new(offset, offset);
@@ -196,7 +196,7 @@ fn convert_string_to_value_strict(string_input: &str, span: Span) -> Result<Valu
         Ok(value) => Ok(convert_nujson_to_value(value, span)),
         Err(err) => Err(if err.is_syntax() {
             let label = err.to_string();
-            let label_span = convert_row_column_to_span(err.line(), err.column() - 1, string_input);
+            let label_span = convert_row_column_to_span(err.line(), err.column(), string_input);
             ShellError::GenericError {
                 error: "Error while parsing JSON text".into(),
                 msg: "error parsing JSON text".into(),

--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -44,6 +44,32 @@ fn from_json_text_to_table() {
 }
 
 #[test]
+fn from_json_text_to_table_strict() {
+    Playground::setup("filter_from_json_test_1_strict", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "katz.txt",
+            r#"
+                {
+                    "katz": [
+                        {"name":   "Yehuda", "rusty_luck": 1},
+                        {"name": "JT", "rusty_luck": 1},
+                        {"name":   "Andres", "rusty_luck": 1},
+                        {"name":"GorbyPuff", "rusty_luck": 1}
+                    ]
+                }
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(),
+            "open katz.txt | from json -s | get katz | get rusty_luck | length "
+        );
+
+        assert_eq!(actual.out, "4");
+    })
+}
+
+#[test]
 fn from_json_text_recognizing_objects_independently_to_table() {
     Playground::setup("filter_from_json_test_2", |dirs, sandbox| {
         sandbox.with_files(vec![FileWithContentToBeTrimmed(
@@ -61,6 +87,33 @@ fn from_json_text_recognizing_objects_independently_to_table() {
             r#"
                 open katz.txt
                 | from json -o
+                | where name == "GorbyPuff"
+                | get rusty_luck.0
+            "#
+        ));
+
+        assert_eq!(actual.out, "3");
+    })
+}
+
+#[test]
+fn from_json_text_recognizing_objects_independently_to_table_strict() {
+    Playground::setup("filter_from_json_test_2_strict", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "katz.txt",
+            r#"
+                {"name":   "Yehuda", "rusty_luck": 1}
+                {"name": "JT", "rusty_luck": 1}
+                {"name":   "Andres", "rusty_luck": 1}
+                {"name":"GorbyPuff", "rusty_luck": 3}
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open katz.txt
+                | from json -o -s
                 | where name == "GorbyPuff"
                 | get rusty_luck.0
             "#
@@ -100,6 +153,35 @@ fn table_to_json_text() {
 }
 
 #[test]
+fn table_to_json_text_strict() {
+    Playground::setup("filter_to_json_test_strict", |dirs, sandbox| {
+        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            "sample.txt",
+            r#"
+                JonAndrehudaTZ,3
+                GorbyPuff,100
+            "#,
+        )]);
+
+        let actual = nu!(
+            cwd: dirs.test(), pipeline(
+            r#"
+                open sample.txt
+                | lines
+                | split column "," name luck
+                | select name
+                | to json
+                | from json -s
+                | get 0
+                | get name
+            "#
+        ));
+
+        assert_eq!(actual.out, "JonAndrehudaTZ");
+    })
+}
+
+#[test]
 fn top_level_values_from_json() {
     for (value, type_name) in [("null", "nothing"), ("true", "bool"), ("false", "bool")] {
         let actual = nu!(r#""{}" | from json | to json"#, value);
@@ -107,6 +189,28 @@ fn top_level_values_from_json() {
         let actual = nu!(r#""{}" | from json | describe"#, value);
         assert_eq!(actual.out, type_name);
     }
+}
+
+#[test]
+fn top_level_values_from_json_strict() {
+    for (value, type_name) in [("null", "nothing"), ("true", "bool"), ("false", "bool")] {
+        let actual = nu!(r#""{}" | from json -s | to json"#, value);
+        assert_eq!(actual.out, value);
+        let actual = nu!(r#""{}" | from json -s | describe"#, value);
+        assert_eq!(actual.out, type_name);
+    }
+}
+
+#[test]
+fn strict_parsing_fails_on_comment() {
+    let actual = nu!(r#"'{ "a": 1, /* comment */ "b": 2 }' | from json -s"#);
+    assert!(actual.err.contains("error parsing JSON text"));
+}
+
+#[test]
+fn strict_parsing_fails_on_trailing_comma() {
+    let actual = nu!(r#"'{ "a": 1, "b": 2, }' | from json -s"#);
+    assert!(actual.err.contains("error parsing JSON text"));
 }
 
 #[test]

--- a/crates/nu-json/src/de.rs
+++ b/crates/nu-json/src/de.rs
@@ -26,15 +26,6 @@ pub struct Deserializer<Iter: Iterator<Item = u8>> {
     state: State,
 }
 
-// macro_rules! try_or_invalid {
-//     ($self_:expr, $e:expr) => {
-//         match $e {
-//             Some(v) => v,
-//             None => { return Err($self_.error(ErrorCode::InvalidNumber)); }
-//         }
-//     }
-// }
-
 impl<Iter> Deserializer<Iter>
 where
     Iter: Iterator<Item = u8>,


### PR DESCRIPTION
# Description
Adds the `--strict` flag for `from json` which will try to parse text while following the exact JSON specification (e.g., no comments or trailing commas allowed). Fixes issue #11548.
