### PR TITLE
Fix commandline --cursor to return int

### DIFF
--- a/crates/nu-cli/src/commands/commandline.rs
+++ b/crates/nu-cli/src/commands/commandline.rs
@@ -19,6 +19,7 @@ impl Command for Commandline {
             .input_output_types(vec![
                 (Type::Nothing, Type::Nothing),
                 (Type::String, Type::String),
+                (Type::String, Type::Int),
             ])
             .switch(
                 "cursor",
@@ -120,7 +121,16 @@ impl Command for Commandline {
                     .chain(std::iter::once((repl.buffer.len(), "")))
                     .position(|(i, _c)| i == repl.cursor_pos)
                     .expect("Cursor position isn't on a grapheme boundary");
-                Ok(Value::string(char_pos.to_string(), call.head).into_pipeline_data())
+                match i64::try_from(char_pos) {
+                    Ok(pos) => Ok(Value::int(pos, call.head).into_pipeline_data()),
+                    Err(e) => Err(ShellError::GenericError {
+                        error: "Failed to convert cursor position to int".to_string(),
+                        msg: e.to_string(),
+                        span: None,
+                        help: None,
+                        inner: vec![],
+                    }),
+                }
             } else {
                 Ok(Value::string(repl.buffer.to_string(), call.head).into_pipeline_data())
             }

--- a/src/tests/test_commandline.rs
+++ b/src/tests/test_commandline.rs
@@ -135,3 +135,8 @@ fn commandline_test_cursor_end() -> TestResult {
         "2", // 2 graphemes
     )
 }
+
+#[test]
+fn commandline_test_cursor_type() -> TestResult {
+    run_test("commandline --cursor | describe", "int")
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Fix #11825 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
`commandline --cursor` returns int.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
