### PR TITLE
Refactor `lines` command

### DIFF
--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -139,16 +139,14 @@ impl Iterator for RawStreamLinesAdapter {
             } else {
                 // inner is complete, feed out remaining state
                 if self.inner_complete {
-                    if !self.incomplete_line.is_empty() {
-                        let r = Some(Ok(Value::string(
-                            self.incomplete_line.to_string(),
+                    return if self.incomplete_line.is_empty() {
+                        None
+                    } else {
+                        Some(Ok(Value::string(
+                            std::mem::take(&mut self.incomplete_line),
                             self.span,
-                        )));
-                        self.incomplete_line = String::new();
-                        return r;
-                    }
-
-                    return None;
+                        )))
+                    };
                 }
 
                 // pull more data from inner

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -164,10 +164,10 @@ impl Iterator for RawStreamLinesAdapter {
                                     // handle incomplete line from previous
                                     if !self.incomplete_line.is_empty() {
                                         if let Some(first) = lines.next() {
-                                            let mut incomplete_line =
-                                                std::mem::take(&mut self.incomplete_line);
-                                            incomplete_line.push_str(first);
-                                            self.queue.push_back(incomplete_line);
+                                            self.incomplete_line.push_str(first);
+                                            self.queue.push_back(std::mem::take(
+                                                &mut self.incomplete_line,
+                                            ));
                                         }
                                     }
 

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -37,10 +37,6 @@ impl Command for Lines {
 
         let span = input.span().unwrap_or(call.head);
         match input {
-            #[allow(clippy::needless_collect)]
-            // Collect is needed because the string may not live long enough for
-            // the Rc structure to continue using it. If split could take ownership
-            // of the split values, then this wouldn't be needed
             PipelineData::Value(Value::String { val, .. }, ..) => {
                 let mut lines = val.lines().map(String::from).collect::<Vec<_>>();
 

--- a/crates/nu-command/src/filters/lines.rs
+++ b/crates/nu-command/src/filters/lines.rs
@@ -97,11 +97,7 @@ impl Command for Lines {
                 stdout: Some(stream),
                 ..
             } => Ok(RawStreamLinesAdapter::new(stream, head, skip_empty)
-                .enumerate()
-                .map(move |(_idx, x)| match x {
-                    Ok(x) => x,
-                    Err(err) => Value::error(err, head),
-                })
+                .map(move |x| x.unwrap_or_else(|err| Value::error(err, head)))
                 .into_pipeline_data(ctrlc)),
         }
     }

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -4,7 +4,6 @@
 
 use std::fmt::{Display, LowerExp};
 use std::io;
-use std::io::{BufRead, BufReader};
 use std::num::FpCategory;
 
 use super::error::{Error, ErrorCode, Result};
@@ -1034,20 +1033,7 @@ where
     T: ser::Serialize,
 {
     let vec = to_vec(value)?;
-    let string = remove_json_whitespace(vec);
-    Ok(string)
-}
-
-fn remove_json_whitespace(v: Vec<u8>) -> String {
-    let reader = BufReader::new(&v[..]);
-    let mut output = String::new();
-    for line in reader.lines() {
-        match line {
-            Ok(line) => output.push_str(line.trim().trim_end()),
-            _ => {
-                eprintln!("Error removing JSON whitespace");
-            }
-        }
-    }
-    output
+    let string = String::from_utf8(vec)?;
+    let output = string.lines().map(|line| line.trim()).collect();
+    Ok(output)
 }

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -1034,6 +1034,6 @@ where
 {
     let vec = to_vec(value)?;
     let string = String::from_utf8(vec)?;
-    let output = string.lines().map(|line| line.trim()).collect();
+    let output = string.lines().map(str::trim).collect();
     Ok(output)
 }


### PR DESCRIPTION
# Description
This PR uses `str::lines` to simplify the `lines` command (and one other section of code). This has two main benefits:
1. We no longer need to use regex to split on lines, as `str::lines` splits on `\r\n` or `\n`.
2. We no longer need to handle blank empty lines at the end. E.g., `str::lines` results in `["text"]` for both `"test\n"` and `"text"`.

These changes give a slight boost to performance for the following benchmarks:
1. lines of `Value::String`:
    ```nushell
    let data = open Cargo.lock
    1..10000 | each { $data | timeit { lines } } | math avg 
    ```
    current main: 392µs
    this PR: 270µs
2. lines of external stream:
    ```nushell
    1..10000 | each { open Cargo.lock | timeit { lines } } | math avg 
    ```
    current main: 794µs
    this PR: 489µs
