### PR TITLE
Replace debug_assert! with assert! in Signature::check_names

### DIFF
--- a/crates/nu-protocol/src/signature.rs
+++ b/crates/nu-protocol/src/signature.rs
@@ -471,7 +471,7 @@ impl Signature {
     /// Panics if one of them is found
     fn check_names(&self, name: impl Into<String>, short: Option<char>) -> (String, Option<char>) {
         let s = short.map(|c| {
-            debug_assert!(
+            assert!(
                 !self.get_shorts().contains(&c),
                 "There may be duplicate short flags for '-{}'",
                 c
@@ -481,7 +481,7 @@ impl Signature {
 
         let name = {
             let name: String = name.into();
-            debug_assert!(
+            assert!(
                 !self.get_names().contains(&name.as_str()),
                 "There may be duplicate name flags for '--{}'",
                 name


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Debug assertions don't run at release, which means that `cargo test --release` fails because the tests for name checks don't run properly. These checks are not really expensive, and there shouldn't be any noticeable difference to startup time, so there isn't much reason not to just leave them in.

It's valuable to be able to run `cargo test --release`, as that can expose race conditions and dependencies on undefined behavior that aren't exposed in debug builds.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

This shouldn't affect anything. Any violations of this rule were being caught with debug tests, which are run by the CI.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`


# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
