### PR TITLE
fix force rm: should suppress error if directory is not found

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -301,6 +301,8 @@ fn rm(
                 }
             }
             Err(e) => {
+                // glob_from may canonicalize path and return `DirectoryNotFound`
+                // nushell should suppress the error if `--force` is used.
                 if !(force && matches!(e, ShellError::DirectoryNotFound { .. })) {
                     return Err(e);
                 }

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -254,7 +254,6 @@ fn rm(
             });
         }
 
-        // let path = currentdir_path.join(target.item.as_ref());
         match nu_engine::glob_from(
             &target,
             &currentdir_path,
@@ -302,13 +301,9 @@ fn rm(
                 }
             }
             Err(e) => {
-                return Err(ShellError::GenericError {
-                    error: e.to_string(),
-                    msg: e.to_string(),
-                    span: Some(target.span),
-                    help: None,
-                    inner: vec![],
-                })
+                if !(force && matches!(e, ShellError::DirectoryNotFound { .. })) {
+                    return Err(e);
+                }
             }
         };
     }

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -480,3 +480,18 @@ fn rm_files_inside_glob_metachars_dir() {
         ));
     });
 }
+
+#[test]
+fn force_rm_suppress_error() {
+    Playground::setup("force_rm_suppress_error", |dirs, sandbox| {
+        sandbox.with_files(vec![EmptyFile("test_file.txt")]);
+
+        // the second rm should suppress error.
+        let actual = nu!(
+            cwd: dirs.test(),
+            "rm test_file.txt; rm -f test_file.txt",
+        );
+
+        assert!(actual.err.is_empty());
+    });
+}


### PR DESCRIPTION
# Description
Fix a breaking change which is introduced by #11621

`rm -f /tmp/aaa` shouldn't return error if `/tmp/aaa/` doesn't exist.

# User-Facing Changes
NaN

# Tests + Formatting
Done
