### PR TITLE
`std config add` for gracefully merging deeply nested options

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -89,6 +89,17 @@ export def --env "path add" [
     }
 }
 
+# TODO: docs pending approval
+export def --env "config add" [path: cell-path value: any]: nothing -> nothing {
+    let value = if ($value | describe) starts-with list {
+        let previous = $env.config | get --ignore-errors $path
+        $previous | default [] | append $value
+    } else {
+        $value
+    }
+    $env.config = ($env.config | upsert $path $value)
+}
+
 # convert an integer amount of nanoseconds to a real duration
 def "from ns" [] {
     [$in "ns"] | str join | into duration


### PR DESCRIPTION
Closes #12148. Will simplify jdx/mise#1763. Request for discussion.

- [x] Local testing
- [ ] Daily driver testing
- [ ] Approval in concept
- [ ] Edge case exploration
- [ ] Tests
- [ ] Docs

<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description (Problem)
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

I updated a couple third party integration scripts with Nushell. mise was notably overwriting my `display_output` hook (original below):
 
```nushell
$env.config = ($env.config | upsert hooks {
  pre_prompt: ($env.config.hooks.pre_prompt ++
    [{
      condition: { "MISE_SHELL" in $env }
      code: { mise_hook }
    }])
  env_change: {
    PWD: ($env.config.hooks.env_change.PWD ++
      [{
        condition: { "MISE_SHELL" in $env }
        code: { mise_hook }
      }])
  }
})
```

Note all the defensive code:

- `upsert` to not overwrite sibling properties
- `$env.config.hooks.pre_prompt ++` to merge hooks lists
- `$env.config.hooks.env_change.PWD ++` same reason

Yet it had the following issues:

- no merging with other hooks besides the 2 defined
- no merging other `env_change` hooks either
- no checking if hooks existed (they're default but not guaranteed)

I found a workaround (basis of this PR) but it feels too clever for other tools to adopt. I've even faced similar issues in my own config. I think basic tasks should be hard to do wrong. This was the problem I wanted to solve in my `merge deep` proposal. But it turns out `merge deep` is verbose and itself slightly error prone.

# User-Facing Changes (Proposal)
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Introduces a new command in the unopened `std` module tentatively named `config add`. It takes inspiration from the underutilized/undocumented `std path add`. Usage:

```console
❯ config add -h
Usage:
  > config add <path> <value>

Flags:
  -h, --help - Display the help message for this command

Parameters:
  path <cell-path>:
  value <any>:

Input/output types:
  ╭───┬─────────┬─────────╮
  │ # │  input  │ output  │
  ├───┼─────────┼─────────┤
  │ 0 │ nothing │ nothing │
  ╰───┴─────────┴─────────╯
```

Example from my `config.nu`:

```nushell
config add show_banner false
config add explore.try.reactive true
config add filesize.metric true
```

Simplification of `mise.nu` example above:

```nushell
# automatic list merging for hook-like options
config add hooks.pre_prompt [{
  condition: { "MISE_SHELL" in $env }
  code: { mise_hook }
}]
config add hooks.env_change.PWD [{
  condition: { "MISE_SHELL" in $env }
  code: { mise_hook }
}]
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Tests pending approval.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Docs pending approval.