### PR TITLE
Canonicalize each component of config files

### DIFF
--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -74,8 +74,10 @@ pub fn add_plugin_file(
     } else if let Some(mut plugin_path) = nu_path::config_dir() {
         // Path to store plugins signatures
         plugin_path.push(storage_path);
+        let mut plugin_path = canonicalize_with(&plugin_path, &cwd).unwrap_or(plugin_path);
         plugin_path.push(PLUGIN_FILE);
-        engine_state.plugin_signatures = Some(plugin_path.clone());
+        let plugin_path = canonicalize_with(&plugin_path, &cwd).unwrap_or(plugin_path);
+        engine_state.plugin_signatures = Some(plugin_path);
     }
 }
 

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -54,7 +54,8 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
                 |e| e,
                 |mut path| {
                     path.push("config.nu");
-                    Value::string(path.to_string_lossy(), span)
+                    let canon_config_path = canonicalize_path(&engine_state, &path);
+                    Value::string(canon_config_path.to_string_lossy(), span)
                 },
             )
         },
@@ -70,7 +71,8 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
                 |e| e,
                 |mut path| {
                     path.push("env.nu");
-                    Value::string(path.to_string_lossy(), span)
+                    let canon_env_path = canonicalize_path(&engine_state, &path);
+                    Value::string(canon_env_path.to_string_lossy(), span)
                 },
             )
         },

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -54,7 +54,7 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
                 |e| e,
                 |mut path| {
                     path.push("config.nu");
-                    let canon_config_path = canonicalize_path(&engine_state, &path);
+                    let canon_config_path = canonicalize_path(engine_state, &path);
                     Value::string(canon_config_path.to_string_lossy(), span)
                 },
             )
@@ -71,7 +71,7 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
                 |e| e,
                 |mut path| {
                     path.push("env.nu");
-                    let canon_env_path = canonicalize_path(&engine_state, &path);
+                    let canon_env_path = canonicalize_path(engine_state, &path);
                     Value::string(canon_env_path.to_string_lossy(), span)
                 },
             )

--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -225,8 +225,9 @@ pub(crate) fn set_config_path(
         Some(s) => canonicalize_with(&s.item, cwd).ok(),
         None => nu_path::config_dir().map(|mut p| {
             p.push(NUSHELL_FOLDER);
+            let mut p = canonicalize_with(&p, cwd).unwrap_or(p);
             p.push(default_config_name);
-            p
+            canonicalize_with(&p, cwd).unwrap_or(p)
         }),
     };
 

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -30,7 +30,7 @@ fn setup_fake_config(playground: &mut Playground) -> PathBuf {
     let nushell_real = "nushell_real";
     let nushell_config_dir = Path::new(config_dir).join("nushell").display().to_string();
     playground.mkdir(nushell_real);
-    playground.mkdir(&config_dir);
+    playground.mkdir(config_dir);
     playground.symlink(nushell_real, &nushell_config_dir);
     playground.symlink(config_dir, config_link);
     playground.with_env(

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -218,11 +218,12 @@ fn test_xdg_config_empty() {
         playground.with_env("XDG_CONFIG_HOME", "");
 
         let actual = nu!("$nu.default-config-dir");
+        let expected = dirs_next::config_dir().unwrap().join("nushell");
         assert_eq!(
             actual.out,
-            dirs_next::config_dir()
-                .unwrap()
-                .join("nushell")
+            expected
+                .canonicalize()
+                .unwrap_or(expected)
                 .display()
                 .to_string()
         );
@@ -235,11 +236,12 @@ fn test_xdg_config_bad() {
         playground.with_env("XDG_CONFIG_HOME", r#"mn2''6t\/k*((*&^//k//: "#);
 
         let actual = nu!("$nu.default-config-dir");
+        let expected = dirs_next::config_dir().unwrap().join("nushell");
         assert_eq!(
             actual.out,
-            dirs_next::config_dir()
-                .unwrap()
-                .join("nushell")
+            expected
+                .canonicalize()
+                .unwrap_or(expected)
                 .display()
                 .to_string()
         );

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -1,3 +1,4 @@
+use nu_path::canonicalize_with;
 use nu_test_support::nu;
 use nu_test_support::playground::{Executable, Playground};
 use pretty_assertions::assert_eq;
@@ -20,18 +21,24 @@ fn adjust_canonicalization<P: AsRef<Path>>(p: P) -> String {
     }
 }
 
-/// Make the config directory a symlink that points to a temporary folder.
+/// Make the config directory a symlink that points to a temporary folder, and also makes
+/// the nushell directory inside a symlink.
 /// Returns the path to the `nushell` config folder inside, via the symlink.
 fn setup_fake_config(playground: &mut Playground) -> PathBuf {
-    let config_dir = "config";
+    let config_dir = "config_real";
     let config_link = "config_link";
-    playground.mkdir(&format!("{config_dir}/nushell"));
+    let nushell_real = "nushell_real";
+    let nushell_config_dir = Path::new(config_dir).join("nushell").display().to_string();
+    playground.mkdir(nushell_real);
+    playground.mkdir(&config_dir);
+    playground.symlink(nushell_real, &nushell_config_dir);
     playground.symlink(config_dir, config_link);
     playground.with_env(
         "XDG_CONFIG_HOME",
         &playground.cwd().join(config_link).display().to_string(),
     );
-    playground.cwd().join(config_link).join("nushell")
+    let path = Path::new(config_link).join("nushell");
+    canonicalize_with(&path, playground.cwd()).unwrap_or(path)
 }
 
 fn run(playground: &mut Playground, command: &str) -> String {

--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -221,11 +221,7 @@ fn test_xdg_config_empty() {
         let expected = dirs_next::config_dir().unwrap().join("nushell");
         assert_eq!(
             actual.out,
-            expected
-                .canonicalize()
-                .unwrap_or(expected)
-                .display()
-                .to_string()
+            adjust_canonicalization(expected.canonicalize().unwrap_or(expected))
         );
     });
 }
@@ -239,11 +235,7 @@ fn test_xdg_config_bad() {
         let expected = dirs_next::config_dir().unwrap().join("nushell");
         assert_eq!(
             actual.out,
-            expected
-                .canonicalize()
-                .unwrap_or(expected)
-                .display()
-                .to_string()
+            adjust_canonicalization(expected.canonicalize().unwrap_or(expected))
         );
     });
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Because `std::fs::canonicalize` requires the path to exist, this PR makes it so that when canonicalizing any config file, the `$nu.default-config-dir/nushell` part is canonicalized first, then `$nu.default-config-dir/nushell/foo.nu` is canonicalized.

This should also fix the issue @devyn pointed out [here](https://github.com/nushell/nushell/pull/12118#issuecomment-1989546708) where a couple of the tests failed if one's `~/.config/nushell` folder was actually a symlink to a different folder. The tests previously didn't canonicalize the expected paths.

I was going to make a PR that caches the config directory on startup (as suggested by fdncred and Ian in Discord), but I can make that part of this PR if we want to avoid creating unnecessary PRs. I think it probably makes more sense to separate them though.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
