### PR TITLE
Use the system clipboard only for explicit copy/paste operations. Addresses issue 11907

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.30.0"
-source = "git+https://github.com/Tastaturtaste/reedline?branch=bug/759-system-clipboard-not-for-everything#39ba760b782343b6c2b3e30cadca7abaa61c7de3"
+source = "git+https://github.com/nushell/reedline?branch=main#dc7063ea4260b7a74ad055f9c34ed14a70333afe"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4521,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "reedline"
 version = "0.30.0"
-source = "git+https://github.com/nushell/reedline?branch=main#0698712701418a7212ebf75d5724d72eccc4b43f"
+source = "git+https://github.com/Tastaturtaste/reedline?branch=bug/759-system-clipboard-not-for-everything#39ba760b782343b6c2b3e30cadca7abaa61c7de3"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,34 +24,34 @@ pkg-fmt = "zip"
 
 [workspace]
 members = [
-  "crates/nu-cli",
-  "crates/nu-engine",
-  "crates/nu-parser",
-  "crates/nu-system",
-  "crates/nu-cmd-base",
-  "crates/nu-cmd-extra",
-  "crates/nu-cmd-lang",
-  "crates/nu-cmd-dataframe",
-  "crates/nu-command",
-  "crates/nu-color-config",
-  "crates/nu-explore",
-  "crates/nu-json",
-  "crates/nu-lsp",
-  "crates/nu-pretty-hex",
-  "crates/nu-protocol",
-  "crates/nu-plugin",
-  "crates/nu_plugin_inc",
-  "crates/nu_plugin_gstat",
-  "crates/nu_plugin_example",
-  "crates/nu_plugin_stream_example",
-  "crates/nu_plugin_query",
-  "crates/nu_plugin_custom_values",
-  "crates/nu_plugin_formats",
-  "crates/nu-std",
-  "crates/nu-table",
-  "crates/nu-term-grid",
-  "crates/nu-test-support",
-  "crates/nu-utils",
+	"crates/nu-cli",
+	"crates/nu-engine",
+	"crates/nu-parser",
+	"crates/nu-system",
+	"crates/nu-cmd-base",
+	"crates/nu-cmd-extra",
+	"crates/nu-cmd-lang",
+	"crates/nu-cmd-dataframe",
+	"crates/nu-command",
+	"crates/nu-color-config",
+	"crates/nu-explore",
+	"crates/nu-json",
+	"crates/nu-lsp",
+	"crates/nu-pretty-hex",
+	"crates/nu-protocol",
+	"crates/nu-plugin",
+	"crates/nu_plugin_inc",
+	"crates/nu_plugin_gstat",
+	"crates/nu_plugin_example",
+	"crates/nu_plugin_stream_example",
+	"crates/nu_plugin_query",
+	"crates/nu_plugin_custom_values",
+	"crates/nu_plugin_formats",
+	"crates/nu-std",
+	"crates/nu-table",
+	"crates/nu-term-grid",
+	"crates/nu-test-support",
+	"crates/nu-utils",
 ]
 
 [workspace.dependencies]
@@ -80,7 +80,7 @@ nu-cli = { path = "./crates/nu-cli", version = "0.91.1" }
 nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.91.1" }
 nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.91.1" }
 nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.91.1", features = [
-  "dataframe",
+	"dataframe",
 ], optional = true }
 nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.91.1" }
 nu-command = { path = "./crates/nu-command", version = "0.91.1" }
@@ -114,10 +114,10 @@ winresource = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = { workspace = true, default-features = false, features = [
-  "signal",
-  "process",
-  "fs",
-  "term",
+	"signal",
+	"process",
+	"fs",
+	"term",
 ] }
 
 [dev-dependencies]
@@ -132,22 +132,22 @@ tempfile = { workspace = true }
 
 [features]
 plugin = [
-  "nu-plugin",
-  "nu-cli/plugin",
-  "nu-parser/plugin",
-  "nu-command/plugin",
-  "nu-protocol/plugin",
-  "nu-engine/plugin",
+	"nu-plugin",
+	"nu-cli/plugin",
+	"nu-parser/plugin",
+	"nu-command/plugin",
+	"nu-protocol/plugin",
+	"nu-engine/plugin",
 ]
 default = ["default-no-clipboard", "system-clipboard"]
 # Enables convenient omitting of the system-clipboard feature, as it leads to problems in ci on linux
 # See https://github.com/nushell/nushell/pull/11535
 default-no-clipboard = [
-  "plugin",
-  "which-support",
-  "trash-support",
-  "sqlite",
-  "mimalloc",
+	"plugin",
+	"which-support",
+	"trash-support",
+	"sqlite",
+	"mimalloc",
 ]
 stable = ["default"]
 wasi = ["nu-cmd-lang/wasi"]
@@ -158,7 +158,7 @@ wasi = ["nu-cmd-lang/wasi"]
 static-link-openssl = ["dep:openssl", "nu-cmd-lang/static-link-openssl"]
 
 mimalloc = ["nu-cmd-lang/mimalloc", "dep:mimalloc"]
-system-clipboard = ["reedline/system_clipboard"]
+system-clipboard = ["reedline/system_clipboard", "nu-cli/system-clipboard"]
 
 # Stable (Default)
 which-support = ["nu-command/which-support", "nu-cmd-lang/which-support"]
@@ -198,7 +198,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+reedline = { git = "https://github.com/Tastaturtaste/reedline", branch = "bug/759-system-clipboard-not-for-everything" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,34 +24,34 @@ pkg-fmt = "zip"
 
 [workspace]
 members = [
-	"crates/nu-cli",
-	"crates/nu-engine",
-	"crates/nu-parser",
-	"crates/nu-system",
-	"crates/nu-cmd-base",
-	"crates/nu-cmd-extra",
-	"crates/nu-cmd-lang",
-	"crates/nu-cmd-dataframe",
-	"crates/nu-command",
-	"crates/nu-color-config",
-	"crates/nu-explore",
-	"crates/nu-json",
-	"crates/nu-lsp",
-	"crates/nu-pretty-hex",
-	"crates/nu-protocol",
-	"crates/nu-plugin",
-	"crates/nu_plugin_inc",
-	"crates/nu_plugin_gstat",
-	"crates/nu_plugin_example",
-	"crates/nu_plugin_stream_example",
-	"crates/nu_plugin_query",
-	"crates/nu_plugin_custom_values",
-	"crates/nu_plugin_formats",
-	"crates/nu-std",
-	"crates/nu-table",
-	"crates/nu-term-grid",
-	"crates/nu-test-support",
-	"crates/nu-utils",
+  "crates/nu-cli",
+  "crates/nu-engine",
+  "crates/nu-parser",
+  "crates/nu-system",
+  "crates/nu-cmd-base",
+  "crates/nu-cmd-extra",
+  "crates/nu-cmd-lang",
+  "crates/nu-cmd-dataframe",
+  "crates/nu-command",
+  "crates/nu-color-config",
+  "crates/nu-explore",
+  "crates/nu-json",
+  "crates/nu-lsp",
+  "crates/nu-pretty-hex",
+  "crates/nu-protocol",
+  "crates/nu-plugin",
+  "crates/nu_plugin_inc",
+  "crates/nu_plugin_gstat",
+  "crates/nu_plugin_example",
+  "crates/nu_plugin_stream_example",
+  "crates/nu_plugin_query",
+  "crates/nu_plugin_custom_values",
+  "crates/nu_plugin_formats",
+  "crates/nu-std",
+  "crates/nu-table",
+  "crates/nu-term-grid",
+  "crates/nu-test-support",
+  "crates/nu-utils",
 ]
 
 [workspace.dependencies]
@@ -80,7 +80,7 @@ nu-cli = { path = "./crates/nu-cli", version = "0.91.1" }
 nu-cmd-base = { path = "./crates/nu-cmd-base", version = "0.91.1" }
 nu-cmd-lang = { path = "./crates/nu-cmd-lang", version = "0.91.1" }
 nu-cmd-dataframe = { path = "./crates/nu-cmd-dataframe", version = "0.91.1", features = [
-	"dataframe",
+  "dataframe",
 ], optional = true }
 nu-cmd-extra = { path = "./crates/nu-cmd-extra", version = "0.91.1" }
 nu-command = { path = "./crates/nu-command", version = "0.91.1" }
@@ -114,10 +114,10 @@ winresource = "0.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = { workspace = true, default-features = false, features = [
-	"signal",
-	"process",
-	"fs",
-	"term",
+  "signal",
+  "process",
+  "fs",
+  "term",
 ] }
 
 [dev-dependencies]
@@ -132,22 +132,22 @@ tempfile = { workspace = true }
 
 [features]
 plugin = [
-	"nu-plugin",
-	"nu-cli/plugin",
-	"nu-parser/plugin",
-	"nu-command/plugin",
-	"nu-protocol/plugin",
-	"nu-engine/plugin",
+  "nu-plugin",
+  "nu-cli/plugin",
+  "nu-parser/plugin",
+  "nu-command/plugin",
+  "nu-protocol/plugin",
+  "nu-engine/plugin",
 ]
 default = ["default-no-clipboard", "system-clipboard"]
 # Enables convenient omitting of the system-clipboard feature, as it leads to problems in ci on linux
 # See https://github.com/nushell/nushell/pull/11535
 default-no-clipboard = [
-	"plugin",
-	"which-support",
-	"trash-support",
-	"sqlite",
-	"mimalloc",
+  "plugin",
+  "which-support",
+  "trash-support",
+  "sqlite",
+  "mimalloc",
 ]
 stable = ["default"]
 wasi = ["nu-cmd-lang/wasi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/Tastaturtaste/reedline", branch = "bug/759-system-clipboard-not-for-everything" }
+reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -34,7 +34,9 @@ fuzzy-matcher = "0.3"
 is_executable = "1.0"
 log = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
-lscolors = { version = "0.17", default-features = false, features = ["nu-ansi-term"] }
+lscolors = { version = "0.17", default-features = false, features = [
+    "nu-ansi-term",
+] }
 once_cell = { workspace = true }
 percent-encoding = { workspace = true }
 pathdiff = { workspace = true }
@@ -45,3 +47,4 @@ which = { workspace = true }
 
 [features]
 plugin = []
+system-clipboard = ["reedline/system_clipboard"]

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -34,9 +34,7 @@ fuzzy-matcher = "0.3"
 is_executable = "1.0"
 log = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
-lscolors = { version = "0.17", default-features = false, features = [
-    "nu-ansi-term",
-] }
+lscolors = { version = "0.17", default-features = false, features = ["nu-ansi-term"] }
 once_cell = { workspace = true }
 percent-encoding = { workspace = true }
 pathdiff = { workspace = true }

--- a/crates/nu-cli/src/reedline_config.rs
+++ b/crates/nu-cli/src/reedline_config.rs
@@ -1284,7 +1284,14 @@ fn edit_from_record(
         }
         "complete" => EditCommand::Complete,
         "cutselection" => EditCommand::CutSelection,
+        #[cfg(feature = "system-clipboard")]
+        "cutselectionsystem" => EditCommand::CutSelectionSystem,
         "copyselection" => EditCommand::CopySelection,
+        #[cfg(feature = "system-clipboard")]
+        "copyselectionsystem" => EditCommand::CopySelectionSystem,
+        "paste" => EditCommand::Paste,
+        #[cfg(feature = "system-clipboard")]
+        "pastesystem" => EditCommand::PasteSystem,
         "selectall" => EditCommand::SelectAll,
         e => {
             return Err(ShellError::UnsupportedConfigValue {

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -824,6 +824,9 @@ $env.config = {
             mode: emacs
             event: { edit: capitalizechar }
         }
+        # The *_system keybindings require terminal support to pass these
+        # keybindings through to nushell and nushell compiled with the
+        # `system-clipboard` feature
         {
             name: copy_selection_system
             modifier: control_shift

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -825,18 +825,18 @@ $env.config = {
             event: { edit: capitalizechar }
         }
         {
-            name: copy_selection
+            name: copy_selection_system
             modifier: control_shift
             keycode: char_c
             mode: emacs
-            event: { edit: copyselection }
+            event: { edit: copyselectionsystem }
         }
         {
-            name: cut_selection
+            name: cut_selection_system
             modifier: control_shift
             keycode: char_x
             mode: emacs
-            event: { edit: cutselection }
+            event: { edit: cutselectionsystem }
         }
         {
             name: select_all
@@ -846,11 +846,11 @@ $env.config = {
             event: { edit: selectall }
         }
         {
-            name: paste
+            name: paste_system
             modifier: control_shift
             keycode: char_v
             mode: emacs
-            event: { edit: pastecutbufferbefore }
+            event: { edit: pastesystem }
         }
     ]
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
With the introduction of the system clipboard to nushell, many commands changed their behavior from using a local cut buffer to the system clipboard, perhaps surprisingly for many users. (See #11907)
This PR changes most of them back to using the local cut buffer and introduces three commands (`CutSelectionSystem`, `CopySelectionSystem` and `PasteSystem`) to explicitly use the system clipboard.


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Users who in the meantime already used the system clipboard now default back to the local clipboard. To be able to use the system clipboard again they have to append the suffix `system` to their current edit command specified in their keybindings.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
The commands themselves are tested in `reedline`. The changes introduces in nushell are minimal and simply forward from a match on the keybinding name to the command. 
# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
