### PR TITLE
Fix: string_to_table in ssv.rs now filters comments. (issue #11997)

### DIFF
--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -315,6 +315,24 @@ mod tests {
     }
 
     #[test]
+    fn it_filters_comment_lines() {
+        let input = r#"
+            a       b
+            1       2
+            3       4
+            #comment       line
+        "#;
+        let result = string_to_table(input, false, false, 1);
+        assert_eq!(
+            result,
+            vec![
+                vec![owned("a", "1"), owned("b", "2")],
+                vec![owned("a", "3"), owned("b", "4")]
+            ]
+        );
+    }
+
+    #[test]
     fn it_trims_empty_and_whitespace_only_lines() {
         let input = r#"
 

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -322,7 +322,7 @@ mod tests {
             3       4
             #comment       line
         "#;
-        let result = string_to_table(input, false, false, 1);
+        let result = string_to_table(input, false, true, 1);
         assert_eq!(
             result,
             vec![

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -240,8 +240,8 @@ fn string_to_table(
     split_at: usize,
 ) -> Vec<Vec<(String, String)>> {
     let mut lines = s
-    .lines()
-    .filter(|l| !l.trim().is_empty() && !l.trim().starts_with("#"));
+        .lines()
+        .filter(|l| !l.trim().is_empty() && !l.trim().starts_with("#"));
     let separator = " ".repeat(std::cmp::max(split_at, 1));
 
     let (ls, header_options) = if noheaders {

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -241,7 +241,7 @@ fn string_to_table(
 ) -> Vec<Vec<(String, String)>> {
     let mut lines = s
         .lines()
-        .filter(|l| !l.trim().is_empty() && !l.trim().starts_with("#"));
+        .filter(|l| !l.trim().is_empty() && !l.trim().starts_with('#'));
     let separator = " ".repeat(std::cmp::max(split_at, 1));
 
     let (ls, header_options) = if noheaders {

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -239,7 +239,7 @@ fn string_to_table(
     aligned_columns: bool,
     split_at: usize,
 ) -> Vec<Vec<(String, String)>> {
-    let mut lines = s.lines().filter(|l| !l.trim().is_empty()).filter(|l| !l.trim().starts_with("#"));
+    let mut lines = s.lines().filter(|l| !l.trim().is_empty() && !l.trim().starts_with("#"));
     let separator = " ".repeat(std::cmp::max(split_at, 1));
 
     let (ls, header_options) = if noheaders {

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -239,7 +239,7 @@ fn string_to_table(
     aligned_columns: bool,
     split_at: usize,
 ) -> Vec<Vec<(String, String)>> {
-    let mut lines = s.lines().filter(|l| !l.trim().is_empty());
+    let mut lines = s.lines().filter(|l| !l.trim().is_empty()).filter(|l| !l.trim().starts_with("#"));
     let separator = " ".repeat(std::cmp::max(split_at, 1));
 
     let (ls, header_options) = if noheaders {

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -239,7 +239,9 @@ fn string_to_table(
     aligned_columns: bool,
     split_at: usize,
 ) -> Vec<Vec<(String, String)>> {
-    let mut lines = s.lines().filter(|l| !l.trim().is_empty() && !l.trim().starts_with("#"));
+    let mut lines = s
+    .lines()
+    .filter(|l| !l.trim().is_empty() && !l.trim().starts_with("#"));
     let separator = " ".repeat(std::cmp::max(split_at, 1));
 
     let (ls, header_options) = if noheaders {


### PR DESCRIPTION
- Fixes #11997

# Description
Fixes the issue that comments are not ignored in SSV formatted data.
![Fix image](https://github.com/nushell/nushell/assets/64328283/1c1bd7dd-ced8-4276-8c21-b50e1c0dba53)

# User-Facing Changes
If you have a comment in the beginning of SSV formatted data it is now not included in the SSV table.

# Tests + Formatting
The PR adds one test in the ssv.rs file. All previous test-cases are still passing. Clippy and Fmt have been ran.


