### PR TITLE
Fix panic in `rotate`; Add safe record creation function

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/eager/schema.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/schema.rs
@@ -33,7 +33,7 @@ impl Command for SchemaDF {
             description: "Dataframe schema",
             example: r#"[[a b]; [1 "foo"] [3 "bar"]] | dfr into-df | dfr schema"#,
             result: Some(Value::record(
-                Record::from_raw_cols_vals(
+                Record::from_raw_cols_vals_unchecked(
                     vec!["a".to_string(), "b".to_string()],
                     vec![
                         Value::string("i64", Span::test_data()),
@@ -98,7 +98,7 @@ fn datatype_list(span: Span) -> Value {
     ]
     .iter()
     .map(|(dtype, note)| {
-        Value::record(Record::from_raw_cols_vals(
+        Value::record(Record::from_raw_cols_vals_unchecked(
             vec!["dtype".to_string(), "note".to_string()],
             vec![Value::string(*dtype, span), Value::string(*note, span)],
         ),span)

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/conversion.rs
@@ -1041,7 +1041,7 @@ fn series_to_values(
                         .iter()
                         .map(|field| field.name.to_string())
                         .collect();
-                    let record = Record::from_raw_cols_vals(cols, vals?);
+                    let record = Record::from_raw_cols_vals_unchecked(cols, vals?);
                     Ok(Value::record(record, span))
                 })
                 .collect();
@@ -1149,7 +1149,7 @@ fn any_value_to_value(any_value: &AnyValue, span: Span) -> Result<Value, ShellEr
                 .map(|f| f.name().to_string())
                 .collect();
             Ok(Value::Record {
-                val: Record::from_raw_cols_vals(fields, values?),
+                val: Record::from_raw_cols_vals_unchecked(fields, values?),
                 internal_span: span,
             })
         }

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
@@ -160,7 +160,7 @@ impl NuDataFrame {
 
                     conversion::insert_record(
                         &mut column_values,
-                        Record::from_raw_cols_vals(cols, vals),
+                        Record::from_raw_cols_vals_unchecked(cols, vals),
                         &maybe_schema,
                     )?
                 }

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_schema.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_schema.rs
@@ -45,7 +45,7 @@ fn fields_to_value(fields: impl Iterator<Item = Field>, span: Span) -> Value {
         })
         .unzip();
 
-    let record = Record::from_raw_cols_vals(cols, vals);
+    let record = Record::from_raw_cols_vals_unchecked(cols, vals);
     Value::record(record, Span::unknown())
 }
 
@@ -193,7 +193,7 @@ mod test {
     #[test]
     fn test_value_to_schema() {
         let value = Value::Record {
-            val: Record::from_raw_cols_vals(
+            val: Record::from_raw_cols_vals_unchecked(
                 vec!["name".into(), "age".into(), "address".into()],
                 vec![
                     Value::String {
@@ -205,7 +205,7 @@ mod test {
                         internal_span: Span::test_data(),
                     },
                     Value::Record {
-                        val: Record::from_raw_cols_vals(
+                        val: Record::from_raw_cols_vals_unchecked(
                             vec!["street".into(), "city".into()],
                             vec![
                                 Value::String {

--- a/crates/nu-cmd-extra/src/extra/filters/roll/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/mod.rs
@@ -70,7 +70,10 @@ fn horizontal_rotate_value(
                 HorizontalDirection::Left => vals.rotate_left(rotations),
             }
 
-            Ok(Value::record(Record::from_raw_cols_vals(cols, vals), span))
+            Ok(Value::record(
+                Record::from_raw_cols_vals_unchecked(cols, vals),
+                span,
+            ))
         }
         Value::List { vals, .. } => {
             let values = vals

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -258,7 +258,7 @@ fn histogram_impl(
         result.push((
             count, // attach count first for easily sorting.
             Value::record(
-                Record::from_raw_cols_vals(
+                Record::from_raw_cols_vals_unchecked(
                     result_cols.clone(),
                     vec![
                         val.into_value(),

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -499,7 +499,10 @@ pub fn convert_sqlite_row_to_nu_value(row: &Row, span: Span, column_names: Vec<S
         vals.push(val);
     }
 
-    Value::record(Record::from_raw_cols_vals(column_names, vals), span)
+    Value::record(
+        Record::from_raw_cols_vals_unchecked(column_names, vals),
+        span,
+    )
 }
 
 pub fn convert_sqlite_value_to_nu_value(value: ValueRef, span: Span) -> Value {

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -55,7 +55,7 @@ fn from_delimited_string_to_value(
             .collect::<Vec<Value>>();
 
         rows.push(Value::record(
-            Record::from_raw_cols_vals(headers.clone(), output_row),
+            Record::from_raw_cols_vals_unchecked(headers.clone(), output_row),
             span,
         ));
     }

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -417,7 +417,7 @@ fn convert_to_value(
                     .collect::<Result<_, _>>()?;
 
                 output.push(Value::record(
-                    Record::from_raw_cols_vals(cols.clone(), vals),
+                    Record::from_raw_cols_vals_unchecked(cols.clone(), vals),
                     span,
                 ));
             }

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -200,7 +200,7 @@ fn detect_columns(
 
                         if !(l_idx <= r_idx && (r_idx >= 0 || l_idx < (cols.len() as isize))) {
                             return Value::record(
-                                Record::from_raw_cols_vals(cols, vals),
+                                Record::from_raw_cols_vals_unchecked(cols, vals),
                                 name_span,
                             );
                         }
@@ -213,7 +213,7 @@ fn detect_columns(
                     }
                 }
             } else {
-                return Value::record(Record::from_raw_cols_vals(cols, vals), name_span);
+                return Value::record(Record::from_raw_cols_vals_unchecked(cols, vals), name_span);
             };
 
             // Merge Columns
@@ -235,7 +235,7 @@ fn detect_columns(
             vals.push(binding);
             last_seg.into_iter().for_each(|v| vals.push(v));
 
-            Value::record(Record::from_raw_cols_vals(cols, vals), name_span)
+            Value::record(Record::from_raw_cols_vals_unchecked(cols, vals), name_span)
         })
         .into_pipeline_data(ctrlc))
     } else {

--- a/crates/nu-command/tests/commands/rotate.rs
+++ b/crates/nu-command/tests/commands/rotate.rs
@@ -89,3 +89,11 @@ fn clockwise() {
 
     assert_eq!(actual.out, expected.out);
 }
+
+#[test]
+fn different_cols_vals_err() {
+    let actual = nu!("[[[one], [two, three]]] | first | rotate");
+    assert!(actual
+        .err
+        .contains("Attempted to create a record from different number of columns and values"))
+}

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -198,7 +198,7 @@ impl<'e, 's> ScopeData<'e, 's> {
 
         // input
         sig_records.push(Value::record(
-            Record::from_raw_cols_vals(
+            Record::from_raw_cols_vals_unchecked(
                 sig_cols.clone(),
                 vec![
                     Value::nothing(span),
@@ -231,7 +231,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             ];
 
             sig_records.push(Value::record(
-                Record::from_raw_cols_vals(sig_cols.clone(), sig_vals),
+                Record::from_raw_cols_vals_unchecked(sig_cols.clone(), sig_vals),
                 span,
             ));
         }
@@ -257,7 +257,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             ];
 
             sig_records.push(Value::record(
-                Record::from_raw_cols_vals(sig_cols.clone(), sig_vals),
+                Record::from_raw_cols_vals_unchecked(sig_cols.clone(), sig_vals),
                 span,
             ));
         }
@@ -279,7 +279,7 @@ impl<'e, 's> ScopeData<'e, 's> {
             ];
 
             sig_records.push(Value::record(
-                Record::from_raw_cols_vals(sig_cols.clone(), sig_vals),
+                Record::from_raw_cols_vals_unchecked(sig_cols.clone(), sig_vals),
                 span,
             ));
         }
@@ -326,14 +326,14 @@ impl<'e, 's> ScopeData<'e, 's> {
             ];
 
             sig_records.push(Value::record(
-                Record::from_raw_cols_vals(sig_cols.clone(), sig_vals),
+                Record::from_raw_cols_vals_unchecked(sig_cols.clone(), sig_vals),
                 span,
             ));
         }
 
         // output
         sig_records.push(Value::record(
-            Record::from_raw_cols_vals(
+            Record::from_raw_cols_vals_unchecked(
                 sig_cols,
                 vec![
                     Value::nothing(span),

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -165,7 +165,10 @@ fn help_frame_data(
 
             let (cols, mut vals) = help_manual_data(manual, aliases);
             let vals = vals.remove(0);
-            Value::record(Record::from_raw_cols_vals(cols, vals), NuSpan::unknown())
+            Value::record(
+                Record::from_raw_cols_vals_unchecked(cols, vals),
+                NuSpan::unknown(),
+            )
         })
         .collect();
     let commands = Value::list(commands, NuSpan::unknown());

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -708,7 +708,7 @@ fn build_table_as_list(v: &RecordView) -> Value {
         .cloned()
         .map(|vals| {
             Value::record(
-                Record::from_raw_cols_vals(headers.clone(), vals),
+                Record::from_raw_cols_vals_unchecked(headers.clone(), vals),
                 NuSpan::unknown(),
             )
         })
@@ -723,7 +723,10 @@ fn build_table_as_record(v: &RecordView) -> Value {
     let cols = layer.columns.to_vec();
     let vals = layer.records.first().map_or(Vec::new(), |row| row.clone());
 
-    Value::record(Record::from_raw_cols_vals(cols, vals), NuSpan::unknown())
+    Value::record(
+        Record::from_raw_cols_vals_unchecked(cols, vals),
+        NuSpan::unknown(),
+    )
 }
 
 fn report_cursor_position(mode: UIMode, cursor: XYCursor) -> String {

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -125,7 +125,7 @@ pub trait Eval {
                     }
                     // length equality already ensured in parser
                     output_rows.push(Value::record(
-                        Record::from_raw_cols_vals(output_headers.clone(), row),
+                        Record::from_raw_cols_vals_unchecked(output_headers.clone(), row),
                         expr.span,
                     ));
                 }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -607,6 +607,20 @@ pub enum ShellError {
         first_use: Span,
     },
 
+    /// Attempted to create a record from different number of columns and values
+    ///
+    /// ## Resolution
+    ///
+    /// Check the record has the same number of columns as values
+    #[error("Attempted to create a record from different number of columns and values")]
+    #[diagnostic(code(nu::shell::record_cols_vals_mismatch))]
+    RecordColsValsMismatch {
+        #[label = "problematic value"]
+        bad_value: Span,
+        #[label = "attempted to create the record here"]
+        creation_site: Span,
+    },
+
     /// An error happened while performing an external command.
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -1,6 +1,6 @@
 use std::ops::RangeBounds;
 
-use crate::Value;
+use crate::{ShellError, Span, Value};
 
 use serde::{Deserialize, Serialize};
 
@@ -28,12 +28,36 @@ impl Record {
 
     // Constructor that checks that `cols` and `vals` are of the same length.
     //
+    // Panics with assertion failure if cols and vals have different length.
+    //
     // For perf reasons does not validate the rest of the record assumptions.
     // - unique keys
-    pub fn from_raw_cols_vals(cols: Vec<String>, vals: Vec<Value>) -> Self {
+    pub fn from_raw_cols_vals_unchecked(cols: Vec<String>, vals: Vec<Value>) -> Self {
         assert_eq!(cols.len(), vals.len());
 
         Self { cols, vals }
+    }
+
+    // Constructor that checks that `cols` and `vals` are of the same length.
+    //
+    // Returns None if cols and vals have different length.
+    //
+    // For perf reasons does not validate the rest of the record assumptions.
+    // - unique keys
+    pub fn from_raw_cols_vals(
+        cols: Vec<String>,
+        vals: Vec<Value>,
+        input_span: Span,
+        creation_site_span: Span,
+    ) -> Result<Self, ShellError> {
+        if cols.len() == vals.len() {
+            Ok(Self { cols, vals })
+        } else {
+            Err(ShellError::RecordColsValsMismatch {
+                bad_value: input_span,
+                creation_site: creation_site_span,
+            })
+        }
     }
 
     pub fn iter(&self) -> Iter {
@@ -455,7 +479,7 @@ impl ExactSizeIterator for Drain<'_> {
 #[macro_export]
 macro_rules! record {
     {$($col:expr => $val:expr),+ $(,)?} => {
-        $crate::Record::from_raw_cols_vals (
+        $crate::Record::from_raw_cols_vals_unchecked (
             vec![$($col.into(),)+],
             vec![$($val,)+]
         )

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -28,7 +28,8 @@ impl Record {
 
     // Constructor that checks that `cols` and `vals` are of the same length.
     //
-    // Panics with assertion failure if cols and vals have different length.
+    // WARNING! Panics with assertion failure if cols and vals have different length!
+    // Should be used only when the same lengths are guaranteed!
     //
     // For perf reasons does not validate the rest of the record assumptions.
     // - unique keys

--- a/crates/nu_plugin_example/src/example.rs
+++ b/crates/nu_plugin_example/src/example.rs
@@ -83,7 +83,10 @@ impl Example {
                     .map(|v| Value::int(v * i, call.head))
                     .collect::<Vec<Value>>();
 
-                Value::record(Record::from_raw_cols_vals(cols.clone(), vals), call.head)
+                Value::record(
+                    Record::from_raw_cols_vals_unchecked(cols.clone(), vals),
+                    call.head,
+                )
             })
             .collect::<Vec<Value>>();
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes https://github.com/nushell/nushell/issues/11716

The problem is in our [record creation API](https://github.com/nushell/nushell/blob/0d518bf8136fd9793dd13c5369ff65288242c682/crates/nu-protocol/src/value/record.rs#L33) which panics if the numbers of columns and values are different. I added a safe variant that returns a `Result` and used it in the `rotate` command. 

## TODO in another PR:

Go through all `from_raw_cols_vals_unchecked()` (this includes the `record!` macro which uses the unchecked version) and make sure that either
a) it is guaranteed the number of cols and vals is the same, or
b) convert the call to `from_raw_cols_vals()`

Reason: Nushell should never panic.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
