### PR TITLE
add match-text style + config setting for ide menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4650,7 +4650,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.28.0"
-source = "git+https://github.com/nushell/reedline?branch=main#c8a52a85f1e166d8ff0a95c6f114da7f40ba0df4"
+source = "git+https://github.com/nushell/reedline?branch=main#090af4d323d09d48ca05a2690658759982df11bd"
 dependencies = [
  "arboard",
  "chrono",

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -236,6 +236,22 @@ pub(crate) fn add_columnar_menu(
             columnar_menu,
             ColumnarMenu::with_description_text_style
         );
+        add_style!(
+            "match_text",
+            val,
+            span,
+            config,
+            columnar_menu,
+            ColumnarMenu::with_match_text_style
+        );
+        add_style!(
+            "selected_match_text",
+            val,
+            span,
+            config,
+            columnar_menu,
+            ColumnarMenu::with_selected_match_text_style
+        );
     }
 
     let marker = menu.marker.into_string("", config);
@@ -492,6 +508,14 @@ pub(crate) fn add_ide_menu(
             }
             Err(_) => ide_menu,
         };
+
+        ide_menu = match extract_value("correct_cursor_pos", val, span) {
+            Ok(correct_cursor_pos) => {
+                let correct_cursor_pos = correct_cursor_pos.as_bool()?;
+                ide_menu.with_correct_cursor_pos(correct_cursor_pos)
+            }
+            Err(_) => ide_menu,
+        };
     }
 
     let span = menu.style.span();
@@ -519,6 +543,22 @@ pub(crate) fn add_ide_menu(
             config,
             ide_menu,
             IdeMenu::with_description_text_style
+        );
+        add_style!(
+            "match_text",
+            val,
+            span,
+            config,
+            ide_menu,
+            IdeMenu::with_match_text_style
+        );
+        add_style!(
+            "selected_match_text",
+            val,
+            span,
+            config,
+            ide_menu,
+            IdeMenu::with_selected_match_text_style
         );
     }
 

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -267,6 +267,8 @@ $env.config = {
                 text: green
                 selected_text: {attr: r}
                 description_text: yellow
+                match_text: {attr: u}
+                selected_match_text: {attr: ur}
             }
         }
         {
@@ -296,8 +298,10 @@ $env.config = {
             }
             style: {
                 text: green
-                selected_text: green_reverse
+                selected_text: {attr: r}
                 description_text: yellow
+                match_text: {attr: u}
+                selected_match_text: {attr: ur}
             }
         }
         {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -286,6 +286,7 @@ $env.config = {
                 max_description_width: 50
                 max_description_height: 10
                 description_offset: 1
+                correct_cursor_pos: false
             }
             style: {
                 text: green

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -286,6 +286,12 @@ $env.config = {
                 max_description_width: 50
                 max_description_height: 10
                 description_offset: 1
+                # If true, the cursor pos will be corrected, so the suggestions match up with the typed text
+                #
+                # C:\> str
+                #      str join
+                #      str trim
+                #      str split
                 correct_cursor_pos: false
             }
             style: {


### PR DESCRIPTION
the match-text style (https://github.com/nushell/reedline/pull/730) is now configurable via the config.nu file.
the option ``correct_cursor_pos`` can now also be set in the config.nu file.