### PR TITLE
fix: process empty headers in `to md` command

### DIFF
--- a/crates/nu-cmd-base/src/formats/to/delimited.rs
+++ b/crates/nu-cmd-base/src/formats/to/delimited.rs
@@ -10,7 +10,7 @@ pub fn merge_descriptors(values: &[Value]) -> Vec<String> {
             _ => vec!["".to_string()],
         };
         for desc in &data_descriptors {
-            if !seen.contains(desc) {
+            if !desc.is_empty() && !seen.contains(desc) {
                 seen.insert(desc.to_string());
                 ret.push(desc.to_string());
             }

--- a/crates/nu-cmd-base/src/formats/to/delimited.rs
+++ b/crates/nu-cmd-base/src/formats/to/delimited.rs
@@ -9,8 +9,8 @@ pub fn merge_descriptors(values: &[Value]) -> Vec<String> {
             Value::Record { val, .. } => val.columns().cloned().collect(),
             _ => vec!["".to_string()],
         };
-        for desc in data_descriptors {
-            if !desc.is_empty() && !seen.contains(&desc) {
+        for desc in &data_descriptors {
+            if !seen.contains(desc) {
                 seen.insert(desc.to_string());
                 ret.push(desc.to_string());
             }

--- a/crates/nu-cmd-base/src/formats/to/delimited.rs
+++ b/crates/nu-cmd-base/src/formats/to/delimited.rs
@@ -9,8 +9,8 @@ pub fn merge_descriptors(values: &[Value]) -> Vec<String> {
             Value::Record { val, .. } => val.columns().cloned().collect(),
             _ => vec!["".to_string()],
         };
-        for desc in &data_descriptors {
-            if !desc.is_empty() && !seen.contains(desc) {
+        for desc in data_descriptors {
+            if !desc.is_empty() && !seen.contains(&desc) {
                 seen.insert(desc.to_string());
                 ret.push(desc.to_string());
             }

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -416,4 +416,32 @@ mod tests {
         "#)
         );
     }
+
+    #[test]
+    fn test_empty_column_header() {
+        let value = Value::test_list(vec![
+            Value::test_record(record! {
+                "" => Value::test_string("1"),
+                "foo" => Value::test_string("2"),
+            }),
+            Value::test_record(record! {
+                "" => Value::test_string("3"),
+                "foo" => Value::test_string("4"),
+            }),
+        ]);
+
+        assert_eq!(
+            table(
+                value.clone().into_pipeline_data(),
+                false,
+                &Config::default()
+            ),
+            one(r#"
+            ||foo|
+            |-|-|
+            |1|2|
+            |3|4|
+        "#)
+        );
+    }
 }

--- a/crates/nu-command/src/formats/to/md.rs
+++ b/crates/nu-command/src/formats/to/md.rs
@@ -151,7 +151,21 @@ fn collect_headers(headers: &[String]) -> (Vec<String>, Vec<usize>) {
 
 fn table(input: PipelineData, pretty: bool, config: &Config) -> String {
     let vec_of_values = input.into_iter().collect::<Vec<Value>>();
-    let headers = merge_descriptors(&vec_of_values);
+    let mut headers = merge_descriptors(&vec_of_values);
+
+    let mut empty_header_index = 0;
+    for value in &vec_of_values {
+        if let Value::Record { val, .. } = value {
+            for column in val.columns() {
+                if column.is_empty() && !headers.contains(&String::new()) {
+                    headers.insert(empty_header_index, String::new());
+                    empty_header_index += 1;
+                    break;
+                }
+                empty_header_index += 1;
+            }
+        }
+    }
 
     let (escaped_headers, mut column_widths) = collect_headers(&headers);
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
fixes #12006

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Process empty headers as well in `to md` command.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
