### PR TITLE
fix ls with empty string

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -90,6 +90,13 @@ impl Command for Ls {
         let pattern_arg = opt_for_glob_pattern(engine_state, stack, call, 0)?;
         let pattern_arg = {
             if let Some(path) = pattern_arg {
+                // it makes no sense to list an empty string.
+                if path.item.as_ref().is_empty() {
+                    return Err(ShellError::FileNotFoundCustom {
+                        msg: "empty string('') file does not exist".to_string(),
+                        span: path.span,
+                    });
+                }
                 match path.item {
                     NuGlob::DoNotExpand(p) => Some(Spanned {
                         item: NuGlob::DoNotExpand(nu_utils::strip_ansi_string_unlikely(p)),

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -172,20 +172,14 @@ impl Command for Ls {
             let p = path.display().to_string();
             let mut glob_escaped = Pattern::escape(&p);
             if extra_star_under_given_directory {
-                if !glob_escaped.is_empty() {
-                    // need to put `MAIN_SEPARATOR` if parent path is not empty
-                    // or else we will list the root directory, e.g: "" -> "/*"
-                    glob_escaped.push(std::path::MAIN_SEPARATOR);
-                }
+                glob_escaped.push(std::path::MAIN_SEPARATOR);
                 glob_escaped.push('*');
             }
             glob_escaped
         } else {
             let mut p = path.display().to_string();
             if extra_star_under_given_directory {
-                if !p.is_empty() {
-                    p.push(std::path::MAIN_SEPARATOR);
-                }
+                p.push(std::path::MAIN_SEPARATOR);
                 p.push('*');
             }
             p

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -93,7 +93,7 @@ impl Command for Ls {
                 // it makes no sense to list an empty string.
                 if path.item.as_ref().is_empty() {
                     return Err(ShellError::FileNotFoundCustom {
-                        msg: "empty string('') file does not exist".to_string(),
+                        msg: "empty string('') directory or file does not exist".to_string(),
                         span: path.span,
                     });
                 }

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -172,14 +172,20 @@ impl Command for Ls {
             let p = path.display().to_string();
             let mut glob_escaped = Pattern::escape(&p);
             if extra_star_under_given_directory {
-                glob_escaped.push(std::path::MAIN_SEPARATOR);
+                if !glob_escaped.is_empty() {
+                    // need to put `MAIN_SEPARATOR` if parent path is not empty
+                    // or else we will list the root directory, e.g: "" -> "/*"
+                    glob_escaped.push(std::path::MAIN_SEPARATOR);
+                }
                 glob_escaped.push('*');
             }
             glob_escaped
         } else {
             let mut p = path.display().to_string();
             if extra_star_under_given_directory {
-                p.push(std::path::MAIN_SEPARATOR);
+                if !p.is_empty() {
+                    p.push(std::path::MAIN_SEPARATOR);
+                }
                 p.push('*');
             }
             p

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -701,3 +701,13 @@ fn list_flag_false() {
         assert_eq!(actual.out, "false");
     })
 }
+
+#[test]
+fn list_empty_string() {
+    Playground::setup("ls_empty_string", |dirs, sandbox| {
+        sandbox.with_files(vec![EmptyFile("yehuda.txt")]);
+
+        let actual = nu!(cwd: dirs.test(), "ls ''");
+        assert!(actual.err.contains("does not exist"));
+    })
+}

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -701,17 +701,3 @@ fn list_flag_false() {
         assert_eq!(actual.out, "false");
     })
 }
-
-#[test]
-fn list_empty_string() {
-    Playground::setup("ls_empty_string", |dirs, sandbox| {
-        sandbox.with_files(vec![
-            EmptyFile("yehuda.txt"),
-            EmptyFile("jttxt"),
-            EmptyFile("andres.txt"),
-        ]);
-
-        let actual = nu!(cwd: dirs.test(), "ls '' | length");
-        assert_eq!(actual.out, "3");
-    })
-}

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -701,3 +701,17 @@ fn list_flag_false() {
         assert_eq!(actual.out, "false");
     })
 }
+
+#[test]
+fn list_empty_string() {
+    Playground::setup("ls_empty_string", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            EmptyFile("yehuda.txt"),
+            EmptyFile("jttxt"),
+            EmptyFile("andres.txt"),
+        ]);
+
+        let actual = nu!(cwd: dirs.test(), "ls '' | length");
+        assert_eq!(actual.out, "3");
+    })
+}


### PR DESCRIPTION
# Description
Fixes: #12054

It's cause by nu always add `/*` if there is a parameter in ls, then `ls ""` becomes `ls "/*"`.  This pr tries to fix it by only append `/` character if pattern is not empty.

# User-Facing Changes
NaN

# Tests + Formatting
Done

# After Submitting
NaN