### PR TITLE
Remove list of cell path support for `select` and `reject`

### DIFF
--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -29,10 +29,7 @@ impl Command for Reject {
             )
             .rest(
                 "rest",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::CellPath,
-                    SyntaxShape::List(Box::new(SyntaxShape::CellPath)),
-                ]),
+                SyntaxShape::CellPath,
                 "The names of columns to remove from the table.",
             )
             .category(Category::Filters)
@@ -64,42 +61,6 @@ impl Command for Reject {
             match col_val {
                 Value::CellPath { val, .. } => {
                     new_columns.push(val);
-                }
-                Value::List { vals, .. } => {
-                    for value in vals {
-                        let val_span = &value.span();
-                        match value {
-                            Value::String { val, .. } => {
-                                let cv = CellPath {
-                                    members: vec![PathMember::String {
-                                        val: val.clone(),
-                                        span: *val_span,
-                                        optional: false,
-                                    }],
-                                };
-                                new_columns.push(cv.clone());
-                            }
-                            Value::Int { val, .. } => {
-                                let cv = CellPath {
-                                    members: vec![PathMember::Int {
-                                        val: val as usize,
-                                        span: *val_span,
-                                        optional: false,
-                                    }],
-                                };
-                                new_columns.push(cv.clone());
-                            }
-                            Value::CellPath { val, .. } => new_columns.push(val),
-                            y => {
-                                return Err(ShellError::CantConvert {
-                                    to_type: "cell path".into(),
-                                    from_type: y.get_type().to_string(),
-                                    span: y.span(),
-                                    help: None,
-                                });
-                            }
-                        }
-                    }
                 }
                 Value::String { val, .. } => {
                     let cv = CellPath {
@@ -186,23 +147,17 @@ impl Command for Reject {
                 })),
             },
             Example {
-                description: "Reject columns by a provided list of columns",
-                example: "let cols = [size type];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | reject $cols",
-                result: None
+                description: "Reject multiple columns",
+                example: "[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | reject type size",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {"name" => Value::test_string("Cargo.toml")}),
+                    Value::test_record(record! {"name" => Value::test_string("Cargo.lock")}),
+                ])),
             },
             Example {
-                description: "Reject columns by a list of columns directly",
-                example: r#"[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | reject ["size", "type"]"#,
-                result: Some(Value::test_list(
-                    vec![
-                        Value::test_record(record! {"name" =>  Value::test_string("Cargo.toml")}),
-                        Value::test_record(record! {"name" => Value::test_string("Cargo.lock")})],
-                )),
-            },
-            Example {
-                description: "Reject rows by a provided list of rows",
-                example: "let rows = [0 2];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb] [file.json json 3kb]] | reject $rows",
-                result: None
+                description: "Reject multiple rows",
+                example: "[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb] [file.json json 3kb]] | reject 0 2",
+                result: None,
             },
         ]
     }

--- a/crates/nu-command/src/filters/reject.rs
+++ b/crates/nu-command/src/filters/reject.rs
@@ -147,17 +147,25 @@ impl Command for Reject {
                 })),
             },
             Example {
-                description: "Reject multiple columns",
-                example: "[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | reject type size",
-                result: Some(Value::test_list(vec![
-                    Value::test_record(record! {"name" => Value::test_string("Cargo.toml")}),
-                    Value::test_record(record! {"name" => Value::test_string("Cargo.lock")}),
-                ])),
-            },
-            Example {
                 description: "Reject multiple rows",
                 example: "[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb] [file.json json 3kb]] | reject 0 2",
                 result: None,
+            },
+            Example {
+                description: "Reject multiple columns",
+                example: "[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | reject type size",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! { "name" => Value::test_string("Cargo.toml") }),
+                    Value::test_record(record! { "name" => Value::test_string("Cargo.lock") }),
+                ])),
+            },
+            Example {
+                description: "Reject multiple columns by spreading a list",
+                example: "let cols = [type size]; [[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | reject ...$cols",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! { "name" => Value::test_string("Cargo.toml") }),
+                    Value::test_record(record! { "name" => Value::test_string("Cargo.lock") }),
+                ])),
             },
         ]
     }

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -30,10 +30,7 @@ impl Command for Select {
             )
             .rest(
                 "rest",
-                SyntaxShape::OneOf(vec![
-                    SyntaxShape::CellPath,
-                    SyntaxShape::List(Box::new(SyntaxShape::CellPath)),
-                ]),
+                SyntaxShape::CellPath,
                 "The columns to select from the table.",
             )
             .allow_variants_without_examples(true)
@@ -68,44 +65,6 @@ produce a table, a list will produce a list, and a record will produce a record.
             match col_val {
                 Value::CellPath { val, .. } => {
                     new_columns.push(val);
-                }
-                Value::List { vals, .. } => {
-                    for value in vals {
-                        let val_span = &value.span();
-                        match value {
-                            Value::String { val, .. } => {
-                                let cv = CellPath {
-                                    members: vec![PathMember::String {
-                                        val: val.clone(),
-                                        span: *val_span,
-                                        optional: false,
-                                    }],
-                                };
-                                new_columns.push(cv.clone());
-                            }
-                            Value::Int { val, .. } => {
-                                let cv = CellPath {
-                                    members: vec![PathMember::Int {
-                                        val: val as usize,
-                                        span: *val_span,
-                                        optional: false,
-                                    }],
-                                };
-                                new_columns.push(cv.clone());
-                            }
-                            Value::CellPath { val, .. } => {
-                                new_columns.push(val);
-                            }
-                            y => {
-                                return Err(ShellError::CantConvert {
-                                    to_type: "cell path".into(),
-                                    from_type: y.get_type().to_string(),
-                                    span: y.span(),
-                                    help: None,
-                                });
-                            }
-                        }
-                    }
                 }
                 Value::String { val, .. } => {
                     let cv = CellPath {
@@ -178,23 +137,12 @@ produce a table, a list will produce a list, and a record will produce a record.
                 result: None,
             },
             Example {
-                description: "Select columns by a provided list of columns",
-                example: "let cols = [name type];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select $cols",
-                result: None
-            },
-            Example {
-                description: "Select columns by a provided list of columns",
-                example: r#"[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select ["name", "type"]"#,
-                result: Some(Value::test_list(
-                    vec![
-                        Value::test_record(record! {"name" => Value::test_string("Cargo.toml"), "type" => Value::test_string("toml")}),
-                        Value::test_record(record! {"name" => Value::test_string("Cargo.lock"), "type" => Value::test_string("toml")})],
-                ))
-            },
-            Example {
-                description: "Select rows by a provided list of rows",
-                example: "let rows = [0 2];[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb] [file.json json 3kb]] | select $rows",
-                result: None
+                description: "Select multiple columns",
+                example: "[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select name type",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {"name" => Value::test_string("Cargo.toml"), "type" => Value::test_string("toml")}),
+                    Value::test_record(record! {"name" => Value::test_string("Cargo.lock"), "type" => Value::test_string("toml")}),
+                ]))
             },
         ]
     }

--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -140,8 +140,28 @@ produce a table, a list will produce a list, and a record will produce a record.
                 description: "Select multiple columns",
                 example: "[[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select name type",
                 result: Some(Value::test_list(vec![
-                    Value::test_record(record! {"name" => Value::test_string("Cargo.toml"), "type" => Value::test_string("toml")}),
-                    Value::test_record(record! {"name" => Value::test_string("Cargo.lock"), "type" => Value::test_string("toml")}),
+                    Value::test_record(record! {
+                        "name" => Value::test_string("Cargo.toml"),
+                        "type" => Value::test_string("toml"),
+                    }),
+                    Value::test_record(record! {
+                        "name" => Value::test_string("Cargo.lock"),
+                        "type" => Value::test_string("toml")
+                    }),
+                ]))
+            },
+            Example {
+                description: "Select multiple columns by spreading a list",
+                example: r#"let cols = [name type]; [[name type size]; [Cargo.toml toml 1kb] [Cargo.lock toml 2kb]] | select ...$cols"#,
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "name" => Value::test_string("Cargo.toml"),
+                        "type" => Value::test_string("toml")
+                    }),
+                    Value::test_record(record! {
+                        "name" => Value::test_string("Cargo.lock"),
+                        "type" => Value::test_string("toml")
+                    }),
                 ]))
             },
         ]

--- a/crates/nu-command/tests/commands/reject.rs
+++ b/crates/nu-command/tests/commands/reject.rs
@@ -128,14 +128,14 @@ fn reject_optional_row() {
 }
 
 #[test]
-fn reject_list_columns() {
-    let actual = nu!("let arg = [type size]; [[name type size];[Cargo.toml file 10mb] [Cargo.lock file 10mb] [src dir 100mb]] | reject $arg | to nuon");
+fn reject_columns_with_list_spread() {
+    let actual = nu!("let arg = [type size]; [[name type size];[Cargo.toml file 10mb] [Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(actual.out, "[[name]; [Cargo.toml], [Cargo.lock], [src]]");
 }
 
 #[test]
-fn reject_list_rows() {
-    let actual = nu!("let arg = [2 0]; [[name type size];[Cargo.toml file 10mb] [Cargo.lock file 10mb] [src dir 100mb]] | reject $arg | to nuon");
+fn reject_rows_with_list_spread() {
+    let actual = nu!("let arg = [2 0]; [[name type size];[Cargo.toml file 10mb] [Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(
         actual.out,
         "[[name, type, size]; [Cargo.lock, file, 10000000b]]"
@@ -143,8 +143,8 @@ fn reject_list_rows() {
 }
 
 #[test]
-fn rject_list_mixed() {
-    let actual = nu!("let arg = [ type 2]; [[name type size];[Cargp.toml file 10mb] [ Cargo.lock file 10mb] [src dir 100mb]] | reject $arg | to nuon");
+fn reject_mixed_with_list_spread() {
+    let actual = nu!("let arg = [type 2]; [[name type size];[Cargp.toml file 10mb] [ Cargo.lock file 10mb] [src dir 100mb]] | reject ...$arg | to nuon");
     assert_eq!(
         actual.out,
         "[[name, size]; [Cargp.toml, 10000000b], [Cargo.lock, 10000000b]]"
@@ -172,6 +172,6 @@ fn test_ignore_errors_flag() {
 #[test]
 fn test_ignore_errors_flag_var() {
     let actual =
-        nu!("let arg = [5 c]; [[a, b]; [1, 2], [3, 4], [5, 6]] | reject $arg -i | to nuon");
+        nu!("let arg = [5 c]; [[a, b]; [1, 2], [3, 4], [5, 6]] | reject ...$arg -i | to nuon");
     assert_eq!(actual.out, "[[a, b]; [1, 2], [3, 4], [5, 6]]");
 }

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -249,20 +249,20 @@ fn select_on_empty_list_returns_empty_list() {
 }
 
 #[test]
-fn select_columns_with_variable_list() {
+fn select_columns_with_list_spread() {
     let actual = nu!(r#"
         let columns = [a c];
-        echo [[a b c]; [1 2 3]] | select $columns | to nuon
+        echo [[a b c]; [1 2 3]] | select ...$columns | to nuon
         "#);
 
     assert_eq!(actual.out, "[[a, c]; [1, 3]]");
 }
 
 #[test]
-fn select_rows_with_variable_list() {
+fn select_rows_with_list_spread() {
     let actual = nu!(r#"
         let rows = [0 2];
-        echo [[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select $rows | to nuon
+        echo [[a b c]; [1 2 3] [4 5 6] [7 8 9]] | select ...$rows | to nuon
         "#);
 
     assert_eq!(actual.out, "[[a, b, c]; [1, 2, 3], [7, 8, 9]]");
@@ -270,7 +270,7 @@ fn select_rows_with_variable_list() {
 
 #[test]
 fn select_single_row_with_variable() {
-    let actual = nu!("let idx = 2;[{a: 1, b: 2} {a: 3, b: 5} {a: 3}] | select $idx | to nuon");
+    let actual = nu!("let idx = 2; [{a: 1, b: 2} {a: 3, b: 5} {a: 3}] | select $idx | to nuon");
 
     assert_eq!(actual.out, "[[a]; [3]]".to_string());
     assert!(actual.err.is_empty());


### PR DESCRIPTION
# Description
Requires each of the rest args for `select` and `reject` to be a cell path instead of the current `oneof(cellpath, list<cellpath>`. This simplifies the command signatures and code for `select` and `reject`. Users can now spread lists into the rest arguments instead of providing them as is.

For example,
```nushell
ls | select [name size]
```
must now be
```nushell
ls | select ...[name size]
```

# User-Facing Changes
Breaking change for the `select` and `reject` command signatures.