### PR TITLE
allow `ansi strip` to work better on other nushell values

### DIFF
--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -88,8 +88,8 @@ fn action(input: &Value, args: &Arguments, _span: Span) -> Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{action, SubCommand};
-    use nu_protocol::{Span, Value};
+    use super::{action, Arguments, SubCommand};
+    use nu_protocol::{engine::EngineState, Span, Value};
 
     #[test]
     fn examples_work_as_expected() {
@@ -104,7 +104,12 @@ mod tests {
             Value::test_string("\u{1b}[3;93;41mHello\u{1b}[0m \u{1b}[1;32mNu \u{1b}[1;35mWorld");
         let expected = Value::test_string("Hello Nu World");
 
-        let actual = action(&input_string, &vec![].into(), Span::test_data());
+        let args = Arguments {
+            cell_paths: vec![].into(),
+            config: EngineState::new().get_config().clone(),
+        };
+
+        let actual = action(&input_string, &args, Span::test_data());
         assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
# Description

This PR help `ansi strip` work on more nushell values. It does this by converting values like filesize and dates to strings. This may not be precisely correct but I think it does more what the user expects.

### Before
![image](https://github.com/nushell/nushell/assets/343840/768ffbb2-e3d7-424e-8e3b-1d20c9aa7d91)


### After
![image](https://github.com/nushell/nushell/assets/343840/6141aebb-481f-45a9-9cb7-084ca9ca1ea5)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
