### PR TITLE
Add streaming API for plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,11 +3161,13 @@ name = "nu-plugin"
 version = "0.90.2"
 dependencies = [
  "bincode",
+ "log",
  "nu-engine",
  "nu-protocol",
  "rmp-serde",
  "serde",
  "serde_json",
+ "typetag",
 ]
 
 [[package]]
@@ -3336,6 +3338,14 @@ dependencies = [
  "scraper",
  "sxd-document",
  "sxd-xpath",
+]
+
+[[package]]
+name = "nu_plugin_stream_example"
+version = "0.90.2"
+dependencies = [
+ "nu-plugin",
+ "nu-protocol",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
 	"crates/nu_plugin_inc",
 	"crates/nu_plugin_gstat",
 	"crates/nu_plugin_example",
+	"crates/nu_plugin_stream_example",
 	"crates/nu_plugin_query",
 	"crates/nu_plugin_custom_values",
 	"crates/nu_plugin_formats",

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -18,3 +18,7 @@ bincode = "1.3"
 rmp-serde = "1.1"
 serde = { version = "1.0" }
 serde_json = { version = "1.0" }
+log = "0.4"
+
+[dev-dependencies]
+typetag = "0.2"

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -48,6 +48,12 @@ mod plugin;
 mod protocol;
 mod serializers;
 
-pub use plugin::{get_signature, serve_plugin, Plugin, PluginDeclaration};
-pub use protocol::{EvaluatedCall, LabeledError, PluginResponse};
+pub use plugin::{
+    get_signature, serve_plugin, Plugin, PluginDeclaration, PluginEncoder, StreamingPlugin,
+};
+pub use protocol::{EvaluatedCall, LabeledError};
 pub use serializers::{json::JsonSerializer, msgpack::MsgPackSerializer, EncodingType};
+
+// Used by external benchmarks.
+#[doc(hidden)]
+pub use protocol::{PluginCallResponse, PluginOutput, StreamData};

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -1,10 +1,10 @@
 use crate::EvaluatedCall;
 
-use super::{call_plugin, create_command, get_plugin_encoding};
-use crate::protocol::{
-    CallInfo, CallInput, PluginCall, PluginCustomValue, PluginData, PluginResponse,
-};
+use super::interface::{make_call_input_from_pipeline_data, PluginExecutionNushellContext};
+use super::{create_command, make_plugin_interface};
+use crate::protocol::{CallInfo, PluginCall};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use nu_engine::eval_block;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -97,35 +97,7 @@ impl Command for PluginDeclaration {
             }
         })?;
 
-        let input = input.into_value(call.head);
-        let span = input.span();
-        let input = match input {
-            Value::CustomValue { val, .. } => {
-                match val.as_any().downcast_ref::<PluginCustomValue>() {
-                    Some(plugin_data) if plugin_data.filename == self.filename => {
-                        CallInput::Data(PluginData {
-                            data: plugin_data.data.clone(),
-                            span,
-                        })
-                    }
-                    _ => {
-                        let custom_value_name = val.value_string();
-                        return Err(ShellError::GenericError {
-                            error: format!(
-                                "Plugin {} can not handle the custom value {}",
-                                self.name, custom_value_name
-                            ),
-                            msg: format!("custom value {custom_value_name}"),
-                            span: Some(span),
-                            help: None,
-                            inner: vec![],
-                        });
-                    }
-                }
-            }
-            Value::LazyRecord { val, .. } => CallInput::Value(val.collect()?),
-            value => CallInput::Value(value),
-        };
+        let call_input = make_call_input_from_pipeline_data(&input, &self.name, &self.filename)?;
 
         // Fetch the configuration for a plugin
         //
@@ -164,67 +136,50 @@ impl Command for PluginDeclaration {
                 }
             });
 
-        let plugin_call = PluginCall::CallInfo(CallInfo {
+        let plugin_call = PluginCall::Run(CallInfo {
             name: self.name.clone(),
             call: EvaluatedCall::try_from_call(call, engine_state, stack)?,
-            input,
+            input: call_input,
             config,
         });
 
-        let encoding = {
-            let stdout_reader = match &mut child.stdout {
-                Some(out) => out,
-                None => {
-                    return Err(ShellError::PluginFailedToLoad {
-                        msg: "Plugin missing stdout reader".into(),
-                    })
+        let context = Arc::new(PluginExecutionNushellContext::new(
+            self.filename.clone(),
+            self.shell.clone(),
+            engine_state,
+            stack,
+            call,
+        ));
+
+        let interface = make_plugin_interface(&mut child, Some(context))?;
+        let interface_clone = interface.clone();
+
+        // Write the call and stream(s) on another thread. If we don't start reading immediately,
+        // we could block the child from being able to read stdin because it's trying to write
+        // something on stdout and its buffer is full.
+        std::thread::spawn(move || {
+            interface_clone.write_call(plugin_call)?;
+            match input {
+                PipelineData::Value(_, _) => Ok(()),
+                PipelineData::ListStream(list_stream, _) => {
+                    interface_clone.write_full_list_stream(list_stream)
                 }
-            };
-            get_plugin_encoding(stdout_reader)?
-        };
-        let response = call_plugin(&mut child, plugin_call, &encoding, call.head).map_err(|err| {
-            let decl = engine_state.get_decl(call.decl_id);
-            ShellError::GenericError {
-                error: format!("Unable to decode call for {}", decl.name()),
-                msg: err.to_string(),
-                span: Some(call.head),
-                help: None,
-                inner: vec![],
+                PipelineData::ExternalStream {
+                    stdout,
+                    stderr,
+                    exit_code,
+                    ..
+                } => interface_clone.write_full_external_stream(stdout, stderr, exit_code),
+                PipelineData::Empty => Ok(()),
             }
         });
 
-        let pipeline_data = match response {
-            Ok(PluginResponse::Value(value)) => {
-                Ok(PipelineData::Value(value.as_ref().clone(), None))
-            }
-            Ok(PluginResponse::PluginData(name, plugin_data)) => Ok(PipelineData::Value(
-                Value::custom_value(
-                    Box::new(PluginCustomValue {
-                        name,
-                        data: plugin_data.data,
-                        filename: self.filename.clone(),
-                        shell: self.shell.clone(),
-                        source: engine_state.get_decl(call.decl_id).name().to_owned(),
-                    }),
-                    plugin_data.span,
-                ),
-                None,
-            )),
-            Ok(PluginResponse::Error(err)) => Err(err.into()),
-            Ok(PluginResponse::Signature(..)) => Err(ShellError::GenericError {
-                error: "Plugin missing value".into(),
-                msg: "Received a signature from plugin instead of value".into(),
-                span: Some(call.head),
-                help: None,
-                inner: vec![],
-            }),
-            Err(err) => Err(err),
-        };
+        // Spawn a thread just to wait for the child.
+        std::thread::spawn(move || child.wait());
 
-        // We need to call .wait() on the child, or we'll risk summoning the zombie horde
-        let _ = child.wait();
-
-        pipeline_data
+        // Return the pipeline data from the response
+        let response = interface.read_call_response()?;
+        interface.make_pipeline_data(response)
     }
 
     fn is_plugin(&self) -> Option<(&Path, Option<&Path>)> {

--- a/crates/nu-plugin/src/plugin/interface.rs
+++ b/crates/nu-plugin/src/plugin/interface.rs
@@ -1,0 +1,352 @@
+//! Implements the stream multiplexing interface for both the plugin side and the engine side.
+
+use std::{
+    path::Path,
+    sync::{atomic::AtomicBool, Arc},
+};
+
+use nu_protocol::{ListStream, PipelineData, RawStream, ShellError, Span, Value};
+
+use crate::{
+    plugin::PluginEncoder,
+    protocol::{
+        CallInput, ExternalStreamInfo, PluginCustomValue, PluginData, PluginInput, PluginOutput,
+        RawStreamInfo,
+    },
+};
+
+mod stream_data_io;
+use stream_data_io::*;
+
+mod engine;
+pub use engine::EngineInterface;
+
+mod plugin;
+pub(crate) use plugin::{PluginExecutionContext, PluginExecutionNushellContext, PluginInterface};
+
+#[cfg(test)]
+mod test_util;
+
+/// Read [PluginInput] or [PluginOutput] from the stream.
+///
+/// This abstraction is really only used to make testing easier; in general this will usually be
+/// used on a pair of a [reader](std::io::BufRead) and an [encoder](PluginEncoder).
+trait PluginRead: Send {
+    /// Returns `Ok(None)` on end of stream.
+    fn read_input(&mut self) -> Result<Option<PluginInput>, ShellError>;
+
+    /// Returns `Ok(None)` on end of stream.
+    fn read_output(&mut self) -> Result<Option<PluginOutput>, ShellError>;
+}
+
+impl<R, E> PluginRead for (R, E)
+where
+    R: std::io::BufRead + Send,
+    E: PluginEncoder,
+{
+    fn read_input(&mut self) -> Result<Option<PluginInput>, ShellError> {
+        self.1.decode_input(&mut self.0)
+    }
+
+    fn read_output(&mut self) -> Result<Option<PluginOutput>, ShellError> {
+        self.1.decode_output(&mut self.0)
+    }
+}
+
+/// Write [PluginInput] or [PluginOutput] to the stream.
+///
+/// This abstraction is really only used to make testing easier; in general this will usually be
+/// used on a pair of a [writer](std:::io::Write) and an [encoder](PluginEncoder).
+trait PluginWrite: Send {
+    fn write_input(&mut self, input: &PluginInput) -> Result<(), ShellError>;
+    fn write_output(&mut self, output: &PluginOutput) -> Result<(), ShellError>;
+
+    /// Flush any internal buffers, if applicable.
+    fn flush(&mut self) -> Result<(), ShellError>;
+}
+
+impl<W, E> PluginWrite for (W, E)
+where
+    W: std::io::Write + Send,
+    E: PluginEncoder,
+{
+    fn write_input(&mut self, input: &PluginInput) -> Result<(), ShellError> {
+        self.1.encode_input(input, &mut self.0)
+    }
+
+    fn write_output(&mut self, output: &PluginOutput) -> Result<(), ShellError> {
+        self.1.encode_output(output, &mut self.0)
+    }
+
+    fn flush(&mut self) -> Result<(), ShellError> {
+        self.0.flush().map_err(|err| ShellError::IOError {
+            msg: err.to_string(),
+        })
+    }
+}
+
+/// Iterate through values received on a `ListStream` input.
+///
+/// Non-fused iterator: should generally call .fuse() when using it, to ensure messages aren't
+/// attempted to be read after end-of-input.
+struct PluginListStream {
+    io: Arc<dyn StreamDataIo>,
+}
+
+impl Iterator for PluginListStream {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Value> {
+        match self.io.read_list() {
+            Ok(value) => value,
+            Err(err) => Some(Value::error(err, Span::unknown())),
+        }
+    }
+}
+
+impl Drop for PluginListStream {
+    fn drop(&mut self) {
+        // Signal that we don't need the stream anymore.
+        self.io.drop_list();
+    }
+}
+
+/// Create [PipelineData] for receiving a [ListStream] input.
+fn make_list_stream(source: Arc<dyn StreamDataIo>, ctrlc: Option<Arc<AtomicBool>>) -> PipelineData {
+    PipelineData::ListStream(
+        ListStream::from_stream(PluginListStream { io: source }.fuse(), ctrlc),
+        None,
+    )
+}
+
+/// Write the contents of a [ListStream] to `io`.
+fn write_full_list_stream(
+    io: &Arc<dyn StreamDataIo>,
+    list_stream: ListStream,
+) -> Result<(), ShellError> {
+    // Consume the stream and write it via StreamDataIo.
+    for value in list_stream {
+        io.write_list(Some(match value {
+            Value::LazyRecord { val, .. } => val.collect()?,
+            _ => value,
+        }))?;
+    }
+    // End of stream
+    io.write_list(None)
+}
+
+/// Iterate through byte chunks received on the `stdout` stream of an `ListStream` input.
+///
+/// Non-fused iterator: should generally call .fuse() when using it, to ensure messages aren't
+/// attempted to be read after end-of-input.
+struct PluginExternalStdoutStream {
+    io: Arc<dyn StreamDataIo>,
+}
+
+impl Iterator for PluginExternalStdoutStream {
+    type Item = Result<Vec<u8>, ShellError>;
+
+    fn next(&mut self) -> Option<Result<Vec<u8>, ShellError>> {
+        self.io.read_external_stdout().transpose()
+    }
+}
+
+impl Drop for PluginExternalStdoutStream {
+    fn drop(&mut self) {
+        // Signal that we don't need the stream anymore.
+        self.io.drop_external_stdout();
+    }
+}
+
+/// Iterate through byte chunks received on the `stderr` stream of an `ListStream` input.
+///
+/// Non-fused iterator: should generally call .fuse() when using it, to ensure messages aren't
+/// attempted to be read after end-of-input.
+struct PluginExternalStderrStream {
+    io: Arc<dyn StreamDataIo>,
+}
+
+impl Iterator for PluginExternalStderrStream {
+    type Item = Result<Vec<u8>, ShellError>;
+
+    fn next(&mut self) -> Option<Result<Vec<u8>, ShellError>> {
+        self.io.read_external_stderr().transpose()
+    }
+}
+
+impl Drop for PluginExternalStderrStream {
+    fn drop(&mut self) {
+        // Signal that we don't need the stream anymore.
+        self.io.drop_external_stderr();
+    }
+}
+
+/// Iterate through values received on the `exit_code` stream of an `ListStream` input.
+///
+/// Non-fused iterator: should generally call .fuse() when using it, to ensure messages aren't
+/// attempted to be read after end-of-input.
+struct PluginExternalExitCodeStream {
+    io: Arc<dyn StreamDataIo>,
+}
+
+impl Iterator for PluginExternalExitCodeStream {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Value> {
+        match self.io.read_external_exit_code() {
+            Ok(value) => value,
+            Err(err) => Some(Value::error(err, Span::unknown())),
+        }
+    }
+}
+
+impl Drop for PluginExternalExitCodeStream {
+    fn drop(&mut self) {
+        // Signal that we don't need the stream anymore.
+        self.io.drop_external_exit_code();
+    }
+}
+
+/// Create [PipelineData] for receiving an [ExternalStream] input.
+fn make_external_stream(
+    source: Arc<dyn StreamDataIo>,
+    info: &ExternalStreamInfo,
+    ctrlc: Option<Arc<AtomicBool>>,
+) -> PipelineData {
+    PipelineData::ExternalStream {
+        stdout: info.stdout.as_ref().map(|stdout_info| {
+            let stream = PluginExternalStdoutStream { io: source.clone() }.fuse();
+            let mut raw = RawStream::new(
+                Box::new(stream),
+                ctrlc.clone(),
+                info.span,
+                stdout_info.known_size,
+            );
+            raw.is_binary = stdout_info.is_binary;
+            raw
+        }),
+        stderr: info.stderr.as_ref().map(|stderr_info| {
+            let stream = PluginExternalStderrStream { io: source.clone() }.fuse();
+            let mut raw = RawStream::new(
+                Box::new(stream),
+                ctrlc.clone(),
+                info.span,
+                stderr_info.known_size,
+            );
+            raw.is_binary = stderr_info.is_binary;
+            raw
+        }),
+        exit_code: info.has_exit_code.then(|| {
+            ListStream::from_stream(
+                PluginExternalExitCodeStream { io: source.clone() }.fuse(),
+                ctrlc.clone(),
+            )
+        }),
+        span: info.span,
+        metadata: None,
+        trim_end_newline: info.trim_end_newline,
+    }
+}
+
+/// Write the contents of a [PipelineData::ExternalStream] to `io`.
+fn write_full_external_stream(
+    io: &Arc<dyn StreamDataIo>,
+    stdout: Option<RawStream>,
+    stderr: Option<RawStream>,
+    exit_code: Option<ListStream>,
+) -> Result<(), ShellError> {
+    // Consume all streams simultaneously by launching three threads
+    for thread in [
+        stdout.map(|stdout| {
+            let io = io.clone();
+            std::thread::spawn(move || {
+                for bytes in stdout.stream {
+                    io.write_external_stdout(Some(bytes))?;
+                }
+                io.write_external_stdout(None)
+            })
+        }),
+        stderr.map(|stderr| {
+            let io = io.clone();
+            std::thread::spawn(move || {
+                for bytes in stderr.stream {
+                    io.write_external_stderr(Some(bytes))?;
+                }
+                io.write_external_stderr(None)
+            })
+        }),
+        exit_code.map(|exit_code| {
+            let io = io.clone();
+            std::thread::spawn(move || {
+                for value in exit_code {
+                    io.write_external_exit_code(Some(value))?;
+                }
+                io.write_external_exit_code(None)
+            })
+        }),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        thread.join().expect("stream consumer thread panicked")?;
+    }
+    Ok(())
+}
+
+/// Prepare [CallInput] for [PipelineData].
+///
+/// Handles converting [PluginCustomValue] to [CallInput::Data] if the `plugin_filename` is correct.
+///
+/// Does not actually send any stream data. You still need to call either [write_full_list_stream]
+/// or [write_full_external_stream] as appropriate.
+pub(crate) fn make_call_input_from_pipeline_data(
+    input: &PipelineData,
+    plugin_name: &str,
+    plugin_filename: &Path,
+) -> Result<CallInput, ShellError> {
+    match *input {
+        PipelineData::Value(ref value @ Value::CustomValue { ref val, .. }, _) => {
+            match val.as_any().downcast_ref::<PluginCustomValue>() {
+                Some(plugin_data) if plugin_data.filename == plugin_filename => {
+                    Ok(CallInput::Data(PluginData {
+                        data: plugin_data.data.clone(),
+                        span: value.span(),
+                    }))
+                }
+                _ => {
+                    let custom_value_name = val.value_string();
+                    Err(ShellError::GenericError {
+                        error: format!(
+                            "Plugin {} can not handle the custom value {}",
+                            plugin_name, custom_value_name
+                        ),
+                        msg: format!("custom value {custom_value_name}"),
+                        span: Some(value.span()),
+                        help: None,
+                        inner: vec![],
+                    })
+                }
+            }
+        }
+        PipelineData::Value(Value::LazyRecord { ref val, .. }, _) => {
+            Ok(CallInput::Value(val.collect()?))
+        }
+        PipelineData::Value(ref value, _) => Ok(CallInput::Value(value.clone())),
+        PipelineData::ListStream(_, _) => Ok(CallInput::ListStream),
+        PipelineData::ExternalStream {
+            span,
+            ref stdout,
+            ref stderr,
+            ref exit_code,
+            trim_end_newline,
+            ..
+        } => Ok(CallInput::ExternalStream(ExternalStreamInfo {
+            span,
+            stdout: stdout.as_ref().map(RawStreamInfo::from),
+            stderr: stderr.as_ref().map(RawStreamInfo::from),
+            has_exit_code: exit_code.is_some(),
+            trim_end_newline,
+        })),
+        PipelineData::Empty => Ok(CallInput::Empty),
+    }
+}

--- a/crates/nu-plugin/src/plugin/interface/engine.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine.rs
@@ -1,0 +1,266 @@
+//! Interface used by the plugin to communicate with the engine.
+
+use std::{
+    io::{BufRead, Write},
+    sync::{Arc, Mutex},
+};
+
+use nu_protocol::{CustomValue, PipelineData, ShellError, Value};
+
+use crate::{
+    plugin::PluginEncoder,
+    protocol::{
+        CallInfo, CallInput, ExternalStreamInfo, PluginCall, PluginCallResponse, PluginData,
+        PluginInput, PluginOutput, RawStreamInfo, StreamData,
+    },
+};
+
+use super::{
+    make_external_stream, make_list_stream,
+    stream_data_io::{impl_stream_data_io, StreamBuffer, StreamBuffers, StreamDataIo},
+    write_full_external_stream, write_full_list_stream, PluginRead, PluginWrite,
+};
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug)]
+pub(crate) struct EngineInterfaceImpl<R, W> {
+    // Always lock read and then write mutex, if using both
+    // Stream inputs that can't be handled immediately can be put on the buffer
+    read: Mutex<(R, StreamBuffers)>,
+    write: Mutex<W>,
+}
+
+impl<R, W> EngineInterfaceImpl<R, W> {
+    pub(crate) fn new(reader: R, writer: W) -> EngineInterfaceImpl<R, W> {
+        EngineInterfaceImpl {
+            read: Mutex::new((reader, StreamBuffers::default())),
+            write: Mutex::new(writer),
+        }
+    }
+}
+
+// Implement the stream handling methods (see StreamDataIo).
+impl_stream_data_io!(
+    EngineInterfaceImpl,
+    PluginInput(read_input),
+    PluginOutput(write_output)
+);
+
+/// The trait indirection is so that we can hide the types with a trait object inside
+/// EngineInterface. As such, this trait must remain object safe.
+pub(crate) trait EngineInterfaceIo: StreamDataIo {
+    fn read_call(&self) -> Result<Option<PluginCall>, ShellError>;
+    fn write_call_response(&self, response: PluginCallResponse) -> Result<(), ShellError>;
+}
+
+impl<R, W> EngineInterfaceIo for EngineInterfaceImpl<R, W>
+where
+    R: PluginRead,
+    W: PluginWrite,
+{
+    fn read_call(&self) -> Result<Option<PluginCall>, ShellError> {
+        let mut read = self.read.lock().expect("read mutex poisoned");
+        loop {
+            let input = read.0.read_input()?;
+            match input {
+                Some(PluginInput::Call(call)) => {
+                    // Check the call input type to set the stream buffers up
+                    match &call {
+                        PluginCall::Run(CallInfo {
+                            input: CallInput::ListStream,
+                            ..
+                        }) => {
+                            read.1 = StreamBuffers::new_list();
+                        }
+                        PluginCall::Run(CallInfo {
+                            input:
+                                CallInput::ExternalStream(ExternalStreamInfo {
+                                    stdout,
+                                    stderr,
+                                    has_exit_code,
+                                    ..
+                                }),
+                            ..
+                        }) => {
+                            read.1 = StreamBuffers::new_external(
+                                stdout.is_some(),
+                                stderr.is_some(),
+                                *has_exit_code,
+                            );
+                        }
+                        _ => {
+                            read.1 = StreamBuffers::default(); // no buffers
+                        }
+                    }
+                    return Ok(Some(call));
+                }
+                // Skip over any remaining stream data for dropped streams
+                Some(PluginInput::StreamData(StreamData::List(_))) if read.1.list.is_dropped() => {
+                    continue
+                }
+                Some(PluginInput::StreamData(StreamData::ExternalStdout(_)))
+                    if read.1.external_stdout.is_dropped() =>
+                {
+                    continue
+                }
+                Some(PluginInput::StreamData(StreamData::ExternalStderr(_)))
+                    if read.1.external_stderr.is_dropped() =>
+                {
+                    continue
+                }
+                Some(PluginInput::StreamData(StreamData::ExternalExitCode(_)))
+                    if read.1.external_exit_code.is_dropped() =>
+                {
+                    continue
+                }
+                // Other stream data is an error
+                Some(PluginInput::StreamData(_)) => {
+                    return Err(ShellError::PluginFailedToDecode {
+                        msg: "expected Call, got unexpected StreamData".into(),
+                    })
+                }
+                // End of input
+                None => return Ok(None),
+            }
+        }
+    }
+
+    fn write_call_response(&self, response: PluginCallResponse) -> Result<(), ShellError> {
+        let mut write = self.write.lock().expect("write mutex poisoned");
+
+        write.write_output(&PluginOutput::CallResponse(response))?;
+        write.flush()
+    }
+}
+
+/// A reference through which the nushell engine can be interacted with during execution.
+#[derive(Clone)]
+pub struct EngineInterface {
+    io: Arc<dyn EngineInterfaceIo>,
+    // FIXME: This is only necessary because trait upcasting is not yet supported, so we have to
+    // generate this variant of the Arc while we know the actual type. It can be removed once
+    // https://github.com/rust-lang/rust/issues/65991 is closed and released.
+    io_stream: Arc<dyn StreamDataIo>,
+}
+
+impl<R, W> From<EngineInterfaceImpl<R, W>> for EngineInterface
+where
+    R: PluginRead + 'static,
+    W: PluginWrite + 'static,
+{
+    fn from(engine_impl: EngineInterfaceImpl<R, W>) -> Self {
+        let arc = Arc::new(engine_impl);
+        EngineInterface {
+            io: arc.clone(),
+            io_stream: arc,
+        }
+    }
+}
+
+impl EngineInterface {
+    /// Create the engine interface from the given reader, writer, and encoder.
+    pub(crate) fn new<R, W, E>(reader: R, writer: W, encoder: E) -> EngineInterface
+    where
+        R: BufRead + Send + 'static,
+        W: Write + Send + 'static,
+        E: PluginEncoder + 'static,
+    {
+        EngineInterfaceImpl::new((reader, encoder.clone()), (writer, encoder)).into()
+    }
+
+    /// Read a plugin call from the engine
+    pub(crate) fn read_call(&self) -> Result<Option<PluginCall>, ShellError> {
+        self.io.read_call()
+    }
+
+    /// Create [PipelineData] appropriate for the given [CallInput].
+    pub(crate) fn make_pipeline_data(
+        &self,
+        call_input: CallInput,
+    ) -> Result<PipelineData, ShellError> {
+        match call_input {
+            CallInput::Empty => Ok(PipelineData::Empty),
+            CallInput::Value(value) => Ok(PipelineData::Value(value, None)),
+            CallInput::Data(plugin_data) => {
+                // Deserialize custom value
+                bincode::deserialize::<Box<dyn CustomValue>>(&plugin_data.data)
+                    .map(|custom_value| {
+                        let value = Value::custom_value(custom_value, plugin_data.span);
+                        PipelineData::Value(value, None)
+                    })
+                    .map_err(|err| ShellError::PluginFailedToDecode {
+                        msg: err.to_string(),
+                    })
+            }
+            CallInput::ListStream => Ok(make_list_stream(self.io_stream.clone(), None)),
+            CallInput::ExternalStream(info) => {
+                Ok(make_external_stream(self.io_stream.clone(), &info, None))
+            }
+        }
+    }
+
+    /// Write a plugin call response back to the engine
+    pub(crate) fn write_call_response(
+        &self,
+        response: PluginCallResponse,
+    ) -> Result<(), ShellError> {
+        self.io.write_call_response(response)
+    }
+
+    /// Write a response appropriate for the given [PipelineData] and consume the stream(s) to
+    /// completion, if any.
+    pub(crate) fn write_pipeline_data_response(
+        &self,
+        data: PipelineData,
+    ) -> Result<(), ShellError> {
+        match data {
+            PipelineData::Value(value, _) => {
+                let span = value.span();
+                let response = match value {
+                    // Serialize custom values as PluginData
+                    Value::CustomValue { val, .. } => match bincode::serialize(&val) {
+                        Ok(data) => {
+                            let name = val.value_string();
+                            PluginCallResponse::PluginData(name, PluginData { data, span })
+                        }
+                        Err(err) => {
+                            return Err(ShellError::PluginFailedToEncode {
+                                msg: err.to_string(),
+                            })
+                        }
+                    },
+                    // Other values can be serialized as-is
+                    value => PluginCallResponse::Value(Box::new(value)),
+                };
+                // Simple response, no stream.
+                self.write_call_response(response)
+            }
+            PipelineData::ListStream(stream, _) => {
+                self.write_call_response(PluginCallResponse::ListStream)?;
+                write_full_list_stream(&self.io_stream, stream)
+            }
+            PipelineData::ExternalStream {
+                stdout,
+                stderr,
+                exit_code,
+                span,
+                trim_end_newline,
+                ..
+            } => {
+                // Gather info from the stream
+                let info = ExternalStreamInfo {
+                    span,
+                    stdout: stdout.as_ref().map(RawStreamInfo::from),
+                    stderr: stderr.as_ref().map(RawStreamInfo::from),
+                    has_exit_code: exit_code.is_some(),
+                    trim_end_newline,
+                };
+                self.write_call_response(PluginCallResponse::ExternalStream(info))?;
+                write_full_external_stream(&self.io_stream, stdout, stderr, exit_code)
+            }
+            PipelineData::Empty => self.write_call_response(PluginCallResponse::Empty),
+        }
+    }
+}

--- a/crates/nu-plugin/src/plugin/interface/engine/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine/tests.rs
@@ -1,0 +1,1019 @@
+use nu_protocol::{CustomValue, ListStream, PipelineData, RawStream, ShellError, Span, Value};
+use serde::{Deserialize, Serialize};
+
+use crate::plugin::interface::engine::EngineInterfaceIo;
+use crate::plugin::interface::stream_data_io::{
+    gen_stream_data_tests, StreamBuffer, StreamBuffers, StreamDataIo,
+};
+use crate::plugin::interface::test_util::TestCase;
+use crate::protocol::{
+    CallInfo, CallInput, EvaluatedCall, ExternalStreamInfo, PluginCall, PluginData, PluginInput,
+    PluginOutput, RawStreamInfo,
+};
+use crate::{PluginCallResponse, StreamData};
+
+use super::EngineInterface;
+
+gen_stream_data_tests!(
+    PluginInput(add_input),
+    PluginOutput(next_written_output),
+    |test| test.engine_interface_impl()
+);
+
+#[test]
+fn read_call_signature() {
+    let test = TestCase::new();
+    test.add_input(PluginInput::Call(PluginCall::Signature));
+
+    match test.engine_interface().read_call().unwrap() {
+        Some(PluginCall::Signature) => (),
+        Some(other) => panic!("read unexpected call: {:?}", other),
+        None => panic!("end of input"),
+    }
+}
+
+#[test]
+fn read_call_run() {
+    let test = TestCase::new();
+    let call_info = CallInfo {
+        name: "test call".into(),
+        call: EvaluatedCall {
+            head: Span::test_data(),
+            positional: vec![],
+            named: vec![],
+        },
+        input: CallInput::Empty,
+        config: None,
+    };
+    test.add_input(PluginInput::Call(PluginCall::Run(call_info.clone())));
+
+    match test.engine_interface().read_call().unwrap() {
+        Some(PluginCall::Run(read_call_info)) => {
+            assert_eq!(call_info.name, read_call_info.name);
+            assert_eq!(call_info.call.head, read_call_info.call.head);
+            assert_eq!(call_info.call.positional, read_call_info.call.positional);
+            assert_eq!(call_info.call.named, read_call_info.call.named);
+            assert_eq!(call_info.input, read_call_info.input);
+            assert_eq!(call_info.config, read_call_info.config);
+        }
+        Some(other) => panic!("read unexpected call: {:?}", other),
+        None => panic!("end of input"),
+    }
+}
+
+#[test]
+fn read_call_collapse_custom_value() {
+    let test = TestCase::new();
+    let data = PluginData {
+        data: vec![42, 13, 37],
+        span: Span::test_data(),
+    };
+    test.add_input(PluginInput::Call(PluginCall::CollapseCustomValue(
+        data.clone(),
+    )));
+
+    match test.engine_interface().read_call().unwrap() {
+        Some(PluginCall::CollapseCustomValue(read_data)) => assert_eq!(data, read_data),
+        Some(other) => panic!("read unexpected call: {:?}", other),
+        None => panic!("end of input"),
+    }
+}
+
+#[test]
+fn read_call_unexpected_stream_data() {
+    let test = TestCase::new();
+    test.add_input(PluginInput::StreamData(StreamData::List(None)));
+    test.add_input(PluginInput::Call(PluginCall::Signature));
+
+    test.engine_interface()
+        .read_call()
+        .expect_err("should be an error");
+}
+
+#[test]
+fn read_call_ignore_dropped_stream_data() {
+    let test = TestCase::new();
+    test.add_input(PluginInput::StreamData(StreamData::List(None)));
+    test.add_input(PluginInput::Call(PluginCall::Signature));
+
+    let interface = test.engine_interface_impl();
+    interface.read.lock().unwrap().1.list = StreamBuffer::Dropped;
+    interface.read_call().expect("should succeed");
+}
+
+fn test_call_with_input(input: CallInput) -> CallInfo {
+    CallInfo {
+        name: "test call".into(),
+        call: EvaluatedCall {
+            head: Span::test_data(),
+            positional: vec![],
+            named: vec![],
+        },
+        input,
+        config: None,
+    }
+}
+
+fn dbg<T>(val: T) -> String
+where
+    T: std::fmt::Debug,
+{
+    format!("{:?}", val)
+}
+
+fn validate_stream_data_acceptance(input: CallInput, accepts: [bool; 4]) {
+    let test = TestCase::new();
+    let call_info = test_call_with_input(input);
+    test.add_input(PluginInput::Call(PluginCall::Run(call_info)));
+
+    let interface = test.engine_interface_impl();
+
+    interface.read_call().expect("call failed");
+
+    let data_types = [
+        StreamData::List(Some(Value::test_bool(true))),
+        StreamData::ExternalStdout(Some(Ok(vec![]))),
+        StreamData::ExternalStderr(Some(Ok(vec![]))),
+        StreamData::ExternalExitCode(Some(Value::test_int(1))),
+    ];
+
+    for (data, accept) in data_types.iter().zip(accepts) {
+        test.clear_input();
+        test.add_input(PluginInput::StreamData(data.clone()));
+        let result = match data {
+            StreamData::List(_) => interface.read_list().map(dbg),
+            StreamData::ExternalStdout(_) => interface.read_external_stdout().map(dbg),
+            StreamData::ExternalStderr(_) => interface.read_external_stderr().map(dbg),
+            StreamData::ExternalExitCode(_) => interface.read_external_exit_code().map(dbg),
+        };
+        match result {
+            Ok(success) if !accept => {
+                panic!("{data:?} was successfully consumed, but shouldn't have been: {success}")
+            }
+            Err(err) if accept => {
+                panic!("{data:?} was rejected, but should have been accepted: {err}")
+            }
+            _ => (),
+        }
+    }
+}
+
+#[test]
+fn read_call_run_with_empty_input_doesnt_accept_stream_data() {
+    validate_stream_data_acceptance(CallInput::Empty, [false; 4])
+}
+
+#[test]
+fn read_call_run_with_value_input_doesnt_accept_stream_data() {
+    validate_stream_data_acceptance(CallInput::Value(Value::test_int(4)), [false; 4])
+}
+
+#[test]
+fn read_call_run_with_list_stream_input_accepts_only_list_stream_data() {
+    validate_stream_data_acceptance(
+        CallInput::ListStream,
+        [
+            true, // list stream
+            false, false, false,
+        ],
+    )
+}
+
+#[test]
+fn read_call_run_with_external_stream_stdout_input_accepts_only_external_stream_stdout_data() {
+    let call_input = CallInput::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        stderr: None,
+        has_exit_code: false,
+        trim_end_newline: false,
+    });
+
+    validate_stream_data_acceptance(
+        call_input,
+        [
+            false, true, // external stdout
+            false, false,
+        ],
+    )
+}
+
+#[test]
+fn read_call_run_with_external_stream_stderr_input_accepts_only_external_stream_stderr_data() {
+    let call_input = CallInput::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: None,
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: false,
+        trim_end_newline: false,
+    });
+
+    validate_stream_data_acceptance(
+        call_input,
+        [
+            false, false, true, // external stderr
+            false,
+        ],
+    )
+}
+
+#[test]
+fn read_call_run_with_external_stream_exit_code_input_accepts_only_external_stream_exit_code_data()
+{
+    let call_input = CallInput::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: None,
+        stderr: None,
+        has_exit_code: true,
+        trim_end_newline: false,
+    });
+
+    validate_stream_data_acceptance(
+        call_input,
+        [
+            false, false, false, true, // external exit code
+        ],
+    )
+}
+
+#[test]
+fn read_call_run_with_external_stream_all_input_accepts_only_all_external_stream_data() {
+    let call_input = CallInput::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: true,
+        trim_end_newline: false,
+    });
+
+    validate_stream_data_acceptance(
+        call_input,
+        [
+            false, true, // external stdout
+            true, // external stderr
+            true, // external exit code
+        ],
+    )
+}
+
+#[test]
+fn read_call_end_of_input() {
+    let test = TestCase::new();
+    if let Some(call) = test.engine_interface().read_call().expect("should succeed") {
+        panic!("should have been end of input, but read {call:?}");
+    }
+}
+
+#[test]
+fn read_call_io_error() {
+    let test = TestCase::new();
+    test.set_read_error(ShellError::IOError {
+        msg: "test error".into(),
+    });
+
+    match test
+        .engine_interface()
+        .read_call()
+        .expect_err("should be an error")
+    {
+        ShellError::IOError { msg } if msg == "test error" => (),
+        other => panic!("got some other error: {other}"),
+    }
+}
+
+#[test]
+fn write_call_response() {
+    let test = TestCase::new();
+    let response = PluginCallResponse::Empty;
+    test.engine_interface()
+        .write_call_response(response.clone())
+        .expect("should succeed");
+    match test.next_written_output() {
+        Some(PluginOutput::CallResponse(PluginCallResponse::Empty)) => (),
+        Some(other) => panic!("wrote the wrong message: {other:?}"),
+        None => panic!("didn't write anything"),
+    }
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn write_call_response_error() {
+    let test = TestCase::new();
+    test.set_write_error(ShellError::IOError {
+        msg: "test error".into(),
+    });
+
+    let response = PluginCallResponse::Empty;
+    match test
+        .engine_interface()
+        .write_call_response(response)
+        .expect_err("should be an error")
+    {
+        ShellError::IOError { msg } if msg == "test error" => (),
+        other => panic!("got some other error: {other}"),
+    }
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn make_pipeline_data_empty() {
+    let test = TestCase::new();
+
+    let pipe = test
+        .engine_interface()
+        .make_pipeline_data(CallInput::Empty)
+        .expect("can't make pipeline data");
+
+    match pipe {
+        PipelineData::Empty => (),
+        PipelineData::Value(_, _) => panic!("got value, expected empty"),
+        PipelineData::ListStream(_, _) => panic!("got list stream"),
+        PipelineData::ExternalStream { .. } => panic!("got external stream"),
+    }
+}
+
+#[test]
+fn make_pipeline_data_value() {
+    let test = TestCase::new();
+
+    let value = Value::test_int(2);
+    let pipe = test
+        .engine_interface()
+        .make_pipeline_data(CallInput::Value(value.clone()))
+        .expect("can't make pipeline data");
+
+    match pipe {
+        PipelineData::Empty => panic!("got empty, expected value"),
+        PipelineData::Value(v, _) => assert_eq!(value, v),
+        PipelineData::ListStream(_, _) => panic!("got list stream"),
+        PipelineData::ExternalStream { .. } => panic!("got external stream"),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct MyCustom(i32);
+
+#[typetag::serde]
+impl CustomValue for MyCustom {
+    fn clone_value(&self, span: Span) -> Value {
+        Value::custom_value(Box::new(self.clone()), span)
+    }
+
+    fn value_string(&self) -> String {
+        self.0.to_string()
+    }
+
+    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+        Ok(Value::int(self.0 as i64, span))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+#[test]
+fn make_pipeline_data_custom_data() {
+    let test = TestCase::new();
+
+    let custom: Box<dyn CustomValue> = Box::new(MyCustom(42));
+    let bincoded = bincode::serialize(&custom).expect("serialization failed");
+
+    let data = PluginData {
+        data: bincoded,
+        span: Span::test_data(),
+    };
+    let call_input = CallInput::Data(data);
+
+    let pipe = test
+        .engine_interface()
+        .make_pipeline_data(call_input)
+        .expect("failed to make pipeline data");
+
+    match pipe {
+        PipelineData::Empty => panic!("got empty, expected value"),
+        PipelineData::Value(v, _) => {
+            let read_custom = v.as_custom_value().expect("not a custom value");
+            let read_downcast: &MyCustom = read_custom.as_any().downcast_ref().expect("wrong type");
+            assert_eq!(&MyCustom(42), read_downcast);
+        }
+        PipelineData::ListStream(_, _) => panic!("got list stream"),
+        PipelineData::ExternalStream { .. } => panic!("got external stream"),
+    }
+}
+
+#[test]
+fn make_pipeline_data_list_stream() {
+    let test = TestCase::new();
+
+    let values = [Value::test_int(4), Value::test_string("hello")];
+
+    for value in &values {
+        test.add_input(PluginInput::StreamData(StreamData::List(Some(
+            value.clone(),
+        ))));
+    }
+    // end
+    test.add_input(PluginInput::StreamData(StreamData::List(None)));
+
+    let call_input = CallInput::ListStream;
+
+    let interface = EngineInterface::from({
+        let interface = test.engine_interface_impl();
+        interface.read.lock().unwrap().1 = StreamBuffers::new_list();
+        interface
+    });
+
+    let pipe = interface
+        .make_pipeline_data(call_input)
+        .expect("failed to make pipeline data");
+
+    assert!(matches!(pipe, PipelineData::ListStream(..)));
+
+    for (defined_value, read_value) in values.into_iter().zip(pipe.into_iter()) {
+        assert_eq!(defined_value, read_value);
+    }
+}
+
+#[test]
+fn make_pipeline_data_external_stream() {
+    let test = TestCase::new();
+
+    // Test many simultaneous streams out of order
+    let stream_data = [
+        StreamData::ExternalStdout(Some(Ok(b"foo".to_vec()))),
+        StreamData::ExternalStderr(Some(Ok(b"bar".to_vec()))),
+        StreamData::ExternalExitCode(Some(Value::test_int(1))),
+        StreamData::ExternalStderr(Some(Ok(b"barr".to_vec()))),
+        StreamData::ExternalStderr(None),
+        StreamData::ExternalStdout(Some(Ok(b"fooo".to_vec()))),
+        StreamData::ExternalStdout(None),
+        StreamData::ExternalExitCode(None),
+    ];
+
+    for data in stream_data {
+        test.add_input(PluginInput::StreamData(data));
+    }
+
+    let call_input = CallInput::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: true,
+            known_size: Some(7),
+        }),
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: true,
+        trim_end_newline: false,
+    });
+
+    let interface = EngineInterface::from({
+        let interface = test.engine_interface_impl();
+        interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+        interface
+    });
+
+    let pipe = interface
+        .make_pipeline_data(call_input)
+        .expect("failed to make pipeline data");
+
+    match pipe {
+        PipelineData::ExternalStream {
+            stdout,
+            stderr,
+            exit_code,
+            span,
+            trim_end_newline,
+            ..
+        } => {
+            assert!(stdout.is_some());
+            assert!(stderr.is_some());
+            assert!(exit_code.is_some());
+            assert_eq!(Span::test_data(), span, "span");
+            assert!(!trim_end_newline);
+
+            if let Some(rs) = stdout.as_ref() {
+                assert!(rs.is_binary, "stdout.is_binary=false");
+                assert_eq!(Some(7), rs.known_size, "stdout.known_size");
+            }
+            if let Some(rs) = stderr.as_ref() {
+                assert!(!rs.is_binary, "stderr.is_binary=false");
+                assert_eq!(None, rs.known_size, "stderr.known_size");
+            }
+
+            let out_bytes = stdout.unwrap().into_bytes().expect("failed to read stdout");
+            let err_bytes = stderr.unwrap().into_bytes().expect("failed to read stderr");
+            let exit_code_vals: Vec<_> = exit_code.unwrap().collect();
+
+            assert_eq!(b"foofooo", &out_bytes.item[..]);
+            assert_eq!(b"barbarr", &err_bytes.item[..]);
+            assert_eq!(vec![Value::test_int(1)], exit_code_vals);
+        }
+        PipelineData::Empty => panic!("expected external stream, got empty"),
+        PipelineData::Value(..) => panic!("expected external stream, got value"),
+        PipelineData::ListStream(..) => panic!("expected external stream, got list stream"),
+    }
+}
+
+#[test]
+fn make_pipeline_data_external_stream_error() {
+    let test = TestCase::new();
+
+    // Just test stdout, but with an error
+    let spec_msg = "failure";
+    let stream_data = [
+        StreamData::ExternalExitCode(Some(Value::int(1, Span::test_data()))),
+        StreamData::ExternalStdout(Some(Err(ShellError::NushellFailed {
+            msg: spec_msg.into(),
+        }))),
+        StreamData::ExternalStdout(None),
+    ];
+
+    for data in stream_data {
+        test.add_input(PluginInput::StreamData(data));
+    }
+
+    // Still enable the other streams, to ensure ignoring the other data works
+    let call_input = CallInput::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: true,
+        trim_end_newline: false,
+    });
+
+    let interface = EngineInterface::from({
+        let interface = test.engine_interface_impl();
+        interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+        interface
+    });
+
+    let pipe = interface
+        .make_pipeline_data(call_input)
+        .expect("failed to make pipeline data");
+
+    match pipe {
+        PipelineData::ExternalStream {
+            stdout,
+            stderr,
+            exit_code,
+            ..
+        } => {
+            assert!(stdout.is_some());
+            assert!(stderr.is_some());
+            assert!(exit_code.is_some());
+
+            match stdout
+                .unwrap()
+                .into_bytes()
+                .expect_err("stdout read successfully")
+            {
+                ShellError::NushellFailed { msg } => assert_eq!(spec_msg, msg),
+                other => panic!("unexpected other error while reading stdout: {other}"),
+            }
+        }
+        PipelineData::Empty => panic!("expected external stream, got empty"),
+        PipelineData::Value(..) => panic!("expected external stream, got value"),
+        PipelineData::ListStream(..) => panic!("expected external stream, got list stream"),
+    }
+}
+
+#[test]
+fn write_pipeline_data_response_empty() {
+    let test = TestCase::new();
+    test.engine_interface()
+        .write_pipeline_data_response(PipelineData::Empty)
+        .expect("failed to write empty response");
+
+    match test.next_written_output() {
+        Some(output) => match output {
+            PluginOutput::CallResponse(PluginCallResponse::Empty) => (),
+            PluginOutput::CallResponse(other) => panic!("unexpected response: {other:?}"),
+            other => panic!("unexpected output: {other:?}"),
+        },
+        None => panic!("no response written"),
+    }
+
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn write_pipeline_data_response_value() {
+    let test = TestCase::new();
+    let value = Value::test_string("hello");
+    let data = PipelineData::Value(value.clone(), None);
+    test.engine_interface()
+        .write_pipeline_data_response(data)
+        .expect("failed to write value response");
+
+    match test.next_written_output() {
+        Some(output) => match output {
+            PluginOutput::CallResponse(PluginCallResponse::Value(v)) => assert_eq!(value, *v),
+            PluginOutput::CallResponse(other) => panic!("unexpected response: {other:?}"),
+            other => panic!("unexpected output: {other:?}"),
+        },
+        None => panic!("no response written"),
+    }
+
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn write_pipeline_data_response_list_stream() {
+    let test = TestCase::new();
+
+    let values = vec![
+        Value::test_int(4),
+        Value::test_bool(false),
+        Value::test_string("foobar"),
+    ];
+
+    let list_stream = ListStream::from_stream(values.clone().into_iter(), None);
+    let data = PipelineData::ListStream(list_stream, None);
+    test.engine_interface()
+        .write_pipeline_data_response(data)
+        .expect("failed to write list stream response");
+
+    // Response starts by signaling a ListStream return value:
+    match test.next_written_output() {
+        Some(PluginOutput::CallResponse(PluginCallResponse::ListStream)) => (),
+        Some(other) => panic!("unexpected response: {other:?}"),
+        None => panic!("response not written"),
+    }
+
+    // Followed by each stream value...
+    for (expected_value, output) in values.into_iter().zip(test.written_outputs()) {
+        match output {
+            PluginOutput::StreamData(StreamData::List(Some(read_value))) => {
+                assert_eq!(expected_value, read_value)
+            }
+            PluginOutput::StreamData(StreamData::List(None)) => {
+                panic!("unexpected early end of stream")
+            }
+            other => panic!("unexpected other output: {other:?}"),
+        }
+    }
+
+    // Followed by List(None) to end the stream
+    match test.next_written_output() {
+        Some(PluginOutput::StreamData(StreamData::List(None))) => (),
+        Some(other) => panic!("expected list end, unexpected output: {other:?}"),
+        None => panic!("missing list stream end signal"),
+    }
+
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn write_pipeline_data_response_external_stream_stdout_only() {
+    let test = TestCase::new();
+
+    let stdout_chunks = vec![b"nushel".to_vec(), b"l rock".to_vec(), b"s!\n".to_vec()];
+
+    let stdout_raw_stream = RawStream::new(
+        Box::new(stdout_chunks.clone().into_iter().map(Ok)),
+        None,
+        Span::test_data(),
+        None,
+    );
+
+    let span = Span::new(1000, 1050);
+
+    let data = PipelineData::ExternalStream {
+        stdout: Some(stdout_raw_stream),
+        stderr: None,
+        exit_code: None,
+        span,
+        metadata: None,
+        trim_end_newline: false,
+    };
+
+    test.engine_interface()
+        .write_pipeline_data_response(data)
+        .expect("failed to write external stream pipeline data");
+
+    // First, there should be a header telling us metadata about the external stream
+    match test.next_written_output() {
+        Some(PluginOutput::CallResponse(PluginCallResponse::ExternalStream(info))) => {
+            assert_eq!(span, info.span, "info.span");
+            match info.stdout {
+                Some(RawStreamInfo {
+                    is_binary,
+                    known_size,
+                }) => {
+                    let _ = is_binary; // undefined, could be anything
+                    assert_eq!(None, known_size);
+                }
+                None => todo!(),
+            }
+            assert!(info.stderr.is_none(), "info.stderr: {:?}", info.stderr);
+            assert!(!info.has_exit_code, "info.has_exit_code=true");
+            assert!(!info.trim_end_newline, "info.trim_end_newline=true");
+        }
+        Some(other) => panic!("unexpected response written: {other:?}"),
+        None => panic!("no response written"),
+    }
+
+    // Then, just check the outputs. They should be in exactly the same order with nothing extra
+    for expected_chunk in stdout_chunks {
+        match test.next_written_output() {
+            Some(PluginOutput::StreamData(StreamData::ExternalStdout(option))) => {
+                let read_chunk = option
+                    .transpose()
+                    .expect("error in stdout stream")
+                    .expect("early EOF signal in stdout stream");
+                assert_eq!(expected_chunk, read_chunk);
+            }
+            Some(other) => panic!("unexpected output: {other:?}"),
+            None => panic!("unexpected end of output"),
+        }
+    }
+
+    // And there should be an end of stream signal (`Ok(None)`)
+    match test.next_written_output() {
+        Some(PluginOutput::StreamData(StreamData::ExternalStdout(option))) => match option {
+            Some(Ok(data)) => panic!("unexpected extra data on stdout stream: {data:?}"),
+            Some(Err(err)) => panic!("unexpected error at end of stdout stream: {err}"),
+            None => (),
+        },
+        Some(other) => panic!("unexpected output: {other:?}"),
+        None => panic!("unexpected end of output"),
+    }
+
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn write_pipeline_data_response_external_stream_stdout_err() {
+    let test = TestCase::new();
+
+    let spec_msg = "something bad";
+    let spec_val_span = Span::new(1090, 1100);
+    let spec_call_span = Span::new(1000, 1030);
+
+    let error = ShellError::IncorrectValue {
+        msg: spec_msg.into(),
+        val_span: spec_val_span,
+        call_span: spec_call_span,
+    };
+
+    let stdout_raw_stream = RawStream::new(
+        Box::new(std::iter::once(Err(error))),
+        None,
+        Span::test_data(),
+        None,
+    );
+
+    let data = PipelineData::ExternalStream {
+        stdout: Some(stdout_raw_stream),
+        stderr: None,
+        exit_code: None,
+        span: Span::test_data(),
+        metadata: None,
+        trim_end_newline: false,
+    };
+
+    test.engine_interface()
+        .write_pipeline_data_response(data)
+        .expect("failed to write external stream pipeline data");
+
+    // Check response header
+    match test.next_written_output() {
+        Some(PluginOutput::CallResponse(PluginCallResponse::ExternalStream(info))) => {
+            assert!(info.stdout.is_some(), "info.stdout is not present");
+            assert!(info.stderr.is_none(), "info.stderr: {:?}", info.stderr);
+            assert!(!info.has_exit_code, "info.has_exit_code=true");
+        }
+        Some(other) => panic!("unexpected response written: {other:?}"),
+        None => panic!("no response written"),
+    }
+
+    // Check error
+    match test.next_written_output() {
+        Some(PluginOutput::StreamData(StreamData::ExternalStdout(Some(result)))) => match result {
+            Ok(value) => panic!("unexpected value in stream: {value:?}"),
+            Err(ShellError::IncorrectValue {
+                msg,
+                val_span,
+                call_span,
+            }) => {
+                assert_eq!(spec_msg, msg, "msg");
+                assert_eq!(spec_val_span, val_span, "val_span");
+                assert_eq!(spec_call_span, call_span, "call_span");
+            }
+            Err(err) => panic!("unexpected other error on stream: {err}"),
+        },
+        Some(other) => panic!("unexpected output: {other:?}"),
+        None => panic!("didn't write the exit code"),
+    }
+
+    // Check end of stream
+    match test.next_written_output() {
+        Some(PluginOutput::StreamData(StreamData::ExternalStdout(None))) => (),
+        Some(other) => panic!("unexpected output: {other:?}"),
+        None => panic!("didn't write the exit code end of stream signal"),
+    }
+
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn write_pipeline_data_response_external_stream_exit_code_only() {
+    let test = TestCase::new();
+
+    let exit_code_stream = ListStream::from_stream(std::iter::once(Value::test_int(0)), None);
+
+    let data = PipelineData::ExternalStream {
+        stdout: None,
+        stderr: None,
+        exit_code: Some(exit_code_stream),
+        span: Span::test_data(),
+        metadata: None,
+        trim_end_newline: false,
+    };
+
+    test.engine_interface()
+        .write_pipeline_data_response(data)
+        .expect("failed to write external stream pipeline data");
+
+    // Check response header
+    match test.next_written_output() {
+        Some(PluginOutput::CallResponse(PluginCallResponse::ExternalStream(info))) => {
+            // just check what matters here, the other tests cover other bits
+            assert!(info.stdout.is_none(), "info.stdout: {:?}", info.stdout);
+            assert!(info.stderr.is_none(), "info.stderr: {:?}", info.stderr);
+            assert!(info.has_exit_code);
+        }
+        Some(other) => panic!("unexpected response: {other:?}"),
+        None => panic!("didn't write any response"),
+    }
+
+    // Check exit code value
+    match test.next_written_output() {
+        Some(PluginOutput::StreamData(StreamData::ExternalExitCode(Some(value)))) => {
+            assert_eq!(Value::test_int(0), value);
+        }
+        Some(other) => panic!("unexpected output: {other:?}"),
+        None => panic!("didn't write the exit code"),
+    }
+
+    // Check end of stream
+    match test.next_written_output() {
+        Some(PluginOutput::StreamData(StreamData::ExternalExitCode(None))) => (),
+        Some(other) => panic!("unexpected output: {other:?}"),
+        None => panic!("didn't write the exit code end of stream signal"),
+    }
+
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn write_pipeline_data_response_external_stream_full() {
+    let test = TestCase::new();
+
+    // Consume three streams simultaneously. Can't predict which order the output will really be
+    // in, though
+    let stdout_chunks = vec![
+        b"hel".to_vec(),
+        b"lo ".to_vec(),
+        b"wor".to_vec(),
+        b"ld".to_vec(),
+    ];
+
+    let stderr_chunks = vec![b"standard ".to_vec(), b"error\n".to_vec()];
+
+    let exit_code_values = vec![
+        // There probably wouldn't be more than one exit code normally, but try just in case...
+        Value::test_int(0),
+        Value::test_int(1),
+        Value::test_int(2),
+    ];
+
+    let stdout_len = stdout_chunks.iter().map(|c| c.len()).sum::<usize>() as u64;
+
+    let stdout_raw_stream = RawStream::new(
+        Box::new(stdout_chunks.clone().into_iter().map(Ok)),
+        None,
+        Span::test_data(),
+        Some(stdout_len),
+    );
+    let stderr_raw_stream = RawStream::new(
+        Box::new(stderr_chunks.clone().into_iter().map(Ok)),
+        None,
+        Span::test_data(),
+        None,
+    );
+    let exit_code_stream = ListStream::from_stream(exit_code_values.clone().into_iter(), None);
+
+    let data = PipelineData::ExternalStream {
+        stdout: Some(stdout_raw_stream),
+        stderr: Some(stderr_raw_stream),
+        exit_code: Some(exit_code_stream),
+        span: Span::test_data(),
+        metadata: None,
+        trim_end_newline: true,
+    };
+
+    test.engine_interface()
+        .write_pipeline_data_response(data)
+        .expect("failed to write external stream pipeline data");
+
+    // First, there should be a header telling us metadata about the external stream
+    match test.next_written_output() {
+        Some(PluginOutput::CallResponse(PluginCallResponse::ExternalStream(info))) => {
+            assert_eq!(Span::test_data(), info.span, "info.span");
+            match info.stdout {
+                Some(RawStreamInfo {
+                    is_binary,
+                    known_size,
+                }) => {
+                    let _ = is_binary; // undefined, could be anything
+                    assert_eq!(Some(stdout_len), known_size);
+                }
+                None => todo!(),
+            }
+            match info.stderr {
+                Some(RawStreamInfo {
+                    is_binary,
+                    known_size,
+                }) => {
+                    let _ = is_binary; // undefined, could be anything
+                    assert_eq!(None, known_size);
+                }
+                None => todo!(),
+            }
+            assert!(info.has_exit_code);
+            assert!(info.trim_end_newline);
+        }
+        Some(other) => panic!("unexpected response written: {other:?}"),
+        None => panic!("no response written"),
+    }
+
+    // Then comes the hard part: check for the StreamData responses matching each of the iterators
+    //
+    // Each stream should be in order, but the order of the responses of unrelated streams is
+    // not defined and may be random
+    let mut stdout_iter = stdout_chunks.into_iter();
+    let mut stderr_iter = stderr_chunks.into_iter();
+    let mut exit_code_iter = exit_code_values.into_iter();
+
+    for output in test.written_outputs() {
+        match output {
+            PluginOutput::StreamData(data) => match data {
+                StreamData::List(_) => panic!("got unexpected list stream data: {data:?}"),
+                StreamData::ExternalStdout(option) => {
+                    let received = option
+                        .transpose()
+                        .expect("unexpected error in stdout stream");
+                    assert_eq!(stdout_iter.next(), received);
+                }
+                StreamData::ExternalStderr(option) => {
+                    let received = option
+                        .transpose()
+                        .expect("unexpected error in stderr stream");
+                    assert_eq!(stderr_iter.next(), received);
+                }
+                StreamData::ExternalExitCode(received) => {
+                    assert_eq!(exit_code_iter.next(), received);
+                }
+            },
+            other => panic!("unexpected output: {other:?}"),
+        }
+    }
+
+    // Make sure we got all of the messages we expected, and nothing extra
+    assert!(
+        stdout_iter.next().is_none(),
+        "didn't match all stdout messages"
+    );
+    assert!(
+        stderr_iter.next().is_none(),
+        "didn't match all stderr messages"
+    );
+    assert!(
+        exit_code_iter.next().is_none(),
+        "didn't match all exit code messages"
+    );
+
+    assert!(!test.has_unconsumed_write());
+}

--- a/crates/nu-plugin/src/plugin/interface/engine/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine/tests.rs
@@ -894,10 +894,10 @@ fn write_pipeline_data_response_external_stream_full() {
     // Consume three streams simultaneously. Can't predict which order the output will really be
     // in, though
     let stdout_chunks = vec![
-        b"hel".to_vec(),
-        b"lo ".to_vec(),
-        b"wor".to_vec(),
-        b"ld".to_vec(),
+        b"hello ".to_vec(),
+        b"world\n".to_vec(),
+        b"test".to_vec(),
+        b" stdout".to_vec(),
     ];
 
     let stderr_chunks = vec![b"standard ".to_vec(), b"error\n".to_vec()];

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -1,0 +1,343 @@
+//! Interface used by the engine to communicate with the plugin.
+
+use std::{
+    io::{BufRead, Write},
+    path::{Path, PathBuf},
+    sync::{atomic::AtomicBool, Arc, Mutex},
+};
+
+use nu_protocol::{
+    ast::Call,
+    engine::{EngineState, Stack},
+    ListStream, PipelineData, RawStream, ShellError, Span, Value,
+};
+
+use crate::{
+    plugin::PluginEncoder,
+    protocol::{
+        ExternalStreamInfo, PluginCall, PluginCallResponse, PluginCustomValue, PluginInput,
+        PluginOutput, StreamData,
+    },
+};
+
+use super::{
+    make_external_stream, make_list_stream,
+    stream_data_io::{impl_stream_data_io, StreamBuffer, StreamBuffers, StreamDataIo},
+    write_full_external_stream, write_full_list_stream, PluginRead, PluginWrite,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// Object safe trait for abstracting operations required of the plugin context.
+pub(crate) trait PluginExecutionContext: Send + Sync {
+    /// The plugin's filename
+    fn filename(&self) -> &Path;
+    /// The shell used to execute the plugin
+    fn shell(&self) -> Option<&Path>;
+    /// The [Span] for the command execution (`call.head`)
+    fn command_span(&self) -> Span;
+    /// The name of the command being executed
+    fn command_name(&self) -> &str;
+    /// The interrupt signal, if present
+    fn ctrlc(&self) -> Option<&Arc<AtomicBool>>;
+}
+
+/// The execution context of a plugin.
+#[derive(Debug)]
+pub(crate) struct PluginExecutionNushellContext {
+    filename: PathBuf,
+    shell: Option<PathBuf>,
+    command_span: Span,
+    command_name: String,
+    ctrlc: Option<Arc<AtomicBool>>,
+    // If more operations are required of the context, fields can be added here.
+    //
+    // It may be required to insert the entire EngineState/Call/Stack in here to support
+    // future features and that's okay
+}
+
+impl PluginExecutionNushellContext {
+    pub fn new(
+        filename: impl Into<PathBuf>,
+        shell: Option<impl Into<PathBuf>>,
+        engine_state: &EngineState,
+        _stack: &Stack,
+        call: &Call,
+    ) -> PluginExecutionNushellContext {
+        PluginExecutionNushellContext {
+            filename: filename.into(),
+            shell: shell.map(Into::into),
+            command_span: call.head,
+            command_name: engine_state.get_decl(call.decl_id).name().to_owned(),
+            ctrlc: engine_state.ctrlc.clone(),
+        }
+    }
+}
+
+impl PluginExecutionContext for PluginExecutionNushellContext {
+    fn filename(&self) -> &Path {
+        &self.filename
+    }
+
+    fn shell(&self) -> Option<&Path> {
+        self.shell.as_deref()
+    }
+
+    fn command_span(&self) -> Span {
+        self.command_span
+    }
+
+    fn command_name(&self) -> &str {
+        &self.command_name
+    }
+
+    fn ctrlc(&self) -> Option<&Arc<AtomicBool>> {
+        self.ctrlc.as_ref()
+    }
+}
+
+pub(crate) struct PluginInterfaceImpl<R, W> {
+    // Always lock read and then write mutex, if using both
+    // Stream inputs that can't be handled immediately can be put on the buffer
+    read: Mutex<(R, StreamBuffers)>,
+    write: Mutex<W>,
+    context: Option<Arc<dyn PluginExecutionContext>>,
+}
+
+impl<R, W> PluginInterfaceImpl<R, W> {
+    pub(crate) fn new(
+        reader: R,
+        writer: W,
+        context: Option<Arc<dyn PluginExecutionContext>>,
+    ) -> PluginInterfaceImpl<R, W> {
+        PluginInterfaceImpl {
+            read: Mutex::new((reader, StreamBuffers::default())),
+            write: Mutex::new(writer),
+            context,
+        }
+    }
+}
+
+// Implement the stream handling methods (see StreamDataIo).
+impl_stream_data_io!(
+    PluginInterfaceImpl,
+    PluginOutput(read_output),
+    PluginInput(write_input)
+);
+
+/// The trait indirection is so that we can hide the types with a trait object inside
+/// PluginInterface. As such, this trait must remain object safe.
+pub(crate) trait PluginInterfaceIo: StreamDataIo {
+    fn context(&self) -> Option<&Arc<dyn PluginExecutionContext>>;
+    fn write_call(&self, call: PluginCall) -> Result<(), ShellError>;
+    fn read_call_response(&self) -> Result<PluginCallResponse, ShellError>;
+}
+
+impl<R, W> PluginInterfaceIo for PluginInterfaceImpl<R, W>
+where
+    R: PluginRead,
+    W: PluginWrite,
+{
+    fn context(&self) -> Option<&Arc<dyn PluginExecutionContext>> {
+        self.context.as_ref()
+    }
+
+    fn write_call(&self, call: PluginCall) -> Result<(), ShellError> {
+        let mut write = self.write.lock().expect("write mutex poisoned");
+        log::trace!("Writing plugin call: {call:?}");
+
+        write.write_input(&PluginInput::Call(call))?;
+        write.flush()?;
+
+        log::trace!("Wrote plugin call");
+        Ok(())
+    }
+
+    fn read_call_response(&self) -> Result<PluginCallResponse, ShellError> {
+        log::trace!("Reading plugin call response");
+
+        let mut read = self.read.lock().expect("read mutex poisoned");
+        loop {
+            match read.0.read_output()? {
+                Some(PluginOutput::CallResponse(response)) => {
+                    // Check the call input type to set the stream buffers up
+                    match &response {
+                        PluginCallResponse::ListStream => {
+                            read.1 = StreamBuffers::new_list();
+                            log::trace!("Read plugin call response. Expecting list stream");
+                        }
+                        PluginCallResponse::ExternalStream(ExternalStreamInfo {
+                            stdout,
+                            stderr,
+                            has_exit_code,
+                            ..
+                        }) => {
+                            read.1 = StreamBuffers::new_external(
+                                stdout.is_some(),
+                                stderr.is_some(),
+                                *has_exit_code,
+                            );
+                            log::trace!("Read plugin call response. Expecting external stream");
+                        }
+                        _ => {
+                            read.1 = StreamBuffers::default(); // no buffers
+                            log::trace!("Read plugin call response. No stream expected");
+                        }
+                    }
+                    return Ok(response);
+                }
+                // Skip over any remaining stream data for dropped streams
+                Some(PluginOutput::StreamData(StreamData::List(_))) if read.1.list.is_dropped() => {
+                    continue
+                }
+                Some(PluginOutput::StreamData(StreamData::ExternalStdout(_)))
+                    if read.1.external_stdout.is_dropped() =>
+                {
+                    continue
+                }
+                Some(PluginOutput::StreamData(StreamData::ExternalStderr(_)))
+                    if read.1.external_stderr.is_dropped() =>
+                {
+                    continue
+                }
+                Some(PluginOutput::StreamData(StreamData::ExternalExitCode(_)))
+                    if read.1.external_exit_code.is_dropped() =>
+                {
+                    continue
+                }
+                // Other stream data is an error
+                Some(PluginOutput::StreamData(_)) => {
+                    return Err(ShellError::PluginFailedToDecode {
+                        msg: "expected CallResponse, got unexpected StreamData".into(),
+                    })
+                }
+                // End of input
+                None => {
+                    return Err(ShellError::PluginFailedToDecode {
+                        msg: "unexpected end of stream before receiving call response".into(),
+                    })
+                }
+            }
+        }
+    }
+}
+
+/// Implements communication and stream handling for a plugin instance.
+#[derive(Clone)]
+pub(crate) struct PluginInterface {
+    io: Arc<dyn PluginInterfaceIo>,
+    // FIXME: This is only necessary because trait upcasting is not yet supported, so we have to
+    // generate this variant of the Arc while we know the actual type. It can be removed once
+    // https://github.com/rust-lang/rust/issues/65991 is closed and released.
+    io_stream: Arc<dyn StreamDataIo>,
+}
+
+impl<R, W> From<PluginInterfaceImpl<R, W>> for PluginInterface
+where
+    R: PluginRead + 'static,
+    W: PluginWrite + 'static,
+{
+    fn from(plugin_impl: PluginInterfaceImpl<R, W>) -> Self {
+        let arc = Arc::new(plugin_impl);
+        PluginInterface {
+            io: arc.clone(),
+            io_stream: arc,
+        }
+    }
+}
+
+impl PluginInterface {
+    /// Create the plugin interface from the given reader, writer, encoder, and context.
+    pub(crate) fn new<R, W, E>(
+        reader: R,
+        writer: W,
+        encoder: E,
+        context: Option<Arc<dyn PluginExecutionContext>>,
+    ) -> PluginInterface
+    where
+        R: BufRead + Send + 'static,
+        W: Write + Send + 'static,
+        E: PluginEncoder + 'static,
+    {
+        PluginInterfaceImpl::new((reader, encoder.clone()), (writer, encoder), context).into()
+    }
+
+    /// Write a [PluginCall] to the plugin
+    pub(crate) fn write_call(&self, call: PluginCall) -> Result<(), ShellError> {
+        self.io.write_call(call)
+    }
+
+    /// Read a [PluginCallResponse] back from the plugin
+    pub(crate) fn read_call_response(&self) -> Result<PluginCallResponse, ShellError> {
+        self.io.read_call_response()
+    }
+
+    /// Create [PipelineData] appropriate for the given [PluginCallResponse].
+    ///
+    /// Only usable with response types that emulate [PipelineData].
+    ///
+    /// # Panics
+    ///
+    /// If [PluginExecutionContext] was not provided when creating the interface.
+    pub(crate) fn make_pipeline_data(
+        &self,
+        response: PluginCallResponse,
+    ) -> Result<PipelineData, ShellError> {
+        let context = self
+            .io
+            .context()
+            .expect("PluginExecutionContext must be provided to call make_pipeline_data");
+
+        match response {
+            PluginCallResponse::Error(err) => Err(err.into()),
+            PluginCallResponse::Signature(_) => Err(ShellError::GenericError {
+                error: "Plugin missing value".into(),
+                msg: "Received a signature from plugin instead of value or stream".into(),
+                span: Some(context.command_span()),
+                help: None,
+                inner: vec![],
+            }),
+            PluginCallResponse::Empty => Ok(PipelineData::Empty),
+            PluginCallResponse::Value(value) => Ok(PipelineData::Value(*value, None)),
+            PluginCallResponse::PluginData(name, plugin_data) => {
+                // Convert to PluginCustomData
+                let value = Value::custom_value(
+                    Box::new(PluginCustomValue {
+                        name,
+                        data: plugin_data.data,
+                        filename: context.filename().to_owned(),
+                        shell: context.shell().map(|p| p.to_owned()),
+                        source: context.command_name().to_owned(),
+                    }),
+                    plugin_data.span,
+                );
+                Ok(PipelineData::Value(value, None))
+            }
+            PluginCallResponse::ListStream => Ok(make_list_stream(
+                self.io_stream.clone(),
+                context.ctrlc().cloned(),
+            )),
+            PluginCallResponse::ExternalStream(info) => Ok(make_external_stream(
+                self.io_stream.clone(),
+                &info,
+                context.ctrlc().cloned(),
+            )),
+        }
+    }
+
+    /// Write the contents of a [ListStream] to `io`.
+    pub fn write_full_list_stream(&self, list_stream: ListStream) -> Result<(), ShellError> {
+        write_full_list_stream(&self.io_stream, list_stream)
+    }
+
+    /// Write the contents of a [PipelineData::ExternalStream].
+    pub fn write_full_external_stream(
+        &self,
+        stdout: Option<RawStream>,
+        stderr: Option<RawStream>,
+        exit_code: Option<ListStream>,
+    ) -> Result<(), ShellError> {
+        write_full_external_stream(&self.io_stream, stdout, stderr, exit_code)
+    }
+}

--- a/crates/nu-plugin/src/plugin/interface/plugin/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin/tests.rs
@@ -1,0 +1,732 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::plugin::interface::stream_data_io::{
+    gen_stream_data_tests, StreamBuffers, StreamDataIo,
+};
+use crate::plugin::interface::test_util::TestCase;
+use crate::plugin::interface::{PluginExecutionContext, PluginInterface};
+use crate::protocol::{
+    CallInfo, CallInput, ExternalStreamInfo, PluginCall, PluginCustomValue, PluginData,
+    PluginInput, PluginOutput, RawStreamInfo, StreamData,
+};
+use crate::PluginCallResponse;
+
+use super::PluginInterfaceIo;
+
+use nu_protocol::{ListStream, PipelineData, ShellError, Span, Value};
+
+gen_stream_data_tests!(
+    PluginOutput(add_output),
+    PluginInput(next_written_input),
+    |test| test.plugin_interface_impl(None)
+);
+
+struct BogusContext;
+impl PluginExecutionContext for BogusContext {
+    fn filename(&self) -> &Path {
+        Path::new("/bogus")
+    }
+
+    fn shell(&self) -> Option<&Path> {
+        None
+    }
+
+    fn command_span(&self) -> nu_protocol::Span {
+        Span::test_data()
+    }
+
+    fn command_name(&self) -> &str {
+        "bogus"
+    }
+
+    fn ctrlc(&self) -> Option<&std::sync::Arc<std::sync::atomic::AtomicBool>> {
+        None
+    }
+}
+
+#[test]
+fn get_context() {
+    let test = TestCase::new();
+    let interface = test.plugin_interface_impl(None);
+    assert!(interface.context().is_none());
+    let interface = test.plugin_interface_impl(Some(Arc::new(BogusContext)));
+    assert_eq!(
+        "bogus",
+        interface
+            .context()
+            .expect("context should be set")
+            .command_name()
+    );
+}
+
+#[test]
+fn write_call() {
+    let test = TestCase::new();
+    let interface = test.plugin_interface_impl(None);
+    interface
+        .write_call(PluginCall::Signature)
+        .expect("write_call failed");
+
+    match test.next_written_input() {
+        Some(PluginInput::Call(PluginCall::Signature)) => (),
+        Some(other) => panic!("wrote wrong input: {other:?}"),
+        None => panic!("didn't write anything"),
+    }
+
+    assert!(!test.has_unconsumed_write());
+}
+
+#[test]
+fn read_call_response_signature() {
+    let test = TestCase::new();
+    test.add_output(PluginOutput::CallResponse(PluginCallResponse::Signature(
+        vec![],
+    )));
+
+    match test.plugin_interface(None).read_call_response().unwrap() {
+        PluginCallResponse::Signature(vec) => assert!(vec.is_empty()),
+        other => panic!("read unexpected response: {:?}", other),
+    }
+}
+
+#[test]
+fn read_call_response_empty() {
+    let test = TestCase::new();
+    test.add_output(PluginOutput::CallResponse(PluginCallResponse::Empty));
+
+    match test.plugin_interface(None).read_call_response().unwrap() {
+        PluginCallResponse::Empty => (),
+        other => panic!("read unexpected response: {:?}", other),
+    }
+}
+
+#[test]
+fn read_call_response_value() {
+    let test = TestCase::new();
+    let value = Box::new(Value::test_int(5));
+    test.add_output(PluginOutput::CallResponse(PluginCallResponse::Value(
+        value.clone(),
+    )));
+
+    match test.plugin_interface(None).read_call_response().unwrap() {
+        PluginCallResponse::Value(read_value) => assert_eq!(value, read_value),
+        other => panic!("read unexpected response: {:?}", other),
+    }
+}
+
+#[test]
+fn read_call_response_data() {
+    let test = TestCase::new();
+    let data = PluginData {
+        data: vec![4, 6],
+        span: Span::new(40, 60),
+    };
+    let name = "Foo";
+    test.add_output(PluginOutput::CallResponse(PluginCallResponse::PluginData(
+        name.into(),
+        data.clone(),
+    )));
+
+    match test.plugin_interface(None).read_call_response().unwrap() {
+        PluginCallResponse::PluginData(read_name, read_data) => {
+            assert_eq!(name, read_name);
+            assert_eq!(data, read_data);
+        }
+        other => panic!("read unexpected response: {:?}", other),
+    }
+}
+
+#[test]
+fn read_call_response_list_stream() {
+    let test = TestCase::new();
+    test.add_output(PluginOutput::CallResponse(PluginCallResponse::ListStream));
+
+    let interface = test.plugin_interface_impl(None);
+
+    match interface.read_call_response().unwrap() {
+        PluginCallResponse::ListStream => (),
+        other => panic!("read unexpected response: {:?}", other),
+    }
+
+    {
+        let read = interface.read.lock().unwrap();
+        assert!(read.1.list.is_present());
+        assert!(read.1.external_stdout.is_not_present());
+        assert!(read.1.external_stderr.is_not_present());
+        assert!(read.1.external_exit_code.is_not_present());
+    }
+}
+
+#[test]
+fn read_call_response_external_stream() {
+    let test = TestCase::new();
+    let info = ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: true,
+        trim_end_newline: false,
+    };
+    test.add_output(PluginOutput::CallResponse(
+        PluginCallResponse::ExternalStream(info),
+    ));
+
+    let interface = test.plugin_interface_impl(None);
+
+    match interface.read_call_response().unwrap() {
+        PluginCallResponse::ExternalStream(..) => (),
+        other => panic!("read unexpected response: {:?}", other),
+    }
+
+    {
+        let read = interface.read.lock().unwrap();
+        assert!(read.1.list.is_not_present());
+        assert!(read.1.external_stdout.is_present());
+        assert!(read.1.external_stderr.is_present());
+        assert!(read.1.external_exit_code.is_present());
+    }
+}
+
+#[test]
+fn read_call_response_unexpected_stream_data() {
+    let test = TestCase::new();
+    test.add_output(PluginOutput::StreamData(StreamData::List(None)));
+    test.add_output(PluginOutput::CallResponse(PluginCallResponse::Empty));
+
+    test.plugin_interface(None)
+        .read_call_response()
+        .expect_err("should be an error");
+}
+
+fn dbg<T>(val: T) -> String
+where
+    T: std::fmt::Debug,
+{
+    format!("{:?}", val)
+}
+
+fn validate_stream_data_acceptance(response: PluginCallResponse, accepts: [bool; 4]) {
+    let test = TestCase::new();
+    test.add_output(PluginOutput::CallResponse(response));
+
+    let interface = test.plugin_interface_impl(None);
+
+    interface.read_call_response().expect("call failed");
+
+    let data_types = [
+        StreamData::List(Some(Value::test_bool(true))),
+        StreamData::ExternalStdout(Some(Ok(vec![]))),
+        StreamData::ExternalStderr(Some(Ok(vec![]))),
+        StreamData::ExternalExitCode(Some(Value::test_int(1))),
+    ];
+
+    for (data, accept) in data_types.iter().zip(accepts) {
+        test.clear_output();
+        test.add_output(PluginOutput::StreamData(data.clone()));
+        let result = match data {
+            StreamData::List(_) => interface.read_list().map(dbg),
+            StreamData::ExternalStdout(_) => interface.read_external_stdout().map(dbg),
+            StreamData::ExternalStderr(_) => interface.read_external_stderr().map(dbg),
+            StreamData::ExternalExitCode(_) => interface.read_external_exit_code().map(dbg),
+        };
+        match result {
+            Ok(success) if !accept => {
+                panic!("{data:?} was successfully consumed, but shouldn't have been: {success}")
+            }
+            Err(err) if accept => {
+                panic!("{data:?} was rejected, but should have been accepted: {err}")
+            }
+            _ => (),
+        }
+    }
+}
+
+#[test]
+fn read_call_response_empty_doesnt_accept_stream_data() {
+    validate_stream_data_acceptance(PluginCallResponse::Empty, [false; 4])
+}
+
+#[test]
+fn read_call_response_value_doesnt_accept_stream_data() {
+    validate_stream_data_acceptance(
+        PluginCallResponse::Value(Value::test_int(4).into()),
+        [false; 4],
+    )
+}
+
+#[test]
+fn read_call_response_list_stream_accepts_only_list_stream_data() {
+    validate_stream_data_acceptance(
+        PluginCallResponse::ListStream,
+        [
+            true, // list stream
+            false, false, false,
+        ],
+    )
+}
+
+#[test]
+fn read_call_response_external_stream_stdout_accepts_only_external_stream_stdout_data() {
+    let response = PluginCallResponse::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        stderr: None,
+        has_exit_code: false,
+        trim_end_newline: false,
+    });
+
+    validate_stream_data_acceptance(
+        response,
+        [
+            false, true, // external stdout
+            false, false,
+        ],
+    )
+}
+
+#[test]
+fn read_call_response_run_with_external_stream_stderr_input_accepts_only_external_stream_stderr_data(
+) {
+    let response = PluginCallResponse::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: None,
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: false,
+        trim_end_newline: false,
+    });
+
+    validate_stream_data_acceptance(
+        response,
+        [
+            false, false, true, // external stderr
+            false,
+        ],
+    )
+}
+
+#[test]
+fn read_call_response_external_stream_exit_code_accepts_only_external_stream_exit_code_data() {
+    let response = PluginCallResponse::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: None,
+        stderr: None,
+        has_exit_code: true,
+        trim_end_newline: false,
+    });
+
+    validate_stream_data_acceptance(
+        response,
+        [
+            false, false, false, true, // external exit code
+        ],
+    )
+}
+
+#[test]
+fn read_call_response_external_stream_all_accepts_only_all_external_stream_data() {
+    let response = PluginCallResponse::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: true,
+        trim_end_newline: false,
+    });
+
+    validate_stream_data_acceptance(
+        response,
+        [
+            false, true, // external stdout
+            true, // external stderr
+            true, // external exit code
+        ],
+    )
+}
+
+#[test]
+fn read_call_response_end_of_input() {
+    let test = TestCase::new();
+    test.plugin_interface(None)
+        .read_call_response()
+        .expect_err("should fail");
+}
+
+#[test]
+fn read_call_response_io_error() {
+    let test = TestCase::new();
+    test.set_read_error(ShellError::IOError {
+        msg: "test error".into(),
+    });
+
+    match test
+        .plugin_interface(None)
+        .read_call_response()
+        .expect_err("should be an error")
+    {
+        ShellError::IOError { msg } if msg == "test error" => (),
+        other => panic!("got some other error: {other}"),
+    }
+}
+
+#[test]
+fn make_pipeline_data_empty() {
+    let test = TestCase::new();
+
+    let pipe = test
+        .plugin_interface(Some(Arc::new(BogusContext)))
+        .make_pipeline_data(PluginCallResponse::Empty)
+        .expect("can't make pipeline data");
+
+    match pipe {
+        PipelineData::Empty => (),
+        PipelineData::Value(_, _) => panic!("got value, expected empty"),
+        PipelineData::ListStream(_, _) => panic!("got list stream"),
+        PipelineData::ExternalStream { .. } => panic!("got external stream"),
+    }
+}
+
+#[test]
+fn make_pipeline_data_value() {
+    let test = TestCase::new();
+
+    let value = Value::test_int(2);
+    let response = PluginCallResponse::Value(value.clone().into());
+    let pipe = test
+        .plugin_interface(Some(Arc::new(BogusContext)))
+        .make_pipeline_data(response)
+        .expect("can't make pipeline data");
+
+    match pipe {
+        PipelineData::Empty => panic!("got empty, expected value"),
+        PipelineData::Value(v, _) => assert_eq!(value, v),
+        PipelineData::ListStream(_, _) => panic!("got list stream"),
+        PipelineData::ExternalStream { .. } => panic!("got external stream"),
+    }
+}
+
+#[test]
+fn make_pipeline_data_custom_data() {
+    let test = TestCase::new();
+
+    let data = PluginData {
+        data: vec![32, 40, 80],
+        span: Span::test_data(),
+    };
+    let name = "Foo";
+    let response = PluginCallResponse::PluginData(name.into(), data.clone());
+
+    let pipe = test
+        .plugin_interface(Some(Arc::new(BogusContext)))
+        .make_pipeline_data(response)
+        .expect("failed to make pipeline data");
+
+    match pipe {
+        PipelineData::Empty => panic!("got empty, expected value"),
+        PipelineData::Value(v, _) => {
+            assert_eq!(data.span, v.span());
+
+            let read_custom = v.as_custom_value().expect("not a custom value");
+            let read_downcast: &PluginCustomValue =
+                read_custom.as_any().downcast_ref().expect("wrong type");
+
+            assert_eq!(name, read_downcast.name);
+            assert_eq!("/bogus", read_downcast.filename.display().to_string());
+            assert_eq!(None, read_downcast.shell);
+            assert_eq!(data.data, read_downcast.data);
+            assert_eq!("bogus", read_downcast.source);
+        }
+        PipelineData::ListStream(_, _) => panic!("got list stream"),
+        PipelineData::ExternalStream { .. } => panic!("got external stream"),
+    }
+}
+
+#[test]
+fn make_pipeline_data_list_stream() {
+    let test = TestCase::new();
+
+    let values = [Value::test_int(4), Value::test_string("hello")];
+
+    for value in &values {
+        test.add_output(PluginOutput::StreamData(StreamData::List(Some(
+            value.clone(),
+        ))));
+    }
+    // end
+    test.add_output(PluginOutput::StreamData(StreamData::List(None)));
+
+    let call_input = PluginCallResponse::ListStream;
+
+    let interface = PluginInterface::from({
+        let interface = test.plugin_interface_impl(Some(Arc::new(BogusContext)));
+        interface.read.lock().unwrap().1 = StreamBuffers::new_list();
+        interface
+    });
+
+    let pipe = interface
+        .make_pipeline_data(call_input)
+        .expect("failed to make pipeline data");
+
+    assert!(matches!(pipe, PipelineData::ListStream(..)));
+
+    for (defined_value, read_value) in values.into_iter().zip(pipe.into_iter()) {
+        assert_eq!(defined_value, read_value);
+    }
+}
+
+#[test]
+fn make_pipeline_data_external_stream() {
+    let test = TestCase::new();
+
+    // Test many simultaneous streams out of order
+    let stream_data = [
+        StreamData::ExternalStdout(Some(Ok(b"foo".to_vec()))),
+        StreamData::ExternalStderr(Some(Ok(b"bar".to_vec()))),
+        StreamData::ExternalExitCode(Some(Value::test_int(1))),
+        StreamData::ExternalStderr(Some(Ok(b"barr".to_vec()))),
+        StreamData::ExternalStderr(None),
+        StreamData::ExternalStdout(Some(Ok(b"fooo".to_vec()))),
+        StreamData::ExternalStdout(None),
+        StreamData::ExternalExitCode(None),
+    ];
+
+    for data in stream_data {
+        test.add_output(PluginOutput::StreamData(data));
+    }
+
+    let call_input = PluginCallResponse::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: true,
+            known_size: Some(7),
+        }),
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: true,
+        trim_end_newline: false,
+    });
+
+    let interface = PluginInterface::from({
+        let interface = test.plugin_interface_impl(Some(Arc::new(BogusContext)));
+        interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+        interface
+    });
+
+    let pipe = interface
+        .make_pipeline_data(call_input)
+        .expect("failed to make pipeline data");
+
+    match pipe {
+        PipelineData::ExternalStream {
+            stdout,
+            stderr,
+            exit_code,
+            span,
+            trim_end_newline,
+            ..
+        } => {
+            assert!(stdout.is_some());
+            assert!(stderr.is_some());
+            assert!(exit_code.is_some());
+            assert_eq!(Span::test_data(), span, "span");
+            assert!(!trim_end_newline);
+
+            if let Some(rs) = stdout.as_ref() {
+                assert!(rs.is_binary, "stdout.is_binary=false");
+                assert_eq!(Some(7), rs.known_size, "stdout.known_size");
+            }
+            if let Some(rs) = stderr.as_ref() {
+                assert!(!rs.is_binary, "stderr.is_binary=true");
+                assert_eq!(None, rs.known_size, "stderr.known_size");
+            }
+
+            let out_bytes = stdout.unwrap().into_bytes().expect("failed to read stdout");
+            let err_bytes = stderr.unwrap().into_bytes().expect("failed to read stderr");
+            let exit_code_vals: Vec<_> = exit_code.unwrap().collect();
+
+            assert_eq!(b"foofooo", &out_bytes.item[..]);
+            assert_eq!(b"barbarr", &err_bytes.item[..]);
+            assert_eq!(vec![Value::test_int(1)], exit_code_vals);
+        }
+        PipelineData::Empty => panic!("expected external stream, got empty"),
+        PipelineData::Value(..) => panic!("expected external stream, got value"),
+        PipelineData::ListStream(..) => panic!("expected external stream, got list stream"),
+    }
+}
+
+#[test]
+fn make_pipeline_data_external_stream_error() {
+    let test = TestCase::new();
+
+    // Just test stdout, but with an error
+    let spec_msg = "failure";
+    let stream_data = [
+        StreamData::ExternalExitCode(Some(Value::int(1, Span::test_data()))),
+        StreamData::ExternalStdout(Some(Err(ShellError::NushellFailed {
+            msg: spec_msg.into(),
+        }))),
+        StreamData::ExternalStdout(None),
+    ];
+
+    for data in stream_data {
+        test.add_output(PluginOutput::StreamData(data));
+    }
+
+    // Still enable the other streams, to ensure ignoring the other data works
+    let call_input = PluginCallResponse::ExternalStream(ExternalStreamInfo {
+        span: Span::test_data(),
+        stdout: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        stderr: Some(RawStreamInfo {
+            is_binary: false,
+            known_size: None,
+        }),
+        has_exit_code: true,
+        trim_end_newline: false,
+    });
+
+    let interface = PluginInterface::from({
+        let interface = test.plugin_interface_impl(Some(Arc::new(BogusContext)));
+        interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+        interface
+    });
+
+    let pipe = interface
+        .make_pipeline_data(call_input)
+        .expect("failed to make pipeline data");
+
+    match pipe {
+        PipelineData::ExternalStream {
+            stdout,
+            stderr,
+            exit_code,
+            ..
+        } => {
+            assert!(stdout.is_some());
+            assert!(stderr.is_some());
+            assert!(exit_code.is_some());
+
+            match stdout
+                .unwrap()
+                .into_bytes()
+                .expect_err("stdout read successfully")
+            {
+                ShellError::NushellFailed { msg } => assert_eq!(spec_msg, msg),
+                other => panic!("unexpected other error while reading stdout: {other}"),
+            }
+        }
+        PipelineData::Empty => panic!("expected external stream, got empty"),
+        PipelineData::Value(..) => panic!("expected external stream, got value"),
+        PipelineData::ListStream(..) => panic!("expected external stream, got list stream"),
+    }
+}
+
+#[test]
+fn round_trip_list_stream() {
+    // First, handle the write to plugin side
+    let test_plugin = TestCase::new();
+    let plug_interface = test_plugin.plugin_interface(Some(Arc::new(BogusContext)));
+
+    let call_info = CallInfo {
+        name: "roundtrip".into(),
+        call: crate::EvaluatedCall {
+            head: Span::test_data(),
+            positional: vec![],
+            named: vec![],
+        },
+        input: CallInput::ListStream,
+        config: None,
+    };
+    let call = PluginCall::Run(call_info.clone());
+
+    let values = vec![Value::test_int(4), Value::test_string("hi")];
+
+    plug_interface.write_call(call).unwrap();
+    plug_interface
+        .write_full_list_stream(ListStream::from_stream(values.clone().into_iter(), None))
+        .unwrap();
+
+    // Copy as input to engine side
+    let test_engine = TestCase::new();
+    let engine_interface = test_engine.engine_interface();
+    test_engine.extend_input(test_plugin.written_inputs());
+
+    let read_call = engine_interface
+        .read_call()
+        .expect("failed to read call")
+        .expect("nothing to read");
+
+    let read_input = match read_call {
+        PluginCall::Run(read_call_info) => {
+            assert_eq!(call_info.name, read_call_info.name);
+            assert_eq!(call_info.call.head, read_call_info.call.head);
+            assert_eq!(call_info.call.positional, read_call_info.call.positional);
+            assert_eq!(call_info.call.named, read_call_info.call.named);
+            assert_eq!(call_info.input, read_call_info.input);
+            assert_eq!(call_info.config, read_call_info.config);
+            read_call_info.input
+        }
+        other => panic!("unexpected call: {other:?}"),
+    };
+
+    // Read the values
+    let pipe = engine_interface
+        .make_pipeline_data(read_input)
+        .expect("failed to make plugin input pipeline data");
+    assert_eq!(values, pipe.into_iter().collect::<Vec<_>>());
+
+    // Write response list stream
+    let output_values = vec![Value::test_float(4.0), Value::test_string("hello there")];
+    engine_interface
+        .write_pipeline_data_response(PipelineData::ListStream(
+            ListStream::from_stream(output_values.clone().into_iter(), None),
+            None,
+        ))
+        .expect("failed to write pipeline data response");
+
+    // Copy response back to plugin
+    test_plugin.extend_output(test_engine.written_outputs());
+
+    // Check the response header
+    let response = plug_interface
+        .read_call_response()
+        .expect("failed to read response");
+
+    match response {
+        PluginCallResponse::ListStream => (),
+        other => panic!("incorrect plugin call response: {other:?}"),
+    }
+
+    // Read the values and check
+    let pipe = plug_interface
+        .make_pipeline_data(response)
+        .expect("failed to make plugin output pipeline data");
+    assert_eq!(output_values, pipe.into_iter().collect::<Vec<_>>());
+
+    // Ensure all data consumed
+    assert!(!test_plugin.has_unconsumed_read());
+    assert!(!test_plugin.has_unconsumed_write());
+    assert!(!test_engine.has_unconsumed_read());
+    assert!(!test_engine.has_unconsumed_write());
+}

--- a/crates/nu-plugin/src/plugin/interface/stream_data_io.rs
+++ b/crates/nu-plugin/src/plugin/interface/stream_data_io.rs
@@ -1,0 +1,402 @@
+use std::collections::VecDeque;
+
+use nu_protocol::{ShellError, Value};
+
+use crate::protocol::StreamData;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+pub(crate) use tests::gen_stream_data_tests;
+
+/// Methods for reading and writing [crate::protocol::StreamData] contents on an interface.
+///
+/// This trait must be object safe.
+pub(crate) trait StreamDataIo: Send + Sync {
+    /// Read a value for a `ListStream`, returning `Ok(None)` at end of stream.
+    ///
+    /// Other streams will be transparently handled or stored for concurrent readers.
+    fn read_list(&self) -> Result<Option<Value>, ShellError>;
+
+    /// Read some bytes for an `ExternalStream`'s `stdout` stream, returning `Ok(None)` at end
+    /// of stream.
+    ///
+    /// Other streams will be transparently handled or stored for concurrent readers.
+    fn read_external_stdout(&self) -> Result<Option<Vec<u8>>, ShellError>;
+
+    /// Read some bytes for an `ExternalStream`'s `stderr` stream, returning `Ok(None)` at end
+    /// of stream.
+    ///
+    /// Other streams will be transparently handled or stored for concurrent readers.
+    fn read_external_stderr(&self) -> Result<Option<Vec<u8>>, ShellError>;
+
+    /// Read a value for an `ExternalStream`'s `exit_code` stream, returning `Ok(None)` at end
+    /// of stream.
+    ///
+    /// Other streams will be transparently handled or stored for concurrent readers.
+    fn read_external_exit_code(&self) -> Result<Option<Value>, ShellError>;
+
+    /// Signal that no more values are desired from a `ListStream` and further messages should
+    /// be ignored.
+    fn drop_list(&self);
+
+    /// Signal that no more bytes are desired from an `ExternalStream`'s `stdout` and further
+    /// messages should be ignored.
+    fn drop_external_stdout(&self);
+
+    /// Signal that no more bytes are desired from an `ExternalStream`'s `stderr` and further
+    /// messages should be ignored.
+    fn drop_external_stderr(&self);
+
+    /// Signal that no more values are desired from an `ExternalStream`'s `exit_code` and further
+    /// messages should be ignored.
+    fn drop_external_exit_code(&self);
+
+    /// Write a value for a `ListStream`, or `None` to signal end of stream.
+    fn write_list(&self, value: Option<Value>) -> Result<(), ShellError>;
+
+    /// Write some bytes for an `ExternalStream`'s `stdout` stream, or `None` to signal end of
+    /// stream.
+    fn write_external_stdout(
+        &self,
+        bytes: Option<Result<Vec<u8>, ShellError>>,
+    ) -> Result<(), ShellError>;
+
+    /// Write some bytes for an `ExternalStream`'s `stderr` stream, or `None` to signal end of
+    /// stream.
+    fn write_external_stderr(
+        &self,
+        bytes: Option<Result<Vec<u8>, ShellError>>,
+    ) -> Result<(), ShellError>;
+
+    /// Write a value for an `ExternalStream`'s `exit_code` stream, or `None` to signal end of
+    /// stream.
+    fn write_external_exit_code(&self, code: Option<Value>) -> Result<(), ShellError>;
+}
+
+/// Implement [StreamDataIo] for the given type. The type is expected to have a shape similar to
+/// `EngineInterfaceImpl` or `PluginInterfaceImpl`. The following struct fields must be defined:
+///
+/// * `read: Mutex<(R, StreamBuffers)>` where `R` implements [`PluginRead`](super::PluginRead)
+/// * `write: Mutex<W>` where `W` implements [`PluginWrite`](super::PluginWrite)
+macro_rules! impl_stream_data_io {
+    (
+        $type:ident,
+        $read_type:ident ($read_method:ident),
+        $write_type:ident ($write_method:ident)
+    ) => {
+        impl<R, W> StreamDataIo for $type<R, W>
+        where
+            R: $crate::plugin::interface::PluginRead,
+            W: $crate::plugin::interface::PluginWrite,
+        {
+            fn read_list(&self) -> Result<Option<Value>, ShellError> {
+                let mut read = self.read.lock().expect("read mutex poisoned");
+                // Read from the buffer first
+                if let Some(value) = read.1.list.pop_front()? {
+                    Ok(value)
+                } else {
+                    // If we are expecting list stream data, there aren't any other simultaneous
+                    // streams, so we don't need to loop. Just try to read and reject it
+                    // otherwise
+                    match read.0.$read_method()? {
+                        Some($read_type::StreamData(StreamData::List(value))) => Ok(value),
+                        _ => Err(ShellError::PluginFailedToDecode {
+                            msg: "Expected list stream data".into(),
+                        }),
+                    }
+                }
+            }
+
+            fn read_external_stdout(&self) -> Result<Option<Vec<u8>>, ShellError> {
+                // Loop on the outside of the lock to allow other streams to make progress
+                loop {
+                    let mut read = self.read.lock().expect("read mutex poisoned");
+                    // Read from the buffer first
+                    if let Some(bytes) = read.1.external_stdout.pop_front()? {
+                        return bytes.transpose();
+                    } else {
+                        // Skip messages from other streams until we get what we want
+                        match read.0.$read_method()? {
+                            Some($read_type::StreamData(StreamData::ExternalStdout(bytes))) => {
+                                return bytes.transpose()
+                            }
+                            Some($read_type::StreamData(other)) => read.1.skip(other)?,
+                            _ => {
+                                return Err(ShellError::PluginFailedToDecode {
+                                    msg: "Expected external stream data".into(),
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+
+            fn read_external_stderr(&self) -> Result<Option<Vec<u8>>, ShellError> {
+                // Loop on the outside of the lock to allow other streams to make progress
+                loop {
+                    let mut read = self.read.lock().expect("read mutex poisoned");
+                    // Read from the buffer first
+                    if let Some(bytes) = read.1.external_stderr.pop_front()? {
+                        return bytes.transpose();
+                    } else {
+                        // Skip messages from other streams until we get what we want
+                        match read.0.$read_method()? {
+                            Some($read_type::StreamData(StreamData::ExternalStderr(bytes))) => {
+                                return bytes.transpose()
+                            }
+                            Some($read_type::StreamData(other)) => read.1.skip(other)?,
+                            _ => {
+                                return Err(ShellError::PluginFailedToDecode {
+                                    msg: "Expected external stream data".into(),
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+
+            fn read_external_exit_code(&self) -> Result<Option<Value>, ShellError> {
+                // Loop on the outside of the lock to allow other streams to make progress
+                loop {
+                    let mut read = self.read.lock().expect("read mutex poisoned");
+                    // Read from the buffer first
+                    if let Some(code) = read.1.external_exit_code.pop_front()? {
+                        return Ok(code);
+                    } else {
+                        // Skip messages from other streams until we get what we want
+                        match read.0.$read_method()? {
+                            Some($read_type::StreamData(StreamData::ExternalExitCode(code))) => {
+                                return Ok(code)
+                            }
+                            Some($read_type::StreamData(other)) => read.1.skip(other)?,
+                            _ => {
+                                return Err(ShellError::PluginFailedToDecode {
+                                    msg: "Expected external stream data".into(),
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+
+            fn drop_list(&self) {
+                let mut read = self.read.lock().expect("read mutex poisoned");
+                if !matches!(read.1.list, StreamBuffer::NotPresent) {
+                    read.1.list = StreamBuffer::Dropped;
+                } else {
+                    panic!("Tried to drop list stream but it's not present");
+                }
+            }
+
+            fn drop_external_stdout(&self) {
+                let mut read = self.read.lock().expect("read mutex poisoned");
+                if !matches!(read.1.external_stdout, StreamBuffer::NotPresent) {
+                    read.1.external_stdout = StreamBuffer::Dropped;
+                } else {
+                    panic!("Tried to drop external_stdout stream but it's not present");
+                }
+            }
+
+            fn drop_external_stderr(&self) {
+                let mut read = self.read.lock().expect("read mutex poisoned");
+                if !matches!(read.1.external_stderr, StreamBuffer::NotPresent) {
+                    read.1.external_stderr = StreamBuffer::Dropped;
+                } else {
+                    panic!("Tried to drop external_stderr stream but it's not present");
+                }
+            }
+
+            fn drop_external_exit_code(&self) {
+                let mut read = self.read.lock().expect("read mutex poisoned");
+                if !matches!(read.1.external_exit_code, StreamBuffer::NotPresent) {
+                    read.1.external_exit_code = StreamBuffer::Dropped;
+                } else {
+                    panic!("Tried to drop external_exit_code stream but it's not present");
+                }
+            }
+
+            fn write_list(&self, value: Option<Value>) -> Result<(), ShellError> {
+                let mut write = self.write.lock().expect("write mutex poisoned");
+                let is_final = value.is_none();
+                write.$write_method(&$write_type::StreamData(StreamData::List(value)))?;
+                // Try to flush final value
+                if is_final {
+                    write.flush()?;
+                }
+                Ok(())
+            }
+
+            fn write_external_stdout(
+                &self,
+                bytes: Option<Result<Vec<u8>, ShellError>>,
+            ) -> Result<(), ShellError> {
+                let mut write = self.write.lock().expect("write mutex poisoned");
+                let is_final = bytes.is_none();
+                write.$write_method(&$write_type::StreamData(StreamData::ExternalStdout(bytes)))?;
+                // Try to flush final value
+                if is_final {
+                    write.flush()?;
+                }
+                Ok(())
+            }
+
+            fn write_external_stderr(
+                &self,
+                bytes: Option<Result<Vec<u8>, ShellError>>,
+            ) -> Result<(), ShellError> {
+                let mut write = self.write.lock().expect("write mutex poisoned");
+                let is_final = bytes.is_none();
+                write.$write_method(&$write_type::StreamData(StreamData::ExternalStderr(bytes)))?;
+                // Try to flush final value
+                if is_final {
+                    write.flush()?;
+                }
+                Ok(())
+            }
+
+            fn write_external_exit_code(&self, code: Option<Value>) -> Result<(), ShellError> {
+                let mut write = self.write.lock().expect("write mutex poisoned");
+                let is_final = code.is_none();
+                write
+                    .$write_method(&$write_type::StreamData(StreamData::ExternalExitCode(code)))?;
+                // Try to flush final value
+                if is_final {
+                    write.flush()?;
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+pub(crate) use impl_stream_data_io;
+
+/// Buffers for stream messages that temporarily can't be handled
+#[derive(Debug, Default)]
+pub(crate) struct StreamBuffers {
+    pub list: StreamBuffer<Option<Value>>,
+    pub external_stdout: StreamBuffer<Option<Result<Vec<u8>, ShellError>>>,
+    pub external_stderr: StreamBuffer<Option<Result<Vec<u8>, ShellError>>>,
+    pub external_exit_code: StreamBuffer<Option<Value>>,
+}
+
+/// A buffer for stream messages that need to be stored temporarily to allow a different stream
+/// to be consumed.
+///
+/// The buffer is a LIFO queue.
+#[derive(Debug, Default)]
+pub(crate) enum StreamBuffer<T> {
+    /// The default state: this stream was not specified for use, so there is no buffer available
+    /// and reading a message directed for this stream will cause an error.
+    #[default]
+    NotPresent,
+    /// This stream was specified for use, but the reader was dropped, so no further messages are
+    /// desired. Any messages read that were directed for this stream will just be silently
+    /// discarded.
+    Dropped,
+    /// This stream was specified for use, and there is still a living reader that expects messages
+    /// from it. We store messages temporarily to allow another stream to proceed out-of-order.
+    Present(VecDeque<T>),
+}
+
+impl<T> StreamBuffer<T> {
+    /// Returns a [StreamBuffer::Present] with a new empty buffer if the `condition` is true, or
+    /// else returns [StreamBuffer::NotPresent].
+    pub fn present_if(condition: bool) -> StreamBuffer<T> {
+        if condition {
+            StreamBuffer::Present(VecDeque::new())
+        } else {
+            StreamBuffer::NotPresent
+        }
+    }
+
+    /// Push a message onto the back of the buffer.
+    ///
+    /// Returns an error if this buffer is `NotPresent`. Discards the message if it is `Dropped`.
+    pub fn push_back(&mut self, value: T) -> Result<(), ShellError> {
+        match self {
+            StreamBuffer::NotPresent => Err(ShellError::PluginFailedToDecode {
+                msg: "Tried to read into a stream that is not present".into(),
+            }),
+            StreamBuffer::Dropped => Ok(()), // just silently drop the message
+            StreamBuffer::Present(ref mut buf) => {
+                buf.push_back(value);
+                Ok(())
+            }
+        }
+    }
+
+    /// Try to pop a message from the front of the buffer.
+    ///
+    /// Returns `Ok(None)` if there are no messages waiting in the buffer, or an error if this
+    /// buffer is either `NotPresent` or `Dropped`.
+    pub fn pop_front(&mut self) -> Result<Option<T>, ShellError> {
+        match self {
+            StreamBuffer::Present(ref mut buf) => Ok(buf.pop_front()),
+
+            StreamBuffer::NotPresent => Err(ShellError::PluginFailedToDecode {
+                msg: "Tried to read from a stream that is not present".into(),
+            }),
+            StreamBuffer::Dropped => Err(ShellError::PluginFailedToDecode {
+                msg: "Tried to read from a stream that is already dropped".into(),
+            }),
+        }
+    }
+
+    /// True if the buffer is [Present].
+    #[allow(dead_code)]
+    pub fn is_present(&self) -> bool {
+        matches!(self, StreamBuffer::Present(..))
+    }
+
+    /// True if the buffer is [NotPresent].
+    #[allow(dead_code)]
+    pub fn is_not_present(&self) -> bool {
+        matches!(self, StreamBuffer::NotPresent)
+    }
+
+    /// True if the buffer is [Dropped].
+    pub fn is_dropped(&self) -> bool {
+        matches!(self, StreamBuffer::Dropped)
+    }
+}
+
+impl StreamBuffers {
+    /// Create a new [StreamBuffers] with an empty buffer for a `ListStream`.
+    ///
+    /// Other stream messages will be rejected with an error.
+    pub fn new_list() -> StreamBuffers {
+        StreamBuffers {
+            list: StreamBuffer::Present(VecDeque::new()),
+            external_stdout: StreamBuffer::NotPresent,
+            external_stderr: StreamBuffer::NotPresent,
+            external_exit_code: StreamBuffer::NotPresent,
+        }
+    }
+
+    /// Create a new [StreamBuffers] with empty buffers for an `ExternalStream`.
+    ///
+    /// The buffers will be `Present` according to the values of the parameters. Any stream messages
+    /// that do not belong to streams specified as present here will be rejected with an error.
+    pub fn new_external(has_stdout: bool, has_stderr: bool, has_exit_code: bool) -> StreamBuffers {
+        StreamBuffers {
+            list: StreamBuffer::NotPresent,
+            external_stdout: StreamBuffer::present_if(has_stdout),
+            external_stderr: StreamBuffer::present_if(has_stderr),
+            external_exit_code: StreamBuffer::present_if(has_exit_code),
+        }
+    }
+
+    /// Temporarily store [StreamData] for a stream. Use this if a message was received that belongs
+    /// to a stream other than the one actively being read.
+    pub fn skip(&mut self, data: StreamData) -> Result<(), ShellError> {
+        match data {
+            StreamData::List(val) => self.list.push_back(val),
+            StreamData::ExternalStdout(bytes) => self.external_stdout.push_back(bytes),
+            StreamData::ExternalStderr(bytes) => self.external_stderr.push_back(bytes),
+            StreamData::ExternalExitCode(code) => self.external_exit_code.push_back(code),
+        }
+    }
+}

--- a/crates/nu-plugin/src/plugin/interface/stream_data_io.rs
+++ b/crates/nu-plugin/src/plugin/interface/stream_data_io.rs
@@ -285,7 +285,7 @@ pub(crate) struct StreamBuffers {
 /// A buffer for stream messages that need to be stored temporarily to allow a different stream
 /// to be consumed.
 ///
-/// The buffer is a LIFO queue.
+/// The buffer is a FIFO queue.
 #[derive(Debug, Default)]
 pub(crate) enum StreamBuffer<T> {
     /// The default state: this stream was not specified for use, so there is no buffer available

--- a/crates/nu-plugin/src/plugin/interface/stream_data_io/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/stream_data_io/tests.rs
@@ -1,0 +1,590 @@
+use std::sync::Arc;
+
+use crate::{plugin::interface::stream_data_io::StreamBuffers, StreamData};
+use nu_protocol::Value;
+
+macro_rules! gen_stream_data_tests {
+    (
+        $read_type:ident ($add_read:ident),
+        $write_type:ident ($get_write:ident),
+        |$test:ident| $gen_interface_impl:expr
+    ) => {
+        #[test]
+        fn read_list_matches_input() {
+            let $test = TestCase::new();
+            $test.$add_read($read_type::StreamData(StreamData::List(Some(
+                Value::test_bool(true),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::List(None)));
+
+            let interface = $gen_interface_impl;
+            interface.read.lock().unwrap().1 = StreamBuffers::new_list();
+
+            match interface.read_list().unwrap() {
+                Some(value) => assert_eq!(value, Value::test_bool(true)),
+                None => panic!("expected to read list value, got end of list"),
+            }
+
+            match interface.read_list().unwrap() {
+                Some(value) => panic!("expected to read end of list, got {value:?}"),
+                None => (),
+            }
+
+            interface
+                .read_list()
+                .expect_err("didn't err on end of input");
+        }
+
+        #[test]
+        fn read_external_matches_input() {
+            let $test = TestCase::new();
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![67]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![68]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalExitCode(Some(
+                Value::test_int(1),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalExitCode(None)));
+
+            let interface = $gen_interface_impl;
+            interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+
+            match interface
+                .read_external_stdout()
+                .expect("while reading stdout")
+            {
+                Some(buffer) => assert_eq!(buffer, vec![67]),
+                None => panic!("unexpected end of stdout stream"),
+            }
+
+            match interface
+                .read_external_stderr()
+                .expect("while reading stderr")
+            {
+                Some(buffer) => assert_eq!(buffer, vec![68]),
+                None => panic!("unexpected end of stderr stream"),
+            }
+
+            match interface
+                .read_external_exit_code()
+                .expect("while reading exit code")
+            {
+                Some(value) => assert_eq!(value, Value::test_int(1)),
+                None => panic!("unexpected end of exit code stream"),
+            }
+
+            match interface
+                .read_external_exit_code()
+                .expect("while reading exit code")
+            {
+                Some(value) => {
+                    panic!("unexpected value in exit code stream, expected end: {value:?}")
+                }
+                None => (),
+            }
+
+            interface
+                .read_external_exit_code()
+                .expect_err("no error at end of input");
+        }
+
+        #[test]
+        fn read_external_streams_out_of_input_order() {
+            let $test = TestCase::new();
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![43]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalExitCode(Some(
+                Value::test_int(42),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![70]),
+            ))));
+
+            let interface = $gen_interface_impl;
+            interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+
+            match interface
+                .read_external_stdout()
+                .expect("while reading stdout")
+            {
+                Some(buffer) => assert_eq!(buffer, vec![70]),
+                None => panic!("unexpected end of stdout stream"),
+            }
+
+            match interface
+                .read_external_stderr()
+                .expect("while reading stderr")
+            {
+                Some(buffer) => assert_eq!(buffer, vec![43]),
+                None => panic!("unexpected end of stderr stream"),
+            }
+
+            match interface
+                .read_external_exit_code()
+                .expect("while reading exit code")
+            {
+                Some(value) => assert_eq!(value, Value::test_int(42)),
+                None => panic!("unexpected end of exit code stream"),
+            }
+        }
+
+        #[test]
+        fn read_external_streams_skip_dropped_stdout() {
+            let $test = TestCase::new();
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![1]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![2]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![3]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![42]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![4]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![43]),
+            ))));
+
+            let interface = $gen_interface_impl;
+            interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+
+            interface.drop_external_stdout();
+            interface
+                .read_external_stdout()
+                .expect_err("reading from dropped stream should be err");
+            assert_eq!(interface.read_external_stderr().unwrap(), Some(vec![42]));
+            assert_eq!(interface.read_external_stderr().unwrap(), Some(vec![43]));
+            assert!(interface
+                .read
+                .lock()
+                .unwrap()
+                .1
+                .external_stdout
+                .is_dropped());
+            interface
+                .read_external_stdout()
+                .expect_err("reading from dropped stream should be err");
+        }
+
+        #[test]
+        fn read_external_streams_skip_dropped_stderr() {
+            let $test = TestCase::new();
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![1]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![2]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![3]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![42]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![4]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![43]),
+            ))));
+
+            let interface = $gen_interface_impl;
+            interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+
+            interface.drop_external_stderr();
+            interface
+                .read_external_stderr()
+                .expect_err("reading from dropped stream should be err");
+            assert_eq!(interface.read_external_stdout().unwrap(), Some(vec![42]));
+            assert_eq!(interface.read_external_stdout().unwrap(), Some(vec![43]));
+            assert!(interface
+                .read
+                .lock()
+                .unwrap()
+                .1
+                .external_stderr
+                .is_dropped());
+            interface
+                .read_external_stderr()
+                .expect_err("reading from dropped stream should be err");
+        }
+
+        #[test]
+        fn read_external_streams_skip_dropped_exit_code() {
+            let $test = TestCase::new();
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![2]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalExitCode(Some(
+                Value::test_int(1),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStderr(Some(
+                Ok(vec![3]),
+            ))));
+            $test.$add_read($read_type::StreamData(StreamData::ExternalStdout(Some(
+                Ok(vec![42]),
+            ))));
+
+            let interface = $gen_interface_impl;
+            interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+
+            interface.drop_external_exit_code();
+            interface
+                .read_external_exit_code()
+                .expect_err("reading from dropped stream should be err");
+            assert_eq!(interface.read_external_stderr().unwrap(), Some(vec![2]));
+            assert_eq!(interface.read_external_stderr().unwrap(), Some(vec![3]));
+            assert_eq!(interface.read_external_stdout().unwrap(), Some(vec![42]));
+            assert!(interface
+                .read
+                .lock()
+                .unwrap()
+                .1
+                .external_exit_code
+                .is_dropped());
+            interface
+                .read_external_exit_code()
+                .expect_err("reading from dropped stream should be err");
+        }
+
+        #[test]
+        fn read_error_passthrough() {
+            let $test = TestCase::new();
+            let test_msg = "test io error";
+            $test.set_read_error(ShellError::IOError {
+                msg: test_msg.into(),
+            });
+
+            let interface = $gen_interface_impl;
+            interface.read.lock().unwrap().1 = StreamBuffers::new_external(true, true, true);
+
+            match interface
+                .read_external_exit_code()
+                .expect_err("succeeded unexpectedly")
+            {
+                ShellError::IOError { msg } => assert_eq!(test_msg, msg),
+                other => panic!("other error: {other}"),
+            }
+        }
+
+        #[test]
+        fn write_error_passthrough() {
+            let $test = TestCase::new();
+            let test_msg = "test io error";
+            $test.set_write_error(ShellError::IOError {
+                msg: test_msg.into(),
+            });
+
+            let interface = $gen_interface_impl;
+
+            match interface
+                .write_list(None)
+                .expect_err("succeeded unexpectedly")
+            {
+                ShellError::IOError { msg } => assert_eq!(test_msg, msg),
+                other => panic!("other error: {other}"),
+            }
+            assert!(!$test.has_unconsumed_write());
+        }
+
+        #[test]
+        fn write_list() {
+            let $test = TestCase::new();
+            let data = [Some(Value::test_int(1)), Some(Value::test_int(2)), None];
+            let interface = $gen_interface_impl;
+            for item in data.iter() {
+                interface.write_list(item.clone()).expect("write failed");
+            }
+            for item in data.iter() {
+                match $test.$get_write() {
+                    Some($write_type::StreamData(StreamData::List(read_item))) => {
+                        assert_eq!(item, &read_item)
+                    }
+                    Some(other) => panic!("got other data: {other:?}"),
+                    None => panic!("no data was written for {item:?}"),
+                }
+            }
+            assert!(!$test.has_unconsumed_write());
+        }
+
+        #[test]
+        fn write_external_stdout() {
+            let $test = TestCase::new();
+            let data = [
+                Some(Ok(vec![42])),
+                Some(Ok(vec![80, 40])),
+                Some(Err(ShellError::IOError {
+                    msg: "test io error".into(),
+                })),
+                None,
+            ];
+            let interface = $gen_interface_impl;
+            for item in data.iter() {
+                interface
+                    .write_external_stdout(item.clone())
+                    .expect("write failed");
+            }
+            for item in data.iter() {
+                match $test.$get_write() {
+                    Some($write_type::StreamData(StreamData::ExternalStdout(read_item))) => {
+                        match (item, &read_item) {
+                            (Some(Ok(a)), Some(Ok(b))) => assert_eq!(a, b),
+                            (Some(Err(a)), Some(Err(b))) => {
+                                assert_eq!(a.to_string(), b.to_string())
+                            }
+                            (None, None) => (),
+                            _ => panic!("expected {item:?}, got {read_item:?}"),
+                        }
+                    }
+                    Some(other) => panic!("got other data: {other:?}"),
+                    None => panic!("no data was written for {item:?}"),
+                }
+            }
+            assert!(!$test.has_unconsumed_write());
+        }
+
+        #[test]
+        fn write_external_stderr() {
+            let $test = TestCase::new();
+            let data = [
+                Some(Ok(vec![42])),
+                Some(Ok(vec![80, 40])),
+                Some(Err(ShellError::IOError {
+                    msg: "test io error".into(),
+                })),
+                None,
+            ];
+            let interface = $gen_interface_impl;
+            for item in data.iter() {
+                interface
+                    .write_external_stderr(item.clone())
+                    .expect("write failed");
+            }
+            for item in data.iter() {
+                match $test.$get_write() {
+                    Some($write_type::StreamData(StreamData::ExternalStderr(read_item))) => {
+                        match (item, &read_item) {
+                            (Some(Ok(a)), Some(Ok(b))) => assert_eq!(a, b),
+                            (Some(Err(a)), Some(Err(b))) => {
+                                assert_eq!(a.to_string(), b.to_string())
+                            }
+                            (None, None) => (),
+                            _ => panic!("expected {item:?}, got {read_item:?}"),
+                        }
+                    }
+                    Some(other) => panic!("got other data: {other:?}"),
+                    None => panic!("no data was written for {item:?}"),
+                }
+            }
+            assert!(!$test.has_unconsumed_write());
+        }
+
+        #[test]
+        fn write_external_exit_code() {
+            let $test = TestCase::new();
+            let data = [Some(Value::test_int(1)), Some(Value::test_int(2)), None];
+            let interface = $gen_interface_impl;
+            for item in data.iter() {
+                interface
+                    .write_external_exit_code(item.clone())
+                    .expect("write failed");
+            }
+            for item in data.iter() {
+                match $test.$get_write() {
+                    Some($write_type::StreamData(StreamData::ExternalExitCode(read_item))) => {
+                        assert_eq!(item, &read_item)
+                    }
+                    Some(other) => panic!("got other data: {other:?}"),
+                    None => panic!("no data was written for {item:?}"),
+                }
+            }
+            assert!(!$test.has_unconsumed_write());
+        }
+    };
+}
+
+pub(crate) use gen_stream_data_tests;
+
+use super::StreamBuffer;
+
+#[test]
+fn stream_buffers_default_doesnt_accept_stream_data() {
+    let mut buffers = StreamBuffers::default();
+
+    buffers
+        .skip(StreamData::List(Some(Value::test_bool(true))))
+        .expect_err("list was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStdout(Some(Ok(vec![]))))
+        .expect_err("external stdout was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStderr(Some(Ok(vec![]))))
+        .expect_err("external stderr was accepted");
+
+    buffers
+        .skip(StreamData::ExternalExitCode(Some(Value::test_int(1))))
+        .expect_err("external exit code was accepted");
+}
+
+#[test]
+fn stream_buffers_list_accepts_only_list_stream_data() {
+    let mut buffers = StreamBuffers::new_list();
+
+    buffers
+        .skip(StreamData::List(Some(Value::test_bool(true))))
+        .expect("list was not accepted");
+
+    buffers
+        .skip(StreamData::ExternalStdout(Some(Ok(vec![]))))
+        .expect_err("external stdout was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStderr(Some(Ok(vec![]))))
+        .expect_err("external stderr was accepted");
+
+    buffers
+        .skip(StreamData::ExternalExitCode(Some(Value::test_int(1))))
+        .expect_err("external exit code was accepted");
+}
+
+#[test]
+fn stream_buffers_external_stream_stdout_accepts_only_external_stream_stdout_data() {
+    let mut buffers = StreamBuffers::new_external(true, false, false);
+
+    buffers
+        .skip(StreamData::List(Some(Value::test_bool(true))))
+        .expect_err("list was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStdout(Some(Ok(vec![]))))
+        .expect("external stdout was not accepted");
+
+    buffers
+        .skip(StreamData::ExternalStderr(Some(Ok(vec![]))))
+        .expect_err("external stderr was accepted");
+
+    buffers
+        .skip(StreamData::ExternalExitCode(Some(Value::test_int(1))))
+        .expect_err("external exit code was accepted");
+}
+
+#[test]
+fn stream_buffers_external_stream_stderr_accepts_only_external_stream_stderr_data() {
+    let mut buffers = StreamBuffers::new_external(false, true, false);
+
+    buffers
+        .skip(StreamData::List(Some(Value::test_bool(true))))
+        .expect_err("list was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStdout(Some(Ok(vec![]))))
+        .expect_err("external stdout was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStderr(Some(Ok(vec![]))))
+        .expect("external stderr was not accepted");
+
+    buffers
+        .skip(StreamData::ExternalExitCode(Some(Value::test_int(1))))
+        .expect_err("external exit code was accepted");
+}
+
+#[test]
+fn stream_buffers_external_stream_exit_code_accepts_only_external_stream_exit_code_data() {
+    let mut buffers = StreamBuffers::new_external(false, false, true);
+
+    buffers
+        .skip(StreamData::List(Some(Value::test_bool(true))))
+        .expect_err("list was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStdout(Some(Ok(vec![]))))
+        .expect_err("external stdout was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStderr(Some(Ok(vec![]))))
+        .expect_err("external stderr was accepted");
+
+    buffers
+        .skip(StreamData::ExternalExitCode(Some(Value::test_int(1))))
+        .expect("external exit code was not accepted");
+}
+
+#[test]
+fn stream_buffers_external_stream_all_true_accepts_only_all_external_stream_data() {
+    let mut buffers = StreamBuffers::new_external(true, true, true);
+
+    buffers
+        .skip(StreamData::List(Some(Value::test_bool(true))))
+        .expect_err("list was accepted");
+
+    buffers
+        .skip(StreamData::ExternalStdout(Some(Ok(vec![]))))
+        .expect("external stdout was not accepted");
+
+    buffers
+        .skip(StreamData::ExternalStderr(Some(Ok(vec![]))))
+        .expect("external stderr was not accepted");
+
+    buffers
+        .skip(StreamData::ExternalExitCode(Some(Value::test_int(1))))
+        .expect("external exit code was not accepted");
+}
+
+#[test]
+fn stream_buffer_push_pop() {
+    let mut buffer = StreamBuffer::Present(Default::default());
+    buffer.push_back(1).unwrap();
+    buffer.push_back(2).unwrap();
+    assert_eq!(buffer.pop_front().unwrap(), Some(1));
+    assert_eq!(buffer.pop_front().unwrap(), Some(2));
+    assert_eq!(buffer.pop_front().unwrap(), None);
+    buffer.push_back(42).unwrap();
+    assert_eq!(buffer.pop_front().unwrap(), Some(42));
+    assert_eq!(buffer.pop_front().unwrap(), None);
+}
+
+#[test]
+fn stream_buffer_not_present_push_err() {
+    StreamBuffer::NotPresent
+        .push_back(2)
+        .expect_err("should be an error");
+}
+
+#[test]
+fn stream_buffer_not_present_pop_err() {
+    StreamBuffer::<()>::NotPresent
+        .pop_front()
+        .expect_err("should be an error");
+}
+
+#[test]
+fn stream_buffer_dropped_push() {
+    // Use an Arc and a Weak copy of it as an indicator of whether the data is still alive
+    let data = Arc::new(1);
+    let data_weak = Arc::downgrade(&data);
+    let mut dropped = StreamBuffer::Dropped;
+    dropped.push_back(data).expect("can't push on dropped");
+    // Should still be dropped - i.e., the message is not stored
+    assert!(matches!(dropped, StreamBuffer::Dropped));
+    // The data itself should also have been dropped - i.e., there are no copies of it around
+    assert!(data_weak.upgrade().is_none(), "dropped data was preserved");
+}
+
+#[test]
+fn stream_buffer_dropped_pop_err() {
+    StreamBuffer::<()>::Dropped
+        .pop_front()
+        .expect_err("should be an error");
+}

--- a/crates/nu-plugin/src/plugin/interface/test_util.rs
+++ b/crates/nu-plugin/src/plugin/interface/test_util.rs
@@ -1,0 +1,195 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
+
+use nu_protocol::ShellError;
+
+use crate::protocol::{PluginInput, PluginOutput};
+
+use super::{
+    engine::EngineInterfaceImpl, plugin::PluginInterfaceImpl, EngineInterface,
+    PluginExecutionContext, PluginInterface, PluginRead, PluginWrite,
+};
+
+/// Mock read/write helper for the engine and plugin interfaces.
+#[derive(Debug, Clone)]
+pub(crate) struct TestCase {
+    r#in: Arc<Mutex<TestData>>,
+    out: Arc<Mutex<TestData>>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct TestData {
+    inputs: VecDeque<PluginInput>,
+    outputs: VecDeque<PluginOutput>,
+    error: Option<ShellError>,
+    flushed: bool,
+}
+
+type TestIo = Arc<Mutex<TestData>>;
+
+impl PluginRead for TestIo {
+    fn read_input(&mut self) -> Result<Option<PluginInput>, ShellError> {
+        let mut lock = self.lock().unwrap();
+        if let Some(err) = lock.error.take() {
+            Err(err)
+        } else {
+            Ok(lock.inputs.pop_front())
+        }
+    }
+
+    fn read_output(&mut self) -> Result<Option<PluginOutput>, ShellError> {
+        let mut lock = self.lock().unwrap();
+        if let Some(err) = lock.error.take() {
+            Err(err)
+        } else {
+            Ok(lock.outputs.pop_front())
+        }
+    }
+}
+
+impl PluginWrite for TestIo {
+    fn write_input(&mut self, input: &PluginInput) -> Result<(), ShellError> {
+        let mut lock = self.lock().unwrap();
+        lock.flushed = false;
+
+        if let Some(err) = lock.error.take() {
+            Err(err)
+        } else {
+            lock.inputs.push_back(input.clone());
+            Ok(())
+        }
+    }
+
+    fn write_output(&mut self, output: &PluginOutput) -> Result<(), ShellError> {
+        let mut lock = self.lock().unwrap();
+        lock.flushed = false;
+
+        if let Some(err) = lock.error.take() {
+            Err(err)
+        } else {
+            lock.outputs.push_back(output.clone());
+            Ok(())
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), ShellError> {
+        let mut lock = self.lock().unwrap();
+        lock.flushed = true;
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+impl TestCase {
+    pub(crate) fn new() -> TestCase {
+        TestCase {
+            r#in: Default::default(),
+            out: Default::default(),
+        }
+    }
+
+    /// Clear the input read buffer.
+    pub(crate) fn clear_input(&self) {
+        self.r#in.lock().unwrap().inputs.truncate(0);
+    }
+
+    /// Clear the output read buffer.
+    pub(crate) fn clear_output(&self) {
+        self.r#in.lock().unwrap().outputs.truncate(0);
+    }
+
+    /// Add input that will be read by the interface.
+    pub(crate) fn add_input(&self, input: PluginInput) {
+        self.r#in.lock().unwrap().inputs.push_back(input);
+    }
+
+    /// Add output that will be read by the interface.
+    pub(crate) fn add_output(&self, output: PluginOutput) {
+        self.r#in.lock().unwrap().outputs.push_back(output);
+    }
+
+    /// Add multiple inputs that will be read by the interface.
+    pub(crate) fn extend_input(&self, inputs: impl IntoIterator<Item = PluginInput>) {
+        self.r#in.lock().unwrap().inputs.extend(inputs);
+    }
+
+    /// Add multiple outputs that will be read by the interface.
+    pub(crate) fn extend_output(&self, outputs: impl IntoIterator<Item = PluginOutput>) {
+        self.r#in.lock().unwrap().outputs.extend(outputs);
+    }
+
+    /// Return an error from the next read operation.
+    pub(crate) fn set_read_error(&self, err: ShellError) {
+        self.r#in.lock().unwrap().error = Some(err);
+    }
+
+    /// Return an error from the next write operation.
+    pub(crate) fn set_write_error(&self, err: ShellError) {
+        self.out.lock().unwrap().error = Some(err);
+    }
+
+    /// Get the next input that was written.
+    pub(crate) fn next_written_input(&self) -> Option<PluginInput> {
+        self.out.lock().unwrap().inputs.pop_front()
+    }
+
+    /// Get the next output that was written.
+    pub(crate) fn next_written_output(&self) -> Option<PluginOutput> {
+        self.out.lock().unwrap().outputs.pop_front()
+    }
+
+    /// Iterator over written inputs.
+    pub(crate) fn written_inputs(&self) -> impl Iterator<Item = PluginInput> + '_ {
+        std::iter::from_fn(|| self.next_written_input())
+    }
+
+    /// Iterator over written outputs.
+    pub(crate) fn written_outputs(&self) -> impl Iterator<Item = PluginOutput> + '_ {
+        std::iter::from_fn(|| self.next_written_output())
+    }
+
+    /// Returns true if the writer was flushed after the last write operation.
+    pub(crate) fn was_flushed(&self) -> bool {
+        self.out.lock().unwrap().flushed
+    }
+
+    /// Returns true if the reader has unconsumed read input/output.
+    pub(crate) fn has_unconsumed_read(&self) -> bool {
+        let lock = self.r#in.lock().unwrap();
+        !lock.inputs.is_empty() || !lock.outputs.is_empty()
+    }
+
+    /// Returns true if the writer has unconsumed write input/output.
+    pub(crate) fn has_unconsumed_write(&self) -> bool {
+        let lock = self.out.lock().unwrap();
+        !lock.inputs.is_empty() || !lock.outputs.is_empty()
+    }
+
+    /// Create an [EngineInterfaceImpl] using the test data.
+    pub(crate) fn engine_interface_impl(&self) -> EngineInterfaceImpl<TestIo, TestIo> {
+        EngineInterfaceImpl::new(self.r#in.clone(), self.out.clone())
+    }
+
+    /// Create an [EngineInterface] using the test data.
+    pub(crate) fn engine_interface(&self) -> EngineInterface {
+        self.engine_interface_impl().into()
+    }
+
+    /// Create a [PluginInterfaceImpl] using the test data.
+    pub(crate) fn plugin_interface_impl(
+        &self,
+        context: Option<Arc<dyn PluginExecutionContext>>,
+    ) -> PluginInterfaceImpl<TestIo, TestIo> {
+        PluginInterfaceImpl::new(self.r#in.clone(), self.out.clone(), context)
+    }
+
+    /// Create a [PluginInterface] using the test data.
+    pub(crate) fn plugin_interface(
+        &self,
+        context: Option<Arc<dyn PluginExecutionContext>>,
+    ) -> PluginInterface {
+        self.plugin_interface_impl(context).into()
+    }
+}

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -1,9 +1,13 @@
 mod declaration;
 pub use declaration::PluginDeclaration;
+mod interface;
 use nu_engine::documentation::get_flags_section;
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use crate::protocol::{CallInput, LabeledError, PluginCall, PluginData, PluginResponse};
+use crate::protocol::{
+    CallInfo, LabeledError, PluginCall, PluginCallResponse, PluginInput, PluginOutput,
+};
 use crate::EncodingType;
 use std::env;
 use std::fmt::Write;
@@ -11,44 +15,68 @@ use std::io::{BufReader, ErrorKind, Read, Write as WriteTrait};
 use std::path::Path;
 use std::process::{Child, ChildStdout, Command as CommandSys, Stdio};
 
-use nu_protocol::{CustomValue, PluginSignature, ShellError, Span, Value};
+use nu_protocol::{CustomValue, PipelineData, PluginSignature, ShellError, Value};
+
+use self::interface::{EngineInterface, PluginExecutionContext, PluginInterface};
 
 use super::EvaluatedCall;
 
 pub(crate) const OUTPUT_BUFFER_SIZE: usize = 8192;
 
 /// Encoding scheme that defines a plugin's communication protocol with Nu
-pub trait PluginEncoder: Clone {
+///
+/// Note: exported for internal use, but not public.
+#[doc(hidden)]
+pub trait PluginEncoder: Clone + Send + Sync {
     /// The name of the encoder (e.g., `json`)
     fn name(&self) -> &str;
 
-    /// Serialize a `PluginCall` in the `PluginEncoder`s format
-    fn encode_call(
+    /// Serialize a `PluginInput` in the `PluginEncoder`s format
+    ///
+    /// Returns [ShellError::IOError] if there was a problem writing, or
+    /// [ShellError::PluginFailedToEncode] for a serialization error.
+    fn encode_input(
         &self,
-        plugin_call: &PluginCall,
+        plugin_input: &PluginInput,
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError>;
 
-    /// Deserialize a `PluginCall` from the `PluginEncoder`s format
-    fn decode_call(&self, reader: &mut impl std::io::BufRead) -> Result<PluginCall, ShellError>;
-
-    /// Serialize a `PluginResponse` from the plugin in this `PluginEncoder`'s preferred
-    /// format
-    fn encode_response(
-        &self,
-        plugin_response: &PluginResponse,
-        writer: &mut impl std::io::Write,
-    ) -> Result<(), ShellError>;
-
-    /// Deserialize a `PluginResponse` from the plugin from this `PluginEncoder`'s
-    /// preferred format
-    fn decode_response(
+    /// Deserialize a `PluginInput` from the `PluginEncoder`s format
+    ///
+    /// Returns `None` if there is no more input to receive, in which case the plugin should exit.
+    ///
+    /// Returns [ShellError::IOError] if there was a problem reading, or
+    /// [ShellError::PluginFailedToDecode] for a deserialization error.
+    fn decode_input(
         &self,
         reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginResponse, ShellError>;
+    ) -> Result<Option<PluginInput>, ShellError>;
+
+    /// Serialize a `PluginOutput` in this `PluginEncoder`'s format
+    ///
+    /// Returns [ShellError::IOError] if there was a problem writing, or
+    /// [ShellError::PluginFailedToEncode] for a serialization error.
+    fn encode_output(
+        &self,
+        plugin_output: &PluginOutput,
+        writer: &mut impl std::io::Write,
+    ) -> Result<(), ShellError>;
+
+    /// Deserialize a `PluginOutput` from the `PluginEncoder`'s format
+    ///
+    /// Returns `None` if there is no more output to receive.
+    ///
+    /// Returns [ShellError::IOError] if there was a problem reading, or
+    /// [ShellError::PluginFailedToDecode] for a deserialization error.
+    fn decode_output(
+        &self,
+        reader: &mut impl std::io::BufRead,
+    ) -> Result<Option<PluginOutput>, ShellError>;
 }
 
 pub(crate) fn create_command(path: &Path, shell: Option<&Path>) -> CommandSys {
+    log::trace!("Starting plugin: {path:?}, shell = {shell:?}");
+
     let mut process = match (path.extension(), shell) {
         (_, Some(shell)) => {
             let mut process = std::process::Command::new(shell);
@@ -90,35 +118,29 @@ pub(crate) fn create_command(path: &Path, shell: Option<&Path>) -> CommandSys {
     process
 }
 
-pub(crate) fn call_plugin(
+pub(crate) fn make_plugin_interface(
     child: &mut Child,
-    plugin_call: PluginCall,
-    encoding: &EncodingType,
-    span: Span,
-) -> Result<PluginResponse, ShellError> {
-    if let Some(mut stdin_writer) = child.stdin.take() {
-        let encoding_clone = encoding.clone();
-        // If the child process fills its stdout buffer, it may end up waiting until the parent
-        // reads the stdout, and not be able to read stdin in the meantime, causing a deadlock.
-        // Writing from another thread ensures that stdout is being read at the same time, avoiding the problem.
-        std::thread::spawn(move || encoding_clone.encode_call(&plugin_call, &mut stdin_writer));
-    }
+    context: Option<Arc<dyn PluginExecutionContext>>,
+) -> Result<PluginInterface, ShellError> {
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| ShellError::PluginFailedToLoad {
+            msg: "plugin missing stdin writer".into(),
+        })?;
 
-    // Deserialize response from plugin to extract the resulting value
-    if let Some(stdout_reader) = &mut child.stdout {
-        let reader = stdout_reader;
-        let mut buf_read = BufReader::with_capacity(OUTPUT_BUFFER_SIZE, reader);
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| ShellError::PluginFailedToLoad {
+            msg: "Plugin missing stdout writer".into(),
+        })?;
 
-        encoding.decode_response(&mut buf_read)
-    } else {
-        Err(ShellError::GenericError {
-            error: "Error with stdout reader".into(),
-            msg: "no stdout reader".into(),
-            span: Some(span),
-            help: None,
-            inner: vec![],
-        })
-    }
+    let encoder = get_plugin_encoding(&mut stdout)?;
+
+    let reader = BufReader::with_capacity(OUTPUT_BUFFER_SIZE, stdout);
+
+    Ok(PluginInterface::new(reader, stdin, encoder, context))
 }
 
 #[doc(hidden)] // Note: not for plugin authors / only used in nu-parser
@@ -149,42 +171,30 @@ pub fn get_signature(
         ShellError::PluginFailedToLoad { msg: error_msg }
     })?;
 
-    let mut stdin_writer = child
-        .stdin
-        .take()
-        .ok_or_else(|| ShellError::PluginFailedToLoad {
-            msg: "plugin missing stdin writer".into(),
-        })?;
-    let mut stdout_reader = child
-        .stdout
-        .take()
-        .ok_or_else(|| ShellError::PluginFailedToLoad {
-            msg: "Plugin missing stdout reader".into(),
-        })?;
-    let encoding = get_plugin_encoding(&mut stdout_reader)?;
+    let interface = make_plugin_interface(&mut child, None)?;
+    let interface_clone = interface.clone();
 
     // Create message to plugin to indicate that signature is required and
     // send call to plugin asking for signature
-    let encoding_clone = encoding.clone();
+    //
     // If the child process fills its stdout buffer, it may end up waiting until the parent
     // reads the stdout, and not be able to read stdin in the meantime, causing a deadlock.
     // Writing from another thread ensures that stdout is being read at the same time, avoiding the problem.
-    std::thread::spawn(move || {
-        encoding_clone.encode_call(&PluginCall::Signature, &mut stdin_writer)
-    });
+    std::thread::spawn(move || interface_clone.write_call(PluginCall::Signature));
 
     // deserialize response from plugin to extract the signature
-    let reader = stdout_reader;
-    let mut buf_read = BufReader::with_capacity(OUTPUT_BUFFER_SIZE, reader);
-    let response = encoding.decode_response(&mut buf_read)?;
+    let response = interface.read_call_response()?;
 
     let signatures = match response {
-        PluginResponse::Signature(sign) => Ok(sign),
-        PluginResponse::Error(err) => Err(err.into()),
+        PluginCallResponse::Signature(sign) => Ok(sign),
+        PluginCallResponse::Error(err) => Err(err.into()),
         _ => Err(ShellError::PluginFailedToLoad {
             msg: "Plugin missing signature".into(),
         }),
     }?;
+
+    // Make sure we drop interface so stdin is closed
+    drop(interface);
 
     match child.wait() {
         Ok(_) => Ok(signatures),
@@ -198,6 +208,9 @@ pub fn get_signature(
 ///
 /// This is the trait that Nushell plugins must implement. The methods defined on
 /// `Plugin` are invoked by [serve_plugin] during plugin registration and execution.
+///
+/// If large amounts of data are expected to need to be received or produced, it may be more
+/// appropriate to implement [StreamingPlugin] instead.
 ///
 /// # Examples
 /// Basic usage:
@@ -244,6 +257,9 @@ pub trait Plugin {
     /// invoked command will be passed in via this argument. The `call` contains
     /// metadata describing how the plugin was invoked and `input` contains the structured
     /// data passed to the command implemented by this [Plugin].
+    ///
+    /// This variant does not support streaming. Consider implementing [StreamingPlugin] instead
+    /// if streaming is desired.
     fn run(
         &mut self,
         name: &str,
@@ -253,8 +269,106 @@ pub trait Plugin {
     ) -> Result<Value, LabeledError>;
 }
 
+/// The streaming API for a Nushell plugin
+///
+/// This is a more low-level version of the [Plugin] trait that supports operating on streams of
+/// data. If you don't need to operate on streams, consider using that trait instead.
+///
+/// The methods defined on `StreamingPlugin` are invoked by [serve_plugin] during plugin
+/// registration and execution.
+///
+/// # Examples
+/// Basic usage:
+/// ```
+/// # use nu_plugin::*;
+/// # use nu_protocol::{PluginSignature, PipelineData, Type, Value};
+/// struct LowercasePlugin;
+///
+/// impl StreamingPlugin for LowercasePlugin {
+///     fn signature(&self) -> Vec<PluginSignature> {
+///         let sig = PluginSignature::build("lowercase")
+///             .usage("Convert each string in a stream to lowercase")
+///             .input_output_type(Type::List(Type::String.into()), Type::List(Type::String.into()));
+///
+///         vec![sig]
+///     }
+///
+///     fn run(
+///         &mut self,
+///         name: &str,
+///         config: &Option<Value>,
+///         call: &EvaluatedCall,
+///         input: PipelineData,
+///     ) -> Result<PipelineData, LabeledError> {
+///         let span = call.head;
+///         Ok(input.map(move |value| {
+///             value.as_string()
+///                 .map(|string| Value::string(string.to_lowercase(), span))
+///                 // Errors in a stream should be returned as values.
+///                 .unwrap_or_else(|err| Value::error(err, span))
+///         }, None)?)
+///     }
+/// }
+/// ```
+pub trait StreamingPlugin {
+    /// The signature of the plugin
+    ///
+    /// This method returns the [PluginSignature]s that describe the capabilities
+    /// of this plugin. Since a single plugin executable can support multiple invocation
+    /// patterns we return a `Vec` of signatures.
+    fn signature(&self) -> Vec<PluginSignature>;
+
+    /// Perform the actual behavior of the plugin
+    ///
+    /// The behavior of the plugin is defined by the implementation of this method.
+    /// When Nushell invoked the plugin [serve_plugin] will call this method and
+    /// print the serialized returned value or error to stdout, which Nushell will
+    /// interpret.
+    ///
+    /// The `name` is only relevant for plugins that implement multiple commands as the
+    /// invoked command will be passed in via this argument. The `call` contains
+    /// metadata describing how the plugin was invoked and `input` contains the structured
+    /// data passed to the command implemented by this [Plugin].
+    ///
+    /// This variant expects to receive and produce [PipelineData], which allows for stream-based
+    /// handling of I/O. This is recommended if the plugin is expected to transform large lists or
+    /// potentially large quantities of bytes. The API is more complex however, and [Plugin] is
+    /// recommended instead if this is not a concern.
+    fn run(
+        &mut self,
+        name: &str,
+        config: &Option<Value>,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError>;
+}
+
+/// All [Plugin]s can be used as [StreamingPlugin]s, but input streams will be fully consumed
+/// before the plugin runs.
+impl<T: Plugin> StreamingPlugin for T {
+    fn signature(&self) -> Vec<PluginSignature> {
+        <Self as Plugin>::signature(self)
+    }
+
+    fn run(
+        &mut self,
+        name: &str,
+        config: &Option<Value>,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        // Unwrap the PipelineData from input, consuming the potential stream, and pass it to the
+        // simpler signature in Plugin
+        let span = input.span().unwrap_or(call.head);
+        let input_value = input.into_value(span);
+        // Wrap the output in PipelineData::Value
+        <Self as Plugin>::run(self, name, config, call, &input_value)
+            .map(|value| PipelineData::Value(value, None))
+    }
+}
+
 /// Function used to implement the communication protocol between
-/// nushell and an external plugin.
+/// nushell and an external plugin. Both [Plugin] and [StreamingPlugin] are supported.
 ///
 /// When creating a new plugin this function is typically used as the main entry
 /// point for the plugin, e.g.
@@ -273,11 +387,7 @@ pub trait Plugin {
 ///    serve_plugin(&mut MyPlugin::new(), MsgPackSerializer)
 /// }
 /// ```
-///
-/// The object that is expected to be received by nushell is the `PluginResponse` struct.
-/// The `serve_plugin` function should ensure that it is encoded correctly and sent
-/// to StdOut for nushell to decode and and present its result.
-pub fn serve_plugin(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
+pub fn serve_plugin(plugin: &mut impl StreamingPlugin, encoder: impl PluginEncoder + 'static) {
     if env::args().any(|arg| (arg == "-h") || (arg == "--help")) {
         print_help(plugin, encoder);
         std::process::exit(0)
@@ -287,8 +397,8 @@ pub fn serve_plugin(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
     //
     //                         1 byte
     // encoding format: |  content-length  | content    |
+    let mut stdout = std::io::stdout();
     {
-        let mut stdout = std::io::stdout();
         let encoding = encoder.name();
         let length = encoding.len() as u8;
         let mut encoding_content: Vec<u8> = encoding.as_bytes().to_vec();
@@ -301,91 +411,76 @@ pub fn serve_plugin(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
             .expect("Failed to tell nushell my encoding when flushing stdout");
     }
 
-    let mut stdin_buf = BufReader::with_capacity(OUTPUT_BUFFER_SIZE, std::io::stdin());
-    let plugin_call = encoder.decode_call(&mut stdin_buf);
+    let stdin_buf = BufReader::with_capacity(OUTPUT_BUFFER_SIZE, std::io::stdin());
 
-    match plugin_call {
-        Err(err) => {
-            let response = PluginResponse::Error(err.into());
-            encoder
-                .encode_response(&response, &mut std::io::stdout())
-                .expect("Error encoding response");
-        }
-        Ok(plugin_call) => {
-            match plugin_call {
-                // Sending the signature back to nushell to create the declaration definition
-                PluginCall::Signature => {
-                    let response = PluginResponse::Signature(plugin.signature());
-                    encoder
-                        .encode_response(&response, &mut std::io::stdout())
-                        .expect("Error encoding response");
-                }
-                PluginCall::CallInfo(call_info) => {
-                    let input = match call_info.input {
-                        CallInput::Value(value) => Ok(value),
-                        CallInput::Data(plugin_data) => {
-                            bincode::deserialize::<Box<dyn CustomValue>>(&plugin_data.data)
-                                .map(|custom_value| {
-                                    Value::custom_value(custom_value, plugin_data.span)
-                                })
-                                .map_err(|err| ShellError::PluginFailedToDecode {
-                                    msg: err.to_string(),
-                                })
-                        }
-                    };
+    let interface = EngineInterface::new(stdin_buf, stdout, encoder);
 
-                    let value = match input {
-                        Ok(input) => {
-                            plugin.run(&call_info.name, &call_info.config, &call_info.call, &input)
-                        }
-                        Err(err) => Err(err.into()),
-                    };
+    // Try an operation that could result in ShellError. Exit if an I/O error is encountered.
+    // Try to report the error to nushell otherwise, and failing that, panic.
+    macro_rules! try_or_report {
+        ($expr:expr) => (match $expr {
+            Ok(val) => val,
+            // Just exit if there is an I/O error. Most likely this just means that nushell
+            // interrupted us. If not, the error probably happened on the other side too, so we
+            // don't need to also report it.
+            Err(ShellError::IOError { .. }) => std::process::exit(1),
+            // If there is another error, try to send it to nushell and then exit.
+            Err(err) => {
+                let response = PluginCallResponse::Error(err.clone().into());
+                interface.write_call_response(response).unwrap_or_else(|_| {
+                    // If we can't send it to nushell, panic with it so at least we get the output
+                    panic!("{}", err)
+                });
+                std::process::exit(1)
+            }
+        })
+    }
 
-                    let response = match value {
-                        Ok(value) => {
-                            let span = value.span();
-                            match value {
-                                Value::CustomValue { val, .. } => match bincode::serialize(&val) {
-                                    Ok(data) => {
-                                        let name = val.value_string();
-                                        PluginResponse::PluginData(name, PluginData { data, span })
-                                    }
-                                    Err(err) => PluginResponse::Error(
-                                        ShellError::PluginFailedToEncode {
-                                            msg: err.to_string(),
-                                        }
-                                        .into(),
-                                    ),
-                                },
-                                value => PluginResponse::Value(Box::new(value)),
-                            }
-                        }
-                        Err(err) => PluginResponse::Error(err),
-                    };
-                    encoder
-                        .encode_response(&response, &mut std::io::stdout())
-                        .expect("Error encoding response");
-                }
-                PluginCall::CollapseCustomValue(plugin_data) => {
-                    let response = bincode::deserialize::<Box<dyn CustomValue>>(&plugin_data.data)
-                        .map_err(|err| ShellError::PluginFailedToDecode {
-                            msg: err.to_string(),
-                        })
-                        .and_then(|val| val.to_base_value(plugin_data.span))
-                        .map(Box::new)
-                        .map_err(LabeledError::from)
-                        .map_or_else(PluginResponse::Error, PluginResponse::Value);
+    while let Some(plugin_call) = try_or_report!(interface.read_call()) {
+        match plugin_call {
+            // Sending the signature back to nushell to create the declaration definition
+            PluginCall::Signature => {
+                let response = PluginCallResponse::Signature(plugin.signature());
+                try_or_report!(interface.write_call_response(response));
+            }
+            // Run the plugin, handling any input or output streams
+            PluginCall::Run(CallInfo {
+                name,
+                call,
+                input,
+                config,
+            }) => {
+                let input = try_or_report!(interface.make_pipeline_data(input));
+                match plugin.run(&name, &config, &call, input) {
+                    Ok(output) => {
+                        // Write the output stream back to nushell.
+                        try_or_report!(interface.write_pipeline_data_response(output));
+                    }
+                    Err(err) => {
+                        // Write the error response, and then loop to get the next call.
+                        let response = PluginCallResponse::Error(err);
+                        try_or_report!(interface.write_call_response(response));
+                    }
+                };
+            }
+            // Collapse a custom value into plain nushell data
+            PluginCall::CollapseCustomValue(plugin_data) => {
+                let response = bincode::deserialize::<Box<dyn CustomValue>>(&plugin_data.data)
+                    .map_err(|err| ShellError::PluginFailedToDecode {
+                        msg: err.to_string(),
+                    })
+                    .and_then(|val| val.to_base_value(plugin_data.span))
+                    .map(Box::new)
+                    .map_err(LabeledError::from)
+                    .map_or_else(PluginCallResponse::Error, PluginCallResponse::Value);
 
-                    encoder
-                        .encode_response(&response, &mut std::io::stdout())
-                        .expect("Error encoding response");
-                }
+                try_or_report!(interface.write_call_response(response));
             }
         }
     }
 }
 
-fn print_help(plugin: &mut impl Plugin, encoder: impl PluginEncoder) {
+fn print_help(plugin: &mut impl StreamingPlugin, encoder: impl PluginEncoder) {
     println!("Nushell Plugin");
     println!("Encoder: {}", encoder.name());
 

--- a/crates/nu-plugin/src/protocol/plugin_data.rs
+++ b/crates/nu-plugin/src/protocol/plugin_data.rs
@@ -1,7 +1,7 @@
 use nu_protocol::Span;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PluginData {
     pub data: Vec<u8>,
     pub span: Span,

--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -1,9 +1,16 @@
+use crate::{
+    plugin::PluginEncoder,
+    protocol::{PluginInput, PluginOutput},
+};
 use nu_protocol::ShellError;
+use serde::Deserialize;
 
-use crate::{plugin::PluginEncoder, protocol::PluginResponse};
-
-/// A `PluginEncoder` that enables the plugin to communicate with Nushel with JSON
+/// A `PluginEncoder` that enables the plugin to communicate with Nushell with JSON
 /// serialized data.
+///
+/// Each message in the stream is followed by a newline when serializing, but is not required for
+/// deserialization. The output is not pretty printed and each object does not contain newlines.
+/// If it is more convenient, a plugin may choose to separate messages by newline.
 #[derive(Clone, Debug)]
 pub struct JsonSerializer;
 
@@ -12,42 +19,72 @@ impl PluginEncoder for JsonSerializer {
         "json"
     }
 
-    fn encode_call(
+    fn encode_input(
         &self,
-        plugin_call: &crate::protocol::PluginCall,
+        plugin_input: &PluginInput,
         writer: &mut impl std::io::Write,
     ) -> Result<(), nu_protocol::ShellError> {
-        serde_json::to_writer(writer, plugin_call).map_err(|err| ShellError::PluginFailedToEncode {
+        serde_json::to_writer(&mut *writer, plugin_input).map_err(json_encode_err)?;
+        writer.write_all(b"\n").map_err(|err| ShellError::IOError {
             msg: err.to_string(),
         })
     }
 
-    fn decode_call(
+    fn decode_input(
         &self,
         reader: &mut impl std::io::BufRead,
-    ) -> Result<crate::protocol::PluginCall, nu_protocol::ShellError> {
-        serde_json::from_reader(reader).map_err(|err| ShellError::PluginFailedToEncode {
-            msg: err.to_string(),
-        })
+    ) -> Result<Option<PluginInput>, nu_protocol::ShellError> {
+        let mut de = serde_json::Deserializer::from_reader(reader);
+        PluginInput::deserialize(&mut de)
+            .map(Some)
+            .or_else(json_decode_err)
     }
 
-    fn encode_response(
+    fn encode_output(
         &self,
-        plugin_response: &PluginResponse,
+        plugin_output: &PluginOutput,
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError> {
-        serde_json::to_writer(writer, plugin_response).map_err(|err| {
-            ShellError::PluginFailedToEncode {
-                msg: err.to_string(),
-            }
+        serde_json::to_writer(&mut *writer, plugin_output).map_err(json_encode_err)?;
+        writer.write_all(b"\n").map_err(|err| ShellError::IOError {
+            msg: err.to_string(),
         })
     }
 
-    fn decode_response(
+    fn decode_output(
         &self,
         reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginResponse, ShellError> {
-        serde_json::from_reader(reader).map_err(|err| ShellError::PluginFailedToEncode {
+    ) -> Result<Option<PluginOutput>, ShellError> {
+        let mut de = serde_json::Deserializer::from_reader(reader);
+        PluginOutput::deserialize(&mut de)
+            .map(Some)
+            .or_else(json_decode_err)
+    }
+}
+
+/// Handle a `serde_json` encode error.
+fn json_encode_err(err: serde_json::Error) -> ShellError {
+    if err.is_io() {
+        ShellError::IOError {
+            msg: err.to_string(),
+        }
+    } else {
+        ShellError::PluginFailedToEncode {
+            msg: err.to_string(),
+        }
+    }
+}
+
+/// Handle a `serde_json` decode error. Returns `Ok(None)` on eof.
+fn json_decode_err<T>(err: serde_json::Error) -> Result<Option<T>, ShellError> {
+    if err.is_eof() {
+        Ok(None)
+    } else if err.is_io() {
+        Err(ShellError::IOError {
+            msg: err.to_string(),
+        })
+    } else {
+        Err(ShellError::PluginFailedToDecode {
             msg: err.to_string(),
         })
     }
@@ -56,306 +93,35 @@ impl PluginEncoder for JsonSerializer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{
-        CallInfo, CallInput, EvaluatedCall, LabeledError, PluginCall, PluginData, PluginResponse,
-    };
-    use nu_protocol::{PluginSignature, Span, Spanned, SyntaxShape, Value};
+    crate::serializers::tests::generate_tests!(JsonSerializer {});
 
     #[test]
-    fn callinfo_round_trip_signature() {
-        let plugin_call = PluginCall::Signature;
-        let encoder = JsonSerializer {};
-
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&plugin_call, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginCall::Signature => {}
-            PluginCall::CallInfo(_) => panic!("decoded into wrong value"),
-            PluginCall::CollapseCustomValue(_) => panic!("decoded into wrong value"),
-        }
-    }
-
-    #[test]
-    fn callinfo_round_trip_callinfo() {
-        let name = "test".to_string();
-
-        let input = Value::bool(false, Span::new(1, 20));
-
-        let call = EvaluatedCall {
-            head: Span::new(0, 10),
-            positional: vec![
-                Value::float(1.0, Span::new(0, 10)),
-                Value::string("something", Span::new(0, 10)),
-            ],
-            named: vec![(
-                Spanned {
-                    item: "name".to_string(),
-                    span: Span::new(0, 10),
-                },
-                Some(Value::float(1.0, Span::new(0, 10))),
-            )],
-        };
-
-        let plugin_call = PluginCall::CallInfo(CallInfo {
-            name: name.clone(),
-            call: call.clone(),
-            input: CallInput::Value(input.clone()),
-            config: None,
-        });
-
-        let encoder = JsonSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&plugin_call, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginCall::Signature => panic!("returned wrong call type"),
-            PluginCall::CallInfo(call_info) => {
-                assert_eq!(name, call_info.name);
-                assert_eq!(CallInput::Value(input), call_info.input);
-                assert_eq!(call.head, call_info.call.head);
-                assert_eq!(call.positional.len(), call_info.call.positional.len());
-
-                call.positional
-                    .iter()
-                    .zip(call_info.call.positional.iter())
-                    .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
-
-                call.named
-                    .iter()
-                    .zip(call_info.call.named.iter())
-                    .for_each(|(lhs, rhs)| {
-                        // Comparing the keys
-                        assert_eq!(lhs.0.item, rhs.0.item);
-
-                        match (&lhs.1, &rhs.1) {
-                            (None, None) => {}
-                            (Some(a), Some(b)) => assert_eq!(a, b),
-                            _ => panic!("not matching values"),
-                        }
-                    });
-            }
-            PluginCall::CollapseCustomValue(_) => panic!("returned wrong call type"),
-        }
-    }
-
-    #[test]
-    fn callinfo_round_trip_collapsecustomvalue() {
-        let data = vec![1, 2, 3, 4, 5, 6, 7];
-        let span = Span::new(0, 20);
-
-        let collapse_custom_value = PluginCall::CollapseCustomValue(PluginData {
-            data: data.clone(),
-            span,
-        });
-
-        let encoder = JsonSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&collapse_custom_value, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginCall::Signature => panic!("returned wrong call type"),
-            PluginCall::CallInfo(_) => panic!("returned wrong call type"),
-            PluginCall::CollapseCustomValue(plugin_data) => {
-                assert_eq!(data, plugin_data.data);
-                assert_eq!(span, plugin_data.span);
-            }
-        }
-    }
-
-    #[test]
-    fn response_round_trip_signature() {
-        let signature = PluginSignature::build("nu-plugin")
-            .required("first", SyntaxShape::String, "first required")
-            .required("second", SyntaxShape::Int, "second required")
-            .required_named("first-named", SyntaxShape::String, "first named", Some('f'))
-            .required_named(
-                "second-named",
-                SyntaxShape::String,
-                "second named",
-                Some('s'),
-            )
-            .rest("remaining", SyntaxShape::Int, "remaining");
-
-        let response = PluginResponse::Signature(vec![signature.clone()]);
-
-        let encoder = JsonSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(_) => panic!("returned wrong call type"),
-            PluginResponse::Value(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
-            PluginResponse::Signature(returned_signature) => {
-                assert_eq!(returned_signature.len(), 1);
-                assert_eq!(signature.sig.name, returned_signature[0].sig.name);
-                assert_eq!(signature.sig.usage, returned_signature[0].sig.usage);
-                assert_eq!(
-                    signature.sig.extra_usage,
-                    returned_signature[0].sig.extra_usage
-                );
-                assert_eq!(signature.sig.is_filter, returned_signature[0].sig.is_filter);
-
-                signature
-                    .sig
-                    .required_positional
-                    .iter()
-                    .zip(returned_signature[0].sig.required_positional.iter())
-                    .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
-
-                signature
-                    .sig
-                    .optional_positional
-                    .iter()
-                    .zip(returned_signature[0].sig.optional_positional.iter())
-                    .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
-
-                signature
-                    .sig
-                    .named
-                    .iter()
-                    .zip(returned_signature[0].sig.named.iter())
-                    .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
-
-                assert_eq!(
-                    signature.sig.rest_positional,
-                    returned_signature[0].sig.rest_positional,
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn response_round_trip_value() {
-        let value = Value::int(10, Span::new(2, 30));
-
-        let response = PluginResponse::Value(Box::new(value.clone()));
-
-        let encoder = JsonSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(_) => panic!("returned wrong call type"),
-            PluginResponse::Signature(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
-            PluginResponse::Value(returned_value) => {
-                assert_eq!(&value, returned_value.as_ref())
-            }
-        }
-    }
-
-    #[test]
-    fn response_round_trip_plugin_data() {
-        let name = "test".to_string();
-
-        let data = vec![1, 2, 3, 4, 5];
-        let span = Span::new(2, 30);
-
-        let response = PluginResponse::PluginData(
-            name.clone(),
-            PluginData {
-                data: data.clone(),
-                span,
-            },
+    fn json_ends_in_newline() {
+        let mut out = vec![];
+        JsonSerializer {}
+            .encode_input(&PluginInput::Call(PluginCall::Signature), &mut out)
+            .expect("serialization error");
+        let string = std::str::from_utf8(&out).expect("utf-8 error");
+        assert!(
+            string.ends_with('\n'),
+            "doesn't end with newline: {:?}",
+            string
         );
-
-        let encoder = JsonSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(_) => panic!("returned wrong call type"),
-            PluginResponse::Signature(_) => panic!("returned wrong call type"),
-            PluginResponse::Value(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(returned_name, returned_plugin_data) => {
-                assert_eq!(name, returned_name);
-                assert_eq!(data, returned_plugin_data.data);
-                assert_eq!(span, returned_plugin_data.span);
-            }
-        }
     }
 
     #[test]
-    fn response_round_trip_error() {
-        let error = LabeledError {
-            label: "label".into(),
-            msg: "msg".into(),
-            span: Some(Span::new(2, 30)),
-        };
-        let response = PluginResponse::Error(error.clone());
-
-        let encoder = JsonSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(msg) => assert_eq!(error, msg),
-            PluginResponse::Signature(_) => panic!("returned wrong call type"),
-            PluginResponse::Value(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
-        }
-    }
-
-    #[test]
-    fn response_round_trip_error_none() {
-        let error = LabeledError {
-            label: "label".into(),
-            msg: "msg".into(),
-            span: None,
-        };
-        let response = PluginResponse::Error(error.clone());
-
-        let encoder = JsonSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(msg) => assert_eq!(error, msg),
-            PluginResponse::Signature(_) => panic!("returned wrong call type"),
-            PluginResponse::Value(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
-        }
+    fn json_has_no_other_newlines() {
+        let mut out = vec![];
+        // use something deeply nested, to try to trigger any pretty printing
+        let output = PluginOutput::StreamData(StreamData::List(Some(Value::test_list(vec![
+            Value::test_int(4),
+            // in case escaping failed
+            Value::test_string("newline\ncontaining\nstring"),
+        ]))));
+        JsonSerializer {}
+            .encode_output(&output, &mut out)
+            .expect("serialization error");
+        let string = std::str::from_utf8(&out).expect("utf-8 error");
+        assert_eq!(1, string.chars().filter(|ch| *ch == '\n').count());
     }
 }

--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -1,11 +1,14 @@
 use crate::{
     plugin::PluginEncoder,
-    protocol::{PluginCall, PluginResponse},
+    protocol::{PluginInput, PluginOutput},
 };
 use nu_protocol::ShellError;
 
 pub mod json;
 pub mod msgpack;
+
+#[cfg(test)]
+mod tests;
 
 #[doc(hidden)]
 #[derive(Clone, Debug)]
@@ -23,52 +26,58 @@ impl EncodingType {
         }
     }
 
-    pub fn encode_call(
-        &self,
-        plugin_call: &PluginCall,
-        writer: &mut impl std::io::Write,
-    ) -> Result<(), ShellError> {
-        match self {
-            EncodingType::Json(encoder) => encoder.encode_call(plugin_call, writer),
-            EncodingType::MsgPack(encoder) => encoder.encode_call(plugin_call, writer),
-        }
-    }
-
-    pub fn decode_call(
-        &self,
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginCall, ShellError> {
-        match self {
-            EncodingType::Json(encoder) => encoder.decode_call(reader),
-            EncodingType::MsgPack(encoder) => encoder.decode_call(reader),
-        }
-    }
-
-    pub fn encode_response(
-        &self,
-        plugin_response: &PluginResponse,
-        writer: &mut impl std::io::Write,
-    ) -> Result<(), ShellError> {
-        match self {
-            EncodingType::Json(encoder) => encoder.encode_response(plugin_response, writer),
-            EncodingType::MsgPack(encoder) => encoder.encode_response(plugin_response, writer),
-        }
-    }
-
-    pub fn decode_response(
-        &self,
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginResponse, ShellError> {
-        match self {
-            EncodingType::Json(encoder) => encoder.decode_response(reader),
-            EncodingType::MsgPack(encoder) => encoder.decode_response(reader),
-        }
-    }
-
     pub fn to_str(&self) -> &'static str {
         match self {
             Self::Json(_) => "json",
             Self::MsgPack(_) => "msgpack",
+        }
+    }
+}
+
+impl PluginEncoder for EncodingType {
+    fn name(&self) -> &str {
+        self.to_str()
+    }
+
+    fn encode_input(
+        &self,
+        plugin_input: &PluginInput,
+        writer: &mut impl std::io::Write,
+    ) -> Result<(), ShellError> {
+        match self {
+            EncodingType::Json(encoder) => encoder.encode_input(plugin_input, writer),
+            EncodingType::MsgPack(encoder) => encoder.encode_input(plugin_input, writer),
+        }
+    }
+
+    fn decode_input(
+        &self,
+        reader: &mut impl std::io::BufRead,
+    ) -> Result<Option<PluginInput>, ShellError> {
+        match self {
+            EncodingType::Json(encoder) => encoder.decode_input(reader),
+            EncodingType::MsgPack(encoder) => encoder.decode_input(reader),
+        }
+    }
+
+    fn encode_output(
+        &self,
+        plugin_output: &PluginOutput,
+        writer: &mut impl std::io::Write,
+    ) -> Result<(), ShellError> {
+        match self {
+            EncodingType::Json(encoder) => encoder.encode_output(plugin_output, writer),
+            EncodingType::MsgPack(encoder) => encoder.encode_output(plugin_output, writer),
+        }
+    }
+
+    fn decode_output(
+        &self,
+        reader: &mut impl std::io::BufRead,
+    ) -> Result<Option<PluginOutput>, ShellError> {
+        match self {
+            EncodingType::Json(encoder) => encoder.decode_output(reader),
+            EncodingType::MsgPack(encoder) => encoder.decode_output(reader),
         }
     }
 }

--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -1,8 +1,16 @@
-use crate::{plugin::PluginEncoder, protocol::PluginResponse};
-use nu_protocol::ShellError;
+use std::io::ErrorKind;
 
-/// A `PluginEncoder` that enables the plugin to communicate with Nushel with MsgPack
+use crate::{
+    plugin::PluginEncoder,
+    protocol::{PluginInput, PluginOutput},
+};
+use nu_protocol::ShellError;
+use serde::Deserialize;
+
+/// A `PluginEncoder` that enables the plugin to communicate with Nushell with MsgPack
 /// serialized data.
+///
+/// Each message is written as a MessagePack object. There is no message envelope or separator.
 #[derive(Clone, Debug)]
 pub struct MsgPackSerializer;
 
@@ -11,352 +19,88 @@ impl PluginEncoder for MsgPackSerializer {
         "msgpack"
     }
 
-    fn encode_call(
+    fn encode_input(
         &self,
-        plugin_call: &crate::protocol::PluginCall,
+        plugin_input: &PluginInput,
         writer: &mut impl std::io::Write,
     ) -> Result<(), nu_protocol::ShellError> {
-        rmp_serde::encode::write(writer, plugin_call).map_err(|err| {
-            ShellError::PluginFailedToEncode {
-                msg: err.to_string(),
-            }
-        })
+        rmp_serde::encode::write(writer, plugin_input).map_err(rmp_encode_err)
     }
 
-    fn decode_call(
+    fn decode_input(
         &self,
         reader: &mut impl std::io::BufRead,
-    ) -> Result<crate::protocol::PluginCall, nu_protocol::ShellError> {
-        rmp_serde::from_read(reader).map_err(|err| ShellError::PluginFailedToDecode {
-            msg: err.to_string(),
-        })
+    ) -> Result<Option<PluginInput>, ShellError> {
+        let mut de = rmp_serde::Deserializer::new(reader);
+        PluginInput::deserialize(&mut de)
+            .map(Some)
+            .or_else(rmp_decode_err)
     }
 
-    fn encode_response(
+    fn encode_output(
         &self,
-        plugin_response: &PluginResponse,
+        plugin_output: &PluginOutput,
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError> {
-        rmp_serde::encode::write(writer, plugin_response).map_err(|err| {
+        rmp_serde::encode::write(writer, plugin_output).map_err(rmp_encode_err)
+    }
+
+    fn decode_output(
+        &self,
+        reader: &mut impl std::io::BufRead,
+    ) -> Result<Option<PluginOutput>, ShellError> {
+        let mut de = rmp_serde::Deserializer::new(reader);
+        PluginOutput::deserialize(&mut de)
+            .map(Some)
+            .or_else(rmp_decode_err)
+    }
+}
+
+/// Handle a msgpack encode error
+fn rmp_encode_err(err: rmp_serde::encode::Error) -> ShellError {
+    match err {
+        rmp_serde::encode::Error::InvalidValueWrite(_) => {
+            // I/O error
+            ShellError::IOError {
+                msg: err.to_string(),
+            }
+        }
+        _ => {
+            // Something else
             ShellError::PluginFailedToEncode {
                 msg: err.to_string(),
             }
-        })
+        }
     }
+}
 
-    fn decode_response(
-        &self,
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<PluginResponse, ShellError> {
-        rmp_serde::from_read(reader).map_err(|err| ShellError::PluginFailedToDecode {
-            msg: err.to_string(),
-        })
+/// Handle a msgpack decode error. Returns `Ok(None)` on eof
+fn rmp_decode_err<T>(err: rmp_serde::decode::Error) -> Result<Option<T>, ShellError> {
+    match err {
+        rmp_serde::decode::Error::InvalidMarkerRead(err)
+            if matches!(err.kind(), ErrorKind::UnexpectedEof) =>
+        {
+            // EOF
+            Ok(None)
+        }
+        rmp_serde::decode::Error::InvalidMarkerRead(_)
+        | rmp_serde::decode::Error::InvalidDataRead(_) => {
+            // I/O error
+            Err(ShellError::IOError {
+                msg: err.to_string(),
+            })
+        }
+        _ => {
+            // Something else
+            Err(ShellError::PluginFailedToDecode {
+                msg: err.to_string(),
+            })
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{
-        CallInfo, CallInput, EvaluatedCall, LabeledError, PluginCall, PluginData, PluginResponse,
-    };
-    use nu_protocol::{PluginSignature, Span, Spanned, SyntaxShape, Value};
-
-    #[test]
-    fn callinfo_round_trip_signature() {
-        let plugin_call = PluginCall::Signature;
-        let encoder = MsgPackSerializer {};
-
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&plugin_call, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginCall::Signature => {}
-            PluginCall::CallInfo(_) => panic!("decoded into wrong value"),
-            PluginCall::CollapseCustomValue(_) => panic!("decoded into wrong value"),
-        }
-    }
-
-    #[test]
-    fn callinfo_round_trip_callinfo() {
-        let name = "test".to_string();
-
-        let input = Value::bool(false, Span::new(1, 20));
-
-        let call = EvaluatedCall {
-            head: Span::new(0, 10),
-            positional: vec![
-                Value::float(1.0, Span::new(0, 10)),
-                Value::string("something", Span::new(0, 10)),
-            ],
-            named: vec![(
-                Spanned {
-                    item: "name".to_string(),
-                    span: Span::new(0, 10),
-                },
-                Some(Value::float(1.0, Span::new(0, 10))),
-            )],
-        };
-
-        let plugin_call = PluginCall::CallInfo(CallInfo {
-            name: name.clone(),
-            call: call.clone(),
-            input: CallInput::Value(input.clone()),
-            config: None,
-        });
-
-        let encoder = MsgPackSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&plugin_call, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginCall::Signature => panic!("returned wrong call type"),
-            PluginCall::CallInfo(call_info) => {
-                assert_eq!(name, call_info.name);
-                assert_eq!(CallInput::Value(input), call_info.input);
-                assert_eq!(call.head, call_info.call.head);
-                assert_eq!(call.positional.len(), call_info.call.positional.len());
-
-                call.positional
-                    .iter()
-                    .zip(call_info.call.positional.iter())
-                    .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
-
-                call.named
-                    .iter()
-                    .zip(call_info.call.named.iter())
-                    .for_each(|(lhs, rhs)| {
-                        // Comparing the keys
-                        assert_eq!(lhs.0.item, rhs.0.item);
-
-                        match (&lhs.1, &rhs.1) {
-                            (None, None) => {}
-                            (Some(a), Some(b)) => assert_eq!(a, b),
-                            _ => panic!("not matching values"),
-                        }
-                    });
-            }
-            PluginCall::CollapseCustomValue(_) => panic!("returned wrong call type"),
-        }
-    }
-
-    #[test]
-    fn callinfo_round_trip_collapsecustomvalue() {
-        let data = vec![1, 2, 3, 4, 5, 6, 7];
-        let span = Span::new(0, 20);
-
-        let collapse_custom_value = PluginCall::CollapseCustomValue(PluginData {
-            data: data.clone(),
-            span,
-        });
-
-        let encoder = MsgPackSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_call(&collapse_custom_value, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_call(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginCall::Signature => panic!("returned wrong call type"),
-            PluginCall::CallInfo(_) => panic!("returned wrong call type"),
-            PluginCall::CollapseCustomValue(plugin_data) => {
-                assert_eq!(data, plugin_data.data);
-                assert_eq!(span, plugin_data.span);
-            }
-        }
-    }
-
-    #[test]
-    fn response_round_trip_signature() {
-        let signature = PluginSignature::build("nu-plugin")
-            .required("first", SyntaxShape::String, "first required")
-            .required("second", SyntaxShape::Int, "second required")
-            .required_named("first-named", SyntaxShape::String, "first named", Some('f'))
-            .required_named(
-                "second-named",
-                SyntaxShape::String,
-                "second named",
-                Some('s'),
-            )
-            .rest("remaining", SyntaxShape::Int, "remaining");
-
-        let response = PluginResponse::Signature(vec![signature.clone()]);
-
-        let encoder = MsgPackSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(_) => panic!("returned wrong call type"),
-            PluginResponse::Value(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
-            PluginResponse::Signature(returned_signature) => {
-                assert_eq!(returned_signature.len(), 1);
-                assert_eq!(signature.sig.name, returned_signature[0].sig.name);
-                assert_eq!(signature.sig.usage, returned_signature[0].sig.usage);
-                assert_eq!(
-                    signature.sig.extra_usage,
-                    returned_signature[0].sig.extra_usage
-                );
-                assert_eq!(signature.sig.is_filter, returned_signature[0].sig.is_filter);
-
-                signature
-                    .sig
-                    .required_positional
-                    .iter()
-                    .zip(returned_signature[0].sig.required_positional.iter())
-                    .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
-
-                signature
-                    .sig
-                    .optional_positional
-                    .iter()
-                    .zip(returned_signature[0].sig.optional_positional.iter())
-                    .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
-
-                signature
-                    .sig
-                    .named
-                    .iter()
-                    .zip(returned_signature[0].sig.named.iter())
-                    .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
-
-                assert_eq!(
-                    signature.sig.rest_positional,
-                    returned_signature[0].sig.rest_positional,
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn response_round_trip_value() {
-        let value = Value::int(10, Span::new(2, 30));
-
-        let response = PluginResponse::Value(Box::new(value.clone()));
-
-        let encoder = MsgPackSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(_) => panic!("returned wrong call type"),
-            PluginResponse::Signature(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
-            PluginResponse::Value(returned_value) => {
-                assert_eq!(&value, returned_value.as_ref())
-            }
-        }
-    }
-
-    #[test]
-    fn response_round_trip_plugin_data() {
-        let name = "test".to_string();
-
-        let data = vec![1, 2, 3, 4, 5];
-        let span = Span::new(2, 30);
-
-        let response = PluginResponse::PluginData(
-            name.clone(),
-            PluginData {
-                data: data.clone(),
-                span,
-            },
-        );
-
-        let encoder = MsgPackSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(_) => panic!("returned wrong call type"),
-            PluginResponse::Signature(_) => panic!("returned wrong call type"),
-            PluginResponse::Value(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(returned_name, returned_plugin_data) => {
-                assert_eq!(name, returned_name);
-                assert_eq!(data, returned_plugin_data.data);
-                assert_eq!(span, returned_plugin_data.span);
-            }
-        }
-    }
-
-    #[test]
-    fn response_round_trip_error() {
-        let error = LabeledError {
-            label: "label".into(),
-            msg: "msg".into(),
-            span: Some(Span::new(2, 30)),
-        };
-        let response = PluginResponse::Error(error.clone());
-
-        let encoder = MsgPackSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(msg) => assert_eq!(error, msg),
-            PluginResponse::Signature(_) => panic!("returned wrong call type"),
-            PluginResponse::Value(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
-        }
-    }
-
-    #[test]
-    fn response_round_trip_error_none() {
-        let error = LabeledError {
-            label: "label".into(),
-            msg: "msg".into(),
-            span: None,
-        };
-        let response = PluginResponse::Error(error.clone());
-
-        let encoder = MsgPackSerializer {};
-        let mut buffer: Vec<u8> = Vec::new();
-        encoder
-            .encode_response(&response, &mut buffer)
-            .expect("unable to serialize message");
-        let returned = encoder
-            .decode_response(&mut buffer.as_slice())
-            .expect("unable to deserialize message");
-
-        match returned {
-            PluginResponse::Error(msg) => assert_eq!(error, msg),
-            PluginResponse::Signature(_) => panic!("returned wrong call type"),
-            PluginResponse::Value(_) => panic!("returned wrong call type"),
-            PluginResponse::PluginData(..) => panic!("returned wrong call type"),
-        }
-    }
+    crate::serializers::tests::generate_tests!(MsgPackSerializer {});
 }

--- a/crates/nu-plugin/src/serializers/tests.rs
+++ b/crates/nu-plugin/src/serializers/tests.rs
@@ -1,0 +1,601 @@
+macro_rules! generate_tests {
+    ($encoder:expr) => {
+        use crate::protocol::{
+            CallInfo, CallInput, EvaluatedCall, LabeledError, PluginCall, PluginCallResponse,
+            PluginData, PluginInput, PluginOutput, StreamData,
+        };
+        use nu_protocol::{PluginSignature, Span, Spanned, SyntaxShape, Value};
+
+        #[test]
+        fn decode_eof() {
+            let mut buffer: &[u8] = &[];
+            let encoder = $encoder;
+            let result = encoder
+                .decode_input(&mut buffer)
+                .expect("eof should not result in an error");
+            assert!(result.is_none(), "decode_input result: {result:?}");
+            let result = encoder
+                .decode_output(&mut buffer)
+                .expect("eof should not result in an error");
+            assert!(result.is_none(), "decode_output result: {result:?}");
+        }
+
+        #[test]
+        fn decode_io_error() {
+            struct ErrorProducer;
+            impl std::io::Read for ErrorProducer {
+                fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                    Err(std::io::Error::from(std::io::ErrorKind::ConnectionReset))
+                }
+            }
+            let encoder = $encoder;
+            let mut buffered = std::io::BufReader::new(ErrorProducer);
+            match encoder.decode_input(&mut buffered) {
+                Ok(_) => panic!("decode_input: i/o error was not passed through"),
+                Err(ShellError::IOError { .. }) => (), // okay
+                Err(other) => panic!(
+                    "decode_input: got other error, should have been a \
+                    ShellError::IOError: {other:?}"
+                ),
+            }
+            match encoder.decode_output(&mut buffered) {
+                Ok(_) => panic!("decode_output: i/o error was not passed through"),
+                Err(ShellError::IOError { .. }) => (), // okay
+                Err(other) => panic!(
+                    "decode_output: got other error, should have been a \
+                    ShellError::IOError: {other:?}"
+                ),
+            }
+        }
+
+        #[test]
+        fn decode_gibberish() {
+            // just a sequence of bytes that shouldn't be valid in anything we use
+            let gibberish: &[u8] = &[
+                0, 80, 74, 85, 117, 122, 86, 100, 74, 115, 20, 104, 55, 98, 67, 203, 83, 85, 77,
+                112, 74, 79, 254, 71, 80,
+            ];
+            let encoder = $encoder;
+
+            let mut buffered = std::io::BufReader::new(&gibberish[..]);
+            match encoder.decode_input(&mut buffered) {
+                Ok(value) => panic!("decode_input: parsed successfully => {value:?}"),
+                Err(ShellError::PluginFailedToDecode { .. }) => (), // okay
+                Err(other) => panic!(
+                    "decode_input: got other error, should have been a \
+                    ShellError::PluginFailedToDecode: {other:?}"
+                ),
+            }
+
+            let mut buffered = std::io::BufReader::new(&gibberish[..]);
+            match encoder.decode_output(&mut buffered) {
+                Ok(value) => panic!("decode_output: parsed successfully => {value:?}"),
+                Err(ShellError::PluginFailedToDecode { .. }) => (), // okay
+                Err(other) => panic!(
+                    "decode_output: got other error, should have been a \
+                    ShellError::PluginFailedToDecode: {other:?}"
+                ),
+            }
+        }
+
+        #[test]
+        fn call_round_trip_signature() {
+            let plugin_call = PluginCall::Signature;
+            let plugin_input = PluginInput::Call(plugin_call);
+            let encoder = $encoder;
+
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_input(&plugin_input, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_input(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginInput::Call(PluginCall::Signature) => {}
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn call_round_trip_run() {
+            let name = "test".to_string();
+
+            let input = Value::bool(false, Span::new(1, 20));
+
+            let call = EvaluatedCall {
+                head: Span::new(0, 10),
+                positional: vec![
+                    Value::float(1.0, Span::new(0, 10)),
+                    Value::string("something", Span::new(0, 10)),
+                ],
+                named: vec![(
+                    Spanned {
+                        item: "name".to_string(),
+                        span: Span::new(0, 10),
+                    },
+                    Some(Value::float(1.0, Span::new(0, 10))),
+                )],
+            };
+
+            let plugin_call = PluginCall::Run(CallInfo {
+                name: name.clone(),
+                call: call.clone(),
+                input: CallInput::Value(input.clone()),
+                config: None,
+            });
+
+            let plugin_input = PluginInput::Call(plugin_call);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_input(&plugin_input, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_input(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginInput::Call(PluginCall::Run(call_info)) => {
+                    assert_eq!(name, call_info.name);
+                    assert_eq!(CallInput::Value(input), call_info.input);
+                    assert_eq!(call.head, call_info.call.head);
+                    assert_eq!(call.positional.len(), call_info.call.positional.len());
+
+                    call.positional
+                        .iter()
+                        .zip(call_info.call.positional.iter())
+                        .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
+
+                    call.named
+                        .iter()
+                        .zip(call_info.call.named.iter())
+                        .for_each(|(lhs, rhs)| {
+                            // Comparing the keys
+                            assert_eq!(lhs.0.item, rhs.0.item);
+
+                            match (&lhs.1, &rhs.1) {
+                                (None, None) => {}
+                                (Some(a), Some(b)) => assert_eq!(a, b),
+                                _ => panic!("not matching values"),
+                            }
+                        });
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn call_round_trip_collapsecustomvalue() {
+            let data = vec![1, 2, 3, 4, 5, 6, 7];
+            let span = Span::new(0, 20);
+
+            let collapse_custom_value = PluginCall::CollapseCustomValue(PluginData {
+                data: data.clone(),
+                span,
+            });
+
+            let plugin_input = PluginInput::Call(collapse_custom_value);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_input(&plugin_input, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_input(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginInput::Call(PluginCall::CollapseCustomValue(plugin_data)) => {
+                    assert_eq!(data, plugin_data.data);
+                    assert_eq!(span, plugin_data.span);
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn response_round_trip_signature() {
+            let signature = PluginSignature::build("nu-plugin")
+                .required("first", SyntaxShape::String, "first required")
+                .required("second", SyntaxShape::Int, "second required")
+                .required_named("first-named", SyntaxShape::String, "first named", Some('f'))
+                .required_named(
+                    "second-named",
+                    SyntaxShape::String,
+                    "second named",
+                    Some('s'),
+                )
+                .rest("remaining", SyntaxShape::Int, "remaining");
+
+            let response = PluginCallResponse::Signature(vec![signature.clone()]);
+            let output = PluginOutput::CallResponse(response);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::CallResponse(PluginCallResponse::Signature(returned_signature)) => {
+                    assert_eq!(returned_signature.len(), 1);
+                    assert_eq!(signature.sig.name, returned_signature[0].sig.name);
+                    assert_eq!(signature.sig.usage, returned_signature[0].sig.usage);
+                    assert_eq!(
+                        signature.sig.extra_usage,
+                        returned_signature[0].sig.extra_usage
+                    );
+                    assert_eq!(signature.sig.is_filter, returned_signature[0].sig.is_filter);
+
+                    signature
+                        .sig
+                        .required_positional
+                        .iter()
+                        .zip(returned_signature[0].sig.required_positional.iter())
+                        .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
+
+                    signature
+                        .sig
+                        .optional_positional
+                        .iter()
+                        .zip(returned_signature[0].sig.optional_positional.iter())
+                        .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
+
+                    signature
+                        .sig
+                        .named
+                        .iter()
+                        .zip(returned_signature[0].sig.named.iter())
+                        .for_each(|(lhs, rhs)| assert_eq!(lhs, rhs));
+
+                    assert_eq!(
+                        signature.sig.rest_positional,
+                        returned_signature[0].sig.rest_positional,
+                    );
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn response_round_trip_value() {
+            let value = Value::int(10, Span::new(2, 30));
+
+            let response = PluginCallResponse::Value(Box::new(value.clone()));
+            let output = PluginOutput::CallResponse(response);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::CallResponse(PluginCallResponse::Value(returned_value)) => {
+                    assert_eq!(&value, returned_value.as_ref())
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn response_round_trip_plugin_data() {
+            let name = "test".to_string();
+
+            let data = vec![1, 2, 3, 4, 5];
+            let span = Span::new(2, 30);
+
+            let response = PluginCallResponse::PluginData(
+                name.clone(),
+                PluginData {
+                    data: data.clone(),
+                    span,
+                },
+            );
+            let output = PluginOutput::CallResponse(response);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::CallResponse(PluginCallResponse::PluginData(
+                    returned_name,
+                    returned_plugin_data,
+                )) => {
+                    assert_eq!(name, returned_name);
+                    assert_eq!(data, returned_plugin_data.data);
+                    assert_eq!(span, returned_plugin_data.span);
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn response_round_trip_error() {
+            let error = LabeledError {
+                label: "label".into(),
+                msg: "msg".into(),
+                span: Some(Span::new(2, 30)),
+            };
+            let response = PluginCallResponse::Error(error.clone());
+            let output = PluginOutput::CallResponse(response);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::CallResponse(PluginCallResponse::Error(msg)) => {
+                    assert_eq!(error, msg)
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn response_round_trip_error_none() {
+            let error = LabeledError {
+                label: "label".into(),
+                msg: "msg".into(),
+                span: None,
+            };
+            let response = PluginCallResponse::Error(error.clone());
+            let output = PluginOutput::CallResponse(response);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::CallResponse(PluginCallResponse::Error(msg)) => {
+                    assert_eq!(error, msg)
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn input_round_trip_stream_data_list() {
+            let span = Span::new(12, 30);
+            let item = Value::int(1, span);
+
+            let stream_data = StreamData::List(Some(item.clone()));
+            let plugin_input = PluginInput::StreamData(stream_data);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_input(&plugin_input, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_input(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginInput::StreamData(StreamData::List(Some(list_data))) => {
+                    assert_eq!(item, list_data);
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn input_round_trip_stream_data_external_stdout() {
+            let data = b"Hello world";
+
+            let stream_data = StreamData::ExternalStdout(Some(Ok(data.to_vec())));
+            let plugin_input = PluginInput::StreamData(stream_data);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_input(&plugin_input, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_input(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginInput::StreamData(StreamData::ExternalStdout(Some(bytes))) => match bytes {
+                    Ok(bytes) => assert_eq!(data, &bytes[..]),
+                    Err(err) => panic!("decoded into error variant: {err:?}"),
+                },
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn input_round_trip_stream_data_external_stderr() {
+            let data = b"Hello world";
+
+            let stream_data = StreamData::ExternalStderr(Some(Ok(data.to_vec())));
+            let plugin_input = PluginInput::StreamData(stream_data);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_input(&plugin_input, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_input(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginInput::StreamData(StreamData::ExternalStderr(Some(bytes))) => match bytes {
+                    Ok(bytes) => assert_eq!(data, &bytes[..]),
+                    Err(err) => panic!("decoded into error variant: {err:?}"),
+                },
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn input_round_trip_stream_data_external_exit_code() {
+            let span = Span::new(0, 0);
+            let exit_code = Value::int(1, span);
+
+            let stream_data = StreamData::ExternalExitCode(Some(exit_code.clone()));
+            let plugin_input = PluginInput::StreamData(stream_data);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_input(&plugin_input, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_input(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginInput::StreamData(StreamData::ExternalExitCode(Some(value))) => {
+                    assert_eq!(exit_code, value);
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn output_round_trip_stream_data_list() {
+            let span = Span::new(12, 30);
+            let item = Value::int(1, span);
+
+            let stream_data = StreamData::List(Some(item.clone()));
+            let plugin_output = PluginOutput::StreamData(stream_data);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&plugin_output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::StreamData(StreamData::List(Some(list_data))) => {
+                    assert_eq!(item, list_data);
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn output_round_trip_stream_data_external_stdout() {
+            let data = b"Hello world";
+
+            let stream_data = StreamData::ExternalStdout(Some(Ok(data.to_vec())));
+            let plugin_output = PluginOutput::StreamData(stream_data);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&plugin_output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::StreamData(StreamData::ExternalStdout(Some(bytes))) => match bytes {
+                    Ok(bytes) => assert_eq!(data, &bytes[..]),
+                    Err(err) => panic!("decoded into error variant: {err:?}"),
+                },
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn output_round_trip_stream_data_external_stderr() {
+            let data = b"Hello world";
+
+            let stream_data = StreamData::ExternalStderr(Some(Ok(data.to_vec())));
+            let plugin_output = PluginOutput::StreamData(stream_data);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&plugin_output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::StreamData(StreamData::ExternalStderr(Some(bytes))) => match bytes {
+                    Ok(bytes) => assert_eq!(data, &bytes[..]),
+                    Err(err) => panic!("decoded into error variant: {err:?}"),
+                },
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+
+        #[test]
+        fn output_round_trip_stream_data_external_exit_code() {
+            let span = Span::new(0, 0);
+            let exit_code = Value::int(1, span);
+
+            let stream_data = StreamData::ExternalExitCode(Some(exit_code.clone()));
+            let plugin_output = PluginOutput::StreamData(stream_data);
+
+            let encoder = $encoder;
+            let mut buffer: Vec<u8> = Vec::new();
+            encoder
+                .encode_output(&plugin_output, &mut buffer)
+                .expect("unable to serialize message");
+            let returned = encoder
+                .decode_output(&mut buffer.as_slice())
+                .expect("unable to deserialize message")
+                .expect("eof");
+
+            match returned {
+                PluginOutput::StreamData(StreamData::ExternalExitCode(Some(value))) => {
+                    assert_eq!(exit_code, value);
+                }
+                _ => panic!("decoded into wrong value: {returned:?}"),
+            }
+        }
+    };
+}
+
+pub(crate) use generate_tests;

--- a/crates/nu-protocol/src/plugin_signature.rs
+++ b/crates/nu-protocol/src/plugin_signature.rs
@@ -6,7 +6,7 @@ use crate::engine::Command;
 use crate::{BlockId, Category, Flag, PositionalArg, SyntaxShape, Type};
 
 /// A simple wrapper for Signature that includes examples.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PluginSignature {
     pub sig: Signature,
     pub examples: Vec<PluginExample>,

--- a/crates/nu_plugin_stream_example/Cargo.toml
+++ b/crates/nu_plugin_stream_example/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+authors = ["The Nushell Project Developers"]
+description = "An example of stream handling in nushell plugins"
+repository = "https://github.com/nushell/nushell/tree/main/crates/nu_plugin_stream_example"
+edition = "2021"
+license = "MIT"
+name = "nu_plugin_stream_example"
+version = "0.90.2"
+
+[[bin]]
+name = "nu_plugin_stream_example"
+bench = false
+
+[lib]
+bench = false
+
+[dependencies]
+nu-plugin = { path = "../nu-plugin", version = "0.90.2" }
+nu-protocol = { path = "../nu-protocol", version = "0.90.2", features = ["plugin"] }

--- a/crates/nu_plugin_stream_example/README.md
+++ b/crates/nu_plugin_stream_example/README.md
@@ -1,0 +1,49 @@
+# Streaming Plugin Example
+
+Crate with a simple example of the `StreamingPlugin` trait that needs to be implemented
+in order to create a binary that can be registered into nushell declaration list
+
+## `stream_example seq`
+
+This command demonstrates generating list streams. It generates numbers from the first argument
+to the second argument just like the builtin `seq` command does.
+
+Examples:
+
+> ```nushell
+> stream_example seq 1 10
+> ```
+
+    [1 2 3 4 5 6 7 8 9 10]
+
+> ```nushell
+> stream_example seq 1 10 | describe
+> ```
+
+    list<int> (stream)
+
+## `stream_example sum`
+
+This command demonstrates consuming list streams. It consumes a stream of numbers and calculates the
+sum just like the builtin `math sum` command does.
+
+Examples:
+
+> ```nushell
+> seq 1 5 | stream_example sum
+> ```
+
+    15
+
+## `stream_example collect-external`
+
+This command demonstrates transforming streams into external streams. The list (or stream) of
+strings on input will be concatenated into an external stream (raw input) on stdout.
+
+> ```nushell
+> [Hello "\n" world how are you] | stream_example collect-external
+> ````
+
+    Hello
+    worldhowareyou
+

--- a/crates/nu_plugin_stream_example/src/example.rs
+++ b/crates/nu_plugin_stream_example/src/example.rs
@@ -1,0 +1,63 @@
+use nu_plugin::{EvaluatedCall, LabeledError};
+use nu_protocol::{ListStream, PipelineData, RawStream, Value};
+
+pub struct Example;
+
+mod int_or_float;
+use self::int_or_float::IntOrFloat;
+
+impl Example {
+    pub fn seq(
+        &self,
+        call: &EvaluatedCall,
+        _input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let first: i64 = call.req(0)?;
+        let last: i64 = call.req(1)?;
+        let span = call.head;
+        let iter = (first..=last).map(move |number| Value::int(number, span));
+        let list_stream = ListStream::from_stream(iter, None);
+        Ok(PipelineData::ListStream(list_stream, None))
+    }
+
+    pub fn sum(
+        &self,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let mut acc = IntOrFloat::Int(0);
+        let span = input.span();
+        for value in input {
+            if let Ok(n) = value.as_i64() {
+                acc.add_i64(n);
+            } else if let Ok(n) = value.as_f64() {
+                acc.add_f64(n);
+            } else {
+                return Err(LabeledError {
+                    label: "Stream only accepts ints and floats".into(),
+                    msg: format!("found {}", value.get_type()),
+                    span,
+                });
+            }
+        }
+        Ok(PipelineData::Value(acc.to_value(call.head), None))
+    }
+
+    pub fn collect_external(
+        &self,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        let stream = input
+            .into_iter()
+            .map(|value| value.as_binary().map(|bin| bin.to_vec()));
+        Ok(PipelineData::ExternalStream {
+            stdout: Some(RawStream::new(Box::new(stream), None, call.head, None)),
+            stderr: None,
+            exit_code: None,
+            span: call.head,
+            metadata: None,
+            trim_end_newline: false,
+        })
+    }
+}

--- a/crates/nu_plugin_stream_example/src/example/int_or_float.rs
+++ b/crates/nu_plugin_stream_example/src/example/int_or_float.rs
@@ -1,0 +1,42 @@
+use nu_protocol::Value;
+
+use nu_protocol::Span;
+
+/// Accumulates numbers into either an int or a float. Changes type to float on the first
+/// float received.
+#[derive(Clone, Copy)]
+pub(crate) enum IntOrFloat {
+    Int(i64),
+    Float(f64),
+}
+
+impl IntOrFloat {
+    pub(crate) fn add_i64(&mut self, n: i64) {
+        match self {
+            IntOrFloat::Int(ref mut v) => {
+                *v += n;
+            }
+            IntOrFloat::Float(ref mut v) => {
+                *v += n as f64;
+            }
+        }
+    }
+
+    pub(crate) fn add_f64(&mut self, n: f64) {
+        match self {
+            IntOrFloat::Int(v) => {
+                *self = IntOrFloat::Float(*v as f64 + n);
+            }
+            IntOrFloat::Float(ref mut v) => {
+                *v += n;
+            }
+        }
+    }
+
+    pub(crate) fn to_value(self, span: Span) -> Value {
+        match self {
+            IntOrFloat::Int(v) => Value::int(v, span),
+            IntOrFloat::Float(v) => Value::float(v, span),
+        }
+    }
+}

--- a/crates/nu_plugin_stream_example/src/lib.rs
+++ b/crates/nu_plugin_stream_example/src/lib.rs
@@ -1,0 +1,4 @@
+mod example;
+mod nu;
+
+pub use example::Example;

--- a/crates/nu_plugin_stream_example/src/main.rs
+++ b/crates/nu_plugin_stream_example/src/main.rs
@@ -1,0 +1,30 @@
+use nu_plugin::{serve_plugin, MsgPackSerializer};
+use nu_plugin_stream_example::Example;
+
+fn main() {
+    // When defining your plugin, you can select the Serializer that could be
+    // used to encode and decode the messages. The available options are
+    // MsgPackSerializer and JsonSerializer. Both are defined in the serializer
+    // folder in nu-plugin.
+    serve_plugin(&mut Example {}, MsgPackSerializer {})
+
+    // Note
+    // When creating plugins in other languages one needs to consider how a plugin
+    // is added and used in nushell.
+    // The steps are:
+    // - The plugin is register. In this stage nushell calls the binary file of
+    //      the plugin sending information using the encoded PluginCall::PluginSignature object.
+    //      Use this encoded data in your plugin to design the logic that will return
+    //      the encoded signatures.
+    //      Nushell is expecting and encoded PluginResponse::PluginSignature with all the
+    //      plugin signatures
+    // - When calling the plugin, nushell sends to the binary file the encoded
+    //      PluginCall::CallInfo which has all the call information, such as the
+    //      values of the arguments, the name of the signature called and the input
+    //      from the pipeline.
+    //      Use this data to design your plugin login and to create the value that
+    //      will be sent to nushell
+    //      Nushell expects an encoded PluginResponse::Value from the plugin
+    // - If an error needs to be sent back to nushell, one can encode PluginResponse::Error.
+    //      This is a labeled error that nushell can format for pretty printing
+}

--- a/crates/nu_plugin_stream_example/src/nu/mod.rs
+++ b/crates/nu_plugin_stream_example/src/nu/mod.rs
@@ -1,0 +1,86 @@
+use crate::Example;
+use nu_plugin::{EvaluatedCall, LabeledError, StreamingPlugin};
+use nu_protocol::{
+    Category, PipelineData, PluginExample, PluginSignature, Span, SyntaxShape, Type, Value,
+};
+
+impl StreamingPlugin for Example {
+    fn signature(&self) -> Vec<PluginSignature> {
+        let span = Span::unknown();
+        vec![
+            PluginSignature::build("stream_example")
+                .usage("Examples for streaming plugins")
+                .search_terms(vec!["example".into()])
+                .category(Category::Experimental),
+            PluginSignature::build("stream_example seq")
+                .usage("Example stream generator for a list of values")
+                .search_terms(vec!["example".into()])
+                .required("first", SyntaxShape::Int, "first number to generate")
+                .required("last", SyntaxShape::Int, "last number to generate")
+                .input_output_type(Type::Nothing, Type::List(Type::Int.into()))
+                .plugin_examples(vec![PluginExample {
+                    example: "stream_example seq 1 3".into(),
+                    description: "generate a sequence from 1 to 3".into(),
+                    result: Some(Value::list(
+                        vec![
+                            Value::int(1, span),
+                            Value::int(2, span),
+                            Value::int(3, span),
+                        ],
+                        span,
+                    )),
+                }])
+                .category(Category::Experimental),
+            PluginSignature::build("stream_example sum")
+                .usage("Example stream consumer for a list of values")
+                .search_terms(vec!["example".into()])
+                .input_output_types(vec![
+                    (Type::List(Type::Int.into()), Type::Int),
+                    (Type::List(Type::Float.into()), Type::Float),
+                ])
+                .plugin_examples(vec![PluginExample {
+                    example: "seq 1 5 | stream_example sum".into(),
+                    description: "sum values from 1 to 5".into(),
+                    result: Some(Value::int(15, span)),
+                }])
+                .category(Category::Experimental),
+            PluginSignature::build("stream_example collect-external")
+                .usage("Example transformer to raw external stream")
+                .search_terms(vec!["example".into()])
+                .input_output_types(vec![
+                    (Type::List(Type::String.into()), Type::String),
+                    (Type::List(Type::Binary.into()), Type::Binary),
+                ])
+                .plugin_examples(vec![PluginExample {
+                    example: "[a b] | stream_example collect-external".into(),
+                    description: "collect strings into one stream".into(),
+                    result: Some(Value::string("ab", span)),
+                }])
+                .category(Category::Experimental),
+        ]
+    }
+
+    fn run(
+        &mut self,
+        name: &str,
+        _config: &Option<Value>,
+        call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        match name {
+            "stream_example" => Err(LabeledError {
+                label: "No subcommand provided".into(),
+                msg: "add --help here to see usage".into(),
+                span: Some(call.head)
+            }),
+            "stream_example seq" => self.seq(call, input),
+            "stream_example sum" => self.sum(call, input),
+            "stream_example collect-external" => self.collect_external(call, input),
+            _ => Err(LabeledError {
+                label: "Plugin call with wrong name signature".into(),
+                msg: "the signature used to call the plugin does not match any name in the plugin signature vector".into(),
+                span: Some(call.head),
+            }),
+        }
+    }
+}

--- a/tests/plugins/mod.rs
+++ b/tests/plugins/mod.rs
@@ -3,3 +3,4 @@ mod core_inc;
 mod custom_values;
 mod formats;
 mod register;
+mod stream;

--- a/tests/plugins/stream.rs
+++ b/tests/plugins/stream.rs
@@ -1,0 +1,122 @@
+use nu_test_support::nu_with_plugins;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn seq_produces_stream() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "stream_example seq 1 5 | describe"
+    );
+
+    assert_eq!(actual.out, "list<int> (stream)");
+}
+
+#[test]
+fn seq_describe_no_collect_succeeds_without_error() {
+    // This tests to ensure that there's no error if the stream is suddenly closed
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "stream_example seq 1 5 | describe --no-collect"
+    );
+
+    assert_eq!(actual.out, "stream");
+    assert_eq!(actual.err, "");
+}
+
+#[test]
+fn seq_stream_collects_to_correct_list() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "stream_example seq 1 5 | to json --raw"
+    );
+
+    assert_eq!(actual.out, "[1,2,3,4,5]");
+
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "stream_example seq 1 0 | to json --raw"
+    );
+
+    assert_eq!(actual.out, "[]");
+}
+
+#[test]
+fn sum_accepts_list_of_int() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "[1 2 3] | stream_example sum"
+    );
+
+    assert_eq!(actual.out, "6");
+}
+
+#[test]
+fn sum_accepts_list_of_float() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "[1.0 2.0 3.5] | stream_example sum"
+    );
+
+    assert_eq!(actual.out, "6.5");
+}
+
+#[test]
+fn sum_accepts_stream_of_int() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "seq 1 5 | stream_example sum"
+    );
+
+    assert_eq!(actual.out, "15");
+}
+
+#[test]
+fn sum_accepts_stream_of_float() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "seq 1 5 | into float | stream_example sum"
+    );
+
+    assert_eq!(actual.out, "15");
+}
+
+#[test]
+fn collect_external_accepts_list_of_string() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "[a b] | stream_example collect-external"
+    );
+
+    assert_eq!(actual.out, "ab");
+}
+
+#[test]
+fn collect_external_accepts_list_of_binary() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "[0x[41] 0x[42]] | stream_example collect-external"
+    );
+
+    assert_eq!(actual.out, "AB");
+}
+
+#[test]
+fn collect_external_produces_raw_input() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "[a b c] | stream_example collect-external | describe"
+    );
+
+    assert_eq!(actual.out, "raw input");
+}


### PR DESCRIPTION

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Plugins can now implement the `StreamingPlugin` trait, which allows them to consume and produce raw `PipelineData`.

Both list streams and external streams are supported, and plugins can handle both stdout and stderr simultaneously if they so wish.

This is not a breaking code change for plugins, but it is incompatible at the serialization level, so they do have to be recompiled.

For plugins using the simpler `Plugin` trait, streams are still sent as normal to the plugin, but they are internally collected to construct a Value on the plugin side now instead of the engine.

This change lays the groundwork for bidirectional communication with plugins in general. The API could be extended with functions to ask the engine to evaluate objects that the plugin cannot, though this is not a part of this patch.

It also allows for plugins to serve multiple calls within a single process lifetime. While not currently being used, this could be helpful in the future to make plugins execution cheaper to run in a loop, for example by having the parser statically allocate the plugin executions that will be necessary to run the command and reusing them for the life of the pipeline.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Plugins will have to be recompiled, but should otherwise work. Plugins written in languages other than Rust (i.e. not using `nu-plugin`) will require significant changes to handle the serialization layer changes and streaming.

Future plugins can be faster, use less memory, and do more heavy work.

A new `stream_example` plugin has been added for demonstrating and testing some of the stream features.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
I will write a documentation section on the new streaming API, and also try to update the python example.