### PR TITLE
allow math avg to work with durations

### DIFF
--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -18,9 +18,12 @@ impl Command for SubCommand {
     fn signature(&self) -> Signature {
         Signature::build("math avg")
             .input_output_types(vec![
-                (Type::List(Box::new(Type::Number)), Type::Number),
                 (Type::List(Box::new(Type::Duration)), Type::Duration),
+                (Type::Duration, Type::Duration),
                 (Type::List(Box::new(Type::Filesize)), Type::Filesize),
+                (Type::Filesize, Type::Filesize),
+                (Type::List(Box::new(Type::Number)), Type::Number),
+                (Type::Number, Type::Number),
                 (Type::Range, Type::Number),
                 (Type::Table(vec![]), Type::Record(vec![])),
                 (Type::Record(vec![]), Type::Record(vec![])),


### PR DESCRIPTION
# Description

I ran into a problem where one of our benchmark tests in nu_scripts wouldn't work because math avg wouldn't work with durations, so I made these changes to support it. I'm confident that there are other math commands that probably need this "fix".

Side note - we should really fix our inout_output_type system.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
