### PR TITLE
Support for all custom value operations on plugin custom values

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/custom_value.rs
@@ -34,13 +34,23 @@ impl CustomValue for NuDataFrame {
         self
     }
 
-    fn follow_path_int(&self, count: usize, span: Span) -> Result<Value, ShellError> {
-        self.get_value(count, span)
+    fn follow_path_int(
+        &self,
+        _self_span: Span,
+        count: usize,
+        path_span: Span,
+    ) -> Result<Value, ShellError> {
+        self.get_value(count, path_span)
     }
 
-    fn follow_path_string(&self, column_name: String, span: Span) -> Result<Value, ShellError> {
-        let column = self.column(&column_name, span)?;
-        Ok(column.into_value(span))
+    fn follow_path_string(
+        &self,
+        _self_span: Span,
+        column_name: String,
+        path_span: Span,
+    ) -> Result<Value, ShellError> {
+        let column = self.column(&column_name, path_span)?;
+        Ok(column.into_value(path_span))
     }
 
     fn partial_cmp(&self, other: &Value) -> Option<std::cmp::Ordering> {

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -372,19 +372,29 @@ impl CustomValue for SQLiteDatabase {
         self
     }
 
-    fn follow_path_int(&self, _count: usize, span: Span) -> Result<Value, ShellError> {
+    fn follow_path_int(
+        &self,
+        _self_span: Span,
+        _index: usize,
+        path_span: Span,
+    ) -> Result<Value, ShellError> {
         // In theory we could support this, but tables don't have an especially well-defined order
-        Err(ShellError::IncompatiblePathAccess { type_name: "SQLite databases do not support integer-indexed access. Try specifying a table name instead".into(), span })
+        Err(ShellError::IncompatiblePathAccess { type_name: "SQLite databases do not support integer-indexed access. Try specifying a table name instead".into(), span: path_span })
     }
 
-    fn follow_path_string(&self, _column_name: String, span: Span) -> Result<Value, ShellError> {
-        let db = open_sqlite_db(&self.path, span)?;
+    fn follow_path_string(
+        &self,
+        _self_span: Span,
+        _column_name: String,
+        path_span: Span,
+    ) -> Result<Value, ShellError> {
+        let db = open_sqlite_db(&self.path, path_span)?;
 
-        read_single_table(db, _column_name, span, self.ctrlc.clone()).map_err(|e| {
+        read_single_table(db, _column_name, path_span, self.ctrlc.clone()).map_err(|e| {
             ShellError::GenericError {
                 error: "Failed to read from SQLite database".into(),
                 msg: e.to_string(),
-                span: Some(span),
+                span: Some(path_span),
                 help: None,
                 inner: vec![],
             }

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -16,7 +16,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
 bincode = "1.3"
 rmp-serde = "1.1"
-serde = { version = "1.0", features = ["rc"] }
+serde = "1.0"
 serde_json = { workspace = true }
 log = "0.4"
 miette = { workspace = true }

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -16,7 +16,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
 bincode = "1.3"
 rmp-serde = "1.1"
-serde = { version = "1.0" }
+serde = { version = "1.0", features = ["rc"] }
 serde_json = { workspace = true }
 log = "0.4"
 miette = { workspace = true }

--- a/crates/nu-plugin/src/plugin/interface/engine.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine.rs
@@ -12,8 +12,8 @@ use nu_protocol::{
 
 use crate::{
     protocol::{
-        CallInfo, CustomValueOp, EngineCall, EngineCallId, EngineCallResponse, PluginCall,
-        PluginCallId, PluginCallResponse, PluginCustomValue, PluginInput, PluginOption,
+        CallInfo, CustomValueOp, EngineCall, EngineCallId, EngineCallResponse, Ordering,
+        PluginCall, PluginCallId, PluginCallResponse, PluginCustomValue, PluginInput, PluginOption,
         ProtocolInfo,
     },
     LabeledError, PluginOutput,
@@ -681,6 +681,16 @@ impl EngineInterface {
     /// The user can still stop the plugin if they want to with the `plugin stop` command.
     pub fn set_gc_disabled(&self, disabled: bool) -> Result<(), ShellError> {
         self.write(PluginOutput::Option(PluginOption::GcDisabled(disabled)))?;
+        self.flush()
+    }
+
+    /// Write a call response of [`Ordering`], for `partial_cmp`.
+    pub(crate) fn write_ordering(
+        &self,
+        ordering: Option<impl Into<Ordering>>,
+    ) -> Result<(), ShellError> {
+        let response = PluginCallResponse::Ordering(ordering.map(|o| o.into()));
+        self.write(PluginOutput::CallResponse(self.context()?, response))?;
         self.flush()
     }
 }

--- a/crates/nu-plugin/src/plugin/interface/engine/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine/tests.rs
@@ -496,7 +496,7 @@ fn manager_consume_call_custom_value_op_forwards_to_receiver_with_context() -> R
             op,
         } => {
             assert_eq!(Some(32), engine.context);
-            assert_eq!("TestCustomValue", custom_value.item.name);
+            assert_eq!("TestCustomValue", custom_value.item.name());
             assert!(
                 matches!(op, CustomValueOp::ToBaseValue),
                 "incorrect op: {op:?}"
@@ -600,11 +600,12 @@ fn manager_prepare_pipeline_data_embeds_deserialization_errors_in_streams() -> R
 {
     let manager = TestCase::new().engine();
 
-    let invalid_custom_value = PluginCustomValue {
-        name: "Invalid".into(),
-        data: vec![0; 8], // should fail to decode to anything
-        source: None,
-    };
+    let invalid_custom_value = PluginCustomValue::new(
+        "Invalid".into(),
+        vec![0; 8], // should fail to decode to anything
+        false,
+        None,
+    );
 
     let span = Span::new(20, 30);
     let data = manager.prepare_pipeline_data(
@@ -965,9 +966,9 @@ fn interface_prepare_pipeline_data_serializes_custom_values() -> Result<(), Shel
         .expect("custom value is not a PluginCustomValue, probably not serialized");
 
     let expected = test_plugin_custom_value();
-    assert_eq!(expected.name, custom_value.name);
-    assert_eq!(expected.data, custom_value.data);
-    assert!(custom_value.source.is_none());
+    assert_eq!(expected.name(), custom_value.name());
+    assert_eq!(expected.data(), custom_value.data());
+    assert!(custom_value.source().is_none());
 
     Ok(())
 }
@@ -994,9 +995,9 @@ fn interface_prepare_pipeline_data_serializes_custom_values_in_streams() -> Resu
         .expect("custom value is not a PluginCustomValue, probably not serialized");
 
     let expected = test_plugin_custom_value();
-    assert_eq!(expected.name, custom_value.name);
-    assert_eq!(expected.data, custom_value.data);
-    assert!(custom_value.source.is_none());
+    assert_eq!(expected.name(), custom_value.name());
+    assert_eq!(expected.data(), custom_value.data());
+    assert!(custom_value.source().is_none());
 
     Ok(())
 }

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -854,11 +854,16 @@ impl PluginInterface {
     /// Invoke comparison logic for custom values.
     pub(crate) fn custom_value_partial_cmp(
         &self,
-        value: Spanned<PluginCustomValue>,
+        value: PluginCustomValue,
         mut other_value: Value,
     ) -> Result<Option<Ordering>, ShellError> {
         PluginCustomValue::verify_source(&mut other_value, &self.state.source)?;
-        let call = PluginCall::CustomValueOp(value, CustomValueOp::PartialCmp(other_value));
+        // Note: the protocol is always designed to have a span with the custom value, but this
+        // operation doesn't support one.
+        let call = PluginCall::CustomValueOp(
+            value.into_spanned(Span::unknown()),
+            CustomValueOp::PartialCmp(other_value),
+        );
         match self.plugin_call(call, &None)? {
             PluginCallResponse::Ordering(ordering) => Ok(ordering),
             PluginCallResponse::Error(err) => Err(err.into()),

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -6,15 +6,15 @@ use std::{
 };
 
 use nu_protocol::{
-    IntoInterruptiblePipelineData, ListStream, PipelineData, PluginSignature, ShellError, Spanned,
-    Value,
+    ast::Operator, IntoInterruptiblePipelineData, ListStream, PipelineData, PluginSignature,
+    ShellError, Spanned, Value,
 };
 
 use crate::{
     plugin::{context::PluginExecutionContext, gc::PluginGc, PluginSource},
     protocol::{
-        CallInfo, CustomValueOp, EngineCall, EngineCallId, EngineCallResponse, PluginCall,
-        PluginCallId, PluginCallResponse, PluginCustomValue, PluginInput, PluginOption,
+        CallInfo, CustomValueOp, EngineCall, EngineCallId, EngineCallResponse, Ordering,
+        PluginCall, PluginCallId, PluginCallResponse, PluginCustomValue, PluginInput, PluginOption,
         PluginOutput, ProtocolInfo, StreamId, StreamMessage,
     },
     sequence::Sequence,
@@ -454,6 +454,9 @@ impl InterfaceManager for PluginInterfaceManager {
                 let response = match response {
                     PluginCallResponse::Error(err) => PluginCallResponse::Error(err),
                     PluginCallResponse::Signature(sigs) => PluginCallResponse::Signature(sigs),
+                    PluginCallResponse::Ordering(ordering) => {
+                        PluginCallResponse::Ordering(ordering)
+                    }
                     PluginCallResponse::PipelineData(data) => {
                         // If there's an error with initializing this stream, change it to a plugin
                         // error response, but send it anyway
@@ -804,21 +807,76 @@ impl PluginInterface {
         }
     }
 
+    /// Do a custom value op that expects a value response (i.e. most of them)
+    fn custom_value_op_expecting_value(
+        &self,
+        value: Spanned<PluginCustomValue>,
+        op: CustomValueOp,
+    ) -> Result<Value, ShellError> {
+        let op_name = op.name();
+        let span = value.span;
+        let call = PluginCall::CustomValueOp(value, op);
+        match self.plugin_call(call, &None)? {
+            PluginCallResponse::PipelineData(out_data) => Ok(out_data.into_value(span)),
+            PluginCallResponse::Error(err) => Err(err.into()),
+            _ => Err(ShellError::PluginFailedToDecode {
+                msg: format!("Received unexpected response to custom value {op_name}() call"),
+            }),
+        }
+    }
+
     /// Collapse a custom value to its base value.
     pub(crate) fn custom_value_to_base_value(
         &self,
         value: Spanned<PluginCustomValue>,
     ) -> Result<Value, ShellError> {
-        let span = value.span;
-        let call = PluginCall::CustomValueOp(value, CustomValueOp::ToBaseValue);
+        self.custom_value_op_expecting_value(value, CustomValueOp::ToBaseValue)
+    }
+
+    /// Follow a numbered cell path on a custom value - e.g. `value.0`.
+    pub(crate) fn custom_value_follow_path_int(
+        &self,
+        value: Spanned<PluginCustomValue>,
+        index: Spanned<usize>,
+    ) -> Result<Value, ShellError> {
+        self.custom_value_op_expecting_value(value, CustomValueOp::FollowPathInt(index))
+    }
+
+    /// Follow a named cell path on a custom value - e.g. `value.column`.
+    pub(crate) fn custom_value_follow_path_string(
+        &self,
+        value: Spanned<PluginCustomValue>,
+        column_name: Spanned<String>,
+    ) -> Result<Value, ShellError> {
+        self.custom_value_op_expecting_value(value, CustomValueOp::FollowPathString(column_name))
+    }
+
+    /// Invoke comparison logic for custom values.
+    pub(crate) fn custom_value_partial_cmp(
+        &self,
+        value: Spanned<PluginCustomValue>,
+        mut other_value: Value,
+    ) -> Result<Option<Ordering>, ShellError> {
+        PluginCustomValue::verify_source(&mut other_value, &self.state.source)?;
+        let call = PluginCall::CustomValueOp(value, CustomValueOp::PartialCmp(other_value));
         match self.plugin_call(call, &None)? {
-            PluginCallResponse::PipelineData(out_data) => Ok(out_data.into_value(span)),
+            PluginCallResponse::Ordering(ordering) => Ok(ordering),
             PluginCallResponse::Error(err) => Err(err.into()),
             _ => Err(ShellError::PluginFailedToDecode {
-                msg: "Received unexpected response to plugin CustomValueOp::ToBaseValue call"
-                    .into(),
+                msg: format!("Received unexpected response to custom value partial_cmp() call"),
             }),
         }
+    }
+
+    /// Invoke functionality for an operator on a custom value.
+    pub(crate) fn custom_value_operation(
+        &self,
+        left: Spanned<PluginCustomValue>,
+        operator: Spanned<Operator>,
+        mut right: Value,
+    ) -> Result<Value, ShellError> {
+        PluginCustomValue::verify_source(&mut right, &self.state.source)?;
+        self.custom_value_op_expecting_value(left, CustomValueOp::Operation(operator, right))
     }
 }
 

--- a/crates/nu-plugin/src/plugin/interface/plugin/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin/tests.rs
@@ -649,7 +649,7 @@ fn manager_prepare_pipeline_data_adds_source_to_values() -> Result<(), ShellErro
         .downcast_ref()
         .expect("custom value is not a PluginCustomValue");
 
-    if let Some(source) = &custom_value.source {
+    if let Some(source) = custom_value.source() {
         assert_eq!("test", source.name());
     } else {
         panic!("source was not set");
@@ -679,7 +679,7 @@ fn manager_prepare_pipeline_data_adds_source_to_list_streams() -> Result<(), She
         .downcast_ref()
         .expect("custom value is not a PluginCustomValue");
 
-    if let Some(source) = &custom_value.source {
+    if let Some(source) = custom_value.source() {
         assert_eq!("test", source.name());
     } else {
         panic!("source was not set");
@@ -1092,12 +1092,13 @@ fn interface_custom_value_to_base_value() -> Result<(), ShellError> {
 fn normal_values(interface: &PluginInterface) -> Vec<Value> {
     vec![
         Value::test_int(5),
-        Value::test_custom_value(Box::new(PluginCustomValue {
-            name: "SomeTest".into(),
-            data: vec![1, 2, 3],
+        Value::test_custom_value(Box::new(PluginCustomValue::new(
+            "SomeTest".into(),
+            vec![1, 2, 3],
+            false,
             // Has the same source, so it should be accepted
-            source: Some(interface.state.source.clone()),
-        })),
+            Some(interface.state.source.clone()),
+        ))),
     ]
 }
 
@@ -1145,17 +1146,19 @@ fn bad_custom_values() -> Vec<Value> {
         // Native custom value (not PluginCustomValue) should be rejected
         Value::test_custom_value(Box::new(expected_test_custom_value())),
         // Has no source, so it should be rejected
-        Value::test_custom_value(Box::new(PluginCustomValue {
-            name: "SomeTest".into(),
-            data: vec![1, 2, 3],
-            source: None,
-        })),
+        Value::test_custom_value(Box::new(PluginCustomValue::new(
+            "SomeTest".into(),
+            vec![1, 2, 3],
+            false,
+            None,
+        ))),
         // Has a different source, so it should be rejected
-        Value::test_custom_value(Box::new(PluginCustomValue {
-            name: "SomeTest".into(),
-            data: vec![1, 2, 3],
-            source: Some(PluginSource::new_fake("pluto").into()),
-        })),
+        Value::test_custom_value(Box::new(PluginCustomValue::new(
+            "SomeTest".into(),
+            vec![1, 2, 3],
+            false,
+            Some(PluginSource::new_fake("pluto").into()),
+        ))),
     ]
 }
 

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -374,6 +374,11 @@ pub trait Plugin: Sync {
     /// This notification is only sent if [`CustomValue::notify_plugin_on_drop`] was true. Unlike
     /// the other custom value handlers, a span is not provided.
     ///
+    /// Note that a new custom value is created each time it is sent to the engine - if you intend
+    /// to accept a custom value and send it back, you may need to implement some kind of unique
+    /// reference counting in your plugin, as you will receive multiple drop notifications even if
+    /// the data within is identical.
+    ///
     /// The default implementation does nothing. Any error generated here is unlikely to be visible
     /// to the user, and will only show up in the engine's log output.
     fn custom_value_dropped(
@@ -552,6 +557,11 @@ pub trait StreamingPlugin: Sync {
     ///
     /// This notification is only sent if [`CustomValue::notify_plugin_on_drop`] was true. Unlike
     /// the other custom value handlers, a span is not provided.
+    ///
+    /// Note that a new custom value is created each time it is sent to the engine - if you intend
+    /// to accept a custom value and send it back, you may need to implement some kind of unique
+    /// reference counting in your plugin, as you will receive multiple drop notifications even if
+    /// the data within is identical.
     ///
     /// The default implementation does nothing. Any error generated here is unlikely to be visible
     /// to the user, and will only show up in the engine's log output.

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -345,11 +345,11 @@ pub trait Plugin: Sync {
     fn custom_value_partial_cmp(
         &self,
         engine: &EngineInterface,
-        custom_value: Spanned<Box<dyn CustomValue>>,
+        custom_value: Box<dyn CustomValue>,
         other_value: Value,
     ) -> Result<Option<Ordering>, LabeledError> {
         let _ = engine;
-        Ok(custom_value.item.partial_cmp(&other_value))
+        Ok(custom_value.partial_cmp(&other_value))
     }
 
     /// Implement functionality for an operator on a custom value.
@@ -524,11 +524,11 @@ pub trait StreamingPlugin: Sync {
     fn custom_value_partial_cmp(
         &self,
         engine: &EngineInterface,
-        custom_value: Spanned<Box<dyn CustomValue>>,
+        custom_value: Box<dyn CustomValue>,
         other_value: Value,
     ) -> Result<Option<Ordering>, LabeledError> {
         let _ = engine;
-        Ok(custom_value.item.partial_cmp(&other_value))
+        Ok(custom_value.partial_cmp(&other_value))
     }
 
     /// Implement functionality for an operator on a custom value.
@@ -617,7 +617,7 @@ impl<T: Plugin> StreamingPlugin for T {
     fn custom_value_partial_cmp(
         &self,
         engine: &EngineInterface,
-        custom_value: Spanned<Box<dyn CustomValue>>,
+        custom_value: Box<dyn CustomValue>,
         other_value: Value,
     ) -> Result<Option<Ordering>, LabeledError> {
         <Self as Plugin>::custom_value_partial_cmp(self, engine, custom_value, other_value)
@@ -886,7 +886,7 @@ fn custom_value_op(
         }
         CustomValueOp::PartialCmp(mut other_value) => {
             PluginCustomValue::deserialize_custom_values_in(&mut other_value)?;
-            match plugin.custom_value_partial_cmp(engine, local_value, other_value) {
+            match plugin.custom_value_partial_cmp(engine, local_value.item, other_value) {
                 Ok(ordering) => engine.write_ordering(ordering),
                 Err(err) => engine
                     .write_response(Err(err))

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -139,6 +139,9 @@ pub enum CustomValueOp {
     PartialCmp(Value),
     /// [`operation()`](nu_protocol::CustomValue::operation)
     Operation(Spanned<Operator>, Value),
+    /// Notify that the custom value has been dropped, if
+    /// [`notify_plugin_on_drop()`](nu_protocol::CustomValue::notify_plugin_on_drop) is true
+    Dropped,
 }
 
 impl CustomValueOp {
@@ -150,6 +153,7 @@ impl CustomValueOp {
             CustomValueOp::FollowPathString(_) => "follow_path_string",
             CustomValueOp::PartialCmp(_) => "partial_cmp",
             CustomValueOp::Operation(_, _) => "operation",
+            CustomValueOp::Dropped => "dropped",
         }
     }
 }

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -10,8 +10,8 @@ pub(crate) mod test_util;
 
 pub use evaluated_call::EvaluatedCall;
 use nu_protocol::{
-    engine::Closure, Config, PipelineData, PluginSignature, RawStream, ShellError, Span, Spanned,
-    Value,
+    ast::Operator, engine::Closure, Config, PipelineData, PluginSignature, RawStream, ShellError,
+    Span, Spanned, Value,
 };
 pub use plugin_custom_value::PluginCustomValue;
 pub use protocol_info::ProtocolInfo;
@@ -131,6 +131,27 @@ pub enum PluginCall<D> {
 pub enum CustomValueOp {
     /// [`to_base_value()`](nu_protocol::CustomValue::to_base_value)
     ToBaseValue,
+    /// [`follow_path_int()`](nu_protocol::CustomValue::follow_path_int)
+    FollowPathInt(Spanned<usize>),
+    /// [`follow_path_string()`](nu_protocol::CustomValue::follow_path_string)
+    FollowPathString(Spanned<String>),
+    /// [`partial_cmp()`](nu_protocol::CustomValue::partial_cmp)
+    PartialCmp(Value),
+    /// [`operation()`](nu_protocol::CustomValue::operation)
+    Operation(Spanned<Operator>, Value),
+}
+
+impl CustomValueOp {
+    /// Get the name of the op, for error messages.
+    pub(crate) fn name(&self) -> &'static str {
+        match self {
+            CustomValueOp::ToBaseValue => "to_base_value",
+            CustomValueOp::FollowPathInt(_) => "follow_path_int",
+            CustomValueOp::FollowPathString(_) => "follow_path_string",
+            CustomValueOp::PartialCmp(_) => "partial_cmp",
+            CustomValueOp::Operation(_, _) => "operation",
+        }
+    }
 }
 
 /// Any data sent to the plugin
@@ -306,6 +327,7 @@ impl From<ShellError> for LabeledError {
 pub enum PluginCallResponse<D> {
     Error(LabeledError),
     Signature(Vec<PluginSignature>),
+    Ordering(Option<Ordering>),
     PipelineData(D),
 }
 
@@ -328,6 +350,34 @@ pub enum PluginOption {
     ///
     /// See [`EngineInterface::set_gc_disabled`] for more information.
     GcDisabled(bool),
+}
+
+/// This is just a serializable version of [std::cmp::Ordering], and can be converted 1:1
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Ordering {
+    Less,
+    Equal,
+    Greater,
+}
+
+impl From<std::cmp::Ordering> for Ordering {
+    fn from(value: std::cmp::Ordering) -> Self {
+        match value {
+            std::cmp::Ordering::Less => Ordering::Less,
+            std::cmp::Ordering::Equal => Ordering::Equal,
+            std::cmp::Ordering::Greater => Ordering::Greater,
+        }
+    }
+}
+
+impl From<Ordering> for std::cmp::Ordering {
+    fn from(value: Ordering) -> Self {
+        match value {
+            Ordering::Less => std::cmp::Ordering::Less,
+            Ordering::Equal => std::cmp::Ordering::Equal,
+            Ordering::Greater => std::cmp::Ordering::Greater,
+        }
+    }
 }
 
 /// Information received from the plugin

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -95,10 +95,7 @@ impl CustomValue for PluginCustomValue {
             .and_then(|plugin| {
                 // We're passing Span::unknown() here because we don't have one, and it probably
                 // shouldn't matter here and is just a consequence of the API
-                plugin.custom_value_partial_cmp(
-                    self.clone().into_spanned(Span::unknown()),
-                    other.clone(),
-                )
+                plugin.custom_value_partial_cmp(self.clone(), other.clone())
             })
             .unwrap_or_else(|err| {
                 // We can't do anything with the error other than log it.

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -39,7 +39,14 @@ struct SharedContent {
     /// The bincoded representation of the custom value on the plugin side
     data: Vec<u8>,
     /// True if the custom value should notify the source if all copies of it are dropped.
+    ///
+    /// This is not serialized if `false`, since most custom values don't need it.
+    #[serde(default, skip_serializing_if = "is_false")]
     notify_on_drop: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
 }
 
 #[typetag::serde]

--- a/crates/nu-plugin/src/protocol/plugin_custom_value/tests.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value/tests.rs
@@ -19,7 +19,7 @@ fn serialize_deserialize() -> Result<(), ShellError> {
     let original_value = TestCustomValue(32);
     let span = Span::test_data();
     let serialized = PluginCustomValue::serialize_from_custom_value(&original_value, span)?;
-    assert_eq!(original_value.value_string(), serialized.name);
+    assert_eq!(original_value.value_string(), serialized.name());
     assert!(serialized.source.is_none());
     let deserialized = serialized.deserialize_to_custom_value(span)?;
     let downcasted = deserialized
@@ -36,8 +36,8 @@ fn expected_serialize_output() -> Result<(), ShellError> {
     let span = Span::test_data();
     let serialized = PluginCustomValue::serialize_from_custom_value(&original_value, span)?;
     assert_eq!(
-        test_plugin_custom_value().data,
-        serialized.data,
+        test_plugin_custom_value().data(),
+        serialized.data(),
         "The bincode configuration is probably different from what we expected. \
             Fix test_plugin_custom_value() to match it"
     );
@@ -417,8 +417,11 @@ fn serialize_in_root() -> Result<(), ShellError> {
 
     let custom_value = val.as_custom_value()?;
     if let Some(plugin_custom_value) = custom_value.as_any().downcast_ref::<PluginCustomValue>() {
-        assert_eq!("TestCustomValue", plugin_custom_value.name);
-        assert_eq!(test_plugin_custom_value().data, plugin_custom_value.data);
+        assert_eq!("TestCustomValue", plugin_custom_value.name());
+        assert_eq!(
+            test_plugin_custom_value().data(),
+            plugin_custom_value.data()
+        );
         assert!(plugin_custom_value.source.is_none());
     } else {
         panic!("Failed to downcast to PluginCustomValue");
@@ -443,7 +446,8 @@ fn serialize_in_range() -> Result<(), ShellError> {
             .downcast_ref()
             .unwrap_or_else(|| panic!("{name} not PluginCustomValue"));
         assert_eq!(
-            "TestCustomValue", plugin_custom_value.name,
+            "TestCustomValue",
+            plugin_custom_value.name(),
             "{name} name not set correctly"
         );
         Ok(())
@@ -465,7 +469,8 @@ fn serialize_in_record() -> Result<(), ShellError> {
             .downcast_ref()
             .unwrap_or_else(|| panic!("'{key}' not PluginCustomValue"));
         assert_eq!(
-            "TestCustomValue", plugin_custom_value.name,
+            "TestCustomValue",
+            plugin_custom_value.name(),
             "'{key}' name not set correctly"
         );
         Ok(())
@@ -484,7 +489,8 @@ fn serialize_in_list() -> Result<(), ShellError> {
             .downcast_ref()
             .unwrap_or_else(|| panic!("[{index}] not PluginCustomValue"));
         assert_eq!(
-            "TestCustomValue", plugin_custom_value.name,
+            "TestCustomValue",
+            plugin_custom_value.name(),
             "[{index}] name not set correctly"
         );
         Ok(())
@@ -506,7 +512,8 @@ fn serialize_in_closure() -> Result<(), ShellError> {
             .downcast_ref()
             .unwrap_or_else(|| panic!("[{index}] not PluginCustomValue"));
         assert_eq!(
-            "TestCustomValue", plugin_custom_value.name,
+            "TestCustomValue",
+            plugin_custom_value.name(),
             "[{index}] name not set correctly"
         );
         Ok(())

--- a/crates/nu-plugin/src/protocol/test_util.rs
+++ b/crates/nu-plugin/src/protocol/test_util.rs
@@ -31,11 +31,7 @@ pub(crate) fn test_plugin_custom_value() -> PluginCustomValue {
     let data = bincode::serialize(&expected_test_custom_value() as &dyn CustomValue)
         .expect("bincode serialization of the expected_test_custom_value() failed");
 
-    PluginCustomValue {
-        name: "TestCustomValue".into(),
-        data,
-        source: None,
-    }
+    PluginCustomValue::new("TestCustomValue".into(), data, false, None)
 }
 
 pub(crate) fn expected_test_custom_value() -> TestCustomValue {
@@ -43,8 +39,5 @@ pub(crate) fn expected_test_custom_value() -> TestCustomValue {
 }
 
 pub(crate) fn test_plugin_custom_value_with_source() -> PluginCustomValue {
-    PluginCustomValue {
-        source: Some(PluginSource::new_fake("test").into()),
-        ..test_plugin_custom_value()
-    }
+    test_plugin_custom_value().with_source(Some(PluginSource::new_fake("test").into()))
 }

--- a/crates/nu-plugin/src/serializers/tests.rs
+++ b/crates/nu-plugin/src/serializers/tests.rs
@@ -176,11 +176,7 @@ macro_rules! generate_tests {
 
             let custom_value_op = PluginCall::CustomValueOp(
                 Spanned {
-                    item: PluginCustomValue {
-                        name: "Foo".into(),
-                        data: data.clone(),
-                        source: None,
-                    },
+                    item: PluginCustomValue::new("Foo".into(), data.clone(), false, None),
                     span,
                 },
                 CustomValueOp::ToBaseValue,
@@ -200,8 +196,8 @@ macro_rules! generate_tests {
 
             match returned {
                 PluginInput::Call(2, PluginCall::CustomValueOp(val, op)) => {
-                    assert_eq!("Foo", val.item.name);
-                    assert_eq!(data, val.item.data);
+                    assert_eq!("Foo", val.item.name());
+                    assert_eq!(data, val.item.data());
                     assert_eq!(span, val.span);
                     #[allow(unreachable_patterns)]
                     match op {
@@ -320,11 +316,12 @@ macro_rules! generate_tests {
             let span = Span::new(2, 30);
 
             let value = Value::custom_value(
-                Box::new(PluginCustomValue {
-                    name: name.into(),
-                    data: data.clone(),
-                    source: None,
-                }),
+                Box::new(PluginCustomValue::new(
+                    name.into(),
+                    data.clone(),
+                    true,
+                    None,
+                )),
                 span,
             );
 
@@ -354,8 +351,9 @@ macro_rules! generate_tests {
                         .as_any()
                         .downcast_ref::<PluginCustomValue>()
                     {
-                        assert_eq!(name, plugin_val.name);
-                        assert_eq!(data, plugin_val.data);
+                        assert_eq!(name, plugin_val.name());
+                        assert_eq!(data, plugin_val.data());
+                        assert!(plugin_val.notify_on_drop());
                     } else {
                         panic!("returned CustomValue is not a PluginCustomValue");
                     }

--- a/crates/nu-protocol/src/value/custom_value.rs
+++ b/crates/nu-protocol/src/value/custom_value.rs
@@ -74,4 +74,15 @@ pub trait CustomValue: fmt::Debug + Send + Sync {
         let _ = (lhs_span, right);
         Err(ShellError::UnsupportedOperator { operator, span: op })
     }
+
+    /// For custom values in plugins: return `true` here if you would like to be notified when all
+    /// copies of this custom value are dropped in the engine.
+    ///
+    /// The notification will take place via
+    /// [`.custom_value_dropped()`](crate::StreamingPlugin::custom_value_dropped) on the plugin.
+    ///
+    /// The default is `false`.
+    fn notify_plugin_on_drop(&self) -> bool {
+        false
+    }
 }

--- a/crates/nu-protocol/src/value/custom_value.rs
+++ b/crates/nu-protocol/src/value/custom_value.rs
@@ -26,18 +26,30 @@ pub trait CustomValue: fmt::Debug + Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
 
     /// Follow cell path by numeric index (e.g. rows)
-    fn follow_path_int(&self, _count: usize, span: Span) -> Result<Value, ShellError> {
+    fn follow_path_int(
+        &self,
+        self_span: Span,
+        index: usize,
+        path_span: Span,
+    ) -> Result<Value, ShellError> {
+        let _ = (self_span, index);
         Err(ShellError::IncompatiblePathAccess {
             type_name: self.value_string(),
-            span,
+            span: path_span,
         })
     }
 
     /// Follow cell path by string key (e.g. columns)
-    fn follow_path_string(&self, _column_name: String, span: Span) -> Result<Value, ShellError> {
+    fn follow_path_string(
+        &self,
+        self_span: Span,
+        column_name: String,
+        path_span: Span,
+    ) -> Result<Value, ShellError> {
+        let _ = (self_span, column_name);
         Err(ShellError::IncompatiblePathAccess {
             type_name: self.value_string(),
-            span,
+            span: path_span,
         })
     }
 
@@ -54,11 +66,12 @@ pub trait CustomValue: fmt::Debug + Send + Sync {
     /// Default impl raises [`ShellError::UnsupportedOperator`].
     fn operation(
         &self,
-        _lhs_span: Span,
+        lhs_span: Span,
         operator: Operator,
         op: Span,
-        _right: &Value,
+        right: &Value,
     ) -> Result<Value, ShellError> {
+        let _ = (lhs_span, right);
         Err(ShellError::UnsupportedOperator { operator, span: op })
     }
 }

--- a/crates/nu_plugin_custom_values/src/cool_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/cool_custom_value.rs
@@ -1,7 +1,9 @@
-use nu_protocol::{CustomValue, ShellError, Span, Value};
+use std::cmp::Ordering;
+
+use nu_protocol::{ast, CustomValue, ShellError, Span, Value};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct CoolCustomValue {
     pub(crate) cool: String,
 }
@@ -44,7 +46,7 @@ impl CoolCustomValue {
 
 #[typetag::serde]
 impl CustomValue for CoolCustomValue {
-    fn clone_value(&self, span: nu_protocol::Span) -> Value {
+    fn clone_value(&self, span: Span) -> Value {
         Value::custom_value(Box::new(self.clone()), span)
     }
 
@@ -52,11 +54,92 @@ impl CustomValue for CoolCustomValue {
         self.typetag_name().to_string()
     }
 
-    fn to_base_value(&self, span: nu_protocol::Span) -> Result<Value, ShellError> {
+    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
         Ok(Value::string(
             format!("I used to be a custom value! My data was ({})", self.cool),
             span,
         ))
+    }
+
+    fn follow_path_int(
+        &self,
+        _self_span: Span,
+        index: usize,
+        path_span: Span,
+    ) -> Result<Value, ShellError> {
+        if index == 0 {
+            Ok(Value::string(&self.cool, path_span))
+        } else {
+            Err(ShellError::AccessBeyondEnd {
+                max_idx: 0,
+                span: path_span,
+            })
+        }
+    }
+
+    fn follow_path_string(
+        &self,
+        self_span: Span,
+        column_name: String,
+        path_span: Span,
+    ) -> Result<Value, ShellError> {
+        if column_name == "cool" {
+            Ok(Value::string(&self.cool, path_span))
+        } else {
+            Err(ShellError::CantFindColumn {
+                col_name: column_name,
+                span: path_span,
+                src_span: self_span,
+            })
+        }
+    }
+
+    fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
+        if let Value::CustomValue { val, .. } = other {
+            val.as_any()
+                .downcast_ref()
+                .and_then(|other: &CoolCustomValue| PartialOrd::partial_cmp(self, other))
+        } else {
+            None
+        }
+    }
+
+    fn operation(
+        &self,
+        lhs_span: Span,
+        operator: ast::Operator,
+        op_span: Span,
+        right: &Value,
+    ) -> Result<Value, ShellError> {
+        match operator {
+            // Append the string inside `cool`
+            ast::Operator::Math(ast::Math::Append) => {
+                if let Some(right) = right
+                    .as_custom_value()
+                    .ok()
+                    .and_then(|c| c.as_any().downcast_ref::<CoolCustomValue>())
+                {
+                    Ok(Value::custom_value(
+                        Box::new(CoolCustomValue {
+                            cool: format!("{}{}", self.cool, right.cool),
+                        }),
+                        op_span,
+                    ))
+                } else {
+                    Err(ShellError::OperatorMismatch {
+                        op_span,
+                        lhs_ty: self.typetag_name().into(),
+                        lhs_span,
+                        rhs_ty: right.get_type().to_string(),
+                        rhs_span: right.span(),
+                    })
+                }
+            }
+            _ => Err(ShellError::UnsupportedOperator {
+                operator,
+                span: op_span,
+            }),
+        }
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/nu_plugin_custom_values/src/drop_check.rs
+++ b/crates/nu_plugin_custom_values/src/drop_check.rs
@@ -1,0 +1,50 @@
+use nu_protocol::{record, CustomValue, ShellError, Span, Value};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DropCheck {
+    pub(crate) msg: String,
+}
+
+impl DropCheck {
+    pub(crate) fn new(msg: String) -> DropCheck {
+        DropCheck { msg }
+    }
+
+    pub(crate) fn into_value(self, span: Span) -> Value {
+        Value::custom_value(Box::new(self), span)
+    }
+
+    pub(crate) fn notify(&self) {
+        eprintln!("DropCheck was dropped: {}", self.msg);
+    }
+}
+
+#[typetag::serde]
+impl CustomValue for DropCheck {
+    fn clone_value(&self, span: Span) -> Value {
+        self.clone().into_value(span)
+    }
+
+    fn value_string(&self) -> String {
+        "DropCheck".into()
+    }
+
+    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+        Ok(Value::record(
+            record! {
+                "msg" => Value::string(&self.msg, span)
+            },
+            span,
+        ))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn notify_plugin_on_drop(&self) -> bool {
+        // This is what causes Nushell to let us know when the value is dropped
+        true
+    }
+}

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -79,6 +79,57 @@ fn can_get_describe_plugin_custom_values() {
     assert_eq!(actual.out, "CoolCustomValue");
 }
 
+#[test]
+fn can_get_plugin_custom_value_int_cell_path() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("nu_plugin_custom_values"),
+        "(custom-value generate).0"
+    );
+
+    assert_eq!(actual.out, "abc");
+}
+
+#[test]
+fn can_get_plugin_custom_value_string_cell_path() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("nu_plugin_custom_values"),
+        "(custom-value generate).cool"
+    );
+
+    assert_eq!(actual.out, "abc");
+}
+
+#[test]
+fn can_sort_plugin_custom_values() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("nu_plugin_custom_values"),
+        "[(custom-value generate | custom-value update) (custom-value generate)] | sort | each { print } | ignore"
+    );
+
+    assert_eq!(
+        actual.out,
+        "I used to be a custom value! My data was (abc)\
+        I used to be a custom value! My data was (abcxyz)"
+    );
+}
+
+#[test]
+fn can_append_plugin_custom_values() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("nu_plugin_custom_values"),
+        "(custom-value generate) ++ (custom-value generate)"
+    );
+
+    assert_eq!(
+        actual.out,
+        "I used to be a custom value! My data was (abcabc)"
+    );
+}
+
 // There are currently no custom values defined by the engine that aren't hidden behind an extra
 // feature
 #[cfg(feature = "sqlite")]

--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -167,3 +167,16 @@ fn fails_if_passing_custom_values_across_plugins() {
         .err
         .contains("the `inc` plugin does not support this kind of value"));
 }
+
+#[test]
+fn drop_check_custom_value_prints_message_on_drop() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("nu_plugin_custom_values"),
+        // We build an array with the value copied twice to verify that it only gets dropped once
+        "do { |v| [$v $v] } (custom-value drop-check 'Hello') | ignore"
+    );
+
+    assert_eq!(actual.err, "DropCheck was dropped: Hello\n");
+    assert!(actual.status.success());
+}


### PR DESCRIPTION
# Description

Adds support for the following operations on plugin custom values, in addition to `to_base_value` which was already present:

- `follow_path_int()`
- `follow_path_string()`
- `partial_cmp()`
- `operation()`
- `Drop` (notification, if opted into with `CustomValue::notify_plugin_on_drop`)

There are additionally customizable methods within the `Plugin` and `StreamingPlugin` traits for implementing these functions in a way that requires access to the plugin state, as a registered handle model such as might be used in a dataframes plugin would.

`Value::append` was also changed to handle custom values correctly.

# User-Facing Changes

- Signature of `CustomValue::follow_path_string` and `CustomValue::follow_path_int` changed to give access to the span of the custom value itself, useful for some errors.
- Plugins using custom values have to be recompiled because the engine will try to do custom value operations that aren't supported
- Plugins can do more things :tada: 

# Tests + Formatting
Tests were added for all of the new custom values functionality.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
- [ ] Document protocol reference `CustomValueOp` variants:
  - [ ] `FollowPathInt`
  - [ ] `FollowPathString`
  - [ ] `PartialCmp`
  - [ ] `Operation`
  - [ ] `Dropped`
- [ ] Document `notify_on_drop` optional field in `PluginCustomValue`