### PR TITLE
remove test warnings

### DIFF
--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -16,9 +16,9 @@ use nu_protocol::{
     Span, Spanned, Value,
 };
 pub use plugin_custom_value::PluginCustomValue;
-pub use protocol_info::ProtocolInfo;
 #[cfg(test)]
-pub use protocol_info::{Feature, Protocol};
+pub use protocol_info::Protocol;
+pub use protocol_info::ProtocolInfo;
 use serde::{Deserialize, Serialize};
 
 /// A sequential identifier for a stream


### PR DESCRIPTION
# Description
I get warnings message when running tests:
```
warning: unused import: `Feature`
  --> crates/nu-plugin/src/protocol/mod.rs:21:25
   |
21 | pub use protocol_info::{Feature, Protocol};
   |                         ^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```
I think it's useless can can be removed.