### PR TITLE
Improve the error message for a plugin version mismatch

### DIFF
--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -240,9 +240,9 @@ impl InterfaceManager for PluginInterfaceManager {
                     self.protocol_info = None;
                     Err(ShellError::PluginFailedToLoad {
                         msg: format!(
-                            "Plugin is compiled for nushell version {}, \
+                            "Plugin `{}` is compiled for nushell version {}, \
                                 which is not compatible with version {}",
-                            info.version, local_info.version
+                            self.state.identity.plugin_name, info.version, local_info.version,
                         ),
                     })
                 }
@@ -250,9 +250,11 @@ impl InterfaceManager for PluginInterfaceManager {
             _ if self.protocol_info.is_none() => {
                 // Must send protocol info first
                 Err(ShellError::PluginFailedToLoad {
-                    msg: "Failed to receive initial Hello message. \
-                        This plugin might be too old"
-                        .into(),
+                    msg: format!(
+                        "Failed to receive initial Hello message from `{}`. \
+                            This plugin might be too old",
+                        self.state.identity.plugin_name
+                    ),
                 })
             }
             PluginOutput::Stream(message) => self.consume_stream_message(message),

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -471,8 +471,13 @@ pub fn serve_plugin(plugin: &mut impl StreamingPlugin, encoder: impl PluginEncod
                 // Do our best to report the read error. Most likely there is some kind of
                 // incompatibility between the plugin and nushell, so it makes more sense to try to
                 // report it on stderr than to send something.
+                //
+                // Don't report a `PluginFailedToLoad` error, as it's probably just from Hello
+                // version mismatch which the engine side would also report.
 
-                eprintln!("Plugin `{plugin_name_clone}` read error: {err}");
+                if !matches!(err, ShellError::PluginFailedToLoad { .. }) {
+                    eprintln!("Plugin `{plugin_name_clone}` read error: {err}");
+                }
                 std::process::exit(1);
             }
         })

--- a/crates/nu_plugin_python/nu_plugin_python_example.py
+++ b/crates/nu_plugin_python/nu_plugin_python_example.py
@@ -27,6 +27,9 @@ import sys
 import json
 
 
+NUSHELL_VERSION = "0.91.1"
+
+
 def signatures():
     """
     Multiple signatures can be sent to Nushell. Each signature will be registered
@@ -175,7 +178,7 @@ def tell_nushell_hello():
     hello = {
         "Hello": {
             "protocol": "nu-plugin", # always this value
-            "version": "0.90.2",
+            "version": NUSHELL_VERSION,
             "features": []
         }
     }
@@ -216,7 +219,10 @@ def write_error(id, msg, span=None):
 
 def handle_input(input):
     if "Hello" in input:
-        return
+        if input["Hello"]["version"] != NUSHELL_VERSION:
+            exit(1)
+        else:
+            return
     elif input == "Goodbye":
         return
     elif "Call" in input:


### PR DESCRIPTION
# Description

Previously, the plugin itself would also print error messages about mismatched versions, and there could be many of them while parsing a `register` command which would be hard to follow. This removes that behavior so that the error message is easier to read, and also makes the error message on the engine side mention the plugin name so that it's easier to tell which plugin needs to be updated.

The python plugin has also been modified to make testing this behavior easier. Just change `NUSHELL_VERSION` in the script file to something incompatible.

# User-Facing Changes
- Better error message

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
