### PR TITLE
add examples for adding paths to PATH, and to load from a custom file in `default_env.nu`

### DIFF
--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -87,7 +87,8 @@ $env.NU_PLUGIN_DIRS = [
 
 # To add entries to PATH (on Windows you might use Path), you can use the following pattern:
 # $env.PATH = ($env.PATH | split row (char esep) | prepend '/some/path')
-# To add multiple paths to PATH this may be simpler:
+# An alternate way to add entries to $env.PATH is to use the custom command `path add`
+# which is built into the nushell stdlib:
 # use std "path add"
 # $env.PATH = ($env.PATH | split row (char esep))
 # path add /some/path

--- a/crates/nu-utils/src/sample_config/default_env.nu
+++ b/crates/nu-utils/src/sample_config/default_env.nu
@@ -87,3 +87,13 @@ $env.NU_PLUGIN_DIRS = [
 
 # To add entries to PATH (on Windows you might use Path), you can use the following pattern:
 # $env.PATH = ($env.PATH | split row (char esep) | prepend '/some/path')
+# To add multiple paths to PATH this may be simpler:
+# use std "path add"
+# $env.PATH = ($env.PATH | split row (char esep))
+# path add /some/path
+# path add ($env.CARGO_HOME | path join "bin")
+# path add ($env.HOME | path join ".local" "bin")
+# $env.PATH = ($env.PATH | uniq)
+
+# To load from a custom file you can use:
+# source ($nu.default-config-dir | path join 'custom.nu')


### PR DESCRIPTION
# Description
Show an example of loading from a custom file, and an example of adding multiple entry to PATH. Loading from a custom file will hopefully allow for greater modularity of configuration files out of the box for new users. Adding multiple paths to PATH is very common, and will help new users to.

Adds this:
```
# To add multiple paths to PATH this may be simpler:
# use std "path add"
# $env.PATH = ($env.PATH | split row (char esep))
# path add /some/path
# path add ($env.CARGO_HOME | path join "bin")
# path add ($env.HOME | path join ".local" "bin")
# $env.PATH = ($env.PATH | uniq)

# To load from a custom file you can use:
# source ($nu.default-config-dir | path join 'custom.nu')
```