### PR TITLE
Disable plugin GC tests on macOS

### DIFF
--- a/tests/plugin_persistence/mod.rs
+++ b/tests/plugin_persistence/mod.rs
@@ -193,6 +193,10 @@ fn custom_values_can_still_be_collapsed_after_stop() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "Plugin GC tests are disabled temporarily on macOS because they get stuck"
+)]
 fn plugin_gc_can_be_configured_to_stop_plugins_immediately() {
     // I know the test is to stop "immediately", but if we actually check immediately it could
     // lead to a race condition. So there's a 1ms sleep just to be fair.
@@ -228,6 +232,10 @@ fn plugin_gc_can_be_configured_to_stop_plugins_immediately() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "Plugin GC tests are disabled temporarily on macOS because they get stuck"
+)]
 fn plugin_gc_can_be_configured_to_stop_plugins_after_delay() {
     let out = nu_with_plugins!(
         cwd: ".",
@@ -285,6 +293,10 @@ fn plugin_gc_can_be_configured_to_stop_plugins_after_delay() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "Plugin GC tests are disabled temporarily on macOS because they get stuck"
+)]
 fn plugin_gc_can_be_configured_as_disabled() {
     let out = nu_with_plugins!(
         cwd: ".",
@@ -317,6 +329,10 @@ fn plugin_gc_can_be_configured_as_disabled() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "Plugin GC tests are disabled temporarily on macOS because they get stuck"
+)]
 fn plugin_gc_can_be_disabled_by_plugin() {
     let out = nu_with_plugins!(
         cwd: ".",
@@ -334,6 +350,10 @@ fn plugin_gc_can_be_disabled_by_plugin() {
 }
 
 #[test]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "Plugin GC tests are disabled temporarily on macOS because they get stuck"
+)]
 fn plugin_gc_does_not_stop_plugin_while_stream_output_is_active() {
     let out = nu_with_plugins!(
         cwd: ".",


### PR DESCRIPTION
# Description
These are hanging the CI sometimes, and that's no good. I'll try to figure out how to make these tests pass consistently in the meantime.

# User-Facing Changes
I haven't heard any feedback so far that the plugin GC doesn't actually work on macOS, so hopefully it's not a big problem, but we won't know until I'm able to track down the problem.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
- [ ] Fix the tests so they don't get stuck
