### PR TITLE
Fix zip signature to mention closure input type

### DIFF
--- a/crates/nu-command/src/filters/zip.rs
+++ b/crates/nu-command/src/filters/zip.rs
@@ -30,7 +30,11 @@ impl Command for Zip {
                     Type::List(Box::new(Type::List(Box::new(Type::Any)))),
                 ),
             ])
-            .required("other", SyntaxShape::Any, "The other input.")
+            .required(
+                "other",
+                SyntaxShape::OneOf(vec![SyntaxShape::Any, SyntaxShape::Closure(Some(vec![]))]),
+                "The other input, or closure returning a stream.",
+            )
             .category(Category::Filters)
     }
 


### PR DESCRIPTION
# Description

`help zip` now reports:

```
other <one_of(any, closure())>: The other input, or closure returning a stream.
```

Thanks to @edhowland for pointing this out :heart:

# User-Facing Changes

- Doc change for zip

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
