### PR TITLE
Report errors that occur on file operations in ls

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -429,7 +429,7 @@ fn ls_for_one_pattern(
                 Err(err) => Some(Value::error(err, call_span)),
             }
         }
-        _ => Some(Value::nothing(call_span)),
+        Err(err) => Some(Value::error(err, call_span)),
     })))
 }
 


### PR DESCRIPTION
Currently errors just create empty entries inside of resulting dataframes.

This changeset is meant to help debug #12004, though generally speaking I do think it's worth having ways to make errors be visible in this kind of pipeline be visible

An example of what this looks like

<img width="954" alt="image" src="https://github.com/nushell/nushell/assets/1408472/2c3c9167-2aaf-4f87-bab5-e8302d7a1170">
