### PR TITLE
Use rest argument in `export use` to match `use`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/export_use.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export_use.rs
@@ -20,7 +20,7 @@ impl Command for ExportUse {
         Signature::build("export use")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .required("module", SyntaxShape::String, "Module or module file.")
-            .optional(
+            .rest(
                 "members",
                 SyntaxShape::Any,
                 "Which members of the module to import.",


### PR DESCRIPTION
# Description
Fixes #12057 where it was pointed out that `export use` takes an **optional** `members` positional argument whereas `use` takes a **rest** `members` argument.