### PR TITLE
Support `into string` for custom values

### DIFF
--- a/tests/plugins/custom_values.rs
+++ b/tests/plugins/custom_values.rs
@@ -194,3 +194,14 @@ fn custom_value_in_example_is_rendered() {
         .contains("I used to be a custom value! My data was (abc)"));
     assert!(actual.status.success());
 }
+
+#[test]
+fn custom_value_into_string() {
+    let actual = nu_with_plugins!(
+        cwd: "tests",
+        plugin: ("nu_plugin_custom_values"),
+        "custom-value generate | into string"
+    );
+
+    assert_eq!(actual.out, "I used to be a custom value! My data was (abc)");
+}


### PR DESCRIPTION
Context: @abusch is working on a semver plugin with custom values and wants users to be able to convert them back to strings

# Description
This allows `into string` to work on custom values if their base value representation could be converted into a string with the same rules.

# User-Facing Changes
`into string` works on custom values.

Unfortunately, I couldn't really demo this with an example, because there aren't any custom values that can be represented that way included.

# Tests + Formatting
I was able to write a test using the custom values plugin.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
