### PR TITLE
Fixed to/from toml date format

### DIFF
--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -1,10 +1,10 @@
-use std::str::FromStr;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     record, Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Type,
     Value,
 };
+use std::str::FromStr;
 
 #[derive(Clone)]
 pub struct FromToml;
@@ -81,8 +81,9 @@ fn convert_toml_to_value(value: &toml::Value, span: Span) -> Value {
             span,
         ),
         toml::Value::String(s) => Value::string(s.clone(), span),
-        toml::Value::Datetime(d) =>
-            Value::date(chrono::DateTime::from_str(&d.to_string()).unwrap(), span),
+        toml::Value::Datetime(d) => {
+            Value::date(chrono::DateTime::from_str(&d.to_string()).unwrap(), span)
+        }
     }
 }
 

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -26,7 +26,7 @@ impl Command for FromToml {
 
     fn run(
         &self,
-        __engine_state: &EngineState,
+        _engine_state: &EngineState,
         _stack: &mut Stack,
         call: &Call,
         input: PipelineData,

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -81,10 +81,13 @@ fn convert_toml_to_value(value: &toml::Value, span: Span) -> Value {
             span,
         ),
         toml::Value::String(s) => Value::string(s.clone(), span),
-        toml::Value::Datetime(d) => Value::date(
-            chrono::DateTime::from_str(&d.to_string()).expect("from toml date conversion"),
-            span,
-        ),
+        toml::Value::Datetime(d) => match chrono::DateTime::from_str(&d.to_string()) {
+            Ok(nushell_date) => Value::date(nushell_date, span),
+            // in the unlikely event that parsing goes wrong, this function still returns a valid
+            // nushell date (however the default one). This decision was made to make the output of
+            // this function uniform amongst all eventualities
+            Err(_) => Value::date(chrono::DateTime::default(), span),
+        },
     }
 }
 

--- a/crates/nu-command/src/formats/from/toml.rs
+++ b/crates/nu-command/src/formats/from/toml.rs
@@ -81,9 +81,10 @@ fn convert_toml_to_value(value: &toml::Value, span: Span) -> Value {
             span,
         ),
         toml::Value::String(s) => Value::string(s.clone(), span),
-        toml::Value::Datetime(d) => {
-            Value::date(chrono::DateTime::from_str(&d.to_string()).unwrap(), span)
-        }
+        toml::Value::Datetime(d) => Value::date(
+            chrono::DateTime::from_str(&d.to_string()).expect("from toml date conversion"),
+            span,
+        ),
     }
 }
 

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -52,8 +52,9 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
         Value::Int { val, .. } => toml::Value::Integer(*val),
         Value::Filesize { val, .. } => toml::Value::Integer(*val),
         Value::Duration { val, .. } => toml::Value::String(val.to_string()),
-        Value::Date { val, .. } =>
-            toml::Value::String(val.to_rfc3339_opts(SecondsFormat::AutoSi, false)),
+        Value::Date { val, .. } => {
+            toml::Value::String(val.to_rfc3339_opts(SecondsFormat::AutoSi, false))
+        }
         Value::Range { .. } => toml::Value::String("<Range>".to_string()),
         Value::Float { val, .. } => toml::Value::Float(*val),
         Value::String { val, .. } | Value::QuotedString { val, .. } => {

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -1,3 +1,4 @@
+use chrono::SecondsFormat;
 use nu_protocol::ast::{Call, PathMember};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
@@ -51,7 +52,8 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
         Value::Int { val, .. } => toml::Value::Integer(*val),
         Value::Filesize { val, .. } => toml::Value::Integer(*val),
         Value::Duration { val, .. } => toml::Value::String(val.to_string()),
-        Value::Date { val, .. } => toml::Value::String(val.to_string()),
+        Value::Date { val, .. } =>
+            toml::Value::String(val.to_rfc3339_opts(SecondsFormat::AutoSi, false)),
         Value::Range { .. } => toml::Value::String("<Range>".to_string()),
         Value::Float { val, .. } => toml::Value::Float(*val),
         Value::String { val, .. } | Value::QuotedString { val, .. } => {

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -174,12 +174,32 @@ fn to_toml(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     #[test]
     fn test_examples() {
         use crate::test_examples;
 
         test_examples(ToToml {})
+    }
+
+    #[test]
+    fn to_toml_creates_correct_date() {
+        let engine_state = EngineState::new();
+
+        let test_date = Value::date(
+            chrono::FixedOffset::east_opt(60 * 120)
+                .unwrap()
+                .with_ymd_and_hms(1980, 10, 12, 10, 12, 44)
+                .unwrap(),
+            Span::test_data(),
+        );
+
+        let reference_date = toml::Value::String(String::from("1980-10-12T10:12:44+02:00"));
+
+        let result = helper(&engine_state, &test_date);
+
+        assert!(result.is_ok_and(|res| res == reference_date));
     }
 
     #[test]


### PR DESCRIPTION
With this PR i try to resolve #11751 

# Description
I am rather new to Rust so if anything is not the way it should be please let me know.

As described in the title I just fixed the date conversion in the to and from toml commands as i thought it would be a good first issue. The example of the original issue will now work as follows:

```
~> {date: 2024-02-02} | to toml
date = "2024-02-02T00:00:00+00:00"
~> "dob = 1979-05-27T07:32:00-08:00" | from toml
╭─────┬───────────────────────────╮
│ dob │ 44 years ago              |
╰─────┴───────────────────────────╯
```

The `from toml` command now returns a nushell date which is displayed as `44 years ago` in this case.

# User-Facing Changes
none

# Tests + Formatting
all tests pass and formatting has been applied
