### PR TITLE
fixes `debug info` not populating process information

### DIFF
--- a/crates/nu-command/src/debug/info.rs
+++ b/crates/nu-command/src/debug/info.rs
@@ -79,12 +79,7 @@ impl LazySystemInfoRecord {
             "ppid" => {
                 // only get information requested
                 let system_opt = SystemOpt::from((system_option, || {
-                    RefreshKind::new().with_processes(
-                        ProcessRefreshKind::new()
-                            .without_cpu()
-                            .without_disk_usage()
-                            .without_user(),
-                    )
+                    RefreshKind::new().with_processes(ProcessRefreshKind::everything())
                 }));
 
                 let system = system_opt.get_system();
@@ -117,16 +112,10 @@ impl LazySystemInfoRecord {
             "process" => {
                 // only get information requested
                 let system_opt = SystemOpt::from((system_option, || {
-                    RefreshKind::new().with_processes(
-                        ProcessRefreshKind::new()
-                            .without_cpu()
-                            .without_disk_usage()
-                            .without_user(),
-                    )
+                    RefreshKind::new().with_processes(ProcessRefreshKind::everything())
                 }));
 
                 let system = system_opt.get_system();
-                // get the process information for the nushell pid
                 let pinfo = system.process(pid);
 
                 if let Some(p) = pinfo {
@@ -236,12 +225,7 @@ impl<'a> LazyRecord<'a> for LazySystemInfoRecord {
 
     fn collect(&'a self) -> Result<Value, ShellError> {
         let rk = RefreshKind::new()
-            .with_processes(
-                ProcessRefreshKind::new()
-                    .without_cpu()
-                    .without_disk_usage()
-                    .without_user(),
-            )
+            .with_processes(ProcessRefreshKind::everything())
             .with_memory(MemoryRefreshKind::everything());
         // only get information requested
         let system = System::new_with_specifics(rk);


### PR DESCRIPTION
# Description

This PR fixes #11901. For some reason `debug info` stopped reporting information. This hopefully fixes it. I think something changes in the `sysinfo` crate that stopped it from working.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
