### PR TITLE
Add Goodbye message to ensure plugins exit when they are no longer needed

### DIFF
--- a/crates/nu-plugin/src/plugin/interface/plugin/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin/tests.rs
@@ -416,6 +416,23 @@ fn interface_hello_sends_protocol_info() -> Result<(), ShellError> {
 }
 
 #[test]
+fn interface_goodbye() -> Result<(), ShellError> {
+    let test = TestCase::new();
+    let interface = test.plugin("test").get_interface();
+    interface.goodbye()?;
+
+    let written = test.next_written().expect("nothing written");
+
+    assert!(
+        matches!(written, PluginInput::Goodbye),
+        "not goodbye: {written:?}"
+    );
+
+    assert!(!test.has_unconsumed_write());
+    Ok(())
+}
+
+#[test]
 fn interface_write_plugin_call_registers_subscription() -> Result<(), ShellError> {
     let mut manager = TestCase::new().plugin("test");
     assert!(

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -114,6 +114,9 @@ pub enum PluginInput {
     /// Execute a [`PluginCall`], such as `Run` or `Signature`. The ID should not have been used
     /// before.
     Call(PluginCallId, PluginCall<PipelineDataHeader>),
+    /// Don't expect any more plugin calls. Exit after all currently executing plugin calls are
+    /// finished.
+    Goodbye,
     /// Stream control or data message. Untagged to keep them as small as possible.
     ///
     /// For example, `Stream(Ack(0))` is encoded as `{"Ack": 0}`

--- a/crates/nu_plugin_python/nu_plugin_python_example.py
+++ b/crates/nu_plugin_python/nu_plugin_python_example.py
@@ -217,6 +217,8 @@ def write_error(id, msg, span=None):
 def handle_input(input):
     if "Hello" in input:
         return
+    elif input == "Goodbye":
+        return
     elif "Call" in input:
         [id, plugin_call] = input["Call"]
         if "Signature" in plugin_call:


### PR DESCRIPTION
# Description

This fixes a race condition where all interfaces to a plugin might have been dropped, but both sides are still expecting input, and the `PluginInterfaceManager` doesn't get a chance to see that the interfaces have been dropped and stop trying to consume input.

As the manager needs to hold on to a writer, we can't automatically close the stream, but we also can't interrupt it if it's in a waiting to read. So the best solution is to send a message to the plugin that we are no longer going to be sending it any plugin calls, so that it knows that it can exit when it's done.

This race condition is a little bit tricky to trigger as-is, but can be more noticeable when running plugins in a tight loop. If too many plugin processes are spawned at one time, Nushell can start to encounter "too many open files" errors, and not be very useful.


# User-Facing Changes


# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

I will need to add `Goodbye` to the protocol docs