### PR TITLE
fix spreading of arguments to externals in toolkit

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -301,7 +301,7 @@ export def "check pr" [
 
 # run Nushell from source with a right indicator
 export def run [] {
-    cargo run -- [
+    cargo run -- ...[
         -e "$env.PROMPT_COMMAND_RIGHT = $'(ansi magenta_reverse)trying Nushell inside Cargo(ansi reset)'"
     ]
 }


### PR DESCRIPTION
as per title, that's just a simple change to avoid the deprecation warning introduced recently and that will be removed in `0.91`