### PR TITLE
Introduce workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,12 +1581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4766,8 +4760,6 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
 dependencies = [
- "futures",
- "futures-timer",
  "rstest_macros",
  "rustc_version",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,42 +24,63 @@ pkg-fmt = "zip"
 
 [workspace]
 members = [
-	"crates/nu-cli",
-	"crates/nu-engine",
-	"crates/nu-parser",
-	"crates/nu-system",
-	"crates/nu-cmd-base",
-	"crates/nu-cmd-extra",
-	"crates/nu-cmd-lang",
-	"crates/nu-cmd-dataframe",
-	"crates/nu-command",
-	"crates/nu-color-config",
-	"crates/nu-explore",
-	"crates/nu-json",
-	"crates/nu-lsp",
-	"crates/nu-pretty-hex",
-	"crates/nu-protocol",
-	"crates/nu-plugin",
-	"crates/nu_plugin_inc",
-	"crates/nu_plugin_gstat",
-	"crates/nu_plugin_example",
-	"crates/nu_plugin_stream_example",
-	"crates/nu_plugin_query",
-	"crates/nu_plugin_custom_values",
-	"crates/nu_plugin_formats",
-	"crates/nu-std",
-	"crates/nu-table",
-	"crates/nu-term-grid",
-	"crates/nu-test-support",
-	"crates/nu-utils",
+  "crates/nu-cli",
+  "crates/nu-engine",
+  "crates/nu-parser",
+  "crates/nu-system",
+  "crates/nu-cmd-base",
+  "crates/nu-cmd-extra",
+  "crates/nu-cmd-lang",
+  "crates/nu-cmd-dataframe",
+  "crates/nu-command",
+  "crates/nu-color-config",
+  "crates/nu-explore",
+  "crates/nu-json",
+  "crates/nu-lsp",
+  "crates/nu-pretty-hex",
+  "crates/nu-protocol",
+  "crates/nu-plugin",
+  "crates/nu_plugin_inc",
+  "crates/nu_plugin_gstat",
+  "crates/nu_plugin_example",
+  "crates/nu_plugin_stream_example",
+  "crates/nu_plugin_query",
+  "crates/nu_plugin_custom_values",
+  "crates/nu_plugin_formats",
+  "crates/nu-std",
+  "crates/nu-table",
+  "crates/nu-term-grid",
+  "crates/nu-test-support",
+  "crates/nu-utils",
 ]
+
+[workspace.dependencies]
+chrono = { default-features = false, version = "0.4" }
+crossterm = "0.27"
+ctrlc = "3.4"
+fancy-regex = "0.13"
+log = "0.4"
+miette = "7.1"
+nix = { version = "0.27", default-features = false }
+nu-ansi-term = "0.50.0"
+once_cell = "1.18"
+pathdiff = "0.2"
+percent-encoding = "2"
+reedline = "0.30.0"
+rstest = { version = "0.18", default-features = false }
+serde_json = "1.0"
+sysinfo = "0.30"
+tempfile = "3.10"
+unicode-segmentation = "1.11"
+uuid = "1.6.0"
+which = "6.0.0"
 
 [dependencies]
 nu-cli = { path = "./crates/nu-cli", version = "0.91.1" }
 nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.91.1" }
 nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.91.1" }
 nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.91.1", features = [
-	"dataframe",
+  "dataframe",
 ], optional = true }
 nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.91.1", optional = true }
 nu-command = { path = "./crates/nu-command", version = "0.91.1" }
@@ -73,14 +94,14 @@ nu-protocol = { path = "./crates/nu-protocol", version = "0.91.1" }
 nu-std = { path = "./crates/nu-std", version = "0.91.1" }
 nu-utils = { path = "./crates/nu-utils", version = "0.91.1" }
 
-reedline = { version = "0.30.0", features = ["bashisms", "sqlite"] }
+reedline = { workspace = true, features = ["bashisms", "sqlite"] }
 
-crossterm = "0.27"
-ctrlc = "3.4"
-log = "0.4"
-miette = { version = "7.1", features = ["fancy-no-backtrace", "fancy"] }
+crossterm = { workspace = true }
+ctrlc = { workspace = true }
+log = { workspace = true }
+miette = { workspace = true, features = ["fancy-no-backtrace", "fancy"] }
 mimalloc = { version = "0.1.37", default-features = false, optional = true }
-serde_json = "1.0"
+serde_json = { workspace = true }
 simplelog = "0.12"
 time = "0.3"
 
@@ -92,11 +113,11 @@ openssl = { version = "0.10", features = ["vendored"], optional = true }
 winresource = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.27", default-features = false, features = [
-	"signal",
-	"process",
-	"fs",
-	"term",
+nix = { workspace = true, default-features = false, features = [
+  "signal",
+  "process",
+  "fs",
+  "term",
 ] }
 
 [dev-dependencies]
@@ -104,28 +125,28 @@ nu-test-support = { path = "./crates/nu-test-support", version = "0.91.1" }
 assert_cmd = "2.0"
 divan = "0.1.14"
 pretty_assertions = "1.4"
-rstest = { version = "0.18", default-features = false }
+rstest = { workspace = true, default-features = false }
 serial_test = "3.0"
-tempfile = "3.10"
+tempfile = { workspace = true }
 
 [features]
 plugin = [
-	"nu-plugin",
-	"nu-cli/plugin",
-	"nu-parser/plugin",
-	"nu-command/plugin",
-	"nu-protocol/plugin",
-	"nu-engine/plugin",
+  "nu-plugin",
+  "nu-cli/plugin",
+  "nu-parser/plugin",
+  "nu-command/plugin",
+  "nu-protocol/plugin",
+  "nu-engine/plugin",
 ]
 default = ["default-no-clipboard", "system-clipboard"]
 # Enables convenient omitting of the system-clipboard feature, as it leads to problems in ci on linux
 # See https://github.com/nushell/nushell/pull/11535
 default-no-clipboard = [
-	"plugin",
-	"which-support",
-	"trash-support",
-	"sqlite",
-	"mimalloc",
+  "plugin",
+  "which-support",
+  "trash-support",
+  "sqlite",
+  "mimalloc",
 ]
 stable = ["default"]
 wasi = ["nu-cmd-lang/wasi"]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.91.1" }
 nu-command = { path = "../nu-command", version = "0.91.1" }
 nu-test-support = { path = "../nu-test-support", version = "0.91.1" }
-rstest = { version = "0.18.1", default-features = false }
+rstest = { workspace = true, default-features = false }
 
 [dependencies]
 nu-cmd-base = { path = "../nu-cmd-base", version = "0.91.1" }
@@ -24,24 +24,24 @@ nu-parser = { path = "../nu-parser", version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.91.1" }
-nu-ansi-term = "0.50.0"
-reedline = { version = "0.30.0", features = ["bashisms", "sqlite"] }
+nu-ansi-term = { workspace = true }
+reedline = { workspace = true, features = ["bashisms", "sqlite"] }
 
-chrono = { default-features = false, features = ["std"], version = "0.4" }
-crossterm = "0.27"
-fancy-regex = "0.13"
+chrono = { default-features = false, features = ["std"], workspace = true }
+crossterm = { workspace = true }
+fancy-regex = { workspace = true }
 fuzzy-matcher = "0.3"
 is_executable = "1.0"
-log = "0.4"
-miette = { version = "7.1", features = ["fancy-no-backtrace"] }
+log = { workspace = true }
+miette = { workspace = true, features = ["fancy-no-backtrace"] }
 lscolors = { version = "0.17", default-features = false, features = ["nu-ansi-term"] }
-once_cell = "1.18"
-percent-encoding = "2"
-pathdiff = "0.2"
-sysinfo = "0.30"
-unicode-segmentation = "1.11"
-uuid = { version = "1.6.0", features = ["v4"] }
-which = "6.0.0"
+once_cell = { workspace = true }
+percent-encoding = { workspace = true }
+pathdiff = { workspace = true }
+sysinfo = { workspace = true }
+unicode-segmentation = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
+which = { workspace = true }
 
 [features]
 plugin = []

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -16,6 +16,6 @@ nu-path = { path = "../nu-path", version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
 indexmap = "2.2"
-miette = "7.1.0"
+miette = { workspace = true }
 
 [dev-dependencies]

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -18,9 +18,9 @@ nu-parser = { path = "../nu-parser", version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
 # Potential dependencies for extras
-chrono = { version = "0.4", features = ["std", "unstable-locales"], default-features = false }
+chrono = { workspace = true, features = ["std", "unstable-locales"], default-features = false }
 chrono-tz = "0.8"
-fancy-regex = "0.13"
+fancy-regex = { workspace = true }
 indexmap = { version = "2.2" }
 num = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -22,8 +22,8 @@ nu-utils = { path = "../nu-utils", version = "0.91.1" }
 # Potential dependencies for extras
 heck = "0.4.1"
 num-traits = "0.2"
-nu-ansi-term = "0.50.0"
-fancy-regex = "0.13.0"
+nu-ansi-term = { workspace = true }
+fancy-regex = { workspace = true }
 rust-embed = "8.2.0"
 serde = "1.0.164"
 nu-pretty-hex = { version = "0.91.1", path = "../nu-pretty-hex" }

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -12,9 +12,9 @@ bench = false
 
 [dependencies]
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
-nu-ansi-term = "0.50.0"
 nu-engine = { path = "../nu-engine", version = "0.91.1" }
 nu-json = { path = "../nu-json", version = "0.91.1" }
+nu-ansi-term = { workspace = true }
 
 serde = { version = "1.0", features = ["derive"] }
 

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.91.1"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.50.0"
 nu-cmd-base = { path = "../nu-cmd-base", version = "0.91.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.91.1" }
 nu-engine = { path = "../nu-engine", version = "0.91.1" }
@@ -27,22 +26,23 @@ nu-system = { path = "../nu-system", version = "0.91.1" }
 nu-table = { path = "../nu-table", version = "0.91.1" }
 nu-term-grid = { path = "../nu-term-grid", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
+nu-ansi-term = { workspace = true }
 
 alphanumeric-sort = "1.5"
 base64 = "0.21"
 byteorder = "1.5"
 bytesize = "1.3"
 calamine = { version = "0.24.0", features = ["dates"] }
-chrono = { version = "0.4.34", features = ["std", "unstable-locales", "clock"], default-features = false }
+chrono = { workspace = true, features = ["std", "unstable-locales", "clock"], default-features = false }
 chrono-humanize = "0.2.3"
 chrono-tz = "0.8"
-crossterm = "0.27"
+crossterm = { workspace = true }
 csv = "1.3"
 dialoguer = { default-features = false, features = ["fuzzy-select"], version = "0.11" }
 digest = { default-features = false, version = "0.10" }
 dtparse = "2.0"
 encoding_rs = "0.8"
-fancy-regex = "0.13"
+fancy-regex = { workspace = true }
 filesize = "0.2"
 filetime = "0.2"
 fs_extra = "1.3"
@@ -50,8 +50,8 @@ human-date-parser = "0.1.1"
 indexmap = "2.2"
 indicatif = "0.17"
 itertools = "0.12"
-log = "0.4"
 lscolors = { version = "0.17", default-features = false, features = ["nu-ansi-term"] }
+log = { workspace = true }
 md5 = { package = "md-5", version = "0.10" }
 mime = "0.3"
 mime_guess = "2.0"
@@ -59,11 +59,11 @@ native-tls = "0.2"
 notify-debouncer-full = { version = "0.3", default-features = false }
 num-format = { version = "0.4" }
 num-traits = "0.2"
-once_cell = "1.18"
 open = "5.1"
+once_cell = { workspace = true }
 os_pipe = "1.1"
-pathdiff = "0.2"
-percent-encoding = "2.3"
+pathdiff = { workspace = true }
+percent-encoding = { workspace = true }
 print-positions = "0.6"
 quick-xml = "0.31.0"
 rand = "0.8"
@@ -73,16 +73,16 @@ roxmltree = "0.19"
 rusqlite = { version = "0.31", features = ["bundled", "backup", "chrono"], optional = true }
 same-file = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
 serde_urlencoded = "0.7"
 serde_yaml = "0.9"
 sha2 = "0.10"
-sysinfo = "0.30"
+sysinfo = { workspace = true }
 tabled = { version = "0.14.0", features = ["color"], default-features = false }
 terminal_size = "0.3"
 titlecase = "2.0"
 toml = "0.8"
-unicode-segmentation = "1.11"
+unicode-segmentation = { workspace = true }
 ureq = { version = "2.9", default-features = false, features = ["charset", "gzip", "json", "native-tls"] }
 url = "2.2"
 uu_mv = "0.0.23"
@@ -90,10 +90,10 @@ uu_cp = "0.0.23"
 uu_whoami = "0.0.23"
 uu_mkdir = "0.0.23"
 uu_mktemp = "0.0.23"
-uuid = { version = "1.6", features = ["v4"] }
+uuid = { workspace = true, features = ["v4"] }
 v_htmlescape = "0.15.0"
 wax = { version = "0.6" }
-which = { version = "6.0", optional = true }
+which = { workspace = true, optional = true }
 bracoxide = "0.1.2"
 chardetng = "0.1.17"
 
@@ -103,7 +103,7 @@ winreg = "0.52"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 umask = "2.1"
-nix = { version = "0.27", default-features = false, features = ["user", "resource"] }
+nix = { workspace = true, default-features = false, features = ["user", "resource"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs = "0.16.0"
@@ -137,4 +137,4 @@ dirs-next = "2.0"
 mockito = { version = "1.4", default-features = false }
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
-rstest = { version = "0.18", default-features = false }
+rstest = { workspace = true, default-features = false }

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.91.1"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.50.0"
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 nu-parser = { path = "../nu-parser", version = "0.91.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.91.1" }
@@ -19,10 +18,11 @@ nu-engine = { path = "../nu-engine", version = "0.91.1" }
 nu-table = { path = "../nu-table", version = "0.91.1" }
 nu-json = { path = "../nu-json", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
+nu-ansi-term = { workspace = true }
 
 terminal_size = "0.3"
 strip-ansi-escapes = "0.2.0"
-crossterm = "0.27"
+crossterm = { workspace = true }
 ratatui = "0.26"
 ansi-str = "0.8"
 unicode-width = "0.1"

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -12,15 +12,15 @@ nu-cli = { path = "../nu-cli", version = "0.91.1" }
 nu-parser = { path = "../nu-parser", version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
-reedline = { version = "0.30" }
+reedline = { workspace = true }
 
 crossbeam-channel = "0.5.8"
 lsp-types = "0.95.0"
 lsp-server = "0.7.5"
-miette = "7.1"
+miette = { workspace = true }
 ropey = "1.6.1"
 serde = "1.0"
-serde_json = "1.0"
+serde_json = { workspace = true }
 
 [dev-dependencies]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.91.1" }

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -18,13 +18,13 @@ nu-plugin = { path = "../nu-plugin", optional = true, version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
 bytesize = "1.3"
-chrono = { default-features = false, features = ['std'], version = "0.4" }
+chrono = { default-features = false, features = ['std'], workspace = true }
 itertools = "0.12"
-log = "0.4"
-serde_json = "1.0"
+log = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-rstest = { version = "0.18", default-features = false }
+rstest = { workspace = true, default-features = false }
 
 [features]
 plugin = ["nu-plugin"]

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -17,8 +17,8 @@ nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 bincode = "1.3"
 rmp-serde = "1.1"
 serde = { version = "1.0" }
-serde_json = { version = "1.0" }
+serde_json = { workspace = true }
 log = "0.4"
-miette = "7.0"
+miette = { workspace = true }
 semver = "1.0"
 typetag = "0.2"

--- a/crates/nu-pretty-hex/Cargo.toml
+++ b/crates/nu-pretty-hex/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 bench = false
 
 [dependencies]
-nu-ansi-term = "0.50.0"
+nu-ansi-term = { workspace = true }
 
 [dev-dependencies]
 heapless = { version = "0.8", default-features = false }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -18,15 +18,15 @@ nu-path = { path = "../nu-path", version = "0.91.1" }
 nu-system = { path = "../nu-system", version = "0.91.1" }
 
 byte-unit = { version = "5.1", features = [ "serde" ] }
-chrono = { version = "0.4.34", features = [ "serde", "std", "unstable-locales" ], default-features = false }
+chrono = { workspace = true, features = [ "serde", "std", "unstable-locales" ], default-features = false }
 chrono-humanize = "0.2"
-fancy-regex = "0.13"
+fancy-regex = { workspace = true }
 indexmap = "2.2"
 lru = "0.12"
-miette = { version = "7.1", features = ["fancy-no-backtrace"] }
+miette = { workspace = true, features = ["fancy-no-backtrace"] }
 num-format = "0.4"
 serde = { version = "1.0", default-features = false }
-serde_json = { version = "1.0", optional = true }
+serde_json = { workspace = true, optional = true }
 thiserror = "1.0"
 typetag = "0.2"
 
@@ -34,11 +34,11 @@ typetag = "0.2"
 plugin = ["serde_json"]
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = { workspace = true }
 strum = "0.25"
 strum_macros = "0.26"
 nu-test-support = { path = "../nu-test-support", version = "0.91.1" }
-rstest = "0.18"
+rstest = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/nu-std/Cargo.toml
+++ b/crates/nu-std/Cargo.toml
@@ -8,8 +8,8 @@ name = "nu-std"
 version = "0.91.1"
 
 [dependencies]
-miette = { version = "7.1", features = ["fancy-no-backtrace"] }
 nu-parser = { version = "0.91.1", path = "../nu-parser" }
 nu-protocol = { version = "0.91.1", path = "../nu-protocol" }
 nu-engine = { version = "0.91.1", path = "../nu-engine" }
+miette = { workspace = true, features = ["fancy-no-backtrace"] }
 

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -14,11 +14,11 @@ bench = false
 
 [dependencies]
 libc = "0.2"
-log = "0.4"
-sysinfo = "0.30"
+log = { workspace = true }
+sysinfo = { workspace = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
-nix = { version = "0.27", default-features = false, features = ["fs", "term", "process", "signal"] }
+nix = { workspace = true, default-features = false, features = ["fs", "term", "process", "signal"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs = "0.16"
@@ -28,9 +28,9 @@ libproc = "0.14"
 mach2 = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-chrono = { version = "0.4", default-features = false, features = ["clock"] }
+chrono = { workspace = true, default-features = false, features = ["clock"] }
 ntapi = "0.4"
-once_cell = "1.18"
+once_cell = { workspace = true }
 windows = { version = "0.52", features = [
   "Wdk_System_SystemServices",
   "Wdk_System_Threading",

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -15,9 +15,9 @@ nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 nu-engine = { path = "../nu-engine", version = "0.91.1" }
 nu-color-config = { path = "../nu-color-config", version = "0.91.1" }
-nu-ansi-term = "0.50.0"
-once_cell = "1.18"
-fancy-regex = "0.13"
+nu-ansi-term = { workspace = true }
+once_cell = { workspace = true }
+fancy-regex = { workspace = true }
 tabled = { version = "0.14.0", features = ["color"], default-features = false }
 
 [dev-dependencies]

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -17,6 +17,6 @@ nu-glob = { path = "../nu-glob", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 
 num-format = "0.4"
-which = "6.0.0"
-tempfile = "3.10"
+which = { workspace = true }
+tempfile = { workspace = true }
 hamcrest2 = "0.3"

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -17,8 +17,8 @@ bench = false
 bench = false
 
 [dependencies]
-log = "0.4"
 lscolors = { version = "0.17", default-features = false, features = ["nu-ansi-term"] }
+log = { workspace = true }
 num-format = { version = "0.4" }
 strip-ansi-escapes = "0.2.0"
 sys-locale = "0.3"


### PR DESCRIPTION
# Description
This PR introduces [workspaces dependencies](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table). The advantages are:
- a single place where dependency versions are declared
- reduces the number of files to change when upgrading a dependency
- reduces the risk of accidentally depending on 2 different versions of the same dependency

I've only done a few so far. If this PR is accepted, I might continue and progressively do the rest.

# User-Facing Changes
N/A

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
N/A
