### PR TITLE
Adjust permissions using `umask` in `mkdir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,6 +2958,7 @@ dependencies = [
  "uu_mktemp",
  "uu_mv",
  "uu_whoami",
+ "uucore",
  "uuid",
  "v_htmlescape",
  "wax",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -100,6 +100,9 @@ chardetng = "0.1.17"
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"
 
+[target.'cfg(not(windows))'.dependencies]
+uucore = { version = "0.0.24", features = ["mode"] }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 umask = "2.1"

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -122,3 +122,23 @@ fn creates_directory_three_dots_quotation_marks() {
         assert!(expected.exists());
     })
 }
+
+#[cfg(not(windows))]
+#[test]
+fn mkdir_umask_permission() {
+    Playground::setup("mkdir_umask_permission", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(),
+            "
+                mkdir test_umask_permission
+                stat -c %a test_umask_permission
+            "
+        );
+
+        assert_eq!(
+            actual.out, "755",
+            "Most *nix systems have 0o022 as the umask. \
+            So directory permission should be 0o755 = 0o777 - 0o022"
+        );
+    })
+}

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -126,19 +126,22 @@ fn creates_directory_three_dots_quotation_marks() {
 #[cfg(not(windows))]
 #[test]
 fn mkdir_umask_permission() {
+    use std::{fs, os::unix::fs::PermissionsExt};
+
     Playground::setup("mkdir_umask_permission", |dirs, _| {
-        let actual = nu!(
+        nu!(
             cwd: dirs.test(),
-            "
-                mkdir test_umask_permission
-                stat -c %a test_umask_permission
-            "
+            "mkdir test_umask_permission"
         );
+        let actual = fs::metadata(dirs.test().join("test_umask_permission"))
+            .unwrap()
+            .permissions()
+            .mode();
 
         assert_eq!(
-            actual.out, "755",
-            "Most *nix systems have 0o022 as the umask. \
-            So directory permission should be 0o755 = 0o777 - 0o022"
+            actual, 0o40755,
+            "Most *nix systems have 0o00022 as the umask. \
+            So directory permission should be 0o40755 = 0o40777 - 0o00022"
         );
     })
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

With this change, `mkdir` mirrors coreutils works. Closes #12161

I referred to the implementation of `mkdir` in uutils/coreutils. I add `uucore` required for implementation to dependencies. Since `uucore` is already included in dependencies of `uu_mkdir`, I don't think there will be any additional dependencies.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

- Directories are created according to `umask` except for Windows.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

I add `mkdir` test considering permissions. The test assumes that the default `umask` is `022`.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
