### PR TITLE
Remove unused/incorrect input type from `start`

### DIFF
--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -29,7 +29,7 @@ impl Command for Start {
 
     fn signature(&self) -> nu_protocol::Signature {
         Signature::build("start")
-            .input_output_types(vec![(Type::Nothing, Type::Any), (Type::String, Type::Any)])
+            .input_output_types(vec![(Type::Nothing, Type::Any)])
             .required("path", SyntaxShape::String, "Path to open.")
             .category(Category::FileSystem)
     }


### PR DESCRIPTION
As noted in https://github.com/nushell/nushell.github.io/pull/1287, `start` _says_ that it can be piped a string but it does not actually do anything with that string. Fixed.