### PR TITLE
bump reedline to test ExecuteHostCommand changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4690,7 +4690,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.29.0"
-source = "git+https://github.com/nushell/reedline?branch=main#c7c17442e09da6419ab174611070de37ec76d006"
+source = "git+https://github.com/nushell/reedline?branch=main#4fd129588a7373acd3e154fb55a5b572948f7df7"
 dependencies = [
  "arboard",
  "chrono",


### PR DESCRIPTION
# Description

This PR bumps reedline to the latest main which has the `executehostcommand` changes https://github.com/nushell/reedline/pull/758 which essentially allows reedline/nushell to call `executehostcommand` in key bindings and rewrite the commandline buffer without inserting a newline.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
