### PR TITLE
Enforce call stack depth limit for all calls

### DIFF
--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -81,3 +81,15 @@ fn catch_block_can_use_error_object() {
     let output = nu!("try {1 / 0} catch {|err| print ($err | get msg)}");
     assert_eq!(output.out, "Division by zero.")
 }
+
+// This test is disabled on Windows because they cause a stack overflow in CI (but not locally!).
+// For reasons we don't understand, the Windows CI runners are prone to stack overflow.
+// TODO: investigate so we can enable on Windows
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn can_catch_infinite_recursion() {
+    let actual = nu!(r#"
+            def bang [] { try { bang } catch { "Caught infinite recursion" } }; bang
+        "#);
+    assert_eq!(actual.out, "Caught infinite recursion");
+}

--- a/crates/nu-protocol/src/ast/block.rs
+++ b/crates/nu-protocol/src/ast/block.rs
@@ -10,7 +10,6 @@ pub struct Block {
     pub captures: Vec<VarId>,
     pub redirect_env: bool,
     pub span: Option<Span>, // None option encodes no span to avoid using test_span()
-    pub recursive: Option<bool>, // does the block call itself?
 }
 
 impl Block {
@@ -51,7 +50,6 @@ impl Block {
             captures: vec![],
             redirect_env: false,
             span: None,
-            recursive: None,
         }
     }
 
@@ -62,7 +60,6 @@ impl Block {
             captures: vec![],
             redirect_env: false,
             span: None,
-            recursive: None,
         }
     }
 
@@ -97,7 +94,6 @@ where
             captures: vec![],
             redirect_env: false,
             span: None,
-            recursive: None,
         }
     }
 }

--- a/src/tests/test_custom_commands.rs
+++ b/src/tests/test_custom_commands.rs
@@ -214,6 +214,18 @@ fn infinite_recursion_does_not_panic() {
     assert!(actual.err.contains("Recursion limit (50) reached"));
 }
 
+// This test is disabled on Windows because they cause a stack overflow in CI (but not locally!).
+// For reasons we don't understand, the Windows CI runners are prone to stack overflow.
+// TODO: investigate so we can enable on Windows
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn infinite_mutual_recursion_does_not_panic() {
+    let actual = nu!(r#"
+            def bang [] { def boom [] { bang }; boom }; bang
+        "#);
+    assert!(actual.err.contains("Recursion limit (50) reached"));
+}
+
 #[test]
 fn type_check_for_during_eval() -> TestResult {
     fail_test(


### PR DESCRIPTION
# Description
Previously, only direcly-recursive calls were checked for recursion depth. But most recursive calls in nushell are mutually recursive since expressions like `for`, `where`, `try` and `do` all execute a separte block.

```nushell
def f [] {
    do { f }
}
```
Calling `f` would crash nushell with a stack overflow.

I think the only general way to prevent such a stack overflow is to enforce a maximum call stack depth instead of only disallowing directly recursive calls.

This commit also moves that logic into `eval_call()` instead of `eval_block()` because the recursion limit is tracked in the `Stack`, but not all blocks are evaluated in a new stack. Incrementing the recursion depth of the caller's stack would permanently increment that for all future calls.

Fixes #11667

# User-Facing Changes
Any function call can now fail with `recursion_limit_reached` instead of just directly recursive calls. Mutually-recursive calls no longer crash nushell.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
