### PR TITLE
add binary data handling to `bits` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2910,6 +2910,7 @@ dependencies = [
  "ahash 0.8.7",
  "fancy-regex",
  "heck",
+ "itertools 0.12.1",
  "nu-ansi-term",
  "nu-cmd-base",
  "nu-cmd-lang",
@@ -2933,7 +2934,7 @@ name = "nu-cmd-lang"
 version = "0.90.2"
 dependencies = [
  "fancy-regex",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nu-ansi-term",
  "nu-engine",
  "nu-parser",
@@ -2983,7 +2984,7 @@ dependencies = [
  "human-date-parser",
  "indexmap",
  "indicatif",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "libc",
  "log",
  "lscolors",
@@ -3134,7 +3135,7 @@ version = "0.90.2"
 dependencies = [
  "bytesize",
  "chrono",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "log",
  "nu-engine",
  "nu-path",
@@ -4632,7 +4633,7 @@ dependencies = [
  "compact_str",
  "crossterm",
  "indoc",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "lru",
  "paste",
  "stability",
@@ -4690,7 +4691,7 @@ dependencies = [
  "chrono",
  "crossterm",
  "fd-lock",
- "itertools 0.12.0",
+ "itertools 0.12.1",
  "nu-ansi-term",
  "rusqlite",
  "serde",

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -31,6 +31,7 @@ nu-pretty-hex = { version = "0.90.2", path = "../nu-pretty-hex" }
 nu-json = { version = "0.90.2", path = "../nu-json" }
 serde_urlencoded = "0.7.1"
 v_htmlescape = "0.15.0"
+itertools = "0.12.1"
 
 [features]
 extra = ["default"]

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -136,6 +136,12 @@ impl Command for BitsAnd {
                     Value::test_binary([0x99, 0x90]),
                 ])),
             },
+            Example {
+                description:
+                    "Apply logical and to binary data of varying lengths with specified endianness",
+                example: "0x[c0 ff ee] | bits and 0x[ff] --endian big",
+                result: Some(Value::test_binary(vec![0xc0, 0x00, 0x00])),
+            },
         ]
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -113,12 +113,12 @@ impl Command for BitsAnd {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Apply bits and to two numbers",
+                description: "Apply logical and to two numbers",
                 example: "2 | bits and 2",
                 result: Some(Value::test_int(2)),
             },
             Example {
-                description: "Apply bits and to two binary values",
+                description: "Apply logical and to two binary values",
                 example: "0x[ab cd] | bits and 0x[99 99]",
                 result: Some(Value::test_binary([137, 137]))
             },

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -1,13 +1,25 @@
-use std::iter;
+use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::CallExt;
-use nu_protocol::ast::Call;
+use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
+use std::iter;
 
 #[derive(Clone)]
 pub struct BitsAnd;
+
+struct Arguments {
+    target: Value,
+    little_endian: bool,
+}
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        None
+    }
+}
 
 impl Command for BitsAnd {
     fn name(&self) -> &str {
@@ -30,11 +42,9 @@ impl Command for BitsAnd {
             ])
             .required(
                 "target",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::Binary,
-                    SyntaxShape::Int
-                ]),
-                "right-hand side of the operation")
+                SyntaxShape::OneOf(vec![SyntaxShape::Binary, SyntaxShape::Int]),
+                "right-hand side of the operation",
+            )
             .named(
                 "endian",
                 SyntaxShape::String,
@@ -62,7 +72,7 @@ impl Command for BitsAnd {
         let head = call.head;
         let target: Value = call.req(engine_state, stack, 0)?;
         let endian = call.get_flag::<Value>(engine_state, stack, "endian")?;
-        
+
         let little_endian = match endian {
             Some(val) => {
                 let span = val.span();
@@ -85,29 +95,16 @@ impl Command for BitsAnd {
             None => cfg!(target_endian = "little"),
         };
 
-        // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 
-        match target {
-            Value::Int { val: rhs, ..} => input.map(
-                move |value| and_int(value, rhs, head),
-                engine_state.ctrlc.clone(),
-            ),
-            Value::Binary { val: rhs, ..} => input.map(
-                move |value| and_bytes(value, rhs.clone(), little_endian, head),
-                engine_state.ctrlc.clone(),
-            ),
-            other => Err(
-                ShellError::OnlySupportsThisInputType {
-                    exp_input_type: "int or binary".into(),
-                    wrong_type: other.get_type().to_string(),
-                    dst_span: head,
-                    src_span: other.span(),
-                },
-            )
-        }
+        let args = Arguments {
+            target,
+            little_endian,
+        };
+
+        operate(action, args, input, head, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -120,78 +117,48 @@ impl Command for BitsAnd {
             Example {
                 description: "Apply logical and to two binary values",
                 example: "0x[ab cd] | bits and 0x[99 99]",
-                result: Some(Value::test_binary([137, 137]))
+                result: Some(Value::test_binary([137, 137])),
             },
             Example {
                 description: "Apply logical and to a list of numbers",
                 example: "[4 3 2] | bits and 2",
-                result: Some(Value::test_list(
-                    vec![Value::test_int(0), Value::test_int(2), Value::test_int(2)],
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_int(0),
+                    Value::test_int(2),
+                    Value::test_int(2),
+                ])),
             },
             Example {
                 description: "Apply logical and to a list of binary data",
                 example: "[0x[7f ff] 0x[ff f0]] | bits and 0x[99 99]",
-                result: Some(Value::test_list(
-                    vec![Value::test_binary([25, 153]), Value::test_binary([153, 144])],
-                )),
+                result: Some(Value::test_list(vec![
+                    Value::test_binary([25, 153]),
+                    Value::test_binary([153, 144]),
+                ])),
             },
         ]
     }
 }
 
-fn and_int(
-    value: Value,
-    target: i64,
-    head: Span
-) -> Value {
-    let span = value.span();
-    match value {
-        Value::Int { val, .. } => Value::int(val & target, span),
-        Value::Error { .. } => value,
-        Value::Binary { .. } => Value::error(
-            ShellError::PipelineMismatch {
-                exp_input_type: "input, and argument, to be both int or both binary"
-                    .to_string(),
-                dst_span: head,
-                src_span: span,
-            },
-            head
-        ),
-        other => Value::error(
-            ShellError::OnlySupportsThisInputType {
-                exp_input_type: "int or binary".into(),
-                wrong_type: other.get_type().to_string(),
-                dst_span: head,
-                src_span: other.span(),
-            },
-            head,
-        ),
-    }
-}
-    
-fn and_bytes(
-    value: Value,
-    target: Vec<u8>,
-    little_endian: bool,
-    head: Span
-) -> Value {
-    let span = value.span();
-    match value {
-        Value::Binary { val: lhs, .. } => {
-            let rhs = target;
+fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+    let Arguments {
+        target,
+        little_endian,
+    } = args;
+    match (input, target) {
+        (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => Value::int(lhs & rhs, span),
+        (Value::Binary { val: lhs, .. }, Value::Binary { val: rhs, .. }) => {
             let max_len = lhs.len().max(rhs.len());
             let min_len = lhs.len().min(rhs.len());
 
-            let bytes = lhs.into_iter().zip(rhs);
+            let bytes = lhs.iter().copied().zip(rhs.iter().copied());
 
-            let pad = iter::repeat((0, 0))
-                .take(max_len - min_len);
+            let pad = iter::repeat((0, 0)).take(max_len - min_len);
 
             let mut a;
             let mut b;
 
-            let padded: &mut dyn Iterator<Item = (u8, u8)> = if little_endian {
+            let padded: &mut dyn Iterator<Item = (u8, u8)> = if *little_endian {
                 a = pad.chain(bytes);
                 &mut a
             } else {
@@ -200,27 +167,28 @@ fn and_bytes(
             };
 
             let val: Vec<u8> = padded.map(|(l, r)| l & r).collect();
-    
+
             Value::binary(val, span)
-        },
-        Value::Error { .. } => value,
-        Value::Int { .. } => Value::error(
-            ShellError::PipelineMismatch {
-                exp_input_type: "input, and argument, to be both int or both binary"
-                    .to_string(),
-                dst_span: head,
-                src_span: span,
-            },
-            head
-        ),
-        other => Value::error(
+        }
+        (Value::Binary { .. }, Value::Int { .. }) | (Value::Int { .. }, Value::Binary { .. }) => {
+            Value::error(
+                ShellError::PipelineMismatch {
+                    exp_input_type: "input, and argument, to be both int or both binary"
+                        .to_string(),
+                    dst_span: target.span(),
+                    src_span: span,
+                },
+                span,
+            )
+        }
+        (other, Value::Int { .. } | Value::Binary { .. }) | (_, other) => Value::error(
             ShellError::OnlySupportsThisInputType {
                 exp_input_type: "int or binary".into(),
                 wrong_type: other.get_type().to_string(),
-                dst_span: head,
-                src_span: other.span(),
+                dst_span: other.span(),
+                src_span: span,
             },
-            head,
+            span,
         ),
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -1,3 +1,4 @@
+use std::iter;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -17,17 +18,34 @@ impl Command for BitsAnd {
         Signature::build("bits and")
             .input_output_types(vec![
                 (Type::Int, Type::Int),
+                (Type::Binary, Type::Binary),
                 (
                     Type::List(Box::new(Type::Int)),
                     Type::List(Box::new(Type::Int)),
                 ),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
             ])
-            .required("target", SyntaxShape::Int, "target int to perform bit and")
+            .required(
+                "target",
+                SyntaxShape::OneOf(vec![
+                    SyntaxShape::Binary,
+                    SyntaxShape::Int
+                ]),
+                "right-hand side of the operation")
+            .named(
+                "endian",
+                SyntaxShape::String,
+                "byte encode endian, available options: native(default), little, big",
+                Some('e'),
+            )
             .category(Category::Bits)
     }
 
     fn usage(&self) -> &str {
-        "Performs bitwise and for ints."
+        "Performs bitwise and for ints or binary."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -42,16 +60,54 @@ impl Command for BitsAnd {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let target: i64 = call.req(engine_state, stack, 0)?;
+        let target: Value = call.req(engine_state, stack, 0)?;
+        let endian = call.get_flag::<Value>(engine_state, stack, "endian")?;
+        
+        let little_endian = match endian {
+            Some(val) => {
+                let span = val.span();
+                match val {
+                    Value::String { val, .. } => match val.as_str() {
+                        "native" => cfg!(target_endian = "little"),
+                        "little" => true,
+                        "big" => false,
+                        _ => {
+                            return Err(ShellError::TypeMismatch {
+                                err_message: "Endian must be one of native, little, big"
+                                    .to_string(),
+                                span,
+                            })
+                        }
+                    },
+                    _ => false,
+                }
+            }
+            None => cfg!(target_endian = "little"),
+        };
 
         // This doesn't match explicit nulls
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        input.map(
-            move |value| operate(value, target, head),
-            engine_state.ctrlc.clone(),
-        )
+
+        match target {
+            Value::Int { val: rhs, ..} => input.map(
+                move |value| and_int(value, rhs, head),
+                engine_state.ctrlc.clone(),
+            ),
+            Value::Binary { val: rhs, ..} => input.map(
+                move |value| and_bytes(value, rhs.clone(), little_endian, head),
+                engine_state.ctrlc.clone(),
+            ),
+            other => Err(
+                ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "int or binary".into(),
+                    wrong_type: other.get_type().to_string(),
+                    dst_span: head,
+                    src_span: other.span(),
+                },
+            )
+        }
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -60,6 +116,11 @@ impl Command for BitsAnd {
                 description: "Apply bits and to two numbers",
                 example: "2 | bits and 2",
                 result: Some(Value::test_int(2)),
+            },
+            Example {
+                description: "Apply bits and to two binary values",
+                example: "0x[ab cd] | bits and 0x[99 99]",
+                result: Some(Value::test_binary([137, 137]))
             },
             Example {
                 description: "Apply logical and to a list of numbers",
@@ -73,15 +134,82 @@ impl Command for BitsAnd {
     }
 }
 
-fn operate(value: Value, target: i64, head: Span) -> Value {
+fn and_int(
+    value: Value,
+    target: i64,
+    head: Span
+) -> Value {
     let span = value.span();
     match value {
         Value::Int { val, .. } => Value::int(val & target, span),
-        // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => value,
+        Value::Binary { .. } => Value::error(
+            ShellError::PipelineMismatch {
+                exp_input_type: "input, and argument, to be both int or both binary"
+                    .to_string(),
+                dst_span: head,
+                src_span: span,
+            },
+            head
+        ),
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "int".into(),
+                exp_input_type: "int or binary".into(),
+                wrong_type: other.get_type().to_string(),
+                dst_span: head,
+                src_span: other.span(),
+            },
+            head,
+        ),
+    }
+}
+    
+fn and_bytes(
+    value: Value,
+    target: Vec<u8>,
+    little_endian: bool,
+    head: Span
+) -> Value {
+    let span = value.span();
+    match value {
+        Value::Binary { val: lhs, .. } => {
+            let rhs = target;
+            let max_len = lhs.len().max(rhs.len());
+            let min_len = lhs.len().min(rhs.len());
+
+            let bytes = lhs.into_iter().zip(rhs);
+
+            let pad = iter::repeat((0, 0))
+                .take(max_len - min_len);
+
+            let mut a;
+            let mut b;
+
+            let padded: &mut dyn Iterator<Item = (u8, u8)> = if little_endian {
+                a = pad.chain(bytes);
+                &mut a
+            } else {
+                b = bytes.chain(pad);
+                &mut b
+            };
+
+            let val: Vec<u8> = padded.map(|(l, r)| l & r).collect();
+    
+            Value::binary(val, span)
+        },
+        Value::Error { .. } => value,
+        Value::Int { .. } => Value::error(
+            ShellError::PipelineMismatch {
+                exp_input_type: "input, and argument, to be both int or both binary"
+                    .to_string(),
+                dst_span: head,
+                src_span: span,
+            },
+            head
+        ),
+        other => Value::error(
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "int or binary".into(),
                 wrong_type: other.get_type().to_string(),
                 dst_span: head,
                 src_span: other.span(),

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -117,7 +117,7 @@ impl Command for BitsAnd {
             Example {
                 description: "Apply logical and to two binary values",
                 example: "0x[ab cd] | bits and 0x[99 99]",
-                result: Some(Value::test_binary([137, 137])),
+                result: Some(Value::test_binary([0x89, 0x89])),
             },
             Example {
                 description: "Apply logical and to a list of numbers",
@@ -132,8 +132,8 @@ impl Command for BitsAnd {
                 description: "Apply logical and to a list of binary data",
                 example: "[0x[7f ff] 0x[ff f0]] | bits and 0x[99 99]",
                 result: Some(Value::test_list(vec![
-                    Value::test_binary([25, 153]),
-                    Value::test_binary([153, 144]),
+                    Value::test_binary([0x19, 0x99]),
+                    Value::test_binary([0x99, 0x90]),
                 ])),
             },
         ]

--- a/crates/nu-cmd-extra/src/extra/bits/and.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/and.rs
@@ -125,9 +125,15 @@ impl Command for BitsAnd {
             Example {
                 description: "Apply logical and to a list of numbers",
                 example: "[4 3 2] | bits and 2",
-                result: Some(Value::list(
+                result: Some(Value::test_list(
                     vec![Value::test_int(0), Value::test_int(2), Value::test_int(2)],
-                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "Apply logical and to a list of binary data",
+                example: "[0x[7f ff] 0x[ff f0]] | bits and 0x[99 99]",
+                result: Some(Value::test_list(
+                    vec![Value::test_binary([25, 153]), Value::test_binary([153, 144])],
                 )),
             },
         ]

--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -9,11 +9,11 @@ mod shift_left;
 mod shift_right;
 mod xor;
 
-use nu_protocol::Value;
 pub use and::BitsAnd;
 pub use bits_::Bits;
 pub use into::BitsInto;
 pub use not::BitsNot;
+use nu_protocol::Value;
 pub use or::BitsOr;
 pub use rotate_left::BitsRol;
 pub use rotate_right::BitsRor;
@@ -61,7 +61,7 @@ fn get_number_bytes(number_bytes: Option<&Value>) -> NumberBytes {
             8 => NumberBytes::Eight,
             _ => NumberBytes::Invalid,
         },
-        _ => NumberBytes::Invalid
+        _ => NumberBytes::Invalid,
     }
 }
 

--- a/crates/nu-cmd-extra/src/extra/bits/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/mod.rs
@@ -9,6 +9,7 @@ mod shift_left;
 mod shift_right;
 mod xor;
 
+use nu_protocol::Value;
 pub use and::BitsAnd;
 pub use bits_::Bits;
 pub use into::BitsInto;
@@ -19,8 +20,6 @@ pub use rotate_right::BitsRor;
 pub use shift_left::BitsShl;
 pub use shift_right::BitsShr;
 pub use xor::BitsXor;
-
-use nu_protocol::Spanned;
 
 #[derive(Clone, Copy)]
 enum NumberBytes {
@@ -44,10 +43,10 @@ enum InputNumType {
     SignedEight,
 }
 
-fn get_number_bytes(number_bytes: Option<&Spanned<String>>) -> NumberBytes {
-    match number_bytes.as_ref() {
+fn get_number_bytes(number_bytes: Option<&Value>) -> NumberBytes {
+    match number_bytes {
         None => NumberBytes::Eight,
-        Some(size) => match size.item.as_str() {
+        Some(Value::String { val, .. }) => match val.as_str() {
             "1" => NumberBytes::One,
             "2" => NumberBytes::Two,
             "4" => NumberBytes::Four,
@@ -55,6 +54,14 @@ fn get_number_bytes(number_bytes: Option<&Spanned<String>>) -> NumberBytes {
             "auto" => NumberBytes::Auto,
             _ => NumberBytes::Invalid,
         },
+        Some(Value::Int { val, .. }) => match val {
+            1 => NumberBytes::One,
+            2 => NumberBytes::Two,
+            4 => NumberBytes::Four,
+            8 => NumberBytes::Eight,
+            _ => NumberBytes::Invalid,
+        },
+        _ => NumberBytes::Invalid
     }
 }
 

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -96,7 +96,10 @@ impl Command for BitsNot {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
 
-        let args = Arguments { signed, number_size };
+        let args = Arguments {
+            signed,
+            number_size,
+        };
 
         operate(action, args, input, head, engine_state.ctrlc.clone())
     }
@@ -142,13 +145,9 @@ impl Command for BitsNot {
                 )),
             },
             Example {
-                description:
-                    "Apply logical negation to binary data",
+                description: "Apply logical negation to binary data",
                 example: "0x[ff 00 7f] | bits not",
-                result: Some(Value::binary(
-                    vec![0x00, 0xff, 0x80],
-                    Span::test_data(),
-                )),
+                result: Some(Value::binary(vec![0x00, 0xff, 0x80], Span::test_data())),
             },
         ]
     }
@@ -187,8 +186,10 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
                 };
                 Value::int(out_val, span)
             }
-        },
-        Value::Binary { val, .. } => Value::binary(val.iter().copied().map(|b| !b).collect::<Vec<_>>(), span),
+        }
+        Value::Binary { val, .. } => {
+            Value::binary(val.iter().copied().map(|b| !b).collect::<Vec<_>>(), span)
+        }
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
                 exp_input_type: "int or binary".into(),

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -49,10 +49,12 @@ impl Command for BitsNot {
             )
             .named(
                 "number-bytes",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::Int,
-                    SyntaxShape::String
-                ]),
+                SyntaxShape::String,
+                // #9960: named flags cannot accept SyntaxShape::OneOf
+                // SyntaxShape::OneOf(vec![
+                //     SyntaxShape::Int,
+                //     SyntaxShape::String
+                // ]),
                 "the size of unsigned number in bytes, it can be 1, 2, 4, 8, auto",
                 Some('n'),
             )
@@ -144,7 +146,7 @@ impl Command for BitsNot {
                     "Apply logical negation to binary data",
                 example: "0x[ff 00 7f] | bits not",
                 result: Some(Value::binary(
-                    vec![0x00, 0xff, 0x7f],
+                    vec![0x00, 0xff, 0x80],
                     Span::test_data(),
                 )),
             },

--- a/crates/nu-cmd-extra/src/extra/bits/or.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/or.rs
@@ -40,6 +40,7 @@ impl Command for BitsOr {
                     Type::List(Box::new(Type::Binary)),
                 ),
             ])
+            .allow_variants_without_examples(true)
             .required(
                 "target",
                 SyntaxShape::OneOf(vec![SyntaxShape::Binary, SyntaxShape::Int]),

--- a/crates/nu-cmd-extra/src/extra/bits/or.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/or.rs
@@ -128,6 +128,12 @@ impl Command for BitsOr {
                 example: "0x[88 cc] | bits or 0x[42 32]",
                 result: Some(Value::binary(vec![0xca, 0xfe], Span::test_data())),
             },
+            Example {
+                description:
+                    "Apply logical or to binary data of varying lengths with specified endianness",
+                example: "0x[c0 ff ee] | bits or 0x[aa] --endian big",
+                result: Some(Value::test_binary(vec![0xea, 0xff, 0xee])),
+            },
         ]
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/or.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/or.rs
@@ -126,10 +126,7 @@ impl Command for BitsOr {
             Example {
                 description: "Apply logical or to binary data",
                 example: "0x[88 cc] | bits or 0x[42 32]",
-                result: Some(Value::binary( 
-                    vec![0xca, 0xfe],
-                    Span::test_data()
-                )),
+                result: Some(Value::binary(vec![0xca, 0xfe], Span::test_data())),
             },
         ]
     }

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -1,9 +1,9 @@
-use nu_protocol::ast::CellPath;
 use super::{get_input_num_type, get_number_bytes, InputNumType, NumberBytes};
 use itertools::Itertools;
-use nu_engine::CallExt;
 use nu_cmd_base::input_handler::{operate, CmdArgument};
+use nu_engine::CallExt;
 use nu_protocol::ast::Call;
+use nu_protocol::ast::CellPath;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
@@ -98,8 +98,12 @@ impl Command for BitsRol {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-            
-        let args = Arguments { signed, number_size, bits };
+
+        let args = Arguments {
+            signed,
+            number_size,
+            bits,
+        };
 
         operate(action, args, input, head, engine_state.ctrlc.clone())
     }
@@ -122,10 +126,7 @@ impl Command for BitsRol {
             Example {
                 description: "rotate left binary data",
                 example: "0x[c0 ff ee] | bits rol 10",
-                result: Some(Value::binary(
-                    vec![0xff, 0xbb, 0x03],
-                    Span::test_data(),
-                )),
+                result: Some(Value::binary(vec![0xff, 0xbb, 0x03], Span::test_data())),
             },
         ]
     }
@@ -145,41 +146,51 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             let bits = bits as u64;
             let input_num_type = get_input_num_type(val, signed, number_size);
             match input_num_type {
-                One if bits <= 0xff => Value::int((val as u8).rotate_left(bits as u32) as i64, span),
-                Two if bits <= 0xffff => Value::int((val as u16).rotate_left(bits as u32) as i64, span), 
-                Four if bits <= 0xffff_ffff => Value::int((val as u32).rotate_left(bits as u32) as i64, span),
+                One if bits <= 0xff => {
+                    Value::int((val as u8).rotate_left(bits as u32) as i64, span)
+                }
+                Two if bits <= 0xffff => {
+                    Value::int((val as u16).rotate_left(bits as u32) as i64, span)
+                }
+                Four if bits <= 0xffff_ffff => {
+                    Value::int((val as u32).rotate_left(bits as u32) as i64, span)
+                }
                 Eight => Value::int((val as u64).rotate_left(bits as u32) as i64, span),
-                SignedOne if bits <= 0xff => Value::int((val as i8).rotate_left(bits as u32) as i64, span),
-                SignedTwo if bits <= 0xffff => Value::int((val as i16).rotate_left(bits as u32) as i64, span),
-                SignedFour if bits <= 0xffff_ffff => Value::int((val as i32).rotate_left(bits as u32) as i64, span),
+                SignedOne if bits <= 0xff => {
+                    Value::int((val as i8).rotate_left(bits as u32) as i64, span)
+                }
+                SignedTwo if bits <= 0xffff => {
+                    Value::int((val as i16).rotate_left(bits as u32) as i64, span)
+                }
+                SignedFour if bits <= 0xffff_ffff => {
+                    Value::int((val as i32).rotate_left(bits as u32) as i64, span)
+                }
                 SignedEight => Value::int(val.rotate_left(bits as u32), span),
                 _ => Value::error(
                     ShellError::GenericError {
                         error: "result out of range for specified number".into(),
-                        msg: format!(
-                            "rotating left by {bits} is out of range for the value {val}"
-                        ),
+                        msg: format!("rotating left by {bits} is out of range for the value {val}"),
                         span: Some(span),
                         help: None,
                         inner: vec![],
                     },
                     span,
-                )
+                ),
             }
-        },
+        }
         Value::Binary { val, .. } => {
             let byte_shift = bits / 8;
             let bit_rotate = bits % 8;
             let mut bytes = val
-            .iter()
-            .copied()
-            .circular_tuple_windows::<(u8, u8)>()
-            .map(|(lhs, rhs)| (lhs << bit_rotate) | (rhs >> (8 - bit_rotate)))
-            .collect::<Vec<u8>>();
+                .iter()
+                .copied()
+                .circular_tuple_windows::<(u8, u8)>()
+                .map(|(lhs, rhs)| (lhs << bit_rotate) | (rhs >> (8 - bit_rotate)))
+                .collect::<Vec<u8>>();
             bytes.rotate_left(byte_shift as usize);
 
             Value::binary(bytes, span)
-        },
+        }
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
                 exp_input_type: "int or binary".into(),

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -52,10 +52,12 @@ impl Command for BitsRol {
             )
             .named(
                 "number-bytes",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::Int,
-                    SyntaxShape::String
-                ]),
+                SyntaxShape::String,
+                // #9960: named flags cannot accept SyntaxShape::OneOf
+                // SyntaxShape::OneOf(vec![
+                //     SyntaxShape::Int,
+                //     SyntaxShape::String
+                // ]),
                 "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -1,12 +1,25 @@
+use nu_protocol::ast::CellPath;
 use super::{get_input_num_type, get_number_bytes, InputNumType, NumberBytes};
+use itertools::Itertools;
 use nu_engine::CallExt;
+use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
-use num_traits::int::PrimInt;
-use std::fmt::Display;
+
+struct Arguments {
+    signed: bool,
+    bits: i64,
+    number_size: NumberBytes,
+}
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        None
+    }
+}
 
 #[derive(Clone)]
 pub struct BitsRol;
@@ -20,11 +33,17 @@ impl Command for BitsRol {
         Signature::build("bits rol")
             .input_output_types(vec![
                 (Type::Int, Type::Int),
+                (Type::Binary, Type::Binary),
                 (
                     Type::List(Box::new(Type::Int)),
                     Type::List(Box::new(Type::Int)),
                 ),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
             ])
+            .allow_variants_without_examples(true)
             .required("bits", SyntaxShape::Int, "number of bits to rotate left")
             .switch(
                 "signed",
@@ -33,7 +52,10 @@ impl Command for BitsRol {
             )
             .named(
                 "number-bytes",
-                SyntaxShape::String,
+                SyntaxShape::OneOf(vec![
+                    SyntaxShape::Int,
+                    SyntaxShape::String
+                ]),
                 "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )
@@ -41,7 +63,7 @@ impl Command for BitsRol {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise rotate left for ints."
+        "Bitwise rotate left for ints or binary."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -56,18 +78,17 @@ impl Command for BitsRol {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let bits: usize = call.req(engine_state, stack, 0)?;
+        let bits: i64 = call.req(engine_state, stack, 0)?;
         let signed = call.has_flag(engine_state, stack, "signed")?;
-        let number_bytes: Option<Spanned<String>> =
-            call.get_flag(engine_state, stack, "number-bytes")?;
-        let bytes_len = get_number_bytes(number_bytes.as_ref());
-        if let NumberBytes::Invalid = bytes_len {
+        let number_bytes: Option<Value> = call.get_flag(engine_state, stack, "number-bytes")?;
+        let number_size = get_number_bytes(number_bytes.as_ref());
+        if let NumberBytes::Invalid = number_size {
             if let Some(val) = number_bytes {
                 return Err(ShellError::UnsupportedInput {
                     msg: "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
                     input: "value originates from here".to_string(),
                     msg_span: head,
-                    input_span: val.span,
+                    input_span: val.span(),
                 });
             }
         }
@@ -75,10 +96,10 @@ impl Command for BitsRol {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        input.map(
-            move |value| operate(value, bits, head, signed, bytes_len),
-            engine_state.ctrlc.clone(),
-        )
+            
+        let args = Arguments { signed, number_size, bits };
+
+        operate(action, args, input, head, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -96,61 +117,75 @@ impl Command for BitsRol {
                     Span::test_data(),
                 )),
             },
+            Example {
+                description: "rotate left binary data",
+                example: "0x[c0 ff ee] | bits rol 10",
+                result: Some(Value::binary(
+                    vec![0xff, 0xbb, 0x03],
+                    Span::test_data(),
+                )),
+            },
         ]
     }
 }
 
-fn get_rotate_left<T: Display + PrimInt>(val: T, bits: u32, span: Span) -> Value
-where
-    i64: std::convert::TryFrom<T>,
-{
-    let rotate_result = i64::try_from(val.rotate_left(bits));
-    match rotate_result {
-        Ok(val) => Value::int(val, span),
-        Err(_) => Value::error(
-            ShellError::GenericError {
-                error: "Rotate left result beyond the range of 64 bit signed number".into(),
-                msg: format!(
-                    "{val} of the specified number of bytes rotate left {bits} bits exceed limit"
-                ),
-                span: Some(span),
-                help: None,
-                inner: vec![],
-            },
-            span,
-        ),
-    }
-}
+fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+    let Arguments {
+        signed,
+        number_size,
+        bits,
+    } = *args;
 
-fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: NumberBytes) -> Value {
-    let span = value.span();
-    match value {
+    match input {
         Value::Int { val, .. } => {
             use InputNumType::*;
-            // let bits = (((bits % 64) + 64) % 64) as u32;
-            let bits = bits as u32;
-            let input_type = get_input_num_type(val, signed, number_size);
-            match input_type {
-                One => get_rotate_left(val as u8, bits, span),
-                Two => get_rotate_left(val as u16, bits, span),
-                Four => get_rotate_left(val as u32, bits, span),
-                Eight => get_rotate_left(val as u64, bits, span),
-                SignedOne => get_rotate_left(val as i8, bits, span),
-                SignedTwo => get_rotate_left(val as i16, bits, span),
-                SignedFour => get_rotate_left(val as i32, bits, span),
-                SignedEight => get_rotate_left(val, bits, span),
+            let val = *val;
+            let bits = bits as u64;
+            let input_num_type = get_input_num_type(val, signed, number_size);
+            match input_num_type {
+                One if bits <= 0xff => Value::int((val as u8).rotate_left(bits as u32) as i64, span),
+                Two if bits <= 0xffff => Value::int((val as u16).rotate_left(bits as u32) as i64, span), 
+                Four if bits <= 0xffff_ffff => Value::int((val as u32).rotate_left(bits as u32) as i64, span),
+                Eight => Value::int((val as u64).rotate_left(bits as u32) as i64, span),
+                SignedOne if bits <= 0xff => Value::int((val as i8).rotate_left(bits as u32) as i64, span),
+                SignedTwo if bits <= 0xffff => Value::int((val as i16).rotate_left(bits as u32) as i64, span),
+                SignedFour if bits <= 0xffff_ffff => Value::int((val as i32).rotate_left(bits as u32) as i64, span),
+                SignedEight => Value::int(val.rotate_left(bits as u32), span),
+                _ => Value::error(
+                    ShellError::GenericError {
+                        error: "result out of range for specified number".into(),
+                        msg: format!(
+                            "rotating left by {bits} is out of range for the value {val}"
+                        ),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    },
+                    span,
+                )
             }
-        }
-        // Propagate errors by explicitly matching them before the final case.
-        Value::Error { .. } => value,
+        },
+        Value::Binary { val, .. } => {
+            let byte_shift = bits / 8;
+            let bit_rotate = bits % 8;
+            let mut bytes = val
+            .iter()
+            .copied()
+            .circular_tuple_windows::<(u8, u8)>()
+            .map(|(lhs, rhs)| (lhs << bit_rotate) | (rhs >> (8 - bit_rotate)))
+            .collect::<Vec<u8>>();
+            bytes.rotate_left(byte_shift as usize);
+
+            Value::binary(bytes, span)
+        },
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "int".into(),
+                exp_input_type: "int or binary".into(),
                 wrong_type: other.get_type().to_string(),
-                dst_span: head,
-                src_span: other.span(),
+                dst_span: other.span(),
+                src_span: span,
             },
-            head,
+            span,
         ),
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -1,12 +1,25 @@
+use nu_protocol::ast::CellPath;
 use super::{get_input_num_type, get_number_bytes, InputNumType, NumberBytes};
+use itertools::Itertools;
 use nu_engine::CallExt;
+use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
-use num_traits::int::PrimInt;
-use std::fmt::Display;
+
+struct Arguments {
+    signed: bool,
+    bits: i64,
+    number_size: NumberBytes,
+}
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        None
+    }
+}
 
 #[derive(Clone)]
 pub struct BitsRor;
@@ -20,11 +33,17 @@ impl Command for BitsRor {
         Signature::build("bits ror")
             .input_output_types(vec![
                 (Type::Int, Type::Int),
+                (Type::Binary, Type::Binary),
                 (
                     Type::List(Box::new(Type::Int)),
                     Type::List(Box::new(Type::Int)),
                 ),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
             ])
+            .allow_variants_without_examples(true)
             .required("bits", SyntaxShape::Int, "number of bits to rotate right")
             .switch(
                 "signed",
@@ -33,7 +52,10 @@ impl Command for BitsRor {
             )
             .named(
                 "number-bytes",
-                SyntaxShape::String,
+                SyntaxShape::OneOf(vec![
+                    SyntaxShape::Int,
+                    SyntaxShape::String
+                ]),
                 "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )
@@ -41,7 +63,7 @@ impl Command for BitsRor {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise rotate right for ints."
+        "Bitwise rotate right for ints or binary."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -56,18 +78,17 @@ impl Command for BitsRor {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let bits: usize = call.req(engine_state, stack, 0)?;
+        let bits: i64 = call.req(engine_state, stack, 0)?;
         let signed = call.has_flag(engine_state, stack, "signed")?;
-        let number_bytes: Option<Spanned<String>> =
-            call.get_flag(engine_state, stack, "number-bytes")?;
-        let bytes_len = get_number_bytes(number_bytes.as_ref());
-        if let NumberBytes::Invalid = bytes_len {
+        let number_bytes: Option<Value> = call.get_flag(engine_state, stack, "number-bytes")?;
+        let number_size = get_number_bytes(number_bytes.as_ref());
+        if let NumberBytes::Invalid = number_size {
             if let Some(val) = number_bytes {
                 return Err(ShellError::UnsupportedInput {
                     msg: "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
                     input: "value originates from here".to_string(),
                     msg_span: head,
-                    input_span: val.span,
+                    input_span: val.span(),
                 });
             }
         }
@@ -75,21 +96,21 @@ impl Command for BitsRor {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        input.map(
-            move |value| operate(value, bits, head, signed, bytes_len),
-            engine_state.ctrlc.clone(),
-        )
+            
+        let args = Arguments { signed, number_size, bits };
+
+        operate(action, args, input, head, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Rotate right a number with 60 bits",
+                description: "rotate right a number with 2 bits",
                 example: "17 | bits ror 60",
                 result: Some(Value::test_int(272)),
             },
             Example {
-                description: "Rotate right a list of numbers of one byte",
+                description: "rotate right a list of numbers of one byte",
                 example: "[15 33 92] | bits ror 2 --number-bytes '1'",
                 result: Some(Value::list(
                     vec![
@@ -100,61 +121,83 @@ impl Command for BitsRor {
                     Span::test_data(),
                 )),
             },
+            Example {
+                description: "rotate right binary data",
+                example: "0x[ff bb 03] | bits ror 10",
+                result: Some(Value::binary(
+                    vec![0xc0, 0xff, 0xee],
+                    Span::test_data(),
+                )),
+            },
+            Example {
+                description: "rotate right binary data",
+                example: "0x[ff bb 03] | bits ror 10",
+                result: Some(Value::binary(
+                    vec![0xc0, 0xff, 0xee],
+                    Span::test_data(),
+                )),
+            },
         ]
     }
 }
 
-fn get_rotate_right<T: Display + PrimInt>(val: T, bits: u32, span: Span) -> Value
-where
-    i64: std::convert::TryFrom<T>,
-{
-    let rotate_result = i64::try_from(val.rotate_right(bits));
-    match rotate_result {
-        Ok(val) => Value::int(val, span),
-        Err(_) => Value::error(
-            ShellError::GenericError {
-                error: "Rotate right result beyond the range of 64 bit signed number".into(),
-                msg: format!(
-                    "{val} of the specified number of bytes rotate right {bits} bits exceed limit"
-                ),
-                span: Some(span),
-                help: None,
-                inner: vec![],
-            },
-            span,
-        ),
-    }
-}
+fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+    let Arguments {
+        signed,
+        number_size,
+        bits,
+    } = *args;
 
-fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: NumberBytes) -> Value {
-    let span = value.span();
-    match value {
+    match input {
         Value::Int { val, .. } => {
             use InputNumType::*;
-            // let bits = (((bits % 64) + 64) % 64) as u32;
-            let bits = bits as u32;
-            let input_type = get_input_num_type(val, signed, number_size);
-            match input_type {
-                One => get_rotate_right(val as u8, bits, span),
-                Two => get_rotate_right(val as u16, bits, span),
-                Four => get_rotate_right(val as u32, bits, span),
-                Eight => get_rotate_right(val as u64, bits, span),
-                SignedOne => get_rotate_right(val as i8, bits, span),
-                SignedTwo => get_rotate_right(val as i16, bits, span),
-                SignedFour => get_rotate_right(val as i32, bits, span),
-                SignedEight => get_rotate_right(val, bits, span),
+            let val = *val;
+            let bits = bits as u64;
+            let input_num_type = get_input_num_type(val, signed, number_size);
+            match input_num_type {
+                One if bits <= 0xff => Value::int(((val as u8).rotate_right(bits as u32)) as i64, span),
+                Two if bits <= 0xffff => Value::int(((val as u16).rotate_right(bits as u32)) as i64, span), 
+                Four if bits <= 0xffff_ffff => Value::int(((val as u32).rotate_right(bits as u32)) as i64, span),
+                Eight => Value::int(((val as u64).rotate_right(bits as u32)) as i64, span),
+                SignedOne if bits <= 0xff => Value::int(((val as i8).rotate_right(bits as u32)) as i64, span),
+                SignedTwo if bits <= 0xffff => Value::int(((val as i16).rotate_right(bits as u32)) as i64, span),
+                SignedFour if bits <= 0xffff_ffff => Value::int(((val as i32).rotate_right(bits as u32)) as i64, span),
+                SignedEight => Value::int(val.rotate_right(bits as u32), span),
+                _ => Value::error(
+                    ShellError::GenericError {
+                        error: "result out of range for specified number".into(),
+                        msg: format!(
+                            "rotating right by {bits} is out of range for the value {val}"
+                        ),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    },
+                    span,
+                )
             }
-        }
-        // Propagate errors by explicitly matching them before the final case.
-        Value::Error { .. } => value,
+        },
+        Value::Binary { val, .. } => {
+            let byte_shift = bits / 8;
+            let bit_rotate = bits % 8;
+            let mut bytes = val
+            .iter()
+            .copied()
+            .circular_tuple_windows::<(u8, u8)>()
+            .map(|(lhs, rhs)| (lhs >> (8 - bit_rotate)) | (rhs << bit_rotate))
+            .collect::<Vec<u8>>();
+            bytes.rotate_right(byte_shift as usize);
+
+            Value::binary(bytes, span)
+        },
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "int".into(),
+                exp_input_type: "int or binary".into(),
                 wrong_type: other.get_type().to_string(),
-                dst_span: head,
-                src_span: other.span(),
+                dst_span: other.span(),
+                src_span: span,
             },
-            head,
+            span,
         ),
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -52,10 +52,12 @@ impl Command for BitsRor {
             )
             .named(
                 "number-bytes",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::Int,
-                    SyntaxShape::String
-                ]),
+                SyntaxShape::String,
+                // #9960: named flags cannot accept SyntaxShape::OneOf
+                // SyntaxShape::OneOf(vec![
+                //     SyntaxShape::Int,
+                //     SyntaxShape::String
+                // ]),
                 "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )
@@ -129,14 +131,6 @@ impl Command for BitsRor {
                     Span::test_data(),
                 )),
             },
-            Example {
-                description: "rotate right binary data",
-                example: "0x[ff bb 03] | bits ror 10",
-                result: Some(Value::binary(
-                    vec![0xc0, 0xff, 0xee],
-                    Span::test_data(),
-                )),
-            },
         ]
     }
 }
@@ -184,7 +178,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             .iter()
             .copied()
             .circular_tuple_windows::<(u8, u8)>()
-            .map(|(lhs, rhs)| (lhs >> (8 - bit_rotate)) | (rhs << bit_rotate))
+            .map(|(lhs, rhs)| (lhs >> bit_rotate) | (rhs << (8 - bit_rotate)))
             .collect::<Vec<u8>>();
             bytes.rotate_right(byte_shift as usize);
 

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -53,10 +53,12 @@ impl Command for BitsShl {
             )
             .named(
                 "number-bytes",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::Int,
-                    SyntaxShape::String
-                ]),
+                SyntaxShape::String,
+                // #9960: named flags cannot accept SyntaxShape::OneOf
+                // SyntaxShape::OneOf(vec![
+                //     SyntaxShape::Int,
+                //     SyntaxShape::String
+                // ]),
                 "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -53,10 +53,12 @@ impl Command for BitsShr {
             )
             .named(
                 "number-bytes",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::Int,
-                    SyntaxShape::String
-                ]),
+                SyntaxShape::String,
+                // #9960: named flags cannot accept SyntaxShape::OneOf
+                // SyntaxShape::OneOf(vec![
+                //     SyntaxShape::Int,
+                //     SyntaxShape::String
+                // ]),
                 "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -1,12 +1,26 @@
+use std::iter;
+use nu_protocol::ast::CellPath;
 use super::{get_input_num_type, get_number_bytes, InputNumType, NumberBytes};
+use itertools::Itertools;
 use nu_engine::CallExt;
+use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
-    Category, Example, PipelineData, ShellError, Signature, Span, Spanned, SyntaxShape, Type, Value,
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
-use num_traits::CheckedShr;
-use std::fmt::Display;
+
+struct Arguments {
+    signed: bool,
+    bits: i64,
+    number_size: NumberBytes,
+}
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        None
+    }
+}
 
 #[derive(Clone)]
 pub struct BitsShr;
@@ -20,11 +34,17 @@ impl Command for BitsShr {
         Signature::build("bits shr")
             .input_output_types(vec![
                 (Type::Int, Type::Int),
+                (Type::Binary, Type::Binary),
                 (
                     Type::List(Box::new(Type::Int)),
                     Type::List(Box::new(Type::Int)),
                 ),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
             ])
+            .allow_variants_without_examples(true)
             .required("bits", SyntaxShape::Int, "number of bits to shift right")
             .switch(
                 "signed",
@@ -33,7 +53,10 @@ impl Command for BitsShr {
             )
             .named(
                 "number-bytes",
-                SyntaxShape::String,
+                SyntaxShape::OneOf(vec![
+                    SyntaxShape::Int,
+                    SyntaxShape::String
+                ]),
                 "the word size in number of bytes, it can be 1, 2, 4, 8, auto, default value `8`",
                 Some('n'),
             )
@@ -41,7 +64,7 @@ impl Command for BitsShr {
     }
 
     fn usage(&self) -> &str {
-        "Bitwise shift right for ints."
+        "Bitwise shift right for ints or binary."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -56,18 +79,17 @@ impl Command for BitsShr {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let bits: usize = call.req(engine_state, stack, 0)?;
+        let bits: i64 = call.req(engine_state, stack, 0)?;
         let signed = call.has_flag(engine_state, stack, "signed")?;
-        let number_bytes: Option<Spanned<String>> =
-            call.get_flag(engine_state, stack, "number-bytes")?;
-        let bytes_len = get_number_bytes(number_bytes.as_ref());
-        if let NumberBytes::Invalid = bytes_len {
+        let number_bytes: Option<Value> = call.get_flag(engine_state, stack, "number-bytes")?;
+        let number_size = get_number_bytes(number_bytes.as_ref());
+        if let NumberBytes::Invalid = number_size {
             if let Some(val) = number_bytes {
                 return Err(ShellError::UnsupportedInput {
                     msg: "Only 1, 2, 4, 8, or 'auto' bytes are supported as word sizes".to_string(),
                     input: "value originates from here".to_string(),
                     msg_span: head,
-                    input_span: val.span,
+                    input_span: val.span(),
                 });
             }
         }
@@ -75,10 +97,10 @@ impl Command for BitsShr {
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        input.map(
-            move |value| operate(value, bits, head, signed, bytes_len),
-            engine_state.ctrlc.clone(),
-        )
+            
+        let args = Arguments { signed, number_size, bits };
+
+        operate(action, args, input, head, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -96,75 +118,85 @@ impl Command for BitsShr {
                     Span::test_data(),
                 )),
             },
+            Example {
+                description: "Shift right a binary value",
+                example: "0x[4f f4] | bits shr 4",
+                result: Some(Value::binary(
+                    vec![0x04, 0xff],
+                    Span::test_data()
+                )),
+            }
         ]
     }
 }
 
-fn get_shift_right<T: CheckedShr + Display + Copy>(val: T, bits: u32, span: Span) -> Value
-where
-    i64: std::convert::TryFrom<T>,
-{
-    match val.checked_shr(bits) {
-        Some(val) => {
-            let shift_result = i64::try_from(val);
-            match shift_result {
-                Ok(val) => Value::int( val, span ),
-                Err(_) => Value::error(
+fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+    let Arguments {
+        signed,
+        number_size,
+        bits,
+    } = *args;
+
+    match input {
+        Value::Int { val, .. } => {
+            use InputNumType::*;
+            let val = *val;
+            let bits = bits as u64;
+            let input_num_type = get_input_num_type(val, signed, number_size);
+            match input_num_type {
+                One if bits <= 0xff => Value::int(((val as u8) >> bits as u32) as i64, span),
+                Two if bits <= 0xffff => Value::int(((val as u16) >> bits as u32) as i64, span), 
+                Four if bits <= 0xffff_ffff => Value::int(((val as u32) >> bits as u32) as i64, span),
+                Eight => Value::int(((val as u64) >> bits as u32) as i64, span),
+                SignedOne if bits <= 0xff => Value::int(((val as i8) >> bits as u32) as i64, span),
+                SignedTwo if bits <= 0xffff => Value::int(((val as i16) >> bits as u32) as i64, span),
+                SignedFour if bits <= 0xffff_ffff => Value::int(((val as i32) >> bits as u32) as i64, span),
+                SignedEight => Value::int(val >> (bits as u32), span),
+                _ => Value::error(
                     ShellError::GenericError {
-                        error: "Shift right result beyond the range of 64 bit signed number".into(),
+                        error: "result out of range for specified number".into(),
                         msg: format!(
-                            "{val} of the specified number of bytes shift right {bits} bits exceed limit"
+                            "shifting right by {bits} is out of range for the value {val}"
                         ),
                         span: Some(span),
                         help: None,
                         inner: vec![],
                     },
                     span,
-                ),
+                )
             }
-        }
-        None => Value::error(
-            ShellError::GenericError {
-                error: "Shift right failed".into(),
-                msg: format!("{val} shift right {bits} bits failed, you may shift too many bits"),
-                span: Some(span),
-                help: None,
-                inner: vec![],
-            },
-            span,
-        ),
-    }
-}
+        },
+        Value::Binary { val, .. } => {
+            let byte_shift = bits / 8;
+            let bit_shift = bits % 8;
+            let len = val.len();
+            use itertools::Position::*;
+            let bytes = iter::repeat(0)
+                .take(byte_shift as usize)
+                .chain(
+                    val
+                    .iter()
+                    .copied()
+                    .circular_tuple_windows::<(u8, u8)>()
+                    .with_position()
+                    .map(|(pos, (lhs, rhs))| match pos {
+                        First | Only => lhs >> bit_shift,
+                        _ => (lhs >> bit_shift) | (rhs << bit_shift)
+                    })
+                    .take(len - byte_shift as usize)
+                )
+            .collect::<Vec<u8>>();
 
-fn operate(value: Value, bits: usize, head: Span, signed: bool, number_size: NumberBytes) -> Value {
-    let span = value.span();
-    match value {
-        Value::Int { val, .. } => {
-            use InputNumType::*;
-            // let bits = (((bits % 64) + 64) % 64) as u32;
-            let bits = bits as u32;
-            let input_type = get_input_num_type(val, signed, number_size);
-            match input_type {
-                One => get_shift_right(val as u8, bits, span),
-                Two => get_shift_right(val as u16, bits, span),
-                Four => get_shift_right(val as u32, bits, span),
-                Eight => get_shift_right(val as u64, bits, span),
-                SignedOne => get_shift_right(val as i8, bits, span),
-                SignedTwo => get_shift_right(val as i16, bits, span),
-                SignedFour => get_shift_right(val as i32, bits, span),
-                SignedEight => get_shift_right(val, bits, span),
-            }
-        }
-        // Propagate errors by explicitly matching them before the final case.
-        Value::Error { .. } => value,
+            Value::binary(bytes, span)
+        },
         other => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "int".into(),
+                exp_input_type: "int or binary".into(),
                 wrong_type: other.get_type().to_string(),
-                dst_span: head,
-                src_span: other.span(),
+                dst_span: other.span(),
+                src_span: span,
             },
-            head,
+            span,
         ),
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/xor.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/xor.rs
@@ -1,12 +1,25 @@
+use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::CallExt;
-use nu_protocol::ast::Call;
+use nu_protocol::ast::{Call, CellPath};
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{
     Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
 };
+use std::iter;
 
 #[derive(Clone)]
 pub struct BitsXor;
+
+struct Arguments {
+    target: Value,
+    little_endian: bool,
+}
+
+impl CmdArgument for Arguments {
+    fn take_cell_paths(&mut self) -> Option<Vec<CellPath>> {
+        None
+    }
+}
 
 impl Command for BitsXor {
     fn name(&self) -> &str {
@@ -17,17 +30,33 @@ impl Command for BitsXor {
         Signature::build("bits xor")
             .input_output_types(vec![
                 (Type::Int, Type::Int),
+                (Type::Binary, Type::Binary),
                 (
                     Type::List(Box::new(Type::Int)),
                     Type::List(Box::new(Type::Int)),
                 ),
+                (
+                    Type::List(Box::new(Type::Binary)),
+                    Type::List(Box::new(Type::Binary)),
+                ),
             ])
-            .required("target", SyntaxShape::Int, "target int to perform bit xor")
+            .allow_variants_without_examples(true)
+            .required(
+                "target",
+                SyntaxShape::OneOf(vec![SyntaxShape::Binary, SyntaxShape::Int]),
+                "right-hand side of the operation",
+            )
+            .named(
+                "endian",
+                SyntaxShape::String,
+                "byte encode endian, available options: native(default), little, big",
+                Some('e'),
+            )
             .category(Category::Bits)
     }
 
     fn usage(&self) -> &str {
-        "Performs bitwise xor for ints."
+        "Performs bitwise xor for ints or binary."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -42,15 +71,41 @@ impl Command for BitsXor {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        let target: i64 = call.req(engine_state, stack, 0)?;
-        // This doesn't match explicit nulls
+        let target: Value = call.req(engine_state, stack, 0)?;
+        let endian = call.get_flag::<Value>(engine_state, stack, "endian")?;
+
+        let little_endian = match endian {
+            Some(val) => {
+                let span = val.span();
+                match val {
+                    Value::String { val, .. } => match val.as_str() {
+                        "native" => cfg!(target_endian = "little"),
+                        "little" => true,
+                        "big" => false,
+                        _ => {
+                            return Err(ShellError::TypeMismatch {
+                                err_message: "Endian must be one of native, little, big"
+                                    .to_string(),
+                                span,
+                            })
+                        }
+                    },
+                    _ => false,
+                }
+            }
+            None => cfg!(target_endian = "little"),
+        };
+
         if matches!(input, PipelineData::Empty) {
             return Err(ShellError::PipelineEmpty { dst_span: head });
         }
-        input.map(
-            move |value| operate(value, target, head),
-            engine_state.ctrlc.clone(),
-        )
+
+        let args = Arguments {
+            target,
+            little_endian,
+        };
+
+        operate(action, args, input, head, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -68,24 +123,72 @@ impl Command for BitsXor {
                     Span::test_data(),
                 )),
             },
+            Example {
+                description: "Apply logical xor to binary data",
+                example: "0x[ca fe] | bits xor 0x[ba be]",
+                result: Some(Value::test_binary(vec![0x70, 0x40])),
+            },
+            Example {
+                description:
+                    "Apply logical xor to binary data of varying lengths with specified endianness",
+                example: "0x[ca fe] | bits xor 0x[aa] --endian big",
+                result: Some(Value::test_binary(vec![0x60, 0xfe])),
+            },
         ]
     }
 }
 
-fn operate(value: Value, target: i64, head: Span) -> Value {
-    let span = value.span();
-    match value {
-        Value::Int { val, .. } => Value::int(val ^ target, span),
-        // Propagate errors by explicitly matching them before the final case.
-        Value::Error { .. } => value,
-        other => Value::error(
+fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+    let Arguments {
+        target,
+        little_endian,
+    } = args;
+    match (input, target) {
+        (Value::Int { val: lhs, .. }, Value::Int { val: rhs, .. }) => Value::int(lhs ^ rhs, span),
+        (Value::Binary { val: lhs, .. }, Value::Binary { val: rhs, .. }) => {
+            let (lhs, rhs, max_len, min_len) = match (lhs.len(), rhs.len()) {
+                (max, min) if max > min => (lhs, rhs, max, min),
+                (min, max) => (rhs, lhs, min, max),
+            };
+
+            let pad = iter::repeat(0).take(max_len - min_len);
+
+            let mut a;
+            let mut b;
+
+            let padded: &mut dyn Iterator<Item = u8> = if *little_endian {
+                a = pad.chain(rhs.iter().copied());
+                &mut a
+            } else {
+                b = rhs.iter().copied().chain(pad);
+                &mut b
+            };
+
+            let bytes = lhs.iter().copied().zip(padded);
+
+            let val: Vec<u8> = bytes.map(|(l, r)| l ^ r).collect();
+
+            Value::binary(val, span)
+        }
+        (Value::Binary { .. }, Value::Int { .. }) | (Value::Int { .. }, Value::Binary { .. }) => {
+            Value::error(
+                ShellError::PipelineMismatch {
+                    exp_input_type: "input, and argument, to be both int or both binary"
+                        .to_string(),
+                    dst_span: target.span(),
+                    src_span: span,
+                },
+                span,
+            )
+        }
+        (other, Value::Int { .. } | Value::Binary { .. }) | (_, other) => Value::error(
             ShellError::OnlySupportsThisInputType {
-                exp_input_type: "int".into(),
+                exp_input_type: "int or binary".into(),
                 wrong_type: other.get_type().to_string(),
-                dst_span: head,
-                src_span: other.span(),
+                dst_span: other.span(),
+                src_span: span,
             },
-            head,
+            span,
         ),
     }
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
- enables `bits` commands to operate on binary data, where both inputs are binary and can vary in length
- adds an `--endian` flag to `bits and`, `or`, `xor` for specifying endianness (for binary values of different lengths)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
- `bits` commands will no longer error for non-int inputs

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

> addendum: first PR, please inform if any changes are needed