### PR TITLE
Bump `iana-time-zone` due to yanked locked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1880,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",


### PR DESCRIPTION
`0.1.59` -> `0.1.60`

e.g. observed in https://github.com/nushell/nushell/actions/runs/8238152611/job/22528639253#step:4:18
