### PR TITLE
feat(sleep): add progress bar for sleep command

### DIFF
--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -1,4 +1,3 @@
-use indicatif::ProgressBar;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -65,16 +64,16 @@ impl Command for Sleep {
             let tsec = tsecs % 60;
 
             let timeout_str = format!("{:02}:{:02}:{:02}", thour, tmin, tsec);
-            Some(
-                indicatif::ProgressBar::new((total_dur.as_millis() / 10) as u64)
-                    .with_message(timeout_str)
-                    .with_style(
-                        indicatif::ProgressStyle::with_template(
-                            "{wide_bar}[{elapsed_precise} / {msg}]",
-                        )
-                        .unwrap(),
-                    ),
-            )
+            if let Ok(style) = indicatif::ProgressStyle::with_template("{wide_bar}[{elapsed_precise} / {msg}]")
+            {
+                Some(
+                    indicatif::ProgressBar::new((total_dur.as_millis() / 10) as u64)
+                        .with_message(timeout_str)
+                        .with_style(style),
+                )
+            } else {
+                None
+            }
         } else {
             None
         };

--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -64,7 +64,8 @@ impl Command for Sleep {
             let tsec = tsecs % 60;
 
             let timeout_str = format!("{:02}:{:02}:{:02}", thour, tmin, tsec);
-            if let Ok(style) = indicatif::ProgressStyle::with_template("{wide_bar}[{elapsed_precise} / {msg}]")
+            if let Ok(style) =
+                indicatif::ProgressStyle::with_template("{wide_bar}[{elapsed_precise} / {msg}]")
             {
                 Some(
                     indicatif::ProgressBar::new((total_dur.as_millis() / 10) as u64)


### PR DESCRIPTION


# Description

This will add a progress bar for sleep command. Not sure this is useful or not, for one of my script i wish this was available, If you feel this is not necessary feel free to close this PR.
![image](https://github.com/nushell/nushell/assets/39230006/37ee4ac4-c84d-40ff-85df-4d9a787d68f2)


# User-Facing Changes

Adds a flag `-p` to sleep command which will show the progress

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
