### PR TITLE
Change the ignore command to use drain() instead of collecting a value

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/ignore.rs
+++ b/crates/nu-cmd-lang/src/core_commands/ignore.rs
@@ -32,20 +32,20 @@ impl Command for Ignore {
         &self,
         _engine_state: &EngineState,
         _stack: &mut Stack,
-        call: &Call,
+        _call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        input.into_value(call.head);
+        input.drain()?;
         Ok(PipelineData::empty())
     }
 
     fn run_const(
         &self,
         _working_set: &StateWorkingSet,
-        call: &Call,
+        _call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        input.into_value(call.head);
+        input.drain()?;
         Ok(PipelineData::empty())
     }
 

--- a/crates/nu-command/tests/commands/ignore.rs
+++ b/crates/nu-command/tests/commands/ignore.rs
@@ -1,0 +1,7 @@
+use nu_test_support::nu;
+
+#[test]
+fn ignore_still_causes_stream_to_be_consumed_fully() {
+    let result = nu!("[foo bar] | each { |val| print $val; $val } | ignore");
+    assert_eq!("foobar", result.out);
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -45,6 +45,7 @@ mod hash_;
 mod headers;
 mod help;
 mod histogram;
+mod ignore;
 mod insert;
 mod inspect;
 mod interleave;


### PR DESCRIPTION
# Description

Change the `ignore` command to use `drain()` instead of collecting a value.

This saves memory usage when piping a lot of output to `ignore`. There's no reason to keep the output in memory if it's going to be discarded anyway.

# User-Facing Changes
Probably none

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

