### PR TITLE
make the `ansi` command `const`

### DIFF
--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -634,7 +634,12 @@ Operating system commands:
             },
             Example {
                 description: "Use structured escape codes",
-                example: r#"$"(ansi --escape {fg: '#0000ff' bg: '#ff0000' attr: b})Hello, Nu World!(ansi reset)""#,
+                example: r#"let bold_blue_on_red = {  # `fg`, `bg`, `attr` are the acceptable keys, all other keys are considered invalid and will throw errors.
+        fg: '#0000ff'
+        bg: '#ff0000'
+        attr: b
+    }
+    $"(ansi --escape $bold_blue_on_red)Hello, Nu World!(ansi reset)""#,
                 result: Some(Value::test_string(
                     "\u{1b}[1;48;2;255;0;0;38;2;0;0;255mHello, Nu World!\u{1b}[0m",
                 )),

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -651,7 +651,7 @@ Operating system commands:
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let working_set = StateWorkingSet::new(&engine_state);
+        let working_set = StateWorkingSet::new(engine_state);
         self.run_const(&working_set, call, _input)
     }
 

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -283,7 +283,7 @@ fn errors_if_moving_to_itself() {
             "umv mydir mydir/mydir_2/"
         );
         assert!(actual.err.contains("cannot move"));
-        assert!(actual.err.contains("to a subdirectory of"));
+        assert!(actual.err.contains("to a subdirectory"));
     });
 }
 


### PR DESCRIPTION
# Description

This PR changes the `ansi` command to be a `const` command. 

- ~~It's breaking because I found that I had to change the way `ansi` is used in scripts a little bit. https://github.com/nushell/nu_scripts/pull/751~~

- I had to change one of the examples because apparently `const` can't be tested yet.

- ~~I'm not sure this is right at all https://github.com/nushell/nushell/pull/11682/files#diff-ba932369a40eb40d6e1985eac1c784af403dab4500a7f0568e593900bf6cd740R654-R655. I just didn't want to duplicate a ton of code. Maybe if I duplicated the code it wouldn't be a breaking change because it would have a run and run_const?~~

- I had to add `opt_const` to CallExt.

/cc @kubouch Can you take a look at this? I'm a little iffy if I'm doing this right, or even if we should do this at all.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
