### PR TITLE
Sync with the plugin garbage collector when setting config

### DIFF
--- a/crates/nu-plugin/src/plugin/persistent.rs
+++ b/crates/nu-plugin/src/plugin/persistent.rs
@@ -176,6 +176,7 @@ impl RegisteredPlugin for PersistentPlugin {
             if let Some(running) = running.as_ref() {
                 // If the plugin is already running, propagate the config change to the running GC
                 running.gc.set_config(gc_config.clone());
+                running.gc.flush();
             }
         }
     }


### PR DESCRIPTION
# Description
This causes `PersistentPlugin` to wait for the plugin garbage collector to actually receive and process its config when setting it in `set_gc_config`.

The motivation behind doing this is to make setting GC config in scripts more deterministic. Before this change we couldn't really guarantee that the GC could see your config before you started doing other things.

There is a slight cost to performance to doing this - we set config before each plugin call because we don't necessarily know that it reflects what's in `$env.config`, and now to do that we have to synchronize with the GC thread.

This was probably the cause of spuriously failing tests as mentioned by @sholderbach. Hopefully this fixes it. It might be the case that launching threads on some platforms (or just on a really busy test runner) sometimes takes a significant amount of time.

# User-Facing Changes
- possibly slightly worse performance for plugin calls

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
