### PR TITLE
add `$.extra_usage` to modules

### DIFF
--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -504,10 +504,9 @@ impl<'e, 's> ScopeData<'e, 's> {
             |block_id| Value::block(block_id, span),
         );
 
-        let module_usage = self
+        let (module_usage, module_extra_usage) = self
             .engine_state
             .build_module_usage(*module_id)
-            .map(|(usage, _)| usage)
             .unwrap_or_default();
 
         Value::record(
@@ -520,6 +519,7 @@ impl<'e, 's> ScopeData<'e, 's> {
                 "constants" => Value::list(export_consts, span),
                 "env_block" => export_env_block,
                 "usage" => Value::string(module_usage, span),
+                "extra_usage" => Value::string(module_extra_usage, span),
                 "module_id" => Value::int(*module_id as i64, span),
             },
             span,

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -91,6 +91,8 @@ fn correctly_report_of_shadowed_alias() {
 fn correct_scope_modules_fields() {
     let module_setup = r#"
         # nice spam
+        #
+        # and some extra usage for spam
 
         export module eggs {
             export module bacon {
@@ -122,6 +124,13 @@ fn correct_scope_modules_fields() {
         ];
         let actual = nu!(cwd: dirs.test(), &inp.join("; "));
         assert_eq!(actual.out, "nice spam");
+
+        let inp = &[
+            "use spam.nu",
+            "scope modules | where name == spam | get 0.extra_usage",
+        ];
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        assert_eq!(actual.out, "and some extra usage for spam");
 
         let inp = &[
             "use spam.nu",


### PR DESCRIPTION
- should fix https://github.com/nushell/nushell/issues/11648

# Description
this PR
- adds a test that should pass but fails
- adds `$.extra_usage` to the output of `scope modules`, fixing both the new test and the linked issue

# User-Facing Changes
`$.extra_usage` is now a column in the output of `scope modules`

# Tests + Formatting
a new test case has been added to `correct_scope_modules_fields`

# After Submitting