### PR TITLE
nu-explore/ Use hex-dump for binary data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2988,6 +2988,7 @@ dependencies = [
  "nu-engine",
  "nu-json",
  "nu-parser",
+ "nu-pretty-hex",
  "nu-protocol",
  "nu-table",
  "nu-utils",

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -19,6 +19,7 @@ nu-table = { path = "../nu-table", version = "0.91.1" }
 nu-json = { path = "../nu-json", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 nu-ansi-term = { workspace = true }
+nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.91.1" }
 
 terminal_size = "0.3"
 strip-ansi-escapes = "0.2.0"

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -188,26 +188,27 @@ fn prepare_default_config(config: &mut HashMap<String, Value>) {
         Some(Color::Rgb(29, 31, 33)),
         Some(Color::Rgb(196, 201, 198)),
     );
-
     const INPUT_BAR: Style = color(Some(Color::Rgb(196, 201, 198)), None);
 
     const HIGHLIGHT: Style = color(Some(Color::Black), Some(Color::Yellow));
 
     const STATUS_ERROR: Style = color(Some(Color::White), Some(Color::Red));
-
     const STATUS_INFO: Style = color(None, None);
-
     const STATUS_SUCCESS: Style = color(Some(Color::Black), Some(Color::Green));
-
     const STATUS_WARN: Style = color(None, None);
 
     const TABLE_SPLIT_LINE: Style = color(Some(Color::Rgb(64, 64, 64)), None);
-
     const TABLE_SELECT_CELL: Style = color(None, None);
-
     const TABLE_SELECT_ROW: Style = color(None, None);
-
     const TABLE_SELECT_COLUMN: Style = color(None, None);
+
+    const HEXDUMP_INDEX: Style = color(Some(Color::Cyan), None);
+    const HEXDUMP_SEGMENT: Style = color(Some(Color::Cyan), None).bold();
+    const HEXDUMP_SEGMENT_ZERO: Style = color(Some(Color::Purple), None).bold();
+    const HEXDUMP_SEGMENT_UNKNOWN: Style = color(Some(Color::Green), None).bold();
+    const HEXDUMP_ASCII: Style = color(Some(Color::Cyan), None).bold();
+    const HEXDUMP_ASCII_ZERO: Style = color(Some(Color::Purple), None).bold();
+    const HEXDUMP_ASCII_UNKNOWN: Style = color(Some(Color::Green), None).bold();
 
     insert_style(config, "status_bar_background", STATUS_BAR);
     insert_style(config, "command_bar_text", INPUT_BAR);
@@ -241,6 +242,28 @@ fn prepare_default_config(config: &mut HashMap<String, Value>) {
         insert_style(&mut hm, "selected_column", TABLE_SELECT_COLUMN);
 
         config.insert(String::from("table"), map_into_value(hm));
+    }
+
+    {
+        let mut hm = config
+            .get("hex-dump")
+            .and_then(create_map)
+            .unwrap_or_default();
+
+        insert_style(&mut hm, "color_index", HEXDUMP_INDEX);
+        insert_style(&mut hm, "color_segment", HEXDUMP_SEGMENT);
+        insert_style(&mut hm, "color_segment_zero", HEXDUMP_SEGMENT_ZERO);
+        insert_style(&mut hm, "color_segment_unknown", HEXDUMP_SEGMENT_UNKNOWN);
+        insert_style(&mut hm, "color_ascii", HEXDUMP_ASCII);
+        insert_style(&mut hm, "color_ascii_zero", HEXDUMP_ASCII_ZERO);
+        insert_style(&mut hm, "color_ascii_unknown", HEXDUMP_ASCII_UNKNOWN);
+
+        insert_int(&mut hm, "segment_size", 2);
+        insert_int(&mut hm, "count_segments", 8);
+
+        insert_bool(&mut hm, "split", true);
+
+        config.insert(String::from("hex-dump"), map_into_value(hm));
     }
 }
 
@@ -289,6 +312,14 @@ fn insert_bool(map: &mut HashMap<String, Value>, key: &str, value: bool) {
     }
 
     map.insert(String::from(key), Value::bool(value, Span::unknown()));
+}
+
+fn insert_int(map: &mut HashMap<String, Value>, key: &str, value: i64) {
+    if map.contains_key(key) {
+        return;
+    }
+
+    map.insert(String::from(key), Value::int(value, Span::unknown()));
 }
 
 fn include_nu_config(config: &mut HashMap<String, Value>, style_computer: &StyleComputer) {

--- a/crates/nu-explore/src/lib.rs
+++ b/crates/nu-explore/src/lib.rs
@@ -20,7 +20,7 @@ use nu_protocol::{
 use pager::{Page, Pager};
 use registry::{Command, CommandRegistry};
 use terminal_size::{Height, Width};
-use views::{InformationView, Orientation, Preview, RecordView};
+use views::{InformationView, Orientation, Preview, RecordView, BinaryView};
 
 use pager::{PagerConfig, StyleConfig};
 
@@ -36,11 +36,19 @@ fn run_pager(
     config: PagerConfig,
 ) -> io::Result<Option<Value>> {
     let mut p = Pager::new(config.clone());
+    let commands = create_command_registry();
 
     let is_record = matches!(input, PipelineData::Value(Value::Record { .. }, ..));
-    let (columns, data) = collect_pipeline(input);
+    let is_binary = matches!(input, PipelineData::Value(Value::Binary { .. }, ..));
 
-    let commands = create_command_registry();
+    if is_binary {
+        p.show_message("For help type :help");
+
+        let view = binary_view(input);
+        return p.run(engine_state, stack, ctrlc, view, commands);
+    }
+
+    let (columns, data) = collect_pipeline(input);
 
     let has_no_input = columns.is_empty() && data.is_empty();
     if has_no_input {
@@ -81,6 +89,17 @@ fn create_record_view(
 
 fn information_view() -> Option<Page> {
     Some(Page::new(InformationView, true))
+}
+
+fn binary_view(input: PipelineData) -> Option<Page> {
+    let data = match input {
+        PipelineData::Value(Value::Binary { val, .. }, _) => val,
+        _ => unreachable!("checked beforehand"),
+    };
+
+    let view = BinaryView::new(data);
+
+    Some(Page::new(view, false))
 }
 
 fn create_command_registry() -> CommandRegistry {

--- a/crates/nu-explore/src/lib.rs
+++ b/crates/nu-explore/src/lib.rs
@@ -20,7 +20,7 @@ use nu_protocol::{
 use pager::{Page, Pager};
 use registry::{Command, CommandRegistry};
 use terminal_size::{Height, Width};
-use views::{InformationView, Orientation, Preview, RecordView, BinaryView};
+use views::{BinaryView, InformationView, Orientation, Preview, RecordView};
 
 use pager::{PagerConfig, StyleConfig};
 

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use nu_engine::get_columns;
-use nu_pretty_hex::pretty_hex;
 use nu_protocol::{record, ListStream, PipelineData, PipelineMetadata, RawStream, Value};
 
 use super::NuSpan;
@@ -9,14 +8,7 @@ use super::NuSpan;
 pub fn collect_pipeline(input: PipelineData) -> (Vec<String>, Vec<Vec<Value>>) {
     match input {
         PipelineData::Empty => (vec![], vec![]),
-        PipelineData::Value(value, ..) => match value {
-            Value::Binary { val, internal_span } => {
-                let hex_dump = pretty_hex(&val);
-                let hex_dump = hex_dump.lines().skip(1).collect::<Vec<_>>().join("\n");
-                collect_input(Value::string(hex_dump, internal_span))
-            }
-            value => collect_input(value),
-        },
+        PipelineData::Value(value, ..) => collect_input(value),
         PipelineData::ListStream(stream, ..) => collect_list_stream(stream),
         PipelineData::ExternalStream {
             stdout,

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use nu_engine::get_columns;
+use nu_pretty_hex::pretty_hex;
 use nu_protocol::{record, ListStream, PipelineData, PipelineMetadata, RawStream, Value};
 
 use super::NuSpan;
@@ -8,7 +9,14 @@ use super::NuSpan;
 pub fn collect_pipeline(input: PipelineData) -> (Vec<String>, Vec<Vec<Value>>) {
     match input {
         PipelineData::Empty => (vec![], vec![]),
-        PipelineData::Value(value, ..) => collect_input(value),
+        PipelineData::Value(value, ..) => match value {
+            Value::Binary { val, internal_span } => {
+                let hex_dump = pretty_hex(&val);
+                let hex_dump = hex_dump.lines().skip(1).collect::<Vec<_>>().join("\n");
+                collect_input(Value::string(hex_dump, internal_span))
+            }
+            value => collect_input(value),
+        },
         PipelineData::ListStream(stream, ..) => collect_list_stream(stream),
         PipelineData::ExternalStream {
             stdout,

--- a/crates/nu-explore/src/views/binary/binary_widget.rs
+++ b/crates/nu-explore/src/views/binary/binary_widget.rs
@@ -1,0 +1,717 @@
+use std::{
+    borrow::Cow,
+    cmp::{max, Ordering},
+    fmt::Write,
+};
+
+use nu_color_config::{Alignment, StyleComputer, TextStyle};
+use nu_protocol::Value;
+use nu_table::string_width;
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    text::Span,
+    widgets::{Block, Borders, Paragraph, StatefulWidget, Widget},
+};
+
+use crate::{
+    nu_common::{truncate_str, NuStyle, NuText},
+    views::util::{nu_style_to_tui, text_style_to_tui_style},
+};
+
+use super::Layout;
+
+type OptStyle = Option<NuStyle>;
+
+#[derive(Debug, Clone)]
+pub struct BinaryWidget<'a> {
+    data: &'a [u8],
+    opts: BinarySettings,
+    style: BinaryStyle,
+}
+
+impl<'a> BinaryWidget<'a> {
+    pub fn new(data: &'a [u8], opts: BinarySettings, style: BinaryStyle) -> Self {
+        Self { data, opts, style }
+    }
+
+    pub fn count_lines(&self) -> usize {
+        self.data.len() / self.count_elements()
+    }
+
+    pub fn count_elements(&self) -> usize {
+        self.opts.count_segments * self.opts.segment_size
+    }
+
+    pub fn set_index_offset(&mut self, offset: usize) {
+        self.opts.index_offset = offset;
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BinarySettings {
+    disable_index: bool,
+    disable_ascii: bool,
+    disable_data: bool,
+    segment_size: usize,
+    count_segments: usize,
+    index_offset: usize,
+}
+
+impl BinarySettings {
+    pub fn new(
+        disable_index: bool,
+        disable_ascii: bool,
+        disable_data: bool,
+        segment_size: usize,
+        count_segments: usize,
+        index_offset: usize,
+    ) -> Self {
+        Self {
+            disable_index,
+            disable_ascii,
+            disable_data,
+            segment_size,
+            count_segments,
+            index_offset,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BinaryStyle {
+    colors: BinaryStyleColors,
+    indent_index: Indent,
+    indent_data: Indent,
+    indent_ascii: Indent,
+    indent_segment: usize,
+    show_split: bool,
+}
+
+impl BinaryStyle {
+    pub fn new(
+        colors: BinaryStyleColors,
+        indent_index: Indent,
+        indent_data: Indent,
+        indent_ascii: Indent,
+        indent_segment: usize,
+        show_split: bool,
+    ) -> Self {
+        Self {
+            colors,
+            indent_index,
+            indent_data,
+            indent_ascii,
+            indent_segment,
+            show_split,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Indent {
+    left: u16,
+    right: u16,
+}
+
+impl Indent {
+    pub fn new(left: u16, right: u16) -> Self {
+        Self { left, right }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct BinaryStyleColors {
+    pub split_left: OptStyle,
+    pub split_right: OptStyle,
+    pub index: OptStyle,
+    pub data: OptStyle,
+    pub data_zero: OptStyle,
+    pub data_unknown: OptStyle,
+    pub ascii: OptStyle,
+    pub ascii_zero: OptStyle,
+    pub ascii_unknown: OptStyle,
+}
+
+impl BinaryStyleColors {
+    pub fn new(
+        split_left: OptStyle,
+        split_right: OptStyle,
+        index: OptStyle,
+        data: OptStyle,
+        data_zero: OptStyle,
+        data_unknown: OptStyle,
+        ascii: OptStyle,
+        ascii_zero: OptStyle,
+        ascii_unknown: OptStyle,
+    ) -> Self {
+        Self {
+            split_left,
+            split_right,
+            index,
+            data,
+            data_zero,
+            data_unknown,
+            ascii,
+            ascii_zero,
+            ascii_unknown,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct BinaryWidgetState {
+    pub layout_index: Layout,
+    pub layout_data: Layout,
+    pub layout_ascii: Layout,
+}
+
+impl StatefulWidget for BinaryWidget<'_> {
+    type State = BinaryWidgetState;
+
+    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        let min_width = get_widget_width(&self);
+
+        if (area.width as usize) < min_width {
+            return;
+        }
+
+        if self.opts.disable_index && self.opts.disable_data && self.opts.disable_ascii {
+            return;
+        }
+
+        render_hexdump(area, buf, state, self);
+    }
+}
+
+// todo: indent color
+fn render_hexdump(area: Rect, buf: &mut Buffer, state: &mut BinaryWidgetState, w: BinaryWidget) {
+    const MIN_INDEX_SIZE: usize = 8;
+
+    let show_index = !w.opts.disable_index;
+    let show_data = !w.opts.disable_data;
+    let show_ascii = !w.opts.disable_ascii;
+    let show_split = w.style.show_split;
+
+    let index_width = get_max_index_size(&w).max(MIN_INDEX_SIZE) as u16; // safe as it's checked before hand that we have enough space
+
+    let mut last_line = None;
+
+    for line in 0..area.height {
+        let data_line_length = w.opts.count_segments * w.opts.segment_size;
+        let start_index = line as usize * data_line_length;
+        let address = w.opts.index_offset + start_index;
+
+        if start_index > w.data.len() {
+            last_line = Some(line);
+            break;
+        }
+
+        let mut x = 0;
+        let y = line;
+        let line = &w.data[start_index..];
+
+        if show_index {
+            x += render_space(buf, x, y, 1, w.style.indent_index.left);
+            x += render_hex_usize(buf, x, y, address, index_width, false, get_index_style(&w));
+            x += render_space(buf, x, y, 1, w.style.indent_index.right);
+        }
+
+        if show_split {
+            x += render_split(buf, x, y);
+        }
+
+        if show_data {
+            x += render_space(buf, x, y, 1, w.style.indent_data.left);
+            x += render_data_line(buf, x, y, line, &w);
+            x += render_space(buf, x, y, 1, w.style.indent_data.right);
+        }
+
+        if show_split {
+            x += render_split(buf, x, y);
+        }
+
+        if show_ascii {
+            x += render_space(buf, x, y, 1, w.style.indent_ascii.left);
+            x += render_ascii_line(buf, x, y, line, &w);
+            render_space(buf, x, y, 1, w.style.indent_ascii.right);
+        }
+    }
+
+    let data_line_size = (w.opts.count_segments * (w.opts.segment_size * 2)
+        + w.opts.count_segments.saturating_sub(1)) as u16;
+    let ascii_line_size = (w.opts.count_segments * w.opts.segment_size) as u16;
+
+    if let Some(last_line) = last_line {
+        for line in last_line..area.height {
+            let data_line_length = w.opts.count_segments * w.opts.segment_size;
+            let start_index = line as usize * data_line_length;
+            let address = w.opts.index_offset + start_index;
+
+            let mut x = 0;
+            let y = line;
+
+            if show_index {
+                x += render_space(buf, x, y, 1, w.style.indent_index.left);
+                x += render_hex_usize(buf, x, y, address, index_width, false, get_index_style(&w));
+                x += render_space(buf, x, y, 1, w.style.indent_index.right);
+            }
+
+            if show_split {
+                x += render_split(buf, x, y);
+            }
+
+            if show_data {
+                x += render_space(buf, x, y, 1, w.style.indent_data.left);
+                x += render_space(buf, x, y, 1, data_line_size);
+                x += render_space(buf, x, y, 1, w.style.indent_data.right);
+            }
+
+            if show_split {
+                x += render_split(buf, x, y);
+            }
+
+            if show_ascii {
+                x += render_space(buf, x, y, 1, w.style.indent_ascii.left);
+                x += render_space(buf, x, y, 1, ascii_line_size);
+                render_space(buf, x, y, 1, w.style.indent_ascii.right);
+            }
+        }
+    }
+}
+
+fn render_data_line(buf: &mut Buffer, x: u16, y: u16, line: &[u8], w: &BinaryWidget) -> u16 {
+    let mut size = 0;
+    let mut count = 0;
+    let count_max = w.opts.count_segments;
+    let segment_size = w.opts.segment_size;
+
+    size += render_segment(buf, x, y, line, w);
+    count += 1;
+
+    while count != count_max && count * segment_size < line.len() {
+        let data = &line[count * segment_size..];
+        size += render_space(buf, x + size, y, 1, w.style.indent_segment as u16);
+        size += render_segment(buf, x + size, y, data, w);
+        count += 1;
+    }
+
+    while count != count_max {
+        size += render_space(buf, x + size, y, 1, w.style.indent_segment as u16);
+        size += render_space(buf, x + size, y, 1, w.opts.segment_size as u16 * 2);
+        count += 1;
+    }
+
+    size
+}
+
+fn render_segment(buf: &mut Buffer, x: u16, y: u16, line: &[u8], w: &BinaryWidget) -> u16 {
+    let mut count = w.opts.segment_size;
+    let mut size = 0;
+
+    for &n in line {
+        if count == 0 {
+            break;
+        }
+
+        size += render_hex_u8(buf, x + size, y, n, false, get_segment_style(w, n));
+        count -= 1;
+    }
+
+    if count > 0 {
+        size += render_space(buf, x + size, y, 1, (count * 2) as u16);
+    }
+
+    size
+}
+
+fn render_ascii_line(buf: &mut Buffer, x: u16, y: u16, line: &[u8], w: &BinaryWidget) -> u16 {
+    let mut size = 0;
+    let mut count = 0;
+    let length = w.count_elements();
+
+    for &n in line {
+        if count == length {
+            break;
+        }
+
+        size += render_ascii_u8(buf, x + size, y, n, get_ascii_style(w, n));
+        count += 1;
+    }
+
+    if count < length {
+        size += render_space(buf, x + size, y, 1, (length - count) as u16);
+    }
+
+    size
+}
+
+fn render_ascii_u8(buf: &mut Buffer, x: u16, y: u16, n: u8, style: OptStyle) -> u16 {
+    let c = u8_to_ascii(n);
+    let text = c.to_string();
+
+    let mut p = Paragraph::new(text);
+    if let Some(style) = style {
+        let style = nu_style_to_tui(style);
+        p = p.style(style);
+    }
+
+    let area = Rect::new(x, y, 1, 1);
+
+    p.render(area, buf);
+
+    1
+}
+
+fn u8_to_ascii(n: u8) -> char {
+    if n == b' ' {
+        '.'
+    } else if n.is_ascii() {
+        n as char
+    } else {
+        ' '
+    }
+}
+
+fn render_hex_u8(buf: &mut Buffer, x: u16, y: u16, n: u8, big: bool, style: OptStyle) -> u16 {
+    render_hex_usize(buf, x, y, n as usize, 2, big, style)
+}
+
+fn render_hex_usize(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    n: usize,
+    width: u16,
+    big: bool,
+    style: OptStyle,
+) -> u16 {
+    let text = usize_to_hex(n, width as usize, big);
+    let mut p = Paragraph::new(text);
+    if let Some(style) = style {
+        let style = nu_style_to_tui(style);
+        p = p.style(style);
+    }
+
+    let area = Rect::new(x, y, width, 1);
+
+    p.render(area, buf);
+
+    width
+}
+
+fn get_ascii_style(w: &BinaryWidget, n: u8) -> OptStyle {
+    if n == 0 {
+        w.style.colors.ascii_zero
+    } else if n.is_ascii() {
+        w.style.colors.ascii
+    } else {
+        w.style.colors.ascii_unknown
+    }
+}
+
+fn get_segment_style(w: &BinaryWidget, n: u8) -> OptStyle {
+    if n == 0 {
+        w.style.colors.data_zero
+    } else if n.is_ascii() {
+        w.style.colors.data
+    } else {
+        w.style.colors.data_unknown
+    }
+}
+
+fn get_index_style(w: &BinaryWidget) -> OptStyle {
+    w.style.colors.index
+}
+
+#[allow(clippy::too_many_arguments)]
+fn truncate_column_width(
+    space: u16,
+    min: u16,
+    w: u16,
+    pad: u16,
+    is_last: bool,
+    column: &mut [(String, TextStyle)],
+    head: Option<&mut String>,
+) -> (u16, bool, bool) {
+    let result = check_column_width(space, min, w, pad, is_last);
+
+    let (width, shift_column) = match result {
+        Some(result) => result,
+        None => return (w, true, false),
+    };
+
+    if width == 0 {
+        return (0, false, shift_column);
+    }
+
+    truncate_list(column, width as usize);
+    if let Some(head) = head {
+        truncate_str(head, width as usize);
+    }
+
+    (width, false, shift_column)
+}
+
+fn check_column_width(
+    space: u16,
+    min: u16,
+    w: u16,
+    pad: u16,
+    is_last: bool,
+) -> Option<(u16, bool)> {
+    if !is_space_available(space, pad) {
+        return Some((0, false));
+    }
+
+    if is_last {
+        if !is_space_available(space, w + pad) {
+            return Some((space - pad, false));
+        } else {
+            return None;
+        }
+    }
+
+    if !is_space_available(space, min + pad) {
+        return Some((0, false));
+    }
+
+    if !is_space_available(space, w + pad + min + pad) {
+        let left_space = space - (min + pad);
+
+        if left_space > pad {
+            let left = left_space - pad;
+            return Some((left, true));
+        } else {
+            return Some((0, true));
+        }
+    }
+
+    None
+}
+
+fn render_header_borders(buf: &mut Buffer, area: Rect, span: u16, style: NuStyle) -> (u16, u16) {
+    let borders = Borders::TOP | Borders::BOTTOM;
+    let block = Block::default()
+        .borders(borders)
+        .border_style(nu_style_to_tui(style));
+    let height = span + 2;
+    let area = Rect::new(area.x, area.y, area.width, height);
+    block.render(area, buf);
+
+    // y pos of header text and next line
+    (height.saturating_sub(2), height)
+}
+
+fn render_vertical(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    height: u16,
+    top_slit: bool,
+    bottom_slit: bool,
+    style: NuStyle,
+) -> u16 {
+    render_vertical_split(buf, x, y, height, style);
+
+    if top_slit && y > 0 {
+        render_top_connector(buf, x, y - 1, style);
+    }
+
+    if bottom_slit {
+        render_bottom_connector(buf, x, y + height, style);
+    }
+
+    1
+}
+
+fn render_vertical_split(buf: &mut Buffer, x: u16, y: u16, height: u16, style: NuStyle) {
+    let style = TextStyle {
+        alignment: Alignment::Left,
+        color_style: Some(style),
+    };
+
+    repeat_vertical(buf, x, y, 1, height, '│', style);
+}
+
+fn render_space(buf: &mut Buffer, x: u16, y: u16, height: u16, padding: u16) -> u16 {
+    repeat_vertical(buf, x, y, padding, height, ' ', TextStyle::default());
+    padding
+}
+
+fn render_split(buf: &mut Buffer, x: u16, y: u16) -> u16 {
+    repeat_vertical(buf, x, y, 1, 1, '│', TextStyle::default());
+    1
+}
+
+fn create_column(data: &[Vec<NuText>], col: usize) -> Vec<NuText> {
+    let mut column = vec![NuText::default(); data.len()];
+    for (row, values) in data.iter().enumerate() {
+        if values.is_empty() {
+            debug_assert!(false, "must never happen?");
+            continue;
+        }
+
+        let value = &values[col];
+
+        let text = value.0.replace('\n', " ");
+
+        column[row] = (text, value.1);
+    }
+
+    column
+}
+
+fn repeat_vertical(
+    buf: &mut Buffer,
+    x_offset: u16,
+    y_offset: u16,
+    width: u16,
+    height: u16,
+    c: char,
+    style: TextStyle,
+) {
+    let text = std::iter::repeat(c)
+        .take(width as usize)
+        .collect::<String>();
+    let style = text_style_to_tui_style(style);
+    let span = Span::styled(text, style);
+
+    for row in 0..height {
+        buf.set_span(x_offset, y_offset + row, &span, width);
+    }
+}
+
+fn is_space_available(available: u16, got: u16) -> bool {
+    match available.cmp(&got) {
+        Ordering::Less => false,
+        Ordering::Equal | Ordering::Greater => true,
+    }
+}
+
+fn truncate_list(list: &mut [NuText], width: usize) {
+    for (text, _) in list {
+        truncate_str(text, width);
+    }
+}
+
+fn render_shift_column(buf: &mut Buffer, x: u16, y: u16, height: u16, style: NuStyle) -> u16 {
+    let style = TextStyle {
+        alignment: Alignment::Left,
+        color_style: Some(style),
+    };
+
+    repeat_vertical(buf, x, y, 1, height, '…', style);
+
+    1
+}
+
+fn render_top_connector(buf: &mut Buffer, x: u16, y: u16, style: NuStyle) {
+    let style = nu_style_to_tui(style);
+    let span = Span::styled("┬", style);
+    buf.set_span(x, y, &span, 1);
+}
+
+fn render_bottom_connector(buf: &mut Buffer, x: u16, y: u16, style: NuStyle) {
+    let style = nu_style_to_tui(style);
+    let span = Span::styled("┴", style);
+    buf.set_span(x, y, &span, 1);
+}
+
+fn calculate_column_width(column: &[NuText]) -> usize {
+    column
+        .iter()
+        .map(|(text, _)| text)
+        .map(|text| string_width(text))
+        .max()
+        .unwrap_or(0)
+}
+
+fn render_column(buf: &mut Buffer, x: u16, y: u16, available_width: u16, rows: &[NuText]) -> u16 {
+    for (row, (text, style)) in rows.iter().enumerate() {
+        let style = text_style_to_tui_style(*style);
+        let text = strip_string(text);
+        let span = Span::styled(text, style);
+        buf.set_span(x, y + row as u16, &span, available_width);
+    }
+
+    available_width
+}
+
+fn strip_string(text: &str) -> String {
+    String::from_utf8(strip_ansi_escapes::strip(text))
+        .map_err(|_| ())
+        .unwrap_or_else(|_| text.to_owned())
+}
+
+fn get_max_index_size(w: &BinaryWidget) -> usize {
+    let line_size = w.opts.count_segments * (w.opts.segment_size * 2);
+    let count_lines = w.data.len() / line_size;
+    let max_index = w.opts.index_offset + count_lines * line_size;
+    usize_to_hex(max_index, 0, false).len()
+}
+
+fn get_count_lines(w: &BinaryWidget) -> usize {
+    let line_size = w.opts.count_segments * (w.opts.segment_size * 2);
+    w.data.len() / line_size
+}
+
+fn get_widget_width(w: &BinaryWidget) -> usize {
+    const MIN_INDEX_SIZE: usize = 8;
+
+    let line_size = w.opts.count_segments * (w.opts.segment_size * 2);
+    let count_lines = w.data.len() / line_size;
+
+    let max_index = w.opts.index_offset + count_lines * line_size;
+    let index_size = usize_to_hex(max_index, 0, false).len();
+    let index_size = index_size.max(MIN_INDEX_SIZE);
+
+    let data_split_size = w.opts.count_segments.saturating_sub(1) * w.style.indent_segment;
+    let data_size = line_size + data_split_size;
+
+    let ascii_size = w.opts.count_segments * w.opts.segment_size;
+
+    let split = w.style.show_split as usize;
+    #[allow(clippy::identity_op)]
+    let min_width = 0
+        + w.style.indent_index.left as usize
+        + index_size
+        + w.style.indent_index.right as usize
+        + split
+        + w.style.indent_data.left as usize
+        + data_size
+        + w.style.indent_data.right as usize
+        + split
+        + w.style.indent_ascii.left as usize
+        + ascii_size
+        + w.style.indent_ascii.right as usize;
+
+    min_width
+}
+
+fn usize_to_hex(n: usize, width: usize, big: bool) -> String {
+    if width == 0 {
+        match big {
+            true => format!("{:X}", n),
+            false => format!("{:x}", n),
+        }
+    } else {
+        match big {
+            true => format!("{:0>width$X}", n, width = width),
+            false => format!("{:0>width$x}", n, width = width),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::views::binary::binary_widget::usize_to_hex;
+
+    #[test]
+    fn test_to_hex() {
+        assert_eq!(usize_to_hex(1, 2, false), "01");
+        assert_eq!(usize_to_hex(16, 2, false), "10");
+        assert_eq!(usize_to_hex(29, 2, false), "1d");
+        assert_eq!(usize_to_hex(29, 2, true), "1D");
+    }
+}

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -277,7 +277,7 @@ fn report_row_position(cursor: XYCursor) -> String {
         return String::from("Top");
     }
 
-    // todo: there's some bug in XYCursor; when we hit PgDOWN/UP and general move it excedes the limit
+    // todo: there's some bug in XYCursor; when we hit PgDOWN/UP and general move it exceeds the limit
     //       not sure when it was introduced and if present in original view.
     //       but it just requires a refactoring as these method names are just ..... not perfect.
     let row = cursor.row().min(cursor.row_limit());

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -1,0 +1,745 @@
+mod binary_widget;
+
+use std::borrow::Cow;
+
+use std::collections::HashMap;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use nu_color_config::{get_color_map, StyleComputer};
+use nu_protocol::{
+    engine::{EngineState, Stack},
+    Record, Value,
+};
+use ratatui::{layout::Rect, widgets::Block};
+
+use crate::{
+    nu_common::{collect_input, lscolorize, NuConfig, NuSpan, NuStyle, NuText},
+    pager::{
+        report::{Report, Severity},
+        ConfigMap, Frame, Transition, ViewInfo,
+    },
+    util::create_map,
+    views::ElementInfo,
+};
+
+use self::binary_widget::{
+    BinarySettings, BinaryStyle, BinaryStyleColors, BinaryWidget, BinaryWidgetState, Indent,
+};
+
+use super::{
+    cursor::XYCursor,
+    util::{make_styled_string, nu_style_to_tui},
+    Layout, RecordView, View, ViewConfig,
+};
+
+#[derive(Debug, Clone)]
+pub struct BinaryView {
+    data: Vec<u8>,
+    mode: Option<CursorMode>,
+    cursor: XYCursor,
+    settings: Settings,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CursorMode {
+    Index,
+    Data,
+    ASCII,
+}
+
+#[derive(Debug, Default, Clone)]
+struct Settings {
+    opts: BinarySettings,
+    style: BinaryStyle,
+}
+
+impl BinaryView {
+    pub fn new(data: Vec<u8>) -> Self {
+        Self {
+            data,
+            mode: None,
+            cursor: XYCursor::default(),
+            settings: Settings::default(),
+        }
+    }
+}
+
+impl View for BinaryView {
+    fn draw(&mut self, f: &mut Frame, area: Rect, cfg: ViewConfig<'_>, layout: &mut Layout) {
+        let mut state = BinaryWidgetState::default();
+        let widget = create_binary_widget(self);
+        f.render_stateful_widget(widget, area, &mut state);
+
+        // *layout = table_layout.layout;
+
+        // self.update_cursors(table_layout.count_rows, table_layout.count_columns);
+
+        // if self.mode == UIMode::Cursor {
+        //     let (row, column) = self.get_current_window();
+        //     let info = get_element_info(
+        //         layout,
+        //         row,
+        //         column,
+        //         table_layout.count_rows,
+        //         self.get_layer_last().orientation,
+        //         self.theme.table.show_header,
+        //     );
+
+        //     if let Some(info) = info {
+        //         highlight_cell(f, area, info.clone(), &self.theme.cursor);
+        //     }
+        // }
+    }
+
+    fn handle_input(
+        &mut self,
+        _: &EngineState,
+        _: &mut Stack,
+        _: &Layout,
+        info: &mut ViewInfo,
+        key: KeyEvent,
+    ) -> Option<Transition> {
+        let result = handle_event_view_mode(self, &key);
+
+        if matches!(&result, Some(Transition::Ok)) {
+            let report = create_report(self.mode, self.cursor);
+            info.status = Some(report);
+        }
+
+        None
+    }
+
+    fn collect_data(&self) -> Vec<NuText> {
+        // // Create a "dummy" style_computer.
+        // let dummy_engine_state = EngineState::new();
+        // let dummy_stack = Stack::new();
+        // let style_computer = StyleComputer::new(&dummy_engine_state, &dummy_stack, HashMap::new());
+
+        // let data = convert_records_to_string(
+        //     &self.get_layer_last().records,
+        //     &NuConfig::default(),
+        //     &style_computer,
+        // );
+
+        // data.iter().flatten().cloned().collect()
+
+        vec![]
+    }
+
+    fn show_data(&mut self, pos: usize) -> bool {
+        // let data = &self.get_layer_last().records;
+
+        // let mut i = 0;
+        // for (row, cells) in data.iter().enumerate() {
+        //     if pos > i + cells.len() {
+        //         i += cells.len();
+        //         continue;
+        //     }
+
+        //     for (column, _) in cells.iter().enumerate() {
+        //         if i == pos {
+        //             self.get_layer_last_mut().cursor.set_position(row, column);
+        //             return true;
+        //         }
+
+        //         i += 1;
+        //     }
+        // }
+
+        // false
+
+        false
+    }
+
+    fn exit(&mut self) -> Option<Value> {
+        // todo: impl Cursor + peek of a value
+        //      do we need to be able to move cursor on address/ascii symbol? (I guess 3 cursor modes one for section?)
+        //
+        None
+    }
+
+    fn setup(&mut self, cfg: ViewConfig<'_>) {
+        let hm = match cfg.config.get("hex-dump").and_then(create_map) {
+            Some(hm) => hm,
+            None => return,
+        };
+
+        self.settings = settings_from_config(&hm);
+
+        let count_rows =
+            BinaryWidget::new(&self.data, self.settings.opts, Default::default()).count_lines();
+        self.cursor = XYCursor::new(count_rows, 0);
+    }
+}
+
+fn create_binary_widget(v: &BinaryView) -> BinaryWidget<'_> {
+    let start_line = v.cursor.row_starts_at();
+    let count_elements =
+        BinaryWidget::new(&[], v.settings.opts, Default::default()).count_elements();
+    let index = start_line * count_elements;
+    let data = &v.data[index..];
+
+    // println!("{:?} {:?}", v.cursor.row(), v.cursor.row_starts_at());
+
+    let mut w = BinaryWidget::new(data, v.settings.opts, v.settings.style.clone());
+    w.set_index_offset(index);
+
+    w
+}
+
+// fn get_element_info(
+//     layout: &mut Layout,
+//     row: usize,
+//     column: usize,
+//     count_rows: usize,
+//     orientation: Orientation,
+//     with_head: bool,
+// ) -> Option<&ElementInfo> {
+//     let with_head = with_head as usize;
+//     let index = match orientation {
+//         Orientation::Top => column * (count_rows + with_head) + row + 1,
+//         Orientation::Left => (column + with_head) * count_rows + row,
+//     };
+
+//     layout.data.get(index)
+// }
+
+// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+// enum UIMode {
+//     Cursor,
+//     View,
+// }
+
+// #[derive(Debug, Clone)]
+// pub struct RecordLayer<'a> {
+//     columns: Cow<'a, [String]>,
+//     records: Cow<'a, [Vec<Value>]>,
+//     orientation: Orientation,
+//     name: Option<String>,
+//     was_transposed: bool,
+//     cursor: XYCursor,
+// }
+
+// impl<'a> RecordLayer<'a> {
+//     fn new(
+//         columns: impl Into<Cow<'a, [String]>>,
+//         records: impl Into<Cow<'a, [Vec<Value>]>>,
+//     ) -> Self {
+//         let columns = columns.into();
+//         let records = records.into();
+//         let cursor = XYCursor::new(records.len(), columns.len());
+
+//         Self {
+//             columns,
+//             records,
+//             cursor,
+//             orientation: Orientation::Top,
+//             name: None,
+//             was_transposed: false,
+//         }
+//     }
+
+//     fn set_name(&mut self, name: impl Into<String>) {
+//         self.name = Some(name.into());
+//     }
+
+//     fn count_rows(&self) -> usize {
+//         match self.orientation {
+//             Orientation::Top => self.records.len(),
+//             Orientation::Left => self.columns.len(),
+//         }
+//     }
+
+//     fn count_columns(&self) -> usize {
+//         match self.orientation {
+//             Orientation::Top => self.columns.len(),
+//             Orientation::Left => self.records.len(),
+//         }
+//     }
+
+//     fn get_column_header(&self) -> Option<String> {
+//         let col = self.cursor.column();
+//         self.columns.get(col).map(|header| header.to_string())
+//     }
+
+//     fn reset_cursor(&mut self) {
+//         self.cursor = XYCursor::new(self.count_rows(), self.count_columns());
+//     }
+// }
+
+fn handle_event_view_mode(view: &mut BinaryView, key: &KeyEvent) -> Option<Transition> {
+    match key {
+        KeyEvent {
+            code: KeyCode::Char('u'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::PageUp,
+            ..
+        } => {
+            view.cursor.prev_row_page();
+
+            return Some(Transition::Ok);
+        }
+        KeyEvent {
+            code: KeyCode::Char('d'),
+            modifiers: KeyModifiers::CONTROL,
+            ..
+        }
+        | KeyEvent {
+            code: KeyCode::PageDown,
+            ..
+        } => {
+            view.cursor.next_row_page();
+
+            return Some(Transition::Ok);
+        }
+        _ => {}
+    }
+
+    match key.code {
+        KeyCode::Esc => Some(Transition::Exit),
+        KeyCode::Up | KeyCode::Char('k') => {
+            view.cursor.prev_row_i();
+
+            Some(Transition::Ok)
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            view.cursor.next_row_i();
+
+            Some(Transition::Ok)
+        }
+        KeyCode::Left | KeyCode::Char('h') => {
+            view.cursor.prev_column_i();
+
+            Some(Transition::Ok)
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            view.cursor.next_column_i();
+
+            Some(Transition::Ok)
+        }
+        KeyCode::Home | KeyCode::Char('g') => {
+            view.cursor.row_move_to_start();
+
+            Some(Transition::Ok)
+        }
+        KeyCode::End | KeyCode::Char('G') => {
+            view.cursor.row_move_to_end();
+
+            Some(Transition::Ok)
+        }
+        _ => None,
+    }
+}
+
+// fn handle_key_event_cursor_mode(view: &mut RecordView, key: &KeyEvent) -> Option<Transition> {
+//     match key {
+//         KeyEvent {
+//             code: KeyCode::Char('u'),
+//             modifiers: KeyModifiers::CONTROL,
+//             ..
+//         }
+//         | KeyEvent {
+//             code: KeyCode::PageUp,
+//             ..
+//         } => {
+//             view.get_layer_last_mut().cursor.prev_row_page();
+
+//             return Some(Transition::Ok);
+//         }
+//         KeyEvent {
+//             code: KeyCode::Char('d'),
+//             modifiers: KeyModifiers::CONTROL,
+//             ..
+//         }
+//         | KeyEvent {
+//             code: KeyCode::PageDown,
+//             ..
+//         } => {
+//             view.get_layer_last_mut().cursor.next_row_page();
+
+//             return Some(Transition::Ok);
+//         }
+//         _ => {}
+//     }
+
+//     match key.code {
+//         KeyCode::Esc => {
+//             view.set_view_mode();
+
+//             Some(Transition::Ok)
+//         }
+//         KeyCode::Up | KeyCode::Char('k') => {
+//             view.get_layer_last_mut().cursor.prev_row();
+
+//             Some(Transition::Ok)
+//         }
+//         KeyCode::Down | KeyCode::Char('j') => {
+//             view.get_layer_last_mut().cursor.next_row();
+
+//             Some(Transition::Ok)
+//         }
+//         KeyCode::Left | KeyCode::Char('h') => {
+//             view.get_layer_last_mut().cursor.prev_column();
+
+//             Some(Transition::Ok)
+//         }
+//         KeyCode::Right | KeyCode::Char('l') => {
+//             view.get_layer_last_mut().cursor.next_column();
+
+//             Some(Transition::Ok)
+//         }
+//         KeyCode::Home | KeyCode::Char('g') => {
+//             view.get_layer_last_mut().cursor.row_move_to_start();
+
+//             Some(Transition::Ok)
+//         }
+//         KeyCode::End | KeyCode::Char('G') => {
+//             view.get_layer_last_mut().cursor.row_move_to_end();
+
+//             Some(Transition::Ok)
+//         }
+//         KeyCode::Enter => {
+//             let value = view.get_current_value();
+//             let is_record = matches!(value, Value::Record { .. });
+//             let next_layer = create_layer(value);
+
+//             push_layer(view, next_layer);
+
+//             if is_record {
+//                 view.set_orientation_current(Orientation::Left);
+//             } else if view.orientation == view.get_layer_last().orientation {
+//                 view.get_layer_last_mut().orientation = view.orientation;
+//             } else {
+//                 view.set_orientation_current(view.orientation);
+//             }
+
+//             Some(Transition::Ok)
+//         }
+//         _ => None,
+//     }
+// }
+
+// fn create_layer(value: Value) -> RecordLayer<'static> {
+//     let (columns, values) = collect_input(value);
+
+//     RecordLayer::new(columns, values)
+// }
+
+// fn push_layer(view: &mut RecordView<'_>, mut next_layer: RecordLayer<'static>) {
+//     let layer = view.get_layer_last();
+//     let header = layer.get_column_header();
+
+//     if let Some(header) = header {
+//         next_layer.set_name(header);
+//     }
+
+//     view.layer_stack.push(next_layer);
+// }
+
+// fn estimate_page_size(area: Rect, show_head: bool) -> u16 {
+//     let mut available_height = area.height;
+//     available_height -= 3; // status_bar
+
+//     if show_head {
+//         available_height -= 3; // head
+//     }
+
+//     available_height
+// }
+
+// fn state_reverse_data(state: &mut RecordView<'_>, page_size: usize) {
+//     let layer = state.get_layer_last_mut();
+//     let count_rows = layer.records.len();
+//     if count_rows > page_size {
+//         layer.cursor.set_position(count_rows - page_size, 0);
+//     }
+// }
+
+// fn convert_records_to_string(
+//     records: &[Vec<Value>],
+//     cfg: &NuConfig,
+//     style_computer: &StyleComputer,
+// ) -> Vec<Vec<NuText>> {
+//     records
+//         .iter()
+//         .map(|row| {
+//             row.iter()
+//                 .map(|value| {
+//                     let text = value.clone().to_abbreviated_string(cfg);
+//                     let float_precision = cfg.float_precision as usize;
+
+//                     make_styled_string(style_computer, text, Some(value), float_precision)
+//                 })
+//                 .collect::<Vec<_>>()
+//         })
+//         .collect::<Vec<_>>()
+// }
+
+// fn highlight_cell(f: &mut Frame, area: Rect, info: ElementInfo, theme: &CursorStyle) {
+//     // highlight selected column
+//     if let Some(style) = theme.selected_column {
+//         let highlight_block = Block::default().style(nu_style_to_tui(style));
+//         let area = Rect::new(info.area.x, area.y, info.area.width, area.height);
+//         f.render_widget(highlight_block.clone(), area);
+//     }
+
+//     // highlight selected row
+//     if let Some(style) = theme.selected_row {
+//         let highlight_block = Block::default().style(nu_style_to_tui(style));
+//         let area = Rect::new(area.x, info.area.y, area.width, 1);
+//         f.render_widget(highlight_block.clone(), area);
+//     }
+
+//     // highlight selected cell
+//     let cell_style = match theme.selected_cell {
+//         Some(s) => s,
+//         None => {
+//             let mut style = nu_ansi_term::Style::new();
+//             // light blue chosen somewhat arbitrarily, looks OK but I'm not set on it
+//             style.background = Some(nu_ansi_term::Color::LightBlue);
+//             style
+//         }
+//     };
+//     let highlight_block = Block::default().style(nu_style_to_tui(cell_style));
+//     let area = Rect::new(info.area.x, info.area.y, info.area.width, 1);
+//     f.render_widget(highlight_block.clone(), area)
+// }
+
+// fn build_last_value(v: &RecordView) -> Value {
+//     if v.mode == UIMode::Cursor {
+//         v.get_current_value()
+//     } else if v.get_layer_last().count_rows() < 2 {
+//         build_table_as_record(v)
+//     } else {
+//         build_table_as_list(v)
+//     }
+// }
+
+// fn build_table_as_list(v: &RecordView) -> Value {
+//     let layer = v.get_layer_last();
+
+//     let cols = &layer.columns;
+//     let vals = layer
+//         .records
+//         .iter()
+//         .map(|vals| {
+//             let record = cols.iter().cloned().zip(vals.iter().cloned()).collect();
+//             Value::record(record, NuSpan::unknown())
+//         })
+//         .collect();
+
+//     Value::list(vals, NuSpan::unknown())
+// }
+
+// fn build_table_as_record(v: &RecordView) -> Value {
+//     let layer = v.get_layer_last();
+
+//     let record = if let Some(row) = layer.records.first() {
+//         layer
+//             .columns
+//             .iter()
+//             .cloned()
+//             .zip(row.iter().cloned())
+//             .collect()
+//     } else {
+//         Record::new()
+//     };
+
+//     Value::record(record, NuSpan::unknown())
+// }
+
+// fn report_cursor_position(mode: UIMode, cursor: XYCursor) -> String {
+//     if mode == UIMode::Cursor {
+//         let row = cursor.row();
+//         let column = cursor.column();
+//         format!("{row},{column}")
+//     } else {
+//         let rows_seen = cursor.row_starts_at();
+//         let columns_seen = cursor.column_starts_at();
+//         format!("{rows_seen},{columns_seen}")
+//     }
+// }
+
+// fn report_row_position(cursor: XYCursor) -> String {
+//     if cursor.row_starts_at() == 0 {
+//         String::from("Top")
+//     } else {
+//         let percent_rows = get_percentage(cursor.row(), cursor.row_limit());
+
+//         match percent_rows {
+//             100 => String::from("All"),
+//             value => format!("{value}%"),
+//         }
+//     }
+// }
+
+// fn get_percentage(value: usize, max: usize) -> usize {
+//     debug_assert!(value <= max, "{value:?} {max:?}");
+
+//     ((value as f32 / max as f32) * 100.0).floor() as usize
+// }
+
+// fn transpose_table(layer: &mut RecordLayer<'_>) {
+//     let count_rows = layer.records.len();
+//     let count_columns = layer.columns.len();
+
+//     if layer.was_transposed {
+//         let data = match &mut layer.records {
+//             Cow::Owned(data) => data,
+//             Cow::Borrowed(_) => unreachable!("must never happen"),
+//         };
+
+//         let headers = pop_first_column(data);
+//         let headers = headers
+//             .into_iter()
+//             .map(|value| match value {
+//                 Value::String { val, .. } => val,
+//                 _ => unreachable!("must never happen"),
+//             })
+//             .collect();
+
+//         let data = _transpose_table(data, count_rows, count_columns - 1);
+
+//         layer.records = Cow::Owned(data);
+//         layer.columns = Cow::Owned(headers);
+//     } else {
+//         let mut data = _transpose_table(&layer.records, count_rows, count_columns);
+
+//         for (column, column_name) in layer.columns.iter().enumerate() {
+//             let value = Value::string(column_name, NuSpan::unknown());
+
+//             data[column].insert(0, value);
+//         }
+
+//         layer.records = Cow::Owned(data);
+//         layer.columns = (1..count_rows + 1 + 1).map(|i| i.to_string()).collect();
+//     }
+
+//     layer.was_transposed = !layer.was_transposed;
+// }
+
+// fn pop_first_column(values: &mut [Vec<Value>]) -> Vec<Value> {
+//     let mut data = vec![Value::default(); values.len()];
+//     for (row, values) in values.iter_mut().enumerate() {
+//         data[row] = values.remove(0);
+//     }
+
+//     data
+// }
+
+// fn _transpose_table(
+//     values: &[Vec<Value>],
+//     count_rows: usize,
+//     count_columns: usize,
+// ) -> Vec<Vec<Value>> {
+//     let mut data = vec![vec![Value::default(); count_rows]; count_columns];
+//     for (row, values) in values.iter().enumerate() {
+//         for (column, value) in values.iter().enumerate() {
+//             data[column][row] = value.to_owned();
+//         }
+//     }
+
+//     data
+// }
+
+fn settings_from_config(config: &ConfigMap) -> Settings {
+    let colors = get_color_map(config);
+
+    Settings {
+        opts: BinarySettings::new(
+            !config_get_bool(config, "show_index", true),
+            !config_get_bool(config, "show_ascii", true),
+            !config_get_bool(config, "show_data", true),
+            config_get_usize(config, "segment_size", 2),
+            config_get_usize(config, "count_segments", 8),
+            0,
+        ),
+        style: BinaryStyle::new(
+            BinaryStyleColors::new(
+                colors.get("color_split_left").cloned(),
+                colors.get("color_split_right").cloned(),
+                colors.get("color_index").cloned(),
+                colors.get("color_segment").cloned(),
+                colors.get("color_segment_zero").cloned(),
+                colors.get("color_segment_unknown").cloned(),
+                colors.get("color_ascii").cloned(),
+                colors.get("color_ascii_zero").cloned(),
+                colors.get("color_ascii_unknown").cloned(),
+            ),
+            Indent::new(
+                config_get_usize(config, "padding_index_left", 2) as u16,
+                config_get_usize(config, "padding_index_right", 2) as u16,
+            ),
+            Indent::new(
+                config_get_usize(config, "padding_data_left", 2) as u16,
+                config_get_usize(config, "padding_data_right", 2) as u16,
+            ),
+            Indent::new(
+                config_get_usize(config, "padding_ascii_left", 2) as u16,
+                config_get_usize(config, "padding_ascii_right", 2) as u16,
+            ),
+            config_get_usize(config, "padding_segment", 1),
+            config_get_bool(config, "split", false),
+        ),
+    }
+}
+
+fn config_get_bool(config: &ConfigMap, key: &str, default: bool) -> bool {
+    config
+        .get(key)
+        .and_then(|v| v.as_bool().ok())
+        .unwrap_or(default)
+}
+
+fn config_get_usize(config: &ConfigMap, key: &str, default: usize) -> usize {
+    config
+        .get(key)
+        .and_then(|v| v.coerce_str().ok())
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+fn create_report(mode: Option<CursorMode>, cursor: XYCursor) -> Report {
+    let covered_percent = report_row_position(cursor);
+    let cursor = report_cursor_position(cursor);
+    let mode = report_mode_name(mode);
+    let msg = String::new();
+
+    Report::new(msg, Severity::Info, mode, cursor, covered_percent)
+}
+
+fn report_mode_name(cursor: Option<CursorMode>) -> String {
+    match cursor {
+        Some(CursorMode::Index) => String::from("ADDR"),
+        Some(CursorMode::Data) => String::from("DUMP"),
+        Some(CursorMode::ASCII) => String::from("TEXT"),
+        None => String::from("VIEW"),
+    }
+}
+
+fn report_row_position(cursor: XYCursor) -> String {
+    if cursor.row_starts_at() == 0 {
+        return String::from("Top");
+    }
+
+    let percent_rows = get_percentage(cursor.row(), cursor.row_limit());
+    match percent_rows {
+        100 => String::from("All"),
+        value => format!("{value}%"),
+    }
+}
+
+fn report_cursor_position(cursor: XYCursor) -> String {
+    let rows_seen = cursor.row_starts_at();
+    let columns_seen = cursor.column_starts_at();
+    format!("{rows_seen},{columns_seen}")
+}
+
+fn get_percentage(value: usize, max: usize) -> usize {
+    debug_assert!(value <= max, "{value:?} {max:?}");
+
+    ((value as f32 / max as f32) * 100.0).floor() as usize
+}

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -1,36 +1,30 @@
+// todo: 3 cursor modes one for section
+
 mod binary_widget;
 
-use std::borrow::Cow;
-
-use std::collections::HashMap;
-
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use nu_color_config::{get_color_map, StyleComputer};
+use nu_color_config::get_color_map;
 use nu_protocol::{
     engine::{EngineState, Stack},
-    Record, Value,
+    Value,
 };
-use ratatui::{layout::Rect, widgets::Block};
+use ratatui::layout::Rect;
 
 use crate::{
-    nu_common::{collect_input, lscolorize, NuConfig, NuSpan, NuStyle, NuText},
+    nu_common::NuText,
     pager::{
         report::{Report, Severity},
         ConfigMap, Frame, Transition, ViewInfo,
     },
     util::create_map,
-    views::ElementInfo,
 };
 
 use self::binary_widget::{
     BinarySettings, BinaryStyle, BinaryStyleColors, BinaryWidget, BinaryWidgetState, Indent,
+    SymbolColor,
 };
 
-use super::{
-    cursor::XYCursor,
-    util::{make_styled_string, nu_style_to_tui},
-    Layout, RecordView, View, ViewConfig,
-};
+use super::{cursor::XYCursor, Layout, View, ViewConfig};
 
 #[derive(Debug, Clone)]
 pub struct BinaryView {
@@ -40,11 +34,12 @@ pub struct BinaryView {
     settings: Settings,
 }
 
+#[allow(dead_code)] // todo:
 #[derive(Debug, Clone, Copy)]
 enum CursorMode {
     Index,
     Data,
-    ASCII,
+    Ascii,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -65,30 +60,10 @@ impl BinaryView {
 }
 
 impl View for BinaryView {
-    fn draw(&mut self, f: &mut Frame, area: Rect, cfg: ViewConfig<'_>, layout: &mut Layout) {
+    fn draw(&mut self, f: &mut Frame, area: Rect, _cfg: ViewConfig<'_>, _layout: &mut Layout) {
         let mut state = BinaryWidgetState::default();
         let widget = create_binary_widget(self);
         f.render_stateful_widget(widget, area, &mut state);
-
-        // *layout = table_layout.layout;
-
-        // self.update_cursors(table_layout.count_rows, table_layout.count_columns);
-
-        // if self.mode == UIMode::Cursor {
-        //     let (row, column) = self.get_current_window();
-        //     let info = get_element_info(
-        //         layout,
-        //         row,
-        //         column,
-        //         table_layout.count_rows,
-        //         self.get_layer_last().orientation,
-        //         self.theme.table.show_header,
-        //     );
-
-        //     if let Some(info) = info {
-        //         highlight_cell(f, area, info.clone(), &self.theme.cursor);
-        //     }
-        // }
     }
 
     fn handle_input(
@@ -110,51 +85,17 @@ impl View for BinaryView {
     }
 
     fn collect_data(&self) -> Vec<NuText> {
-        // // Create a "dummy" style_computer.
-        // let dummy_engine_state = EngineState::new();
-        // let dummy_stack = Stack::new();
-        // let style_computer = StyleComputer::new(&dummy_engine_state, &dummy_stack, HashMap::new());
-
-        // let data = convert_records_to_string(
-        //     &self.get_layer_last().records,
-        //     &NuConfig::default(),
-        //     &style_computer,
-        // );
-
-        // data.iter().flatten().cloned().collect()
-
+        // todo: impl to allow search
         vec![]
     }
 
-    fn show_data(&mut self, pos: usize) -> bool {
-        // let data = &self.get_layer_last().records;
-
-        // let mut i = 0;
-        // for (row, cells) in data.iter().enumerate() {
-        //     if pos > i + cells.len() {
-        //         i += cells.len();
-        //         continue;
-        //     }
-
-        //     for (column, _) in cells.iter().enumerate() {
-        //         if i == pos {
-        //             self.get_layer_last_mut().cursor.set_position(row, column);
-        //             return true;
-        //         }
-
-        //         i += 1;
-        //     }
-        // }
-
-        // false
-
+    fn show_data(&mut self, _pos: usize) -> bool {
+        // todo: impl to allow search
         false
     }
 
     fn exit(&mut self) -> Option<Value> {
         // todo: impl Cursor + peek of a value
-        //      do we need to be able to move cursor on address/ascii symbol? (I guess 3 cursor modes one for section?)
-        //
         None
     }
 
@@ -179,93 +120,11 @@ fn create_binary_widget(v: &BinaryView) -> BinaryWidget<'_> {
     let index = start_line * count_elements;
     let data = &v.data[index..];
 
-    // println!("{:?} {:?}", v.cursor.row(), v.cursor.row_starts_at());
-
     let mut w = BinaryWidget::new(data, v.settings.opts, v.settings.style.clone());
     w.set_index_offset(index);
 
     w
 }
-
-// fn get_element_info(
-//     layout: &mut Layout,
-//     row: usize,
-//     column: usize,
-//     count_rows: usize,
-//     orientation: Orientation,
-//     with_head: bool,
-// ) -> Option<&ElementInfo> {
-//     let with_head = with_head as usize;
-//     let index = match orientation {
-//         Orientation::Top => column * (count_rows + with_head) + row + 1,
-//         Orientation::Left => (column + with_head) * count_rows + row,
-//     };
-
-//     layout.data.get(index)
-// }
-
-// #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-// enum UIMode {
-//     Cursor,
-//     View,
-// }
-
-// #[derive(Debug, Clone)]
-// pub struct RecordLayer<'a> {
-//     columns: Cow<'a, [String]>,
-//     records: Cow<'a, [Vec<Value>]>,
-//     orientation: Orientation,
-//     name: Option<String>,
-//     was_transposed: bool,
-//     cursor: XYCursor,
-// }
-
-// impl<'a> RecordLayer<'a> {
-//     fn new(
-//         columns: impl Into<Cow<'a, [String]>>,
-//         records: impl Into<Cow<'a, [Vec<Value>]>>,
-//     ) -> Self {
-//         let columns = columns.into();
-//         let records = records.into();
-//         let cursor = XYCursor::new(records.len(), columns.len());
-
-//         Self {
-//             columns,
-//             records,
-//             cursor,
-//             orientation: Orientation::Top,
-//             name: None,
-//             was_transposed: false,
-//         }
-//     }
-
-//     fn set_name(&mut self, name: impl Into<String>) {
-//         self.name = Some(name.into());
-//     }
-
-//     fn count_rows(&self) -> usize {
-//         match self.orientation {
-//             Orientation::Top => self.records.len(),
-//             Orientation::Left => self.columns.len(),
-//         }
-//     }
-
-//     fn count_columns(&self) -> usize {
-//         match self.orientation {
-//             Orientation::Top => self.columns.len(),
-//             Orientation::Left => self.records.len(),
-//         }
-//     }
-
-//     fn get_column_header(&self) -> Option<String> {
-//         let col = self.cursor.column();
-//         self.columns.get(col).map(|header| header.to_string())
-//     }
-
-//     fn reset_cursor(&mut self) {
-//         self.cursor = XYCursor::new(self.count_rows(), self.count_columns());
-//     }
-// }
 
 fn handle_event_view_mode(view: &mut BinaryView, key: &KeyEvent) -> Option<Transition> {
     match key {
@@ -334,317 +193,6 @@ fn handle_event_view_mode(view: &mut BinaryView, key: &KeyEvent) -> Option<Trans
     }
 }
 
-// fn handle_key_event_cursor_mode(view: &mut RecordView, key: &KeyEvent) -> Option<Transition> {
-//     match key {
-//         KeyEvent {
-//             code: KeyCode::Char('u'),
-//             modifiers: KeyModifiers::CONTROL,
-//             ..
-//         }
-//         | KeyEvent {
-//             code: KeyCode::PageUp,
-//             ..
-//         } => {
-//             view.get_layer_last_mut().cursor.prev_row_page();
-
-//             return Some(Transition::Ok);
-//         }
-//         KeyEvent {
-//             code: KeyCode::Char('d'),
-//             modifiers: KeyModifiers::CONTROL,
-//             ..
-//         }
-//         | KeyEvent {
-//             code: KeyCode::PageDown,
-//             ..
-//         } => {
-//             view.get_layer_last_mut().cursor.next_row_page();
-
-//             return Some(Transition::Ok);
-//         }
-//         _ => {}
-//     }
-
-//     match key.code {
-//         KeyCode::Esc => {
-//             view.set_view_mode();
-
-//             Some(Transition::Ok)
-//         }
-//         KeyCode::Up | KeyCode::Char('k') => {
-//             view.get_layer_last_mut().cursor.prev_row();
-
-//             Some(Transition::Ok)
-//         }
-//         KeyCode::Down | KeyCode::Char('j') => {
-//             view.get_layer_last_mut().cursor.next_row();
-
-//             Some(Transition::Ok)
-//         }
-//         KeyCode::Left | KeyCode::Char('h') => {
-//             view.get_layer_last_mut().cursor.prev_column();
-
-//             Some(Transition::Ok)
-//         }
-//         KeyCode::Right | KeyCode::Char('l') => {
-//             view.get_layer_last_mut().cursor.next_column();
-
-//             Some(Transition::Ok)
-//         }
-//         KeyCode::Home | KeyCode::Char('g') => {
-//             view.get_layer_last_mut().cursor.row_move_to_start();
-
-//             Some(Transition::Ok)
-//         }
-//         KeyCode::End | KeyCode::Char('G') => {
-//             view.get_layer_last_mut().cursor.row_move_to_end();
-
-//             Some(Transition::Ok)
-//         }
-//         KeyCode::Enter => {
-//             let value = view.get_current_value();
-//             let is_record = matches!(value, Value::Record { .. });
-//             let next_layer = create_layer(value);
-
-//             push_layer(view, next_layer);
-
-//             if is_record {
-//                 view.set_orientation_current(Orientation::Left);
-//             } else if view.orientation == view.get_layer_last().orientation {
-//                 view.get_layer_last_mut().orientation = view.orientation;
-//             } else {
-//                 view.set_orientation_current(view.orientation);
-//             }
-
-//             Some(Transition::Ok)
-//         }
-//         _ => None,
-//     }
-// }
-
-// fn create_layer(value: Value) -> RecordLayer<'static> {
-//     let (columns, values) = collect_input(value);
-
-//     RecordLayer::new(columns, values)
-// }
-
-// fn push_layer(view: &mut RecordView<'_>, mut next_layer: RecordLayer<'static>) {
-//     let layer = view.get_layer_last();
-//     let header = layer.get_column_header();
-
-//     if let Some(header) = header {
-//         next_layer.set_name(header);
-//     }
-
-//     view.layer_stack.push(next_layer);
-// }
-
-// fn estimate_page_size(area: Rect, show_head: bool) -> u16 {
-//     let mut available_height = area.height;
-//     available_height -= 3; // status_bar
-
-//     if show_head {
-//         available_height -= 3; // head
-//     }
-
-//     available_height
-// }
-
-// fn state_reverse_data(state: &mut RecordView<'_>, page_size: usize) {
-//     let layer = state.get_layer_last_mut();
-//     let count_rows = layer.records.len();
-//     if count_rows > page_size {
-//         layer.cursor.set_position(count_rows - page_size, 0);
-//     }
-// }
-
-// fn convert_records_to_string(
-//     records: &[Vec<Value>],
-//     cfg: &NuConfig,
-//     style_computer: &StyleComputer,
-// ) -> Vec<Vec<NuText>> {
-//     records
-//         .iter()
-//         .map(|row| {
-//             row.iter()
-//                 .map(|value| {
-//                     let text = value.clone().to_abbreviated_string(cfg);
-//                     let float_precision = cfg.float_precision as usize;
-
-//                     make_styled_string(style_computer, text, Some(value), float_precision)
-//                 })
-//                 .collect::<Vec<_>>()
-//         })
-//         .collect::<Vec<_>>()
-// }
-
-// fn highlight_cell(f: &mut Frame, area: Rect, info: ElementInfo, theme: &CursorStyle) {
-//     // highlight selected column
-//     if let Some(style) = theme.selected_column {
-//         let highlight_block = Block::default().style(nu_style_to_tui(style));
-//         let area = Rect::new(info.area.x, area.y, info.area.width, area.height);
-//         f.render_widget(highlight_block.clone(), area);
-//     }
-
-//     // highlight selected row
-//     if let Some(style) = theme.selected_row {
-//         let highlight_block = Block::default().style(nu_style_to_tui(style));
-//         let area = Rect::new(area.x, info.area.y, area.width, 1);
-//         f.render_widget(highlight_block.clone(), area);
-//     }
-
-//     // highlight selected cell
-//     let cell_style = match theme.selected_cell {
-//         Some(s) => s,
-//         None => {
-//             let mut style = nu_ansi_term::Style::new();
-//             // light blue chosen somewhat arbitrarily, looks OK but I'm not set on it
-//             style.background = Some(nu_ansi_term::Color::LightBlue);
-//             style
-//         }
-//     };
-//     let highlight_block = Block::default().style(nu_style_to_tui(cell_style));
-//     let area = Rect::new(info.area.x, info.area.y, info.area.width, 1);
-//     f.render_widget(highlight_block.clone(), area)
-// }
-
-// fn build_last_value(v: &RecordView) -> Value {
-//     if v.mode == UIMode::Cursor {
-//         v.get_current_value()
-//     } else if v.get_layer_last().count_rows() < 2 {
-//         build_table_as_record(v)
-//     } else {
-//         build_table_as_list(v)
-//     }
-// }
-
-// fn build_table_as_list(v: &RecordView) -> Value {
-//     let layer = v.get_layer_last();
-
-//     let cols = &layer.columns;
-//     let vals = layer
-//         .records
-//         .iter()
-//         .map(|vals| {
-//             let record = cols.iter().cloned().zip(vals.iter().cloned()).collect();
-//             Value::record(record, NuSpan::unknown())
-//         })
-//         .collect();
-
-//     Value::list(vals, NuSpan::unknown())
-// }
-
-// fn build_table_as_record(v: &RecordView) -> Value {
-//     let layer = v.get_layer_last();
-
-//     let record = if let Some(row) = layer.records.first() {
-//         layer
-//             .columns
-//             .iter()
-//             .cloned()
-//             .zip(row.iter().cloned())
-//             .collect()
-//     } else {
-//         Record::new()
-//     };
-
-//     Value::record(record, NuSpan::unknown())
-// }
-
-// fn report_cursor_position(mode: UIMode, cursor: XYCursor) -> String {
-//     if mode == UIMode::Cursor {
-//         let row = cursor.row();
-//         let column = cursor.column();
-//         format!("{row},{column}")
-//     } else {
-//         let rows_seen = cursor.row_starts_at();
-//         let columns_seen = cursor.column_starts_at();
-//         format!("{rows_seen},{columns_seen}")
-//     }
-// }
-
-// fn report_row_position(cursor: XYCursor) -> String {
-//     if cursor.row_starts_at() == 0 {
-//         String::from("Top")
-//     } else {
-//         let percent_rows = get_percentage(cursor.row(), cursor.row_limit());
-
-//         match percent_rows {
-//             100 => String::from("All"),
-//             value => format!("{value}%"),
-//         }
-//     }
-// }
-
-// fn get_percentage(value: usize, max: usize) -> usize {
-//     debug_assert!(value <= max, "{value:?} {max:?}");
-
-//     ((value as f32 / max as f32) * 100.0).floor() as usize
-// }
-
-// fn transpose_table(layer: &mut RecordLayer<'_>) {
-//     let count_rows = layer.records.len();
-//     let count_columns = layer.columns.len();
-
-//     if layer.was_transposed {
-//         let data = match &mut layer.records {
-//             Cow::Owned(data) => data,
-//             Cow::Borrowed(_) => unreachable!("must never happen"),
-//         };
-
-//         let headers = pop_first_column(data);
-//         let headers = headers
-//             .into_iter()
-//             .map(|value| match value {
-//                 Value::String { val, .. } => val,
-//                 _ => unreachable!("must never happen"),
-//             })
-//             .collect();
-
-//         let data = _transpose_table(data, count_rows, count_columns - 1);
-
-//         layer.records = Cow::Owned(data);
-//         layer.columns = Cow::Owned(headers);
-//     } else {
-//         let mut data = _transpose_table(&layer.records, count_rows, count_columns);
-
-//         for (column, column_name) in layer.columns.iter().enumerate() {
-//             let value = Value::string(column_name, NuSpan::unknown());
-
-//             data[column].insert(0, value);
-//         }
-
-//         layer.records = Cow::Owned(data);
-//         layer.columns = (1..count_rows + 1 + 1).map(|i| i.to_string()).collect();
-//     }
-
-//     layer.was_transposed = !layer.was_transposed;
-// }
-
-// fn pop_first_column(values: &mut [Vec<Value>]) -> Vec<Value> {
-//     let mut data = vec![Value::default(); values.len()];
-//     for (row, values) in values.iter_mut().enumerate() {
-//         data[row] = values.remove(0);
-//     }
-
-//     data
-// }
-
-// fn _transpose_table(
-//     values: &[Vec<Value>],
-//     count_rows: usize,
-//     count_columns: usize,
-// ) -> Vec<Vec<Value>> {
-//     let mut data = vec![vec![Value::default(); count_rows]; count_columns];
-//     for (row, values) in values.iter().enumerate() {
-//         for (column, value) in values.iter().enumerate() {
-//             data[column][row] = value.to_owned();
-//         }
-//     }
-
-//     data
-// }
-
 fn settings_from_config(config: &ConfigMap) -> Settings {
     let colors = get_color_map(config);
 
@@ -659,15 +207,19 @@ fn settings_from_config(config: &ConfigMap) -> Settings {
         ),
         style: BinaryStyle::new(
             BinaryStyleColors::new(
+                colors.get("color_index").cloned(),
+                SymbolColor::new(
+                    colors.get("color_segment").cloned(),
+                    colors.get("color_segment_zero").cloned(),
+                    colors.get("color_segment_unknown").cloned(),
+                ),
+                SymbolColor::new(
+                    colors.get("color_ascii").cloned(),
+                    colors.get("color_ascii_zero").cloned(),
+                    colors.get("color_ascii_unknown").cloned(),
+                ),
                 colors.get("color_split_left").cloned(),
                 colors.get("color_split_right").cloned(),
-                colors.get("color_index").cloned(),
-                colors.get("color_segment").cloned(),
-                colors.get("color_segment_zero").cloned(),
-                colors.get("color_segment_unknown").cloned(),
-                colors.get("color_ascii").cloned(),
-                colors.get("color_ascii_zero").cloned(),
-                colors.get("color_ascii_unknown").cloned(),
             ),
             Indent::new(
                 config_get_usize(config, "padding_index_left", 2) as u16,
@@ -715,7 +267,7 @@ fn report_mode_name(cursor: Option<CursorMode>) -> String {
     match cursor {
         Some(CursorMode::Index) => String::from("ADDR"),
         Some(CursorMode::Data) => String::from("DUMP"),
-        Some(CursorMode::ASCII) => String::from("TEXT"),
+        Some(CursorMode::Ascii) => String::from("TEXT"),
         None => String::from("VIEW"),
     }
 }
@@ -725,7 +277,12 @@ fn report_row_position(cursor: XYCursor) -> String {
         return String::from("Top");
     }
 
-    let percent_rows = get_percentage(cursor.row(), cursor.row_limit());
+    // todo: there's some bug in XYCursor; when we hit PgDOWN/UP and general move it excedes the limit
+    //       not sure when it was introduced and if present in original view.
+    //       but it just requires a refactoring as these method names are just ..... not perfect.
+    let row = cursor.row().min(cursor.row_limit());
+    let count_rows = cursor.row_limit();
+    let percent_rows = get_percentage(row, count_rows);
     match percent_rows {
         100 => String::from("All"),
         value => format!("{value}%"),

--- a/crates/nu-explore/src/views/mod.rs
+++ b/crates/nu-explore/src/views/mod.rs
@@ -1,10 +1,10 @@
+mod binary;
 mod coloredtextw;
 mod cursor;
 mod information;
 mod interactive;
 mod preview;
 mod record;
-mod binary;
 pub mod util;
 
 use crossterm::event::KeyEvent;
@@ -23,10 +23,10 @@ use super::{
     pager::{Frame, Transition, ViewInfo},
 };
 
+pub use binary::BinaryView;
 pub use information::InformationView;
 pub use interactive::InteractiveView;
 pub use preview::Preview;
-pub use binary::BinaryView;
 pub use record::{Orientation, RecordView};
 
 #[derive(Debug, Default)]

--- a/crates/nu-explore/src/views/mod.rs
+++ b/crates/nu-explore/src/views/mod.rs
@@ -4,6 +4,7 @@ mod information;
 mod interactive;
 mod preview;
 mod record;
+mod binary;
 pub mod util;
 
 use crossterm::event::KeyEvent;
@@ -25,6 +26,7 @@ use super::{
 pub use information::InformationView;
 pub use interactive::InteractiveView;
 pub use preview::Preview;
+pub use binary::BinaryView;
 pub use record::{Orientation, RecordView};
 
 #[derive(Debug, Default)]

--- a/crates/nu-pretty-hex/src/pretty_hex.rs
+++ b/crates/nu-pretty-hex/src/pretty_hex.rs
@@ -110,7 +110,7 @@ impl HexConfig {
     }
 }
 
-fn categorize_byte(byte: &u8) -> (Style, Option<char>) {
+pub fn categorize_byte(byte: &u8) -> (Style, Option<char>) {
     // This section is here so later we can configure these items
     let null_char_style = Style::default().fg(Color::Fixed(242));
     let null_char = Some('0');


### PR DESCRIPTION
Hi there

So as 2 minute thing we could show `hex-dump` as it is as a string (no-coloring).

But I'd do some more things around,.
Probably will take a few days (WIP).

```
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

─────────────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────
  00000000:   6d 6f 64 20  63 6f 6d 6d  61 6e 64 3b  0a 6d 6f 64   mod command;_mod  │
  00000010:   20 63 6f 6e  66 69 67 5f  66 69 6c 65  73 3b 0a 6d    config_files;_m  │
  00000020:   6f 64 20 69  64 65 3b 0a  6d 6f 64 20  6c 6f 67 67   od ide;_mod logg  │
  00000030:   65 72 3b 0a  6d 6f 64 20  72 75 6e 3b  0a 6d 6f 64   er;_mod run;_mod  │
  00000040:   20 73 69 67  6e 61 6c 73  3b 0a 23 5b  63 66 67 28    signals;_#[cfg(  │
  00000050:   75 6e 69 78  29 5d 0a 6d  6f 64 20 74  65 72 6d 69   unix)]_mod termi  │
  00000060:   6e 61 6c 3b  0a 6d 6f 64  20 74 65 73  74 5f 62 69   nal;_mod test_bi  │
  00000070:   6e 73 3b 0a  23 5b 63 66  67 28 74 65  73 74 29 5d   ns;_#[cfg(test)]  │
  00000080:   0a 6d 6f 64  20 74 65 73  74 73 3b 0a  0a 23 5b 63   _mod tests;__#[c  │
  00000090:   66 67 28 66  65 61 74 75  72 65 20 3d  20 22 6d 69   fg(feature = "mi  │
  000000a0:   6d 61 6c 6c  6f 63 22 29  5d 0a 23 5b  67 6c 6f 62   malloc")]_#[glob  │
  000000b0:   61 6c 5f 61  6c 6c 6f 63  61 74 6f 72  5d 0a 73 74   al_allocator]_st  │
  000000c0:   61 74 69 63  20 47 4c 4f  42 41 4c 3a  20 6d 69 6d   atic GLOBAL: mim  │
  000000d0:   61 6c 6c 6f  63 3a 3a 4d  69 4d 61 6c  6c 6f 63 20   alloc::MiMalloc   │
  000000e0:   3d 20 6d 69  6d 61 6c 6c  6f 63 3a 3a  4d 69 4d 61   = mimalloc::MiMa  │
  000000f0:   6c 6c 6f 63  3b 0a 0a 75  73 65 20 63  72 61 74 65   lloc;__use crate  │
  00000100:   3a 3a 7b 0a  20 20 20 20  63 6f 6d 6d  61 6e 64 3a   ::{_    command:  │
  00000110:   3a 70 61 72  73 65 5f 63  6f 6d 6d 61  6e 64 6c 69   :parse_commandli  │
  00000120:   6e 65 5f 61  72 67 73 2c  0a 20 20 20  20 63 6f 6e   ne_args,_    con  │
  00000130:   66 69 67 5f  66 69 6c 65  73 3a 3a 73  65 74 5f 63   fig_files::set_c  │
  00000140:   6f 6e 66 69  67 5f 70 61  74 68 2c 0a  20 20 20 20   onfig_path,_      │
  00000150:   6c 6f 67 67  65 72 3a 3a  7b 63 6f 6e  66 69 67 75   logger::{configu  │
  00000160:   72 65 2c 20  6c 6f 67 67  65 72 7d 2c  0a 7d 3b 0a   re, logger},_};_  │
  00000170:   75 73 65 20  63 6f 6d 6d  61 6e 64 3a  3a 67 61 74   use command::gat  │
  00000180:   68 65 72 5f  63 6f 6d 6d  61 6e 64 6c  69 6e 65 5f   her_commandline_  │
  00000190:   61 72 67 73  3b 0a 75 73  65 20 6c 6f  67 3a 3a 4c   args;_use log::L  │
  000001a0:   65 76 65 6c  3b 0a 75 73  65 20 6d 69  65 74 74 65   evel;_use miette  │
  000001b0:   3a 3a 52 65  73 75 6c 74  3b 0a 75 73  65 20 6e 75   ::Result;_use nu  │
  000001c0:   5f 63 6c 69  3a 3a 67 61  74 68 65 72  5f 70 61 72   _cli::gather_par  │

```

ref: #12157
cc: @fdncred @lrdickson