### PR TITLE
Disable flaky network tests

### DIFF
--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -244,31 +244,31 @@ fn http_get_redirect_mode_error() {
 // These tests require network access; they use badssl.com which is a Google-affiliated site for testing various SSL errors.
 // Revisit this if these tests prove to be flaky or unstable.
 //
-// These tests are flaky and cause CI to fail somewhat regularly.
+// These tests are flaky and cause CI to fail somewhat regularly. See PR #12010.
 
 #[test]
-#[ignore]
+#[ignore = "unreliable test"]
 fn http_get_expired_cert_fails() {
     let actual = nu!("http get https://expired.badssl.com/");
     assert!(actual.err.contains("network_failure"));
 }
 
 #[test]
-#[ignore]
+#[ignore = "unreliable test"]
 fn http_get_expired_cert_override() {
     let actual = nu!("http get --insecure https://expired.badssl.com/");
     assert!(actual.out.contains("<html>"));
 }
 
 #[test]
-#[ignore]
+#[ignore = "unreliable test"]
 fn http_get_self_signed_fails() {
     let actual = nu!("http get https://self-signed.badssl.com/");
     assert!(actual.err.contains("network_failure"));
 }
 
 #[test]
-#[ignore]
+#[ignore = "unreliable test"]
 fn http_get_self_signed_override() {
     let actual = nu!("http get --insecure https://self-signed.badssl.com/");
     assert!(actual.out.contains("<html>"));

--- a/crates/nu-command/tests/commands/network/http/get.rs
+++ b/crates/nu-command/tests/commands/network/http/get.rs
@@ -243,26 +243,32 @@ fn http_get_redirect_mode_error() {
 
 // These tests require network access; they use badssl.com which is a Google-affiliated site for testing various SSL errors.
 // Revisit this if these tests prove to be flaky or unstable.
+//
+// These tests are flaky and cause CI to fail somewhat regularly.
 
 #[test]
+#[ignore]
 fn http_get_expired_cert_fails() {
     let actual = nu!("http get https://expired.badssl.com/");
     assert!(actual.err.contains("network_failure"));
 }
 
 #[test]
+#[ignore]
 fn http_get_expired_cert_override() {
     let actual = nu!("http get --insecure https://expired.badssl.com/");
     assert!(actual.out.contains("<html>"));
 }
 
 #[test]
+#[ignore]
 fn http_get_self_signed_fails() {
     let actual = nu!("http get https://self-signed.badssl.com/");
     assert!(actual.err.contains("network_failure"));
 }
 
 #[test]
+#[ignore]
 fn http_get_self_signed_override() {
     let actual = nu!("http get --insecure https://self-signed.badssl.com/");
     assert!(actual.out.contains("<html>"));


### PR DESCRIPTION
# Description
Ignores some network tests that sometimes fail in CI. E.g., in [11953](https://github.com/nushell/nushell/pull/11953#issuecomment-1962275863) and [11654](https://github.com/nushell/nushell/pull/11654#issuecomment-1968404551).