### PR TITLE
Fix panic in `seq date`

### DIFF
--- a/crates/nu-command/src/generators/seq_date.rs
+++ b/crates/nu-command/src/generators/seq_date.rs
@@ -7,6 +7,7 @@ use nu_protocol::{
     Category, Example, IntoPipelineData, PipelineData, ShellError, Signature, Span, Spanned,
     SyntaxShape, Type, Value,
 };
+use std::fmt::Write;
 
 #[derive(Clone)]
 pub struct SeqDate;
@@ -315,7 +316,19 @@ pub fn run_seq_dates(
 
     let mut ret = vec![];
     loop {
-        let date_string = &next.format(&out_format).to_string();
+        let mut date_string = String::new();
+        match write!(date_string, "{}", next.format(&out_format)) {
+            Ok(_) => {}
+            Err(e) => {
+                return Err(ShellError::GenericError {
+                    error: "Invalid output format".into(),
+                    msg: e.to_string(),
+                    span: Some(call_span),
+                    help: None,
+                    inner: vec![],
+                });
+            }
+        }
         ret.push(Value::string(date_string, call_span));
         next += Duration::days(step_size);
 

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -93,6 +93,7 @@ mod select;
 mod semicolon;
 mod seq;
 mod seq_char;
+mod seq_date;
 mod skip;
 mod sort;
 mod sort_by;

--- a/crates/nu-command/tests/commands/seq_date.rs
+++ b/crates/nu-command/tests/commands/seq_date.rs
@@ -1,0 +1,8 @@
+use nu_test_support::nu;
+
+#[test]
+fn fails_when_output_format_contains_time() {
+    let actual = nu!("seq date --output-format '%H-%M-%S'");
+
+    assert!(actual.err.contains("Invalid output format"));
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Fix #11732 

<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Invalid output format causes an error, not a panic.
```nu
❯ seq date --output-format '%H-%M-%S'
Error:   × Invalid output format
   ╭─[entry #1:1:1]
 1 │ seq date --output-format '%H-%M-%S'
   · ────┬───
   ·     ╰── an error occurred when formatting an argument
   ╰────
```
# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
