### PR TITLE
Add `upsert` example

### DIFF
--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -13,7 +13,7 @@ mod test_examples {
         Math, MathRound, ParEach, Path, PathParse, Random, Seq, Sort, SortBy, Split, SplitColumn,
         SplitRow, Str, StrJoin, StrLength, StrReplace, Update, Url, Values, Wrap,
     };
-    use crate::{Each, To};
+    use crate::{Default, Each, To};
     use nu_cmd_lang::example_support::{
         check_all_signature_input_output_types_entries_have_examples,
         check_example_evaluates_to_expected_output,
@@ -67,6 +67,7 @@ mod test_examples {
             working_set.add_decl(Box::new(Ansi));
             working_set.add_decl(Box::new(Break));
             working_set.add_decl(Box::new(Date));
+            working_set.add_decl(Box::new(Default));
             working_set.add_decl(Box::new(Each));
             working_set.add_decl(Box::new(Echo));
             working_set.add_decl(Box::new(Enumerate));

--- a/crates/nu-command/src/filters/upsert.rs
+++ b/crates/nu-command/src/filters/upsert.rs
@@ -108,6 +108,21 @@ impl Command for Upsert {
                 ])),
             },
             Example {
+                description: "Update null values in a column to a default value",
+                example: "[[foo]; [2] [null] [4]] | upsert foo { default 0 }",
+                result: Some(Value::test_list(vec![
+                    Value::test_record(record! {
+                        "foo" => Value::test_int(2),
+                    }),
+                    Value::test_record(record! {
+                        "foo" => Value::test_int(0),
+                    }),
+                    Value::test_record(record! {
+                        "foo" => Value::test_int(4),
+                    }),
+                ])),
+            },
+            Example {
                 description: "Upsert into a list, updating an existing value at an index",
                 example: "[1 2 3] | upsert 0 2",
                 result: Some(Value::test_list(vec![


### PR DESCRIPTION
# Description
Adds one example to `help upsert` that indirectly uses the `$in` value in a closure.