### PR TITLE
stdin changes to allow script syntax to be piped into nushell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae037714f313c1353189ead58ef9eec30a8e8dc101b2622d461418fd59e28a9"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +1845,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
@@ -2059,7 +2079,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.4",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -2778,6 +2798,7 @@ name = "nu"
 version = "0.90.2"
 dependencies = [
  "assert_cmd",
+ "atty",
  "criterion",
  "crossterm",
  "ctrlc",
@@ -3475,7 +3496,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.4",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ nu-utils = { path = "./crates/nu-utils", version = "0.90.2" }
 nu-ansi-term = "0.50.0"
 reedline = { version = "0.29.0", features = ["bashisms", "sqlite"] }
 
+atty = "0.2.14"
 crossterm = "0.27"
 ctrlc = "3.4"
 log = "0.4"

--- a/crates/nu-command/tests/commands/date/format.rs
+++ b/crates/nu-command/tests/commands/date/format.rs
@@ -15,7 +15,7 @@ fn fails_without_input() {
         format date "%c"
         "#);
 
-    assert!(actual.err.contains("Pipeline empty"));
+    assert!(actual.err.contains("no input value was piped in"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -48,7 +48,7 @@ fn parse_script_with_wrong_type() {
             "
         ));
 
-        assert!(actual.err.contains("Failed to parse content"));
+        assert!(actual.err.contains("Expected keyword"));
     })
 }
 #[test]
@@ -130,7 +130,7 @@ fn parse_module_with_wrong_type() {
             "
         ));
 
-        assert!(actual.err.contains("Failed to parse content"));
+        assert!(actual.err.contains("Unexpected end of code"));
     })
 }
 #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+use atty::Stream;
 use nu_engine::{get_full_help, CallExt};
 use nu_parser::parse;
 use nu_parser::{escape_for_script_arg, escape_quote_string};
@@ -17,6 +18,36 @@ pub(crate) fn gather_commandline_args() -> (Vec<String>, String, Vec<String>) {
     let mut args_to_nushell = Vec::from(["nu".into()]);
     let mut script_name = String::new();
     let mut args = std::env::args();
+
+    // Is there anything being redirected into nushell?
+    if !atty::is(Stream::Stdin) {
+        args_to_nushell.push("--stdin".into());
+    }
+
+    // Above is the only way I could get stdin without consuming it
+    // Below almost worked but when you started nushell normally it
+    // would hang waiting for input
+
+    // Get a handle to stdin
+    // let stdin = std::io::stdin();
+    // let mut stdin_lock = stdin.lock();
+
+    // Peek into stdin without consuming it
+    // let input_available = match stdin_lock.fill_buf() {
+    //     Ok(buf) => !buf.is_empty(),
+    //     Err(_) => false,
+    // };
+    // if input_available {
+    //     args_to_nushell.push("--stdin".into());
+    // }
+
+    // if stdin_lock
+    //     .fill_buf()
+    //     .map(|buf| !buf.is_empty())
+    //     .unwrap_or(false)
+    // {
+    //     args_to_nushell.push("--stdin".into());
+    // }
 
     // Mimic the behaviour of bash/zsh
     if let Some(argv0) = args.next() {
@@ -216,6 +247,7 @@ pub(crate) fn parse_commandline_args(
     std::process::exit(1);
 }
 
+#[derive(Debug, Clone)]
 pub(crate) struct NushellCliArgs {
     pub(crate) redirect_stdin: Option<Spanned<String>>,
     pub(crate) login_shell: Option<Spanned<String>>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,22 +308,25 @@ fn main() -> Result<()> {
     // let input = if let Some(redirect_stdin) = &parsed_nu_cli_args.redirect_stdin {
     let input = if should_process_stdin_as_script {
         // eprintln!("redirect stdin");
-        let redirect_stdin = parsed_nu_cli_args.redirect_stdin.as_ref().unwrap();
-        let stdin = std::io::stdin();
-        let buf_reader = BufReader::new(stdin);
+        if let Some(redirect_stdin) = parsed_nu_cli_args.redirect_stdin.as_ref() {
+            let stdin = std::io::stdin();
+            let buf_reader = BufReader::new(stdin);
 
-        PipelineData::ExternalStream {
-            stdout: Some(RawStream::new(
-                Box::new(BufferedReader::new(buf_reader)),
-                Some(ctrlc),
-                redirect_stdin.span,
-                None,
-            )),
-            stderr: None,
-            exit_code: None,
-            span: redirect_stdin.span,
-            metadata: None,
-            trim_end_newline: false,
+            PipelineData::ExternalStream {
+                stdout: Some(RawStream::new(
+                    Box::new(BufferedReader::new(buf_reader)),
+                    Some(ctrlc),
+                    redirect_stdin.span,
+                    None,
+                )),
+                stderr: None,
+                exit_code: None,
+                span: redirect_stdin.span,
+                metadata: None,
+                trim_end_newline: false,
+            }
+        } else {
+            PipelineData::empty()
         }
     } else {
         PipelineData::empty()


### PR DESCRIPTION
# Description

This PR _attempts_ to allow nushell script syntax to be piped into the nushell executable without using --stdin parameter. I'm pretty confident there are bugs. Let me know your thoughts. The trickiest part was determining if there is data being piped in without consuming it. I tried about 20 different things and this PR is where I landed.

### Example1
This is me running the PR. My rust setup puts all the build artifacts in d:\cartar i.e. cargo target
The `-l` is provided in this sample to force nushell to act as a `--login` client and read all my config files. 
![image](https://github.com/nushell/nushell/assets/343840/024e1bb4-7a8f-4105-b1cd-cb719f5dec0a)

### Example2
The same command but without the `-l` parameter to show that nushell is launching with the default_config/env.nu files.
![image](https://github.com/nushell/nushell/assets/343840/ecf50bec-b34b-4462-ac4b-06874b4eff04)



# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
