### PR TITLE
Fix: Convert help example results to text

### DIFF
--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -647,6 +647,7 @@ def build-command-page [command: record] {
             (if not ($example.result | is-empty) {
                 $example.result
                 | table
+                | to text
                 | if ($example.result | describe) == "binary" { str join } else { lines }
                 | each {|line|
                     $"  ($line)"


### PR DESCRIPTION
# Description

Converts help example results `to text` in `build-command-page`.  This prevents an `item_not_found` error when attempting to `help <command>` on many legitimate commands.

Fixes #12073

# User-Facing Changes

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
    - `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
