### PR TITLE
allow `last` to work with ranges

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -69,6 +69,11 @@ impl Command for First {
                 example: "0x[01 23 45] | first 2",
                 result: Some(Value::binary(vec![0x01, 0x23], Span::test_data())),
             },
+            Example {
+                description: "Return the first item of a range",
+                example: "1..3 | first",
+                result: Some(Value::test_int(1)),
+            },
         ]
     }
 }

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -27,6 +27,7 @@ impl Command for Last {
                     Type::Any,
                 ),
                 (Type::Binary, Type::Binary),
+                (Type::Range, Type::Any),
             ])
             .optional(
                 "rows",
@@ -59,6 +60,11 @@ impl Command for Last {
                 example: "0x[01 23 45] | last 2",
                 description: "Return the last 2 bytes of a binary value",
                 result: Some(Value::binary(vec![0x23, 0x45], Span::test_data())),
+            },
+            Example {
+                example: "1..3 | last",
+                description: "Return the last item of a range",
+                result: Some(Value::test_int(3)),
             },
         ]
     }


### PR DESCRIPTION
# Description

This PR allows `last` to work with ranges in the same way that `first` does. It also adds a couple examples demonstrating it.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
