### PR TITLE
Allow comments in match blocks

### DIFF
--- a/crates/nu-command/tests/commands/match_.rs
+++ b/crates/nu-command/tests/commands/match_.rs
@@ -1,4 +1,6 @@
 use nu_test_support::nu;
+use nu_test_support::playground::Playground;
+use std::fs;
 
 #[test]
 fn match_for_range() {
@@ -225,4 +227,41 @@ fn match_with_guard_no_expr_after_if() {
     );
 
     assert!(actual.err.contains("Match guard without an expression"));
+}
+
+#[test]
+fn match_with_comment_1() {
+    Playground::setup("match_with_comment", |dirs, _| {
+        let data = r#"
+match 1 {
+    # comment
+    _ => { print 'success' }
+}
+            "#;
+        fs::write(dirs.root().join("match_test"), data).expect("Unable to write file");
+        let actual = nu!(
+            cwd: dirs.root(),
+            "source match_test"
+        );
+
+        assert_eq!(actual.out, "success");
+    });
+}
+
+#[test]
+fn match_with_comment_2() {
+    Playground::setup("match_with_comment", |dirs, _| {
+        let data = r#"
+match 1 {
+    _ => { print 'success' } # comment
+}
+            "#;
+        fs::write(dirs.root().join("match_test"), data).expect("Unable to write file");
+        let actual = nu!(
+            cwd: dirs.root(),
+            "source match_test"
+        );
+
+        assert_eq!(actual.out, "success");
+    });
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4177,7 +4177,7 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
 
     let source = working_set.get_span_contents(inner_span);
 
-    let (output, err) = lex(source, start, &[b' ', b'\r', b'\n', b',', b'|'], &[], false);
+    let (output, err) = lex(source, start, &[b' ', b'\r', b'\n', b',', b'|'], &[], true);
     if let Some(err) = err {
         working_set.error(err);
     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Fix #9878 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Writing comments in match blocks will be allowed.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
