### PR TITLE
Improve sleep resolution

### DIFF
--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -56,7 +56,7 @@ impl Command for Sleep {
         let ctrlc_ref = &engine_state.ctrlc.clone();
         let start = Instant::now();
         loop {
-            thread::sleep(CTRL_C_CHECK_INTERVAL);
+            thread::sleep(CTRL_C_CHECK_INTERVAL.min(total_dur));
             if start.elapsed() >= total_dur {
                 break;
             }


### PR DESCRIPTION
# Description
This improves the resolution of the sleep commands by simply not clamping to the default 100ms ctrl+c signal checking loop if the passed-in duration is shorter.

# User-Facing Changes
You can use smaller values in sleep.

```
# Before
timeit { 0..100 | each { |row| print $row; sleep 10ms; } } # +10sec

# After
timeit { 0..100 | each { |row| print $row; sleep 10ms; } } # +1sec
```

It still depends on the internal behavior of thread::sleep and the OS timers. In windows it doesn't seem to go much lower than 15 or 10ms, or 0 if you asked for that.

# After Submitting
Sleep didn't have anything documenting its minimum value, so this should be more in line with its standard procedure. It will still never sleep for less time than allocated.

Did you know `sleep` can take multiple durations, and it'll add them up? I didn't