### PR TITLE
new `var` command

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/mod.rs
+++ b/crates/nu-cmd-lang/src/core_commands/mod.rs
@@ -32,6 +32,7 @@ mod return_;
 mod scope;
 mod try_;
 mod use_;
+mod var;
 mod version;
 mod while_;
 
@@ -69,6 +70,7 @@ pub use return_::Return;
 pub use scope::*;
 pub use try_::Try;
 pub use use_::Use;
+pub use var::Var;
 pub use version::Version;
 pub use while_::While;
 //#[cfg(feature = "plugin")]

--- a/crates/nu-cmd-lang/src/core_commands/var.rs
+++ b/crates/nu-cmd-lang/src/core_commands/var.rs
@@ -1,0 +1,90 @@
+use nu_protocol::ast::Call;
+use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::{
+    Category, Example, PipelineData, ShellError, Signature, Span, SyntaxShape, Type, Value,
+};
+
+#[derive(Clone)]
+pub struct Var;
+
+impl Command for Var {
+    fn name(&self) -> &str {
+        "var"
+    }
+
+    fn usage(&self) -> &str {
+        "Create a variable from a pipeline."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build("var")
+            .input_output_types(vec![(Type::Any, Type::Nothing)])
+            .allow_variants_without_examples(true)
+            .required("var_name", SyntaxShape::VarWithOptType, "Variable name.")
+            .category(Category::Core)
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true // this is not true but needs to be, we should probably just build this into let
+    }
+
+    fn extra_usage(&self) -> &str {
+        "This should work like `let` but gets the variable value from the end of the pipeline."
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["set", "const", "let"]
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let input_span = input.span().unwrap_or(Span::unknown());
+        let var_id = call
+            .positional_nth(0)
+            .expect("already checked positional")
+            .as_var()
+            .expect("internal error: missing variable");
+
+        let input_as_value = input.into_value(input_span);
+
+        stack.add_var(var_id, input_as_value);
+        Ok(PipelineData::empty())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Set a variable to a value",
+                example: "echo 10 | var val;echo $val",
+                result: Some(Value::test_int(10)),
+            },
+            Example {
+                description: "Set a variable to the result of an expression",
+                example: "10 + 100 | var expr;echo $expr",
+                result: Some(Value::test_int(110)),
+            },
+            Example {
+                description: "Set a variable based on the condition",
+                example: "if false { -1 } else { 1 } | var cond;echo $cond",
+                result: Some(Value::test_int(1)),
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_examples() {
+        use crate::test_examples;
+
+        test_examples(Var {})
+    }
+}

--- a/crates/nu-cmd-lang/src/default_context.rs
+++ b/crates/nu-cmd-lang/src/default_context.rs
@@ -62,6 +62,7 @@ pub fn create_default_context() -> EngineState {
             Use,
             Version,
             While,
+            Var,
         };
 
         //#[cfg(feature = "plugin")]


### PR DESCRIPTION
# Description

The point of this PR was an attempt to address a question that is asked many times which is, "Can I set a variable with a pipeline?". After some discussions with the core-team, this PR is not proper because variable names need to be checkable at parse time. I'm putting this PR up to continue the conversation. Maybe this can be folded into `let` since it is a parse time keyword?

Either way, it's fun!

![image](https://github.com/nushell/nushell/assets/343840/9255f005-e9a9-495b-8bc7-22e133cb9bd9)



# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
