### PR TITLE
Canonicalize default-config-dir and plugin-path

### DIFF
--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -61,10 +61,10 @@ pub fn add_plugin_file(
     plugin_file: Option<Spanned<String>>,
     storage_path: &str,
 ) {
-    if let Some(plugin_file) = plugin_file {
-        let working_set = StateWorkingSet::new(engine_state);
-        let cwd = working_set.get_cwd();
+    let working_set = StateWorkingSet::new(engine_state);
+    let cwd = working_set.get_cwd();
 
+    if let Some(plugin_file) = plugin_file {
         if let Ok(path) = canonicalize_with(&plugin_file.item, cwd) {
             engine_state.plugin_signatures = Some(path)
         } else {
@@ -72,7 +72,7 @@ pub fn add_plugin_file(
             report_error(&working_set, &e);
         }
     } else if let Some(plugin_path) = nu_path::config_dir() {
-        let mut plugin_path = plugin_path.canonicalize().unwrap_or(plugin_path);
+        let mut plugin_path = canonicalize_with(&plugin_path, cwd).unwrap_or(plugin_path);
         // Path to store plugins signatures
         plugin_path.push(storage_path);
         plugin_path.push(PLUGIN_FILE);

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -71,7 +71,8 @@ pub fn add_plugin_file(
             let e = ParseError::FileNotFound(plugin_file.item, plugin_file.span);
             report_error(&working_set, &e);
         }
-    } else if let Some(mut plugin_path) = nu_path::config_dir() {
+    } else if let Some(plugin_path) = nu_path::config_dir() {
+        let mut plugin_path = plugin_path.canonicalize().unwrap_or(plugin_path);
         // Path to store plugins signatures
         plugin_path.push(storage_path);
         plugin_path.push(PLUGIN_FILE);

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -121,7 +121,8 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
                     |e| e,
                     |mut path| {
                         path.push("plugin.nu");
-                        Value::string(path.to_string_lossy(), span)
+                        let canonical_plugin_path = canonicalize_path(engine_state, &path);
+                        Value::string(canonical_plugin_path.to_string_lossy(), span)
                     },
                 )
             },

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -121,8 +121,7 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
                     |e| e,
                     |mut path| {
                         path.push("plugin.nu");
-                        let canon_plugin_path = canonicalize_path(engine_state, &path);
-                        Value::string(canon_plugin_path.to_string_lossy(), span)
+                        Value::string(path.to_string_lossy(), span)
                     },
                 )
             },

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -29,7 +29,7 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
     let config_path = match nu_path::config_dir() {
         Some(mut path) => {
             path.push("nushell");
-            Ok(path)
+            Ok(canonicalize_path(engine_state, &path))
         }
         None => Err(Value::error(
             ShellError::ConfigDirNotFound { span: Some(span) },
@@ -121,7 +121,8 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
                     |e| e,
                     |mut path| {
                         path.push("plugin.nu");
-                        Value::string(path.to_string_lossy(), span)
+                        let canon_plugin_path = canonicalize_path(engine_state, &path);
+                        Value::string(canon_plugin_path.to_string_lossy(), span)
                     },
                 )
             },

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -1,8 +1,12 @@
 use nu_test_support::nu;
-use nu_test_support::playground::Playground;
 use pretty_assertions::assert_eq;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use nu_test_support::playground::Playground;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::path::PathBuf;
 
 #[cfg(not(target_os = "windows"))]
 fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -1,7 +1,8 @@
 use nu_test_support::nu;
+use nu_test_support::playground::Playground;
 use pretty_assertions::assert_eq;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[cfg(not(target_os = "windows"))]
 fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
@@ -19,8 +20,41 @@ fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
     }
 }
 
-#[test]
-fn test_default_config_path() {
+/// Make the config directory a symlink that points to a temporary folder.
+/// Returns the path to the `nushell` config folder inside, via the symlink.
+///
+/// Need to figure out how to change config directory on Windows.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn setup_fake_config(playground: &mut Playground) -> PathBuf {
+    #[cfg(target_os = "linux")]
+    {
+        let config_dir = "config";
+        let config_link = "config_link";
+        playground.mkdir(&format!("{config_dir}/nushell"));
+        playground.symlink(config_dir, config_link);
+        playground.with_env(
+            "XDG_CONFIG_HOME",
+            &playground.cwd().join(config_link).display().to_string(),
+        );
+        Path::new(config_link).join("nushell")
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let fake_home = "fake_home";
+        let home_link = "home_link";
+        let dir_end = "fake-home/Library/Application\\ Support/nushell";
+        playground.mkdir(format!("{fake_home}/{dir_end}"));
+        playground.symlink(fake_home, home_link);
+        playground.with_env(
+            "HOME",
+            &playground.cwd().join(home_link).display().to_string(),
+        );
+        PathBuf::from(home_link).join(dir_end)
+    }
+}
+
+fn test_config_path_helper() {
     let config_dir = nu_path::config_dir().expect("Could not get config directory");
     let config_dir_nushell = config_dir.join("nushell");
     // Create the config dir folder structure if it does not already exist
@@ -67,6 +101,59 @@ fn test_default_config_path() {
         let actual = nu!(cwd: &cwd, "$nu.plugin-path");
         assert_eq!(actual.out, canon_plugin_path);
     }
+}
+
+#[test]
+fn test_default_config_path() {
+    test_config_path_helper();
+}
+
+/// Make the config folder a symlink to a temporary folder without any config files
+/// and see if the config files' paths are properly canonicalized
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn test_default_config_path_symlinked_empty() {
+    Playground::setup("symlinked_empty_config_dir", |_, playground| {
+        let _ = setup_fake_config(playground);
+
+        test_config_path_helper();
+    });
+}
+
+/// Like [[test_default_config_path_symlinked_empty]], but fill the temporary folder
+/// with symlinks to the real config files and see if they're properly canonicalized
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[test]
+fn test_default_config_path_symlinked_config_files() {
+    Playground::setup(
+        "symlinked_cfg_dir_with_symlinked_cfg_files",
+        |_, playground| {
+            let real_config_dir_nushell = nu_path::config_dir()
+                .expect("Could not get config directory")
+                .join("nushell");
+
+            let fake_config_dir_nushell = setup_fake_config(playground);
+
+            for config_file in [
+                "config.nu",
+                "env.nu",
+                "history.txt",
+                "history.sqlite3",
+                "login.nu",
+                "plugin.nu",
+            ] {
+                playground.symlink(
+                    &real_config_dir_nushell
+                        .join(config_file)
+                        .display()
+                        .to_string(),
+                    fake_config_dir_nushell.join(config_file),
+                );
+            }
+
+            test_config_path_helper();
+        },
+    );
 }
 
 #[test]

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -173,9 +173,9 @@ fn test_default_config_path_symlinked_config_files() {
                 "login.nu",
                 "plugin.nu",
             ] {
-                let path = format!("empty-{config_file}");
-                File::create(&path).unwrap();
-                playground.symlink(path, fake_config_dir_nushell.join(config_file));
+                let empty_file = playground.cwd().join(format!("empty-{config_file}"));
+                File::create(&empty_file).unwrap();
+                playground.symlink(empty_file, fake_config_dir_nushell.join(config_file));
             }
 
             test_config_path_helper();

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -44,7 +44,7 @@ fn setup_fake_config(playground: &mut Playground) -> PathBuf {
         let fake_home = "fake_home";
         let home_link = "home_link";
         let dir_end = "fake-home/Library/Application\\ Support/nushell";
-        playground.mkdir(format!("{fake_home}/{dir_end}"));
+        playground.mkdir(&format!("{fake_home}/{dir_end}"));
         playground.symlink(fake_home, home_link);
         playground.with_env(
             "HOME",


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR makes sure `$nu.default-config-dir` and `$nu.plugin-path` are canonicalized.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

`$nu.default-config-dir` (and `$nu.plugin-path`) will now give canonical paths, with symlinks and whatnot resolved.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

I've added a couple of tests to check that even if the config folder and/or any of the config files within are symlinks, the `$nu.*` variables are properly canonicalized. These tests unfortunately only run on Linux and MacOS, because I couldn't figure out how to change the config directory on Windows. Also, given that they involve creating files, I'm not sure if they're excessive, so I could remove one or two of them.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
