### PR TITLE
Bump `roxmltree` to 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4850,12 +4850,9 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
-dependencies = [
- "xmlparser",
-]
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "rstest"
@@ -6896,12 +6893,6 @@ dependencies = [
  "linux-raw-sys",
  "rustix",
 ]
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -71,7 +71,7 @@ quick-xml = "0.31.0"
 rand = "0.8"
 rayon = "1.8"
 regex = "1.9.5"
-roxmltree = "0.18"
+roxmltree = "0.19"
 rusqlite = { version = "0.29", features = ["bundled", "backup", "chrono"], optional = true }
 same-file = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -280,7 +280,39 @@ fn process_xml_parse_error(err: roxmltree::Error, span: Span) -> ShellError {
         roxmltree::Error::NamespacesLimitReached => {
             make_cant_convert_error("Namespace limit reached", span)
         }
-        roxmltree::Error::ParserError(_) => make_cant_convert_error("Parser error", span),
+        roxmltree::Error::UnexpectedDeclaration(_) => {
+            make_cant_convert_error("An XML document can have only one XML declaration and it must be at the start of the document.", span)
+        }
+        roxmltree::Error::InvalidName(_) => {
+            make_cant_convert_error("Invalid name found.", span)
+        }
+        roxmltree::Error::NonXmlChar(_, _) => {
+            make_cant_convert_error("A non-XML character has occurred. Valid characters are: <https://www.w3.org/TR/xml/#char32>", span)
+        }
+        roxmltree::Error::InvalidChar(_, _, _) => {
+            make_cant_convert_error("An invalid/unexpected character in XML.", span)
+        }
+        roxmltree::Error::InvalidChar2(_, _, _) => {
+            make_cant_convert_error("An invalid/unexpected character in XML.", span)
+        }
+        roxmltree::Error::InvalidString(_, _) => {
+            make_cant_convert_error("An invalid/unexpected string in XML.", span)
+        }
+        roxmltree::Error::InvalidExternalID(_) => {
+            make_cant_convert_error("An invalid ExternalID in the DTD.", span)
+        }
+        roxmltree::Error::InvalidComment(_) => {
+            make_cant_convert_error("A comment cannot contain `--` or end with `-`.", span)
+        }
+        roxmltree::Error::InvalidCharacterData(_) => {
+            make_cant_convert_error("A Character Data node contains an invalid data. Currently, only `]]>` is not allowed.", span)
+        }
+        roxmltree::Error::UnknownToken(_) => {
+            make_cant_convert_error("Unknown token in XML.", span)
+        }
+        roxmltree::Error::UnexpectedEndOfStream => {
+            make_cant_convert_error("Unexpected end of stream while parsing XML.", span)
+        }
     }
 }
 


### PR DESCRIPTION
Manual changes to adapt to new error variants. Error text adapted from docs.

Supersedes #11605
