### PR TITLE
Fix `workspace.members` for dependabot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
 	"crates/nu-std",
 	"crates/nu-table",
 	"crates/nu-term-grid",
+	"crates/nu-test-support",
 	"crates/nu-utils",
 ]
 


### PR DESCRIPTION
Missed `nu-test-support` with #11387

Saw the issue on https://github.com/nushell/nushell/pull/11832/files
where `which` was not updated for `nu-test-support`
