### PR TITLE
allow current day to be highlighted

### DIFF
--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -342,7 +342,7 @@ fn add_month_to_table(
                     if current_day == adjusted_day_number {
                         // This colors the current day
                         let header_style =
-                            style_computer.compute("header", &Value::string("search result", tag));
+                            style_computer.compute("header", &Value::nothing(Span::unknown()));
 
                         value = Value::string(
                             header_style

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -1,5 +1,6 @@
 use chrono::{Datelike, Local, NaiveDate};
 use indexmap::IndexMap;
+use nu_color_config::StyleComputer;
 use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
@@ -92,7 +93,6 @@ pub fn cal(
     engine_state: &EngineState,
     stack: &mut Stack,
     call: &Call,
-    // TODO: Error if a value is piped in
     _input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let mut calendar_vec_deque = VecDeque::new();
@@ -108,6 +108,8 @@ pub fn cal(
         full_year: call.get_flag(engine_state, stack, "full-year")?,
         week_start: call.get_flag(engine_state, stack, "week-start")?,
     };
+
+    let style_computer = &StyleComputer::from_config(&engine_state, stack);
 
     let mut selected_year: i32 = current_year;
     let mut current_day_option: Option<u32> = Some(current_day);
@@ -132,6 +134,7 @@ pub fn cal(
         month_range,
         current_month,
         current_day_option,
+        style_computer,
     )?;
 
     Ok(Value::list(calendar_vec_deque.into_iter().collect(), tag).into_pipeline_data())
@@ -208,6 +211,7 @@ fn add_months_of_year_to_table(
     (start_month, end_month): (u32, u32),
     current_month: u32,
     current_day_option: Option<u32>,
+    style_computer: &StyleComputer,
 ) -> Result<(), ShellError> {
     for month_number in start_month..=end_month {
         let mut new_current_day_option: Option<u32> = None;
@@ -225,6 +229,7 @@ fn add_months_of_year_to_table(
             selected_year,
             month_number,
             new_current_day_option,
+            style_computer,
         );
 
         add_month_to_table_result?
@@ -240,6 +245,7 @@ fn add_month_to_table(
     selected_year: i32,
     current_month: u32,
     current_day_option: Option<u32>,
+    style_computer: &StyleComputer,
 ) -> Result<(), ShellError> {
     let month_helper_result = MonthHelper::new(selected_year, current_month);
 
@@ -258,15 +264,7 @@ fn add_month_to_table(
         },
     };
 
-    let mut days_of_the_week = [
-        "sunday",
-        "monday",
-        "tuesday",
-        "wednesday",
-        "thursday",
-        "friday",
-        "saturday",
-    ];
+    let mut days_of_the_week = ["su", "mo", "tu", "we", "th", "fr", "sa"];
 
     let mut week_start_day = days_of_the_week[0].to_string();
     if let Some(day) = &arguments.week_start {
@@ -341,8 +339,16 @@ fn add_month_to_table(
 
                 if let Some(current_day) = current_day_option {
                     if current_day == adjusted_day_number {
-                        // TODO: Update the value here with a color when color support is added
                         // This colors the current day
+                        let header_style =
+                            style_computer.compute("header", &Value::string("search result", tag));
+
+                        value = Value::string(
+                            header_style
+                                .paint(adjusted_day_number.to_string())
+                                .to_string(),
+                            tag,
+                        );
                     }
                 }
             }

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -109,7 +109,7 @@ pub fn cal(
         week_start: call.get_flag(engine_state, stack, "week-start")?,
     };
 
-    let style_computer = &StyleComputer::from_config(&engine_state, stack);
+    let style_computer = &StyleComputer::from_config(engine_state, stack);
 
     let mut selected_year: i32 = current_year;
     let mut current_day_option: Option<u32> = Some(current_day);
@@ -203,6 +203,7 @@ fn get_current_date() -> (i32, u32, u32) {
     (current_year, current_month, current_day)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn add_months_of_year_to_table(
     arguments: &Arguments,
     calendar_vec_deque: &mut VecDeque<Value>,

--- a/crates/nu-command/tests/commands/cal.rs
+++ b/crates/nu-command/tests/commands/cal.rs
@@ -4,7 +4,8 @@ use nu_test_support::{nu, pipeline};
 fn cal_full_year() {
     let actual = nu!("cal -y --full-year 2010 | first | to json -r");
 
-    let first_week_2010_json = r#"{"year": 2010,"sunday": null,"monday": null,"tuesday": null,"wednesday": null,"thursday": null,"friday": 1,"saturday": 2}"#;
+    let first_week_2010_json =
+        r#"{"year": 2010,"su": null,"mo": null,"tu": null,"we": null,"th": null,"fr": 1,"sa": 2}"#;
 
     assert_eq!(actual.out, first_week_2010_json);
 }
@@ -17,16 +18,16 @@ fn cal_february_2020_leap_year() {
         "#
     ));
 
-    let cal_february_json = r#"[{"year": 2020,"month": "february","sunday": null,"monday": null,"tuesday": null,"wednesday": null,"thursday": null,"friday": null,"saturday": 1},{"year": 2020,"month": "february","sunday": 2,"monday": 3,"tuesday": 4,"wednesday": 5,"thursday": 6,"friday": 7,"saturday": 8},{"year": 2020,"month": "february","sunday": 9,"monday": 10,"tuesday": 11,"wednesday": 12,"thursday": 13,"friday": 14,"saturday": 15},{"year": 2020,"month": "february","sunday": 16,"monday": 17,"tuesday": 18,"wednesday": 19,"thursday": 20,"friday": 21,"saturday": 22},{"year": 2020,"month": "february","sunday": 23,"monday": 24,"tuesday": 25,"wednesday": 26,"thursday": 27,"friday": 28,"saturday": 29}]"#;
+    let cal_february_json = r#"[{"year": 2020,"month": "february","su": null,"mo": null,"tu": null,"we": null,"th": null,"fr": null,"sa": 1},{"year": 2020,"month": "february","su": 2,"mo": 3,"tu": 4,"we": 5,"th": 6,"fr": 7,"sa": 8},{"year": 2020,"month": "february","su": 9,"mo": 10,"tu": 11,"we": 12,"th": 13,"fr": 14,"sa": 15},{"year": 2020,"month": "february","su": 16,"mo": 17,"tu": 18,"we": 19,"th": 20,"fr": 21,"sa": 22},{"year": 2020,"month": "february","su": 23,"mo": 24,"tu": 25,"we": 26,"th": 27,"fr": 28,"sa": 29}]"#;
 
     assert_eq!(actual.out, cal_february_json);
 }
 
 #[test]
-fn cal_friday_the_thirteenths_in_2015() {
+fn cal_fr_the_thirteenths_in_2015() {
     let actual = nu!(pipeline(
         r#"
-        cal --full-year 2015 | default 0 friday | where friday == 13 | length
+        cal --full-year 2015 | default 0 fr | where fr == 13 | length
         "#
     ));
 
@@ -45,14 +46,14 @@ fn cal_rows_in_2020() {
 }
 
 #[test]
-fn cal_week_day_start_monday() {
+fn cal_week_day_start_mo() {
     let actual = nu!(pipeline(
         r#"
-        cal --full-year 2020 -m --month-names --week-start monday | where month == january | to json -r
+        cal --full-year 2020 -m --month-names --week-start mo | where month == january | to json -r
         "#
     ));
 
-    let cal_january_json = r#"[{"month": "january","monday": null,"tuesday": null,"wednesday": 1,"thursday": 2,"friday": 3,"saturday": 4,"sunday": 5},{"month": "january","monday": 6,"tuesday": 7,"wednesday": 8,"thursday": 9,"friday": 10,"saturday": 11,"sunday": 12},{"month": "january","monday": 13,"tuesday": 14,"wednesday": 15,"thursday": 16,"friday": 17,"saturday": 18,"sunday": 19},{"month": "january","monday": 20,"tuesday": 21,"wednesday": 22,"thursday": 23,"friday": 24,"saturday": 25,"sunday": 26},{"month": "january","monday": 27,"tuesday": 28,"wednesday": 29,"thursday": 30,"friday": 31,"saturday": null,"sunday": null}]"#;
+    let cal_january_json = r#"[{"month": "january","mo": null,"tu": null,"we": 1,"th": 2,"fr": 3,"sa": 4,"su": 5},{"month": "january","mo": 6,"tu": 7,"we": 8,"th": 9,"fr": 10,"sa": 11,"su": 12},{"month": "january","mo": 13,"tu": 14,"we": 15,"th": 16,"fr": 17,"sa": 18,"su": 19},{"month": "january","mo": 20,"tu": 21,"we": 22,"th": 23,"fr": 24,"sa": 25,"su": 26},{"month": "january","mo": 27,"tu": 28,"we": 29,"th": 30,"fr": 31,"sa": null,"su": null}]"#;
 
     assert_eq!(actual.out, cal_january_json);
 }
@@ -61,7 +62,7 @@ fn cal_week_day_start_monday() {
 fn cal_sees_pipeline_year() {
     let actual = nu!(pipeline(
         r#"
-        cal --full-year 1020 | get monday | first 4 | to json -r
+        cal --full-year 1020 | get mo | first 4 | to json -r
         "#
     ));
 


### PR DESCRIPTION
# Description

This PR tweaks the built-in `cal` command so that it's still nushell-y but looks closer to the "expected" cal by abbreviating the name of the days. I also added the ability to color the current day with the current "header" color.

### Before
![image](https://github.com/nushell/nushell/assets/343840/c7ad3017-d872-4d39-926d-cc99b097d934)

### After
![image](https://github.com/nushell/nushell/assets/343840/735c4f2e-9867-4cd7-ae3b-397dd02059d7)



# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
