### PR TITLE
Allow specifying a cellpath in `input list` to get the value to display

### DIFF
--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -4,8 +4,8 @@ use nu_engine::CallExt;
 use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    record, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape,
-    Type, Value,
+    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type,
+    Value,
 };
 use std::fmt::{Display, Formatter};
 
@@ -254,9 +254,7 @@ impl Command for InputList {
             Example {
                 description: "Choose an item from a table using a column as display value",
                 example: r#"[[name price]; [Banana 12] [Kiwi 4] [Pear 7]] | input list -d name"#,
-                result: Some(Value::test_record(
-                    record!("name" => Value::test_string("Kiwi"), "price" => Value::test_int(4)),
-                )),
+                result: None,
             },
         ]
     }

--- a/crates/nu-command/src/platform/input/list.rs
+++ b/crates/nu-command/src/platform/input/list.rs
@@ -1,11 +1,11 @@
 use dialoguer::{console::Term, Select};
 use dialoguer::{FuzzySelect, MultiSelect};
 use nu_engine::CallExt;
-use nu_protocol::ast::Call;
+use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape, Type,
-    Value,
+    record, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, SyntaxShape,
+    Type, Value,
 };
 use std::fmt::{Display, Formatter};
 
@@ -50,6 +50,12 @@ impl Command for InputList {
             )
             .switch("fuzzy", "Use a fuzzy select.", Some('f'))
             .switch("index", "Returns list indexes.", Some('i'))
+            .named(
+                "display",
+                SyntaxShape::CellPath,
+                "Field to use as display value",
+                Some('d'),
+            )
             .allow_variants_without_examples(true)
             .category(Category::Platform)
     }
@@ -78,17 +84,27 @@ impl Command for InputList {
         let multi = call.has_flag(engine_state, stack, "multi")?;
         let fuzzy = call.has_flag(engine_state, stack, "fuzzy")?;
         let index = call.has_flag(engine_state, stack, "index")?;
+        let display_path: Option<CellPath> = call.get_flag(engine_state, stack, "display")?;
 
         let options: Vec<Options> = match input {
             PipelineData::Value(Value::Range { .. }, ..)
             | PipelineData::Value(Value::List { .. }, ..)
             | PipelineData::ListStream { .. } => input
                 .into_iter()
-                .map(move |val| Options {
-                    name: val.into_string(", ", engine_state.get_config()),
-                    value: val,
+                .map(move |val| {
+                    let display_value = if let Some(ref cellpath) = display_path {
+                        val.clone()
+                            .follow_cell_path(&cellpath.members, false)?
+                            .into_string(", ", engine_state.get_config())
+                    } else {
+                        val.into_string(", ", engine_state.get_config())
+                    };
+                    Ok(Options {
+                        name: display_value,
+                        value: val,
+                    })
                 })
-                .collect(),
+                .collect::<Result<Vec<_>, ShellError>>()?,
 
             _ => {
                 return Err(ShellError::TypeMismatch {
@@ -234,6 +250,13 @@ impl Command for InputList {
                 description: "Return the index of a selected item",
                 example: r#"[Banana Kiwi Pear Peach Strawberry] | input list --index"#,
                 result: None,
+            },
+            Example {
+                description: "Choose an item from a table using a column as display value",
+                example: r#"[[name price]; [Banana 12] [Kiwi 4] [Pear 7]] | input list -d name"#,
+                result: Some(Value::test_record(
+                    record!("name" => Value::test_string("Kiwi"), "price" => Value::test_int(4)),
+                )),
             },
         ]
     }


### PR DESCRIPTION
# Description
When using a table (or a list of records) as input to `input list`, allow specifying a cellpath for the field/column to use as the display value.

For instance, at the moment, using a table as input results in the following:

```
❯ [[name price]; [Banana 12] [Kiwi 4] [Pear 7]] | input list
> {name: Banana, price: 12}
  {name: Kiwi, price: 4}
  {name: Pear, price: 7}
```

With the new `--display` flag introduced by this PR, you can do the following:

```
❯ [[name price]; [Banana 12] [Kiwi 4] [Pear 7]] | input list -d name
> Banana
  Kiwi
  Pear
```

Note that it doesn't change what gets returned after selecting an item: the full row/record is still returned.

# User-Facing Changes
A new optional flag is allowed.

# Tests + Formatting

# After Submitting
