### PR TITLE
Fix const string interpolation test

### DIFF
--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -1,6 +1,7 @@
 use nu_test_support::nu;
 use pretty_assertions::assert_eq;
 use rstest::rstest;
+use regex::Regex;
 
 const MODULE_SETUP: &str = r#"
     module spam {
@@ -115,10 +116,8 @@ fn const_string_interpolation() {
         const s = $"var: ($x), date: (2021-02-27T13:55:40+00:00), file size: (2kb)"
         $s
     "#);
-    assert_eq!(
-        actual.out,
-        "var: 2, date: Sat, 27 Feb 2021 13:55:40 +0000 (3 years ago), file size: 2.0 KiB"
-    );
+    let re = Regex::new(r"^var\: 2, date\: Sat, 27 Feb 2021 13\:55\:40 \+0000 (\d+ years ago), file size\: 2\.0 KiB$").unwrap();
+    assert!(re.is_match(out));
 }
 
 #[test]

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -1,7 +1,7 @@
 use nu_test_support::nu;
 use pretty_assertions::assert_eq;
-use rstest::rstest;
 use regex::Regex;
+use rstest::rstest;
 
 const MODULE_SETUP: &str = r#"
     module spam {

--- a/tests/const_/mod.rs
+++ b/tests/const_/mod.rs
@@ -1,6 +1,5 @@
 use nu_test_support::nu;
 use pretty_assertions::assert_eq;
-use regex::Regex;
 use rstest::rstest;
 
 const MODULE_SETUP: &str = r#"
@@ -110,14 +109,21 @@ fn const_string() {
 }
 
 #[test]
-fn const_string_interpolation() {
-    let actual = nu!(r#"
-        const x = 2
-        const s = $"var: ($x), date: (2021-02-27T13:55:40+00:00), file size: (2kb)"
-        $s
-    "#);
-    let re = Regex::new(r"^var\: 2, date\: Sat, 27 Feb 2021 13\:55\:40 \+0000 (\d+ years ago), file size\: 2\.0 KiB$").unwrap();
-    assert!(re.is_match(out));
+fn const_string_interpolation_var() {
+    let actual = nu!(r#"const x = 2; const s = $"($x)"; $s"#);
+    assert_eq!(actual.out, "2");
+}
+
+#[test]
+fn const_string_interpolation_date() {
+    let actual = nu!(r#"const s = $"(2021-02-27T13:55:40+00:00)"; $s"#);
+    assert!(actual.out.contains("Sat, 27 Feb 2021 13:55:40 +0000"));
+}
+
+#[test]
+fn const_string_interpolation_filesize() {
+    let actual = nu!(r#"const s = $"(2kb)"; $s"#);
+    assert_eq!(actual.out, "2.0 KiB");
 }
 
 #[test]


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Currently, in the test for interpolating strings at parse-time, the formatted string includes `(X years ago)` (from formatting a date) (test came from https://github.com/nushell/nushell/pull/11562). I didn't realize when I was writing it that it would have to be updated every year. This PR uses regex to check the output instead.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
