### PR TITLE
Pin reedline to version 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4640,8 +4640,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.28.0"
-source = "git+https://github.com/nushell/reedline?branch=main#f2447364b923eaab55f6de4f73c1f79511c6b5eb"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e01ebfbdb1a88963121d3c928c97be7f10fec7795bec8b918c8cda1db7c29e6"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ nu-std = { path = "./crates/nu-std", version = "0.89.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.89.1" }
 
 nu-ansi-term = "0.50.0"
-reedline = { version = "0.28.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.29.0", features = ["bashisms", "sqlite"] }
 
 crossterm = "0.27"
 ctrlc = "3.4"
@@ -183,8 +183,8 @@ bench = false
 
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
-[patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+#[patch.crates-io]
+#reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 # uu_cp = { git = "https://github.com/uutils/coreutils.git", branch = "main" }
 

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -25,7 +25,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.89.1" }
 nu-utils = { path = "../nu-utils", version = "0.89.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.89.1" }
 nu-ansi-term = "0.50.0"
-reedline = { version = "0.28.0", features = ["bashisms", "sqlite"] }
+reedline = { version = "0.29.0", features = ["bashisms", "sqlite"] }
 
 chrono = { default-features = false, features = ["std"], version = "0.4" }
 crossterm = "0.27"

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -12,7 +12,7 @@ nu-cli = { path = "../nu-cli", version = "0.89.1" }
 nu-parser = { path = "../nu-parser", version = "0.89.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.89.1" }
 
-reedline = { version = "0.28" }
+reedline = { version = "0.29" }
 
 crossbeam-channel = "0.5.8"
 lsp-types = "0.95.0"


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

See full release notes: https://github.com/nushell/reedline/releases/tag/v0.29.0

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
