### PR TITLE
Disable riscv64 build target temporarily to make release and nightly-build work

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -81,7 +81,7 @@ jobs:
         - x86_64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
         - armv7-unknown-linux-gnueabihf
-        - riscv64gc-unknown-linux-gnu
+        # - riscv64gc-unknown-linux-gnu
         extra: ['bin']
         include:
         - target: aarch64-apple-darwin
@@ -118,9 +118,9 @@ jobs:
         - target: armv7-unknown-linux-gnueabihf
           os: ubuntu-20.04
           target_rustflags: ''
-        - target: riscv64gc-unknown-linux-gnu
-          os: ubuntu-latest
-          target_rustflags: ''
+        # - target: riscv64gc-unknown-linux-gnu
+        #   os: ubuntu-latest
+        #   target_rustflags: ''
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         - x86_64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
         - armv7-unknown-linux-gnueabihf
-        - riscv64gc-unknown-linux-gnu
+        # - riscv64gc-unknown-linux-gnu
         extra: ['bin']
         include:
         - target: aarch64-apple-darwin
@@ -65,9 +65,9 @@ jobs:
         - target: armv7-unknown-linux-gnueabihf
           os: ubuntu-20.04
           target_rustflags: ''
-        - target: riscv64gc-unknown-linux-gnu
-          os: ubuntu-latest
-          target_rustflags: ''
+        # - target: riscv64gc-unknown-linux-gnu
+        #   os: ubuntu-latest
+        #   target_rustflags: ''
 
     runs-on: ${{matrix.os}}
 


### PR DESCRIPTION
Let's disable riscv64 build target temporarily to make release and nightly-build workflow work, close #11604
We will add this target later if the related issue got fixed