### PR TITLE
Specify which file not found in error

### DIFF
--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -131,7 +131,10 @@ impl Command for History {
                 }
             }
         } else {
-            Err(ShellError::FileNotFound { span: head })
+            Err(ShellError::FileNotFound {
+                file: "history file".into(),
+                span: head,
+            })
         }
     }
 

--- a/crates/nu-cli/src/commands/history/history_.rs
+++ b/crates/nu-cli/src/commands/history/history_.rs
@@ -72,7 +72,7 @@ impl Command for History {
             } else {
                 let history_reader: Option<Box<dyn ReedlineHistory>> = match history.file_format {
                     HistoryFileFormat::Sqlite => {
-                        SqliteBackedHistory::with_file(history_path, None, None)
+                        SqliteBackedHistory::with_file(history_path.clone(), None, None)
                             .map(|inner| {
                                 let boxed: Box<dyn ReedlineHistory> = Box::new(inner);
                                 boxed
@@ -80,14 +80,15 @@ impl Command for History {
                             .ok()
                     }
 
-                    HistoryFileFormat::PlainText => {
-                        FileBackedHistory::with_file(history.max_size as usize, history_path)
-                            .map(|inner| {
-                                let boxed: Box<dyn ReedlineHistory> = Box::new(inner);
-                                boxed
-                            })
-                            .ok()
-                    }
+                    HistoryFileFormat::PlainText => FileBackedHistory::with_file(
+                        history.max_size as usize,
+                        history_path.clone(),
+                    )
+                    .map(|inner| {
+                        let boxed: Box<dyn ReedlineHistory> = Box::new(inner);
+                        boxed
+                    })
+                    .ok(),
                 };
 
                 match history.file_format {
@@ -107,7 +108,10 @@ impl Command for History {
                                 )
                             })
                         })
-                        .ok_or(ShellError::FileNotFound { span: head })?
+                        .ok_or(ShellError::FileNotFound {
+                            file: history_path.display().to_string(),
+                            span: head,
+                        })?
                         .into_pipeline_data(ctrlc)),
                     HistoryFileFormat::Sqlite => Ok(history_reader
                         .and_then(|h| {
@@ -119,7 +123,10 @@ impl Command for History {
                                 create_history_record(idx, entry, long, head)
                             })
                         })
-                        .ok_or(ShellError::FileNotFound { span: head })?
+                        .ok_or(ShellError::FileNotFound {
+                            file: history_path.display().to_string(),
+                            span: head,
+                        })?
                         .into_pipeline_data(ctrlc)),
                 }
             }

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -56,6 +56,7 @@ impl Command for SourceEnv {
             PathBuf::from(&path)
         } else {
             return Err(ShellError::FileNotFound {
+                file: source_filename.item,
                 span: source_filename.span,
             });
         };

--- a/crates/nu-command/src/filesystem/mv.rs
+++ b/crates/nu-command/src/filesystem/mv.rs
@@ -81,6 +81,7 @@ impl Command for Mv {
 
         if sources.is_empty() {
             return Err(ShellError::FileNotFound {
+                file: spanned_source.item.to_string(),
                 span: spanned_source.span,
             });
         }

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -107,7 +107,10 @@ impl Command for Open {
 
             for path in nu_engine::glob_from(&path, &cwd, call_span, None)
                 .map_err(|err| match err {
-                    ShellError::DirectoryNotFound { span, .. } => ShellError::FileNotFound { span },
+                    ShellError::DirectoryNotFound { span, .. } => ShellError::FileNotFound {
+                        file: path.item.to_string(),
+                        span,
+                    },
                     _ => err,
                 })?
                 .1

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -195,7 +195,10 @@ impl Command for UCp {
                     .map(|f| f.1)?
                     .collect();
             if exp_files.is_empty() {
-                return Err(ShellError::FileNotFound { span: p.span });
+                return Err(ShellError::FileNotFound {
+                    file: p.item.to_string(),
+                    span: p.span,
+                });
             };
             let mut app_vals: Vec<PathBuf> = Vec::new();
             for v in exp_files {

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -121,7 +121,10 @@ impl Command for UMv {
                     .map(|f| f.1)?
                     .collect();
             if exp_files.is_empty() {
-                return Err(ShellError::FileNotFound { span: p.span });
+                return Err(ShellError::FileNotFound {
+                    file: p.item.to_string(),
+                    span: p.span,
+                });
             };
             let mut app_vals: Vec<PathBuf> = Vec::new();
             for v in exp_files {

--- a/crates/nu-command/src/system/nu_check.rs
+++ b/crates/nu-command/src/system/nu_check.rs
@@ -120,6 +120,7 @@ impl Command for NuCheck {
                                 path
                             } else {
                                 return Err(ShellError::FileNotFound {
+                                    file: path_str.item,
                                     span: path_str.span,
                                 });
                             }

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -727,10 +727,10 @@ pub enum ShellError {
     ///
     /// Does the file in the error message exist? Is it readable and accessible? Is the casing right?
     #[error("File not found")]
-    #[diagnostic(code(nu::shell::file_not_found))]
+    #[diagnostic(code(nu::shell::file_not_found), help("{file} does not exist"))]
     FileNotFound {
         file: String,
-        #[label("file not found: {file}")]
+        #[label("file not found")]
         span: Span,
     },
 

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -729,7 +729,8 @@ pub enum ShellError {
     #[error("File not found")]
     #[diagnostic(code(nu::shell::file_not_found))]
     FileNotFound {
-        #[label("file not found")]
+        file: String,
+        #[label("file not found: {file}")]
         span: Span,
     },
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Currently, `ShellError::FileNotFound` shows the span where the error occurred but doesn't say which file wasn't found. This PR makes it so the help includes that (like the `DirectoryNotFound` error).

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

No breaking changes, it's just that when a file can't be found, the help will say which file couldn't be found:

![image](https://github.com/nushell/nushell/assets/45539777/e52f1e65-55c1-4cd2-8108-a4ccc334a66f)

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

I didn't add any since I figured only the error message was being changed.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
