### PR TITLE
Prevent Commands from killing nushell on panic

### DIFF
--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -6,6 +6,7 @@ use nu_engine::eval_block;
 use nu_engine::{convert_env_values, current_dir};
 use nu_parser::parse;
 use nu_path::canonicalize_with;
+use nu_protocol::engine::run_command;
 use nu_protocol::report_error;
 use nu_protocol::{
     ast::Call,
@@ -215,7 +216,7 @@ pub(crate) fn print_table_or_error(
             // The final call on table command, it's ok to set redirect_output to false.
             let mut call = Call::new(Span::new(0, 0));
             call.redirect_stdout = false;
-            let table = command.run(engine_state, stack, &call, pipeline_data);
+            let table = run_command(command, engine_state, stack, &call, pipeline_data);
 
             match table {
                 Ok(table) => {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -1,7 +1,7 @@
 use nu_engine::{current_dir, eval_block, CallExt};
 use nu_path::expand_to_real_path;
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::engine::{run_command, Command, EngineState, Stack};
 use nu_protocol::util::BufferedReader;
 use nu_protocol::{
     Category, DataSource, Example, IntoInterruptiblePipelineData, NuPath, PipelineData,
@@ -202,7 +202,13 @@ impl Command for Open {
                                 let block = engine_state.get_block(block_id);
                                 eval_block(engine_state, stack, block, file_contents, false, false)
                             } else {
-                                decl.run(engine_state, stack, &Call::new(call_span), file_contents)
+                                run_command(
+                                    decl,
+                                    engine_state,
+                                    stack,
+                                    &Call::new(call_span),
+                                    file_contents,
+                                )
                             };
                             output.push(command_output.map_err(|inner| {
                                     ShellError::GenericError{

--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -2,6 +2,7 @@ use nu_engine::current_dir;
 use nu_engine::CallExt;
 use nu_path::expand_path_with;
 use nu_protocol::ast::{Call, Expr, Expression};
+use nu_protocol::engine::run_command;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, DataSource, Example, PipelineData, PipelineMetadata, RawStream, ShellError,
@@ -307,7 +308,8 @@ fn convert_to_extension(
 
     let output = match converter {
         Some(converter_id) => {
-            let output = engine_state.get_decl(converter_id).run(
+            let output = run_command(
+                engine_state.get_decl(converter_id),
                 engine_state,
                 stack,
                 &Call::new(span),

--- a/crates/nu-command/src/misc/tutor.rs
+++ b/crates/nu-command/src/misc/tutor.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::engine::{run_command, Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, SyntaxShape,
     Type, Value,
@@ -416,7 +416,8 @@ fn display(help: &str, engine_state: &EngineState, stack: &mut Stack, span: Span
             if let Some(highlighter) = engine_state.find_decl(b"nu-highlight", &[]) {
                 let decl = engine_state.get_decl(highlighter);
 
-                if let Ok(output) = decl.run(
+                if let Ok(output) = run_command(
+                    decl,
                     engine_state,
                     stack,
                     &Call::new(span),

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -3,7 +3,7 @@ use base64::engine::general_purpose::PAD;
 use base64::engine::GeneralPurpose;
 use base64::{alphabet, Engine};
 use nu_protocol::ast::Call;
-use nu_protocol::engine::{EngineState, Stack};
+use nu_protocol::engine::{run_command, EngineState, Stack};
 use nu_protocol::{
     record, BufferedReader, IntoPipelineData, PipelineData, RawStream, ShellError, Span, Spanned,
     Value,
@@ -468,7 +468,8 @@ fn transform_response_using_content_type(
         return Ok(output);
     } else if let Some(ext) = ext {
         return match engine_state.find_decl(format!("from {ext}").as_bytes(), &[]) {
-            Some(converter_id) => engine_state.get_decl(converter_id).run(
+            Some(converter_id) => run_command(
+                engine_state.get_decl(converter_id),
                 engine_state,
                 stack,
                 &Call::new(span),

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -1,4 +1,5 @@
 use nu_protocol::ast::{Argument, Expr, Expression, RecordItem};
+use nu_protocol::engine::run_command;
 use nu_protocol::{
     ast::Call,
     engine::{EngineState, Stack},
@@ -44,7 +45,8 @@ fn nu_highlight_string(code_string: &str, engine_state: &EngineState, stack: &mu
     if let Some(highlighter) = engine_state.find_decl(b"nu-highlight", &[]) {
         let decl = engine_state.get_decl(highlighter);
 
-        if let Ok(output) = decl.run(
+        if let Ok(output) = run_command(
+            decl,
             engine_state,
             stack,
             &Call::new(Span::unknown()),
@@ -272,7 +274,8 @@ fn get_documentation(
         } else if let Some(highlighter) = engine_state.find_decl(b"nu-highlight", &[]) {
             let decl = engine_state.get_decl(highlighter);
 
-            match decl.run(
+            match run_command(
+                decl,
                 engine_state,
                 stack,
                 &Call::new(Span::unknown()),
@@ -301,15 +304,14 @@ fn get_documentation(
             let table = engine_state
                 .find_decl("table".as_bytes(), &[])
                 .and_then(|decl_id| {
-                    engine_state
-                        .get_decl(decl_id)
-                        .run(
-                            engine_state,
-                            stack,
-                            &Call::new(Span::new(0, 0)),
-                            PipelineData::Value(result.clone(), None),
-                        )
-                        .ok()
+                    run_command(
+                        engine_state.get_decl(decl_id),
+                        engine_state,
+                        stack,
+                        &Call::new(Span::new(0, 0)),
+                        PipelineData::Value(result.clone(), None),
+                    )
+                    .ok()
                 });
 
             for item in table.into_iter().flatten() {

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
         Argument, Assignment, Block, Call, Expr, Expression, ExternalArgument, PathMember,
         PipelineElement, Redirection,
     },
-    engine::{Closure, EngineState, Stack},
+    engine::{run_command, Closure, EngineState, Stack},
     eval_base::Eval,
     Config, DeclId, IntoPipelineData, PipelineData, ShellError, Span, Spanned, Type, Value, VarId,
     ENV_VARIABLE_ID,
@@ -175,7 +175,7 @@ pub fn eval_call(
         // We pass caller_stack here with the knowledge that internal commands
         // are going to be specifically looking for global state in the stack
         // rather than any local state.
-        decl.run(engine_state, caller_stack, call, input)
+        run_command(decl, engine_state, caller_stack, call, input)
     }
 }
 
@@ -274,8 +274,7 @@ fn eval_external(
             None,
         ))
     }
-
-    command.run(engine_state, stack, &call, input)
+    run_command(command, engine_state, stack, &call, input)
 }
 
 pub fn eval_expression(

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -1,4 +1,4 @@
-use nu_protocol::engine::{EngineState, Stack};
+use nu_protocol::engine::{run_command, EngineState, Stack};
 use nu_protocol::{
     ast::{Argument, Call, Expr, Expression},
     engine::Command,
@@ -132,6 +132,6 @@ impl Command for KnownExternal {
             ))
         }
 
-        command.run(engine_state, stack, &extern_call, input)
+        run_command(command, engine_state, stack, &extern_call, input)
     }
 }

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Call, PathMember},
-    engine::{EngineState, Stack, StateWorkingSet},
+    engine::{run_command, EngineState, Stack, StateWorkingSet},
     format_error, Config, ListStream, RawStream, ShellError, Span, Value,
 };
 use nu_utils::{stderr_write_all_and_flush, stdout_write_all_and_flush};
@@ -738,7 +738,7 @@ impl PipelineData {
 
             let mut call = Call::new(Span::new(0, 0));
             call.redirect_stdout = false;
-            let table = command.run(engine_state, stack, &call, self)?;
+            let table = run_command(command, engine_state, stack, &call, self)?;
 
             table.write_all_and_flush(engine_state, config, no_newline, to_stderr)?;
         } else {

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1309,6 +1309,11 @@ This is an internal Nushell error, please file an issue https://github.com/nushe
         #[label = "byte index is not a char boundary or is out of bounds of the input"]
         span: Span,
     },
+
+    /// The executed command panicked.
+    #[error("Command Panicked")]
+    #[diagnostic(code(nu::shell::command_panicked))]
+    CommandPanic { msg: String, span: Span },
 }
 
 // TODO: Implement as From trait


### PR DESCRIPTION
WIP/POC

Wrap calls to Command::run in a newly introduced run_command function. This function wraps the call to run in a wrap_unwind and generates a ShellError::CommandPanic if the command fails.

This came in the conversion with @fdncred  on this pull request: [11393](https://github.com/nushell/nushell/pull/11393)
