### PR TITLE
Tighten def body parsing

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -281,7 +281,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, spans: &[Span]) -> Expressio
             let starting_error_count = working_set.parse_errors.len();
             check_call(working_set, call_span, &sig, &call);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return garbage(spans[0]);
             };
 
@@ -470,7 +470,7 @@ pub fn parse_def(
             check_call(working_set, call_span, &sig, &call);
             working_set.parse_errors.append(&mut new_errors);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return (garbage_pipeline(spans), None);
             };
 
@@ -490,10 +490,10 @@ pub fn parse_def(
         }
     };
 
-    let Ok(has_env) = has_flag_wrapped(working_set, &call, "env") else {
+    let Ok(has_env) = has_flag_const(working_set, &call, "env") else {
         return (garbage_pipeline(spans), None);
     };
-    let Ok(has_wrapped) = has_flag_wrapped(working_set, &call, "wrapped") else {
+    let Ok(has_wrapped) = has_flag_const(working_set, &call, "wrapped") else {
         return (garbage_pipeline(spans), None);
     };
 
@@ -884,7 +884,7 @@ pub fn parse_alias(
             .parse_errors
             .truncate(original_starting_error_count);
 
-        let Ok(has_help_flag) = has_flag_wrapped(working_set, &alias_call, "help") else {
+        let Ok(has_help_flag) = has_flag_const(working_set, &alias_call, "help") else {
             return garbage_pipeline(spans);
         };
 
@@ -1139,7 +1139,7 @@ pub fn parse_export_in_block(
         let starting_error_count = working_set.parse_errors.len();
         check_call(working_set, call_span, &decl.signature(), &call);
 
-        let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+        let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
             return garbage_pipeline(&lite_command.parts);
         };
 
@@ -1628,7 +1628,7 @@ pub fn parse_export_env(
             let starting_error_count = working_set.parse_errors.len();
             check_call(working_set, call_span, &decl.signature(), &call);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return (garbage_pipeline(spans), None);
             };
 
@@ -2134,7 +2134,7 @@ pub fn parse_module(
             let starting_error_count = working_set.parse_errors.len();
             check_call(working_set, call_span, &decl.signature(), &call);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return (garbage_pipeline(spans), None);
             };
 
@@ -2334,7 +2334,7 @@ pub fn parse_use(working_set: &mut StateWorkingSet, spans: &[Span]) -> (Pipeline
             let starting_error_count = working_set.parse_errors.len();
             check_call(working_set, call_span, &decl.signature(), &call);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return (garbage_pipeline(spans), vec![]);
             };
 
@@ -2524,7 +2524,7 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline
             let starting_error_count = working_set.parse_errors.len();
             check_call(working_set, call_span, &decl.signature(), &call);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return garbage_pipeline(spans);
             };
 
@@ -2789,10 +2789,10 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         None
     };
 
-    let Ok(has_prefix) = has_flag_wrapped(working_set, &call, "prefix") else {
+    let Ok(has_prefix) = has_flag_const(working_set, &call, "prefix") else {
         return garbage_pipeline(&[call_span]);
     };
-    let Ok(do_reload) = has_flag_wrapped(working_set, &call, "reload") else {
+    let Ok(do_reload) = has_flag_const(working_set, &call, "reload") else {
         return garbage_pipeline(&[call_span]);
     };
 
@@ -2980,7 +2980,7 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
         )
     };
 
-    let Ok(keep_custom) = has_flag_wrapped(working_set, &call, "keep-custom") else {
+    let Ok(keep_custom) = has_flag_const(working_set, &call, "keep-custom") else {
         return garbage_pipeline(&[call_span]);
     };
 
@@ -3398,7 +3398,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeli
             let ParsedInternalCall { call, output } =
                 parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return garbage_pipeline(spans);
             };
 
@@ -3536,7 +3536,7 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
             let starting_error_count = working_set.parse_errors.len();
             check_call(working_set, call_span, &decl.signature(), &call);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return garbage(span(spans));
             };
 
@@ -3611,7 +3611,7 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
             let starting_error_count = working_set.parse_errors.len();
             check_call(working_set, call_span, &decl.signature(), &call);
 
-            let Ok(is_help) = has_flag_wrapped(working_set, &call, "help") else {
+            let Ok(is_help) = has_flag_const(working_set, &call, "help") else {
                 return garbage_pipeline(spans);
             };
 
@@ -3939,11 +3939,7 @@ fn detect_params_in_name(
 }
 
 /// Run has_flag_const and and push possible error to working_set
-fn has_flag_wrapped(
-    working_set: &mut StateWorkingSet,
-    call: &Call,
-    name: &str,
-) -> Result<bool, ()> {
+fn has_flag_const(working_set: &mut StateWorkingSet, call: &Call, name: &str) -> Result<bool, ()> {
     call.has_flag_const(working_set, name).map_err(|err| {
         working_set.error(err.wrap(working_set, call.span()));
     })

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -448,21 +448,16 @@ pub fn parse_def(
             if let Some(arg) = call.positional_nth(2) {
                 match arg {
                     Expression {
-                        expr: Expr::Block(block_id),
-                        ..
-                    }
-                    | Expression {
                         expr: Expr::Closure(block_id),
-                        ..
-                    }
-                    | Expression {
-                        expr: Expr::RowCondition(block_id),
                         ..
                     } => {
                         let block = working_set.get_block_mut(*block_id);
                         block.signature = Box::new(sig.clone());
                     }
-                    _ => {}
+                    _ => working_set.parse_errors.push(ParseError::Expected(
+                        "definition body closure { ... }",
+                        arg.span,
+                    )),
                 }
             }
 

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -774,3 +774,8 @@ fn record_expected_colon() -> TestResult {
 fn record_missing_value() -> TestResult {
     fail_test(r#"{ a: 2 b: }"#, "expected value for record field")
 }
+
+#[test]
+fn def_requires_body_closure() -> TestResult {
+    fail_test("def a [] (echo 4)", "expected definition body closure")
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes https://github.com/nushell/nushell/issues/11711

Previously, syntax `def a [] (echo 4)` was allowed to parse and then failed with panic duting eval.

Current error:
```
Error: nu::parser::parse_mismatch

  × Parse mismatch during operation.
   ╭─[entry #1:1:1]
 1 │ def a [] (echo 4)
   ·          ────┬───
   ·              ╰── expected definition body closure { ... }
   ╰────
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
