### PR TITLE
remove stdlib logging env variables

### DIFF
--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -1,38 +1,42 @@
-export-env {
-    $env.LOG_ANSI = {
+export def log-ansi [] {
+    {
         "CRITICAL": (ansi red_bold),
         "ERROR": (ansi red),
         "WARNING": (ansi yellow),
         "INFO": (ansi default),
         "DEBUG": (ansi default_dimmed)
     }
+}
 
-    $env.LOG_LEVEL = {
+export def log-level [] {
+    {
         "CRITICAL": 50,
         "ERROR": 40,
         "WARNING": 30,
         "INFO": 20,
         "DEBUG": 10
     }
-
-    $env.LOG_PREFIX = {
+}
+export def log-prefix [] {
+    {
         "CRITICAL": "CRT",
         "ERROR": "ERR",
         "WARNING": "WRN",
         "INFO": "INF",
         "DEBUG": "DBG"
     }
-
-    $env.LOG_SHORT_PREFIX = {
+}
+export def log-short-prefix [] {
+    {
         "CRITICAL": "C",
         "ERROR": "E",
         "WARNING": "W",
         "INFO": "I",
         "DEBUG": "D"
     }
-
+}
+export-env {
     $env.NU_LOG_FORMAT = $"%ANSI_START%%DATE%|%LEVEL%|%MSG%%ANSI_STOP%"
-
     $env.NU_LOG_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S%.3f"
 }
 
@@ -40,34 +44,34 @@ def log-types [] {
     (
         {
             "CRITICAL": {
-                "ansi": $env.LOG_ANSI.CRITICAL,
-                "level": $env.LOG_LEVEL.CRITICAL,
-                "prefix": $env.LOG_PREFIX.CRITICAL,
-                "short_prefix": $env.LOG_SHORT_PREFIX.CRITICAL
+                "ansi": ((log-ansi).CRITICAL),
+                "level": ((log-level).CRITICAL),
+                "prefix": ((log-prefix).CRITICAL),
+                "short_prefix": ((log-short-prefix).CRITICAL)
             },
             "ERROR": {
-                "ansi": $env.LOG_ANSI.ERROR,
-                "level": $env.LOG_LEVEL.ERROR,
-                "prefix": $env.LOG_PREFIX.ERROR,
-                "short_prefix": $env.LOG_SHORT_PREFIX.ERROR
+                "ansi": ((log-ansi).ERROR),
+                "level": ((log-level).ERROR),
+                "prefix": ((log-prefix).ERROR),
+                "short_prefix": ((log-short-prefix).ERROR)
             },
             "WARNING": {
-                "ansi": $env.LOG_ANSI.WARNING,
-                "level": $env.LOG_LEVEL.WARNING,
-                "prefix": $env.LOG_PREFIX.WARNING,
-                "short_prefix": $env.LOG_SHORT_PREFIX.WARNING
+                "ansi": ((log-ansi).WARNING),
+                "level": ((log-level).WARNING),
+                "prefix": ((log-prefix).WARNING),
+                "short_prefix": ((log-short-prefix).WARNING)
             },
             "INFO": {
-                "ansi": $env.LOG_ANSI.INFO,
-                "level": $env.LOG_LEVEL.INFO,
-                "prefix": $env.LOG_PREFIX.INFO,
-                "short_prefix": $env.LOG_SHORT_PREFIX.INFO
+                "ansi": ((log-ansi).INFO),
+                "level": ((log-level).INFO),
+                "prefix": ((log-prefix).INFO),
+                "short_prefix": ((log-short-prefix).INFO)
             },
             "DEBUG": {
-                "ansi": $env.LOG_ANSI.DEBUG,
-                "level": $env.LOG_LEVEL.DEBUG,
-                "prefix": $env.LOG_PREFIX.DEBUG,
-                "short_prefix": $env.LOG_SHORT_PREFIX.DEBUG
+                "ansi": ((log-ansi).DEBUG),
+                "level": ((log-level).DEBUG),
+                "prefix": ((log-prefix).DEBUG),
+                "short_prefix": ((log-short-prefix).DEBUG)
             }
         }
     )
@@ -79,16 +83,16 @@ def parse-string-level [
 ] {
     let level = ($level | str upcase)
 
-    if $level in [$env.LOG_PREFIX.CRITICAL $env.LOG_SHORT_PREFIX.CRITICAL "CRIT" "CRITICAL"] {
-        $env.LOG_LEVEL.CRITICAL
-    } else if $level in [$env.LOG_PREFIX.ERROR $env.LOG_SHORT_PREFIX.ERROR "ERROR"] {
-        $env.LOG_LEVEL.ERROR
-    } else if $level in [$env.LOG_PREFIX.WARNING $env.LOG_SHORT_PREFIX.WARNING "WARN" "WARNING"] {
-        $env.LOG_LEVEL.WARNING
-    } else if $level in [$env.LOG_PREFIX.DEBUG $env.LOG_SHORT_PREFIX.DEBUG "DEBUG"] {
-        $env.LOG_LEVEL.DEBUG
+    if $level in [((log-prefix).CRITICAL) ((log-short-prefix).CRITICAL) "CRIT" "CRITICAL"] {
+        ((log-level).CRITICAL)
+    } else if $level in [((log-prefix).ERROR) ((log-short-prefix).ERROR) "ERROR"] {
+        ((log-level).ERROR)
+    } else if $level in [((log-prefix).WARNING) ((log-short-prefix).WARNING) "WARN" "WARNING"] {
+        ((log-level).WARNING)
+    } else if $level in [((log-prefix).DEBUG) ((log-short-prefix).DEBUG) "DEBUG"] {
+        ((log-level).DEBUG)
     } else {
-        $env.LOG_LEVEL.INFO
+        ((log-level).INFO)
     }
 }
 
@@ -97,41 +101,41 @@ def parse-int-level [
     level: int,
     --short (-s)
 ] {
-    if $level >= $env.LOG_LEVEL.CRITICAL {
+    if $level >= ((log-level).CRITICAL) {
         if $short {
-            $env.LOG_SHORT_PREFIX.CRITICAL
+            ((log-short-prefix).CRITICAL)
         } else {
-            $env.LOG_PREFIX.CRITICAL
+            ((log-prefix).CRITICAL)
         }
-    } else if $level >= $env.LOG_LEVEL.ERROR {
+    } else if $level >= ((log-level).ERROR) {
         if $short {
-            $env.LOG_SHORT_PREFIX.ERROR
+            ((log-short-prefix).ERROR)
         } else {
-            $env.LOG_PREFIX.ERROR
+            ((log-prefix).ERROR)
         }
-    } else if $level >= $env.LOG_LEVEL.WARNING {
+    } else if $level >= ((log-level).WARNING) {
         if $short {
-            $env.LOG_SHORT_PREFIX.WARNING
+            ((log-short-prefix).WARNING)
         } else {
-            $env.LOG_PREFIX.WARNING
+            ((log-prefix).WARNING)
         }
-    } else if $level >= $env.LOG_LEVEL.INFO {
+    } else if $level >= ((log-level).INFO) {
         if $short {
-            $env.LOG_SHORT_PREFIX.INFO
+            ((log-short-prefix).INFO)
         } else {
-            $env.LOG_PREFIX.INFO
+            ((log-prefix).INFO)
         }
     } else {
         if $short {
-            $env.LOG_SHORT_PREFIX.DEBUG
+            ((log-short-prefix).DEBUG)
         } else {
-            $env.LOG_PREFIX.DEBUG
+            ((log-prefix).DEBUG)
         }
     }
 }
 
 def current-log-level [] {
-    let env_level = ($env.NU_LOG_LEVEL? | default ($env.LOG_LEVEL.INFO))
+    let env_level = ($env.NU_log-level? | default (((log-level).INFO)))
 
     try {
         $env_level | into int
@@ -239,8 +243,8 @@ def log-level-deduction-error [
         label: {
             text: ([
                  "Invalid log level."
-                $"        Available log levels in $env.LOG_LEVEL:"
-                 ($env.LOG_LEVEL | to text | lines | each {|it| $"            ($it)" } | to text)
+                $"        Available log levels in log-level:"
+                 (log-level | to text | lines | each {|it| $"            ($it)" } | to text)
             ] | str join "\n")
             span: $span
         }
@@ -251,7 +255,7 @@ def log-level-deduction-error [
 export def custom [
     message: string, # A message
     format: string, # A format (for further reference: help std log)
-    log_level: int # A log level (has to be one of the $env.LOG_LEVEL values for correct ansi/prefix deduction)
+    log_level: int # A log level (has to be one of the log-level values for correct ansi/prefix deduction)
     --level-prefix (-p): string # %LEVEL% placeholder extension
     --ansi (-a): string # %ANSI_START% placeholder extension
 ] {
@@ -260,11 +264,11 @@ export def custom [
     }
 
     let valid_levels_for_defaulting = [
-        $env.LOG_LEVEL.CRITICAL
-        $env.LOG_LEVEL.ERROR
-        $env.LOG_LEVEL.WARNING
-        $env.LOG_LEVEL.INFO
-        $env.LOG_LEVEL.DEBUG
+        ((log-level).CRITICAL)
+        ((log-level).ERROR)
+        ((log-level).WARNING)
+        ((log-level).INFO)
+        ((log-level).DEBUG)
     ]
 
     let prefix = if ($level_prefix | is-empty) {

--- a/crates/nu-std/tests/logger_tests/test_basic_commands.nu
+++ b/crates/nu-std/tests/logger_tests/test_basic_commands.nu
@@ -7,9 +7,9 @@ def run [
 ] {
     do {
         if $short {
-            ^$nu.current-exe --commands $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) --short "test message"'
+            ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log ($message_level) --short "test message"'
         } else {
-            ^$nu.current-exe --commands $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) "test message"'
+            ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log ($message_level) "test message"'
         }
     } | complete | get --ignore-errors stderr
 }

--- a/crates/nu-std/tests/logger_tests/test_log_custom.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_custom.nu
@@ -1,4 +1,5 @@
 use std *
+use std log *
 use commons.nu *
 
 def run-command [
@@ -12,12 +13,12 @@ def run-command [
     do {
         if ($level_prefix | is-empty) {
             if ($ansi | is-empty) {
-                ^$nu.current-exe --commands $'use std; NU_LOG_LEVEL=($system_level) std log custom "($message)" "($format)" ($log_level)'
+                ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level)'
             } else {
-                ^$nu.current-exe --commands $'use std; NU_LOG_LEVEL=($system_level) std log custom "($message)" "($format)" ($log_level) --ansi "($ansi)"'
+                ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level) --ansi "($ansi)"'
             }
         } else {
-            ^$nu.current-exe --commands $'use std; NU_LOG_LEVEL=($system_level) std log custom "($message)" "($format)" ($log_level) --level-prefix "($level_prefix)" --ansi "($ansi)"'
+            ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level) --level-prefix "($level_prefix)" --ansi "($ansi)"'
         }
     }  | complete | get --ignore-errors stderr
 }
@@ -32,13 +33,13 @@ def errors_during_deduction [] {
 #[test]
 def valid_calls [] {
     assert equal (run-command "DEBUG" "msg" "%MSG%" 25 --level-prefix "abc" --ansi (ansi default) | str trim --right) "msg"
-    assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" 20 | str trim --right) $"($env.LOG_PREFIX.INFO) msg"
+    assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" 20 | str trim --right) $"((log-prefix).INFO) msg"
     assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" --level-prefix "abc" 20 | str trim --right) "abc msg"
-    assert equal (run-command "INFO" "msg" "%ANSI_START%%LEVEL% %MSG%%ANSI_STOP%" $env.LOG_LEVEL.CRITICAL | str trim --right) $"($env.LOG_ANSI.CRITICAL)CRT msg(ansi reset)"
+    assert equal (run-command "INFO" "msg" "%ANSI_START%%LEVEL% %MSG%%ANSI_STOP%" ((log-level).CRITICAL) | str trim --right) $"((log-ansi).CRITICAL)CRT msg(ansi reset)"
 }
 
 #[test]
-def log_level_handling [] {
-    assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" 20 | str trim --right) $"($env.LOG_PREFIX.INFO) msg"
+def log-level_handling [] {
+    assert equal (run-command "DEBUG" "msg" "%LEVEL% %MSG%" 20 | str trim --right) $"((log-prefix).INFO) msg"
     assert equal (run-command "WARNING" "msg" "%LEVEL% %MSG%" 20 | str trim --right) ""
 }

--- a/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
@@ -1,4 +1,5 @@
 use std *
+use std log *
 use commons.nu *
 
 def run-command [
@@ -10,9 +11,9 @@ def run-command [
 ] {
     do {
         if $short {
-            ^$nu.current-exe --commands $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) --format "($format)" --short "($message)"'
+            ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log ($message_level) --format "($format)" --short "($message)"'
         } else {
-            ^$nu.current-exe --commands $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) --format "($format)" "($message)"'
+            ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log ($message_level) --format "($format)" "($message)"'
         }
     } | complete | get --ignore-errors stderr
 }
@@ -26,14 +27,14 @@ def "assert formatted" [
 ] {
     let output = (run-command "debug" $command_level $message --format $format)
     let prefix = if $short {
-            ($env.LOG_SHORT_PREFIX | get ($command_level | str upcase))
+            (log-short-prefix | get ($command_level | str upcase))
         } else {
-            ($env.LOG_PREFIX | get ($command_level | str upcase))
+            (log-prefix | get ($command_level | str upcase))
         }
     let ansi = if $short {
-            ($env.LOG_ANSI | get ($command_level | str upcase))
+            (log-ansi | get ($command_level | str upcase))
         } else {
-            ($env.LOG_ANSI | get ($command_level | str upcase))
+            (log-ansi | get ($command_level | str upcase))
         }
 
     assert equal ($output | str trim --right) (format-message $message $format $prefix $ansi)

--- a/crates/nu-std/tests/logger_tests/test_logger_env.nu
+++ b/crates/nu-std/tests/logger_tests/test_logger_env.nu
@@ -1,39 +1,40 @@
 use std *
+use std log *
 
 #[test]
-def env_log_ansi [] {
-    assert equal $env.LOG_ANSI.CRITICAL (ansi red_bold)
-    assert equal $env.LOG_ANSI.ERROR (ansi red)
-    assert equal $env.LOG_ANSI.WARNING (ansi yellow)
-    assert equal $env.LOG_ANSI.INFO (ansi default)
-    assert equal $env.LOG_ANSI.DEBUG (ansi default_dimmed)
+def env_log-ansi [] {
+    assert equal ((log-ansi).CRITICAL) (ansi red_bold)
+    assert equal ((log-ansi).ERROR) (ansi red)
+    assert equal ((log-ansi).WARNING) (ansi yellow)
+    assert equal ((log-ansi).INFO) (ansi default)
+    assert equal ((log-ansi).DEBUG) (ansi default_dimmed)
 }
 
 #[test]
-def env_log_level [] {
-    assert equal $env.LOG_LEVEL.CRITICAL 50
-    assert equal $env.LOG_LEVEL.ERROR 40
-    assert equal $env.LOG_LEVEL.WARNING 30
-    assert equal $env.LOG_LEVEL.INFO 20
-    assert equal $env.LOG_LEVEL.DEBUG 10
+def env_log-level [] {
+    assert equal ((log-level).CRITICAL) 50
+    assert equal ((log-level).ERROR) 40
+    assert equal ((log-level).WARNING) 30
+    assert equal ((log-level).INFO) 20
+    assert equal ((log-level).DEBUG) 10
 }
 
 #[test]
-def env_log_prefix [] {
-    assert equal $env.LOG_PREFIX.CRITICAL "CRT"
-    assert equal $env.LOG_PREFIX.ERROR "ERR"
-    assert equal $env.LOG_PREFIX.WARNING "WRN"
-    assert equal $env.LOG_PREFIX.INFO "INF"
-    assert equal $env.LOG_PREFIX.DEBUG "DBG"
+def env_log-prefix [] {
+    assert equal ((log-prefix).CRITICAL) "CRT"
+    assert equal ((log-prefix).ERROR) "ERR"
+    assert equal ((log-prefix).WARNING) "WRN"
+    assert equal ((log-prefix).INFO) "INF"
+    assert equal ((log-prefix).DEBUG) "DBG"
 }
 
 #[test]
-def env_log_short_prefix [] {
-    assert equal $env.LOG_SHORT_PREFIX.CRITICAL "C"
-    assert equal $env.LOG_SHORT_PREFIX.ERROR "E"
-    assert equal $env.LOG_SHORT_PREFIX.WARNING "W"
-    assert equal $env.LOG_SHORT_PREFIX.INFO "I"
-    assert equal $env.LOG_SHORT_PREFIX.DEBUG "D"
+def env_log-short-prefix [] {
+    assert equal ((log-short-prefix).CRITICAL) "C"
+    assert equal ((log-short-prefix).ERROR) "E"
+    assert equal ((log-short-prefix).WARNING) "W"
+    assert equal ((log-short-prefix).INFO) "I"
+    assert equal ((log-short-prefix).DEBUG) "D"
 }
 
 #[test]


### PR DESCRIPTION
# Description

This PR removes the environment variables associated with stdlib logging. We need not pollute the environment since it contains a finite amount of space. This PR changes the env vars to exported custom commands.
 
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
