### PR TITLE
Allow file redirection to `null`

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -439,3 +439,22 @@ fn no_duplicate_redirection() {
         );
     });
 }
+
+#[test]
+fn redirect_to_null() {
+    let actual = nu!("nu -c 'print hello' o> null");
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn redirect_to_null_variable() {
+    let actual = nu!("let null = null; nu -c 'print hello' o> $null");
+    assert_eq!(actual.out, "");
+}
+
+#[test]
+fn redirect_to_null_with_pipe() {
+    let actual = nu!("nu -c 'print -e error; print hello' e> null | str upcase");
+    assert_eq!(actual.out, "HELLO");
+    assert_eq!(actual.err, "");
+}


### PR DESCRIPTION
# Description
Adds `null`/nothing as a valid file redirection destination which can serve as a cross platform `/dev/null`.
```nushell
^extern o> null # stdout is ignored
```

`ignore` with pipe redirections (`|`, `e>|`, `o+e>|`) almost gets us the whole way, but it has a limitation. That is, it is not possible to pass along the other, non-ignored stdio stream further into the pipeline. E.g., this is not possible with `ignore`: 
```nushell
^extern1 e> null | ^extern2
```

Another benefit for `null` file redirections is that this allows ergonomic dynamic output redirection. Simply passing around the file destination as a value between functions will work. On the other hand, for `ignore`, there would need to be `if` statements at every redirection site. 

One potential pitfall with `null` file redirections is that if a file path expression is unintentionally evaluated to `null`, then this would silently discard output.