### PR TITLE
Allow plugins to set environment variables in their caller's scope

### DIFF
--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -59,6 +59,7 @@ mod plugin;
 mod protocol;
 mod sequence;
 mod serializers;
+mod util;
 
 pub use plugin::{
     serve_plugin, EngineInterface, Plugin, PluginCommand, PluginEncoder, SimplePluginCommand,

--- a/crates/nu-plugin/src/plugin/context.rs
+++ b/crates/nu-plugin/src/plugin/context.rs
@@ -29,8 +29,10 @@ pub(crate) trait PluginExecutionContext: Send + Sync {
     fn get_env_var(&self, name: &str) -> Result<Option<Value>, ShellError>;
     /// Get all environment variables
     fn get_env_vars(&self) -> Result<HashMap<String, Value>, ShellError>;
-    // Get current working directory
+    /// Get current working directory
     fn get_current_dir(&self) -> Result<Spanned<String>, ShellError>;
+    /// Set an environment variable
+    fn add_env_var(&mut self, name: String, value: Value) -> Result<(), ShellError>;
     /// Evaluate a closure passed to the plugin
     fn eval_closure(
         &self,
@@ -134,6 +136,11 @@ impl<'a> PluginExecutionContext for PluginExecutionCommandContext<'a> {
         let cwd = nu_engine::env::current_dir_str(&self.engine_state, &self.stack)?;
         // The span is not really used, so just give it call.head
         Ok(cwd.into_spanned(self.call.head))
+    }
+
+    fn add_env_var(&mut self, name: String, value: Value) -> Result<(), ShellError> {
+        self.stack.add_env_var(name, value);
+        Ok(())
     }
 
     fn eval_closure(
@@ -250,6 +257,12 @@ impl PluginExecutionContext for PluginExecutionBogusContext {
     fn get_current_dir(&self) -> Result<Spanned<String>, ShellError> {
         Err(ShellError::NushellFailed {
             msg: "get_current_dir not implemented on bogus".into(),
+        })
+    }
+
+    fn add_env_var(&mut self, _name: String, _value: Value) -> Result<(), ShellError> {
+        Err(ShellError::NushellFailed {
+            msg: "add_env_var not implemented on bogus".into(),
         })
     }
 

--- a/crates/nu-plugin/src/plugin/declaration.rs
+++ b/crates/nu-plugin/src/plugin/declaration.rs
@@ -108,12 +108,12 @@ impl Command for PluginDeclaration {
             })?;
 
         // Create the context to execute in - this supports engine calls and custom values
-        let context = Arc::new(PluginExecutionCommandContext::new(
+        let mut context = PluginExecutionCommandContext::new(
             self.source.identity.clone(),
             engine_state,
             stack,
             call,
-        ));
+        );
 
         plugin.run(
             CallInfo {
@@ -121,7 +121,7 @@ impl Command for PluginDeclaration {
                 call: evaluated_call,
                 input,
             },
-            context,
+            &mut context,
         )
     }
 

--- a/crates/nu-plugin/src/plugin/interface/engine.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine.rs
@@ -458,6 +458,9 @@ impl EngineInterface {
             EngineCall::GetEnvVar(name) => (EngineCall::GetEnvVar(name), Default::default()),
             EngineCall::GetEnvVars => (EngineCall::GetEnvVars, Default::default()),
             EngineCall::GetCurrentDir => (EngineCall::GetCurrentDir, Default::default()),
+            EngineCall::AddEnvVar(name, value) => {
+                (EngineCall::AddEnvVar(name, value), Default::default())
+            }
         };
 
         // Register the channel
@@ -618,6 +621,30 @@ impl EngineInterface {
             EngineCallResponse::Error(err) => Err(err),
             _ => Err(ShellError::PluginFailedToDecode {
                 msg: "Received unexpected response type for EngineCall::GetEnvVars".into(),
+            }),
+        }
+    }
+
+    /// Set an environment variable in the caller's scope.
+    ///
+    /// If called after the plugin response has already been sent (i.e. during a stream), this will
+    /// only affect the environment for engine calls related to this plugin call, and will not be
+    /// propagated to the environment of the caller.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// # use nu_protocol::{Value, ShellError};
+    /// # use nu_plugin::EngineInterface;
+    /// # fn example(engine: &EngineInterface) -> Result<(), ShellError> {
+    /// engine.add_env_var("FOO", Value::test_string("bar"))
+    /// # }
+    /// ```
+    pub fn add_env_var(&self, name: impl Into<String>, value: Value) -> Result<(), ShellError> {
+        match self.engine_call(EngineCall::AddEnvVar(name.into(), value))? {
+            EngineCallResponse::PipelineData(_) => Ok(()),
+            EngineCallResponse::Error(err) => Err(err),
+            _ => Err(ShellError::PluginFailedToDecode {
+                msg: "Received unexpected response type for EngineCall::AddEnvVar".into(),
             }),
         }
     }

--- a/crates/nu-plugin/src/plugin/interface/engine/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine/tests.rs
@@ -954,6 +954,20 @@ fn interface_get_env_vars() -> Result<(), ShellError> {
 }
 
 #[test]
+fn interface_add_env_var() -> Result<(), ShellError> {
+    let test = TestCase::new();
+    let manager = test.engine();
+    let interface = manager.interface_for_context(0);
+
+    start_fake_plugin_call_responder(manager, 1, move |_| EngineCallResponse::empty());
+
+    interface.add_env_var("FOO", Value::test_string("bar"))?;
+
+    assert!(test.has_unconsumed_write());
+    Ok(())
+}
+
+#[test]
 fn interface_eval_closure_with_stream() -> Result<(), ShellError> {
     let test = TestCase::new();
     let manager = test.engine();

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -348,6 +348,21 @@ impl PluginCallResponse<PipelineDataHeader> {
     }
 }
 
+impl PluginCallResponse<PipelineData> {
+    /// Does this response have a stream?
+    pub(crate) fn has_stream(&self) -> bool {
+        match self {
+            PluginCallResponse::PipelineData(data) => match data {
+                PipelineData::Empty => false,
+                PipelineData::Value(..) => false,
+                PipelineData::ListStream(..) => true,
+                PipelineData::ExternalStream { .. } => true,
+            },
+            _ => false,
+        }
+    }
+}
+
 /// Options that can be changed to affect how the engine treats the plugin
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum PluginOption {

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -462,6 +462,8 @@ pub enum EngineCall<D> {
     GetEnvVars,
     /// Get current working directory
     GetCurrentDir,
+    /// Set an environment variable in the caller's scope
+    AddEnvVar(String, Value),
     /// Evaluate a closure with stream input/output
     EvalClosure {
         /// The closure to call.
@@ -488,6 +490,7 @@ impl<D> EngineCall<D> {
             EngineCall::GetEnvVar(_) => "GetEnv",
             EngineCall::GetEnvVars => "GetEnvs",
             EngineCall::GetCurrentDir => "GetCurrentDir",
+            EngineCall::AddEnvVar(..) => "AddEnvVar",
             EngineCall::EvalClosure { .. } => "EvalClosure",
         }
     }

--- a/crates/nu-plugin/src/util/mod.rs
+++ b/crates/nu-plugin/src/util/mod.rs
@@ -1,0 +1,3 @@
+mod mutable_cow;
+
+pub(crate) use mutable_cow::*;

--- a/crates/nu-plugin/src/util/mutable_cow.rs
+++ b/crates/nu-plugin/src/util/mutable_cow.rs
@@ -1,0 +1,35 @@
+/// Like [`Cow`] but with a mutable reference instead. So not exactly clone-on-write, but can be
+/// made owned.
+pub enum MutableCow<'a, T> {
+    Borrowed(&'a mut T),
+    Owned(T),
+}
+
+impl<'a, T: Clone> MutableCow<'a, T> {
+    pub fn owned(&self) -> MutableCow<'static, T> {
+        match self {
+            MutableCow::Borrowed(r) => MutableCow::Owned((*r).clone()),
+            MutableCow::Owned(o) => MutableCow::Owned(o.clone()),
+        }
+    }
+}
+
+impl<'a, T> std::ops::Deref for MutableCow<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        match self {
+            MutableCow::Borrowed(r) => r,
+            MutableCow::Owned(o) => o,
+        }
+    }
+}
+
+impl<'a, T> std::ops::DerefMut for MutableCow<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            MutableCow::Borrowed(r) => r,
+            MutableCow::Owned(o) => o,
+        }
+    }
+}

--- a/tests/plugins/env.rs
+++ b/tests/plugins/env.rs
@@ -42,3 +42,14 @@ fn get_current_dir() {
     assert!(result.status.success());
     assert_eq!(cwd, result.out);
 }
+
+#[test]
+fn set_env() {
+    let result = nu_with_plugins!(
+        cwd: ".",
+        plugin: ("nu_plugin_example"),
+        "nu-example-env NUSHELL_OPINION --set=rocks; $env.NUSHELL_OPINION"
+    );
+    assert!(result.status.success());
+    assert_eq!("rocks", result.out);
+}


### PR DESCRIPTION
# Description

Adds the `AddEnvVar` plugin call, which allows plugins to set environment variables in the caller's scope. This is the first engine call that mutates the caller's stack, and opens the door to more operations like this if needed.

This also comes with an extra benefit: in doing this, I needed to refactor how context was handled, and I was able to avoid cloning `EngineInterface` / `Stack` / `Call` in most cases that plugin calls are used. They now only need to be cloned if the plugin call returns a stream. The performance increase is welcome (5.5x faster on `inc`!):

```nushell
# Before
> timeit { 1..100 | each { |i| $"2.0.($i)" | inc -p } }
405ms 941µs 952ns
# After
> timeit { 1..100 | each { |i| $"2.0.($i)" | inc -p } }
73ms 68µs 749ns
```

# User-Facing Changes
- New engine call: `add_env_var()`
- Performance enhancement for plugin calls

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
- [x] Document env manipulation in plugins guide
- [x] Document `AddEnvVar` in plugin protocol
