### PR TITLE
Fix `cargo b -p nu-command --tests`

### DIFF
--- a/crates/nu-command/tests/commands/database/mod.rs
+++ b/crates/nu-command/tests/commands/database/mod.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "sqlite")]
 mod into_sqlite;

--- a/crates/nu-command/tests/commands/database/mod.rs
+++ b/crates/nu-command/tests/commands/database/mod.rs
@@ -1,2 +1,1 @@
-#[cfg(feature = "sqlite")]
 mod into_sqlite;

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -13,6 +13,7 @@ mod config_nu_default;
 mod continue_;
 mod conversions;
 mod cp;
+#[cfg(feature = "sqlite")]
 mod database;
 mod date;
 mod debug_info;


### PR DESCRIPTION
The feature `sqlite` is not active by default on `nu-command`.
Only when building `cargo b --all --tests` would the feature be activated via `nu`'s feature requirements.

Make the tests conditional

Saw this when double checking the removals from #11938.
Making sure each crate still compiles individually, ensures both that you can run subcrate tests independently and that the `cargo publish` run will succeed to build the crate with the default feature set (see the problems occurring for the `0.90.0` release.  
