### PR TITLE
Add environment engine calls for plugins

### DIFF
--- a/crates/nu-plugin/src/plugin/interface/engine.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine.rs
@@ -1,7 +1,8 @@
 //! Interface used by the plugin to communicate with the engine.
 
 use std::{
-    collections::{btree_map, BTreeMap},
+    collections::{btree_map, BTreeMap, HashMap},
+    path::Path,
     sync::{mpsc, Arc},
 };
 
@@ -300,6 +301,7 @@ impl InterfaceManager for EngineInterfaceManager {
                 let response = match response {
                     EngineCallResponse::Error(err) => EngineCallResponse::Error(err),
                     EngineCallResponse::Config(config) => EngineCallResponse::Config(config),
+                    EngineCallResponse::ValueMap(map) => EngineCallResponse::ValueMap(map),
                     EngineCallResponse::PipelineData(header) => {
                         // If there's an error with initializing this stream, change it to an engine
                         // call error response, but send it anyway
@@ -454,6 +456,8 @@ impl EngineInterface {
             // These calls have no pipeline data, so they're just the same on both sides
             EngineCall::GetConfig => (EngineCall::GetConfig, Default::default()),
             EngineCall::GetPluginConfig => (EngineCall::GetPluginConfig, Default::default()),
+            EngineCall::GetEnvVar(name) => (EngineCall::GetEnvVar(name), Default::default()),
+            EngineCall::GetEnvVars => (EngineCall::GetEnvVars, Default::default()),
         };
 
         // Register the channel
@@ -495,7 +499,7 @@ impl EngineInterface {
     ///
     /// Format a value in the user's preferred way:
     ///
-    /// ```
+    /// ```rust,no_run
     /// # use nu_protocol::{Value, ShellError};
     /// # use nu_plugin::EngineInterface;
     /// # fn example(engine: &EngineInterface, value: &Value) -> Result<(), ShellError> {
@@ -514,6 +518,23 @@ impl EngineInterface {
         }
     }
 
+    /// Do an engine call returning an `Option<Value>` as either `PipelineData::Empty` or
+    /// `PipelineData::Value`
+    fn engine_call_option_value(
+        &self,
+        engine_call: EngineCall<PipelineData>,
+    ) -> Result<Option<Value>, ShellError> {
+        let name = engine_call.name();
+        match self.engine_call(engine_call)? {
+            EngineCallResponse::PipelineData(PipelineData::Empty) => Ok(None),
+            EngineCallResponse::PipelineData(PipelineData::Value(value, _)) => Ok(Some(value)),
+            EngineCallResponse::Error(err) => Err(err),
+            _ => Err(ShellError::PluginFailedToDecode {
+                msg: format!("Received unexpected response for EngineCall::{name}"),
+            }),
+        }
+    }
+
     /// Get the plugin-specific configuration from the engine. This lives in
     /// `$env.config.plugins.NAME` for a plugin named `NAME`. If the config is set to a closure,
     /// it is automatically evaluated each time.
@@ -522,7 +543,7 @@ impl EngineInterface {
     ///
     /// Print this plugin's config:
     ///
-    /// ```
+    /// ```rust,no_run
     /// # use nu_protocol::{Value, ShellError};
     /// # use nu_plugin::EngineInterface;
     /// # fn example(engine: &EngineInterface, value: &Value) -> Result<(), ShellError> {
@@ -532,12 +553,127 @@ impl EngineInterface {
     /// # }
     /// ```
     pub fn get_plugin_config(&self) -> Result<Option<Value>, ShellError> {
-        match self.engine_call(EngineCall::GetPluginConfig)? {
-            EngineCallResponse::PipelineData(PipelineData::Empty) => Ok(None),
-            EngineCallResponse::PipelineData(PipelineData::Value(value, _)) => Ok(Some(value)),
+        self.engine_call_option_value(EngineCall::GetPluginConfig)
+    }
+
+    /// Get an environment variable from the engine.
+    ///
+    /// Returns `Some(value)` if present, and `None` if not found.
+    ///
+    /// # Example
+    ///
+    /// Get `$env.PATH`:
+    ///
+    /// ```rust,no_run
+    /// # use nu_protocol::{Value, ShellError};
+    /// # use nu_plugin::EngineInterface;
+    /// # fn example(engine: &EngineInterface) -> Result<Option<Value>, ShellError> {
+    /// engine.get_env_var("PATH") // => Ok(Some(Value::List([...])))
+    /// # }
+    /// ```
+    pub fn get_env_var(&self, name: impl Into<String>) -> Result<Option<Value>, ShellError> {
+        self.engine_call_option_value(EngineCall::GetEnvVar(name.into()))
+    }
+
+    /// Get the current working directory from the engine.
+    ///
+    /// This gets the `PWD` environment variable, and returns an error if it isn't valid. The result
+    /// is always an absolute path.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use nu_protocol::{Value, ShellError};
+    /// # use nu_plugin::EngineInterface;
+    /// # fn example(engine: &EngineInterface) -> Result<String, ShellError> {
+    /// engine.get_current_dir() // => "/home/user"
+    /// # }
+    /// ```
+    pub fn get_current_dir(&self) -> Result<String, ShellError> {
+        if let Some(pwd) = self.get_env_var("PWD")? {
+            if let Ok(cwd) = pwd.coerce_string() {
+                if Path::new(&cwd).is_absolute() {
+                    Ok(cwd)
+                } else {
+                    Err(ShellError::GenericError {
+                        error: "Invalid current directory".into(),
+                        msg: format!("The 'PWD' environment variable must be set to an absolute path. Found: '{cwd}'"),
+                        span: Some(pwd.span()),
+                        help: None,
+                        inner: vec![]
+                    })
+                }
+            } else {
+                Err(ShellError::EnvVarNotAString {
+                    envvar_name: "PWD".into(),
+                    span: pwd.span(),
+                })
+            }
+        } else {
+            Err(ShellError::GenericError {
+                error: "Current directory not found".into(),
+                msg: "".into(),
+                span: None,
+                help: Some("The environment variable 'PWD' was not found. It is required to define the current directory.".into()),
+                inner: vec![],
+            })
+        }
+    }
+
+    /// Execute a function within the current working directory of the engine.
+    ///
+    /// This is provided for convenience for plugins that do filesystem operations. The current
+    /// directory of the thread the command is running on will be changed to reflect that of the
+    /// context in the engine during the function, and changed back after the function returns.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use nu_protocol::{Value, ShellError};
+    /// # use nu_plugin::EngineInterface;
+    /// # fn example(engine: &EngineInterface) -> Result<(), ShellError> {
+    /// engine.with_current_dir(|| {
+    ///     eprintln!("{}", std::env::current_dir()?.display());
+    ///     Ok(())
+    /// })
+    /// # }
+    /// ```
+    pub fn with_current_dir<T, E>(&self, fun: impl FnOnce() -> Result<T, E>) -> Result<T, E>
+    where
+        E: From<ShellError>,
+    {
+        let cwd = self.get_current_dir()?;
+        let original_cwd = std::env::current_dir().map_err(ShellError::from)?;
+        std::env::set_current_dir(cwd).map_err(ShellError::from)?;
+        let result = fun();
+        // We always want to set the current directory back, but the result from the function
+        // should take priority
+        let set_back_result = std::env::set_current_dir(original_cwd).map_err(ShellError::from);
+        match (result, set_back_result) {
+            (Err(err), _) => Err(err),
+            (_, Err(err)) => Err(err.into()),
+            (Ok(value), Ok(())) => Ok(value),
+        }
+    }
+
+    /// Get all environment variables from the engine.
+    ///
+    /// Since this is quite a large map that has to be sent, prefer to use [`.get_env_var()`] if
+    /// the variables needed are known ahead of time and there are only a small number needed.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use nu_protocol::{Value, ShellError};
+    /// # use nu_plugin::EngineInterface;
+    /// # use std::collections::HashMap;
+    /// # fn example(engine: &EngineInterface) -> Result<HashMap<String, Value>, ShellError> {
+    /// engine.get_env_vars() // => Ok({"PATH": Value::List([...]), ...})
+    /// # }
+    /// ```
+    pub fn get_env_vars(&self) -> Result<HashMap<String, Value>, ShellError> {
+        match self.engine_call(EngineCall::GetEnvVars)? {
+            EngineCallResponse::ValueMap(map) => Ok(map),
             EngineCallResponse::Error(err) => Err(err),
             _ => Err(ShellError::PluginFailedToDecode {
-                msg: "Received unexpected response for EngineCall::GetConfig".into(),
+                msg: "Received unexpected response type for EngineCall::GetEnvVars".into(),
             }),
         }
     }
@@ -559,7 +695,7 @@ impl EngineInterface {
     /// my_command { seq 1 $in | each { |n| $"Hello, ($n)" } }
     /// ```
     ///
-    /// ```
+    /// ```rust,no_run
     /// # use nu_protocol::{Value, ShellError, PipelineData};
     /// # use nu_plugin::{EngineInterface, EvaluatedCall};
     /// # fn example(engine: &EngineInterface, call: &EvaluatedCall) -> Result<(), ShellError> {
@@ -636,7 +772,7 @@ impl EngineInterface {
     /// my_command { |number| $number + 1}
     /// ```
     ///
-    /// ```
+    /// ```rust,no_run
     /// # use nu_protocol::{Value, ShellError};
     /// # use nu_plugin::{EngineInterface, EvaluatedCall};
     /// # fn example(engine: &EngineInterface, call: &EvaluatedCall) -> Result<(), ShellError> {

--- a/crates/nu-plugin/src/plugin/interface/engine/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine/tests.rs
@@ -1,4 +1,7 @@
-use std::sync::mpsc::{self, TryRecvError};
+use std::{
+    collections::HashMap,
+    sync::mpsc::{self, TryRecvError},
+};
 
 use nu_protocol::{
     engine::Closure, Config, CustomValue, IntoInterruptiblePipelineData, PipelineData,
@@ -880,6 +883,97 @@ fn interface_get_plugin_config() -> Result<(), ShellError> {
 
     let second_config = interface.get_plugin_config()?;
     assert_eq!(Some(Value::test_int(2)), second_config);
+
+    assert!(test.has_unconsumed_write());
+    Ok(())
+}
+
+#[test]
+fn interface_get_env_var() -> Result<(), ShellError> {
+    let test = TestCase::new();
+    let manager = test.engine();
+    let interface = manager.interface_for_context(0);
+
+    start_fake_plugin_call_responder(manager, 2, |id| {
+        if id == 0 {
+            EngineCallResponse::empty()
+        } else {
+            EngineCallResponse::value(Value::test_string("/foo"))
+        }
+    });
+
+    let first_val = interface.get_env_var("FOO")?;
+    assert!(first_val.is_none(), "should be None: {first_val:?}");
+
+    let second_val = interface.get_env_var("FOO")?;
+    assert_eq!(Some(Value::test_string("/foo")), second_val);
+
+    assert!(test.has_unconsumed_write());
+    Ok(())
+}
+
+#[test]
+fn interface_get_current_dir() -> Result<(), ShellError> {
+    let test = TestCase::new();
+    let manager = test.engine();
+    let interface = manager.interface_for_context(0);
+
+    start_fake_plugin_call_responder(manager, 1, |_| {
+        EngineCallResponse::value(Value::test_string("/current/directory"))
+    });
+
+    let val = interface.get_env_var("FOO")?;
+    assert_eq!(Some(Value::test_string("/current/directory")), val);
+
+    assert!(test.has_unconsumed_write());
+    Ok(())
+}
+
+#[test]
+fn interface_with_current_dir() -> Result<(), ShellError> {
+    let test = TestCase::new();
+    let manager = test.engine();
+    let interface = manager.interface_for_context(0);
+
+    // We have to use a real directory for this test.
+    let real_dir = std::env::temp_dir().canonicalize()?;
+    let real_dir_string = real_dir
+        .to_str()
+        .map(|s| s.to_owned())
+        .expect("Can't do test because of invalid UTF-8 in temp directory name");
+
+    start_fake_plugin_call_responder(manager, 1, move |_| {
+        EngineCallResponse::value(Value::test_string(&real_dir_string))
+    });
+
+    interface.with_current_dir(|| {
+        let current_dir = std::env::current_dir()?;
+        assert_eq!(real_dir, current_dir);
+        Ok::<_, ShellError>(())
+    })?;
+
+    assert!(test.has_unconsumed_write());
+    Ok(())
+}
+
+#[test]
+fn interface_get_env_vars() -> Result<(), ShellError> {
+    let test = TestCase::new();
+    let manager = test.engine();
+    let interface = manager.interface_for_context(0);
+
+    let envs: HashMap<String, Value> = [("FOO".to_owned(), Value::test_string("foo"))]
+        .into_iter()
+        .collect();
+    let envs_clone = envs.clone();
+
+    start_fake_plugin_call_responder(manager, 1, move |_| {
+        EngineCallResponse::ValueMap(envs_clone.clone())
+    });
+
+    let received_envs = interface.get_env_vars()?;
+
+    assert_eq!(envs, received_envs);
 
     assert!(test.has_unconsumed_write());
     Ok(())

--- a/crates/nu-plugin/src/plugin/interface/engine/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine/tests.rs
@@ -930,33 +930,6 @@ fn interface_get_current_dir() -> Result<(), ShellError> {
 }
 
 #[test]
-fn interface_with_current_dir() -> Result<(), ShellError> {
-    let test = TestCase::new();
-    let manager = test.engine();
-    let interface = manager.interface_for_context(0);
-
-    // We have to use a real directory for this test.
-    let real_dir = std::env::temp_dir().canonicalize()?;
-    let real_dir_string = real_dir
-        .to_str()
-        .map(|s| s.to_owned())
-        .expect("Can't do test because of invalid UTF-8 in temp directory name");
-
-    start_fake_plugin_call_responder(manager, 1, move |_| {
-        EngineCallResponse::value(Value::test_string(&real_dir_string))
-    });
-
-    interface.with_current_dir(|| {
-        let current_dir = std::env::current_dir()?;
-        assert_eq!(real_dir, current_dir);
-        Ok::<_, ShellError>(())
-    })?;
-
-    assert!(test.has_unconsumed_write());
-    Ok(())
-}
-
-#[test]
 fn interface_get_env_vars() -> Result<(), ShellError> {
     let test = TestCase::new();
     let manager = test.engine();

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -489,6 +489,7 @@ impl InterfaceManager for PluginInterfaceManager {
                     EngineCall::GetPluginConfig => Ok(EngineCall::GetPluginConfig),
                     EngineCall::GetEnvVar(name) => Ok(EngineCall::GetEnvVar(name)),
                     EngineCall::GetEnvVars => Ok(EngineCall::GetEnvVars),
+                    EngineCall::GetCurrentDir => Ok(EngineCall::GetCurrentDir),
                     EngineCall::EvalClosure {
                         closure,
                         mut positional,
@@ -936,6 +937,14 @@ pub(crate) fn handle_engine_call(
         EngineCall::GetEnvVars => {
             let context = require_context()?;
             context.get_env_vars().map(EngineCallResponse::ValueMap)
+        }
+        EngineCall::GetCurrentDir => {
+            let context = require_context()?;
+            let current_dir = context.get_current_dir()?;
+            Ok(EngineCallResponse::value(Value::string(
+                current_dir.item,
+                current_dir.span,
+            )))
         }
         EngineCall::EvalClosure {
             closure,

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -136,6 +136,12 @@ fn create_command(path: &Path, shell: Option<&Path>) -> CommandSys {
     #[cfg(windows)]
     process.creation_flags(windows::Win32::System::Threading::CREATE_NEW_PROCESS_GROUP.0);
 
+    // In order to make bugs with improper use of filesystem without getting the engine current
+    // directory more obvious, the plugin always starts in the directory of its executable
+    if let Some(dirname) = path.parent() {
+        process.current_dir(dirname);
+    }
+
     process
 }
 

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -8,6 +8,8 @@ mod tests;
 #[cfg(test)]
 pub(crate) mod test_util;
 
+use std::collections::HashMap;
+
 pub use evaluated_call::EvaluatedCall;
 use nu_protocol::{
     engine::Closure, Config, PipelineData, PluginSignature, RawStream, ShellError, Span, Spanned,
@@ -385,6 +387,10 @@ pub enum EngineCall<D> {
     GetConfig,
     /// Get the plugin-specific configuration (`$env.config.plugins.NAME`)
     GetPluginConfig,
+    /// Get an environment variable
+    GetEnvVar(String),
+    /// Get all environment variables
+    GetEnvVars,
     /// Evaluate a closure with stream input/output
     EvalClosure {
         /// The closure to call.
@@ -408,6 +414,8 @@ impl<D> EngineCall<D> {
         match self {
             EngineCall::GetConfig => "GetConfig",
             EngineCall::GetPluginConfig => "GetPluginConfig",
+            EngineCall::GetEnvVar(_) => "GetEnv",
+            EngineCall::GetEnvVars => "GetEnvs",
             EngineCall::EvalClosure { .. } => "EvalClosure",
         }
     }
@@ -420,6 +428,7 @@ pub enum EngineCallResponse<D> {
     Error(ShellError),
     PipelineData(D),
     Config(Box<Config>),
+    ValueMap(HashMap<String, Value>),
 }
 
 impl EngineCallResponse<PipelineData> {

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -391,6 +391,8 @@ pub enum EngineCall<D> {
     GetEnvVar(String),
     /// Get all environment variables
     GetEnvVars,
+    /// Get current working directory
+    GetCurrentDir,
     /// Evaluate a closure with stream input/output
     EvalClosure {
         /// The closure to call.
@@ -416,6 +418,7 @@ impl<D> EngineCall<D> {
             EngineCall::GetPluginConfig => "GetPluginConfig",
             EngineCall::GetEnvVar(_) => "GetEnv",
             EngineCall::GetEnvVars => "GetEnvs",
+            EngineCall::GetCurrentDir => "GetCurrentDir",
             EngineCall::EvalClosure { .. } => "EvalClosure",
         }
     }

--- a/crates/nu_plugin_example/src/example.rs
+++ b/crates/nu_plugin_example/src/example.rs
@@ -100,6 +100,25 @@ impl Example {
         })
     }
 
+    pub fn env(
+        &self,
+        engine: &EngineInterface,
+        call: &EvaluatedCall,
+    ) -> Result<Value, LabeledError> {
+        if let Some(name) = call.opt::<String>(0)? {
+            // Get single env var
+            Ok(engine
+                .get_env_var(name)?
+                .unwrap_or(Value::nothing(call.head)))
+        } else {
+            // Get all env vars, converting the map to a record
+            Ok(Value::record(
+                engine.get_env_vars()?.into_iter().collect(),
+                call.head,
+            ))
+        }
+    }
+
     pub fn disable_gc(
         &self,
         engine: &EngineInterface,

--- a/crates/nu_plugin_example/src/example.rs
+++ b/crates/nu_plugin_example/src/example.rs
@@ -105,7 +105,10 @@ impl Example {
         engine: &EngineInterface,
         call: &EvaluatedCall,
     ) -> Result<Value, LabeledError> {
-        if let Some(name) = call.opt::<String>(0)? {
+        if call.has_flag("cwd")? {
+            // Get working directory
+            Ok(Value::string(engine.get_current_dir()?, call.head))
+        } else if let Some(name) = call.opt::<String>(0)? {
             // Get single env var
             Ok(engine
                 .get_env_var(name)?

--- a/crates/nu_plugin_example/src/nu/mod.rs
+++ b/crates/nu_plugin_example/src/nu/mod.rs
@@ -48,6 +48,17 @@ impl Plugin for Example {
                 .category(Category::Experimental)
                 .search_terms(vec!["example".into(), "configuration".into()])
                 .input_output_type(Type::Nothing, Type::Table(vec![])),
+            PluginSignature::build("nu-example-env")
+                .usage("Get environment variable(s)")
+                .extra_usage("Returns all environment variables if no name provided")
+                .category(Category::Experimental)
+                .optional(
+                    "name",
+                    SyntaxShape::String,
+                    "The name of the environment variable to get",
+                )
+                .search_terms(vec!["example".into(), "env".into()])
+                .input_output_type(Type::Nothing, Type::Any),
             PluginSignature::build("nu-example-disable-gc")
                 .usage("Disable the plugin garbage collector for `example`")
                 .extra_usage(
@@ -85,6 +96,7 @@ using `plugin stop example`.",
             "nu-example-2" => self.test2(call, input),
             "nu-example-3" => self.test3(call, input),
             "nu-example-config" => self.config(engine, call),
+            "nu-example-env" => self.env(engine, call),
             "nu-example-disable-gc" => self.disable_gc(engine, call),
             _ => Err(LabeledError {
                 label: "Plugin call with wrong name signature".into(),

--- a/crates/nu_plugin_example/src/nu/mod.rs
+++ b/crates/nu_plugin_example/src/nu/mod.rs
@@ -57,6 +57,7 @@ impl Plugin for Example {
                     SyntaxShape::String,
                     "The name of the environment variable to get",
                 )
+                .switch("cwd", "Get current working directory instead", None)
                 .search_terms(vec!["example".into(), "env".into()])
                 .input_output_type(Type::Nothing, Type::Any),
             PluginSignature::build("nu-example-disable-gc")

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -23,6 +23,7 @@ impl Plugin for GStat {
 
         let repo_path: Option<Spanned<String>> = call.opt(0)?;
         // eprintln!("input value: {:#?}", &input);
-        engine.with_current_dir(|| self.gstat(input, repo_path, call.head))
+        let current_dir = engine.get_current_dir()?;
+        self.gstat(input, &current_dir, repo_path, call.head)
     }
 }

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -13,7 +13,7 @@ impl Plugin for GStat {
     fn run(
         &self,
         name: &str,
-        _engine: &EngineInterface,
+        engine: &EngineInterface,
         call: &EvaluatedCall,
         input: &Value,
     ) -> Result<Value, LabeledError> {
@@ -23,6 +23,6 @@ impl Plugin for GStat {
 
         let repo_path: Option<Spanned<String>> = call.opt(0)?;
         // eprintln!("input value: {:#?}", &input);
-        self.gstat(input, repo_path, call.head)
+        engine.with_current_dir(|| self.gstat(input, repo_path, call.head))
     }
 }

--- a/tests/plugins/env.rs
+++ b/tests/plugins/env.rs
@@ -26,3 +26,19 @@ fn get_envs() {
     assert!(result.status.success());
     assert_eq!("foo", result.out);
 }
+
+#[test]
+fn get_current_dir() {
+    let cwd = std::env::current_dir()
+        .expect("failed to get current dir")
+        .join("tests")
+        .to_string_lossy()
+        .into_owned();
+    let result = nu_with_plugins!(
+        cwd: ".",
+        plugin: ("nu_plugin_example"),
+        "cd tests; nu-example-env --cwd"
+    );
+    assert!(result.status.success());
+    assert_eq!(cwd, result.out);
+}

--- a/tests/plugins/env.rs
+++ b/tests/plugins/env.rs
@@ -1,0 +1,28 @@
+use nu_test_support::nu_with_plugins;
+
+#[test]
+fn get_env_by_name() {
+    let result = nu_with_plugins!(
+        cwd: ".",
+        plugin: ("nu_plugin_example"),
+        r#"
+            $env.FOO = bar
+            nu-example-env FOO | print
+            $env.FOO = baz
+            nu-example-env FOO | print
+        "#
+    );
+    assert!(result.status.success());
+    assert_eq!("barbaz", result.out);
+}
+
+#[test]
+fn get_envs() {
+    let result = nu_with_plugins!(
+        cwd: ".",
+        plugin: ("nu_plugin_example"),
+        "$env.BAZ = foo; nu-example-env | get BAZ"
+    );
+    assert!(result.status.success());
+    assert_eq!("foo", result.out);
+}

--- a/tests/plugins/mod.rs
+++ b/tests/plugins/mod.rs
@@ -1,6 +1,7 @@
 mod config;
 mod core_inc;
 mod custom_values;
+mod env;
 mod formats;
 mod register;
 mod stream;


### PR DESCRIPTION
# Description

This adds three engine calls: `GetEnvVar`, `GetEnvVars`, for getting environment variables from the plugin command context, and `GetCurrentDir` for getting the current working directory.

Plugins are now launched in the directory of their executable to try to make improper use of the current directory without first setting it more obvious. Plugins previously launched in whatever the current directory of the engine was at the time the plugin command was run, but switching to persistent plugins broke this, because they stay in whatever directory they launched in initially.

This also fixes the `gstat` plugin to use `get_current_dir()` to determine its repo location, which was directly affected by this problem.

# User-Facing Changes
- Adds new engine calls (`GetEnvVar`, `GetEnvVars`, `GetCurrentDir`)
- Runs plugins in a different directory from before, in order to catch bugs
- Plugins will have to use the new engine calls if they do filesystem stuff to work properly

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
- [ ] Document the working directory behavior on plugin launch
- [ ] Document the new engine calls + response type (`ValueMap`)
