### PR TITLE
Prune unused `ShellError` variants

### DIFF
--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -833,19 +833,6 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// Attempted to perform an operation on a directory that doesn't exist.
-    ///
-    /// ## Resolution
-    ///
-    /// Make sure the directory in the error message actually exists before trying again.
-    #[error("Directory not found")]
-    #[diagnostic(code(nu::shell::directory_not_found_custom))]
-    DirectoryNotFoundCustom {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
     /// The requested move operation cannot be completed. This is typically because both paths exist,
     /// but are of different types. For example, you might be trying to overwrite an existing file with
     /// a directory.

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -808,19 +808,6 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// Out of memory.
-    ///
-    /// ## Resolution
-    ///
-    /// This is a generic error. Refer to the specific error message for further details.
-    #[error("Out of memory")]
-    #[diagnostic(code(nu::shell::out_of_memory))]
-    OutOfMemoryError {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
     /// Tried to `cd` to a path that isn't a directory.
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -808,19 +808,6 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// Permission for an operation was denied.
-    ///
-    /// ## Resolution
-    ///
-    /// This is a generic error. Refer to the specific error message for further details.
-    #[error("Permission Denied")]
-    #[diagnostic(code(nu::shell::permission_denied))]
-    PermissionDeniedError {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
     /// Out of memory.
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -1060,15 +1060,6 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// Non-Unicode input received.
-    ///
-    /// ## Resolution
-    ///
-    /// Check that your path is UTF-8 compatible.
-    #[error("Non-Unicode input received.")]
-    #[diagnostic(code(nu::shell::non_unicode_input))]
-    NonUnicodeInput,
-
     // It should be only used by commands accepts block, and accept inputs from pipeline.
     /// Failed to eval block with specific pipeline input.
     #[error("Eval block failed with pipeline input")]

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -851,22 +851,6 @@ pub enum ShellError {
         destination_span: Span,
     },
 
-    /// The requested move operation cannot be completed. This is typically because both paths exist,
-    /// but are of different types. For example, you might be trying to overwrite an existing file with
-    /// a directory.
-    ///
-    /// ## Resolution
-    ///
-    /// Make sure the destination path does not exist before moving a directory.
-    #[error("Move not possible")]
-    #[diagnostic(code(nu::shell::move_not_possible_single))]
-    // NOTE: Currently not actively used.
-    MoveNotPossibleSingle {
-        msg: String,
-        #[label("{msg}")]
-        span: Span,
-    },
-
     /// Failed to create either a file or directory.
     ///
     /// ## Resolution


### PR DESCRIPTION
# Description
Same procedure as #11881

Remove unused variants to avoid confusion and foster better practices around error variants.

- Remove `SE::PermissionDeniedError`
- Remove `SE::OutOfMemoryError`
- Remove `SE::DirectoryNotFoundCustom`
- Remove `SE::MoveNotPossibleSingle`
- Remove `SE::NonUnicodeInput`

# User-Facing Changes
Plugin authors may have matched against or emitted those variants
