### PR TITLE
Bump `reedline` to dev (and `strum`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,8 +4520,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413a9fa6a5d8c937d3ae1e975bfb6a918bb0b6cdfae6a10416218c837a31b8fc"
+source = "git+https://github.com/nushell/reedline?branch=main#0698712701418a7212ebf75d5724d72eccc4b43f"
 dependencies = [
  "arboard",
  "chrono",
@@ -4533,8 +4532,8 @@ dependencies = [
  "serde",
  "serde_json",
  "strip-ansi-escapes",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.1",
+ "strum_macros 0.26.1",
  "thiserror",
  "unicode-segmentation",
  "unicode-width",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,7 +3103,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "strum 0.25.0",
+ "strum 0.26.1",
  "strum_macros 0.26.1",
  "thiserror",
  "typetag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -35,7 +35,7 @@ plugin = ["serde_json"]
 
 [dev-dependencies]
 serde_json = { workspace = true }
-strum = "0.25"
+strum = "0.26"
 strum_macros = "0.26"
 nu-test-support = { path = "../nu-test-support", version = "0.91.1" }
 rstest = { workspace = true }


### PR DESCRIPTION
Resolve version duplication around `strum(_macros)`

- Pull recent reedline (`strum` update)
- Update `strum` in `nu-protocol`
