### PR TITLE
Upgrade hustcer/setup-nu action to v3.9 and Nu to v0.90.1 for workflows

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -36,12 +36,10 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Setup Nushell
-        uses: hustcer/setup-nu@v3.8
+        uses: hustcer/setup-nu@v3.9
         if: github.repository == 'nushell/nightly'
         with:
-          version: 0.86.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.90.1
 
       # Synchronize the main branch of nightly repo with the main branch of Nushell official repo
       - name: Prepare for Nightly Release
@@ -141,11 +139,9 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.8
+      uses: hustcer/setup-nu@v3.9
       with:
-        version: 0.86.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        version: 0.90.1
 
     - name: Release Nu Binary
       id: nu
@@ -255,11 +251,9 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.8
+      uses: hustcer/setup-nu@v3.9
       with:
-        version: 0.86.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        version: 0.90.1
 
     - name: Release Nu Binary
       id: nu
@@ -321,11 +315,9 @@ jobs:
           ref: main
 
       - name: Setup Nushell
-        uses: hustcer/setup-nu@v3.8
+        uses: hustcer/setup-nu@v3.9
         with:
-          version: 0.86.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.90.1
 
       # Keep the last a few releases
       - name: Delete Older Releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,11 +85,9 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.8
+      uses: hustcer/setup-nu@v3.9
       with:
-        version: 0.86.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        version: 0.90.1
 
     - name: Release Nu Binary
       id: nu
@@ -176,11 +174,9 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.8
+      uses: hustcer/setup-nu@v3.9
       with:
-        version: 0.86.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        version: 0.90.1
 
     - name: Release Nu Binary
       id: nu


### PR DESCRIPTION
Upgrade `hustcer/setup-nu` action to v3.9:
1. `GITHUB_TOKEN` is no longer required
2. Upgrade Nu to v0.90.1 for release and nightly workflows