### PR TITLE
Fix regression in help menu introduced by #11488

### DIFF
--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -119,3 +119,42 @@ impl Completer for NuHelpCompleter {
         self.completion_helper(line, pos)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("who", 5, 8, &["whoami"])]
+    #[case("hash", 1, 5, &["hash", "hash md5", "hash sha256"])]
+    #[case("into f", 0, 6, &["into float", "into filesize"])]
+    #[case("into nonexistent", 0, 16, &[])]
+    fn test_help_completer(
+        #[case] line: &str,
+        #[case] start: usize,
+        #[case] end: usize,
+        #[case] expected: &[&str],
+    ) {
+        let engine_state =
+            nu_command::add_shell_command_context(nu_cmd_lang::create_default_context());
+        let mut completer = NuHelpCompleter::new(engine_state.into());
+        let suggestions = completer.complete(line, end);
+
+        assert_eq!(
+            expected.len(),
+            suggestions.len(),
+            "expected {:?}, got {:?}",
+            expected,
+            suggestions
+                .iter()
+                .map(|s| s.value.clone())
+                .collect::<Vec<_>>()
+        );
+
+        for (exp, actual) in expected.iter().zip(suggestions) {
+            assert_eq!(exp, &actual.value);
+            assert_eq!(reedline::Span::new(start, end), actual.span);
+        }
+    }
+}

--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -104,8 +104,8 @@ impl NuHelpCompleter {
                     description: Some(long_desc),
                     extra: Some(extra),
                     span: reedline::Span {
-                        start: pos,
-                        end: pos + line.len(),
+                        start: pos - line.len(),
+                        end: pos,
                     },
                     append_whitespace: false,
                 }

--- a/crates/nu-cli/src/menus/menu_completions.rs
+++ b/crates/nu-cli/src/menus/menu_completions.rs
@@ -101,9 +101,13 @@ fn convert_to_suggestions(
                             }
                         }
                         _ => reedline::Span {
-                            start: if only_buffer_difference { pos } else { 0 },
+                            start: if only_buffer_difference {
+                                pos - line.len()
+                            } else {
+                                0
+                            },
                             end: if only_buffer_difference {
-                                pos + line.len()
+                                pos
                             } else {
                                 line.len()
                             },
@@ -111,9 +115,13 @@ fn convert_to_suggestions(
                     }
                 }
                 _ => reedline::Span {
-                    start: if only_buffer_difference { pos } else { 0 },
+                    start: if only_buffer_difference {
+                        pos - line.len()
+                    } else {
+                        0
+                    },
                     end: if only_buffer_difference {
-                        pos + line.len()
+                        pos
                     } else {
                         line.len()
                     },
@@ -152,8 +160,16 @@ fn convert_to_suggestions(
             description: None,
             extra: None,
             span: reedline::Span {
-                start: 0,
-                end: line.len(),
+                start: if only_buffer_difference {
+                    pos - line.len()
+                } else {
+                    0
+                },
+                end: if only_buffer_difference {
+                    pos
+                } else {
+                    line.len()
+                },
             },
             append_whitespace: false,
         }],


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

For fixing #11599

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Turns out I didn't properly test the description menu in #11488, apologies for that. It turns out that `NuHelpCompleter`, which provides completions for the description/help menu, was treating the position it was given as the start of the line rather than the start. Flipping that appears to fix the issue.

I missed not only `NuHelpCompleter` but also `NuMenuCompleter` in my previous PR. If the menu's source is a closure and it doesn't return a record with the start and end, then `pos` is again treated as the start, so I've changed that too. External completers shouldn't need changing.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- [X] Test description menu
- [X] Test menu sources that return records that don't have `start` and `end`
- [ ] <s>Test external completers if any changes have to be made there</s> No changes needed, it looks like

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
