### PR TITLE
Allow clear command to clear terminal's history

### DIFF
--- a/crates/nu-command/src/platform/clear.rs
+++ b/crates/nu-command/src/platform/clear.rs
@@ -3,6 +3,7 @@ use crossterm::{
     terminal::{Clear as ClearCommand, ClearType},
     QueueableCommand,
 };
+use nu_engine::CallExt;
 use nu_protocol::ast::Call;
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{Category, Example, PipelineData, ShellError, Signature, Type};
@@ -24,17 +25,22 @@ impl Command for Clear {
         Signature::build("clear")
             .category(Category::Platform)
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .switch("all", "Clear the terminal and its history", Some('a'))
     }
 
     fn run(
         &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
-        _call: &Call,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        let clear_type: ClearType = match call.has_flag(engine_state, stack, "all")? {
+            true => ClearType::Purge,
+            _ => ClearType::All,
+        };
         std::io::stdout()
-            .queue(ClearCommand(ClearType::All))?
+            .queue(ClearCommand(clear_type))?
             .queue(MoveTo(0, 0))?
             .flush()?;
 
@@ -42,10 +48,17 @@ impl Command for Clear {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![Example {
-            description: "Clear the terminal",
-            example: "clear",
-            result: None,
-        }]
+        vec![
+            Example {
+                description: "Clear the terminal",
+                example: "clear",
+                result: None,
+            },
+            Example {
+                description: "Clear the terminal and its history",
+                example: "clear --all",
+                result: None,
+            },
+        ]
     }
 }


### PR DESCRIPTION
This PR should close #11693.

# Description

This PR just adds a '--all' flag to the `clear` command in order to clear the terminal and its history.

By default, the `clear` command only scrolls down.
In some cases, clearing the history as well can be useful.

Default behavior does not change.

Even if the `clear` command can be extended form within nushell, having it in out of the box would allow to use it raw, without any customization required.
Last but not least, it is pretty easy to implement as it is already supported by the crate which is used to clear the terminal (`crossterm`).

Providing relevant screenshot is pretty difficult because the result is the same.
In the `clear --all` case, you just cannot scroll back anymore.

# User-Facing Changes

`clear` just scrolls down as usual without wiping the history of the terminal.

` clear --all` scrolls down and wipe the terminal's history which means scrolling back is no more possible.

# Tests + Formatting

General formatting and tests pass and have been executed on Linux only.
I don't have any way to test it on other systems.
There are no specific tests for the `clear` command so I didn't add any (and I am not sure how to do if I had to).
Clear command is just a wrapper of the `crossterm` crate Clear command.

I would be more than happy if someone else was able to test it in other context (even if it may be good as we rely on the crossterm crate).

# After Submitting

PR for documentation has be drafted: https://github.com/nushell/nushell.github.io/pull/1266.
I'll update it with version if this PR is merged.