### PR TITLE
fix: allow `view source` to view aliases again

### DIFF
--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -46,8 +46,19 @@ impl Command for ViewSource {
                     let vec_of_optional = &sig.optional_positional;
                     let rest = &sig.rest_positional;
                     let vec_of_flags = &sig.named;
+
+                    if decl.is_alias() {
+                        if let Some(alias) = &decl.as_alias() {
+                            let contents = String::from_utf8_lossy(
+                                engine_state.get_span_contents(alias.wrapped_call.span),
+                            );
+                            Ok(Value::string(contents, call.head).into_pipeline_data())
+                        } else {
+                            Ok(Value::string("no alias found", call.head).into_pipeline_data())
+                        }
+                    }
                     // gets vector of positionals.
-                    if let Some(block_id) = decl.get_block_id() {
+                    else if let Some(block_id) = decl.get_block_id() {
                         let block = engine_state.get_block(block_id);
                         if let Some(block_span) = block.span {
                             let contents = engine_state.get_span_contents(block_span);
@@ -87,7 +98,7 @@ impl Command for ViewSource {
                         } else {
                             Err(ShellError::GenericError {
                                 error: "Cannot view value".to_string(),
-                                msg: "the command does not have a viewable block".to_string(),
+                                msg: "the command does not have a viewable block span".to_string(),
                                 span: Some(arg_span),
                                 help: None,
                                 inner: vec![],


### PR DESCRIPTION
# Description

This PR allows `view source` to view aliases again. It looks like it's been half broken for a while now.

fixes #12044

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
