### PR TITLE
Tidy up the REPL main loop

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -57,13 +57,6 @@ pub fn evaluate_repl(
     let config = engine_state.get_config();
     let use_color = config.use_ansi_coloring;
 
-    // this macro helps to keep perf measurements to 2 lines instead of 6 (in lines of code)
-    macro_rules! perf {
-        ($name:expr, $start_time: expr) => {
-            perf($name, $start_time, file!(), line!(), column!(), use_color)
-        };
-    }
-
     confirm_stdin_is_terminal()?;
 
     let mut entry_num = 0;
@@ -75,7 +68,14 @@ pub fn evaluate_repl(
     if let Some(e) = convert_env_values(engine_state, stack) {
         report_error_new(engine_state, &e);
     }
-    perf!("translate env vars", start_time);
+    perf(
+        "translate env vars",
+        start_time,
+        file!(),
+        line!(),
+        column!(),
+        use_color,
+    );
 
     // seed env vars
     stack.add_env_var(
@@ -91,14 +91,28 @@ pub fn evaluate_repl(
 
     // Now that reedline is created, get the history session id and store it in engine_state
     store_history_id_in_engine(engine_state, &line_editor);
-    perf!("setup reedline", start_time);
+    perf(
+        "setup reedline",
+        start_time,
+        file!(),
+        line!(),
+        column!(),
+        use_color,
+    );
 
     if let Some(history) = engine_state.history_config() {
         start_time = std::time::Instant::now();
 
         line_editor = setup_history(nushell_path, engine_state, line_editor, history)?;
 
-        perf!("setup history", start_time);
+        perf(
+            "setup history",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
     }
 
     if let Some(s) = prerun_command {
@@ -143,14 +157,28 @@ pub fn evaluate_repl(
         if let Err(err) = engine_state.merge_env(stack, cwd) {
             report_error_new(engine_state, &err);
         }
-        perf!("merge env", start_time);
+        perf(
+            "merge env",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         start_time = std::time::Instant::now();
         //Reset the ctrl-c handler
         if let Some(ctrlc) = &mut engine_state.ctrlc {
             ctrlc.store(false, Ordering::SeqCst);
         }
-        perf!("reset ctrlc", start_time);
+        perf(
+            "reset ctrlc",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         start_time = std::time::Instant::now();
         let config = engine_state.get_config();
@@ -163,7 +191,14 @@ pub fn evaluate_repl(
             vi_normal: map_nucursorshape_to_cursorshape(config.cursor_shape_vi_normal),
             emacs: map_nucursorshape_to_cursorshape(config.cursor_shape_emacs),
         };
-        perf!("get config/cursor config", start_time);
+        perf(
+            "get config/cursor config",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         start_time = std::time::Instant::now();
 
@@ -188,7 +223,14 @@ pub fn evaluate_repl(
             .with_partial_completions(config.partial_completions)
             .with_ansi_colors(config.use_ansi_coloring)
             .with_cursor_config(cursor_config);
-        perf!("reedline builder", start_time);
+        perf(
+            "reedline builder",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         let style_computer = StyleComputer::from_config(engine_state, stack);
 
@@ -202,14 +244,28 @@ pub fn evaluate_repl(
         } else {
             line_editor.disable_hints()
         };
-        perf!("reedline coloring/style_computer", start_time);
+        perf(
+            "reedline coloring/style_computer",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         start_time = std::time::Instant::now();
         line_editor = add_menus(line_editor, engine_reference, stack, config).unwrap_or_else(|e| {
             report_error_new(engine_state, &e);
             Reedline::create()
         });
-        perf!("reedline menus", start_time);
+        perf(
+            "reedline menus",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         start_time = std::time::Instant::now();
         let buffer_editor = get_editor(engine_state, stack, Span::unknown());
@@ -223,7 +279,14 @@ pub fn evaluate_repl(
         } else {
             line_editor
         };
-        perf!("reedline buffer_editor", start_time);
+        perf(
+            "reedline buffer_editor",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         if let Some(history) = engine_state.history_config() {
             start_time = std::time::Instant::now();
@@ -232,13 +295,27 @@ pub fn evaluate_repl(
                     warn!("Failed to sync history: {}", e);
                 }
             }
-            perf!("sync_history", start_time);
+            perf(
+                "sync_history",
+                start_time,
+                file!(),
+                line!(),
+                column!(),
+                use_color,
+            );
         }
 
         start_time = std::time::Instant::now();
         // Changing the line editor based on the found keybindings
         line_editor = setup_keybindings(engine_state, line_editor);
-        perf!("keybindings", start_time);
+        perf(
+            "keybindings",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         start_time = std::time::Instant::now();
         // Right before we start our prompt and take input from the user,
@@ -248,7 +325,14 @@ pub fn evaluate_repl(
                 report_error_new(engine_state, &err);
             }
         }
-        perf!("pre-prompt hook", start_time);
+        perf(
+            "pre-prompt hook",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         start_time = std::time::Instant::now();
         // Next, check all the environment variables they ask for
@@ -259,14 +343,28 @@ pub fn evaluate_repl(
         {
             report_error_new(engine_state, &error)
         }
-        perf!("env-change hook", start_time);
+        perf(
+            "env-change hook",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         start_time = std::time::Instant::now();
         let config = &engine_state.get_config().clone();
         prompt_update::update_prompt(config, engine_state, stack, &mut nu_prompt);
         let transient_prompt =
             prompt_update::make_transient_prompt(config, engine_state, stack, &nu_prompt);
-        perf!("update_prompt", start_time);
+        perf(
+            "update_prompt",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
         entry_num += 1;
 
@@ -386,9 +484,23 @@ pub fn evaluate_repl(
                 }
             }
         }
-        perf!("processing line editor input", start_time);
+        perf(
+            "processing line editor input",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
 
-        perf!("finished repl loop", loop_start_time);
+        perf(
+            "finished repl loop",
+            loop_start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        );
     }
 
     Ok(())

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -503,49 +503,7 @@ pub fn evaluate_repl(
                 )?;
 
                 if shell_integration {
-                    run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
-                    if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
-                        let path = cwd.as_string()?;
-
-                        // Supported escape sequences of Microsoft's Visual Studio Code (vscode)
-                        // https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences
-                        if stack.get_env_var(engine_state, "TERM_PROGRAM")
-                            == Some(Value::test_string("vscode"))
-                        {
-                            // If we're in vscode, run their specific ansi escape sequence.
-                            // This is helpful for ctrl+g to change directories in the terminal.
-                            run_ansi_sequence(&format!("\x1b]633;P;Cwd={}\x1b\\", path))?;
-                        } else {
-                            // Otherwise, communicate the path as OSC 7 (often used for spawning new tabs in the same dir)
-                            run_ansi_sequence(&format!(
-                                "\x1b]7;file://{}{}{}\x1b\\",
-                                percent_encoding::utf8_percent_encode(
-                                    &hostname.unwrap_or_else(|| "localhost".to_string()),
-                                    percent_encoding::CONTROLS
-                                ),
-                                if path.starts_with('/') { "" } else { "/" },
-                                percent_encoding::utf8_percent_encode(
-                                    &path,
-                                    percent_encoding::CONTROLS
-                                )
-                            ))?;
-                        }
-
-                        // Try to abbreviate string for windows title
-                        let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
-                            path.replace(&p.as_path().display().to_string(), "~")
-                        } else {
-                            path
-                        };
-
-                        // Set window title too
-                        // https://tldp.org/HOWTO/Xterm-Title-3.html
-                        // ESC]0;stringBEL -- Set icon name and window title to string
-                        // ESC]1;stringBEL -- Set icon name to string
-                        // ESC]2;stringBEL -- Set window title to string
-                        run_ansi_sequence(&format!("\x1b]2;{maybe_abbrev_path}\x07"))?;
-                    }
-                    run_ansi_sequence(RESET_APPLICATION_MODE)?;
+                    do_shell_integration_finalize_command(hostname, engine_state, stack)?;
                 }
 
                 let mut repl = engine_state.repl_state.lock().expect("repl state mutex");
@@ -778,6 +736,52 @@ fn do_run_cmd(
     );
 
     Ok(line_editor)
+}
+
+fn do_shell_integration_finalize_command(
+    hostname: Option<String>,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+) -> Result<()> {
+    run_ansi_sequence(&get_command_finished_marker(stack, engine_state))?;
+    if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
+        let path = cwd.as_string()?;
+
+        // Supported escape sequences of Microsoft's Visual Studio Code (vscode)
+        // https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences
+        if stack.get_env_var(engine_state, "TERM_PROGRAM") == Some(Value::test_string("vscode")) {
+            // If we're in vscode, run their specific ansi escape sequence.
+            // This is helpful for ctrl+g to change directories in the terminal.
+            run_ansi_sequence(&format!("\x1b]633;P;Cwd={}\x1b\\", path))?;
+        } else {
+            // Otherwise, communicate the path as OSC 7 (often used for spawning new tabs in the same dir)
+            run_ansi_sequence(&format!(
+                "\x1b]7;file://{}{}{}\x1b\\",
+                percent_encoding::utf8_percent_encode(
+                    &hostname.unwrap_or_else(|| "localhost".to_string()),
+                    percent_encoding::CONTROLS
+                ),
+                if path.starts_with('/') { "" } else { "/" },
+                percent_encoding::utf8_percent_encode(&path, percent_encoding::CONTROLS)
+            ))?;
+        }
+
+        // Try to abbreviate string for windows title
+        let maybe_abbrev_path = if let Some(p) = nu_path::home_dir() {
+            path.replace(&p.as_path().display().to_string(), "~")
+        } else {
+            path
+        };
+
+        // Set window title too
+        // https://tldp.org/HOWTO/Xterm-Title-3.html
+        // ESC]0;stringBEL -- Set icon name and window title to string
+        // ESC]1;stringBEL -- Set icon name to string
+        // ESC]2;stringBEL -- Set window title to string
+        run_ansi_sequence(&format!("\x1b]2;{maybe_abbrev_path}\x07"))?;
+    }
+    run_ansi_sequence(RESET_APPLICATION_MODE)?;
+    Ok(())
 }
 
 fn store_history_id_in_engine(engine_state: &mut EngineState, line_editor: &Reedline) {

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -64,15 +64,7 @@ pub fn evaluate_repl(
         };
     }
 
-    // Guard against invocation without a connected terminal.
-    // reedline / crossterm event polling will fail without a connected tty
-    if !std::io::stdin().is_terminal() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            "Nushell launched as a REPL, but STDIN is not a TTY; either launch in a valid terminal or provide arguments to invoke a script!",
-        ))
-        .into_diagnostic();
-    }
+    confirm_stdin_is_terminal()?;
 
     let mut entry_num = 0;
 
@@ -712,6 +704,18 @@ fn update_line_editor_history(
     Ok(line_editor)
 }
 
+fn confirm_stdin_is_terminal() -> Result<()> {
+    // Guard against invocation without a connected terminal.
+    // reedline / crossterm event polling will fail without a connected tty
+    if !std::io::stdin().is_terminal() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Nushell launched as a REPL, but STDIN is not a TTY; either launch in a valid terminal or provide arguments to invoke a script!",
+        ))
+        .into_diagnostic();
+    }
+    Ok(())
+}
 fn map_nucursorshape_to_cursorshape(shape: NuCursorShape) -> Option<SetCursorStyle> {
     match shape {
         NuCursorShape::Block => Some(SetCursorStyle::SteadyBlock),

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -130,9 +130,7 @@ pub fn evaluate_repl(
         );
     }
 
-    if engine_state.get_config().use_kitty_protocol && !reedline::kitty_protocol_available() {
-        warn!("Terminal doesn't support use_kitty_protocol config");
-    }
+    kitty_protocol_healthcheck(engine_state);
 
     loop {
         let loop_start_time = std::time::Instant::now();
@@ -671,6 +669,13 @@ fn setup_keybindings(engine_state: &EngineState, line_editor: Reedline) -> Reedl
         }
     };
 }
+
+fn kitty_protocol_healthcheck(engine_state: &EngineState) {
+    if engine_state.get_config().use_kitty_protocol && !reedline::kitty_protocol_available() {
+        warn!("Terminal doesn't support use_kitty_protocol config");
+    }
+}
+
 fn store_history_id_in_engine(engine_state: &mut EngineState, line_editor: &Reedline) {
     let session_id = line_editor
         .get_history_session_id()

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -17,8 +17,8 @@ use nu_protocol::{
     config::NuCursorShape,
     engine::{EngineState, Stack, StateWorkingSet},
     eval_const::create_nu_constant,
-    report_error, report_error_new, HistoryConfig, HistoryFileFormat, PipelineData, ShellError,
-    Span, Spanned, Value, NU_VARIABLE_ID,
+    report_error_new, HistoryConfig, HistoryFileFormat, PipelineData, ShellError, Span, Spanned,
+    Value, NU_VARIABLE_ID,
 };
 use nu_utils::utils::perf;
 use reedline::{
@@ -73,8 +73,7 @@ pub fn evaluate_repl(
     let start_time = std::time::Instant::now();
     // Translate environment variables from Strings to Values
     if let Some(e) = convert_env_values(engine_state, stack) {
-        let working_set = StateWorkingSet::new(engine_state);
-        report_error(&working_set, &e);
+        report_error_new(engine_state, &e);
     }
     perf!("translate env vars", start_time);
 
@@ -225,8 +224,7 @@ pub fn evaluate_repl(
 
         start_time = std::time::Instant::now();
         line_editor = add_menus(line_editor, engine_reference, stack, config).unwrap_or_else(|e| {
-            let working_set = StateWorkingSet::new(engine_state);
-            report_error(&working_set, &e);
+            report_error_new(engine_state, &e);
             Reedline::create()
         });
         perf!("reedline menus", start_time);
@@ -272,8 +270,7 @@ pub fn evaluate_repl(
                 }
             },
             Err(e) => {
-                let working_set = StateWorkingSet::new(engine_state);
-                report_error(&working_set, &e);
+                report_error_new(&engine_state, &e);
                 line_editor
             }
         };
@@ -501,10 +498,8 @@ fn do_auto_cd(
 ) {
     let path = {
         if !path.exists() {
-            let working_set = StateWorkingSet::new(engine_state);
-
-            report_error(
-                &working_set,
+            report_error_new(
+                engine_state,
                 &ShellError::DirectoryNotFound {
                     dir: path.to_string_lossy().to_string(),
                     span,


### PR DESCRIPTION
While working on #11288 I was having some trouble tracking the main REPL loop, so I've sent in a bunch of tiny refactorings on this branch.

These are almost all of the "move code from one place to another" variety, and each commit is meant to be independent, _except for the last one_, which is trying to be a bit more clever to handle the decision of autocd'ing vs running a command. Feel free to just go through each commit and cherry pick the ones that look good.

This leads to `evaluate_repl` going from ending on line 715 to ending on line 395. Again, this is mostly just moving code around, but I think this set of changes will make other changes around juggling the stack to avoid cloning easier to review.
