### PR TITLE
FreeBSD compatibility patches

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -238,7 +238,10 @@ fn any_group(_current_user_gid: gid_t, owner_group: u32) -> bool {
     user_groups.iter().any(|gid| gid.as_raw() == owner_group)
 }
 
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "freebsd", target_os = "android"))))]
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "freebsd", target_os = "android"))
+))]
 fn any_group(current_user_gid: gid_t, owner_group: u32) -> bool {
     use crate::filesystem::util::users;
 

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -229,7 +229,7 @@ fn have_permission(dir: impl AsRef<Path>) -> PermissionResult<'static> {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "android"))]
 fn any_group(_current_user_gid: gid_t, owner_group: u32) -> bool {
     use crate::filesystem::util::users;
     let Some(user_groups) = users::current_user_groups() else {
@@ -238,7 +238,7 @@ fn any_group(_current_user_gid: gid_t, owner_group: u32) -> bool {
     user_groups.iter().any(|gid| gid.as_raw() == owner_group)
 }
 
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "freebsd", target_os = "android"))))]
 fn any_group(current_user_gid: gid_t, owner_group: u32) -> bool {
     use crate::filesystem::util::users;
 

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -141,9 +141,9 @@ impl Command for UCp {
         } else {
             uu_cp::OverwriteMode::Clobber(uu_cp::ClobberMode::Standard)
         };
-        #[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
+        #[cfg(any(target_os = "linux", target_os = "freebsd" , target_os = "android", target_os = "macos"))]
         let reflink_mode = uu_cp::ReflinkMode::Auto;
-        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "macos")))]
+        #[cfg(not(any(target_os = "linux", target_os = "freebsd" , target_os = "android", target_os = "macos")))]
         let reflink_mode = uu_cp::ReflinkMode::Never;
         let mut paths: Vec<Spanned<NuPath>> = call.rest(engine_state, stack, 0)?;
         if paths.is_empty() {
@@ -283,6 +283,7 @@ fn make_attributes(preserve: Option<Value>) -> Result<uu_cp::Attributes, ShellEr
         let mut attributes = uu_cp::Attributes {
             #[cfg(any(
                 target_os = "linux",
+                target_os = "freebsd",
                 target_os = "android",
                 target_os = "macos",
                 target_os = "netbsd"
@@ -303,6 +304,7 @@ fn make_attributes(preserve: Option<Value>) -> Result<uu_cp::Attributes, ShellEr
             mode: ATTR_SET,
             #[cfg(any(
                 target_os = "linux",
+                target_os = "freebsd",
                 target_os = "android",
                 target_os = "macos",
                 target_os = "netbsd"
@@ -344,6 +346,7 @@ fn parse_and_set_attribute(
                 "mode" => &mut attribute.mode,
                 #[cfg(any(
                     target_os = "linux",
+                    target_os = "freebsd",
                     target_os = "android",
                     target_os = "macos",
                     target_os = "netbsd"

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -141,9 +141,19 @@ impl Command for UCp {
         } else {
             uu_cp::OverwriteMode::Clobber(uu_cp::ClobberMode::Standard)
         };
-        #[cfg(any(target_os = "linux", target_os = "freebsd" , target_os = "android", target_os = "macos"))]
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "android",
+            target_os = "macos"
+        ))]
         let reflink_mode = uu_cp::ReflinkMode::Auto;
-        #[cfg(not(any(target_os = "linux", target_os = "freebsd" , target_os = "android", target_os = "macos")))]
+        #[cfg(not(any(
+            target_os = "linux",
+            target_os = "freebsd",
+            target_os = "android",
+            target_os = "macos"
+        )))]
         let reflink_mode = uu_cp::ReflinkMode::Never;
         let mut paths: Vec<Spanned<NuPath>> = call.rest(engine_state, stack, 0)?;
         if paths.is_empty() {

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -107,7 +107,7 @@ pub mod users {
         Gid::current().as_raw()
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "android")))]
     pub fn get_current_username() -> Option<String> {
         User::from_uid(Uid::current())
             .ok()
@@ -115,7 +115,7 @@ pub mod users {
             .map(|user| user.name)
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "android"))]
     pub fn current_user_groups() -> Option<Vec<Gid>> {
         // SAFETY:
         // if first arg is 0 then it ignores second argument and returns number of groups present for given user.
@@ -154,7 +154,7 @@ pub mod users {
     ///     println!("User is a member of group #{group}");
     /// }
     /// ```
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "android")))]
     pub fn get_user_groups(username: &str, gid: gid_t) -> Option<Vec<Gid>> {
         use std::ffi::CString;
         // MacOS uses i32 instead of gid_t in getgrouplist for unknown reasons

--- a/crates/nu-command/src/platform/ulimit.rs
+++ b/crates/nu-command/src/platform/ulimit.rs
@@ -111,6 +111,7 @@ static RESOURCE_ARRAY: Lazy<Vec<ResourceInfo>> = Lazy::new(|| {
             target_os = "freebsd",
             target_os = "openbsd",
             target_os = "linux",
+            target_os = "freebsd",
             target_os = "netbsd"
         ))]
         (
@@ -126,6 +127,7 @@ static RESOURCE_ARRAY: Lazy<Vec<ResourceInfo>> = Lazy::new(|| {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "linux",
+            target_os = "freebsd",
             target_os = "aix",
         ))]
         (
@@ -178,6 +180,7 @@ static RESOURCE_ARRAY: Lazy<Vec<ResourceInfo>> = Lazy::new(|| {
             target_os = "netbsd",
             target_os = "openbsd",
             target_os = "linux",
+            target_os = "freebsd",
             target_os = "aix",
         ))]
         (

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -4,6 +4,7 @@ mod nu_check;
 #[cfg(any(
     target_os = "android",
     target_os = "linux",
+    target_os = "freebsd",
     target_os = "macos",
     target_os = "windows"
 ))]
@@ -20,6 +21,7 @@ pub use nu_check::NuCheck;
 #[cfg(any(
     target_os = "android",
     target_os = "linux",
+    target_os = "freebsd",
     target_os = "macos",
     target_os = "windows"
 ))]

--- a/crates/nu-command/src/system/ps.rs
+++ b/crates/nu-command/src/system/ps.rs
@@ -16,6 +16,7 @@ use nu_protocol::{
 };
 #[cfg(all(
     unix,
+    not(target_os = "freebsd"),
     not(target_os = "macos"),
     not(target_os = "windows"),
     not(target_os = "android"),
@@ -27,6 +28,7 @@ use std::time::Duration;
 #[derive(Clone)]
 pub struct Ps;
 
+#[cfg(not(target_os = "freebsd"))]
 impl Command for Ps {
     fn name(&self) -> &str {
         "ps"
@@ -93,6 +95,7 @@ impl Command for Ps {
     }
 }
 
+#[cfg(not(target_os = "freebsd"))]
 fn run_ps(
     engine_state: &EngineState,
     stack: &mut Stack,

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -603,7 +603,7 @@ fn list_a_directory_not_exists() {
     })
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "freebsd"))]
 #[test]
 fn list_directory_contains_invalid_utf8() {
     use std::ffi::OsStr;

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -436,19 +436,19 @@ fn mv_change_case_of_directory() {
             .map(|de| de.unwrap().file_name().to_string_lossy().into_owned())
             .collect();
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         assert!(
             !_files_in_test_directory.contains(&original_dir)
                 && _files_in_test_directory.contains(&new_dir)
         );
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         assert!(files_exist_at(
             vec!["somefile.txt",],
             dirs.test().join(new_dir)
         ));
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
         _actual.err.contains("to a subdirectory of itself");
     })
 }
@@ -474,12 +474,12 @@ fn mv_change_case_of_file() {
             .unwrap()
             .map(|de| de.unwrap().file_name().to_string_lossy().into_owned())
             .collect();
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         assert!(
             !_files_in_test_directory.contains(&original_file_name)
                 && _files_in_test_directory.contains(&new_file_name)
         );
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "freebsd")))]
         _actual.err.contains("are the same file");
     })
 }

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -903,7 +903,7 @@ fn test_cp_debug_default() {
         {
             panic!("{}", format!("Failure: stdout was \n{}", actual.out));
         }
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         if !actual
             .out
             .contains("copy offload: unknown, reflink: unsupported, sparse detection: no")

--- a/crates/nu-command/tests/commands/ulimit.rs
+++ b/crates/nu-command/tests/commands/ulimit.rs
@@ -93,7 +93,7 @@ fn limit_set_invalid1() {
     });
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 #[test]
 fn limit_set_invalid2() {
     Playground::setup("limit_set_invalid2", |dirs, _sandbox| {


### PR DESCRIPTION
# Description

nushell is verified to work on FreeBSD 14 with these patches.

What isn't supported on FreeBSD:
* the crate 'procfs' doesn't support FreeBSD yet, all functionality depending on procfs is disabled
* several RLIMIT_* values aren't supported on FreeBSD - functions related to these are disabled




# User-Facing Changes
n/a

# Tests + Formatting
n/a

# After Submitting
n/a