### PR TITLE
Benchmark changes

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -115,8 +115,9 @@ fn encoding_test_data(row_cnt: usize, col_cnt: usize) -> Value {
 
 fn encoding_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Encoding");
-    let test_cnt_pairs = [(100, 5), (100, 15), (10000, 5), (10000, 15)];
-    for (row_cnt, col_cnt) in test_cnt_pairs.into_iter() {
+    let row_cnt = 10000;
+    let col_cnt = 15;
+
         for fmt in ["json", "msgpack"] {
             group.bench_function(&format!("{fmt} encode {row_cnt} * {col_cnt}"), |b| {
                 let mut res = vec![];
@@ -128,14 +129,15 @@ fn encoding_benchmarks(c: &mut Criterion) {
                 b.iter(|| encoder.encode(&test_data, &mut res))
             });
         }
-    }
+
     group.finish();
 }
 
 fn decoding_benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("Decoding");
-    let test_cnt_pairs = [(100, 5), (100, 15), (10000, 5), (10000, 15)];
-    for (row_cnt, col_cnt) in test_cnt_pairs.into_iter() {
+    let row_cnt = 10000;
+    let col_cnt = 15;
+
         for fmt in ["json", "msgpack"] {
             group.bench_function(&format!("{fmt} decode for {row_cnt} * {col_cnt}"), |b| {
                 let mut res = vec![];
@@ -152,7 +154,7 @@ fn decoding_benchmarks(c: &mut Criterion) {
                 })
             });
         }
-    }
+
     group.finish();
 }
 

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -61,34 +61,6 @@ fn parser_benchmarks(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
-
-    c.bench_function("eval default_env.nu", |b| {
-        b.iter(|| {
-            let mut stack = nu_protocol::engine::Stack::new();
-            eval_source(
-                &mut engine_state,
-                &mut stack,
-                get_default_env().as_bytes(),
-                "default_env.nu",
-                PipelineData::empty(),
-                false,
-            )
-        })
-    });
-
-    c.bench_function("eval default_config.nu", |b| {
-        b.iter(|| {
-            let mut stack = nu_protocol::engine::Stack::new();
-            eval_source(
-                &mut engine_state,
-                &mut stack,
-                get_default_config().as_bytes(),
-                "default_config.nu",
-                PipelineData::empty(),
-                false,
-            )
-        })
-    });
 }
 
 fn eval_benchmarks(c: &mut Criterion) {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR does a total of 3 things,
1. It fixes an error when running the `cargo bench` suit where nushell constants where not set correctly ending in an error when running the code.
2. It removes 2 redundant benchmark runs as these where duplicates of existing ones.
3. It reduced encoding and decoding benchmark suit future, only having 4 benches instead of the previous 8.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
