### PR TITLE
Fix file completions which contains glob pattern

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -157,10 +157,10 @@ pub fn escape_path(path: String, dir: bool) -> String {
     // make glob pattern have the highest priority.
     let glob_contaminated = path.contains(['[', '*', ']']);
     if glob_contaminated {
-        return if path.contains('"') {
-            format!("'{path}'")
-        } else {
+        return if path.contains('\'') {
             format!("\"{path}\"")
+        } else {
+            format!("'{path}'")
         };
     }
 

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -155,10 +155,12 @@ pub fn complete_item(
 // Fix files or folders with quotes or hashes
 pub fn escape_path(path: String, dir: bool) -> String {
     // make glob pattern have the highest priority.
-    let glob_contaminated = path.contains(['[', '*', ']']);
+    let glob_contaminated = path.contains(['[', '*', ']', '?']);
     if glob_contaminated {
         return if path.contains('\'') {
-            format!("\"{path}\"")
+            // decide to use double quote, also need to escape `"` in path
+            // or else users can't do anything with completed path either.
+            format!("\"{}\"", path.replace('"', r#"\""#))
         } else {
             format!("'{path}'")
         };

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -154,6 +154,16 @@ pub fn complete_item(
 
 // Fix files or folders with quotes or hashes
 pub fn escape_path(path: String, dir: bool) -> String {
+    // make glob pattern have the highest priority.
+    let glob_contaminated = path.contains(['[', '*', ']']);
+    if glob_contaminated {
+        return if path.contains('"') {
+            format!("'{path}'")
+        } else {
+            format!("\"{path}\"")
+        };
+    }
+
     let filename_contaminated = !dir && path.contains(['\'', '"', ' ', '#', '(', ')']);
     let dirname_contaminated = dir && path.contains(['\'', '"', ' ', '#']);
     let maybe_flag = path.starts_with('-');

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -584,6 +584,7 @@ fn file_completion_quoted() {
     let suggestions = completer.complete(target_dir, target_dir.len());
 
     let expected_paths: Vec<String> = vec![
+        r#"ab [b]'c\".txt"#.to_string()
         "\'[a] bc.txt\'".to_string(),
         "`--help`".to_string(),
         "`-42`".to_string(),

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -584,7 +584,7 @@ fn file_completion_quoted() {
     let suggestions = completer.complete(target_dir, target_dir.len());
 
     let expected_paths: Vec<String> = vec![
-        r#"ab [b]'c\".txt"#.to_string()
+        r#"ab [b]'c\".txt"#.to_string(),
         "\'[a] bc.txt\'".to_string(),
         "`--help`".to_string(),
         "`-42`".to_string(),

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -584,7 +584,6 @@ fn file_completion_quoted() {
     let suggestions = completer.complete(target_dir, target_dir.len());
 
     let expected_paths: Vec<String> = vec![
-        r#"ab [b]'c\".txt"#.to_string(),
         "\'[a] bc.txt\'".to_string(),
         "`--help`".to_string(),
         "`-42`".to_string(),

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -584,6 +584,7 @@ fn file_completion_quoted() {
     let suggestions = completer.complete(target_dir, target_dir.len());
 
     let expected_paths: Vec<String> = vec![
+        "\"[a] bc\"".to_string(),
         "`--help`".to_string(),
         "`-42`".to_string(),
         "`-inf`".to_string(),

--- a/crates/nu-cli/tests/completions.rs
+++ b/crates/nu-cli/tests/completions.rs
@@ -584,7 +584,7 @@ fn file_completion_quoted() {
     let suggestions = completer.complete(target_dir, target_dir.len());
 
     let expected_paths: Vec<String> = vec![
-        "\"[a] bc\"".to_string(),
+        "\'[a] bc.txt\'".to_string(),
         "`--help`".to_string(),
         "`-42`".to_string(),
         "`-inf`".to_string(),


### PR DESCRIPTION
# Description
Fixes: https://github.com/nushell/nushell/issues/11762

The auto-completion is somehow annoying if a path contains a glob pattern, let's say if user type `ls` and it auto-completes to <code>ls `[a] bc.txt`</code>, and user can't list the file because it's backtick quoted.

This pr is going to fix it.

# User-Facing Changes
### Before
```
❯ | ls
`[a] bc.txt`        `a bc`
```
### After
```
❯ | ls
"[a] bc.txt"        `a bc`
```
# Tests + Formatting
Done

# After Submitting
NaN
