### PR TITLE
Fix #11750: `LazyRecord` error message

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1201,9 +1201,8 @@ impl Value {
                     }
                     Value::LazyRecord { val, .. } => {
                         // convert to Record first.
-                        let mut record = val.collect()?;
-                        record.upsert_data_at_cell_path(cell_path, new_val)?;
-                        *self = record;
+                        *self = val.collect()?;
+                        self.upsert_data_at_cell_path(cell_path, new_val)?;
                     }
                     Value::Error { error, .. } => return Err(*error.clone()),
                     v => {
@@ -1318,9 +1317,8 @@ impl Value {
                     }
                     Value::LazyRecord { val, .. } => {
                         // convert to Record first.
-                        let mut record = val.collect()?;
-                        record.update_data_at_cell_path(cell_path, new_val)?;
-                        *self = record;
+                        *self = val.collect()?;
+                        self.update_data_at_cell_path(cell_path, new_val)?;
                     }
                     Value::Error { error, .. } => return Err(*error.clone()),
                     v => {
@@ -1408,10 +1406,8 @@ impl Value {
                         }
                         Value::LazyRecord { val, .. } => {
                             // convert to Record first.
-                            let mut record = val.collect()?;
-                            record.remove_data_at_cell_path(cell_path)?;
-                            *self = record;
-                            Ok(())
+                            *self = val.collect()?;
+                            self.remove_data_at_cell_path(cell_path)
                         }
                         v => Err(ShellError::CantFindColumn {
                             col_name: col_name.clone(),
@@ -1494,10 +1490,8 @@ impl Value {
                         }
                         Value::LazyRecord { val, .. } => {
                             // convert to Record first.
-                            let mut record = val.collect()?;
-                            record.remove_data_at_cell_path(cell_path)?;
-                            *self = record;
-                            Ok(())
+                            *self = val.collect()?;
+                            self.remove_data_at_cell_path(cell_path)
                         }
                         v => Err(ShellError::CantFindColumn {
                             col_name: col_name.clone(),
@@ -1623,9 +1617,8 @@ impl Value {
                     }
                     Value::LazyRecord { val, .. } => {
                         // convert to Record first.
-                        let mut record = val.collect()?;
-                        record.insert_data_at_cell_path(cell_path, new_val, v_span)?;
-                        *self = record;
+                        *self = val.collect()?;
+                        self.insert_data_at_cell_path(cell_path, new_val, v_span)?;
                     }
                     other => {
                         return Err(ShellError::UnsupportedInput {

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -975,7 +975,7 @@ impl Value {
                         }
                         // Records (and tables) are the only built-in which support column names,
                         // so only use this message for them.
-                        Value::Record { .. } => {
+                        Value::Record { .. } | Value::LazyRecord { .. } => {
                             return Err(ShellError::TypeMismatch {
                                 err_message:"Can't access record values with a row index. Try specifying a column name instead".into(),
                                 span: *origin_span,


### PR DESCRIPTION
# Description
Makes `LazyRecord`s have the same error message as regular `Records` for `Value::follow_cell_path`. Fixes #11750.