### PR TITLE
resolving external highlight should take current PATH into account

### DIFF
--- a/crates/nu-cli/src/nu_highlight.rs
+++ b/crates/nu-cli/src/nu_highlight.rs
@@ -28,7 +28,7 @@ impl Command for NuHighlight {
     fn run(
         &self,
         engine_state: &EngineState,
-        _stack: &mut Stack,
+        stack: &mut Stack,
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
@@ -40,6 +40,7 @@ impl Command for NuHighlight {
 
         let highlighter = crate::NuHighlighter {
             engine_state,
+            stack: std::sync::Arc::new(stack.clone()),
             config,
         };
 

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -236,6 +236,7 @@ pub fn evaluate_repl(
             .use_bracketed_paste(cfg!(not(target_os = "windows")) && config.bracketed_paste)
             .with_highlighter(Box::new(NuHighlighter {
                 engine_state: engine_reference.clone(),
+                stack: std::sync::Arc::new(stack.clone()),
                 config: config.clone(),
             }))
             .with_validator(Box::new(NuValidator {

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -1,15 +1,17 @@
 use log::trace;
 use nu_ansi_term::Style;
 use nu_color_config::{get_matching_brackets_style, get_shape_color};
+use nu_engine::env;
 use nu_parser::{flatten_block, parse, FlatShape};
 use nu_protocol::ast::{Argument, Block, Expr, Expression, PipelineElement, RecordItem};
-use nu_protocol::engine::{EngineState, StateWorkingSet};
+use nu_protocol::engine::{EngineState, Stack, StateWorkingSet};
 use nu_protocol::{Config, Span};
 use reedline::{Highlighter, StyledText};
 use std::sync::Arc;
 
 pub struct NuHighlighter {
     pub engine_state: Arc<EngineState>,
+    pub stack: Arc<Stack>,
     pub config: Config,
 }
 
@@ -32,7 +34,17 @@ impl Highlighter for NuHighlighter {
                             working_set.get_span_contents(Span::new(span.start, span.end));
 
                         let str_word = String::from_utf8_lossy(str_contents).to_string();
-                        if which::which(str_word).ok().is_some() {
+                        let paths = env::path_str(&self.engine_state, &self.stack, *span).ok();
+                        let res = if let Ok(cwd) =
+                            env::current_dir_str(&self.engine_state, &self.stack)
+                        {
+                            which::which_in(str_word, paths.as_ref(), cwd).ok()
+                        } else {
+                            which::which_in_global(str_word, paths.as_ref())
+                                .ok()
+                                .and_then(|mut i| i.next())
+                        };
+                        if res.is_some() {
                             *shape = FlatShape::ExternalResolved;
                         }
                     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

When resolving external commands, the current `PATH` was not taken into account. 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
