### PR TITLE
Upgrade openssl-src to fix riscv64 target building error

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -79,7 +79,7 @@ jobs:
         - x86_64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
         - armv7-unknown-linux-gnueabihf
-        # - riscv64gc-unknown-linux-gnu
+        - riscv64gc-unknown-linux-gnu
         extra: ['bin']
         include:
         - target: aarch64-apple-darwin
@@ -116,9 +116,9 @@ jobs:
         - target: armv7-unknown-linux-gnueabihf
           os: ubuntu-20.04
           target_rustflags: ''
-        # - target: riscv64gc-unknown-linux-gnu
-        #   os: ubuntu-latest
-        #   target_rustflags: ''
+        - target: riscv64gc-unknown-linux-gnu
+          os: ubuntu-latest
+          target_rustflags: ''
 
     runs-on: ${{matrix.os}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         - x86_64-unknown-linux-musl
         - aarch64-unknown-linux-gnu
         - armv7-unknown-linux-gnueabihf
-        # - riscv64gc-unknown-linux-gnu
+        - riscv64gc-unknown-linux-gnu
         extra: ['bin']
         include:
         - target: aarch64-apple-darwin
@@ -65,9 +65,9 @@ jobs:
         - target: armv7-unknown-linux-gnueabihf
           os: ubuntu-20.04
           target_rustflags: ''
-        # - target: riscv64gc-unknown-linux-gnu
-        #   os: ubuntu-latest
-        #   target_rustflags: ''
+        - target: riscv64gc-unknown-linux-gnu
+          os: ubuntu-latest
+          target_rustflags: ''
 
     runs-on: ${{matrix.os}}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,9 +3595,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Upgrade openssl-src to fix riscv64 target building error
Workflow Test: https://github.com/nushell/nightly/actions/runs/7914366860