### PR TITLE
Replace panics with errors in thread spawning

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -3,6 +3,7 @@ use nu_engine::CallExt;
 use nu_path::expand_path_with;
 use nu_protocol::ast::{Call, Expr, Expression};
 use nu_protocol::engine::{Command, EngineState, Stack};
+use nu_protocol::IntoSpanned;
 use nu_protocol::{
     Category, DataSource, Example, PipelineData, PipelineMetadata, RawStream, ShellError,
     Signature, Span, Spanned, SyntaxShape, Type, Value,
@@ -123,19 +124,22 @@ impl Command for Save {
                 )?;
 
                 // delegate a thread to redirect stderr to result.
-                let handler = stderr.map(|stderr_stream| match stderr_file {
-                    Some(stderr_file) => thread::Builder::new()
-                        .name("stderr redirector".to_string())
-                        .spawn(move || stream_to_file(stderr_stream, stderr_file, span, progress))
-                        .expect("Failed to create thread"),
-                    None => thread::Builder::new()
-                        .name("stderr redirector".to_string())
-                        .spawn(move || {
-                            let _ = stderr_stream.into_bytes();
-                            Ok(PipelineData::empty())
-                        })
-                        .expect("Failed to create thread"),
-                });
+                let handler = stderr
+                    .map(|stderr_stream| match stderr_file {
+                        Some(stderr_file) => thread::Builder::new()
+                            .name("stderr redirector".to_string())
+                            .spawn(move || {
+                                stream_to_file(stderr_stream, stderr_file, span, progress)
+                            }),
+                        None => thread::Builder::new()
+                            .name("stderr redirector".to_string())
+                            .spawn(move || {
+                                let _ = stderr_stream.into_bytes();
+                                Ok(PipelineData::empty())
+                            }),
+                    })
+                    .transpose()
+                    .map_err(|e| e.into_spanned(span))?;
 
                 let res = stream_to_file(stream, file, span, progress);
                 if let Some(h) = handler {

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -283,7 +283,7 @@ fn send_cancellable_request(
             let ret = request_fn();
             let _ = tx.send(ret); // may fail if the user has cancelled the operation
         })
-        .expect("Failed to create thread");
+        .map_err(ShellError::from)?;
 
     // ...and poll the channel for responses
     loop {

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -1,7 +1,8 @@
 use nu_protocol::{
     ast::Call,
     engine::{Command, EngineState, Stack},
-    Category, Example, IntoPipelineData, PipelineData, Record, ShellError, Signature, Type, Value,
+    Category, Example, IntoPipelineData, IntoSpanned, PipelineData, Record, ShellError, Signature,
+    Type, Value,
 };
 
 use std::thread;
@@ -52,9 +53,9 @@ impl Command for Complete {
                 // consumes the first 65535 bytes
                 // So we need a thread to receive stderr message, then the current thread can continue to consume
                 // stdout messages.
-                let stderr_handler = stderr.map(|stderr| {
-                    let stderr_span = stderr.span;
-                    (
+                let stderr_handler = stderr
+                    .map(|stderr| {
+                        let stderr_span = stderr.span;
                         thread::Builder::new()
                             .name("stderr consumer".to_string())
                             .spawn(move || {
@@ -65,10 +66,10 @@ impl Command for Complete {
                                     Ok::<_, ShellError>(Value::binary(stderr.item, stderr.span))
                                 }
                             })
-                            .expect("failed to create thread"),
-                        stderr_span,
-                    )
-                });
+                            .map(|handle| (handle, stderr_span))
+                            .map_err(|err| err.into_spanned(call.head))
+                    })
+                    .transpose()?;
 
                 if let Some(stdout) = stdout {
                     let stdout = stdout.into_bytes()?;

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -2,6 +2,7 @@ use nu_cmd_base::hook::eval_hook;
 use nu_engine::env_to_strings;
 use nu_engine::eval_expression;
 use nu_engine::CallExt;
+use nu_protocol::IntoSpanned;
 use nu_protocol::NuGlob;
 use nu_protocol::{
     ast::{Call, Expr},
@@ -438,7 +439,7 @@ impl ExternalCommand {
 
                                 Ok(())
                             })
-                            .expect("Failed to create thread");
+                            .map_err(|e| e.into_spanned(head))?;
                     }
                 }
 
@@ -526,7 +527,7 @@ impl ExternalCommand {
                             Ok(())
                         }
                     }
-                }).expect("Failed to create thread");
+                }).map_err(|e| e.into_spanned(head))?;
 
                 let (stderr_tx, stderr_rx) = mpsc::sync_channel(OUTPUT_BUFFERS_IN_FLIGHT);
                 if redirect_stderr {
@@ -543,7 +544,7 @@ impl ExternalCommand {
                             read_and_redirect_message(stderr, stderr_tx, stderr_ctrlc);
                             Ok::<(), ShellError>(())
                         })
-                        .expect("Failed to create thread");
+                        .map_err(|e| e.into_spanned(head))?;
                 }
 
                 let stdout_receiver = ChannelReceiver::new(stdout_rx);

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -419,7 +419,7 @@ impl PluginInterface {
         let (writer, rx) = self.write_plugin_call(call, context.clone())?;
 
         // Finish writing stream in the background
-        writer.write_background();
+        writer.write_background()?;
 
         self.receive_plugin_call_response(rx)
     }

--- a/crates/nu-protocol/src/pipeline_data.rs
+++ b/crates/nu-protocol/src/pipeline_data.rs
@@ -868,8 +868,7 @@ pub fn print_if_stream(
                         let _ = stderr.write_all(&bytes);
                     }
                 }
-            })
-            .expect("could not create thread");
+            })?;
     }
 
     if let Some(stream) = stream {

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -2,7 +2,9 @@ use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use crate::{ast::Operator, engine::StateWorkingSet, format_error, ParseError, Span, Value};
+use crate::{
+    ast::Operator, engine::StateWorkingSet, format_error, ParseError, Span, Spanned, Value,
+};
 
 /// The fundamental error type for the evaluation engine. These cases represent different kinds of errors
 /// the evaluator might face, along with helpful spans to label. An error renderer will take this error value
@@ -1357,6 +1359,15 @@ impl From<std::io::Error> for ShellError {
     fn from(input: std::io::Error) -> ShellError {
         ShellError::IOError {
             msg: format!("{input:?}"),
+        }
+    }
+}
+
+impl From<Spanned<std::io::Error>> for ShellError {
+    fn from(error: Spanned<std::io::Error>) -> Self {
+        ShellError::IOErrorSpanned {
+            msg: error.item.to_string(),
+            span: error.span,
         }
     }
 }

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -3,12 +3,31 @@ use serde::{Deserialize, Serialize};
 
 /// A spanned area of interest, generic over what kind of thing is of interest
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-pub struct Spanned<T>
-where
-    T: Clone + std::fmt::Debug,
-{
+pub struct Spanned<T> {
     pub item: T,
     pub span: Span,
+}
+
+/// Helper trait to create [`Spanned`] more ergonomically.
+pub trait IntoSpanned: Sized {
+    /// Wrap items together with a span into [`Spanned`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use nu_protocol::{Span, IntoSpanned};
+    /// # let span = Span::test_data();
+    /// let spanned = "Hello, world!".into_spanned(span);
+    /// assert_eq!("Hello, world!", spanned.item);
+    /// assert_eq!(span, spanned.span);
+    /// ```
+    fn into_spanned(self, span: Span) -> Spanned<Self>;
+}
+
+impl<T> IntoSpanned for T {
+    fn into_spanned(self, span: Span) -> Spanned<Self> {
+        Spanned { item: self, span }
+    }
 }
 
 /// Spans are a global offset across all seen files, which are cached in the engine's state. The start and


### PR DESCRIPTION
# Description
Replace panics with errors in thread spawning.

Also adds `IntoSpanned` trait for easily constructing `Spanned`, and an implementation of `From<Spanned<std::io::Error>>` for `ShellError`, which is used to provide context for the error wherever there was a span conveniently available. In general this should make it more convenient to do the right thing with `std::io::Error` and always add a span to it when it's possible to do so.

# User-Facing Changes
Fewer panics!

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

