### PR TITLE
Fix inaccurate sleep duration

### DIFF
--- a/crates/nu-command/src/platform/sleep.rs
+++ b/crates/nu-command/src/platform/sleep.rs
@@ -52,16 +52,17 @@ impl Command for Sleep {
 
         let total_dur =
             duration_from_i64(duration) + rest.into_iter().map(duration_from_i64).sum::<Duration>();
+        let deadline = Instant::now() + total_dur;
 
-        let ctrlc_ref = &engine_state.ctrlc.clone();
-        let start = Instant::now();
         loop {
-            thread::sleep(CTRL_C_CHECK_INTERVAL.min(total_dur));
-            if start.elapsed() >= total_dur {
+            // sleep for 100ms, or until the deadline
+            let time_until_deadline = deadline.saturating_duration_since(Instant::now());
+            if time_until_deadline.is_zero() {
                 break;
             }
-
-            if nu_utils::ctrl_c::was_pressed(ctrlc_ref) {
+            thread::sleep(CTRL_C_CHECK_INTERVAL.min(time_until_deadline));
+            // exit early if Ctrl+C was pressed
+            if nu_utils::ctrl_c::was_pressed(&engine_state.ctrlc) {
                 return Err(ShellError::InterruptedByUser {
                     span: Some(call.head),
                 });


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Improves the accuracy of sleep when the duration is larger than 100ms. Fixes #12223.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Sleeping for 150ms should work now.

```nushell
~/nushell> timeit { sleep 150ms }                                                                                                                                          03/19/2024 10:41:55 AM AM
151ms 344µs 201ns
```


<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->


<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
