### PR TITLE
Fix unused IntoSpanned warning in nu_parser::parse_keywords when 'plugin' feature not enabled

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -13,8 +13,8 @@ use nu_protocol::{
     },
     engine::{StateWorkingSet, DEFAULT_OVERLAY_NAME},
     eval_const::eval_constant,
-    span, Alias, BlockId, DeclId, Exportable, IntoSpanned, Module, ModuleId, ParseError,
-    PositionalArg, ResolvedImportPattern, Span, Spanned, SyntaxShape, Type, Value, VarId,
+    span, Alias, BlockId, DeclId, Exportable, Module, ModuleId, ParseError, PositionalArg,
+    ResolvedImportPattern, Span, Spanned, SyntaxShape, Type, Value, VarId,
 };
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -3546,7 +3546,9 @@ pub fn parse_register(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipe
     use std::sync::Arc;
 
     use nu_plugin::{get_signature, PersistentPlugin, PluginDeclaration};
-    use nu_protocol::{engine::Stack, PluginIdentity, PluginSignature, RegisteredPlugin};
+    use nu_protocol::{
+        engine::Stack, IntoSpanned, PluginIdentity, PluginSignature, RegisteredPlugin,
+    };
 
     let cwd = working_set.get_cwd();
 


### PR DESCRIPTION
# Description

There is a warning about unused `IntoSpanned` currently when running `cargo check -p nu-parser`, introduced accidentally by #12064. This fixes that.

# User-Facing Changes
None

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
