### PR TITLE
fix `du` `--exclude` globbing bug

### DIFF
--- a/crates/nu-command/src/filesystem/du.rs
+++ b/crates/nu-command/src/filesystem/du.rs
@@ -18,7 +18,7 @@ pub struct DuArgs {
     path: Option<Spanned<NuGlob>>,
     all: bool,
     deref: bool,
-    exclude: Option<Spanned<String>>,
+    exclude: Option<Spanned<NuGlob>>,
     #[serde(rename = "max-depth")]
     max_depth: Option<Spanned<i64>>,
     #[serde(rename = "min-size")]
@@ -110,7 +110,7 @@ impl Command for Du {
         };
 
         let exclude = args.exclude.map_or(Ok(None), move |x| {
-            Pattern::new(&x.item)
+            Pattern::new(x.item.as_ref())
                 .map(Some)
                 .map_err(|e| ShellError::InvalidGlobPattern {
                     msg: e.msg.into(),


### PR DESCRIPTION
# Description

This PR fixes a globbing bug in the `du` command. The problem was that `--exclude` needed to be a `NuGlob` instead of a `String`. A variety of ways were tried to fix this, including spread operators and `into glob` but none of them worked. Here's the [Discord Conversation](https://discord.com/channels/601130461678272522/1214950311207243796/1214950311207243796) that documents the attempts.

### Before
```nushell
❯ du $env.PWD -x crates/**
Error: nu::shell::cant_convert

  × Can't convert to string.
   ╭─[entry #1:1:16]
 1 │ du $env.PWD -x crates/**
   ·                ────┬────
   ·                    ╰── can't convert glob to string
   ╰────
```
### After
```nushell
❯ du $env.PWD -x crates/**
╭─#─┬────path────┬apparent─┬physical─┬───directories───┬files╮
│ 0 │ D:\nushell │ 55.6 MB │ 55.6 MB │ [table 17 rows] │     │
╰───┴────────────┴─────────┴─────────┴─────────────────┴─────╯
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
