### PR TITLE
Fix Nu release packages after upgrading to Nu v0.91

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -160,9 +160,9 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
     let archive = $'($dist)/($dest).tar.gz'
 
     mkdir $dest
-    $files | each {|it| mv $it $dest } | ignore
+    $files | each {|it| cp -v $it $dest }
 
-    print $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls $dest
+    print $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls $dest | print
 
     tar -czf $archive $dest
     print $'archive: ---> ($archive)'; ls $archive


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Fix Nu release packages after upgrading to Nu v0.91
`mv` fails here: https://github.com/nushell/nightly/actions/runs/8199461348/job/22424601700 with error:
```console
Error: nu::shell::eval_block_with_input

  × Eval block failed with pipeline input
     ╭─[/home/runner/work/nightly/nightly/.github/workflows/release-pkg.nu:158:18]
 157 │ 
 158 │     let files = (ls | get name)
     ·                  ─┬
     ·                   ╰── source value
 159 │     let dest = if $env.RELEASE_TYPE == 'full' { $'($bin)-($version)-($FULL_NAME)' } else { $'($bin)-($version)-($target)' }
     ╰────

Error:   × cannot move '/home/runner/work/nightly/nightly/output/nu' to a
  │ subdirectory of itself, '/home/runner/work/nightly/nightly/output/nu-
  │ 0.91.1-x86_64-unknown-linux-gnu//home/runner/work/nightly/nightly/output/
  │ nu'
```
Is this a bug of `mv`? At least the `mv` command in 0.90.1 works
