### PR TITLE
Adapt tests for internationalization

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -251,7 +251,10 @@ export def "check pr" [
     --fast # use the "nextext" `cargo` subcommand to speed up the tests (see [`cargo-nextest`](https://nexte.st/) and [`nextest-rs/nextest`](https://github.com/nextest-rs/nextest))
     --features: list<string> # the list of features to check the current PR on
 ] {
-    $env.NU_TEST_LOCALE_OVERRIDE = 'en_US.utf8';
+    $env.NU_TEST_LOCALE_OVERRIDE = 'en_US.utf8'
+    $env.LANG = 'en_US.UTF-8'
+    $env.LANGUAGE = 'en'
+
     try {
         fmt --check --verbose
     } catch {


### PR DESCRIPTION
I've noticed that two tests fail on my system when running `toolkit check pr`. The reason for this is that my locale is set to German. `ls` is translated, so checking the error message will only work on systems set to English.

I've adapted the test to check the exit code instead.

Alternatively, we could set the locale, I am not sure if the `nu!` macro supports that though. 