### PR TITLE
Add support for engine calls from plugins

### DIFF
--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -16,7 +16,7 @@
 //! invoked by Nushell.
 //!
 //! ```rust,no_run
-//! use nu_plugin::{EvaluatedCall, LabeledError, MsgPackSerializer, Plugin, serve_plugin};
+//! use nu_plugin::*;
 //! use nu_protocol::{PluginSignature, Value};
 //!
 //! struct MyPlugin;
@@ -26,9 +26,9 @@
 //!         todo!();
 //!     }
 //!     fn run(
-//!         &mut self,
+//!         &self,
 //!         name: &str,
-//!         config: &Option<Value>,
+//!         engine: &EngineInterface,
 //!         call: &EvaluatedCall,
 //!         input: &Value
 //!     ) -> Result<Value, LabeledError> {
@@ -37,7 +37,7 @@
 //! }
 //!
 //! fn main() {
-//!    serve_plugin(&mut MyPlugin{}, MsgPackSerializer)
+//!    serve_plugin(&MyPlugin{}, MsgPackSerializer)
 //! }
 //! ```
 //!
@@ -49,7 +49,7 @@ mod protocol;
 mod sequence;
 mod serializers;
 
-pub use plugin::{serve_plugin, Plugin, PluginEncoder, StreamingPlugin};
+pub use plugin::{serve_plugin, EngineInterface, Plugin, PluginEncoder, StreamingPlugin};
 pub use protocol::{EvaluatedCall, LabeledError};
 pub use serializers::{json::JsonSerializer, msgpack::MsgPackSerializer};
 

--- a/crates/nu-plugin/src/plugin/context.rs
+++ b/crates/nu-plugin/src/plugin/context.rs
@@ -1,36 +1,166 @@
 use std::sync::{atomic::AtomicBool, Arc};
 
+use nu_engine::get_eval_block_with_early_return;
 use nu_protocol::{
     ast::Call,
-    engine::{EngineState, Stack},
+    engine::{Closure, EngineState, Stack},
+    Config, PipelineData, ShellError, Span, Spanned, Value,
 };
+
+use super::PluginIdentity;
 
 /// Object safe trait for abstracting operations required of the plugin context.
 pub(crate) trait PluginExecutionContext: Send + Sync {
+    /// The [Span] for the command execution (`call.head`)
+    fn command_span(&self) -> Span;
+    /// The name of the command being executed
+    fn command_name(&self) -> &str;
     /// The interrupt signal, if present
     fn ctrlc(&self) -> Option<&Arc<AtomicBool>>;
+    /// Get engine configuration
+    fn get_config(&self) -> Result<Config, ShellError>;
+    /// Get plugin configuration
+    fn get_plugin_config(&self) -> Result<Option<Value>, ShellError>;
+    /// Evaluate a closure passed to the plugin
+    fn eval_closure(
+        &self,
+        closure: Spanned<Closure>,
+        positional: Vec<Value>,
+        input: PipelineData,
+        redirect_stdout: bool,
+        redirect_stderr: bool,
+    ) -> Result<PipelineData, ShellError>;
 }
 
-/// The execution context of a plugin command. May be extended with more fields in the future.
+/// The execution context of a plugin command.
 pub(crate) struct PluginExecutionCommandContext {
-    ctrlc: Option<Arc<AtomicBool>>,
+    identity: Arc<PluginIdentity>,
+    engine_state: EngineState,
+    stack: Stack,
+    call: Call,
 }
 
 impl PluginExecutionCommandContext {
     pub fn new(
+        identity: Arc<PluginIdentity>,
         engine_state: &EngineState,
-        _stack: &Stack,
-        _call: &Call,
+        stack: &Stack,
+        call: &Call,
     ) -> PluginExecutionCommandContext {
         PluginExecutionCommandContext {
-            ctrlc: engine_state.ctrlc.clone(),
+            identity,
+            engine_state: engine_state.clone(),
+            stack: stack.clone(),
+            call: call.clone(),
         }
     }
 }
 
 impl PluginExecutionContext for PluginExecutionCommandContext {
+    fn command_span(&self) -> Span {
+        self.call.head
+    }
+
+    fn command_name(&self) -> &str {
+        self.engine_state.get_decl(self.call.decl_id).name()
+    }
+
     fn ctrlc(&self) -> Option<&Arc<AtomicBool>> {
-        self.ctrlc.as_ref()
+        self.engine_state.ctrlc.as_ref()
+    }
+
+    fn get_config(&self) -> Result<Config, ShellError> {
+        Ok(nu_engine::get_config(&self.engine_state, &self.stack))
+    }
+
+    fn get_plugin_config(&self) -> Result<Option<Value>, ShellError> {
+        // Fetch the configuration for a plugin
+        //
+        // The `plugin` must match the registered name of a plugin.  For
+        // `register nu_plugin_example` the plugin config lookup uses `"example"`
+        Ok(self
+            .get_config()?
+            .plugins
+            .get(&self.identity.plugin_name)
+            .cloned()
+            .map(|value| {
+                let span = value.span();
+                match value {
+                    Value::Closure { val, .. } => {
+                        let input = PipelineData::Empty;
+
+                        let block = self.engine_state.get_block(val.block_id).clone();
+                        let mut stack = self.stack.captures_to_stack(val.captures);
+
+                        let eval_block_with_early_return =
+                            get_eval_block_with_early_return(&self.engine_state);
+
+                        match eval_block_with_early_return(
+                            &self.engine_state,
+                            &mut stack,
+                            &block,
+                            input,
+                            false,
+                            false,
+                        ) {
+                            Ok(v) => v.into_value(span),
+                            Err(e) => Value::error(e, self.call.head),
+                        }
+                    }
+                    _ => value.clone(),
+                }
+            }))
+    }
+
+    fn eval_closure(
+        &self,
+        closure: Spanned<Closure>,
+        positional: Vec<Value>,
+        input: PipelineData,
+        redirect_stdout: bool,
+        redirect_stderr: bool,
+    ) -> Result<PipelineData, ShellError> {
+        let block = self
+            .engine_state
+            .try_get_block(closure.item.block_id)
+            .ok_or_else(|| ShellError::GenericError {
+                error: "Plugin misbehaving".into(),
+                msg: format!(
+                    "Tried to evaluate unknown block id: {}",
+                    closure.item.block_id
+                ),
+                span: Some(closure.span),
+                help: None,
+                inner: vec![],
+            })?;
+
+        let mut stack = self.stack.captures_to_stack(closure.item.captures);
+
+        // Set up the positional arguments
+        for (idx, value) in positional.into_iter().enumerate() {
+            if let Some(arg) = block.signature.get_positional(idx) {
+                if let Some(var_id) = arg.var_id {
+                    stack.add_var(var_id, value);
+                } else {
+                    return Err(ShellError::NushellFailedSpanned {
+                        msg: "Error while evaluating closure from plugin".into(),
+                        label: "closure argument missing var_id".into(),
+                        span: closure.span,
+                    });
+                }
+            }
+        }
+
+        let eval_block_with_early_return = get_eval_block_with_early_return(&self.engine_state);
+
+        eval_block_with_early_return(
+            &self.engine_state,
+            &mut stack,
+            block,
+            input,
+            redirect_stdout,
+            redirect_stderr,
+        )
     }
 }
 
@@ -40,7 +170,38 @@ pub(crate) struct PluginExecutionBogusContext;
 
 #[cfg(test)]
 impl PluginExecutionContext for PluginExecutionBogusContext {
+    fn command_span(&self) -> Span {
+        Span::test_data()
+    }
+
+    fn command_name(&self) -> &str {
+        "bogus"
+    }
+
     fn ctrlc(&self) -> Option<&Arc<AtomicBool>> {
         None
+    }
+
+    fn get_config(&self) -> Result<Config, ShellError> {
+        Err(ShellError::NushellFailed {
+            msg: "get_config not implemented on bogus".into(),
+        })
+    }
+
+    fn get_plugin_config(&self) -> Result<Option<Value>, ShellError> {
+        Ok(None)
+    }
+
+    fn eval_closure(
+        &self,
+        _closure: Spanned<Closure>,
+        _positional: Vec<Value>,
+        _input: PipelineData,
+        _redirect_stdout: bool,
+        _redirect_stderr: bool,
+    ) -> Result<PipelineData, ShellError> {
+        Err(ShellError::NushellFailed {
+            msg: "eval_closure not implemented on bogus".into(),
+        })
     }
 }

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -3,11 +3,11 @@ use crate::protocol::{CallInfo, EvaluatedCall};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use nu_engine::{get_eval_block, get_eval_expression};
+use nu_engine::get_eval_expression;
 
 use nu_protocol::engine::{Command, EngineState, Stack};
 use nu_protocol::{ast::Call, PluginSignature, Signature};
-use nu_protocol::{Example, PipelineData, ShellError, Value};
+use nu_protocol::{Example, PipelineData, ShellError};
 
 #[doc(hidden)] // Note: not for plugin authors / only used in nu-parser
 #[derive(Clone)]
@@ -72,39 +72,12 @@ impl Command for PluginDeclaration {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let eval_block = get_eval_block(engine_state);
         let eval_expression = get_eval_expression(engine_state);
 
         // Create the EvaluatedCall to send to the plugin first - it's best for this to fail early,
         // before we actually try to run the plugin command
         let evaluated_call =
             EvaluatedCall::try_from_call(call, engine_state, stack, eval_expression)?;
-
-        // Fetch the configuration for a plugin
-        //
-        // The `plugin` must match the registered name of a plugin.  For
-        // `register nu_plugin_example` the plugin config lookup uses `"example"`
-        let config = nu_engine::get_config(engine_state, stack)
-            .plugins
-            .get(&self.identity.plugin_name)
-            .cloned()
-            .map(|value| {
-                let span = value.span();
-                match value {
-                    Value::Closure { val, .. } => {
-                        let input = PipelineData::Empty;
-
-                        let block = engine_state.get_block(val.block_id).clone();
-                        let mut stack = stack.captures_to_stack(val.captures);
-
-                        match eval_block(engine_state, &mut stack, &block, input, false, false) {
-                            Ok(v) => v.into_value(span),
-                            Err(e) => Value::error(e, call.head),
-                        }
-                    }
-                    _ => value.clone(),
-                }
-            });
 
         // We need the current environment variables for `python` based plugins
         // Or we'll likely have a problem when a plugin is implemented in a virtual Python environment.
@@ -122,8 +95,9 @@ impl Command for PluginDeclaration {
             }
         })?;
 
-        // Create the context to execute in
+        // Create the context to execute in - this supports engine calls and custom values
         let context = Arc::new(PluginExecutionCommandContext::new(
+            self.identity.clone(),
             engine_state,
             stack,
             call,
@@ -134,7 +108,6 @@ impl Command for PluginDeclaration {
                 name: self.name.clone(),
                 call: evaluated_call,
                 input,
-                config,
             },
             context,
         )

--- a/crates/nu-plugin/src/plugin/interface.rs
+++ b/crates/nu-plugin/src/plugin/interface.rs
@@ -22,6 +22,7 @@ use crate::{
 mod stream;
 
 mod engine;
+pub use engine::EngineInterface;
 pub(crate) use engine::{EngineInterfaceManager, ReceivedPluginCall};
 
 mod plugin;

--- a/crates/nu-plugin/src/plugin/interface/engine.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine.rs
@@ -589,11 +589,16 @@ impl EngineInterface {
     pub fn eval_closure_with_stream(
         &self,
         closure: &Spanned<Closure>,
-        positional: Vec<Value>,
+        mut positional: Vec<Value>,
         input: PipelineData,
         redirect_stdout: bool,
         redirect_stderr: bool,
     ) -> Result<PipelineData, ShellError> {
+        // Ensure closure args have custom values serialized
+        positional
+            .iter_mut()
+            .try_for_each(PluginCustomValue::serialize_custom_values_in)?;
+
         let call = EngineCall::EvalClosure {
             closure: closure.clone(),
             positional,

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -440,11 +440,15 @@ impl InterfaceManager for PluginInterfaceManager {
                     EngineCall::GetPluginConfig => Ok(EngineCall::GetPluginConfig),
                     EngineCall::EvalClosure {
                         closure,
-                        positional,
+                        mut positional,
                         input,
                         redirect_stdout,
                         redirect_stderr,
                     } => {
+                        // Add source to any plugin custom values in the arguments
+                        for arg in positional.iter_mut() {
+                            PluginCustomValue::add_source(arg, &self.state.identity);
+                        }
                         self.read_pipeline_data(input, ctrlc)
                             .map(|input| EngineCall::EvalClosure {
                                 closure,

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -402,13 +402,7 @@ impl InterfaceManager for PluginInterfaceManager {
                     ),
                 })
             }
-            PluginOutput::Stream(message) => {
-                // Keep track of streams that end so we know if we don't need the context anymore
-                if let StreamMessage::End(id) = message {
-                    self.recv_stream_ended(id);
-                }
-                self.consume_stream_message(message)
-            }
+            PluginOutput::Stream(message) => self.consume_stream_message(message),
             PluginOutput::CallResponse(id, response) => {
                 // Handle reading the pipeline data, if any
                 let response = match response {
@@ -492,6 +486,14 @@ impl InterfaceManager for PluginInterfaceManager {
             }
             PipelineData::Empty | PipelineData::ExternalStream { .. } => Ok(data),
         }
+    }
+
+    fn consume_stream_message(&mut self, message: StreamMessage) -> Result<(), ShellError> {
+        // Keep track of streams that end so we know if we don't need the context anymore
+        if let StreamMessage::End(id) = message {
+            self.recv_stream_ended(id);
+        }
+        self.stream_manager.handle_message(message)
     }
 }
 

--- a/crates/nu-plugin/src/plugin/interface/plugin/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin/tests.rs
@@ -1,7 +1,11 @@
-use std::sync::mpsc;
+use std::{
+    sync::{mpsc, Arc},
+    time::Duration,
+};
 
 use nu_protocol::{
-    IntoInterruptiblePipelineData, PipelineData, PluginSignature, ShellError, Span, Spanned, Value,
+    engine::Closure, IntoInterruptiblePipelineData, PipelineData, PluginSignature, ShellError,
+    Span, Spanned, Value,
 };
 
 use crate::{
@@ -12,15 +16,16 @@ use crate::{
     },
     protocol::{
         test_util::{expected_test_custom_value, test_plugin_custom_value},
-        CallInfo, CustomValueOp, ExternalStreamInfo, ListStreamInfo, PipelineDataHeader,
-        PluginCall, PluginCallId, PluginCustomValue, PluginInput, Protocol, ProtocolInfo,
-        RawStreamInfo, StreamData, StreamMessage,
+        CallInfo, CustomValueOp, EngineCall, EngineCallResponse, ExternalStreamInfo,
+        ListStreamInfo, PipelineDataHeader, PluginCall, PluginCallId, PluginCustomValue,
+        PluginInput, Protocol, ProtocolInfo, RawStreamInfo, StreamData, StreamMessage,
     },
     EvaluatedCall, PluginCallResponse, PluginOutput,
 };
 
 use super::{
-    PluginCallSubscription, PluginInterface, PluginInterfaceManager, ReceivedPluginCallMessage,
+    Context, PluginCallSubscription, PluginInterface, PluginInterfaceManager,
+    ReceivedPluginCallMessage,
 };
 
 #[test]
@@ -185,8 +190,9 @@ fn fake_plugin_call(
     manager.plugin_call_subscriptions.insert(
         id,
         PluginCallSubscription {
-            sender: tx,
+            sender: Some(tx),
             context: None,
+            remaining_streams_to_read: 0,
         },
     );
 
@@ -336,6 +342,282 @@ fn manager_consume_call_response_forwards_to_subscriber_with_pipeline_data(
         },
         _ => panic!("unexpected response message: {message:?}"),
     }
+}
+
+#[test]
+fn manager_consume_call_response_registers_streams() -> Result<(), ShellError> {
+    let mut manager = TestCase::new().plugin("test");
+    manager.protocol_info = Some(ProtocolInfo::default());
+
+    for n in [0, 1] {
+        fake_plugin_call(&mut manager, n);
+    }
+
+    // Check list streams, external streams
+    manager.consume(PluginOutput::CallResponse(
+        0,
+        PluginCallResponse::PipelineData(PipelineDataHeader::ListStream(ListStreamInfo { id: 0 })),
+    ))?;
+    manager.consume(PluginOutput::CallResponse(
+        1,
+        PluginCallResponse::PipelineData(PipelineDataHeader::ExternalStream(ExternalStreamInfo {
+            span: Span::test_data(),
+            stdout: Some(RawStreamInfo {
+                id: 1,
+                is_binary: false,
+                known_size: None,
+            }),
+            stderr: Some(RawStreamInfo {
+                id: 2,
+                is_binary: false,
+                known_size: None,
+            }),
+            exit_code: Some(ListStreamInfo { id: 3 }),
+            trim_end_newline: false,
+        })),
+    ))?;
+
+    // ListStream should have one
+    if let Some(sub) = manager.plugin_call_subscriptions.get(&0) {
+        assert_eq!(
+            1, sub.remaining_streams_to_read,
+            "ListStream remaining_streams_to_read should be 1"
+        );
+    } else {
+        panic!("failed to find subscription for ListStream (0), maybe it was removed");
+    }
+    assert_eq!(
+        Some(&0),
+        manager.plugin_call_input_streams.get(&0),
+        "plugin_call_input_streams[0] should be Some(0)"
+    );
+
+    // ExternalStream should have three
+    if let Some(sub) = manager.plugin_call_subscriptions.get(&1) {
+        assert_eq!(
+            3, sub.remaining_streams_to_read,
+            "ExternalStream remaining_streams_to_read should be 3"
+        );
+    } else {
+        panic!("failed to find subscription for ExternalStream (1), maybe it was removed");
+    }
+    for n in [1, 2, 3] {
+        assert_eq!(
+            Some(&1),
+            manager.plugin_call_input_streams.get(&n),
+            "plugin_call_input_streams[{n}] should be Some(1)"
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn manager_consume_engine_call_forwards_to_subscriber_with_pipeline_data() -> Result<(), ShellError>
+{
+    let mut manager = TestCase::new().plugin("test");
+    manager.protocol_info = Some(ProtocolInfo::default());
+
+    let rx = fake_plugin_call(&mut manager, 37);
+
+    manager.consume(PluginOutput::EngineCall {
+        context: 37,
+        id: 46,
+        call: EngineCall::EvalClosure {
+            closure: Spanned {
+                item: Closure {
+                    block_id: 0,
+                    captures: vec![],
+                },
+                span: Span::test_data(),
+            },
+            positional: vec![],
+            input: PipelineDataHeader::ListStream(ListStreamInfo { id: 2 }),
+            redirect_stdout: false,
+            redirect_stderr: false,
+        },
+    })?;
+
+    for i in 0..2 {
+        manager.consume(PluginOutput::Stream(StreamMessage::Data(
+            2,
+            Value::test_int(i).into(),
+        )))?;
+    }
+    manager.consume(PluginOutput::Stream(StreamMessage::End(2)))?;
+
+    // Make sure the streams end and we don't deadlock
+    drop(manager);
+
+    let message = rx.try_recv().expect("failed to get plugin call message");
+
+    match message {
+        ReceivedPluginCallMessage::EngineCall(id, call) => {
+            assert_eq!(46, id, "id");
+            match call {
+                EngineCall::EvalClosure { input, .. } => {
+                    // Count the stream messages
+                    assert_eq!(2, input.into_iter().count());
+                    Ok(())
+                }
+                _ => panic!("unexpected call: {call:?}"),
+            }
+        }
+        _ => panic!("unexpected response message: {message:?}"),
+    }
+}
+
+#[test]
+fn manager_handle_engine_call_after_response_received() -> Result<(), ShellError> {
+    let test = TestCase::new();
+    let mut manager = test.plugin("test");
+    manager.protocol_info = Some(ProtocolInfo::default());
+
+    let bogus = Context(Arc::new(PluginExecutionBogusContext));
+
+    // Set up a situation identical to what we would find if the response had been read, but there
+    // was still a stream being processed. We have nowhere to send the engine call in that case,
+    // so the manager has to create a place to handle it.
+    manager.plugin_call_subscriptions.insert(
+        0,
+        PluginCallSubscription {
+            sender: None,
+            context: Some(bogus),
+            remaining_streams_to_read: 1,
+        },
+    );
+
+    manager.send_engine_call(0, 0, EngineCall::GetConfig)?;
+
+    // Not really much choice but to wait here, as the thread will have been spawned in the
+    // background; we don't have a way to know if it's executed
+    let mut waited = 0;
+    while !test.has_unconsumed_write() {
+        if waited > 100 {
+            panic!("nothing written before timeout, expected engine call response");
+        } else {
+            std::thread::sleep(Duration::from_millis(1));
+            waited += 1;
+        }
+    }
+
+    // The GetConfig call on bogus should result in an error response being written
+    match test.next_written().expect("nothing written") {
+        PluginInput::EngineCallResponse(id, resp) => {
+            assert_eq!(0, id, "id");
+            match resp {
+                EngineCallResponse::Error(err) => {
+                    assert!(err.to_string().contains("bogus"), "wrong error: {err}");
+                }
+                _ => panic!("unexpected engine call response, expected error: {resp:?}"),
+            }
+        }
+        other => panic!("unexpected message, not engine call response: {other:?}"),
+    }
+
+    // Whatever was used to make this happen should have been held onto, since spawning a thread
+    // is expensive
+    let sender = &manager
+        .plugin_call_subscriptions
+        .get(&0)
+        .expect("missing subscription 0")
+        .sender;
+
+    assert!(
+        sender.is_some(),
+        "failed to keep spawned engine call handler channel"
+    );
+    Ok(())
+}
+
+#[test]
+fn manager_send_plugin_call_response_removes_context_only_if_no_streams_to_read(
+) -> Result<(), ShellError> {
+    let mut manager = TestCase::new().plugin("test");
+
+    for n in [0, 1] {
+        manager.plugin_call_subscriptions.insert(
+            n,
+            PluginCallSubscription {
+                sender: None,
+                context: None,
+                remaining_streams_to_read: n as i32,
+            },
+        );
+    }
+
+    for n in [0, 1] {
+        manager.send_plugin_call_response(n, PluginCallResponse::Signature(vec![]))?;
+    }
+
+    // 0 should not still be present, but 1 should be
+    assert!(
+        !manager.plugin_call_subscriptions.contains_key(&0),
+        "didn't clean up when there weren't remaining streams"
+    );
+    assert!(
+        manager.plugin_call_subscriptions.contains_key(&1),
+        "clean up even though there were remaining streams"
+    );
+    Ok(())
+}
+
+#[test]
+fn manager_consume_stream_end_removes_context_only_if_last_stream() -> Result<(), ShellError> {
+    let mut manager = TestCase::new().plugin("test");
+    manager.protocol_info = Some(ProtocolInfo::default());
+
+    for n in [1, 2] {
+        manager.plugin_call_subscriptions.insert(
+            n,
+            PluginCallSubscription {
+                sender: None,
+                context: None,
+                remaining_streams_to_read: n as i32,
+            },
+        );
+    }
+
+    // 1 owns [10], 2 owns [21, 22]
+    manager.plugin_call_input_streams.insert(10, 1);
+    manager.plugin_call_input_streams.insert(21, 2);
+    manager.plugin_call_input_streams.insert(22, 2);
+
+    // Register the streams so we don't have errors
+    let streams: Vec<_> = [10, 21, 22]
+        .into_iter()
+        .map(|id| {
+            let interface = manager.get_interface();
+            manager
+                .stream_manager
+                .get_handle()
+                .read_stream::<Value, _>(id, interface)
+        })
+        .collect();
+
+    // Ending 10 should cause 1 to be removed
+    manager.consume(StreamMessage::End(10).into())?;
+    assert!(
+        !manager.plugin_call_subscriptions.contains_key(&1),
+        "contains(1) after End(10)"
+    );
+
+    // Ending 21 should not cause 2 to be removed
+    manager.consume(StreamMessage::End(21).into())?;
+    assert!(
+        manager.plugin_call_subscriptions.contains_key(&2),
+        "!contains(2) after End(21)"
+    );
+
+    // Ending 22 should cause 2 to be removed
+    manager.consume(StreamMessage::End(22).into())?;
+    assert!(
+        !manager.plugin_call_subscriptions.contains_key(&2),
+        "contains(2) after End(22)"
+    );
+
+    drop(streams);
+    Ok(())
 }
 
 #[test]
@@ -518,7 +800,6 @@ fn interface_write_plugin_call_writes_run_with_value_input() -> Result<(), Shell
                 named: vec![],
             },
             input: PipelineData::Value(Value::test_int(-1), None),
-            config: None,
         }),
         None,
     )?;
@@ -557,7 +838,6 @@ fn interface_write_plugin_call_writes_run_with_stream_input() -> Result<(), Shel
                 named: vec![],
             },
             input: values.clone().into_pipeline_data(None),
-            config: None,
         }),
         None,
     )?;
@@ -622,7 +902,7 @@ fn interface_receive_plugin_call_receives_response() -> Result<(), ShellError> {
     .expect("failed to send on new channel");
     drop(tx); // so we don't deadlock on recv()
 
-    let response = interface.receive_plugin_call_response(rx)?;
+    let response = interface.receive_plugin_call_response(rx, &None)?;
     assert!(
         matches!(response, PluginCallResponse::Signature(_)),
         "wrong response: {response:?}"
@@ -645,12 +925,55 @@ fn interface_receive_plugin_call_receives_error() -> Result<(), ShellError> {
     drop(tx); // so we don't deadlock on recv()
 
     let error = interface
-        .receive_plugin_call_response(rx)
+        .receive_plugin_call_response(rx, &None)
         .expect_err("did not receive error");
     assert!(
         matches!(error, ShellError::ExternalNotSupported { .. }),
         "wrong error: {error:?}"
     );
+    Ok(())
+}
+
+#[test]
+fn interface_receive_plugin_call_handles_engine_call() -> Result<(), ShellError> {
+    let test = TestCase::new();
+    let interface = test.plugin("test").get_interface();
+
+    // Set up a fake channel just for the engine call
+    let (tx, rx) = mpsc::channel();
+    tx.send(ReceivedPluginCallMessage::EngineCall(
+        0,
+        EngineCall::GetConfig,
+    ))
+    .expect("failed to send on new channel");
+
+    // The context should be a bogus context, which will return an error for GetConfig
+    let context = Some(Context(Arc::new(PluginExecutionBogusContext)));
+
+    // We don't actually send a response, so `receive_plugin_call_response` should actually return
+    // an error, but it should still do the engine call
+    drop(tx);
+    interface
+        .receive_plugin_call_response(rx, &context)
+        .expect_err("no error even though there was no response");
+
+    // Check for the engine call response output
+    match test
+        .next_written()
+        .expect("no engine call response written")
+    {
+        PluginInput::EngineCallResponse(id, resp) => {
+            assert_eq!(0, id, "id");
+            match resp {
+                EngineCallResponse::Error(err) => {
+                    assert!(err.to_string().contains("bogus"), "wrong error: {err}");
+                }
+                _ => panic!("unexpected engine call response, maybe bogus is wrong: {resp:?}"),
+            }
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+    assert!(!test.has_unconsumed_write());
     Ok(())
 }
 
@@ -669,7 +992,11 @@ fn start_fake_plugin_call_responder(
                 .take(take)
             {
                 for message in f(id) {
-                    sub.sender.send(message).expect("failed to send");
+                    sub.sender
+                        .as_ref()
+                        .expect("sender is None")
+                        .send(message)
+                        .expect("failed to send");
                 }
             }
         })
@@ -717,7 +1044,6 @@ fn interface_run() -> Result<(), ShellError> {
                 named: vec![],
             },
             input: PipelineData::Empty,
-            config: None,
         },
         PluginExecutionBogusContext.into(),
     )?;

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -14,7 +14,9 @@ use nu_protocol::{
     Value,
 };
 pub use plugin_custom_value::PluginCustomValue;
-pub use protocol_info::{Feature, Protocol, ProtocolInfo};
+pub use protocol_info::ProtocolInfo;
+#[cfg(test)]
+pub use protocol_info::{Feature, Protocol};
 use serde::{Deserialize, Serialize};
 
 /// A sequential identifier for a stream

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -146,6 +146,11 @@ impl PluginCustomValue {
                     Self::add_source(list_value, source);
                 }
             }
+            Value::Closure { ref mut val, .. } => {
+                for (_, captured_value) in val.captures.iter_mut() {
+                    Self::add_source(captured_value, source);
+                }
+            }
             // All of these don't contain other values
             Value::Bool { .. }
             | Value::Int { .. }
@@ -156,7 +161,6 @@ impl PluginCustomValue {
             | Value::String { .. }
             | Value::Glob { .. }
             | Value::Block { .. }
-            | Value::Closure { .. }
             | Value::Nothing { .. }
             | Value::Error { .. }
             | Value::Binary { .. }
@@ -214,6 +218,10 @@ impl PluginCustomValue {
             Value::List { ref mut vals, .. } => vals
                 .iter_mut()
                 .try_for_each(|list_value| Self::verify_source(list_value, source)),
+            Value::Closure { ref mut val, .. } => val
+                .captures
+                .iter_mut()
+                .try_for_each(|(_, captured_value)| Self::verify_source(captured_value, source)),
             // All of these don't contain other values
             Value::Bool { .. }
             | Value::Int { .. }
@@ -224,7 +232,6 @@ impl PluginCustomValue {
             | Value::String { .. }
             | Value::Glob { .. }
             | Value::Block { .. }
-            | Value::Closure { .. }
             | Value::Nothing { .. }
             | Value::Error { .. }
             | Value::Binary { .. }
@@ -266,6 +273,11 @@ impl PluginCustomValue {
             Value::List { ref mut vals, .. } => vals
                 .iter_mut()
                 .try_for_each(Self::serialize_custom_values_in),
+            Value::Closure { ref mut val, .. } => val
+                .captures
+                .iter_mut()
+                .map(|(_, captured_value)| captured_value)
+                .try_for_each(Self::serialize_custom_values_in),
             // All of these don't contain other values
             Value::Bool { .. }
             | Value::Int { .. }
@@ -276,7 +288,6 @@ impl PluginCustomValue {
             | Value::String { .. }
             | Value::Glob { .. }
             | Value::Block { .. }
-            | Value::Closure { .. }
             | Value::Nothing { .. }
             | Value::Error { .. }
             | Value::Binary { .. }
@@ -316,6 +327,11 @@ impl PluginCustomValue {
             Value::List { ref mut vals, .. } => vals
                 .iter_mut()
                 .try_for_each(Self::deserialize_custom_values_in),
+            Value::Closure { ref mut val, .. } => val
+                .captures
+                .iter_mut()
+                .map(|(_, captured_value)| captured_value)
+                .try_for_each(Self::deserialize_custom_values_in),
             // All of these don't contain other values
             Value::Bool { .. }
             | Value::Int { .. }
@@ -326,7 +342,6 @@ impl PluginCustomValue {
             | Value::String { .. }
             | Value::Glob { .. }
             | Value::Block { .. }
-            | Value::Closure { .. }
             | Value::Nothing { .. }
             | Value::Error { .. }
             | Value::Binary { .. }

--- a/crates/nu-plugin/src/serializers/tests.rs
+++ b/crates/nu-plugin/src/serializers/tests.rs
@@ -125,7 +125,6 @@ macro_rules! generate_tests {
                 name: name.clone(),
                 call: call.clone(),
                 input: PipelineDataHeader::Value(input.clone()),
-                config: None,
             });
 
             let plugin_input = PluginInput::Call(1, plugin_call);

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -855,6 +855,15 @@ impl EngineState {
             .expect("internal error: missing block")
     }
 
+    /// Optionally get a block by id, if it exists
+    ///
+    /// Prefer to use [`.get_block()`] in most cases - `BlockId`s that don't exist are normally a
+    /// compiler error. This only exists to stop plugins from crashing the engine if they send us
+    /// something invalid.
+    pub fn try_get_block(&self, block_id: BlockId) -> Option<&Block> {
+        self.blocks.get(block_id)
+    }
+
     pub fn get_module(&self, module_id: ModuleId) -> &Module {
         self.modules
             .get(module_id)

--- a/crates/nu_plugin_custom_values/src/main.rs
+++ b/crates/nu_plugin_custom_values/src/main.rs
@@ -2,7 +2,7 @@ mod cool_custom_value;
 mod second_custom_value;
 
 use cool_custom_value::CoolCustomValue;
-use nu_plugin::{serve_plugin, MsgPackSerializer, Plugin};
+use nu_plugin::{serve_plugin, EngineInterface, MsgPackSerializer, Plugin};
 use nu_plugin::{EvaluatedCall, LabeledError};
 use nu_protocol::{Category, PluginSignature, ShellError, SyntaxShape, Value};
 use second_custom_value::SecondCustomValue;
@@ -33,9 +33,9 @@ impl Plugin for CustomValuePlugin {
     }
 
     fn run(
-        &mut self,
+        &self,
         name: &str,
-        _config: &Option<Value>,
+        _engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {
@@ -54,15 +54,15 @@ impl Plugin for CustomValuePlugin {
 }
 
 impl CustomValuePlugin {
-    fn generate(&mut self, call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
+    fn generate(&self, call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
         Ok(CoolCustomValue::new("abc").into_value(call.head))
     }
 
-    fn generate2(&mut self, call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
+    fn generate2(&self, call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
         Ok(SecondCustomValue::new("xyz").into_value(call.head))
     }
 
-    fn update(&mut self, call: &EvaluatedCall, input: &Value) -> Result<Value, LabeledError> {
+    fn update(&self, call: &EvaluatedCall, input: &Value) -> Result<Value, LabeledError> {
         if let Ok(mut value) = CoolCustomValue::try_from_value(input) {
             value.cool += "xyz";
             return Ok(value.into_value(call.head));
@@ -84,5 +84,5 @@ impl CustomValuePlugin {
 }
 
 fn main() {
-    serve_plugin(&mut CustomValuePlugin, MsgPackSerializer {})
+    serve_plugin(&CustomValuePlugin, MsgPackSerializer {})
 }

--- a/crates/nu_plugin_custom_values/src/main.rs
+++ b/crates/nu_plugin_custom_values/src/main.rs
@@ -17,6 +17,11 @@ impl Plugin for CustomValuePlugin {
                 .category(Category::Experimental),
             PluginSignature::build("custom-value generate2")
                 .usage("PluginSignature for a plugin that generates a different custom value")
+                .optional(
+                    "closure",
+                    SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                    "An optional closure to pass the custom value to",
+                )
                 .category(Category::Experimental),
             PluginSignature::build("custom-value update")
                 .usage("PluginSignature for a plugin that updates a custom value")
@@ -35,13 +40,13 @@ impl Plugin for CustomValuePlugin {
     fn run(
         &self,
         name: &str,
-        _engine: &EngineInterface,
+        engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {
         match name {
             "custom-value generate" => self.generate(call, input),
-            "custom-value generate2" => self.generate2(call, input),
+            "custom-value generate2" => self.generate2(engine, call),
             "custom-value update" => self.update(call, input),
             "custom-value update-arg" => self.update(call, &call.req(0)?),
             _ => Err(LabeledError {
@@ -58,8 +63,23 @@ impl CustomValuePlugin {
         Ok(CoolCustomValue::new("abc").into_value(call.head))
     }
 
-    fn generate2(&self, call: &EvaluatedCall, _input: &Value) -> Result<Value, LabeledError> {
-        Ok(SecondCustomValue::new("xyz").into_value(call.head))
+    fn generate2(
+        &self,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+    ) -> Result<Value, LabeledError> {
+        let second_custom_value = SecondCustomValue::new("xyz").into_value(call.head);
+        // If we were passed a closure, execute that instead
+        if let Some(closure) = call.opt(0)? {
+            let result = engine.eval_closure(
+                &closure,
+                vec![second_custom_value.clone()],
+                Some(second_custom_value),
+            )?;
+            Ok(result)
+        } else {
+            Ok(second_custom_value)
+        }
     }
 
     fn update(&self, call: &EvaluatedCall, input: &Value) -> Result<Value, LabeledError> {

--- a/crates/nu_plugin_example/src/example.rs
+++ b/crates/nu_plugin_example/src/example.rs
@@ -1,13 +1,14 @@
-use nu_plugin::{EvaluatedCall, LabeledError};
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError};
 use nu_protocol::{record, Value};
 pub struct Example;
 
 impl Example {
     pub fn config(
         &self,
-        config: &Option<Value>,
+        engine: &EngineInterface,
         call: &EvaluatedCall,
     ) -> Result<Value, LabeledError> {
+        let config = engine.get_plugin_config()?;
         match config {
             Some(config) => Ok(config.clone()),
             None => Err(LabeledError {

--- a/crates/nu_plugin_example/src/main.rs
+++ b/crates/nu_plugin_example/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     // used to encode and decode the messages. The available options are
     // MsgPackSerializer and JsonSerializer. Both are defined in the serializer
     // folder in nu-plugin.
-    serve_plugin(&mut Example {}, MsgPackSerializer {})
+    serve_plugin(&Example {}, MsgPackSerializer {})
 
     // Note
     // When creating plugins in other languages one needs to consider how a plugin

--- a/crates/nu_plugin_example/src/nu/mod.rs
+++ b/crates/nu_plugin_example/src/nu/mod.rs
@@ -1,5 +1,5 @@
 use crate::Example;
-use nu_plugin::{EvaluatedCall, LabeledError, Plugin};
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError, Plugin};
 use nu_protocol::{Category, PluginExample, PluginSignature, SyntaxShape, Type, Value};
 
 impl Plugin for Example {
@@ -52,9 +52,9 @@ impl Plugin for Example {
     }
 
     fn run(
-        &mut self,
+        &self,
         name: &str,
-        config: &Option<Value>,
+        engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {
@@ -63,7 +63,7 @@ impl Plugin for Example {
             "nu-example-1" => self.test1(call, input),
             "nu-example-2" => self.test2(call, input),
             "nu-example-3" => self.test3(call, input),
-            "nu-example-config" => self.config(config, call),
+            "nu-example-config" => self.config(engine, call),
             _ => Err(LabeledError {
                 label: "Plugin call with wrong name signature".into(),
                 msg: "the signature used to call the plugin does not match any name in the plugin signature vector".into(),

--- a/crates/nu_plugin_formats/src/lib.rs
+++ b/crates/nu_plugin_formats/src/lib.rs
@@ -1,7 +1,7 @@
 mod from;
 
 use from::{eml, ics, ini, vcf};
-use nu_plugin::{EvaluatedCall, LabeledError, Plugin};
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError, Plugin};
 use nu_protocol::{Category, PluginSignature, SyntaxShape, Type, Value};
 
 pub struct FromCmds;
@@ -39,9 +39,9 @@ impl Plugin for FromCmds {
     }
 
     fn run(
-        &mut self,
+        &self,
         name: &str,
-        _config: &Option<Value>,
+        _engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {

--- a/crates/nu_plugin_formats/src/main.rs
+++ b/crates/nu_plugin_formats/src/main.rs
@@ -2,5 +2,5 @@ use nu_plugin::{serve_plugin, MsgPackSerializer};
 use nu_plugin_formats::FromCmds;
 
 fn main() {
-    serve_plugin(&mut FromCmds, MsgPackSerializer {})
+    serve_plugin(&FromCmds, MsgPackSerializer {})
 }

--- a/crates/nu_plugin_gstat/src/main.rs
+++ b/crates/nu_plugin_gstat/src/main.rs
@@ -2,5 +2,5 @@ use nu_plugin::{serve_plugin, MsgPackSerializer};
 use nu_plugin_gstat::GStat;
 
 fn main() {
-    serve_plugin(&mut GStat::new(), MsgPackSerializer {})
+    serve_plugin(&GStat::new(), MsgPackSerializer {})
 }

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -1,5 +1,5 @@
 use crate::GStat;
-use nu_plugin::{EvaluatedCall, LabeledError, Plugin};
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError, Plugin};
 use nu_protocol::{Category, PluginSignature, Spanned, SyntaxShape, Value};
 
 impl Plugin for GStat {
@@ -11,9 +11,9 @@ impl Plugin for GStat {
     }
 
     fn run(
-        &mut self,
+        &self,
         name: &str,
-        _config: &Option<Value>,
+        _engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {

--- a/crates/nu_plugin_inc/src/inc.rs
+++ b/crates/nu_plugin_inc/src/inc.rs
@@ -2,20 +2,20 @@ use nu_plugin::LabeledError;
 use nu_protocol::{ast::CellPath, Span, Value};
 use semver::{BuildMetadata, Prerelease, Version};
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum Action {
     SemVerAction(SemVerAction),
     Default,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum SemVerAction {
     Major,
     Minor,
     Patch,
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Inc {
     pub error: Option<String>,
     pub cell_path: Option<CellPath>,

--- a/crates/nu_plugin_inc/src/main.rs
+++ b/crates/nu_plugin_inc/src/main.rs
@@ -2,5 +2,5 @@ use nu_plugin::{serve_plugin, JsonSerializer};
 use nu_plugin_inc::Inc;
 
 fn main() {
-    serve_plugin(&mut Inc::new(), JsonSerializer {})
+    serve_plugin(&Inc::new(), JsonSerializer {})
 }

--- a/crates/nu_plugin_inc/src/nu/mod.rs
+++ b/crates/nu_plugin_inc/src/nu/mod.rs
@@ -1,6 +1,6 @@
 use crate::inc::SemVerAction;
 use crate::Inc;
-use nu_plugin::{EvaluatedCall, LabeledError, Plugin};
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError, Plugin};
 use nu_protocol::{ast::CellPath, PluginSignature, SyntaxShape, Value};
 
 impl Plugin for Inc {
@@ -26,9 +26,9 @@ impl Plugin for Inc {
     }
 
     fn run(
-        &mut self,
+        &self,
         name: &str,
-        _config: &Option<Value>,
+        _engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {
@@ -36,20 +36,22 @@ impl Plugin for Inc {
             return Ok(Value::nothing(call.head));
         }
 
+        let mut inc = self.clone();
+
         let cell_path: Option<CellPath> = call.opt(0)?;
 
-        self.cell_path = cell_path;
+        inc.cell_path = cell_path;
 
         if call.has_flag("major")? {
-            self.for_semver(SemVerAction::Major);
+            inc.for_semver(SemVerAction::Major);
         }
         if call.has_flag("minor")? {
-            self.for_semver(SemVerAction::Minor);
+            inc.for_semver(SemVerAction::Minor);
         }
         if call.has_flag("patch")? {
-            self.for_semver(SemVerAction::Patch);
+            inc.for_semver(SemVerAction::Patch);
         }
 
-        self.inc(call.head, input)
+        inc.inc(call.head, input)
     }
 }

--- a/crates/nu_plugin_query/src/main.rs
+++ b/crates/nu_plugin_query/src/main.rs
@@ -2,5 +2,5 @@ use nu_plugin::{serve_plugin, JsonSerializer};
 use nu_plugin_query::Query;
 
 fn main() {
-    serve_plugin(&mut Query {}, JsonSerializer {})
+    serve_plugin(&Query {}, JsonSerializer {})
 }

--- a/crates/nu_plugin_query/src/nu/mod.rs
+++ b/crates/nu_plugin_query/src/nu/mod.rs
@@ -1,5 +1,5 @@
 use crate::Query;
-use nu_plugin::{EvaluatedCall, LabeledError, Plugin};
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError, Plugin};
 use nu_protocol::{Category, PluginExample, PluginSignature, Spanned, SyntaxShape, Value};
 
 impl Plugin for Query {
@@ -46,9 +46,9 @@ impl Plugin for Query {
     }
 
     fn run(
-        &mut self,
+        &self,
         name: &str,
-        _config: &Option<Value>,
+        _engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {

--- a/crates/nu_plugin_stream_example/README.md
+++ b/crates/nu_plugin_stream_example/README.md
@@ -46,3 +46,18 @@ strings on input will be concatenated into an external stream (raw input) on std
 
     Hello
     worldhowareyou
+
+## `stream_example for-each`
+
+This command demonstrates executing closures on values in streams. Each value received on the input
+will be printed to the plugin's stderr. This works even with external commands.
+
+> ```nushell
+> ls | get name | stream_example for-each { |f| ^file $f }
+> ```
+
+    CODE_OF_CONDUCT.md: ASCII text
+
+    CONTRIBUTING.md: ASCII text, with very long lines (303)
+
+    ...

--- a/crates/nu_plugin_stream_example/src/main.rs
+++ b/crates/nu_plugin_stream_example/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
     // used to encode and decode the messages. The available options are
     // MsgPackSerializer and JsonSerializer. Both are defined in the serializer
     // folder in nu-plugin.
-    serve_plugin(&mut Example {}, MsgPackSerializer {})
+    serve_plugin(&Example {}, MsgPackSerializer {})
 
     // Note
     // When creating plugins in other languages one needs to consider how a plugin

--- a/crates/nu_plugin_stream_example/src/nu/mod.rs
+++ b/crates/nu_plugin_stream_example/src/nu/mod.rs
@@ -1,5 +1,5 @@
 use crate::Example;
-use nu_plugin::{EvaluatedCall, LabeledError, StreamingPlugin};
+use nu_plugin::{EngineInterface, EvaluatedCall, LabeledError, StreamingPlugin};
 use nu_protocol::{
     Category, PipelineData, PluginExample, PluginSignature, Span, SyntaxShape, Type, Value,
 };
@@ -57,13 +57,50 @@ impl StreamingPlugin for Example {
                     result: Some(Value::string("ab", span)),
                 }])
                 .category(Category::Experimental),
+            PluginSignature::build("stream_example for-each")
+                .usage("Example execution of a closure with a stream")
+                .extra_usage("Prints each value the closure returns to stderr")
+                .input_output_type(Type::ListStream, Type::Nothing)
+                .required(
+                    "closure",
+                    SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                    "The closure to run for each input value",
+                )
+                .plugin_examples(vec![PluginExample {
+                    example: "ls | get name | stream_example for-each { |f| ^file $f }".into(),
+                    description: "example with an external command".into(),
+                    result: None,
+                }])
+                .category(Category::Experimental),
+            PluginSignature::build("stream_example generate")
+                .usage("Example execution of a closure to produce a stream")
+                .extra_usage("See the builtin `generate` command")
+                .input_output_type(Type::Nothing, Type::ListStream)
+                .required(
+                    "initial",
+                    SyntaxShape::Any,
+                    "The initial value to pass to the closure"
+                )
+                .required(
+                    "closure",
+                    SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
+                    "The closure to run to generate values",
+                )
+                .plugin_examples(vec![PluginExample {
+                    example: "stream_example generate 0 { |i| if $i <= 10 { {out: $i, next: ($i + 2)} } }".into(),
+                    description: "Generate a sequence of numbers".into(),
+                    result: Some(Value::test_list(
+                        [0, 2, 4, 6, 8, 10].into_iter().map(Value::test_int).collect(),
+                    )),
+                }])
+                .category(Category::Experimental),
         ]
     }
 
     fn run(
-        &mut self,
+        &self,
         name: &str,
-        _config: &Option<Value>,
+        engine: &EngineInterface,
         call: &EvaluatedCall,
         input: PipelineData,
     ) -> Result<PipelineData, LabeledError> {
@@ -76,6 +113,8 @@ impl StreamingPlugin for Example {
             "stream_example seq" => self.seq(call, input),
             "stream_example sum" => self.sum(call, input),
             "stream_example collect-external" => self.collect_external(call, input),
+            "stream_example for-each" => self.for_each(engine, call, input),
+            "stream_example generate" => self.generate(engine, call),
             _ => Err(LabeledError {
                 label: "Plugin call with wrong name signature".into(),
                 msg: "the signature used to call the plugin does not match any name in the plugin signature vector".into(),

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -55,6 +55,20 @@ fn can_generate_and_updated_multiple_types_of_custom_values() {
 }
 
 #[test]
+fn can_generate_custom_value_and_pass_through_closure() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("nu_plugin_custom_values"),
+        "custom-value generate2 { custom-value update }"
+    );
+
+    assert_eq!(
+        actual.out,
+        "I used to be a DIFFERENT custom value! (xyzabc)"
+    );
+}
+
+#[test]
 fn can_get_describe_plugin_custom_values() {
     let actual = nu_with_plugins!(
         cwd: "tests",

--- a/tests/plugins/stream.rs
+++ b/tests/plugins/stream.rs
@@ -164,3 +164,25 @@ fn collect_external_big_stream() {
 
     assert_eq!(actual.out, "10000");
 }
+
+#[test]
+fn for_each_prints_on_stderr() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "[a b c] | stream_example for-each { $in }"
+    );
+
+    assert_eq!(actual.err, "a\nb\nc\n");
+}
+
+#[test]
+fn generate_sequence() {
+    let actual = nu_with_plugins!(
+        cwd: "tests/fixtures/formats",
+        plugin: ("nu_plugin_stream_example"),
+        "stream_example generate 0 { |i| if $i <= 10 { {out: $i, next: ($i + 2)} } } | to json --raw"
+    );
+
+    assert_eq!(actual.out, "[0,2,4,6,8,10]");
+}


### PR DESCRIPTION
# Description

This allows plugins to make calls back to the engine to get config, evaluate closures, and do other things that must be done within the engine process.

Engine calls can both produce and consume streams as necessary. Closures passed to plugins can both accept stream input and produce stream output sent back to the plugin.

Engine calls referring to a plugin call's context can be processed as long either the response hasn't been received, or the response created streams that haven't ended yet.

This is a breaking API change for plugins. There are some pretty major changes to the interface that plugins must implement, including:

1. Plugins now run with `&self` and must be `Sync`. Executing multiple plugin calls in parallel is supported, and there's a chance that a closure passed to a plugin could invoke the same plugin. Supporting state across plugin invocations is left up to the plugin author to do in whichever way they feel best, but the plugin object itself is still shared. Even though the engine doesn't run multiple plugin calls through the same process yet, I still considered it important to break the API in this way at this stage. We might want to consider an optional threadpool feature for performance.

2. Plugins take a reference to `EngineInterface`, which can be cloned. This interface allows plugins to make calls back to the engine, including for getting config and running closures.

3. Plugins no longer take the `config` parameter. This can be accessed from the interface via the `.get_plugin_config()` engine call.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Not only does this have plugin protocol changes, it will require plugins to make some code changes before they will work again. But on the plus side, the engine call feature is extensible, and we can add more things to it as needed.

Plugin maintainers will have to change the trait signature at the very least. If they were using `config`, they will have to call `engine.get_plugin_config()` instead.

If they were using the mutable reference to the plugin, they will have to come up with some strategy to work around it (for example, for `Inc` I just cloned it). This shouldn't be such a big deal at the moment as it's not like plugins have ever run as daemons with persistent state in the past, and they don't in this PR either. But I thought it was important to make the change before we support plugins as daemons, as an exclusive mutable reference is not compatible with parallel plugin calls.

I suggest this gets merged sometime *after* the current pending release, so that we have some time to adjust to the previous plugin protocol changes that don't require code changes before making ones that do.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`


# After Submitting
I will document the additional protocol features (`EngineCall`, `EngineCallResponse`), and constraints on plugin call processing if engine calls are used - basically, to be aware that an engine call could result in a nested plugin call, so the plugin should be able to handle that.