### PR TITLE
Fix future lint by `truncate(false)` in `touch`

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -135,7 +135,12 @@ impl Command for Touch {
                 }
             }
 
-            if let Err(err) = OpenOptions::new().write(true).create(true).open(&item) {
+            if let Err(err) = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&item)
+            {
                 return Err(ShellError::CreateNotPossible {
                     msg: format!("Failed to create file: {err}"),
                     span: call


### PR DESCRIPTION
The following clippy lint on nightly would complain:
- https://rust-lang.github.io/rust-clippy/master/#/suspicious_open

We don't want to alter the content in `touch` or truncate by not
writing. While not fully applicable, may be good practice for
platforms/filesystems we are not aware of.
