### PR TITLE
(WIP) Start moving from Spans to SpanIDs

### DIFF
--- a/crates/nu-cli/src/commands/commandline/commandline_.rs
+++ b/crates/nu-cli/src/commands/commandline/commandline_.rs
@@ -75,7 +75,7 @@ impl Command for Commandline {
                         error: "`--cursor (-c)` is deprecated".into(),
                         msg: "Setting the current cursor position by `--cursor (-c)` is deprecated"
                             .into(),
-                        span: Some(call.arguments_span()),
+                        span: Some(call.arguments_span(&engine_state)),
                         help: Some("Use `commandline set-cursor`".into()),
                         inner: vec![],
                     },
@@ -107,7 +107,7 @@ impl Command for Commandline {
                     &ShellError::GenericError {
                         error: "`--append (-a)` is deprecated".into(),
                         msg: "Appending the string to the end of the buffer by `--append (-a)` is deprecated".into(),
-                        span: Some(call.arguments_span()),
+                        span: Some(call.arguments_span(&engine_state)),
                         help: Some("Use `commandline edit --append (-a)`".into()),
                         inner: vec![],
                     },
@@ -119,7 +119,7 @@ impl Command for Commandline {
                     &ShellError::GenericError {
                         error: "`--insert (-i)` is deprecated".into(),
                         msg: "Inserts the string into the buffer at the cursor position by `--insert (-i)` is deprecated".into(),
-                        span: Some(call.arguments_span()),
+                        span: Some(call.arguments_span(&engine_state)),
                         help: Some("Use `commandline edit --insert (-i)`".into()),
                         inner: vec![],
                     },
@@ -133,7 +133,7 @@ impl Command for Commandline {
                     &ShellError::GenericError {
                         error: "`--replace (-r)` is deprecated".into(),
                         msg: "Replaceing the current contents of the buffer by `--replace (-p)` or positional argument is deprecated".into(),
-                        span: Some(call.arguments_span()),
+                        span: Some(call.arguments_span(&engine_state)),
                         help: Some("Use `commandline edit --replace (-r)`".into()),
                         inner: vec![],
                     },
@@ -150,7 +150,7 @@ impl Command for Commandline {
                     &ShellError::GenericError {
                         error: "`--cursor-end (-e)` is deprecated".into(),
                         msg: "Setting the current cursor position to the end of the buffer by `--cursor-end (-e)` is deprecated".into(),
-                        span: Some(call.arguments_span()),
+                        span: Some(call.arguments_span(&engine_state)),
                         help: Some("Use `commandline set-cursor --end (-e)`".into()),
                         inner: vec![],
                     },
@@ -164,7 +164,7 @@ impl Command for Commandline {
                         error: "`--cursor (-c)` is deprecated".into(),
                         msg: "Getting the current cursor position by `--cursor (-c)` is deprecated"
                             .into(),
-                        span: Some(call.arguments_span()),
+                        span: Some(call.arguments_span(&engine_state)),
                         help: Some("Use `commandline get-cursor`".into()),
                         inner: vec![],
                     },

--- a/crates/nu-cli/src/completions/base.rs
+++ b/crates/nu-cli/src/completions/base.rs
@@ -1,5 +1,5 @@
 use crate::completions::{CompletionOptions, SortBy};
-use nu_protocol::{engine::StateWorkingSet, levenshtein_distance, Span};
+use nu_protocol::{engine::StateWorkingSet, levenshtein_distance, Span, SpanId};
 use reedline::Suggestion;
 
 // Completer trait represents the three stages of the completion
@@ -10,6 +10,7 @@ pub trait Completer {
         working_set: &StateWorkingSet,
         prefix: Vec<u8>,
         span: Span,
+        span_id: SpanId,
         offset: usize,
         pos: usize,
         options: &CompletionOptions,

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -55,12 +55,10 @@ impl Completer for CustomCompletion {
                 arguments: vec![
                     Argument::Positional(Expression::new_unknown(
                         Expr::String(self.line.clone()),
-                        Span::unknown(),
                         Type::String,
                     )),
                     Argument::Positional(Expression::new_unknown(
                         Expr::Int(line_pos as i64),
-                        Span::unknown(),
                         Type::Int,
                     )),
                 ],

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -53,18 +53,16 @@ impl Completer for CustomCompletion {
                 decl_id: self.decl_id,
                 head: span,
                 arguments: vec![
-                    Argument::Positional(Expression {
-                        span: Span::unknown(),
-                        ty: Type::String,
-                        expr: Expr::String(self.line.clone()),
-                        custom_completion: None,
-                    }),
-                    Argument::Positional(Expression {
-                        span: Span::unknown(),
-                        ty: Type::Int,
-                        expr: Expr::Int(line_pos as i64),
-                        custom_completion: None,
-                    }),
+                    Argument::Positional(Expression::new_unknown(
+                        Expr::String(self.line.clone()),
+                        Span::unknown(),
+                        Type::String,
+                    )),
+                    Argument::Positional(Expression::new_unknown(
+                        Expr::Int(line_pos as i64),
+                        Span::unknown(),
+                        Type::Int,
+                    )),
                 ],
                 parser_info: HashMap::new(),
             },

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -3,12 +3,7 @@ use crate::completions::{
     SemanticSuggestion, SortBy,
 };
 use nu_engine::eval_call;
-use nu_protocol::{
-    ast::{Argument, Call, Expr, Expression},
-    debugger::WithoutDebug,
-    engine::{EngineState, Stack, StateWorkingSet},
-    PipelineData, Span, Type, Value,
-};
+use nu_protocol::{ast::{Argument, Call, Expr, Expression}, debugger::WithoutDebug, engine::{EngineState, Stack, StateWorkingSet}, PipelineData, Span, SpanId, Type, Value};
 use nu_utils::IgnoreCaseExt;
 use std::{collections::HashMap, sync::Arc};
 
@@ -38,6 +33,7 @@ impl Completer for CustomCompletion {
         _: &StateWorkingSet,
         prefix: Vec<u8>,
         span: Span,
+        span_id: SpanId,
         offset: usize,
         pos: usize,
         completion_options: &CompletionOptions,
@@ -52,6 +48,7 @@ impl Completer for CustomCompletion {
             &Call {
                 decl_id: self.decl_id,
                 head: span,
+                head_id: span_id,
                 arguments: vec![
                     Argument::Positional(Expression::new_unknown(
                         Expr::String(self.line.clone()),

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -264,7 +264,7 @@ fn find_matching_block_end_in_block(
 ) -> Option<usize> {
     for p in &block.pipelines {
         for e in &p.elements {
-            if e.expr.span.contains(global_cursor_offset) {
+            if e.expr.get_span(&working_set).contains(global_cursor_offset) {
                 if let Some(pos) = find_matching_block_end_in_expr(
                     line,
                     working_set,
@@ -324,16 +324,19 @@ fn find_matching_block_end_in_expr(
         };
     }
 
-    if expression.span.contains(global_cursor_offset) && expression.span.start >= global_span_offset
+    if expression
+        .get_span(&working_set)
+        .contains(global_cursor_offset)
+        && expression.get_span(&working_set).start >= global_span_offset
     {
-        let expr_first = expression.span.start;
-        let span_str = &line
-            [expression.span.start - global_span_offset..expression.span.end - global_span_offset];
+        let expr_first = expression.get_span(&working_set).start;
+        let span_str = &line[expression.get_span(&working_set).start - global_span_offset
+            ..expression.get_span(&working_set).end - global_span_offset];
         let expr_last = span_str
             .chars()
             .last()
-            .map(|c| expression.span.end - get_char_length(c))
-            .unwrap_or(expression.span.start);
+            .map(|c| expression.get_span(&working_set).end - get_char_length(c))
+            .unwrap_or(expression.get_span(&working_set).start);
 
         return match &expression.expr {
             Expr::Bool(_) => None,

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_avro.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_avro.rs
@@ -51,10 +51,13 @@ impl Command for ToAvro {
     }
 }
 
-fn get_compression(call: &Call) -> Result<Option<AvroCompression>, ShellError> {
+fn get_compression(
+    engine_state: &EngineState,
+    call: &Call,
+) -> Result<Option<AvroCompression>, ShellError> {
     if let Some((compression, span)) = call
         .get_flag_expr("compression")
-        .and_then(|e| e.as_string().map(|s| (s, e.span)))
+        .and_then(|e| e.as_string().map(|s| (s, e.get_span(&engine_state))))
     {
         match compression.as_ref() {
             "snappy" => Ok(Some(AvroCompression::Snappy)),
@@ -77,7 +80,7 @@ fn command(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let file_name: Spanned<PathBuf> = call.req(engine_state, stack, 0)?;
-    let compression = get_compression(call)?;
+    let compression = get_compression(engine_state, call)?;
 
     let mut df = NuDataFrame::try_from_pipeline(input, call.head)?;
 

--- a/crates/nu-cmd-dataframe/src/dataframe/eager/to_nu.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/to_nu.rs
@@ -97,13 +97,13 @@ fn dataframe_command(
     let df = NuDataFrame::try_from_value(input)?;
 
     let values = if tail {
-        df.tail(rows, call.head)?
+        df.tail(rows, call.head, call.head_id)?
     } else {
         // if rows is specified, return those rows, otherwise return everything
         if rows.is_some() {
-            df.head(rows, call.head)?
+            df.head(rows, call.head, call.head_id)?
         } else {
-            df.head(Some(df.height()), call.head)?
+            df.head(Some(df.height()), call.head, call.head_id)?
         }
     };
 
@@ -113,7 +113,7 @@ fn dataframe_command(
 }
 fn expression_command(call: &Call, input: Value) -> Result<PipelineData, ShellError> {
     let expr = NuExpression::try_from_value(input)?;
-    let value = expr.to_value(call.head)?;
+    let value = expr.to_value(call.head, call.head_id)?;
 
     Ok(PipelineData::Value(value, None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/fill_nan.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/fill_nan.rs
@@ -95,8 +95,9 @@ impl Command for LazyFillNA {
             ))
         } else {
             let val_span = value.span();
+            let val_span_id = value.span_id();
             let frame = NuDataFrame::try_from_value(value)?;
-            let columns = frame.columns(val_span)?;
+            let columns = frame.columns(val_span, val_span_id)?;
             let dataframe = columns
                 .into_iter()
                 .map(|column| {

--- a/crates/nu-cmd-dataframe/src/dataframe/series/all_false.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/all_false.rs
@@ -87,7 +87,7 @@ fn command(
         inner: vec![],
     })?;
 
-    let value = Value::bool(!bool.any(), call.head);
+    let value = Value::bool(!bool.any(), call.head_id);
 
     NuDataFrame::try_from_columns(
         vec![Column::new("all_false".to_string(), vec![value])],

--- a/crates/nu-cmd-dataframe/src/dataframe/series/all_true.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/series/all_true.rs
@@ -87,7 +87,7 @@ fn command(
         inner: vec![],
     })?;
 
-    let value = Value::bool(bool.all(), call.head);
+    let value = Value::bool(bool.all(), call.head_id);
 
     NuDataFrame::try_from_columns(vec![Column::new("all_true".to_string(), vec![value])], None)
         .map(|df| PipelineData::Value(NuDataFrame::into_value(df, call.head), None))

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/custom_value.rs
@@ -1,5 +1,5 @@
 use super::NuDataFrame;
-use nu_protocol::{ast::Operator, CustomValue, ShellError, Span, Value};
+use nu_protocol::{ast::Operator, CustomValue, ShellError, Span, SpanId, Value};
 
 // CustomValue implementation for NuDataFrame
 impl CustomValue for NuDataFrame {
@@ -24,8 +24,8 @@ impl CustomValue for NuDataFrame {
         self.typetag_name().to_string()
     }
 
-    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
-        let vals = self.print(span)?;
+    fn to_base_value(&self, span: Span, span_id: SpanId) -> Result<Value, ShellError> {
+        let vals = self.print(span, span_id)?;
 
         Ok(Value::list(vals, span))
     }
@@ -37,17 +37,21 @@ impl CustomValue for NuDataFrame {
     fn follow_path_int(
         &self,
         _self_span: Span,
+        _self_span_id: SpanId,
         count: usize,
         path_span: Span,
+        path_span_id: SpanId,
     ) -> Result<Value, ShellError> {
-        self.get_value(count, path_span)
+        self.get_value(count, path_span, path_span_id)
     }
 
     fn follow_path_string(
         &self,
         _self_span: Span,
+        _self_span_id: SpanId,
         column_name: String,
         path_span: Span,
+        path_span_id: SpanId,
     ) -> Result<Value, ShellError> {
         let column = self.column(&column_name, path_span)?;
         Ok(column.into_value(path_span))
@@ -66,10 +70,12 @@ impl CustomValue for NuDataFrame {
     fn operation(
         &self,
         lhs_span: Span,
+        lhs_span_id: SpanId,
         operator: Operator,
         op: Span,
+        op_id: SpanId,
         right: &Value,
     ) -> Result<Value, ShellError> {
-        self.compute_with_value(lhs_span, operator, op, right)
+        self.compute_with_value(lhs_span, operator, op, op_id, right)
     }
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/operations.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/operations.rs
@@ -2,7 +2,7 @@ use super::{
     between_values::{between_dataframes, compute_between_series, compute_series_single_value},
     NuDataFrame,
 };
-use nu_protocol::{ast::Operator, ShellError, Span, Spanned, Value};
+use nu_protocol::{ast::Operator, ShellError, Span, SpanId, Spanned, Value};
 use polars::prelude::{DataFrame, Series};
 
 pub enum Axis {
@@ -16,6 +16,7 @@ impl NuDataFrame {
         lhs_span: Span,
         operator: Operator,
         op_span: Span,
+        op_span_id: SpanId,
         right: &Value,
     ) -> Result<Value, ShellError> {
         let rhs_span = right.span();
@@ -58,6 +59,7 @@ impl NuDataFrame {
                         let op = Spanned {
                             item: operator,
                             span: op_span,
+                            span_id: op_span_id,
                         };
 
                         compute_between_series(
@@ -81,6 +83,7 @@ impl NuDataFrame {
                         let op = Spanned {
                             item: operator,
                             span: op_span,
+                            span_id: op_span_id,
                         };
 
                         between_dataframes(
@@ -97,6 +100,7 @@ impl NuDataFrame {
                 let op = Spanned {
                     item: operator,
                     span: op_span,
+                    span_id: op_span_id,
                 };
 
                 compute_series_single_value(op, &NuDataFrame::default_value(lhs_span), self, right)

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/custom_value.rs
@@ -1,8 +1,5 @@
 use super::NuExpression;
-use nu_protocol::{
-    ast::{Comparison, Math, Operator},
-    CustomValue, ShellError, Span, Type, Value,
-};
+use nu_protocol::{ast::{Comparison, Math, Operator}, CustomValue, ShellError, Span, SpanId, Type, Value};
 use polars::prelude::Expr;
 use std::ops::{Add, Div, Mul, Rem, Sub};
 
@@ -26,8 +23,8 @@ impl CustomValue for NuExpression {
         self.typetag_name().to_string()
     }
 
-    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
-        self.to_value(span)
+    fn to_base_value(&self, span: Span, span_id: SpanId) -> Result<Value, ShellError> {
+        self.to_value(span, span_id)
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -37,8 +34,10 @@ impl CustomValue for NuExpression {
     fn operation(
         &self,
         lhs_span: Span,
+        lhs_span_id: SpanId,
         operator: Operator,
         op: Span,
+        op_id: SpanId,
         right: &Value,
     ) -> Result<Value, ShellError> {
         compute_with_value(self, lhs_span, operator, op, right)

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/custom_value.rs
@@ -1,5 +1,5 @@
 use super::NuLazyFrame;
-use nu_protocol::{record, CustomValue, ShellError, Span, Value};
+use nu_protocol::{record, CustomValue, ShellError, Span, Value, SpanId};
 
 // CustomValue implementation for NuDataFrame
 impl CustomValue for NuLazyFrame {
@@ -25,7 +25,7 @@ impl CustomValue for NuLazyFrame {
         self.typetag_name().to_string()
     }
 
-    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+    fn to_base_value(&self, span: Span, span_id: SpanId) -> Result<Value, ShellError> {
         let optimized_plan = self
             .as_ref()
             .describe_optimized_plan()

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazygroupby/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazygroupby/custom_value.rs
@@ -1,5 +1,5 @@
 use super::NuLazyGroupBy;
-use nu_protocol::{record, CustomValue, ShellError, Span, Value};
+use nu_protocol::{record, CustomValue, ShellError, Span, Value, SpanId};
 
 // CustomValue implementation for NuDataFrame
 impl CustomValue for NuLazyGroupBy {
@@ -25,7 +25,7 @@ impl CustomValue for NuLazyGroupBy {
         self.typetag_name().to_string()
     }
 
-    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+    fn to_base_value(&self, span: Span, span_id: SpanId) -> Result<Value, ShellError> {
         Ok(Value::record(
             record! {
                 "LazyGroupBy" => Value::string("apply aggregation to complete execution plan", span)

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_when/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_when/custom_value.rs
@@ -1,5 +1,5 @@
 use super::NuWhen;
-use nu_protocol::{CustomValue, ShellError, Span, Value};
+use nu_protocol::{CustomValue, ShellError, Span, SpanId, Value};
 
 // CustomValue implementation for NuDataFrame
 impl CustomValue for NuWhen {
@@ -21,7 +21,7 @@ impl CustomValue for NuWhen {
         self.typetag_name().to_string()
     }
 
-    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+    fn to_base_value(&self, span: Span, span_id: SpanId) -> Result<Value, ShellError> {
         let val: String = match self {
             NuWhen::Then(_) => "whenthen".into(),
             NuWhen::ChainedThen(_) => "whenthenthen".into(),

--- a/crates/nu-cmd-dataframe/src/dataframe/values/utils.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/utils.rs
@@ -25,10 +25,11 @@ pub(crate) fn convert_columns(
         .into_iter()
         .map(|value| {
             let span = value.span();
+            let span_id = value.span_id();
             match value {
                 Value::String { val, .. } => {
                     col_span = span_join(&[col_span, span]);
-                    Ok(Spanned { item: val, span })
+                    Ok(Spanned { item: val, span, span_id})
                 }
                 _ => Err(ShellError::GenericError {
                     error: "Incorrect column format".into(),

--- a/crates/nu-cmd-extra/src/extra/bits/into.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/into.rs
@@ -2,6 +2,7 @@ use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
 use num_traits::ToPrimitive;
+use nu_protocol::SpanId;
 
 pub struct Arguments {
     cell_paths: Option<Vec<CellPath>>,
@@ -140,7 +141,7 @@ fn into_bits(
         }
         _ => {
             let args = Arguments { cell_paths };
-            operate(action, args, input, call.head, engine_state.ctrlc.clone())
+            operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
         }
     }
 }
@@ -177,7 +178,7 @@ fn convert_to_smallest_number_type(num: i64, span: Span) -> Value {
     }
 }
 
-pub fn action(input: &Value, _args: &Arguments, span: Span) -> Value {
+pub fn action(input: &Value, _args: &Arguments, span: Span, span_id: SpanId) -> Value {
     match input {
         Value::Binary { val, .. } => {
             let mut raw_string = "".to_string();

--- a/crates/nu-cmd-extra/src/extra/bits/not.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/not.rs
@@ -1,6 +1,7 @@
 use super::{get_number_bytes, NumberBytes};
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct BitsNot;
@@ -67,6 +68,7 @@ impl Command for BitsNot {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        let head_id = call.head_id;
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
             call.get_flag(engine_state, stack, "number-bytes")?;
@@ -82,7 +84,7 @@ impl Command for BitsNot {
             number_size,
         };
 
-        operate(action, args, input, head, engine_state.ctrlc.clone())
+        operate(action, args, input, head, head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -134,7 +136,7 @@ impl Command for BitsNot {
     }
 }
 
-fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+fn action(input: &Value, args: &Arguments, span: Span, span_id: SpanId) -> Value {
     let Arguments {
         signed,
         number_size,

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_left.rs
@@ -2,6 +2,7 @@ use super::{get_input_num_type, get_number_bytes, InputNumType, NumberBytes};
 use itertools::Itertools;
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 struct Arguments {
     signed: bool,
@@ -69,6 +70,7 @@ impl Command for BitsRol {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        let head_id = call.head_id;
         let bits: usize = call.req(engine_state, stack, 0)?;
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
@@ -86,7 +88,7 @@ impl Command for BitsRol {
             bits,
         };
 
-        operate(action, args, input, head, engine_state.ctrlc.clone())
+        operate(action, args, input, head, head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -113,7 +115,7 @@ impl Command for BitsRol {
     }
 }
 
-fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+fn action(input: &Value, args: &Arguments, span: Span, span_id: SpanId) -> Value {
     let Arguments {
         signed,
         number_size,

--- a/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/rotate_right.rs
@@ -2,6 +2,7 @@ use super::{get_input_num_type, get_number_bytes, InputNumType, NumberBytes};
 use itertools::Itertools;
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 struct Arguments {
     signed: bool,
@@ -69,6 +70,7 @@ impl Command for BitsRor {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        let head_id = call.head_id;
         let bits: usize = call.req(engine_state, stack, 0)?;
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
@@ -86,7 +88,7 @@ impl Command for BitsRor {
             bits,
         };
 
-        operate(action, args, input, head, engine_state.ctrlc.clone())
+        operate(action, args, input, head, head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -117,7 +119,7 @@ impl Command for BitsRor {
     }
 }
 
-fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+fn action(input: &Value, args: &Arguments, span: Span, span_id: SpanId) -> Value {
     let Arguments {
         signed,
         number_size,

--- a/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_left.rs
@@ -4,6 +4,7 @@ use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
 use std::iter;
+use nu_protocol::SpanId;
 
 struct Arguments {
     signed: bool,
@@ -71,6 +72,7 @@ impl Command for BitsShl {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        let head_id = call.head_id;
         let bits: usize = call.req(engine_state, stack, 0)?;
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
@@ -88,7 +90,7 @@ impl Command for BitsShl {
             bits,
         };
 
-        operate(action, args, input, head, engine_state.ctrlc.clone())
+        operate(action, args, input, head, head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -125,7 +127,7 @@ impl Command for BitsShl {
     }
 }
 
-fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+fn action(input: &Value, args: &Arguments, span: Span, span_id: SpanId) -> Value {
     let Arguments {
         signed,
         number_size,

--- a/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/shift_right.rs
@@ -4,6 +4,7 @@ use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
 use std::iter;
+use nu_protocol::SpanId;
 
 struct Arguments {
     signed: bool,
@@ -71,6 +72,7 @@ impl Command for BitsShr {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        let head_id = call.head_id;
         let bits: usize = call.req(engine_state, stack, 0)?;
         let signed = call.has_flag(engine_state, stack, "signed")?;
         let number_bytes: Option<Spanned<usize>> =
@@ -88,7 +90,7 @@ impl Command for BitsShr {
             bits,
         };
 
-        operate(action, args, input, head, engine_state.ctrlc.clone())
+        operate(action, args, input, head, head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -115,7 +117,7 @@ impl Command for BitsShr {
     }
 }
 
-fn action(input: &Value, args: &Arguments, span: Span) -> Value {
+fn action(input: &Value, args: &Arguments, span: Span, span_id: SpanId) -> Value {
     let Arguments {
         signed,
         number_size,

--- a/crates/nu-cmd-extra/src/extra/conversions/fmt.rs
+++ b/crates/nu-cmd-extra/src/extra/conversions/fmt.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CellPathOnlyArgs};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct Fmt;
@@ -59,10 +60,10 @@ fn fmt(
 ) -> Result<PipelineData, ShellError> {
     let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
     let args = CellPathOnlyArgs::from(cell_paths);
-    operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
 }
 
-fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
+fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span, span_id: SpanId) -> Value {
     match input {
         Value::Float { val, .. } => fmt_it_64(*val, span),
         Value::Int { val, .. } => fmt_it(*val, span),

--- a/crates/nu-cmd-extra/src/extra/formats/from/url.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/from/url.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct FromUrl;
@@ -26,7 +27,7 @@ impl Command for FromUrl {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        from_url(input, head)
+        from_url(input, head, call.head_id)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -43,8 +44,8 @@ impl Command for FromUrl {
     }
 }
 
-fn from_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> {
-    let (concat_string, span, metadata) = input.collect_string_strict(head)?;
+fn from_url(input: PipelineData, head: Span, head_id: SpanId) -> Result<PipelineData, ShellError> {
+    let (concat_string, span, span_id, metadata) = input.collect_string_strict(head, head_id)?;
 
     let result = serde_urlencoded::from_str::<Vec<(String, String)>>(&concat_string);
 

--- a/crates/nu-cmd-extra/src/extra/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/mod.rs
@@ -44,7 +44,8 @@ pub fn add_extra_command_context(mut engine_state: EngineState) -> EngineState {
         bind_command!(platform::ansi::Gradient);
 
         bind_command!(
-            strings::format::FormatPattern,
+            // TODO: Re-enable after fixing the command
+            // strings::format::FormatPattern,
             strings::encode_decode::EncodeHex,
             strings::encode_decode::DecodeHex,
             strings::str_::case::Str,

--- a/crates/nu-cmd-extra/src/extra/strings/encode_decode/hex.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/encode_decode/hex.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate as general_operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 enum HexDecodingError {
     InvalidLength(usize),
@@ -88,7 +89,7 @@ pub fn operate(
         cell_paths,
     };
 
-    general_operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    general_operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
 }
 
 fn action(
@@ -96,6 +97,7 @@ fn action(
     // only used for `decode` action
     args: &Arguments,
     command_span: Span,
+    command_span_id: SpanId,
 ) -> Value {
     let hex_config = &args.encoding_config;
 

--- a/crates/nu-cmd-extra/src/extra/strings/format/command.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/command.rs
@@ -290,6 +290,7 @@ fn format_record(
                 let exp = parse_expression(working_set, &[*span]);
                 match working_set.parse_errors.first() {
                     None => {
+                        // TODO: The span of exp if in the working set which is not merged to engine state
                         let parsed_result = eval_expression(engine_state, stack, &exp);
                         if let Ok(val) = parsed_result {
                             output.push_str(&val.to_abbreviated_string(config))

--- a/crates/nu-cmd-extra/src/extra/strings/format/mod.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/format/mod.rs
@@ -1,3 +1,4 @@
 mod command;
 
-pub(crate) use command::FormatPattern;
+// TODO: Re-enable back after fixing the command
+// pub(crate) use command::FormatPattern;

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -90,6 +90,7 @@ impl Command for Do {
                 stderr,
                 exit_code,
                 span,
+                span_id,
                 metadata,
                 trim_end_newline,
             }) if capture_errors => {
@@ -114,10 +115,11 @@ impl Command for Do {
                                     )),
                                     ctrlc,
                                     span,
+                                    span_id,
                                     None,
                                 )
                             })
-                            .map_err(|e| e.into_spanned(call.head))
+                            .map_err(|e| e.into_spanned(call.head, call.head_id))
                     })
                     .transpose()?;
 
@@ -172,6 +174,7 @@ impl Command for Do {
                         Box::new(std::iter::once(Ok(stderr_msg.into_bytes()))),
                         stderr_ctrlc,
                         span,
+                        span_id,
                         None,
                     )),
                     exit_code: Some(ListStream::from_stream(
@@ -179,6 +182,7 @@ impl Command for Do {
                         exit_code_ctrlc,
                     )),
                     span,
+                    span_id,
                     metadata,
                     trim_end_newline,
                 })
@@ -188,6 +192,7 @@ impl Command for Do {
                 stderr,
                 exit_code: _,
                 span,
+                span_id,
                 metadata,
                 trim_end_newline,
             }) if ignore_program_errors
@@ -198,6 +203,7 @@ impl Command for Do {
                     stderr,
                     exit_code: None,
                     span,
+                    span_id,
                     metadata,
                     trim_end_newline,
                 })

--- a/crates/nu-cmd-lang/src/core_commands/match_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/match_.rs
@@ -59,7 +59,9 @@ impl Command for Match {
                     let guard_matches = if let Some(guard) = &match_.0.guard {
                         let Value::Bool { val, .. } = eval_expression(engine_state, stack, guard)?
                         else {
-                            return Err(ShellError::MatchGuardNotBool { span: guard.span });
+                            return Err(ShellError::MatchGuardNotBool {
+                                span: guard.get_span(&engine_state),
+                            });
                         };
 
                         val

--- a/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/hide.rs
@@ -52,6 +52,7 @@ impl Command for OverlayHide {
             Spanned {
                 item: stack.last_overlay_name()?,
                 span: call.head,
+                span_id: call.head_id,
             }
         };
 

--- a/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/use_.rs
@@ -72,7 +72,7 @@ impl Command for OverlayUse {
                     return Err(ShellError::NushellFailedSpanned {
                         msg: "Not an overlay".to_string(),
                         label: "requires an overlay (path or a string)".to_string(),
-                        span: overlay_expr.span,
+                        span: overlay_expr.get_span(&engine_state),
                     });
                 }
             } else {

--- a/crates/nu-cmd-lang/src/core_commands/plugin_list.rs
+++ b/crates/nu-cmd-lang/src/core_commands/plugin_list.rs
@@ -62,7 +62,7 @@ impl Command for PluginList {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let span = call.span();
+        let span = call.span(&engine_state);
         // Group plugin decls by plugin identity
         let decls = engine_state.plugin_decls().into_group_map_by(|decl| {
             decl.plugin_identity()

--- a/crates/nu-cmd-lang/src/core_commands/plugin_list.rs
+++ b/crates/nu-cmd-lang/src/core_commands/plugin_list.rs
@@ -62,7 +62,10 @@ impl Command for PluginList {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let span = call.span(&engine_state);
+        // TODO SPAN: Changed to head
+        let span = call.head;
+        let span_id = call.head_id;
+
         // Group plugin decls by plugin identity
         let decls = engine_state.plugin_decls().into_group_map_by(|decl| {
             decl.plugin_identity()
@@ -80,7 +83,7 @@ impl Command for PluginList {
 
             Value::record(record! {
                 "name" => Value::string(plugin.identity().name(), span),
-                "is_running" => Value::bool(plugin.is_running(), span),
+                "is_running" => Value::bool(plugin.is_running(), span_id),
                 "pid" => plugin.pid()
                     .map(|p| Value::int(p as i64, span))
                     .unwrap_or(Value::nothing(span)),

--- a/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
@@ -27,12 +27,13 @@ impl Command for ScopeCommands {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
+        let span_id = call.head_id;
         let ctrlc = engine_state.ctrlc.clone();
 
         let mut scope_data = ScopeData::new(engine_state, stack);
         scope_data.populate_decls();
 
-        Ok(scope_data.collect_commands(span).into_pipeline_data(ctrlc))
+        Ok(scope_data.collect_commands(span, span_id).into_pipeline_data(ctrlc))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/variables.rs
@@ -27,12 +27,14 @@ impl Command for ScopeVariables {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
+        let span_id = call.head_id;
+
         let ctrlc = engine_state.ctrlc.clone();
 
         let mut scope_data = ScopeData::new(engine_state, stack);
         scope_data.populate_vars();
 
-        Ok(scope_data.collect_vars(span).into_pipeline_data(ctrlc))
+        Ok(scope_data.collect_vars(span, span_id).into_pipeline_data(ctrlc))
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/bytes/build_.rs
+++ b/crates/nu-command/src/bytes/build_.rs
@@ -42,7 +42,7 @@ impl Command for BytesBuild {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let mut output = vec![];
-        for val in call.rest_iter_flattened(0, |expr| {
+        for val in call.rest_iter_flattened(engine_state, 0, |expr| {
             let eval_expression = get_eval_expression(engine_state);
             eval_expression(engine_state, stack, expr)
         })? {

--- a/crates/nu-command/src/bytes/ends_with.rs
+++ b/crates/nu-command/src/bytes/ends_with.rs
@@ -84,9 +84,9 @@ impl Command for BytesEndsWith {
 }
 
 fn ends_with(val: &Value, args: &Arguments, span: Span) -> Value {
-    let val_span = val.span();
+    let val_span_id = val.span_id();
     match val {
-        Value::Binary { val, .. } => Value::bool(val.ends_with(&args.pattern), val_span),
+        Value::Binary { val, .. } => Value::bool(val.ends_with(&args.pattern), val_span_id),
         // Propagate errors by explicitly matching them before the final case.
         Value::Error { .. } => val.clone(),
         other => Value::error(

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -71,7 +71,7 @@ pub fn get_pipeline_elements(
         while i < pipeline.elements.len() {
             let pipeline_element = &pipeline.elements[i];
             let pipeline_expression = &pipeline_element.expr;
-            let pipeline_span = pipeline_element.expr.span;
+            let pipeline_span = pipeline_element.expr.get_span(engine_state);
 
             let element_str =
                 String::from_utf8_lossy(engine_state.get_span_contents(pipeline_span));
@@ -166,12 +166,12 @@ fn get_arguments(
 
                     let record = record! {
                         "arg_type" => Value::string(arg_type, span),
-                        "name" => Value::string(arg_value_name, expression.span),
+                        "name" => Value::string(arg_value_name, expression.get_span(engine_state)),
                         "type" => Value::string(arg_value_type, span),
                         "span_start" => Value::int(arg_value_name_span_start, span),
                         "span_end" => Value::int(arg_value_name_span_end, span),
                     };
-                    arg_value.push(Value::record(record, expression.span));
+                    arg_value.push(Value::record(record, expression.get_span(engine_state)));
                 };
             }
             Argument::Positional(inner_expr) => {
@@ -186,12 +186,12 @@ fn get_arguments(
 
                 let record = record! {
                     "arg_type" => Value::string(arg_type, span),
-                    "name" => Value::string(arg_value_name, inner_expr.span),
+                    "name" => Value::string(arg_value_name, inner_expr.get_span(engine_state)),
                     "type" => Value::string(arg_value_type, span),
                     "span_start" => Value::int(arg_value_name_span_start, span),
                     "span_end" => Value::int(arg_value_name_span_end, span),
                 };
-                arg_value.push(Value::record(record, inner_expr.span));
+                arg_value.push(Value::record(record, inner_expr.get_span(engine_state)));
             }
             Argument::Unknown(inner_expr) => {
                 let arg_type = "unknown";
@@ -205,12 +205,12 @@ fn get_arguments(
 
                 let record = record! {
                     "arg_type" => Value::string(arg_type, span),
-                    "name" => Value::string(arg_value_name, inner_expr.span),
+                    "name" => Value::string(arg_value_name, inner_expr.get_span(engine_state)),
                     "type" => Value::string(arg_value_type, span),
                     "span_start" => Value::int(arg_value_name_span_start, span),
                     "span_end" => Value::int(arg_value_name_span_end, span),
                 };
-                arg_value.push(Value::record(record, inner_expr.span));
+                arg_value.push(Value::record(record, inner_expr.get_span(engine_state)));
             }
             Argument::Spread(inner_expr) => {
                 let arg_type = "spread";
@@ -224,12 +224,12 @@ fn get_arguments(
 
                 let record = record! {
                     "arg_type" => Value::string(arg_type, span),
-                    "name" => Value::string(arg_value_name, inner_expr.span),
+                    "name" => Value::string(arg_value_name, inner_expr.get_span(engine_state)),
                     "type" => Value::string(arg_value_type, span),
                     "span_start" => Value::int(arg_value_name_span_start, span),
                     "span_end" => Value::int(arg_value_name_span_end, span),
                 };
-                arg_value.push(Value::record(record, inner_expr.span));
+                arg_value.push(Value::record(record, inner_expr.get_span(engine_state)));
             }
         };
     }
@@ -245,7 +245,7 @@ fn get_expression_as_value(
 ) -> Value {
     match eval_expression_fn(engine_state, stack, inner_expr) {
         Ok(v) => v,
-        Err(error) => Value::error(error, inner_expr.span),
+        Err(error) => Value::error(error, inner_expr.get_span(engine_state)),
     }
 }
 

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -1,7 +1,7 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::{
     ast::{Expr, Expression},
-    DataSource, PipelineMetadata,
+    DataSource, GetSpan, PipelineMetadata,
 };
 
 #[derive(Clone)]
@@ -41,7 +41,7 @@ impl Command for Metadata {
         match arg {
             Some(Expression {
                 expr: Expr::FullCellPath(full_cell_path),
-                span,
+                span_id,
                 ..
             }) => {
                 if full_cell_path.tail.is_empty() {
@@ -50,7 +50,8 @@ impl Command for Metadata {
                             expr: Expr::Var(var_id),
                             ..
                         } => {
-                            let origin = stack.get_var_with_origin(*var_id, *span)?;
+                            let span = engine_state.get_span(*span_id);
+                            let origin = stack.get_var_with_origin(*var_id, span)?;
 
                             Ok(
                                 build_metadata_record(&origin, input.metadata().as_ref(), head)

--- a/crates/nu-command/src/debug/profile.rs
+++ b/crates/nu-command/src/debug/profile.rs
@@ -109,7 +109,7 @@ confusing the id/parent_id hierarchy. The --expr flag is helpful for investigati
             collect_expanded_source,
             collect_values,
             collect_exprs,
-            call.span(),
+            call.span(engine_state),
         );
 
         let lock_err = {
@@ -136,14 +136,14 @@ confusing the id/parent_id hierarchy. The --expr flag is helpful for investigati
         // TODO: See eval_source()
         match result {
             Ok(pipeline_data) => {
-                let _ = pipeline_data.into_value(call.span());
+                let _ = pipeline_data.into_value(call.span(engine_state));
                 // pipeline_data.print(engine_state, caller_stack, true, false)
             }
             Err(_e) => (), // TODO: Report error
         }
 
         let debugger = engine_state.deactivate_debugger().map_err(lock_err)?;
-        let res = debugger.report(engine_state, call.span());
+        let res = debugger.report(engine_state, call.span(engine_state));
 
         res.map(|val| val.into_pipeline_data())
     }

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -45,7 +45,8 @@ impl Command for ViewSource {
                     if decl.is_alias() {
                         if let Some(alias) = &decl.as_alias() {
                             let contents = String::from_utf8_lossy(
-                                engine_state.get_span_contents(alias.wrapped_call.span),
+                                engine_state
+                                    .get_span_contents(alias.wrapped_call.get_span(engine_state)),
                             );
                             Ok(Value::string(contents, call.head).into_pipeline_data())
                         } else {

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -100,7 +100,7 @@ fn with_env(
                             span: call
                                 .positional_nth(1)
                                 .expect("already checked through .req")
-                                .span,
+                                .get_span(engine_state),
                             help: None,
                         });
                     }
@@ -128,7 +128,7 @@ fn with_env(
                 span: call
                     .positional_nth(1)
                     .expect("already checked through .req")
-                    .span,
+                    .get_span(engine_state),
                 help: None,
             });
         }

--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -165,6 +165,7 @@ fn rm(
                 NuGlob::Expand(s) => NuGlob::Expand(nu_utils::strip_ansi_string_unlikely(s)),
             },
             span: path.span,
+            span_id: path.span_id,
         };
         let _ = std::mem::replace(&mut paths[idx], corrected_path);
     }

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -41,6 +41,7 @@ impl Command for Start {
         let path = Spanned {
             item: nu_utils::strip_ansi_string_unlikely(path.item),
             span: path.span,
+            span_id: path.span_id,
         };
         let path_no_whitespace = &path.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
         // only check if file exists in current current directory

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -126,7 +126,7 @@ impl Command for Touch {
                         span: call
                             .positional_nth(index)
                             .expect("already checked positional")
-                            .span,
+                            .get_span(engine_state),
                     });
                 };
             }
@@ -139,7 +139,7 @@ impl Command for Touch {
                         span: call
                             .positional_nth(index)
                             .expect("already checked positional")
-                            .span,
+                            .get_span(engine_state),
                     });
                 };
             }
@@ -152,7 +152,7 @@ impl Command for Touch {
                         span: call
                             .positional_nth(index)
                             .expect("already checked positional")
-                            .span,
+                            .get_span(engine_state),
                     });
                 };
             }

--- a/crates/nu-command/src/filesystem/util.rs
+++ b/crates/nu-command/src/filesystem/util.rs
@@ -218,7 +218,7 @@ pub fn get_rest_for_glob_pattern(
     let mut output = vec![];
     let eval_expression = get_eval_expression(engine_state);
 
-    for result in call.rest_iter_flattened(starting_pos, |expr| {
+    for result in call.rest_iter_flattened(engine_state, starting_pos, |expr| {
         let result = eval_expression(engine_state, stack, expr);
         match result {
             Err(e) => Err(e),

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -185,7 +185,10 @@ impl Command for Watch {
 
                     if let Some(position) = block.signature.get_positional(0) {
                         if let Some(position_id) = &position.var_id {
-                            stack.add_var(*position_id, Value::string(operation, call.span()));
+                            stack.add_var(
+                                *position_id,
+                                Value::string(operation, call.span(engine_state)),
+                            );
                         }
                     }
 
@@ -193,7 +196,7 @@ impl Command for Watch {
                         if let Some(position_id) = &position.var_id {
                             stack.add_var(
                                 *position_id,
-                                Value::string(path.to_string_lossy(), call.span()),
+                                Value::string(path.to_string_lossy(), call.span(engine_state)),
                             );
                         }
                     }
@@ -204,7 +207,7 @@ impl Command for Watch {
                                 *position_id,
                                 Value::string(
                                     new_path.unwrap_or_else(|| "".into()).to_string_lossy(),
-                                    call.span(),
+                                    call.span(engine_state),
                                 ),
                             );
                         }
@@ -214,7 +217,7 @@ impl Command for Watch {
                         engine_state,
                         stack,
                         &block,
-                        Value::nothing(call.span()).into_pipeline_data(),
+                        Value::nothing(call.span(engine_state)).into_pipeline_data(),
                     );
 
                     match eval_result {

--- a/crates/nu-command/src/filters/empty.rs
+++ b/crates/nu-command/src/filters/empty.rs
@@ -8,6 +8,7 @@ pub fn empty(
     negate: bool,
 ) -> Result<PipelineData, ShellError> {
     let head = call.head;
+    let head_id = call.head_id;
     let columns: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
 
     if !columns.is_empty() {
@@ -18,9 +19,9 @@ pub fn empty(
                     Ok(Value::Nothing { .. }) => {}
                     Ok(_) => {
                         if negate {
-                            return Ok(Value::bool(true, head).into_pipeline_data());
+                            return Ok(Value::bool(true, head_id).into_pipeline_data());
                         } else {
-                            return Ok(Value::bool(false, head).into_pipeline_data());
+                            return Ok(Value::bool(false, head_id).into_pipeline_data());
                         }
                     }
                     Err(err) => return Err(err),
@@ -29,9 +30,9 @@ pub fn empty(
         }
 
         if negate {
-            Ok(Value::bool(false, head).into_pipeline_data())
+            Ok(Value::bool(false, head_id).into_pipeline_data())
         } else {
-            Ok(Value::bool(true, head).into_pipeline_data())
+            Ok(Value::bool(true, head_id).into_pipeline_data())
         }
     } else {
         match input {
@@ -43,9 +44,9 @@ pub fn empty(
                     match bytes {
                         Ok(s) => {
                             if negate {
-                                Ok(Value::bool(!s.item.is_empty(), head).into_pipeline_data())
+                                Ok(Value::bool(!s.item.is_empty(), head_id).into_pipeline_data())
                             } else {
-                                Ok(Value::bool(s.item.is_empty(), head).into_pipeline_data())
+                                Ok(Value::bool(s.item.is_empty(), head_id).into_pipeline_data())
                             }
                         }
                         Err(err) => Err(err),
@@ -53,24 +54,24 @@ pub fn empty(
                 }
                 None => {
                     if negate {
-                        Ok(Value::bool(false, head).into_pipeline_data())
+                        Ok(Value::bool(false, head_id).into_pipeline_data())
                     } else {
-                        Ok(Value::bool(true, head).into_pipeline_data())
+                        Ok(Value::bool(true, head_id).into_pipeline_data())
                     }
                 }
             },
             PipelineData::ListStream(s, ..) => {
                 if negate {
-                    Ok(Value::bool(s.count() != 0, head).into_pipeline_data())
+                    Ok(Value::bool(s.count() != 0, head_id).into_pipeline_data())
                 } else {
-                    Ok(Value::bool(s.count() == 0, head).into_pipeline_data())
+                    Ok(Value::bool(s.count() == 0, head_id).into_pipeline_data())
                 }
             }
             PipelineData::Value(value, ..) => {
                 if negate {
-                    Ok(Value::bool(!value.is_empty(), head).into_pipeline_data())
+                    Ok(Value::bool(!value.is_empty(), head_id).into_pipeline_data())
                 } else {
-                    Ok(Value::bool(value.is_empty(), head).into_pipeline_data())
+                    Ok(Value::bool(value.is_empty(), head_id).into_pipeline_data())
                 }
             }
         }

--- a/crates/nu-command/src/filters/move_.rs
+++ b/crates/nu-command/src/filters/move_.rs
@@ -116,10 +116,12 @@ impl Command for Move {
         let before_or_after = match (after, before) {
             (Some(v), None) => Spanned {
                 span: v.span(),
+                span_id: v.span_id(),
                 item: BeforeOrAfter::After(v.coerce_into_string()?),
             },
             (None, Some(v)) => Spanned {
                 span: v.span(),
+                span_id: v.span_id(),
                 item: BeforeOrAfter::Before(v.coerce_into_string()?),
             },
             (Some(_), Some(_)) => {
@@ -263,6 +265,8 @@ fn move_record_columns(
 
 #[cfg(test)]
 mod test {
+    use nu_parser::UNALIASABLE_PARSER_KEYWORDS;
+    use nu_protocol::engine::UNKNOWN_SPAN_ID;
     use super::*;
 
     // helper
@@ -291,6 +295,7 @@ mod test {
         let after: Spanned<BeforeOrAfter> = Spanned {
             item: BeforeOrAfter::After("c".to_string()),
             span: test_span,
+            span_id: UNKNOWN_SPAN_ID,
         };
         let columns = [Value::test_string("a")];
 
@@ -315,6 +320,7 @@ mod test {
         let after: Spanned<BeforeOrAfter> = Spanned {
             item: BeforeOrAfter::After("c".to_string()),
             span: test_span,
+            span_id: UNKNOWN_SPAN_ID,
         };
         let columns = [Value::test_string("b"), Value::test_string("e")];
 
@@ -340,6 +346,7 @@ mod test {
         let after: Spanned<BeforeOrAfter> = Spanned {
             item: BeforeOrAfter::Before("b".to_string()),
             span: test_span,
+            span_id: UNKNOWN_SPAN_ID,
         };
         let columns = [Value::test_string("d")];
 
@@ -364,6 +371,7 @@ mod test {
         let after: Spanned<BeforeOrAfter> = Spanned {
             item: BeforeOrAfter::Before("b".to_string()),
             span: test_span,
+            span_id: UNKNOWN_SPAN_ID,
         };
         let columns = [Value::test_string("c"), Value::test_string("e")];
 
@@ -389,6 +397,7 @@ mod test {
         let after: Spanned<BeforeOrAfter> = Spanned {
             item: BeforeOrAfter::After("e".to_string()),
             span: test_span,
+            span_id: UNKNOWN_SPAN_ID,
         };
         let columns = [
             Value::test_string("d"),
@@ -418,6 +427,7 @@ mod test {
         let after: Spanned<BeforeOrAfter> = Spanned {
             item: BeforeOrAfter::Before("non-existent".to_string()),
             span: test_span,
+            span_id: UNKNOWN_SPAN_ID,
         };
         let columns = [Value::test_string("a")];
 
@@ -433,6 +443,7 @@ mod test {
         let after: Spanned<BeforeOrAfter> = Spanned {
             item: BeforeOrAfter::Before("b".to_string()),
             span: test_span,
+            span_id: UNKNOWN_SPAN_ID,
         };
         let columns = [Value::test_string("a"), Value::test_string("non-existent")];
 
@@ -448,6 +459,7 @@ mod test {
         let after: Spanned<BeforeOrAfter> = Spanned {
             item: BeforeOrAfter::After("b".to_string()),
             span: test_span,
+            span_id: UNKNOWN_SPAN_ID,
         };
         let columns = [Value::test_string("b"), Value::test_string("d")];
 

--- a/crates/nu-command/src/filters/rename.rs
+++ b/crates/nu-command/src/filters/rename.rs
@@ -155,6 +155,7 @@ fn rename(
         .map(
             move |item| {
                 let span = item.span();
+                let span_id = item.span_id();
                 match item {
                     Value::Record { val: record, .. } => {
                         let record =
@@ -181,8 +182,8 @@ fn rename(
                                             &block,
                                             Value::string(col, span).into_pipeline_data(),
                                         )
-                                        .and_then(|data| data.collect_string_strict(span))
-                                        .map(|(col, _, _)| (col, val))
+                                        .and_then(|data| data.collect_string_strict(span, span_id))
+                                        .map(|(col, _, _, _)| (col, val))
                                     })
                                     .collect::<Result<Record, _>>()
                             } else {

--- a/crates/nu-command/src/filters/split_by.rs
+++ b/crates/nu-command/src/filters/split_by.rs
@@ -84,6 +84,7 @@ pub fn split_by(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let name = call.head;
+    let name_id = call.head_id;
 
     let splitter: Option<Value> = call.opt(engine_state, stack, 0)?;
 
@@ -92,6 +93,7 @@ pub fn split_by(
             let splitter = Some(Spanned {
                 item: v.coerce_into_string()?,
                 span: name,
+                span_id: name_id,
             });
             Ok(split(splitter.as_ref(), input, name)?)
         }

--- a/crates/nu-command/src/filters/utils.rs
+++ b/crates/nu-command/src/filters/utils.rs
@@ -27,6 +27,7 @@ pub fn boolean_fold(
     accumulator: bool,
 ) -> Result<PipelineData, ShellError> {
     let span = call.head;
+    let span_id = call.head_id;
 
     let capture_block: Closure = call.req(engine_state, stack, 0)?;
     let block_id = capture_block.block_id;
@@ -59,11 +60,11 @@ pub fn boolean_fold(
             }
             Ok(pipeline_data) => {
                 if pipeline_data.into_value(span).is_true() == accumulator {
-                    return Ok(Value::bool(accumulator, span).into_pipeline_data());
+                    return Ok(Value::bool(accumulator, span_id).into_pipeline_data());
                 }
             }
         }
     }
 
-    Ok(Value::bool(!accumulator, span).into_pipeline_data())
+    Ok(Value::bool(!accumulator, span_id).into_pipeline_data())
 }

--- a/crates/nu-command/src/filters/values.rs
+++ b/crates/nu-command/src/filters/values.rs
@@ -140,6 +140,7 @@ fn values(
         PipelineData::Empty => Ok(PipelineData::Empty),
         PipelineData::Value(v, ..) => {
             let span = v.span();
+            let span_id = v.span_id();
             match v {
                 Value::List { vals, .. } => match get_values(&vals, head, span) {
                     Ok(cols) => Ok(cols
@@ -148,7 +149,7 @@ fn values(
                     Err(err) => Err(err),
                 },
                 Value::Custom { val, .. } => {
-                    let input_as_base_value = val.to_base_value(span)?;
+                    let input_as_base_value = val.to_base_value(span, span_id)?;
                     match get_values(&[input_as_base_value], head, span) {
                         Ok(cols) => Ok(cols
                             .into_iter()

--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -141,7 +141,7 @@ fn from_csv(
             } else {
                 return Err(ShellError::NonUtf8Custom {
                     msg: "separator should be a single char or a 4-byte unicode".into(),
-                    span: call.span(),
+                    span: call.span(engine_state),
                 });
             }
         }

--- a/crates/nu-command/src/formats/from/csv.rs
+++ b/crates/nu-command/src/formats/from/csv.rs
@@ -123,6 +123,7 @@ fn from_csv(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let name = call.head;
+    let name_id = call.head_id;
     if let PipelineData::Value(Value::List { .. }, _) = input {
         return Err(ShellError::TypeMismatch {
             err_message: "received list stream, did you forget to open file with --raw flag?"
@@ -176,7 +177,7 @@ fn from_csv(
         trim,
     };
 
-    from_delimited_data(config, input, name)
+    from_delimited_data(config, input, name, name_id)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -1,5 +1,5 @@
 use csv::{ReaderBuilder, Trim};
-use nu_protocol::{IntoPipelineData, PipelineData, ShellError, Span, Value};
+use nu_protocol::{IntoPipelineData, PipelineData, ShellError, Span, SpanId, Value};
 
 fn from_delimited_string_to_value(
     DelimitedReaderConfig {
@@ -78,8 +78,9 @@ pub(super) fn from_delimited_data(
     config: DelimitedReaderConfig,
     input: PipelineData,
     name: Span,
+    name_id: SpanId,
 ) -> Result<PipelineData, ShellError> {
-    let (concat_string, _span, metadata) = input.collect_string_strict(name)?;
+    let (concat_string, _span, _span_id, metadata) = input.collect_string_strict(name, name_id)?;
 
     Ok(from_delimited_string_to_value(config, concat_string, name)
         .map_err(|x| ShellError::DelimiterError {

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -1,7 +1,7 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::{
     ast::{Expr, Expression, RecordItem},
-    engine::StateWorkingSet,
+    engine::{StateWorkingSet, UNKNOWN_SPAN_ID},
     Range, Unit,
 };
 use std::sync::Arc;
@@ -91,7 +91,7 @@ impl Command for FromNuon {
             }
         }
 
-        let head_id = engine_state.find_span_id(head).expect("missing nuon head span");
+        let head_id = engine_state.find_span_id(head).unwrap_or(UNKNOWN_SPAN_ID);
 
         let expr = if block.pipelines.is_empty() {
             Expression::new_existing(Expr::Nothing, head, head_id, Type::Nothing)

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -92,12 +92,7 @@ impl Command for FromNuon {
         }
 
         let expr = if block.pipelines.is_empty() {
-            Expression::new_existing(
-                &engine_state,
-                Expr::Nothing,
-                head,
-                Type::Nothing,
-            )
+            Expression::new_existing(&engine_state, Expr::Nothing, head, Type::Nothing)
         } else {
             let mut pipeline = Arc::make_mut(&mut block).pipelines.remove(0);
 
@@ -117,11 +112,7 @@ impl Command for FromNuon {
             }
 
             if pipeline.elements.is_empty() {
-                Expression::new_existing(&engine_state,
-                    Expr::Nothing,
-                    head,
-                    Type::Nothing,
-                    )
+                Expression::new_existing(&engine_state, Expr::Nothing, head, Type::Nothing)
             } else {
                 pipeline.elements.remove(0).expr
             }

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -94,7 +94,7 @@ impl Command for FromNuon {
         let head_id = engine_state.find_span_id(head).unwrap_or(UNKNOWN_SPAN_ID);
 
         let expr = if block.pipelines.is_empty() {
-            Expression::new_existing(Expr::Nothing, head, head_id, Type::Nothing)
+            Expression::new_existing(Expr::Nothing, head_id, Type::Nothing)
         } else {
             let mut pipeline = Arc::make_mut(&mut block).pipelines.remove(0);
 
@@ -114,7 +114,7 @@ impl Command for FromNuon {
             }
 
             if pipeline.elements.is_empty() {
-                Expression::new_existing(Expr::Nothing, head, head_id, Type::Nothing)
+                Expression::new_existing(Expr::Nothing, head_id, Type::Nothing)
             } else {
                 pipeline.elements.remove(0).expr
             }

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -92,12 +92,12 @@ impl Command for FromNuon {
         }
 
         let expr = if block.pipelines.is_empty() {
-            Expression {
-                expr: Expr::Nothing,
-                span: head,
-                custom_completion: None,
-                ty: Type::Nothing,
-            }
+            Expression::new_existing(
+                &engine_state,
+                Expr::Nothing,
+                head,
+                Type::Nothing,
+            )
         } else {
             let mut pipeline = Arc::make_mut(&mut block).pipelines.remove(0);
 
@@ -117,12 +117,11 @@ impl Command for FromNuon {
             }
 
             if pipeline.elements.is_empty() {
-                Expression {
-                    expr: Expr::Nothing,
-                    span: head,
-                    custom_completion: None,
-                    ty: Type::Nothing,
-                }
+                Expression::new_existing(&engine_state,
+                    Expr::Nothing,
+                    head,
+                    Type::Nothing,
+                    )
             } else {
                 pipeline.elements.remove(0).expr
             }

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -91,8 +91,10 @@ impl Command for FromNuon {
             }
         }
 
+        let head_id = engine_state.find_span_id(head).expect("missing nuon head span");
+
         let expr = if block.pipelines.is_empty() {
-            Expression::new_existing(&engine_state, Expr::Nothing, head, Type::Nothing)
+            Expression::new_existing(Expr::Nothing, head, head_id, Type::Nothing)
         } else {
             let mut pipeline = Arc::make_mut(&mut block).pipelines.remove(0);
 
@@ -112,7 +114,7 @@ impl Command for FromNuon {
             }
 
             if pipeline.elements.is_empty() {
-                Expression::new_existing(&engine_state, Expr::Nothing, head, Type::Nothing)
+                Expression::new_existing(Expr::Nothing, head, head_id, Type::Nothing)
             } else {
                 pipeline.elements.remove(0).expr
             }

--- a/crates/nu-command/src/formats/from/ods.rs
+++ b/crates/nu-command/src/formats/from/ods.rs
@@ -3,6 +3,7 @@ use indexmap::IndexMap;
 use nu_engine::command_prelude::*;
 
 use std::io::Cursor;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct FromOds;
@@ -37,6 +38,7 @@ impl Command for FromOds {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
+        let head_id = call.head_id;
 
         let sel_sheets = if let Some(Value::List { vals: columns, .. }) =
             call.get_flag(engine_state, stack, "sheets")?
@@ -46,7 +48,7 @@ impl Command for FromOds {
             vec![]
         };
 
-        from_ods(input, head, sel_sheets)
+        from_ods(input, head, head_id, sel_sheets)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -108,6 +110,7 @@ fn collect_binary(input: PipelineData, span: Span) -> Result<Vec<u8>, ShellError
 fn from_ods(
     input: PipelineData,
     head: Span,
+    head_id: SpanId,
     sel_sheets: Vec<String>,
 ) -> Result<PipelineData, ShellError> {
     let span = input.span();
@@ -141,7 +144,7 @@ fn from_ods(
                             Data::String(s) => Value::string(s, head),
                             Data::Float(f) => Value::float(*f, head),
                             Data::Int(i) => Value::int(*i, head),
-                            Data::Bool(b) => Value::bool(*b, head),
+                            Data::Bool(b) => Value::bool(*b, head_id),
                             _ => Value::nothing(head),
                         };
 

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -284,13 +284,14 @@ fn from_ssv(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let name = call.head;
+    let name_id = call.head_id;
 
     let noheaders = call.has_flag(engine_state, stack, "noheaders")?;
     let aligned_columns = call.has_flag(engine_state, stack, "aligned-columns")?;
     let minimum_spaces: Option<Spanned<usize>> =
         call.get_flag(engine_state, stack, "minimum-spaces")?;
 
-    let (concat_string, _span, metadata) = input.collect_string_strict(name)?;
+    let (concat_string, _span, _span_id, metadata) = input.collect_string_strict(name, name_id)?;
     let split_at = match minimum_spaces {
         Some(number) => number.item,
         None => DEFAULT_MINIMUM_SPACES,

--- a/crates/nu-command/src/formats/from/tsv.rs
+++ b/crates/nu-command/src/formats/from/tsv.rs
@@ -112,6 +112,7 @@ fn from_tsv(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let name = call.head;
+    let name_id = call.head_id;
 
     let comment = call
         .get_flag(engine_state, stack, "comment")?
@@ -142,7 +143,7 @@ fn from_tsv(
         trim,
     };
 
-    from_delimited_data(config, input, name)
+    from_delimited_data(config, input, name, name_id)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -102,6 +102,7 @@ impl Command for ToJson {
 
 pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
     let span = v.span();
+    let span_id = v.span_id();
     Ok(match v {
         Value::Bool { val, .. } => nu_json::Value::Bool(*val),
         Value::Filesize { val, .. } => nu_json::Value::I64(*val),
@@ -140,7 +141,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
             value_to_json_value(&collected)?
         }
         Value::Custom { val, .. } => {
-            let collected = val.to_base_value(span)?;
+            let collected = val.to_base_value(span, span_id)?;
             value_to_json_value(&collected)?
         }
     })

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -28,6 +28,7 @@ impl Command for ToText {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
+        let span_id = call.head_id;
         let config = engine_state.get_config();
 
         let line_ending = if cfg!(target_os = "windows") {
@@ -47,11 +48,13 @@ impl Command for ToText {
                     }),
                     engine_state.ctrlc.clone(),
                     span,
+                    span_id,
                     None,
                 )),
                 stderr: None,
                 exit_code: None,
                 span,
+                span_id,
                 metadata: None,
                 trim_end_newline: false,
             })
@@ -107,6 +110,7 @@ impl Iterator for ListStreamIterator {
 
 fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
     let span = value.span();
+    let span_id = value.span_id();
     match value {
         Value::Bool { val, .. } => val.to_string(),
         Value::Int { val, .. } => val.to_string(),
@@ -148,7 +152,7 @@ fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
         // If we fail to collapse the custom value, just print <{type_name}> - failure is not
         // that critical here
         Value::Custom { val, .. } => val
-            .to_base_value(span)
+            .to_base_value(span, span_id)
             .map(|val| local_into_string(val, separator, config))
             .unwrap_or_else(|_| format!("<{}>", val.type_name())),
     }

--- a/crates/nu-command/src/hash/generic_digest.rs
+++ b/crates/nu-command/src/hash/generic_digest.rs
@@ -127,13 +127,14 @@ where
                 args,
                 input,
                 call.head,
+                call.head_id,
                 engine_state.ctrlc.clone(),
             ),
         }
     }
 }
 
-pub(super) fn action<D>(input: &Value, args: &Arguments, _span: Span) -> Value
+pub(super) fn action<D>(input: &Value, args: &Arguments, _span: Span, _span_id: SpanId) -> Value
 where
     D: HashDigest,
     digest::Output<D>: core::fmt::LowerHex,

--- a/crates/nu-command/src/help/help_aliases.rs
+++ b/crates/nu-command/src/help/help_aliases.rs
@@ -125,8 +125,9 @@ pub fn help_aliases(
             });
         };
 
-        let alias_expansion =
-            String::from_utf8_lossy(engine_state.get_span_contents(alias.wrapped_call.span));
+        let alias_expansion = String::from_utf8_lossy(
+            engine_state.get_span_contents(alias.wrapped_call.get_span(engine_state)),
+        );
         let usage = alias.usage();
         let extra_usage = alias.extra_usage();
 

--- a/crates/nu-command/src/math/avg.rs
+++ b/crates/nu-command/src/math/avg.rs
@@ -3,6 +3,7 @@ use crate::math::{
     utils::run_with_function,
 };
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 const NS_PER_SEC: i64 = 1_000_000_000;
 #[derive(Clone)]
@@ -72,14 +73,14 @@ impl Command for SubCommand {
     }
 }
 
-pub fn average(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
+pub fn average(values: &[Value], span: Span, span_id: SpanId, head: Span, head_id: SpanId) -> Result<Value, ShellError> {
     let sum = reducer_for(Reduce::Summation);
-    let total = &sum(Value::int(0, head), values.to_vec(), span, head)?;
+    let total = &sum(Value::int(0, head), values.to_vec(), span, span_id, head, head_id)?;
     let span = total.span();
     match total {
         Value::Filesize { val, .. } => Ok(Value::filesize(val / values.len() as i64, span)),
         Value::Duration { val, .. } => Ok(Value::duration(val / values.len() as i64, span)),
-        _ => total.div(head, &Value::int(values.len() as i64, head), head),
+        _ => total.div(head, head_id, &Value::int(values.len() as i64, head), head),
     }
 }
 

--- a/crates/nu-command/src/math/max.rs
+++ b/crates/nu-command/src/math/max.rs
@@ -3,6 +3,7 @@ use crate::math::{
     utils::run_with_function,
 };
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -71,9 +72,9 @@ impl Command for SubCommand {
     }
 }
 
-pub fn maximum(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
+pub fn maximum(values: &[Value], span: Span, span_id: SpanId, head: Span, head_id: SpanId) -> Result<Value, ShellError> {
     let max_func = reducer_for(Reduce::Maximum);
-    max_func(Value::nothing(head), values.to_vec(), span, head)
+    max_func(Value::nothing(head), values.to_vec(), span, span_id, head, head_id)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/median.rs
+++ b/crates/nu-command/src/math/median.rs
@@ -1,6 +1,7 @@
 use crate::math::{avg::average, utils::run_with_function};
 use nu_engine::command_prelude::*;
 use std::cmp::Ordering;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -71,7 +72,7 @@ enum Pick {
     Median,
 }
 
-pub fn median(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
+pub fn median(values: &[Value], span: Span, span_id: SpanId, head: Span, head_id: SpanId) -> Result<Value, ShellError> {
     let take = if values.len() % 2 == 0 {
         Pick::MedianAverage
     } else {
@@ -142,7 +143,7 @@ pub fn median(values: &[Value], span: Span, head: Span) -> Result<Value, ShellEr
                 })?
                 .clone();
 
-            average(&[left, right], span, head)
+            average(&[left, right], span, span_id, head, head_id)
         }
     }
 }

--- a/crates/nu-command/src/math/min.rs
+++ b/crates/nu-command/src/math/min.rs
@@ -3,6 +3,7 @@ use crate::math::{
     utils::run_with_function,
 };
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -69,9 +70,9 @@ impl Command for SubCommand {
     }
 }
 
-pub fn minimum(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
+pub fn minimum(values: &[Value], span: Span, span_id: SpanId, head: Span, head_id: SpanId) -> Result<Value, ShellError> {
     let min_func = reducer_for(Reduce::Minimum);
-    min_func(Value::nothing(head), values.to_vec(), span, head)
+    min_func(Value::nothing(head), values.to_vec(), span, span_id, head, head_id)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/mode.rs
+++ b/crates/nu-command/src/math/mode.rs
@@ -1,6 +1,7 @@
 use crate::math::utils::run_with_function;
 use nu_engine::command_prelude::*;
 use std::{cmp::Ordering, collections::HashMap};
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -97,7 +98,7 @@ impl Command for SubCommand {
     }
 }
 
-pub fn mode(values: &[Value], _span: Span, head: Span) -> Result<Value, ShellError> {
+pub fn mode(values: &[Value], _span: Span, _span_id: SpanId, head: Span, head_id: SpanId) -> Result<Value, ShellError> {
     if let Some(Err(values)) = values
         .windows(2)
         .map(|elem| {

--- a/crates/nu-command/src/math/product.rs
+++ b/crates/nu-command/src/math/product.rs
@@ -3,6 +3,7 @@ use crate::math::{
     utils::run_with_function,
 };
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -62,9 +63,9 @@ impl Command for SubCommand {
 }
 
 /// Calculate product of given values
-pub fn product(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
+pub fn product(values: &[Value], span: Span, span_id: SpanId, head: Span, head_id: SpanId) -> Result<Value, ShellError> {
     let product_func = reducer_for(Reduce::Product);
-    product_func(Value::nothing(head), values.to_vec(), span, head)
+    product_func(Value::nothing(head), values.to_vec(), span, span_id, head, head_id)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/math/stddev.rs
+++ b/crates/nu-command/src/math/stddev.rs
@@ -1,6 +1,7 @@
 use super::variance::compute_variance as variance;
 use crate::math::utils::run_with_function;
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -76,10 +77,10 @@ impl Command for SubCommand {
     }
 }
 
-pub fn compute_stddev(sample: bool) -> impl Fn(&[Value], Span, Span) -> Result<Value, ShellError> {
-    move |values: &[Value], span: Span, head: Span| {
+pub fn compute_stddev(sample: bool) -> impl Fn(&[Value], Span, SpanId, Span, SpanId) -> Result<Value, ShellError> {
+    move |values: &[Value], span: Span, span_id: SpanId, head: Span, head_id: SpanId| {
         // variance() produces its own usable error, so we can use `?` to propagated the error.
-        let variance = variance(sample)(values, span, head)?;
+        let variance = variance(sample)(values, span, span_id, head, head_id)?;
         let val_span = variance.span();
         match variance {
             Value::Float { val, .. } => Ok(Value::float(val.sqrt(), val_span)),

--- a/crates/nu-command/src/math/sum.rs
+++ b/crates/nu-command/src/math/sum.rs
@@ -3,6 +3,7 @@ use crate::math::{
     utils::run_with_function,
 };
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -68,9 +69,9 @@ impl Command for SubCommand {
     }
 }
 
-pub fn summation(values: &[Value], span: Span, head: Span) -> Result<Value, ShellError> {
+pub fn summation(values: &[Value], span: Span, span_id: SpanId, head: Span, head_id: SpanId) -> Result<Value, ShellError> {
     let sum_func = reducer_for(Reduce::Summation);
-    sum_func(Value::nothing(head), values.to_vec(), span, head)
+    sum_func(Value::nothing(head), values.to_vec(), span, span_id, head, head_id)
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -184,6 +184,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
+    let span_id = args.url.span_id();
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -208,6 +209,7 @@ fn helper(
         engine_state,
         stack,
         span,
+        span_id,
         &requested_url,
         request_flags,
         response,

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -169,6 +169,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
+    let span_id = args.url.span_id();
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -193,6 +194,7 @@ fn helper(
         engine_state,
         stack,
         span,
+        span_id,
         &requested_url,
         request_flags,
         response,

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -149,6 +149,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
+    let span_id = args.url.span_id();
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
 
@@ -174,6 +175,7 @@ fn helper(
         engine_state,
         stack,
         span,
+        span_id,
         &requested_url,
         request_flags,
         response,

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -176,6 +176,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
+    let span_id = args.url.span_id();
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -200,6 +201,7 @@ fn helper(
         engine_state,
         stack,
         span,
+        span_id,
         &requested_url,
         request_flags,
         response,

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -174,6 +174,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
+    let span_id = args.url.span_id();
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -198,6 +199,7 @@ fn helper(
         engine_state,
         stack,
         span,
+        span_id,
         &requested_url,
         request_flags,
         response,

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -174,6 +174,7 @@ fn helper(
     args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let span = args.url.span();
+    let span_id = args.url.span_id();
     let ctrl_c = engine_state.ctrlc.clone();
     let (requested_url, _) = http_parse_url(call, span, args.url)?;
     let redirect_mode = http_parse_redirect_mode(args.redirect)?;
@@ -198,6 +199,7 @@ fn helper(
         engine_state,
         stack,
         span,
+        span_id,
         &requested_url,
         request_flags,
         response,

--- a/crates/nu-command/src/network/url/decode.rs
+++ b/crates/nu-command/src/network/url/decode.rs
@@ -2,6 +2,7 @@ use nu_cmd_base::input_handler::{operate, CellPathOnlyArgs};
 use nu_engine::command_prelude::*;
 
 use percent_encoding::percent_decode_str;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -48,7 +49,7 @@ impl Command for SubCommand {
     ) -> Result<PipelineData, ShellError> {
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let args = CellPathOnlyArgs::from(cell_paths);
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -74,7 +75,7 @@ impl Command for SubCommand {
     }
 }
 
-fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
+fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span, head_id: SpanId) -> Value {
     let input_span = input.span();
     match input {
         Value::String { val, .. } => {

--- a/crates/nu-command/src/network/url/encode.rs
+++ b/crates/nu-command/src/network/url/encode.rs
@@ -2,6 +2,7 @@ use nu_cmd_base::input_handler::{operate, CellPathOnlyArgs};
 use nu_engine::command_prelude::*;
 
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -55,10 +56,11 @@ impl Command for SubCommand {
                 args,
                 input,
                 call.head,
+                call.head_id,
                 engine_state.ctrlc.clone(),
             )
         } else {
-            operate(action, args, input, call.head, engine_state.ctrlc.clone())
+            operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
         }
     }
 
@@ -90,7 +92,7 @@ impl Command for SubCommand {
     }
 }
 
-fn action_all(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
+fn action_all(input: &Value, _arg: &CellPathOnlyArgs, head: Span, head_id: SpanId) -> Value {
     match input {
         Value::String { val, .. } => {
             const FRAGMENT: &AsciiSet = NON_ALPHANUMERIC;
@@ -109,7 +111,7 @@ fn action_all(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
     }
 }
 
-fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
+fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span, head_id: SpanId) -> Value {
     match input {
         Value::String { val, .. } => {
             const FRAGMENT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'/').remove(b':').remove(b'.');

--- a/crates/nu-command/src/path/basename.rs
+++ b/crates/nu-command/src/path/basename.rs
@@ -2,6 +2,7 @@ use super::PathSubcommandArguments;
 use nu_engine::command_prelude::*;
 use nu_protocol::engine::StateWorkingSet;
 use std::path::Path;
+use nu_protocol::SpanId;
 
 struct Arguments {
     replace: Option<Spanned<String>>,
@@ -135,7 +136,7 @@ impl Command for SubCommand {
     }
 }
 
-fn get_basename(path: &Path, span: Span, args: &Arguments) -> Value {
+fn get_basename(path: &Path, span: Span, span_id: SpanId, args: &Arguments) -> Value {
     match &args.replace {
         Some(r) => Value::string(path.with_file_name(r.item.clone()).to_string_lossy(), span),
         None => Value::string(

--- a/crates/nu-command/src/path/dirname.rs
+++ b/crates/nu-command/src/path/dirname.rs
@@ -2,6 +2,7 @@ use super::PathSubcommandArguments;
 use nu_engine::command_prelude::*;
 use nu_protocol::engine::StateWorkingSet;
 use std::path::Path;
+use nu_protocol::SpanId;
 
 struct Arguments {
     replace: Option<Spanned<String>>,
@@ -156,7 +157,7 @@ impl Command for SubCommand {
     }
 }
 
-fn get_dirname(path: &Path, span: Span, args: &Arguments) -> Value {
+fn get_dirname(path: &Path, span: Span, span_id: SpanId, args: &Arguments) -> Value {
     let num_levels = args.num_levels.as_ref().map_or(1, |val| *val);
 
     let mut dirname = path;

--- a/crates/nu-command/src/path/exists.rs
+++ b/crates/nu-command/src/path/exists.rs
@@ -3,6 +3,7 @@ use nu_engine::{command_prelude::*, current_dir, current_dir_const};
 use nu_path::expand_path_with;
 use nu_protocol::engine::StateWorkingSet;
 use std::path::{Path, PathBuf};
+use nu_protocol::SpanId;
 
 struct Arguments {
     pwd: PathBuf,
@@ -127,9 +128,9 @@ If you need to distinguish dirs and files, please use `path type`."#
     }
 }
 
-fn exists(path: &Path, span: Span, args: &Arguments) -> Value {
+fn exists(path: &Path, span: Span, span_id: SpanId, args: &Arguments) -> Value {
     if path.as_os_str().is_empty() {
-        return Value::bool(false, span);
+        return Value::bool(false, span_id);
     }
     let path = expand_path_with(path, &args.pwd, true);
     let exists = if args.not_follow_symlink {
@@ -159,7 +160,7 @@ fn exists(path: &Path, span: Span, args: &Arguments) -> Value {
                 )
             }
         },
-        span,
+        span_id,
     )
 }
 

--- a/crates/nu-command/src/path/expand.rs
+++ b/crates/nu-command/src/path/expand.rs
@@ -6,6 +6,7 @@ use nu_engine::{
 use nu_path::{canonicalize_with, expand_path_with};
 use nu_protocol::engine::StateWorkingSet;
 use std::path::Path;
+use nu_protocol::SpanId;
 
 struct Arguments {
     strict: bool,
@@ -143,7 +144,7 @@ impl Command for SubCommand {
     }
 }
 
-fn expand(path: &Path, span: Span, args: &Arguments) -> Value {
+fn expand(path: &Path, span: Span, span_id: SpanId, args: &Arguments) -> Value {
     if args.strict {
         match canonicalize_with(path, &args.cwd) {
             Ok(p) => {

--- a/crates/nu-command/src/path/mod.rs
+++ b/crates/nu-command/src/path/mod.rs
@@ -20,7 +20,7 @@ pub use r#type::SubCommand as PathType;
 pub use relative_to::SubCommand as PathRelativeTo;
 pub use split::SubCommand as PathSplit;
 
-use nu_protocol::{ShellError, Span, Value};
+use nu_protocol::{ShellError, Span, SpanId, Value};
 use std::path::Path as StdPath;
 
 #[cfg(windows)]
@@ -32,12 +32,13 @@ trait PathSubcommandArguments {}
 
 fn operate<F, A>(cmd: &F, args: &A, v: Value, name: Span) -> Value
 where
-    F: Fn(&StdPath, Span, &A) -> Value + Send + Sync + 'static,
+    F: Fn(&StdPath, Span, SpanId, &A) -> Value + Send + Sync + 'static,
     A: PathSubcommandArguments + Send + Sync + 'static,
 {
     let span = v.span();
+    let span_id = v.span_id();
     match v {
-        Value::String { val, .. } => cmd(StdPath::new(&val), span, args),
+        Value::String { val, .. } => cmd(StdPath::new(&val), span, span_id, args),
         _ => handle_invalid_values(v, name),
     }
 }

--- a/crates/nu-command/src/path/parse.rs
+++ b/crates/nu-command/src/path/parse.rs
@@ -2,6 +2,7 @@ use super::PathSubcommandArguments;
 use nu_engine::command_prelude::*;
 use nu_protocol::engine::StateWorkingSet;
 use std::path::Path;
+use nu_protocol::SpanId;
 
 struct Arguments {
     extension: Option<Spanned<String>>,
@@ -183,7 +184,7 @@ On Windows, an extra 'prefix' column is added."#
     }
 }
 
-fn parse(path: &Path, span: Span, args: &Arguments) -> Value {
+fn parse(path: &Path, span: Span, span_id: SpanId, args: &Arguments) -> Value {
     let mut record = Record::new();
 
     #[cfg(windows)]
@@ -215,6 +216,7 @@ fn parse(path: &Path, span: Span, args: &Arguments) -> Value {
         Some(Spanned {
             item: extension,
             span: extension_span,
+            span_id: extension_span_id,
         }) => {
             let ext_with_dot = [".", extension].concat();
             if basename.ends_with(&ext_with_dot) && !extension.is_empty() {

--- a/crates/nu-command/src/path/relative_to.rs
+++ b/crates/nu-command/src/path/relative_to.rs
@@ -3,6 +3,7 @@ use nu_engine::command_prelude::*;
 use nu_path::expand_to_real_path;
 use nu_protocol::engine::StateWorkingSet;
 use std::path::Path;
+use nu_protocol::SpanId;
 
 struct Arguments {
     path: Spanned<String>,
@@ -141,7 +142,7 @@ path."#
     }
 }
 
-fn relative_to(path: &Path, span: Span, args: &Arguments) -> Value {
+fn relative_to(path: &Path, span: Span, span_id: SpanId, args: &Arguments) -> Value {
     let lhs = expand_to_real_path(path);
     let rhs = expand_to_real_path(&args.path.item);
     match lhs.strip_prefix(&rhs) {

--- a/crates/nu-command/src/path/split.rs
+++ b/crates/nu-command/src/path/split.rs
@@ -2,6 +2,7 @@ use super::PathSubcommandArguments;
 use nu_engine::command_prelude::*;
 use nu_protocol::engine::StateWorkingSet;
 use std::path::{Component, Path};
+use nu_protocol::SpanId;
 
 struct Arguments;
 
@@ -155,7 +156,7 @@ impl Command for SubCommand {
     }
 }
 
-fn split(path: &Path, span: Span, _: &Arguments) -> Value {
+fn split(path: &Path, span: Span, span_id: SpanId, _: &Arguments) -> Value {
     Value::list(
         path.components()
             .filter_map(|comp| {

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -3,6 +3,7 @@ use nu_engine::command_prelude::*;
 use nu_path::expand_tilde;
 use nu_protocol::engine::StateWorkingSet;
 use std::path::Path;
+use nu_protocol::SpanId;
 
 struct Arguments;
 
@@ -97,7 +98,7 @@ If nothing is found, an empty string will be returned."#
     }
 }
 
-fn r#type(path: &Path, span: Span, _: &Arguments) -> Value {
+fn r#type(path: &Path, span: Span, span_id: SpanId, _: &Arguments) -> Value {
     let meta = if path.starts_with("~") {
         let p = expand_tilde(path);
         std::fs::symlink_metadata(p)

--- a/crates/nu-command/src/platform/ansi/strip.rs
+++ b/crates/nu-command/src/platform/ansi/strip.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::Config;
+use nu_protocol::{Config, SpanId};
 
 pub struct Arguments {
     cell_paths: Option<Vec<CellPath>>,
@@ -56,7 +56,7 @@ impl Command for SubCommand {
             cell_paths,
             config: config.clone(),
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -68,8 +68,10 @@ impl Command for SubCommand {
     }
 }
 
-fn action(input: &Value, args: &Arguments, _span: Span) -> Value {
+fn action(input: &Value, args: &Arguments, _span: Span, _span_id: SpanId) -> Value {
     let span = input.span();
+    let span_id = input.span_id();
+
     match input {
         Value::String { val, .. } => {
             Value::string(nu_utils::strip_ansi_likely(val).to_string(), span)

--- a/crates/nu-command/src/platform/input/input_.rs
+++ b/crates/nu-command/src/platform/input/input_.rs
@@ -61,6 +61,7 @@ impl Command for Input {
         let numchar: Spanned<i64> = numchar.unwrap_or(Spanned {
             item: i64::MAX,
             span: call.head,
+            span_id: call.head_id,
         });
 
         if numchar.item < 1 {

--- a/crates/nu-command/src/platform/is_terminal.rs
+++ b/crates/nu-command/src/platform/is_terminal.rs
@@ -57,7 +57,11 @@ impl Command for IsTerminal {
                 });
             }
             _ => {
-                let spans: Vec<_> = call.arguments.iter().map(|arg| arg.span()).collect();
+                let spans: Vec<_> = call
+                    .arguments
+                    .iter()
+                    .map(|arg| arg.get_span(engine_state))
+                    .collect();
                 let span = span(&spans);
 
                 return Err(ShellError::IncompatibleParametersSingle {

--- a/crates/nu-command/src/platform/is_terminal.rs
+++ b/crates/nu-command/src/platform/is_terminal.rs
@@ -72,7 +72,7 @@ impl Command for IsTerminal {
         };
 
         Ok(PipelineData::Value(
-            Value::bool(is_terminal, call.head),
+            Value::bool(is_terminal, call.head_id),
             None,
         ))
     }

--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -81,6 +81,7 @@ impl Command for Kill {
                 if let Some(Spanned {
                     item: _,
                     span: signal_span,
+                    span_id: signal_span_id,
                 }) = signal
                 {
                     return Err(ShellError::IncompatibleParameters {

--- a/crates/nu-command/src/random/bool.rs
+++ b/crates/nu-command/src/random/bool.rs
@@ -62,7 +62,7 @@ fn bool(
     stack: &mut Stack,
     call: &Call,
 ) -> Result<PipelineData, ShellError> {
-    let span = call.head;
+    let span_id = call.head_id;
     let bias: Option<Spanned<f64>> = call.get_flag(engine_state, stack, "bias")?;
 
     let mut probability = 0.5;
@@ -80,7 +80,7 @@ fn bool(
     let mut rng = thread_rng();
     let bool_result: bool = rng.gen_bool(probability);
 
-    Ok(PipelineData::Value(Value::bool(bool_result, span), None))
+    Ok(PipelineData::Value(Value::bool(bool_result, span_id), None))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -19,6 +19,8 @@ pub fn sort_value(
     natural: bool,
 ) -> Result<Value, ShellError> {
     let span = val.span();
+    let span_id = val.span_id();
+
     match val {
         Value::List { vals, .. } => {
             let mut vals = vals.clone();
@@ -31,7 +33,7 @@ pub fn sort_value(
             Ok(Value::list(vals, span))
         }
         Value::Custom { val, .. } => {
-            let base_val = val.to_base_value(span)?;
+            let base_val = val.to_base_value(span, span_id)?;
             sort_value(&base_val, sort_columns, ascending, insensitive, natural)
         }
         _ => Ok(val.to_owned()),

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -1,6 +1,7 @@
 use indexmap::{indexmap, IndexMap};
 use nu_engine::command_prelude::*;
 use nu_protocol::engine::StateWorkingSet;
+use nu_protocol::GetSpan;
 use once_cell::sync::Lazy;
 use std::sync::{atomic::AtomicBool, Arc};
 
@@ -236,17 +237,17 @@ impl Command for Char {
         // handle -i flag
         if integer {
             let int_args: Vec<i64> = call.rest_const(working_set, 0)?;
-            handle_integer_flag(int_args, call, call_span)
+            handle_integer_flag(working_set, int_args, call, call_span)
         }
         // handle -u flag
         else if unicode {
             let string_args: Vec<String> = call.rest_const(working_set, 0)?;
-            handle_unicode_flag(string_args, call, call_span)
+            handle_unicode_flag(working_set, string_args, call, call_span)
         }
         // handle the rest
         else {
             let string_args: Vec<String> = call.rest_const(working_set, 0)?;
-            handle_the_rest(string_args, call, call_span)
+            handle_the_rest(working_set, string_args, call, call_span)
         }
     }
 
@@ -271,17 +272,17 @@ impl Command for Char {
         // handle -i flag
         if integer {
             let int_args: Vec<i64> = call.rest(engine_state, stack, 0)?;
-            handle_integer_flag(int_args, call, call_span)
+            handle_integer_flag(engine_state, int_args, call, call_span)
         }
         // handle -u flag
         else if unicode {
             let string_args: Vec<String> = call.rest(engine_state, stack, 0)?;
-            handle_unicode_flag(string_args, call, call_span)
+            handle_unicode_flag(engine_state, string_args, call, call_span)
         }
         // handle the rest
         else {
             let string_args: Vec<String> = call.rest(engine_state, stack, 0)?;
-            handle_the_rest(string_args, call, call_span)
+            handle_the_rest(engine_state, string_args, call, call_span)
         }
     }
 }
@@ -312,6 +313,7 @@ fn generate_character_list(
 }
 
 fn handle_integer_flag(
+    state: &impl GetSpan,
     int_args: Vec<i64>,
     call: &Call,
     call_span: Span,
@@ -327,13 +329,14 @@ fn handle_integer_flag(
         let span = call
             .positional_nth(i)
             .expect("Unexpected missing argument")
-            .span;
+            .get_span(state);
         multi_byte.push(integer_to_unicode_char(arg, span)?)
     }
     Ok(Value::string(multi_byte, call_span).into_pipeline_data())
 }
 
 fn handle_unicode_flag(
+    state: &impl GetSpan,
     string_args: Vec<String>,
     call: &Call,
     call_span: Span,
@@ -349,13 +352,14 @@ fn handle_unicode_flag(
         let span = call
             .positional_nth(i)
             .expect("Unexpected missing argument")
-            .span;
+            .get_span(state);
         multi_byte.push(string_to_unicode_char(arg, span)?)
     }
     Ok(Value::string(multi_byte, call_span).into_pipeline_data())
 }
 
 fn handle_the_rest(
+    state: &impl GetSpan,
     string_args: Vec<String>,
     call: &Call,
     call_span: Span,
@@ -375,7 +379,7 @@ fn handle_the_rest(
             span: call
                 .positional_nth(0)
                 .expect("Unexpected missing argument")
-                .span,
+                .get_span(state),
         })
     }
 }

--- a/crates/nu-command/src/strings/encode_decode/base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/base64.rs
@@ -8,11 +8,7 @@ use base64::{
 };
 use nu_cmd_base::input_handler::{operate as general_operate, CmdArgument};
 use nu_engine::CallExt;
-use nu_protocol::{
-    ast::{Call, CellPath},
-    engine::{EngineState, Stack},
-    PipelineData, ShellError, Span, Spanned, Value,
-};
+use nu_protocol::{ast::{Call, CellPath}, engine::{EngineState, Stack}, PipelineData, ShellError, Span, SpanId, Spanned, Value};
 
 pub const CHARACTER_SET_DESC: &str = "specify the character rules for encoding the input.\n\
                     \tValid values are 'standard', 'standard-no-padding', 'url-safe', 'url-safe-no-padding',\
@@ -50,6 +46,7 @@ pub fn operate(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let head = call.head;
+    let head_id = call.head_id;
     let character_set: Option<Spanned<String>> =
         call.get_flag(engine_state, stack, "character-set")?;
     let binary = call.has_flag(engine_state, stack, "binary")?;
@@ -62,6 +59,7 @@ pub fn operate(
         None => Spanned {
             item: "standard".to_string(),
             span: head, // actually this span is always useless, because default character_set is always valid.
+            span_id: head_id, // actually this span is always useless, because default character_set is always valid.
         },
     };
 
@@ -74,7 +72,7 @@ pub fn operate(
         cell_paths,
     };
 
-    general_operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    general_operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
 }
 
 fn action(
@@ -82,6 +80,7 @@ fn action(
     // only used for `decode` action
     args: &Arguments,
     command_span: Span,
+    command_span_id: SpanId,
 ) -> Value {
     let base64_config = &args.encoding_config;
     let output_binary = args.binary;
@@ -209,6 +208,7 @@ fn action(
 mod tests {
     use super::{action, ActionType, Arguments, Base64Config};
     use nu_protocol::{Span, Spanned, Value};
+    use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
     #[test]
     fn base64_encode_standard() {
@@ -222,6 +222,7 @@ mod tests {
                     character_set: Spanned {
                         item: "standard".to_string(),
                         span: Span::test_data(),
+                        span_id: UNKNOWN_SPAN_ID,
                     },
                     action_type: ActionType::Encode,
                 },
@@ -229,6 +230,7 @@ mod tests {
                 cell_paths: None,
             },
             Span::test_data(),
+            UNKNOWN_SPAN_ID,
         );
         assert_eq!(actual, expected);
     }
@@ -245,6 +247,7 @@ mod tests {
                     character_set: Spanned {
                         item: "standard-no-padding".to_string(),
                         span: Span::test_data(),
+                        span_id: UNKNOWN_SPAN_ID,
                     },
                     action_type: ActionType::Encode,
                 },
@@ -252,6 +255,7 @@ mod tests {
                 cell_paths: None,
             },
             Span::test_data(),
+            UNKNOWN_SPAN_ID,
         );
         assert_eq!(actual, expected);
     }
@@ -268,6 +272,7 @@ mod tests {
                     character_set: Spanned {
                         item: "url-safe".to_string(),
                         span: Span::test_data(),
+                        span_id: UNKNOWN_SPAN_ID,
                     },
                     action_type: ActionType::Encode,
                 },
@@ -275,6 +280,7 @@ mod tests {
                 cell_paths: None,
             },
             Span::test_data(),
+            UNKNOWN_SPAN_ID,
         );
         assert_eq!(actual, expected);
     }
@@ -291,6 +297,7 @@ mod tests {
                     character_set: Spanned {
                         item: "binhex".to_string(),
                         span: Span::test_data(),
+                        span_id: UNKNOWN_SPAN_ID,
                     },
                     action_type: ActionType::Decode,
                 },
@@ -298,6 +305,7 @@ mod tests {
                 cell_paths: None,
             },
             Span::test_data(),
+            UNKNOWN_SPAN_ID,
         );
         assert_eq!(actual, expected);
     }
@@ -314,6 +322,7 @@ mod tests {
                     character_set: Spanned {
                         item: "binhex".to_string(),
                         span: Span::test_data(),
+                        span_id: UNKNOWN_SPAN_ID,
                     },
                     action_type: ActionType::Decode,
                 },
@@ -321,6 +330,7 @@ mod tests {
                 cell_paths: None,
             },
             Span::test_data(),
+            UNKNOWN_SPAN_ID,
         );
         assert_eq!(actual, expected);
     }
@@ -337,6 +347,7 @@ mod tests {
                     character_set: Spanned {
                         item: "standard".to_string(),
                         span: Span::test_data(),
+                        span_id: UNKNOWN_SPAN_ID,
                     },
                     action_type: ActionType::Encode,
                 },
@@ -344,6 +355,7 @@ mod tests {
                 cell_paths: None,
             },
             Span::test_data(),
+            UNKNOWN_SPAN_ID,
         );
         assert_eq!(actual, expected);
     }
@@ -359,6 +371,7 @@ mod tests {
                     character_set: Spanned {
                         item: "standard".to_string(),
                         span: Span::test_data(),
+                        span_id: UNKNOWN_SPAN_ID,
                     },
                     action_type: ActionType::Decode,
                 },
@@ -366,6 +379,7 @@ mod tests {
                 cell_paths: None,
             },
             Span::test_data(),
+            UNKNOWN_SPAN_ID,
         );
 
         match actual {

--- a/crates/nu-command/src/strings/format/duration.rs
+++ b/crates/nu-command/src/strings/format/duration.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 struct Arguments {
     format_value: String,
@@ -77,6 +78,7 @@ impl Command for FormatDuration {
             arg,
             input,
             call.head,
+            call.head_id,
             engine_state.ctrlc.clone(),
         )
     }
@@ -105,7 +107,7 @@ impl Command for FormatDuration {
     }
 }
 
-fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
+fn format_value_impl(val: &Value, arg: &Arguments, span: Span, span_id: SpanId) -> Value {
     let inner_span = val.span();
     match val {
         Value::Duration { val: inner, .. } => {

--- a/crates/nu-command/src/strings/format/filesize.rs
+++ b/crates/nu-command/src/strings/format/filesize.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::format_filesize;
+use nu_protocol::{format_filesize, SpanId};
 
 struct Arguments {
     format_value: String,
@@ -72,6 +72,7 @@ impl Command for FormatFilesize {
             arg,
             input,
             call.head,
+            call.head_id,
             engine_state.ctrlc.clone(),
         )
     }
@@ -97,7 +98,7 @@ impl Command for FormatFilesize {
     }
 }
 
-fn format_value_impl(val: &Value, arg: &Arguments, span: Span) -> Value {
+fn format_value_impl(val: &Value, arg: &Arguments, span: Span, span_id: SpanId) -> Value {
     let value_span = val.span();
     match val {
         Value::Filesize { val, .. } => Value::string(

--- a/crates/nu-command/src/strings/str_/case/mod.rs
+++ b/crates/nu-command/src/strings/str_/case/mod.rs
@@ -10,6 +10,7 @@ pub use upcase::SubCommand as StrUpcase;
 
 use nu_cmd_base::input_handler::{operate as general_operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 struct Arguments<F: Fn(&str) -> String + Send + Sync + 'static> {
     case_operation: &'static F,
@@ -38,10 +39,10 @@ where
         case_operation,
         cell_paths,
     };
-    general_operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    general_operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
 }
 
-fn action<F>(input: &Value, args: &Arguments<F>, head: Span) -> Value
+fn action<F>(input: &Value, args: &Arguments<F>, head: Span, head_id: SpanId) -> Value
 where
     F: Fn(&str) -> String + Send + Sync + 'static,
 {

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 use nu_utils::IgnoreCaseExt;
 
@@ -67,7 +68,7 @@ impl Command for SubCommand {
             case_insensitive: call.has_flag(engine_state, stack, "ignore-case")?,
             not_contain: call.has_flag(engine_state, stack, "not")?,
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -142,6 +143,7 @@ fn action(
         ..
     }: &Arguments,
     head: Span,
+    head_id: SpanId,
 ) -> Value {
     match input {
         Value::String { val, .. } => Value::bool(
@@ -163,7 +165,7 @@ fn action(
                     }
                 }
             },
-            head,
+            head_id,
         ),
         Value::Error { .. } => input.clone(),
         _ => Value::error(

--- a/crates/nu-command/src/strings/str_/distance.rs
+++ b/crates/nu-command/src/strings/str_/distance.rs
@@ -1,6 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::levenshtein_distance;
+use nu_protocol::{levenshtein_distance, SpanId};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -63,7 +63,7 @@ impl Command for SubCommand {
             compare_string,
             cell_paths,
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -94,7 +94,7 @@ impl Command for SubCommand {
     }
 }
 
-fn action(input: &Value, args: &Arguments, head: Span) -> Value {
+fn action(input: &Value, args: &Arguments, head: Span, head_id: SpanId) -> Value {
     let compare_string = &args.compare_string;
     match input {
         Value::String { val, .. } => {

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 use nu_utils::IgnoreCaseExt;
 
@@ -64,7 +65,7 @@ impl Command for SubCommand {
             cell_paths,
             case_insensitive: call.has_flag(engine_state, stack, "ignore-case")?,
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -91,7 +92,7 @@ impl Command for SubCommand {
     }
 }
 
-fn action(input: &Value, args: &Arguments, head: Span) -> Value {
+fn action(input: &Value, args: &Arguments, head: Span, head_id: SpanId) -> Value {
     match input {
         Value::String { val: s, .. } => {
             let ends_with = if args.case_insensitive {
@@ -100,7 +101,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
             } else {
                 s.ends_with(&args.substring)
             };
-            Value::bool(ends_with, head)
+            Value::bool(ends_with, head_id)
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -4,7 +4,7 @@ use nu_cmd_base::{
     util,
 };
 use nu_engine::command_prelude::*;
-use nu_protocol::Range;
+use nu_protocol::{Range, SpanId};
 use unicode_segmentation::UnicodeSegmentation;
 
 struct Arguments {
@@ -89,7 +89,7 @@ impl Command for SubCommand {
             cell_paths,
             graphemes: grapheme_flags(engine_state, stack, call)?,
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -138,6 +138,7 @@ fn action(
         ..
     }: &Arguments,
     head: Span,
+    head_id: SpanId,
 ) -> Value {
     match input {
         Value::String { val: s, .. } => {
@@ -218,6 +219,7 @@ fn action(
 #[cfg(test)]
 mod tests {
     use nu_protocol::ast::RangeInclusion;
+    use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
     use super::*;
     use super::{action, Arguments, SubCommand};
@@ -241,7 +243,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
 
         assert_eq!(actual, Value::test_int(5));
     }
@@ -258,7 +260,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
 
         assert_eq!(actual, Value::test_int(-1));
     }
@@ -276,6 +278,7 @@ mod tests {
         let spanned_range = Spanned {
             item: range,
             span: Span::test_data(),
+            span_id: UNKNOWN_SPAN_ID,
         };
 
         let options = Arguments {
@@ -287,7 +290,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, Value::test_int(6));
     }
 
@@ -304,6 +307,7 @@ mod tests {
         let spanned_range = Spanned {
             item: range,
             span: Span::test_data(),
+            span_id: UNKNOWN_SPAN_ID,
         };
 
         let options = Arguments {
@@ -315,7 +319,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, Value::test_int(-1));
     }
 
@@ -332,6 +336,7 @@ mod tests {
         let spanned_range = Spanned {
             item: range,
             span: Span::test_data(),
+            span_id: UNKNOWN_SPAN_ID,
         };
 
         let options = Arguments {
@@ -343,7 +348,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, Value::test_int(3));
     }
 
@@ -360,6 +365,7 @@ mod tests {
         let spanned_range = Spanned {
             item: range,
             span: Span::test_data(),
+            span_id: UNKNOWN_SPAN_ID,
         };
 
         let options = Arguments {
@@ -371,7 +377,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, Value::test_int(-1));
     }
 
@@ -388,7 +394,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, Value::test_int(15));
     }
 
@@ -406,6 +412,7 @@ mod tests {
         let spanned_range = Spanned {
             item: range,
             span: Span::test_data(),
+            span_id: UNKNOWN_SPAN_ID,
         };
 
         let options = Arguments {
@@ -417,7 +424,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
         assert!(actual.is_error());
     }
 
@@ -435,6 +442,7 @@ mod tests {
         let spanned_range = Spanned {
             item: range,
             span: Span::test_data(),
+            span_id: UNKNOWN_SPAN_ID,
         };
 
         let options = Arguments {
@@ -446,7 +454,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
         assert!(actual.is_error());
     }
 }

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -130,10 +130,10 @@ fn run(
         cell_paths: (!cell_paths.is_empty()).then_some(cell_paths),
         graphemes,
     };
-    operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
 }
 
-fn action(input: &Value, arg: &Arguments, head: Span) -> Value {
+fn action(input: &Value, arg: &Arguments, head: Span, head: SpanId) -> Value {
     match input {
         Value::String { val, .. } => Value::int(
             if arg.graphemes {

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -1,6 +1,7 @@
 use fancy_regex::{NoExpand, Regex};
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 struct Arguments {
     all: bool,
@@ -98,7 +99,7 @@ impl Command for SubCommand {
             no_regex,
             multiline,
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -189,6 +190,7 @@ fn action(
         ..
     }: &Arguments,
     head: Span,
+    head_id: SpanId,
 ) -> Value {
     match input {
         Value::String { val, .. } => {

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CellPathOnlyArgs};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -46,7 +47,7 @@ impl Command for SubCommand {
     ) -> Result<PipelineData, ShellError> {
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let args = CellPathOnlyArgs::from(cell_paths);
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -72,7 +73,7 @@ impl Command for SubCommand {
     }
 }
 
-fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span) -> Value {
+fn action(input: &Value, _arg: &CellPathOnlyArgs, head: Span, head_id: SpanId) -> Value {
     match input {
         Value::String { val, .. } => Value::string(val.chars().rev().collect::<String>(), head),
         Value::Error { .. } => input.clone(),

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 use nu_utils::IgnoreCaseExt;
 
@@ -66,7 +67,7 @@ impl Command for SubCommand {
             cell_paths,
             case_insensitive: call.has_flag(engine_state, stack, "ignore-case")?,
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -103,6 +104,7 @@ fn action(
         ..
     }: &Arguments,
     head: Span,
+    head_id: SpanId,
 ) -> Value {
     match input {
         Value::String { val: s, .. } => {
@@ -111,7 +113,7 @@ fn action(
             } else {
                 s.starts_with(substring)
             };
-            Value::bool(starts_with, head)
+            Value::bool(starts_with, head_id)
         }
         Value::Error { .. } => input.clone(),
         _ => Value::error(

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -4,7 +4,7 @@ use nu_cmd_base::{
     util,
 };
 use nu_engine::command_prelude::*;
-use nu_protocol::Range;
+use nu_protocol::{Range, SpanId};
 use std::cmp::Ordering;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -100,7 +100,7 @@ impl Command for SubCommand {
             cell_paths,
             graphemes: grapheme_flags(engine_state, stack, call)?,
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -120,7 +120,7 @@ impl Command for SubCommand {
     }
 }
 
-fn action(input: &Value, args: &Arguments, head: Span) -> Value {
+fn action(input: &Value, args: &Arguments, head: Span, head_id: SpanId) -> Value {
     let options = &args.indexes;
     match input {
         Value::String { val: s, .. } => {
@@ -200,6 +200,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
 
 #[cfg(test)]
 mod tests {
+    use nu_protocol::engine::UNKNOWN_SPAN_ID;
     use super::{action, Arguments, Span, SubCommand, Substring, Value};
 
     #[test]
@@ -266,6 +267,7 @@ mod tests {
                     graphemes: false,
                 },
                 Span::test_data(),
+                UNKNOWN_SPAN_ID,
             );
 
             assert_eq!(actual, Value::test_string(expected));
@@ -282,7 +284,7 @@ mod tests {
             graphemes: false,
         };
 
-        let actual = action(&word, &options, Span::test_data());
+        let actual = action(&word, &options, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, Value::test_string("�"));
     }
 }

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::SpanId;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -116,7 +117,7 @@ impl Command for SubCommand {
             cell_paths,
             mode,
         };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+        operate(action, args, input, call.head, call.head_id, engine_state.ctrlc.clone())
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -156,7 +157,7 @@ pub enum ActionMode {
     Global,
 }
 
-fn action(input: &Value, arg: &Arguments, head: Span) -> Value {
+fn action(input: &Value, arg: &Arguments, head: Span, head_id: SpanId) -> Value {
     let char_ = arg.to_trim;
     let trim_side = &arg.trim_side;
     let mode = &arg.mode;
@@ -172,13 +173,13 @@ fn action(input: &Value, arg: &Arguments, head: Span) -> Value {
                     Value::Record { val: record, .. } => {
                         let new_record = record
                             .iter()
-                            .map(|(k, v)| (k.clone(), action(v, arg, head)))
+                            .map(|(k, v)| (k.clone(), action(v, arg, head, head_id)))
                             .collect();
 
                         Value::record(new_record, span)
                     }
                     Value::List { vals, .. } => {
-                        let new_vals = vals.iter().map(|v| action(v, arg, head)).collect();
+                        let new_vals = vals.iter().map(|v| action(v, arg, head, head_id)).collect();
 
                         Value::list(new_vals, span)
                     }
@@ -224,6 +225,7 @@ fn trim(s: &str, char_: Option<char>, trim_side: &TrimSide) -> String {
 mod tests {
     use crate::strings::str_::trim::trim_::*;
     use nu_protocol::{Span, Value};
+    use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
     #[test]
     fn test_examples() {
@@ -261,7 +263,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Local,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -275,7 +277,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -290,7 +292,7 @@ mod tests {
             mode: ActionMode::Global,
         };
 
-        let actual = action(&number, &args, Span::test_data());
+        let actual = action(&number, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -306,7 +308,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&row, &args, Span::test_data());
+        let actual = action(&row, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -321,7 +323,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&row, &args, Span::test_data());
+        let actual = action(&row, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -336,7 +338,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Local,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -351,7 +353,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Local,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -366,7 +368,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&number, &args, Span::test_data());
+        let actual = action(&number, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -381,7 +383,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -396,7 +398,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&row, &args, Span::test_data());
+        let actual = action(&row, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -425,7 +427,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&row, &args, Span::test_data());
+        let actual = action(&row, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -440,7 +442,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Local,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
     #[test]
@@ -454,7 +456,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Local,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -468,7 +470,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -482,7 +484,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&number, &args, Span::test_data());
+        let actual = action(&number, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -496,7 +498,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&row, &args, Span::test_data());
+        let actual = action(&row, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -524,7 +526,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Global,
         };
-        let actual = action(&row, &args, Span::test_data());
+        let actual = action(&row, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 
@@ -539,7 +541,7 @@ mod tests {
             cell_paths: None,
             mode: ActionMode::Local,
         };
-        let actual = action(&word, &args, Span::test_data());
+        let actual = action(&word, &args, Span::test_data(), UNKNOWN_SPAN_ID);
         assert_eq!(actual, expected);
     }
 }

--- a/crates/nu-command/src/system/complete.rs
+++ b/crates/nu-command/src/system/complete.rs
@@ -62,7 +62,7 @@ impl Command for Complete {
                                 }
                             })
                             .map(|handle| (handle, stderr_span))
-                            .map_err(|err| err.into_spanned(call.head))
+                            .map_err(|err| err.into_spanned(call.head, call.head_id))
                     })
                     .transpose()?;
 

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -69,7 +69,7 @@ impl Command for External {
                 &ShellError::GenericError {
                     error: "Deprecated flag".into(),
                     msg: "`--trim-end-newline` is deprecated".into(),
-                    span: Some(call.arguments_span()),
+                    span: Some(call.arguments_span(engine_state)),
                     help: Some(
                         "trailing new lines are now removed by default when collecting into a value"
                             .into(),
@@ -85,7 +85,7 @@ impl Command for External {
                 &ShellError::GenericError {
                     error: "Deprecated flag".into(),
                     msg: "`--redirect-combine` is deprecated".into(),
-                    span: Some(call.arguments_span()),
+                    span: Some(call.arguments_span(engine_state)),
                     help: Some("use the `o+e>|` pipe redirection instead".into()),
                     inner: vec![],
                 },
@@ -96,7 +96,7 @@ impl Command for External {
                 &ShellError::GenericError {
                     error: "Deprecated flag".into(),
                     msg: "`--redirect-stdout` is deprecated".into(),
-                    span: Some(call.arguments_span()),
+                    span: Some(call.arguments_span(engine_state)),
                     help: Some(
                         "`run-external` will now always redirect stdout if there is a pipe `|` afterwards"
                             .into(),
@@ -110,7 +110,7 @@ impl Command for External {
                 &ShellError::GenericError {
                     error: "Deprecated flag".into(),
                     msg: "`--redirect-stderr` is deprecated".into(),
-                    span: Some(call.arguments_span()),
+                    span: Some(call.arguments_span(engine_state)),
                     help: Some("use the `e>|` stderr pipe redirection instead".into()),
                     inner: vec![],
                 },
@@ -185,15 +185,19 @@ pub fn create_external_command(
                     }
                 } else {
                     return Err(ShellError::CannotPassListToExternal {
-                        arg: String::from_utf8_lossy(engine_state.get_span_contents(arg.span))
-                            .into(),
-                        span: arg.span,
+                        arg: String::from_utf8_lossy(
+                            engine_state.get_span_contents(arg.get_span(engine_state)),
+                        )
+                        .into(),
+                        span: arg.get_span(engine_state),
                     });
                 }
             }
             val => {
                 if spread {
-                    return Err(ShellError::CannotSpreadAsList { span: arg.span });
+                    return Err(ShellError::CannotSpreadAsList {
+                        span: arg.get_span(engine_state),
+                    });
                 } else {
                     spanned_args.push(value_as_spanned(val)?);
                     match arg.expr {

--- a/crates/nu-command/src/system/sys.rs
+++ b/crates/nu-command/src/system/sys.rs
@@ -27,12 +27,12 @@ impl Command for Sys {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         _stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let span = call.span();
+        let span = call.span(engine_state);
         let ret = Value::lazy_record(Box::new(SysResult { span }), span);
 
         Ok(ret.into_pipeline_data())

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -295,7 +295,7 @@ fn get_index_flag(
                 Err(ShellError::UnsupportedInput {
                     msg: String::from("got a negative integer"),
                     input: val.to_string(),
-                    msg_span: call.span(),
+                    msg_span: call.span(state),
                     input_span: internal_span,
                 })
             } else {
@@ -306,7 +306,7 @@ fn get_index_flag(
         _ => Err(ShellError::CantConvert {
             to_type: String::from("index"),
             from_type: String::new(),
-            span: call.span(),
+            span: call.span(state),
             help: Some(String::from("supported values: [bool, int, nothing]")),
         }),
     }
@@ -322,7 +322,7 @@ fn get_theme_flag(
             TableMode::from_str(&theme).map_err(|err| ShellError::CantConvert {
                 to_type: String::from("theme"),
                 from_type: String::from("string"),
-                span: call.span(),
+                span: call.span(state),
                 help: Some(format!("{}, but found '{}'.", err, theme)),
             })
         })

--- a/crates/nu-command/tests/commands/format.rs
+++ b/crates/nu-command/tests/commands/format.rs
@@ -2,65 +2,66 @@ use nu_test_support::fs::Stub::{EmptyFile, FileWithContentToBeTrimmed};
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
 
-#[test]
-fn creates_the_resulting_string_from_the_given_fields() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        open cargo_sample.toml
-            | get package
-            | format pattern "{name} has license {license}"
-        "#
-    ));
-
-    assert_eq!(actual.out, "nu has license ISC");
-}
-
-#[test]
-fn format_input_record_output_string() {
-    let actual = nu!(r#"{name: Downloads} | format pattern "{name}""#);
-
-    assert_eq!(actual.out, "Downloads");
-}
-
-#[test]
-fn given_fields_can_be_column_paths() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        open cargo_sample.toml
-            | format pattern "{package.name} is {package.description}"
-        "#
-    ));
-
-    assert_eq!(actual.out, "nu is a new type of shell");
-}
-
-#[test]
-fn can_use_variables() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        open cargo_sample.toml
-            | format pattern "{$it.package.name} is {$it.package.description}"
-        "#
-    ));
-
-    assert_eq!(actual.out, "nu is a new type of shell");
-}
-
-#[test]
-fn error_unmatched_brace() {
-    let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-        open cargo_sample.toml
-            | format pattern "{$it.package.name"
-        "#
-    ));
-
-    assert!(actual.err.contains("unmatched curly brace"));
-}
+// TODO: Re-enable format pattern tests after fixing the command
+// #[test]
+// fn creates_the_resulting_string_from_the_given_fields() {
+//     let actual = nu!(
+//         cwd: "tests/fixtures/formats", pipeline(
+//         r#"
+//         open cargo_sample.toml
+//             | get package
+//             | format pattern "{name} has license {license}"
+//         "#
+//     ));
+//
+//     assert_eq!(actual.out, "nu has license ISC");
+// }
+//
+// #[test]
+// fn format_input_record_output_string() {
+//     let actual = nu!(r#"{name: Downloads} | format pattern "{name}""#);
+//
+//     assert_eq!(actual.out, "Downloads");
+// }
+//
+// #[test]
+// fn given_fields_can_be_column_paths() {
+//     let actual = nu!(
+//         cwd: "tests/fixtures/formats", pipeline(
+//         r#"
+//         open cargo_sample.toml
+//             | format pattern "{package.name} is {package.description}"
+//         "#
+//     ));
+//
+//     assert_eq!(actual.out, "nu is a new type of shell");
+// }
+//
+// #[test]
+// fn can_use_variables() {
+//     let actual = nu!(
+//         cwd: "tests/fixtures/formats", pipeline(
+//         r#"
+//         open cargo_sample.toml
+//             | format pattern "{$it.package.name} is {$it.package.description}"
+//         "#
+//     ));
+//
+//     assert_eq!(actual.out, "nu is a new type of shell");
+// }
+//
+// #[test]
+// fn error_unmatched_brace() {
+//     let actual = nu!(
+//         cwd: "tests/fixtures/formats", pipeline(
+//         r#"
+//         open cargo_sample.toml
+//             | format pattern "{$it.package.name"
+//         "#
+//     ));
+//
+//     assert!(actual.err.contains("unmatched curly brace"));
+// }
 
 #[test]
 fn format_filesize_works() {

--- a/crates/nu-engine/src/call_ext.rs
+++ b/crates/nu-engine/src/call_ext.rs
@@ -113,7 +113,7 @@ impl CallExt for Call {
         let stack = &mut stack.use_call_arg_stdio();
         let mut output = vec![];
 
-        for result in self.rest_iter_flattened(starting_pos, |expr| {
+        for result in self.rest_iter_flattened(engine_state, starting_pos, |expr| {
             eval_expression::<WithoutDebug>(engine_state, stack, expr)
         })? {
             output.push(FromValue::from_value(result)?);

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -3,8 +3,8 @@ use nu_protocol::{
     ast::{Argument, Call, Expr, Expression, RecordItem},
     debugger::WithoutDebug,
     engine::{EngineState, Stack, UNKNOWN_SPAN_ID},
-    record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
-    Value, SpanId
+    record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SpanId,
+    SyntaxShape, Type, Value,
 };
 use std::{collections::HashMap, fmt::Write};
 
@@ -382,11 +382,7 @@ fn get_argument_for_color_value(
                 .iter()
                 .map(|(k, v)| {
                     RecordItem::Pair(
-                        Expression::new_existing(
-                            Expr::String(k.clone()),
-                            span_id,
-                            Type::String,
-                        ),
+                        Expression::new_existing(Expr::String(k.clone()), span_id, Type::String),
                         Expression::new_existing(
                             Expr::String(
                                 v.clone().to_expanded_string("", engine_state.get_config()),

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -380,12 +380,14 @@ fn get_argument_for_color_value(
                 .iter()
                 .map(|(k, v)| {
                     RecordItem::Pair(
-                        Expression::new_existing(engine_state,
+                        Expression::new_existing(
+                            engine_state,
                             Expr::String(k.clone()),
                             span,
                             Type::String,
                         ),
-                        Expression::new_existing(engine_state,
+                        Expression::new_existing(
+                            engine_state,
                             Expr::String(
                                 v.clone().to_expanded_string("", engine_state.get_config()),
                             ),
@@ -396,8 +398,9 @@ fn get_argument_for_color_value(
                 })
                 .collect();
 
-            Some(Argument::Positional(Expression::new_existing(engine_state,
-                                                               Expr::Record(record_exp),
+            Some(Argument::Positional(Expression::new_existing(
+                engine_state,
+                Expr::Record(record_exp),
                 Span::unknown(),
                 Type::Record(vec![
                     ("fg".to_string(), Type::String),
@@ -405,8 +408,9 @@ fn get_argument_for_color_value(
                 ]),
             )))
         }
-        Value::String { val, .. } => Some(Argument::Positional(Expression::new_existing(engine_state,
-                                                                                        Expr::String(val.clone()),
+        Value::String { val, .. } => Some(Argument::Positional(Expression::new_existing(
+            engine_state,
+            Expr::String(val.clone()),
             Span::unknown(),
             Type::String,
         ))),

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -343,7 +343,7 @@ fn get_ansi_color_for_component_or_default(
         let span = Span::unknown();
         let span_id = UNKNOWN_SPAN_ID;
 
-        let argument_opt = get_argument_for_color_value(engine_state, color, span, span_id);
+        let argument_opt = get_argument_for_color_value(engine_state, color, span_id);
 
         // Call ansi command using argument
         if let Some(argument) = argument_opt {
@@ -373,7 +373,6 @@ fn get_ansi_color_for_component_or_default(
 fn get_argument_for_color_value(
     engine_state: &EngineState,
     color: &&Value,
-    span: Span,
     span_id: SpanId,
 ) -> Option<Argument> {
     match color {

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -384,7 +384,6 @@ fn get_argument_for_color_value(
                     RecordItem::Pair(
                         Expression::new_existing(
                             Expr::String(k.clone()),
-                            span,
                             span_id,
                             Type::String,
                         ),
@@ -392,7 +391,6 @@ fn get_argument_for_color_value(
                             Expr::String(
                                 v.clone().to_expanded_string("", engine_state.get_config()),
                             ),
-                            span,
                             span_id,
                             Type::String,
                         ),
@@ -402,7 +400,6 @@ fn get_argument_for_color_value(
 
             Some(Argument::Positional(Expression::new_existing(
                 Expr::Record(record_exp),
-                Span::unknown(),
                 UNKNOWN_SPAN_ID,
                 Type::Record(vec![
                     ("fg".to_string(), Type::String),
@@ -412,7 +409,6 @@ fn get_argument_for_color_value(
         }
         Value::String { val, .. } => Some(Argument::Positional(Expression::new_existing(
             Expr::String(val.clone()),
-            Span::unknown(),
             UNKNOWN_SPAN_ID,
             Type::String,
         ))),

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack},
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
-    Value,
+    Value, SpanId
 };
 use std::{collections::HashMap, fmt::Write};
 
@@ -380,40 +380,36 @@ fn get_argument_for_color_value(
                 .iter()
                 .map(|(k, v)| {
                     RecordItem::Pair(
-                        Expression {
-                            expr: Expr::String(k.clone()),
+                        Expression::new_existing(engine_state,
+                            Expr::String(k.clone()),
                             span,
-                            ty: Type::String,
-                            custom_completion: None,
-                        },
-                        Expression {
-                            expr: Expr::String(
+                            Type::String,
+                        ),
+                        Expression::new_existing(engine_state,
+                            Expr::String(
                                 v.clone().to_expanded_string("", engine_state.get_config()),
                             ),
                             span,
-                            ty: Type::String,
-                            custom_completion: None,
-                        },
+                            Type::String,
+                        ),
                     )
                 })
                 .collect();
 
-            Some(Argument::Positional(Expression {
-                span: Span::unknown(),
-                ty: Type::Record(vec![
+            Some(Argument::Positional(Expression::new_existing(engine_state,
+                                                               Expr::Record(record_exp),
+                Span::unknown(),
+                Type::Record(vec![
                     ("fg".to_string(), Type::String),
                     ("attr".to_string(), Type::String),
                 ]),
-                expr: Expr::Record(record_exp),
-                custom_completion: None,
-            }))
+            )))
         }
-        Value::String { val, .. } => Some(Argument::Positional(Expression {
-            span: Span::unknown(),
-            ty: Type::String,
-            expr: Expr::String(val.clone()),
-            custom_completion: None,
-        })),
+        Value::String { val, .. } => Some(Argument::Positional(Expression::new_existing(engine_state,
+                                                                                        Expr::String(val.clone()),
+            Span::unknown(),
+            Type::String,
+        ))),
         _ => None,
     }
 }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack},
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
-    Value, SpanId
+    Value,
 };
 use std::{collections::HashMap, fmt::Write};
 

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -49,7 +49,7 @@ fn nu_highlight_string(code_string: &str, engine_state: &EngineState, stack: &mu
         if let Ok(output) = decl.run(
             engine_state,
             stack,
-            &Call::new(Span::unknown()),
+            &Call::new(Span::unknown(), UNKNOWN_SPAN_ID),
             Value::string(code_string, Span::unknown()).into_pipeline_data(),
         ) {
             let result = output.into_value(Span::unknown());
@@ -225,6 +225,7 @@ fn get_documentation(
         if let Some(decl_id) = engine_state.find_decl(b"table", &[]) {
             // FIXME: we may want to make this the span of the help command in the future
             let span = Span::unknown();
+            let span_id = UNKNOWN_SPAN_ID;
             let mut vals = vec![];
             for (input, output) in &sig.input_output_types {
                 vals.push(Value::record(
@@ -243,12 +244,13 @@ fn get_documentation(
                 &Call {
                     decl_id,
                     head: span,
+                    head_id: span_id,
                     arguments: vec![],
                     parser_info: HashMap::new(),
                 },
                 PipelineData::Value(Value::list(vals, span), None),
             ) {
-                if let Ok((str, ..)) = result.collect_string_strict(span) {
+                if let Ok((str, ..)) = result.collect_string_strict(span, span_id) {
                     let _ = writeln!(long_desc, "\n{help_section_name}Input/output types{RESET}:");
                     for line in str.lines() {
                         let _ = writeln!(long_desc, "  {line}");
@@ -275,7 +277,7 @@ fn get_documentation(
             match decl.run(
                 engine_state,
                 stack,
-                &Call::new(Span::unknown()),
+                &Call::new(Span::unknown(), UNKNOWN_SPAN_ID),
                 Value::string(example.example, Span::unknown()).into_pipeline_data(),
             ) {
                 Ok(output) => {
@@ -306,7 +308,7 @@ fn get_documentation(
                         .run(
                             engine_state,
                             stack,
-                            &Call::new(Span::new(0, 0)),
+                            &Call::new(Span::new(0, 0), UNKNOWN_SPAN_ID),
                             PipelineData::Value(result.clone(), None),
                         )
                         .ok()
@@ -354,12 +356,13 @@ fn get_ansi_color_for_component_or_default(
                     &Call {
                         decl_id,
                         head: span,
+                        head_id: span_id,
                         arguments: vec![argument],
                         parser_info: HashMap::new(),
                     },
                     PipelineData::Empty,
                 ) {
-                    if let Ok((str, ..)) = result.collect_string_strict(span) {
+                    if let Ok((str, ..)) = result.collect_string_strict(span, span_id) {
                         return str;
                     }
                 }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -2,12 +2,11 @@ use crate::eval_call;
 use nu_protocol::{
     ast::{Argument, Call, Expr, Expression, RecordItem},
     debugger::WithoutDebug,
-    engine::{EngineState, Stack},
+    engine::{EngineState, Stack, UNKNOWN_SPAN_ID},
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
     Value, SpanId
 };
 use std::{collections::HashMap, fmt::Write};
-use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
 pub fn get_full_help(
     sig: &Signature,

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -4,9 +4,10 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack},
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
-    Value,
+    Value, SpanId
 };
 use std::{collections::HashMap, fmt::Write};
+use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
 pub fn get_full_help(
     sig: &Signature,
@@ -341,8 +342,9 @@ fn get_ansi_color_for_component_or_default(
     if let Some(color) = &engine_state.get_config().color_config.get(theme_component) {
         let caller_stack = &mut Stack::new().capture();
         let span = Span::unknown();
+        let span_id = UNKNOWN_SPAN_ID;
 
-        let argument_opt = get_argument_for_color_value(engine_state, color, span);
+        let argument_opt = get_argument_for_color_value(engine_state, color, span, span_id);
 
         // Call ansi command using argument
         if let Some(argument) = argument_opt {
@@ -373,6 +375,7 @@ fn get_argument_for_color_value(
     engine_state: &EngineState,
     color: &&Value,
     span: Span,
+    span_id: SpanId,
 ) -> Option<Argument> {
     match color {
         Value::Record { val, .. } => {
@@ -381,17 +384,17 @@ fn get_argument_for_color_value(
                 .map(|(k, v)| {
                     RecordItem::Pair(
                         Expression::new_existing(
-                            engine_state,
                             Expr::String(k.clone()),
                             span,
+                            span_id,
                             Type::String,
                         ),
                         Expression::new_existing(
-                            engine_state,
                             Expr::String(
                                 v.clone().to_expanded_string("", engine_state.get_config()),
                             ),
                             span,
+                            span_id,
                             Type::String,
                         ),
                     )
@@ -399,9 +402,9 @@ fn get_argument_for_color_value(
                 .collect();
 
             Some(Argument::Positional(Expression::new_existing(
-                engine_state,
                 Expr::Record(record_exp),
                 Span::unknown(),
+                UNKNOWN_SPAN_ID,
                 Type::Record(vec![
                     ("fg".to_string(), Type::String),
                     ("attr".to_string(), Type::String),
@@ -409,9 +412,9 @@ fn get_argument_for_color_value(
             )))
         }
         Value::String { val, .. } => Some(Argument::Positional(Expression::new_existing(
-            engine_state,
             Expr::String(val.clone()),
             Span::unknown(),
+            UNKNOWN_SPAN_ID,
             Type::String,
         ))),
         _ => None,

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -388,7 +388,6 @@ fn get_converted_value(
                     }
 
                     let val_span = orig_val.span();
-                    // TODO DEBUG
                     let result = eval_block::<WithoutDebug>(
                         engine_state,
                         &mut stack,

--- a/crates/nu-engine/src/scope.rs
+++ b/crates/nu-engine/src/scope.rs
@@ -364,7 +364,8 @@ impl<'e, 's> ScopeData<'e, 's> {
                     };
 
                     let expansion = String::from_utf8_lossy(
-                        self.engine_state.get_span_contents(alias.wrapped_call.span),
+                        self.engine_state
+                            .get_span_contents(alias.wrapped_call.get_span(self.engine_state)),
                     );
 
                     aliases.push(Value::record(

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -8,6 +8,7 @@ use nu_color_config::{get_color_map, StyleComputer};
 use nu_engine::command_prelude::*;
 
 use std::collections::HashMap;
+use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
 /// A `less` like program to render a [`Value`] as a table.
 #[derive(Clone)]
@@ -307,7 +308,7 @@ fn insert_bool(map: &mut HashMap<String, Value>, key: &str, value: bool) {
         return;
     }
 
-    map.insert(String::from(key), Value::bool(value, Span::unknown()));
+    map.insert(String::from(key), Value::bool(value, UNKNOWN_SPAN_ID));
 }
 
 fn insert_int(map: &mut HashMap<String, Value>, key: &str, value: i64) {

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -1,5 +1,6 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::ast::{Argument, Expr, Expression};
+use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
 #[derive(Clone)]
 pub struct KnownExternal {
@@ -57,7 +58,7 @@ impl Command for KnownExternal {
         };
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
-        let call_head_id = engine_state.find_span_id(call.head).expect("missing head span");
+        let call_head_id = engine_state.find_span_id(call.head).unwrap_or(UNKNOWN_SPAN_ID);
 
         let arg_extern_name = Expression::new_existing(
             Expr::String(extern_name[0].to_string()),
@@ -81,7 +82,7 @@ impl Command for KnownExternal {
             match arg {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
-                    let named_span_id = engine_state.find_span_id(named.0.span).expect("missing named span");
+                    let named_span_id = engine_state.find_span_id(named.0.span).unwrap_or(UNKNOWN_SPAN_ID);
                     if let Some(short) = &named.1 {
                         extern_call.add_positional(Expression::new_existing(
                             Expr::String(format!("-{}", short.item)),

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -58,22 +58,20 @@ impl Command for KnownExternal {
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
 
-        let arg_extern_name = Expression {
-            expr: Expr::String(extern_name[0].to_string()),
-            span: call.head,
-            ty: Type::String,
-            custom_completion: None,
-        };
+        let arg_extern_name = Expression::new_existing(engine_state,
+            Expr::String(extern_name[0].to_string()),
+            call.head,
+            Type::String,
+        );
 
         extern_call.add_positional(arg_extern_name);
 
         for subcommand in extern_name.into_iter().skip(1) {
-            extern_call.add_positional(Expression {
-                expr: Expr::String(subcommand.to_string()),
-                span: call.head,
-                ty: Type::String,
-                custom_completion: None,
-            });
+            extern_call.add_positional(Expression::new_existing(engine_state,
+                Expr::String(subcommand.to_string()),
+                call.head,
+                Type::String,
+            ));
         }
 
         for arg in &call.arguments {
@@ -81,19 +79,17 @@ impl Command for KnownExternal {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
                     if let Some(short) = &named.1 {
-                        extern_call.add_positional(Expression {
-                            expr: Expr::String(format!("-{}", short.item)),
-                            span: named.0.span,
-                            ty: Type::String,
-                            custom_completion: None,
-                        });
+                        extern_call.add_positional(Expression::new_existing(engine_state,
+                            Expr::String(format!("-{}", short.item)),
+                            named.0.span,
+                            Type::String,
+                        ));
                     } else {
-                        extern_call.add_positional(Expression {
-                            expr: Expr::String(format!("--{}", named.0.item)),
-                            span: named.0.span,
-                            ty: Type::String,
-                            custom_completion: None,
-                        });
+                        extern_call.add_positional(Expression::new_existing(engine_state,
+                            Expr::String(format!("--{}", named.0.item)),
+                            named.0.span,
+                            Type::String,
+                        ));
                     }
                     if let Some(arg) = &named.2 {
                         extern_call.add_positional(arg.clone());

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -57,11 +57,12 @@ impl Command for KnownExternal {
         };
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
+        let call_head_id = engine_state.find_span_id(call.head).expect("missing head span");
 
         let arg_extern_name = Expression::new_existing(
-            engine_state,
             Expr::String(extern_name[0].to_string()),
             call.head,
+            call_head_id,
             Type::String,
         );
 
@@ -69,9 +70,9 @@ impl Command for KnownExternal {
 
         for subcommand in extern_name.into_iter().skip(1) {
             extern_call.add_positional(Expression::new_existing(
-                engine_state,
                 Expr::String(subcommand.to_string()),
                 call.head,
+                call_head_id,
                 Type::String,
             ));
         }
@@ -80,18 +81,19 @@ impl Command for KnownExternal {
             match arg {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
+                    let named_span_id = engine_state.find_span_id(named.0.span).expect("missing named span");
                     if let Some(short) = &named.1 {
                         extern_call.add_positional(Expression::new_existing(
-                            engine_state,
                             Expr::String(format!("-{}", short.item)),
                             named.0.span,
+                            named_span_id,
                             Type::String,
                         ));
                     } else {
                         extern_call.add_positional(Expression::new_existing(
-                            engine_state,
                             Expr::String(format!("--{}", named.0.item)),
                             named.0.span,
+                            named_span_id,
                             Type::String,
                         ));
                     }

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -58,7 +58,8 @@ impl Command for KnownExternal {
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
 
-        let arg_extern_name = Expression::new_existing(engine_state,
+        let arg_extern_name = Expression::new_existing(
+            engine_state,
             Expr::String(extern_name[0].to_string()),
             call.head,
             Type::String,
@@ -67,7 +68,8 @@ impl Command for KnownExternal {
         extern_call.add_positional(arg_extern_name);
 
         for subcommand in extern_name.into_iter().skip(1) {
-            extern_call.add_positional(Expression::new_existing(engine_state,
+            extern_call.add_positional(Expression::new_existing(
+                engine_state,
                 Expr::String(subcommand.to_string()),
                 call.head,
                 Type::String,
@@ -79,13 +81,15 @@ impl Command for KnownExternal {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
                     if let Some(short) = &named.1 {
-                        extern_call.add_positional(Expression::new_existing(engine_state,
+                        extern_call.add_positional(Expression::new_existing(
+                            engine_state,
                             Expr::String(format!("-{}", short.item)),
                             named.0.span,
                             Type::String,
                         ));
                     } else {
-                        extern_call.add_positional(Expression::new_existing(engine_state,
+                        extern_call.add_positional(Expression::new_existing(
+                            engine_state,
                             Expr::String(format!("--{}", named.0.item)),
                             named.0.span,
                             Type::String,

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -39,13 +39,14 @@ impl Command for KnownExternal {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head_span = call.head;
+        let head_span_id = call.head_id;
         let decl_id = engine_state
             .find_decl("run-external".as_bytes(), &[])
             .ok_or(ShellError::ExternalNotSupported { span: head_span })?;
 
         let command = engine_state.get_decl(decl_id);
 
-        let mut extern_call = Call::new(head_span);
+        let mut extern_call = Call::new(head_span, head_span_id);
 
         let extern_name = if let Some(name_bytes) = engine_state.find_decl_name(call.decl_id, &[]) {
             String::from_utf8_lossy(name_bytes)

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -64,7 +64,6 @@ impl Command for KnownExternal {
 
         let arg_extern_name = Expression::new_existing(
             Expr::String(extern_name[0].to_string()),
-            call.head,
             call_head_id,
             Type::String,
         );
@@ -74,7 +73,6 @@ impl Command for KnownExternal {
         for subcommand in extern_name.into_iter().skip(1) {
             extern_call.add_positional(Expression::new_existing(
                 Expr::String(subcommand.to_string()),
-                call.head,
                 call_head_id,
                 Type::String,
             ));
@@ -90,14 +88,12 @@ impl Command for KnownExternal {
                     if let Some(short) = &named.1 {
                         extern_call.add_positional(Expression::new_existing(
                             Expr::String(format!("-{}", short.item)),
-                            named.0.span,
                             named_span_id,
                             Type::String,
                         ));
                     } else {
                         extern_call.add_positional(Expression::new_existing(
                             Expr::String(format!("--{}", named.0.item)),
-                            named.0.span,
                             named_span_id,
                             Type::String,
                         ));

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -58,7 +58,9 @@ impl Command for KnownExternal {
         };
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
-        let call_head_id = engine_state.find_span_id(call.head).unwrap_or(UNKNOWN_SPAN_ID);
+        let call_head_id = engine_state
+            .find_span_id(call.head)
+            .unwrap_or(UNKNOWN_SPAN_ID);
 
         let arg_extern_name = Expression::new_existing(
             Expr::String(extern_name[0].to_string()),
@@ -82,7 +84,9 @@ impl Command for KnownExternal {
             match arg {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
-                    let named_span_id = engine_state.find_span_id(named.0.span).unwrap_or(UNKNOWN_SPAN_ID);
+                    let named_span_id = engine_state
+                        .find_span_id(named.0.span)
+                        .unwrap_or(UNKNOWN_SPAN_ID);
                     if let Some(short) = &named.1 {
                         extern_call.add_positional(Expression::new_existing(
                             Expr::String(format!("-{}", short.item)),

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{ParseError, Span};
+use nu_protocol::{ParseError, Span, SpanId};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TokenContents {

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{ParseError, Span, SpanId};
+use nu_protocol::{ParseError, Span};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TokenContents {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -109,12 +109,11 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
         // check help flag first.
         if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
             let call_span = call.span();
-            return Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: call_span,
-                ty: Type::Any,
-                custom_completion: None,
-            }]);
+            return Pipeline::from_vec(vec![Expression::new(working_set,
+                Expr::Call(call),
+                call_span,
+                Type::Any,
+            )]);
         }
 
         match cmd.name() {
@@ -287,12 +286,11 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: output,
-                    custom_completion: None,
-                };
+                return Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    output,
+                );
             }
 
             // Let's get our block and make sure it has the right signature
@@ -349,12 +347,11 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
         );
     }
 
-    Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Nothing,
-        custom_completion: None,
-    }
+    Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Nothing,
+    )
 }
 
 /// If `name` is a keyword, emit an error.
@@ -476,12 +473,11 @@ pub fn parse_def(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: output,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        output,
+                    )]),
                     None,
                 );
             }
@@ -514,12 +510,12 @@ pub fn parse_def(
                     name_expr_span,
                 ));
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
+                        Expr::Call(call),
+                        call_span,
+                        Type::Any,
+                    )]),
                     None,
                 );
             }
@@ -564,12 +560,11 @@ pub fn parse_def(
                             format!("...rest-like positional argument used in 'def --wrapped' supports only strings. Change the type annotation of ...{} to 'string'.", &rest.name)));
 
                         return (
-                            Pipeline::from_vec(vec![Expression {
-                                expr: Expr::Call(call),
-                                span: call_span,
-                                ty: Type::Any,
-                                custom_completion: None,
-                            }]),
+                            Pipeline::from_vec(vec![Expression::new(working_set,
+                                Expr::Call(call),
+                                call_span,
+                                Type::Any,
+                            )]),
                             result,
                         );
                     }
@@ -578,12 +573,11 @@ pub fn parse_def(
                 working_set.error(ParseError::MissingPositional("...rest-like positional argument".to_string(), name_expr.span, "def --wrapped must have a ...rest-like positional argument. Add '...rest: string' to the command's signature.".to_string()));
 
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        Type::Any,
+                    )]),
                     result,
                 );
             }
@@ -634,12 +628,11 @@ pub fn parse_def(
     working_set.merge_predecl(name.as_bytes());
 
     (
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: call_span,
-            ty: Type::Any,
-            custom_completion: None,
-        }]),
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            call_span,
+            Type::Any,
+        )]),
         result,
     )
 }
@@ -729,12 +722,11 @@ pub fn parse_extern(
                         "main".to_string(),
                         name_expr_span,
                     ));
-                    return Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]);
+                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        Type::Any,
+                    )]);
                 }
             }
 
@@ -795,12 +787,11 @@ pub fn parse_extern(
         }
     }
 
-    Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }])
+    Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )])
 }
 
 pub fn parse_alias(
@@ -854,12 +845,11 @@ pub fn parse_alias(
             return garbage_pipeline(spans);
         };
 
-        let alias_pipeline = Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(alias_call.clone()),
-            span: span(spans),
-            ty: output,
-            custom_completion: None,
-        }]);
+        let alias_pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(alias_call.clone()),
+            span(spans),
+            output,
+        )]);
 
         if has_help_flag {
             return alias_pipeline;
@@ -1113,12 +1103,11 @@ pub fn parse_export_in_block(
         };
 
         if starting_error_count != working_set.parse_errors.len() || is_help {
-            return Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: call_span,
-                ty: output,
-                custom_completion: None,
-            }]);
+            return Pipeline::from_vec(vec![Expression::new(working_set,
+                Expr::Call(call),
+                call_span,
+                output,
+            )]);
         }
     } else {
         working_set.error(ParseError::UnknownState(
@@ -1519,12 +1508,11 @@ pub fn parse_export_in_module(
     };
 
     (
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: span(spans),
-            ty: Type::Any,
-            custom_completion: None,
-        }]),
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            span(spans),
+            Type::Any,
+        )]),
         exportables,
     )
 }
@@ -1567,12 +1555,11 @@ pub fn parse_export_env(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: output,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        output,
+                    )]),
                     None,
                 );
             }
@@ -1606,12 +1593,11 @@ pub fn parse_export_env(
         return (garbage_pipeline(spans), None);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: span(spans),
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        span(spans),
+        Type::Any,
+    )]);
 
     (pipeline, Some(block_id))
 }
@@ -2039,12 +2025,11 @@ pub fn parse_module(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: output,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        output,
+                    )]),
                     None,
                 );
             }
@@ -2072,12 +2057,11 @@ pub fn parse_module(
                             name.span,
                         ));
                         return (
-                            Pipeline::from_vec(vec![Expression {
-                                expr: Expr::Call(call),
-                                span: call_span,
-                                ty: Type::Any,
-                                custom_completion: None,
-                            }]),
+                            Pipeline::from_vec(vec![Expression::new(working_set,
+                                Expr::Call(call),
+                                call_span,
+                                Type::Any,
+                            )]),
                             None,
                         );
                     }
@@ -2098,12 +2082,11 @@ pub fn parse_module(
             return (garbage_pipeline(spans), None);
         };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )]);
 
     if spans.len() == split_id + 1 {
         if let Some(module_id) = parse_module_file_or_dir(
@@ -2161,12 +2144,11 @@ pub fn parse_module(
     module_comments.extend(inner_comments);
     let module_id = working_set.add_module(&module_name, module, module_comments);
 
-    let block_expr = Expression {
-        expr: Expr::Block(block_id),
-        span: block_span,
-        ty: Type::Block,
-        custom_completion: None,
-    };
+    let block_expr = Expression::new(working_set,
+        Expr::Block(block_id),
+        block_span,
+        Type::Block,
+    );
 
     let module_decl_id = working_set
         .find_decl(b"module")

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2165,12 +2165,11 @@ pub fn parse_module(
     });
 
     (
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: span(spans),
-            ty: Type::Any,
-            custom_completion: None,
-        }]),
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            span(spans),
+            Type::Any,
+        )]),
         Some(module_id),
     )
 }
@@ -2229,12 +2228,11 @@ pub fn parse_use(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: output,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        output,
+                    )]),
                     vec![],
                 );
             }
@@ -2309,12 +2307,11 @@ pub fn parse_use(
             String::from_utf8_lossy(&import_pattern.head.name).to_string(),
         ));
         return (
-            Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: call_span,
-                ty: Type::Any,
-                custom_completion: None,
-            }]),
+            Pipeline::from_vec(vec![Expression::new(working_set,
+                Expr::Call(call),
+                call_span,
+                Type::Any,
+            )]),
             vec![],
         );
     };
@@ -2372,23 +2369,21 @@ pub fn parse_use(
     working_set.use_variables(constants);
 
     // Create a new Use command call to pass the import pattern as parser info
-    let import_pattern_expr = Expression {
-        expr: Expr::ImportPattern(import_pattern),
-        span: span(args_spans),
-        ty: Type::Any,
-        custom_completion: None,
-    };
+    let import_pattern_expr = Expression::new(working_set,
+        Expr::ImportPattern(import_pattern),
+        span(args_spans),
+        Type::Any,
+        );
 
     let mut call = call;
     call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
     (
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: span(spans),
-            ty: Type::Any,
-            custom_completion: None,
-        }]),
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            span(spans),
+            Type::Any,
+        )]),
         exportables,
     )
 }
@@ -2424,12 +2419,11 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: output,
-                    custom_completion: None,
-                }]);
+                return Pipeline::from_vec(vec![Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    output,
+                )]);
             }
 
             (call, &spans[1..])
@@ -2556,22 +2550,20 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
         working_set.hide_decls(&decls_to_hide);
 
         // Create a new Use command call to pass the new import pattern
-        let import_pattern_expr = Expression {
-            expr: Expr::ImportPattern(import_pattern),
-            span: span(args_spans),
-            ty: Type::Any,
-            custom_completion: None,
-        };
+        let import_pattern_expr = Expression::new(working_set,
+            Expr::ImportPattern(import_pattern),
+            span(args_spans),
+            Type::Any,
+        );
 
         let mut call = call;
         call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: span(spans),
-            ty: Type::Any,
-            custom_completion: None,
-        }])
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            span(spans),
+            Type::Any,
+        )])
     } else {
         working_set.error(ParseError::UnknownState(
             "Expected structure: hide <name>".into(),
@@ -2606,12 +2598,11 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )]);
 
     let module_id = working_set.add_module(
         &overlay_name,
@@ -2691,12 +2682,11 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call.clone()),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call.clone()),
+        call_span,
+        Type::Any,
+    )]);
 
     let (final_overlay_name, origin_module, origin_module_id, is_module_updated) =
         if let Some(overlay_frame) = working_set.find_overlay(overlay_name.as_bytes()) {
@@ -2831,24 +2821,22 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
     let mut call = call;
     call.set_parser_info(
         "overlay_expr".to_string(),
-        Expression {
-            expr: Expr::Overlay(if is_module_updated {
+        Expression::new(working_set,
+            Expr::Overlay(if is_module_updated {
                 Some(origin_module_id)
             } else {
                 None
             }),
-            span: overlay_name_span,
-            ty: Type::Any,
-            custom_completion: None,
-        },
+            overlay_name_span,
+            Type::Any,
+    ),
     );
 
-    Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }])
+    Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )])
 }
 
 pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
@@ -2879,12 +2867,11 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )]);
 
     if overlay_name == DEFAULT_OVERLAY_NAME {
         working_set.error(ParseError::CantHideDefaultOverlay(
@@ -2949,12 +2936,11 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 
-                    let rvalue = Expression {
-                        expr: Expr::Block(block_id),
-                        span: rvalue_span,
-                        ty: output_type,
-                        custom_completion: None,
-                    };
+                    let rvalue = Expression::new(working_set,
+                        Expr::Block(block_id),
+                        rvalue_span,
+                        output_type,
+                    );
 
                     let mut idx = 0;
                     let (lvalue, explicit_type) =
@@ -2999,24 +2985,22 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: nu_protocol::span(spans),
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]);
+                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        nu_protocol::span(spans),
+                        Type::Any,
+                        )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: nu_protocol::span(spans),
-            ty: output,
-            custom_completion: None,
-        }]);
+        return Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            nu_protocol::span(spans),
+            output,
+        )]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3145,24 +3129,22 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: nu_protocol::span(spans),
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]);
+                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        nu_protocol::span(spans),
+                        Type::Any,
+                        )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: nu_protocol::span(spans),
-            ty: output,
-            custom_completion: None,
-        }]);
+        return Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            nu_protocol::span(spans),
+            output,
+        )]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3213,12 +3195,11 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 
-                    let rvalue = Expression {
-                        expr: Expr::Block(block_id),
-                        span: rvalue_span,
-                        ty: output_type,
-                        custom_completion: None,
-                    };
+                    let rvalue = Expression::new(working_set,
+                        Expr::Block(block_id),
+                        rvalue_span,
+                        output_type,
+                        );
 
                     let mut idx = 0;
 
@@ -3264,24 +3245,22 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: nu_protocol::span(spans),
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]);
+                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        nu_protocol::span(spans),
+                        Type::Any,
+                        )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: nu_protocol::span(spans),
-            ty: output,
-            custom_completion: None,
-        }]);
+        return Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            nu_protocol::span(spans),
+            output,
+        )]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3327,12 +3306,11 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
             };
 
             if is_help {
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: span(spans),
-                    ty: output,
-                    custom_completion: None,
-                }]);
+                return Pipeline::from_vec(vec![Expression::new(working_set,
+                    Expr::Call(call),
+                    span(spans),
+                    output,
+                )]);
             }
 
             // Command and one file name
@@ -3343,12 +3321,11 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(val) => val,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, span(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call),
-                            span: span(&spans[1..]),
-                            ty: Type::Any,
-                            custom_completion: None,
-                        }]);
+                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                            Expr::Call(call),
+                            span(&spans[1..]),
+                            Type::Any,
+                        )]);
                     }
                 };
 
@@ -3356,12 +3333,11 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(s) => s,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, span(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call),
-                            span: span(&spans[1..]),
-                            ty: Type::Any,
-                            custom_completion: None,
-                        }]);
+                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                            Expr::Call(call),
+                            span(&spans[1..]),
+                            Type::Any,
+                        )]);
                     }
                 };
 
@@ -3395,31 +3371,28 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                         // after writing `source example.nu`
                         call_with_block.set_parser_info(
                             "block_id".to_string(),
-                            Expression {
-                                expr: Expr::Int(block_id as i64),
-                                span: spans[1],
-                                ty: Type::Any,
-                                custom_completion: None,
-                            },
+                            Expression::new(working_set,
+                                Expr::Int(block_id as i64),
+                                spans[1],
+                                Type::Any,
+                            ),
                         );
 
-                        return Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call_with_block),
-                            span: span(spans),
-                            ty: Type::Any,
-                            custom_completion: None,
-                        }]);
+                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                            Expr::Call(call_with_block),
+                            span(spans),
+                            Type::Any,
+                        )]);
                     }
                 } else {
                     working_set.error(ParseError::SourcedFileNotFound(filename, spans[1]));
                 }
             }
-            return Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: span(spans),
-                ty: Type::Any,
-                custom_completion: None,
-            }]);
+            return Pipeline::from_vec(vec![Expression::new(working_set,
+                Expr::Call(call),
+                span(spans),
+                Type::Any,
+)]);
         }
     }
     working_set.error(ParseError::UnknownState(
@@ -3465,12 +3438,11 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: output,
-                    custom_completion: None,
-                };
+                return Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    output,
+                );
             }
 
             call
@@ -3484,12 +3456,11 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
         }
     };
 
-    Expression {
-        expr: Expr::Call(call),
-        span: span(spans),
-        ty: Type::Any,
-        custom_completion: None,
-    }
+    Expression::new(working_set,
+        Expr::Call(call),
+        span(spans),
+        Type::Any,
+)
 }
 
 pub fn parse_where(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
@@ -3561,12 +3532,11 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: output,
-                    custom_completion: None,
-                }]);
+                return Pipeline::from_vec(vec![Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    output,
+                )]);
             }
 
             (call, call_span)
@@ -3636,12 +3606,11 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             Ok(path) => Some(path),
             Err(err) => {
                 working_set.error(err);
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: Type::Any,
-                    custom_completion: None,
-                }]);
+                return Pipeline::from_vec(vec![Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    Type::Any,
+                    )]);
             }
         },
     };
@@ -3730,12 +3699,11 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
         working_set.error(err);
     }
 
-    Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Nothing,
-        custom_completion: None,
-    }])
+    Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Nothing,
+)])
 }
 
 pub fn find_dirs_var(working_set: &StateWorkingSet, var_name: &str) -> Option<VarId> {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -254,7 +254,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
     }
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error("for", redirection));
-        return garbage(spans[0]);
+        return garbage(working_set, spans[0]);
     }
 
     // Parsing the spans and checking that they match the register signature
@@ -385,7 +385,7 @@ pub fn parse_def(
     }
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error("def", redirection));
-        return (garbage_pipeline(spans), None);
+        return (garbage_pipeline(working_set, spans), None);
     }
 
     // Parsing the spans and checking that they match the register signature
@@ -663,7 +663,7 @@ pub fn parse_extern(
     }
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error("extern", redirection));
-        return garbage_pipeline(spans);
+        return garbage_pipeline(working_set, spans);
     }
 
     // Parsing the spans and checking that they match the register signature
@@ -818,7 +818,7 @@ pub fn parse_alias(
     }
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error("alias", redirection));
-        return garbage_pipeline(spans);
+        return garbage_pipeline(working_set, spans);
     }
 
     if let Some(span) = check_name(working_set, spans) {
@@ -1074,7 +1074,7 @@ pub fn parse_export_in_block(
 
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error(full_name, redirection));
-        return garbage_pipeline(&lite_command.parts);
+        return garbage_pipeline(working_set, &lite_command.parts);
     }
 
     if let Some(decl_id) = working_set.find_decl(full_name.as_bytes()) {
@@ -1807,7 +1807,9 @@ pub fn parse_module_block(
                         command.parts[0],
                     ));
 
-                    block.pipelines.push(garbage_pipeline(working_set, &command.parts))
+                    block
+                        .pipelines
+                        .push(garbage_pipeline(working_set, &command.parts))
                 }
             }
         } else {
@@ -1999,7 +2001,7 @@ pub fn parse_module(
 
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error("module", redirection));
-        return (garbage_pipeline(spans), None);
+        return (garbage_pipeline(working_set, spans), None);
     }
 
     let mut module_comments = lite_command.comments.clone();
@@ -2210,7 +2212,7 @@ pub fn parse_use(
 
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error("use", redirection));
-        return (garbage_pipeline(spans), vec![]);
+        return (garbage_pipeline(working_set, spans), vec![]);
     }
 
     let (call, call_span, args_spans) = match working_set.find_decl(b"use") {
@@ -2408,7 +2410,7 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
     }
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error("hide", redirection));
-        return garbage_pipeline(spans);
+        return garbage_pipeline(working_set, spans);
     }
 
     let (call, args_spans) = match working_set.find_decl(b"hide") {
@@ -3312,7 +3314,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                 "source-env"
             };
             working_set.error(redirecting_builtin_error(name, redirection));
-            return garbage_pipeline(spans);
+            return garbage_pipeline(working_set, spans);
         }
 
         let scoped = name == b"source-env";
@@ -3525,7 +3527,7 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
     }
     if let Some(redirection) = lite_command.redirection.as_ref() {
         working_set.error(redirecting_builtin_error("register", redirection));
-        return garbage_pipeline(spans);
+        return garbage_pipeline(working_set, spans);
     }
 
     // Parsing the spans and checking that they match the register signature

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -109,7 +109,8 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
         // check help flag first.
         if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
             let call_span = call.span();
-            return Pipeline::from_vec(vec![Expression::new(working_set,
+            return Pipeline::from_vec(vec![Expression::new(
+                working_set,
                 Expr::Call(call),
                 call_span,
                 Type::Any,
@@ -286,11 +287,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Expression::new(working_set,
-                    Expr::Call(call),
-                    call_span,
-                    output,
-                );
+                return Expression::new(working_set, Expr::Call(call), call_span, output);
             }
 
             // Let's get our block and make sure it has the right signature
@@ -347,11 +344,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
         );
     }
 
-    Expression::new(working_set,
-        Expr::Call(call),
-        call_span,
-        Type::Nothing,
-    )
+    Expression::new(working_set, Expr::Call(call), call_span, Type::Nothing)
 }
 
 /// If `name` is a keyword, emit an error.
@@ -473,7 +466,8 @@ pub fn parse_def(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         output,
@@ -560,7 +554,8 @@ pub fn parse_def(
                             format!("...rest-like positional argument used in 'def --wrapped' supports only strings. Change the type annotation of ...{} to 'string'.", &rest.name)));
 
                         return (
-                            Pipeline::from_vec(vec![Expression::new(working_set,
+                            Pipeline::from_vec(vec![Expression::new(
+                                working_set,
                                 Expr::Call(call),
                                 call_span,
                                 Type::Any,
@@ -573,7 +568,8 @@ pub fn parse_def(
                 working_set.error(ParseError::MissingPositional("...rest-like positional argument".to_string(), name_expr.span, "def --wrapped must have a ...rest-like positional argument. Add '...rest: string' to the command's signature.".to_string()));
 
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         Type::Any,
@@ -628,7 +624,8 @@ pub fn parse_def(
     working_set.merge_predecl(name.as_bytes());
 
     (
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             call_span,
             Type::Any,
@@ -722,7 +719,8 @@ pub fn parse_extern(
                         "main".to_string(),
                         name_expr_span,
                     ));
-                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                    return Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         Type::Any,
@@ -787,7 +785,8 @@ pub fn parse_extern(
         }
     }
 
-    Pipeline::from_vec(vec![Expression::new(working_set,
+    Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -845,7 +844,8 @@ pub fn parse_alias(
             return garbage_pipeline(spans);
         };
 
-        let alias_pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        let alias_pipeline = Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(alias_call.clone()),
             span(spans),
             output,
@@ -1103,7 +1103,8 @@ pub fn parse_export_in_block(
         };
 
         if starting_error_count != working_set.parse_errors.len() || is_help {
-            return Pipeline::from_vec(vec![Expression::new(working_set,
+            return Pipeline::from_vec(vec![Expression::new(
+                working_set,
                 Expr::Call(call),
                 call_span,
                 output,
@@ -1508,7 +1509,8 @@ pub fn parse_export_in_module(
     };
 
     (
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             span(spans),
             Type::Any,
@@ -1555,7 +1557,8 @@ pub fn parse_export_env(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         output,
@@ -1593,7 +1596,8 @@ pub fn parse_export_env(
         return (garbage_pipeline(spans), None);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         span(spans),
         Type::Any,
@@ -2025,7 +2029,8 @@ pub fn parse_module(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         output,
@@ -2057,7 +2062,8 @@ pub fn parse_module(
                             name.span,
                         ));
                         return (
-                            Pipeline::from_vec(vec![Expression::new(working_set,
+                            Pipeline::from_vec(vec![Expression::new(
+                                working_set,
                                 Expr::Call(call),
                                 call_span,
                                 Type::Any,
@@ -2082,7 +2088,8 @@ pub fn parse_module(
             return (garbage_pipeline(spans), None);
         };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -2144,11 +2151,7 @@ pub fn parse_module(
     module_comments.extend(inner_comments);
     let module_id = working_set.add_module(&module_name, module, module_comments);
 
-    let block_expr = Expression::new(working_set,
-        Expr::Block(block_id),
-        block_span,
-        Type::Block,
-    );
+    let block_expr = Expression::new(working_set, Expr::Block(block_id), block_span, Type::Block);
 
     let module_decl_id = working_set
         .find_decl(b"module")
@@ -2165,7 +2168,8 @@ pub fn parse_module(
     });
 
     (
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             span(spans),
             Type::Any,
@@ -2228,7 +2232,8 @@ pub fn parse_use(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         output,
@@ -2307,7 +2312,8 @@ pub fn parse_use(
             String::from_utf8_lossy(&import_pattern.head.name).to_string(),
         ));
         return (
-            Pipeline::from_vec(vec![Expression::new(working_set,
+            Pipeline::from_vec(vec![Expression::new(
+                working_set,
                 Expr::Call(call),
                 call_span,
                 Type::Any,
@@ -2369,17 +2375,19 @@ pub fn parse_use(
     working_set.use_variables(constants);
 
     // Create a new Use command call to pass the import pattern as parser info
-    let import_pattern_expr = Expression::new(working_set,
+    let import_pattern_expr = Expression::new(
+        working_set,
         Expr::ImportPattern(import_pattern),
         span(args_spans),
         Type::Any,
-        );
+    );
 
     let mut call = call;
     call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
     (
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             span(spans),
             Type::Any,
@@ -2419,7 +2427,8 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression::new(working_set,
+                return Pipeline::from_vec(vec![Expression::new(
+                    working_set,
                     Expr::Call(call),
                     call_span,
                     output,
@@ -2550,7 +2559,8 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
         working_set.hide_decls(&decls_to_hide);
 
         // Create a new Use command call to pass the new import pattern
-        let import_pattern_expr = Expression::new(working_set,
+        let import_pattern_expr = Expression::new(
+            working_set,
             Expr::ImportPattern(import_pattern),
             span(args_spans),
             Type::Any,
@@ -2559,7 +2569,8 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
         let mut call = call;
         call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             span(spans),
             Type::Any,
@@ -2598,7 +2609,8 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -2682,7 +2694,8 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call.clone()),
         call_span,
         Type::Any,
@@ -2821,7 +2834,8 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
     let mut call = call;
     call.set_parser_info(
         "overlay_expr".to_string(),
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Overlay(if is_module_updated {
                 Some(origin_module_id)
             } else {
@@ -2829,10 +2843,11 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
             }),
             overlay_name_span,
             Type::Any,
-    ),
+        ),
     );
 
-    Pipeline::from_vec(vec![Expression::new(working_set,
+    Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -2867,7 +2882,8 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -2936,7 +2952,8 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 
-                    let rvalue = Expression::new(working_set,
+                    let rvalue = Expression::new(
+                        working_set,
                         Expr::Block(block_id),
                         rvalue_span,
                         output_type,
@@ -2985,18 +3002,20 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                    return Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         nu_protocol::span(spans),
                         Type::Any,
-                        )]);
+                    )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(working_set,
+        return Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             nu_protocol::span(spans),
             output,
@@ -3129,18 +3148,20 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                    return Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         nu_protocol::span(spans),
                         Type::Any,
-                        )]);
+                    )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(working_set,
+        return Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             nu_protocol::span(spans),
             output,
@@ -3195,11 +3216,12 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 
-                    let rvalue = Expression::new(working_set,
+                    let rvalue = Expression::new(
+                        working_set,
                         Expr::Block(block_id),
                         rvalue_span,
                         output_type,
-                        );
+                    );
 
                     let mut idx = 0;
 
@@ -3245,18 +3267,20 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                    return Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         nu_protocol::span(spans),
                         Type::Any,
-                        )]);
+                    )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(working_set,
+        return Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             nu_protocol::span(spans),
             output,
@@ -3306,7 +3330,8 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
             };
 
             if is_help {
-                return Pipeline::from_vec(vec![Expression::new(working_set,
+                return Pipeline::from_vec(vec![Expression::new(
+                    working_set,
                     Expr::Call(call),
                     span(spans),
                     output,
@@ -3321,7 +3346,8 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(val) => val,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, span(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                        return Pipeline::from_vec(vec![Expression::new(
+                            working_set,
                             Expr::Call(call),
                             span(&spans[1..]),
                             Type::Any,
@@ -3333,7 +3359,8 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(s) => s,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, span(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                        return Pipeline::from_vec(vec![Expression::new(
+                            working_set,
                             Expr::Call(call),
                             span(&spans[1..]),
                             Type::Any,
@@ -3371,14 +3398,16 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                         // after writing `source example.nu`
                         call_with_block.set_parser_info(
                             "block_id".to_string(),
-                            Expression::new(working_set,
+                            Expression::new(
+                                working_set,
                                 Expr::Int(block_id as i64),
                                 spans[1],
                                 Type::Any,
                             ),
                         );
 
-                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                        return Pipeline::from_vec(vec![Expression::new(
+                            working_set,
                             Expr::Call(call_with_block),
                             span(spans),
                             Type::Any,
@@ -3388,11 +3417,12 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     working_set.error(ParseError::SourcedFileNotFound(filename, spans[1]));
                 }
             }
-            return Pipeline::from_vec(vec![Expression::new(working_set,
+            return Pipeline::from_vec(vec![Expression::new(
+                working_set,
                 Expr::Call(call),
                 span(spans),
                 Type::Any,
-)]);
+            )]);
         }
     }
     working_set.error(ParseError::UnknownState(
@@ -3438,11 +3468,7 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Expression::new(working_set,
-                    Expr::Call(call),
-                    call_span,
-                    output,
-                );
+                return Expression::new(working_set, Expr::Call(call), call_span, output);
             }
 
             call
@@ -3456,11 +3482,7 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
         }
     };
 
-    Expression::new(working_set,
-        Expr::Call(call),
-        span(spans),
-        Type::Any,
-)
+    Expression::new(working_set, Expr::Call(call), span(spans), Type::Any)
 }
 
 pub fn parse_where(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
@@ -3532,7 +3554,8 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression::new(working_set,
+                return Pipeline::from_vec(vec![Expression::new(
+                    working_set,
                     Expr::Call(call),
                     call_span,
                     output,
@@ -3606,11 +3629,12 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             Ok(path) => Some(path),
             Err(err) => {
                 working_set.error(err);
-                return Pipeline::from_vec(vec![Expression::new(working_set,
+                return Pipeline::from_vec(vec![Expression::new(
+                    working_set,
                     Expr::Call(call),
                     call_span,
                     Type::Any,
-                    )]);
+                )]);
             }
         },
     };
@@ -3699,11 +3723,12 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
         working_set.error(err);
     }
 
-    Pipeline::from_vec(vec![Expression::new(working_set,
+    Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Nothing,
-)])
+    )])
 }
 
 pub fn find_dirs_var(working_set: &StateWorkingSet, var_name: &str) -> Option<VarId> {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -108,23 +108,21 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
         let cmd = working_set.get_decl(call.decl_id);
         // check help flag first.
         if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
-            let call_span = call.span();
-            return Pipeline::from_vec(vec![Expression::new(
-                working_set,
-                Expr::Call(call),
-                call_span,
-                Type::Any,
-            )]);
+            let call_span = call.span(&working_set);
+
+            let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+            return Pipeline::from_vec(&working_set, vec![pipe_expr]);
         }
 
         match cmd.name() {
             "overlay hide" => parse_overlay_hide(working_set, call),
             "overlay new" => parse_overlay_new(working_set, call),
             "overlay use" => parse_overlay_use(working_set, call),
-            _ => Pipeline::from_vec(vec![call_expr]),
+            _ => Pipeline::from_vec(&working_set, vec![call_expr]),
         }
     } else {
-        Pipeline::from_vec(vec![call_expr])
+        Pipeline::from_vec(&working_set, vec![call_expr])
     }
 }
 
@@ -451,7 +449,7 @@ pub fn parse_def(
                     }
                     _ => working_set.parse_errors.push(ParseError::Expected(
                         "definition body closure { ... }",
-                        arg.span,
+                        arg.get_span(&working_set),
                     )),
                 }
             }
@@ -465,15 +463,9 @@ pub fn parse_def(
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return (
-                    Pipeline::from_vec(vec![Expression::new(
-                        working_set,
-                        Expr::Call(call),
-                        call_span,
-                        output,
-                    )]),
-                    None,
-                );
+                let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, output);
+
+                return (Pipeline::from_vec(&working_set, vec![pipe_expr]), None);
             }
 
             (call, call_span)
@@ -495,7 +487,7 @@ pub fn parse_def(
     let name = if let Some(name) = name_expr.as_string() {
         if let Some(mod_name) = module_name {
             if name.as_bytes() == mod_name {
-                let name_expr_span = name_expr.span;
+                let name_expr_span = name_expr.get_span(&working_set);
 
                 working_set.error(ParseError::NamedAsModule(
                     "command".to_string(),
@@ -503,15 +495,11 @@ pub fn parse_def(
                     "main".to_string(),
                     name_expr_span,
                 ));
-                return (
-                    Pipeline::from_vec(vec![Expression::new(
-                        working_set,
-                        Expr::Call(call),
-                        call_span,
-                        Type::Any,
-                    )]),
-                    None,
-                );
+
+                let pipe_expr =
+                    Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+                return (Pipeline::from_vec(&working_set, vec![pipe_expr]), None);
             }
         }
 
@@ -519,7 +507,7 @@ pub fn parse_def(
     } else {
         working_set.error(ParseError::UnknownState(
             "Could not get string from string expression".into(),
-            name_expr.span,
+            name_expr.get_span(&working_set),
         ));
         return (garbage_pipeline(working_set, spans), None);
     };
@@ -528,16 +516,28 @@ pub fn parse_def(
 
     if let (Some(mut signature), Some(block_id)) = (sig.as_signature(), block.as_block()) {
         for arg_name in &signature.required_positional {
-            verify_not_reserved_variable_name(working_set, &arg_name.name, sig.span);
+            verify_not_reserved_variable_name(
+                working_set,
+                &arg_name.name,
+                sig.get_span(&working_set),
+            );
         }
         for arg_name in &signature.optional_positional {
-            verify_not_reserved_variable_name(working_set, &arg_name.name, sig.span);
+            verify_not_reserved_variable_name(
+                working_set,
+                &arg_name.name,
+                sig.get_span(&working_set),
+            );
         }
         for arg_name in &signature.rest_positional {
-            verify_not_reserved_variable_name(working_set, &arg_name.name, sig.span);
+            verify_not_reserved_variable_name(
+                working_set,
+                &arg_name.name,
+                sig.get_span(&working_set),
+            );
         }
         for flag_name in &signature.get_names() {
-            verify_not_reserved_variable_name(working_set, flag_name, sig.span);
+            verify_not_reserved_variable_name(working_set, flag_name, sig.get_span(&working_set));
         }
 
         if has_wrapped {
@@ -553,29 +553,19 @@ pub fn parse_def(
                             rest_var.declaration_span,
                             format!("...rest-like positional argument used in 'def --wrapped' supports only strings. Change the type annotation of ...{} to 'string'.", &rest.name)));
 
-                        return (
-                            Pipeline::from_vec(vec![Expression::new(
-                                working_set,
-                                Expr::Call(call),
-                                call_span,
-                                Type::Any,
-                            )]),
-                            result,
-                        );
+                        let pipe_expr =
+                            Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+                        return (Pipeline::from_vec(&working_set, vec![pipe_expr]), result);
                     }
                 }
             } else {
-                working_set.error(ParseError::MissingPositional("...rest-like positional argument".to_string(), name_expr.span, "def --wrapped must have a ...rest-like positional argument. Add '...rest: string' to the command's signature.".to_string()));
+                working_set.error(ParseError::MissingPositional("...rest-like positional argument".to_string(), name_expr.get_span(&working_set), "def --wrapped must have a ...rest-like positional argument. Add '...rest: string' to the command's signature.".to_string()));
 
-                return (
-                    Pipeline::from_vec(vec![Expression::new(
-                        working_set,
-                        Expr::Call(call),
-                        call_span,
-                        Type::Any,
-                    )]),
-                    result,
-                );
+                let pipe_expr =
+                    Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+                return (Pipeline::from_vec(&working_set, vec![pipe_expr]), result);
             }
         }
 
@@ -615,7 +605,7 @@ pub fn parse_def(
         } else {
             working_set.error(ParseError::InternalError(
                 "Predeclaration failed to add declaration".into(),
-                name_expr.span,
+                name_expr.get_span(&working_set),
             ));
         };
     }
@@ -623,15 +613,9 @@ pub fn parse_def(
     // It's OK if it returns None: The decl was already merged in previous parse pass.
     working_set.merge_predecl(name.as_bytes());
 
-    (
-        Pipeline::from_vec(vec![Expression::new(
-            working_set,
-            Expr::Call(call),
-            call_span,
-            Type::Any,
-        )]),
-        result,
-    )
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+    (Pipeline::from_vec(&working_set, vec![pipe_expr]), result)
 }
 
 pub fn parse_extern(
@@ -712,19 +696,18 @@ pub fn parse_extern(
         if let (Some(name), Some(mut signature)) = (&name_expr.as_string(), sig.as_signature()) {
             if let Some(mod_name) = module_name {
                 if name.as_bytes() == mod_name {
-                    let name_expr_span = name_expr.span;
+                    let name_expr_span = name_expr.get_span(&working_set);
                     working_set.error(ParseError::NamedAsModule(
                         "known external".to_string(),
                         name.clone(),
                         "main".to_string(),
                         name_expr_span,
                     ));
-                    return Pipeline::from_vec(vec![Expression::new(
-                        working_set,
-                        Expr::Call(call),
-                        call_span,
-                        Type::Any,
-                    )]);
+
+                    let pipe_expr =
+                        Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+                    return Pipeline::from_vec(&working_set, vec![pipe_expr]);
                 }
             }
 
@@ -750,7 +733,7 @@ pub fn parse_extern(
                     if signature.rest_positional.is_none() {
                         working_set.error(ParseError::InternalError(
                             "Extern block must have a rest positional argument".into(),
-                            name_expr.span,
+                            name_expr.get_span(&working_set),
                         ));
                     } else {
                         *declaration = signature.clone().into_block_command(block_id);
@@ -780,17 +763,14 @@ pub fn parse_extern(
         } else {
             working_set.error(ParseError::UnknownState(
                 "Could not get string from string expression".into(),
-                name_expr.span,
+                name_expr.get_span(&working_set),
             ));
         }
     }
 
-    Pipeline::from_vec(vec![Expression::new(
-        working_set,
-        Expr::Call(call),
-        call_span,
-        Type::Any,
-    )])
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+    Pipeline::from_vec(&working_set, vec![pipe_expr])
 }
 
 pub fn parse_alias(
@@ -822,7 +802,8 @@ pub fn parse_alias(
     }
 
     if let Some(span) = check_name(working_set, spans) {
-        return Pipeline::from_vec(vec![garbage(working_set, *span)]);
+        let garbage_expr = garbage(working_set, *span);
+        return Pipeline::from_vec(&working_set, vec![garbage_expr]);
     }
 
     if let Some(decl_id) = working_set.find_decl(b"alias") {
@@ -844,12 +825,14 @@ pub fn parse_alias(
             return garbage_pipeline(working_set, spans);
         };
 
-        let alias_pipeline = Pipeline::from_vec(vec![Expression::new(
+        let alias_expr = Expression::new(
             working_set,
             Expr::Call(alias_call.clone()),
             span(spans),
             output,
-        )]);
+        );
+
+        let alias_pipeline = Pipeline::from_vec(&working_set, vec![alias_expr]);
 
         if has_help_flag {
             return alias_pipeline;
@@ -869,13 +852,17 @@ pub fn parse_alias(
                 || name.parse::<bytesize::ByteSize>().is_ok()
                 || name.parse::<f64>().is_ok()
             {
-                working_set.error(ParseError::AliasNotValid(alias_name_expr.span));
+                working_set.error(ParseError::AliasNotValid(
+                    alias_name_expr.get_span(&working_set),
+                ));
                 return garbage_pipeline(working_set, spans);
             } else {
                 name
             }
         } else {
-            working_set.error(ParseError::AliasNotValid(alias_name_expr.span));
+            working_set.error(ParseError::AliasNotValid(
+                alias_name_expr.get_span(&working_set),
+            ));
             return garbage_pipeline(working_set, spans);
         };
 
@@ -972,7 +959,7 @@ pub fn parse_alias(
                 _ => {
                     working_set.error(ParseError::InternalError(
                         "Parsed call not a call".into(),
-                        expr.span,
+                        expr.get_span(&working_set),
                     ));
                     return alias_pipeline;
                 }
@@ -988,7 +975,7 @@ pub fn parse_alias(
                         expr: Expr::Keyword(.., expr),
                         ..
                     })) => {
-                        let aliased = working_set.get_span_contents(expr.span);
+                        let aliased = working_set.get_span_contents(expr.get_span(&working_set));
                         (
                             format!("Alias for `{}`", String::from_utf8_lossy(aliased)),
                             String::new(),
@@ -1103,12 +1090,9 @@ pub fn parse_export_in_block(
         };
 
         if starting_error_count != working_set.parse_errors.len() || is_help {
-            return Pipeline::from_vec(vec![Expression::new(
-                working_set,
-                Expr::Call(call),
-                call_span,
-                output,
-            )]);
+            let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, output);
+
+            return Pipeline::from_vec(&working_set, vec![pipe_expr]);
         }
     } else {
         working_set.error(ParseError::UnknownState(
@@ -1508,13 +1492,10 @@ pub fn parse_export_in_module(
         vec![]
     };
 
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), span(spans), Type::Any);
+
     (
-        Pipeline::from_vec(vec![Expression::new(
-            working_set,
-            Expr::Call(call),
-            span(spans),
-            Type::Any,
-        )]),
+        Pipeline::from_vec(&working_set, vec![pipe_expr]),
         exportables,
     )
 }
@@ -1556,15 +1537,9 @@ pub fn parse_export_env(
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return (
-                    Pipeline::from_vec(vec![Expression::new(
-                        working_set,
-                        Expr::Call(call),
-                        call_span,
-                        output,
-                    )]),
-                    None,
-                );
+                let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, output);
+
+                return (Pipeline::from_vec(&working_set, vec![pipe_expr]), None);
             }
 
             call
@@ -1584,7 +1559,7 @@ pub fn parse_export_env(
         } else {
             working_set.error(ParseError::UnknownState(
                 "internal error: 'export-env' block is not a block".into(),
-                block.span,
+                block.get_span(&working_set),
             ));
             return (garbage_pipeline(working_set, spans), None);
         }
@@ -1596,12 +1571,9 @@ pub fn parse_export_env(
         return (garbage_pipeline(working_set, spans), None);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(
-        working_set,
-        Expr::Call(call),
-        span(spans),
-        Type::Any,
-    )]);
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), span(spans), Type::Any);
+
+    let pipeline = Pipeline::from_vec(&working_set, vec![pipe_expr]);
 
     (pipeline, Some(block_id))
 }
@@ -1724,7 +1696,7 @@ pub fn parse_module_block(
                                             if let Expr::Call(call) = &pipe.elements[0].expr.expr {
                                                 call.head
                                             } else {
-                                                pipe.elements[0].expr.span
+                                                pipe.elements[0].expr.get_span(&working_set)
                                             }
                                         } else {
                                             span
@@ -1761,7 +1733,7 @@ pub fn parse_module_block(
                                                 {
                                                     call.head
                                                 } else {
-                                                    pipe.elements[0].expr.span
+                                                    pipe.elements[0].expr.get_span(&working_set)
                                                 }
                                             } else {
                                                 span
@@ -2030,15 +2002,9 @@ pub fn parse_module(
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return (
-                    Pipeline::from_vec(vec![Expression::new(
-                        working_set,
-                        Expr::Call(call),
-                        call_span,
-                        output,
-                    )]),
-                    None,
-                );
+                let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, output);
+
+                return (Pipeline::from_vec(&working_set, vec![pipe_expr]), None);
             }
 
             (call, call_span)
@@ -2061,20 +2027,16 @@ pub fn parse_module(
                             "module".to_string(),
                             s,
                             "mod".to_string(),
-                            name.span,
+                            name.get_span(&working_set),
                         ));
-                        return (
-                            Pipeline::from_vec(vec![Expression::new(
-                                working_set,
-                                Expr::Call(call),
-                                call_span,
-                                Type::Any,
-                            )]),
-                            None,
-                        );
+
+                        let pipe_expr =
+                            Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+                        return (Pipeline::from_vec(&working_set, vec![pipe_expr]), None);
                     }
                 }
-                (s, name.span, name.clone())
+                (s, name.get_span(&working_set), name.clone())
             } else {
                 working_set.error(ParseError::UnknownState(
                     "internal error: name not a string".into(),
@@ -2090,12 +2052,9 @@ pub fn parse_module(
             return (garbage_pipeline(working_set, spans), None);
         };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(
-        working_set,
-        Expr::Call(call),
-        call_span,
-        Type::Any,
-    )]);
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+    let pipeline = Pipeline::from_vec(&working_set, vec![pipe_expr]);
 
     if spans.len() == split_id + 1 {
         if let Some(module_id) = parse_module_file_or_dir(
@@ -2169,13 +2128,10 @@ pub fn parse_module(
         parser_info: HashMap::new(),
     });
 
+    let pipe_expr_2 = Expression::new(working_set, Expr::Call(call), span(spans), Type::Any);
+
     (
-        Pipeline::from_vec(vec![Expression::new(
-            working_set,
-            Expr::Call(call),
-            span(spans),
-            Type::Any,
-        )]),
+        Pipeline::from_vec(&working_set, vec![pipe_expr_2]),
         Some(module_id),
     )
 }
@@ -2233,15 +2189,9 @@ pub fn parse_use(
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return (
-                    Pipeline::from_vec(vec![Expression::new(
-                        working_set,
-                        Expr::Call(call),
-                        call_span,
-                        output,
-                    )]),
-                    vec![],
-                );
+                let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, output);
+
+                return (Pipeline::from_vec(&working_set, vec![pipe_expr]), vec![]);
             }
 
             (call, call_span, rest_spans)
@@ -2266,7 +2216,7 @@ pub fn parse_use(
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: Import pattern positional is not import pattern".into(),
-            import_pattern_expr.span,
+            import_pattern_expr.get_span(&working_set),
         ));
         return (garbage_pipeline(working_set, spans), vec![]);
     };
@@ -2313,15 +2263,10 @@ pub fn parse_use(
             import_pattern.head.span,
             String::from_utf8_lossy(&import_pattern.head.name).to_string(),
         ));
-        return (
-            Pipeline::from_vec(vec![Expression::new(
-                working_set,
-                Expr::Call(call),
-                call_span,
-                Type::Any,
-            )]),
-            vec![],
-        );
+
+        let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+        return (Pipeline::from_vec(&working_set, vec![pipe_expr]), vec![]);
     };
 
     let (definitions, errors) = module.resolve_import_pattern(
@@ -2387,13 +2332,10 @@ pub fn parse_use(
     let mut call = call;
     call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), span(spans), Type::Any);
+
     (
-        Pipeline::from_vec(vec![Expression::new(
-            working_set,
-            Expr::Call(call),
-            span(spans),
-            Type::Any,
-        )]),
+        Pipeline::from_vec(&working_set, vec![pipe_expr]),
         exportables,
     )
 }
@@ -2429,12 +2371,9 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression::new(
-                    working_set,
-                    Expr::Call(call),
-                    call_span,
-                    output,
-                )]);
+                let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, output);
+
+                return Pipeline::from_vec(&working_set, vec![pipe_expr]);
             }
 
             (call, &spans[1..])
@@ -2459,7 +2398,7 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: Import pattern positional is not import pattern".into(),
-            import_pattern_expr.span,
+            import_pattern_expr.get_span(&working_set),
         ));
         return garbage_pipeline(working_set, spans);
     };
@@ -2571,12 +2510,9 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
         let mut call = call;
         call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
-        Pipeline::from_vec(vec![Expression::new(
-            working_set,
-            Expr::Call(call),
-            span(spans),
-            Type::Any,
-        )])
+        let pipe_expr = Expression::new(working_set, Expr::Call(call), span(spans), Type::Any);
+
+        Pipeline::from_vec(&working_set, vec![pipe_expr])
     } else {
         working_set.error(ParseError::UnknownState(
             "Expected structure: hide <name>".into(),
@@ -2587,12 +2523,12 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
 }
 
 pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
-    let call_span = call.span();
+    let call_span = call.span(&working_set);
 
     let (overlay_name, _) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
             Ok(val) => match val.coerce_into_string() {
-                Ok(s) => (s, expr.span),
+                Ok(s) => (s, expr.get_span(&working_set)),
                 Err(err) => {
                     working_set.error(err.wrap(working_set, call_span));
                     return garbage_pipeline(working_set, &[call_span]);
@@ -2611,12 +2547,9 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(working_set, &[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(
-        working_set,
-        Expr::Call(call),
-        call_span,
-        Type::Any,
-    )]);
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+    let pipeline = Pipeline::from_vec(&working_set, vec![pipe_expr]);
 
     let module_id = working_set.add_module(
         &overlay_name,
@@ -2636,12 +2569,12 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
 }
 
 pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
-    let call_span = call.span();
+    let call_span = call.span(&working_set);
 
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
             Ok(val) => match val.coerce_into_string() {
-                Ok(s) => (s, expr.span),
+                Ok(s) => (s, expr.get_span(&working_set)),
                 Err(err) => {
                     working_set.error(err.wrap(working_set, call_span));
                     return garbage_pipeline(working_set, &[call_span]);
@@ -2666,7 +2599,7 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
                 Ok(val) => match val.coerce_into_string() {
                     Ok(s) => Some(Spanned {
                         item: s,
-                        span: new_name_expression.span,
+                        span: new_name_expression.get_span(&working_set),
                     }),
                     Err(err) => {
                         working_set.error(err.wrap(working_set, call_span));
@@ -2681,7 +2614,7 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         } else {
             working_set.error(ParseError::ExpectedKeyword(
                 "as keyword".to_string(),
-                kw_expression.span,
+                kw_expression.get_span(&working_set),
             ));
             return garbage_pipeline(working_set, &[call_span]);
         }
@@ -2696,12 +2629,9 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(working_set, &[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(
-        working_set,
-        Expr::Call(call.clone()),
-        call_span,
-        Type::Any,
-    )]);
+    let pipe_expr = Expression::new(working_set, Expr::Call(call.clone()), call_span, Type::Any);
+
+    let pipeline = Pipeline::from_vec(&working_set, vec![pipe_expr]);
 
     let (final_overlay_name, origin_module, origin_module_id, is_module_updated) =
         if let Some(overlay_frame) = working_set.find_overlay(overlay_name.as_bytes()) {
@@ -2848,21 +2778,18 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         ),
     );
 
-    Pipeline::from_vec(vec![Expression::new(
-        working_set,
-        Expr::Call(call),
-        call_span,
-        Type::Any,
-    )])
+    let pipe_expr_2 = Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+    Pipeline::from_vec(&working_set, vec![pipe_expr_2])
 }
 
 pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
-    let call_span = call.span();
+    let call_span = call.span(&working_set);
 
     let (overlay_name, overlay_name_span) = if let Some(expr) = call.positional_nth(0) {
         match eval_constant(working_set, expr) {
             Ok(val) => match val.coerce_into_string() {
-                Ok(s) => (s, expr.span),
+                Ok(s) => (s, expr.get_span(&working_set)),
                 Err(err) => {
                     working_set.error(err.wrap(working_set, call_span));
                     return garbage_pipeline(working_set, &[call_span]);
@@ -2884,12 +2811,9 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
         return garbage_pipeline(working_set, &[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(
-        working_set,
-        Expr::Call(call),
-        call_span,
-        Type::Any,
-    )]);
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+    let pipeline = Pipeline::from_vec(&working_set, vec![pipe_expr]);
 
     if overlay_name == DEFAULT_OVERLAY_NAME {
         working_set.error(ParseError::CantHideDefaultOverlay(
@@ -2969,13 +2893,17 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         working_set.error(ParseError::ExtraTokens(spans[idx + 2]));
                     }
 
-                    let var_name =
-                        String::from_utf8_lossy(working_set.get_span_contents(lvalue.span))
-                            .trim_start_matches('$')
-                            .to_string();
+                    let var_name = String::from_utf8_lossy(
+                        working_set.get_span_contents(lvalue.get_span(&working_set)),
+                    )
+                    .trim_start_matches('$')
+                    .to_string();
 
                     if RESERVED_VARIABLE_NAMES.contains(&var_name.as_str()) {
-                        working_set.error(ParseError::NameIsBuiltinVar(var_name, lvalue.span))
+                        working_set.error(ParseError::NameIsBuiltinVar(
+                            var_name,
+                            lvalue.get_span(&working_set),
+                        ))
                     }
 
                     let var_id = lvalue.as_var();
@@ -3004,24 +2932,28 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(
+                    let pipe_expr = Expression::new(
                         working_set,
                         Expr::Call(call),
                         nu_protocol::span(spans),
                         Type::Any,
-                    )]);
+                    );
+
+                    return Pipeline::from_vec(&working_set, vec![pipe_expr]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(
+        let pipe_expr = Expression::new(
             working_set,
             Expr::Call(call),
             nu_protocol::span(spans),
             output,
-        )]);
+        );
+
+        return Pipeline::from_vec(&working_set, vec![pipe_expr]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3078,13 +3010,17 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                         working_set.error(ParseError::ExtraTokens(spans[idx + 2]));
                     }
 
-                    let var_name =
-                        String::from_utf8_lossy(working_set.get_span_contents(lvalue.span))
-                            .trim_start_matches('$')
-                            .to_string();
+                    let var_name = String::from_utf8_lossy(
+                        working_set.get_span_contents(lvalue.get_span(&working_set)),
+                    )
+                    .trim_start_matches('$')
+                    .to_string();
 
                     if RESERVED_VARIABLE_NAMES.contains(&var_name.as_str()) {
-                        working_set.error(ParseError::NameIsBuiltinVar(var_name, lvalue.span))
+                        working_set.error(ParseError::NameIsBuiltinVar(
+                            var_name,
+                            lvalue.get_span(&working_set),
+                        ))
                     }
 
                     let var_id = lvalue.as_var();
@@ -3139,7 +3075,8 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                                 // Assign the constant value to the variable
                                 working_set.set_variable_const_val(var_id, value);
                             }
-                            Err(err) => working_set.error(err.wrap(working_set, rvalue.span)),
+                            Err(err) => working_set
+                                .error(err.wrap(working_set, rvalue.get_span(&working_set))),
                         }
                     }
 
@@ -3150,24 +3087,28 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(
+                    let pipe_expr = Expression::new(
                         working_set,
                         Expr::Call(call),
                         nu_protocol::span(spans),
                         Type::Any,
-                    )]);
+                    );
+
+                    return Pipeline::from_vec(&working_set, vec![pipe_expr]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(
+        let pipe_expr = Expression::new(
             working_set,
             Expr::Call(call),
             nu_protocol::span(spans),
             output,
-        )]);
+        );
+
+        return Pipeline::from_vec(&working_set, vec![pipe_expr]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3234,13 +3175,17 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         working_set.error(ParseError::ExtraTokens(spans[idx + 2]));
                     }
 
-                    let var_name =
-                        String::from_utf8_lossy(working_set.get_span_contents(lvalue.span))
-                            .trim_start_matches('$')
-                            .to_string();
+                    let var_name = String::from_utf8_lossy(
+                        working_set.get_span_contents(lvalue.get_span(&working_set)),
+                    )
+                    .trim_start_matches('$')
+                    .to_string();
 
                     if RESERVED_VARIABLE_NAMES.contains(&var_name.as_str()) {
-                        working_set.error(ParseError::NameIsBuiltinVar(var_name, lvalue.span))
+                        working_set.error(ParseError::NameIsBuiltinVar(
+                            var_name,
+                            lvalue.get_span(&working_set),
+                        ))
                     }
 
                     let var_id = lvalue.as_var();
@@ -3269,24 +3214,28 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(
+                    let pipe_expr = Expression::new(
                         working_set,
                         Expr::Call(call),
                         nu_protocol::span(spans),
                         Type::Any,
-                    )]);
+                    );
+
+                    return Pipeline::from_vec(&working_set, vec![pipe_expr]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(
+        let pipe_expr = Expression::new(
             working_set,
             Expr::Call(call),
             nu_protocol::span(spans),
             output,
-        )]);
+        );
+
+        return Pipeline::from_vec(&working_set, vec![pipe_expr]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3332,12 +3281,9 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
             };
 
             if is_help {
-                return Pipeline::from_vec(vec![Expression::new(
-                    working_set,
-                    Expr::Call(call),
-                    span(spans),
-                    output,
-                )]);
+                let pipe_expr = Expression::new(working_set, Expr::Call(call), span(spans), output);
+
+                return Pipeline::from_vec(&working_set, vec![pipe_expr]);
             }
 
             // Command and one file name
@@ -3348,12 +3294,15 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(val) => val,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, span(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression::new(
+
+                        let pipe_expr = Expression::new(
                             working_set,
                             Expr::Call(call),
                             span(&spans[1..]),
                             Type::Any,
-                        )]);
+                        );
+
+                        return Pipeline::from_vec(&working_set, vec![pipe_expr]);
                     }
                 };
 
@@ -3361,12 +3310,15 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(s) => s,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, span(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression::new(
+
+                        let pipe_expr = Expression::new(
                             working_set,
                             Expr::Call(call),
                             span(&spans[1..]),
                             Type::Any,
-                        )]);
+                        );
+
+                        return Pipeline::from_vec(&working_set, vec![pipe_expr]);
                     }
                 };
 
@@ -3408,23 +3360,23 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                             ),
                         );
 
-                        return Pipeline::from_vec(vec![Expression::new(
+                        let pipe_expr = Expression::new(
                             working_set,
                             Expr::Call(call_with_block),
                             span(spans),
                             Type::Any,
-                        )]);
+                        );
+
+                        return Pipeline::from_vec(&working_set, vec![pipe_expr]);
                     }
                 } else {
                     working_set.error(ParseError::SourcedFileNotFound(filename, spans[1]));
                 }
             }
-            return Pipeline::from_vec(vec![Expression::new(
-                working_set,
-                Expr::Call(call),
-                span(spans),
-                Type::Any,
-            )]);
+
+            let pipe_expr = Expression::new(working_set, Expr::Call(call), span(spans), Type::Any);
+
+            return Pipeline::from_vec(&working_set, vec![pipe_expr]);
         }
     }
     working_set.error(ParseError::UnknownState(
@@ -3556,12 +3508,9 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression::new(
-                    working_set,
-                    Expr::Call(call),
-                    call_span,
-                    output,
-                )]);
+                let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, output);
+
+                return Pipeline::from_vec(&working_set, vec![pipe_expr]);
             }
 
             (call, call_span)
@@ -3579,13 +3528,19 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
                 .map_err(|err| err.wrap(working_set, call.head))?;
 
             let Some(path) = find_in_dirs(&filename, working_set, &cwd, PLUGIN_DIRS_VAR) else {
-                return Err(ParseError::RegisteredFileNotFound(filename, expr.span));
+                return Err(ParseError::RegisteredFileNotFound(
+                    filename,
+                    expr.get_span(&working_set),
+                ));
             };
 
             if path.exists() && path.is_file() {
-                Ok((path, expr.span))
+                Ok((path, expr.get_span(&working_set)))
             } else {
-                Err(ParseError::RegisteredFileNotFound(filename, expr.span))
+                Err(ParseError::RegisteredFileNotFound(
+                    filename,
+                    expr.get_span(&working_set),
+                ))
             }
         })
         .expect("required positional has being checked");
@@ -3593,7 +3548,7 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
     // Signature is an optional value from the call and will be used to decide if
     // the plugin is called to get the signatures or to use the given signature
     let signature = call.positional_nth(1).map(|expr| {
-        let signature = working_set.get_span_contents(expr.span);
+        let signature = working_set.get_span_contents(expr.get_span(&working_set));
         serde_json::from_slice::<PluginSignature>(signature).map_err(|e| {
             ParseError::LabeledError(
                 "Signature deserialization error".into(),
@@ -3605,13 +3560,14 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
 
     // Shell is another optional value used as base to call shell to plugins
     let shell = call.get_flag_expr("shell").map(|expr| {
-        let shell_expr = working_set.get_span_contents(expr.span);
+        let shell_expr = working_set.get_span_contents(expr.get_span(&working_set));
 
         String::from_utf8(shell_expr.to_vec())
-            .map_err(|_| ParseError::NonUtf8(expr.span))
+            .map_err(|_| ParseError::NonUtf8(expr.get_span(&working_set)))
             .and_then(|name| {
-                canonicalize_with(&name, cwd)
-                    .map_err(|_| ParseError::RegisteredFileNotFound(name, expr.span))
+                canonicalize_with(&name, cwd).map_err(|_| {
+                    ParseError::RegisteredFileNotFound(name, expr.get_span(&working_set))
+                })
             })
             .and_then(|path| {
                 if path.exists() & path.is_file() {
@@ -3619,7 +3575,7 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
                 } else {
                     Err(ParseError::RegisteredFileNotFound(
                         format!("{path:?}"),
-                        expr.span,
+                        expr.get_span(&working_set),
                     ))
                 }
             })
@@ -3631,12 +3587,11 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             Ok(path) => Some(path),
             Err(err) => {
                 working_set.error(err);
-                return Pipeline::from_vec(vec![Expression::new(
-                    working_set,
-                    Expr::Call(call),
-                    call_span,
-                    Type::Any,
-                )]);
+
+                let pipe_expr =
+                    Expression::new(working_set, Expr::Call(call), call_span, Type::Any);
+
+                return Pipeline::from_vec(&working_set, vec![pipe_expr]);
             }
         },
     };
@@ -3725,12 +3680,9 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
         working_set.error(err);
     }
 
-    Pipeline::from_vec(vec![Expression::new(
-        working_set,
-        Expr::Call(call),
-        call_span,
-        Type::Nothing,
-    )])
+    let pipe_expr = Expression::new(working_set, Expr::Call(call), call_span, Type::Nothing);
+
+    Pipeline::from_vec(&working_set, vec![pipe_expr])
 }
 
 pub fn find_dirs_var(working_set: &StateWorkingSet, var_name: &str) -> Option<VarId> {
@@ -3907,6 +3859,6 @@ fn detect_params_in_name(
 /// Run has_flag_const and push possible error to working_set
 fn has_flag_const(working_set: &mut StateWorkingSet, call: &Call, name: &str) -> Result<bool, ()> {
     call.has_flag_const(working_set, name).map_err(|err| {
-        working_set.error(err.wrap(working_set, call.span()));
+        working_set.error(err.wrap(working_set, call.span(&working_set)));
     })
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -12,8 +12,8 @@ use log::trace;
 use nu_engine::DIR_VAR_PARSER_INFO;
 use nu_protocol::{
     ast::*, engine::StateWorkingSet, eval_const::eval_constant, span, BlockId, DidYouMean, Flag,
-    ParseError, PositionalArg, Signature, Span, Spanned, SyntaxShape, Type, VarId, ENV_VARIABLE_ID,
-    IN_VARIABLE_ID, GetSpan
+    GetSpan, ParseError, PositionalArg, Signature, Span, Spanned, SyntaxShape, Type, VarId,
+    ENV_VARIABLE_ID, IN_VARIABLE_ID,
 };
 use std::{
     collections::{HashMap, HashSet},

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -279,7 +279,8 @@ fn parse_external_arg(working_set: &mut StateWorkingSet, span: Span) -> External
             String::from_utf8_lossy(contents).to_string()
         };
 
-        ExternalArgument::Regular(Expression::new(working_set,
+        ExternalArgument::Regular(Expression::new(
+            working_set,
             Expr::String(contents),
             span,
             Type::String,
@@ -312,7 +313,8 @@ pub fn parse_external_call(working_set: &mut StateWorkingSet, spans: &[Span]) ->
             working_set.error(err)
         }
 
-        Box::new(Expression::new(working_set,
+        Box::new(Expression::new(
+            working_set,
             Expr::String(contents),
             head_span,
             Type::String,
@@ -728,7 +730,8 @@ pub fn parse_multispan_value(
                     String::from_utf8_lossy(keyword).into(),
                     Span::new(spans[*spans_idx - 1].end, spans[*spans_idx - 1].end),
                 ));
-                return Expression::new(working_set,
+                return Expression::new(
+                    working_set,
                     Expr::Keyword(
                         keyword.clone(),
                         spans[*spans_idx - 1],
@@ -742,7 +745,8 @@ pub fn parse_multispan_value(
             let expr = parse_multispan_value(working_set, spans, spans_idx, arg);
             let ty = expr.ty.clone();
 
-            Expression::new(working_set,
+            Expression::new(
+                working_set,
                 Expr::Keyword(keyword.clone(), keyword_span, Box::new(expr)),
                 arg_span,
                 ty,
@@ -821,7 +825,7 @@ pub fn parse_internal_call(
                     None
                 }
             }
-            _ => None
+            _ => None,
         }
     } else {
         None
@@ -860,11 +864,7 @@ pub fn parse_internal_call(
     if let Some(var_id) = lib_dirs_var_id {
         call.set_parser_info(
             DIR_VAR_PARSER_INFO.to_owned(),
-            Expression::new(working_set,
-                            Expr::Var(var_id),
-                            call.head,
-                            Type::Any,
-            ),
+            Expression::new(working_set, Expr::Var(var_id), call.head, Type::Any),
         );
     }
 
@@ -1232,7 +1232,8 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
             )
         };
 
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Call(parsed_call.call),
             span(spans),
             parsed_call.output,
@@ -1337,13 +1338,7 @@ fn parse_binary_with_base(
             let str = String::from_utf8_lossy(&binary_value).to_string();
 
             match decode_with_base(&str, base, min_digits_per_byte) {
-                Ok(v) => {
-                    return Expression::new(working_set,
-                        Expr::Binary(v),
-                        span,
-                        Type::Binary,
-                    )
-                }
+                Ok(v) => return Expression::new(working_set, Expr::Binary(v), span, Type::Binary),
                 Err(x) => {
                     working_set.error(ParseError::IncorrectValue(
                         "not a binary value".into(),
@@ -1388,11 +1383,7 @@ pub fn parse_int(working_set: &mut StateWorkingSet, span: Span) -> Expression {
         radix: u32,
     ) -> Expression {
         if let Ok(num) = i64::from_str_radix(token, radix) {
-            Expression::new(working_set,
-                Expr::Int(num),
-                span,
-                Type::Int,
-            )
+            Expression::new(working_set, Expr::Int(num), span, Type::Int)
         } else {
             working_set.error(ParseError::InvalidLiteral(
                 format!("invalid digits for radix {}", radix),
@@ -1418,11 +1409,7 @@ pub fn parse_int(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     } else if let Some(num) = token.strip_prefix("0x") {
         extract_int(working_set, num, span, 16)
     } else if let Ok(num) = token.parse::<i64>() {
-        Expression::new(working_set,
-            Expr::Int(num),
-            span,
-            Type::Int,
-        )
+        Expression::new(working_set, Expr::Int(num), span, Type::Int)
     } else {
         working_set.error(ParseError::Expected("int", span));
         garbage(span)
@@ -1434,11 +1421,7 @@ pub fn parse_float(working_set: &mut StateWorkingSet, span: Span) -> Expression 
     let token = strip_underscores(token);
 
     if let Ok(x) = token.parse::<f64>() {
-        Expression::new(working_set,
-            Expr::Float(x),
-            span,
-            Type::Float,
-        )
+        Expression::new(working_set, Expr::Float(x), span, Type::Float)
     } else {
         working_set.error(ParseError::Expected("float", span));
 
@@ -1604,7 +1587,8 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression 
         next_op_span,
     };
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::Range(from, next, to, range_op),
         span,
         Type::Range,
@@ -1798,7 +1782,8 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
                         working_set.error(err);
                     }
 
-                    output.push(Expression::new(working_set,
+                    output.push(Expression::new(
+                        working_set,
                         Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
                         span,
                         Type::String,
@@ -1867,7 +1852,8 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
                     working_set.error(err);
                 }
 
-                output.push(Expression::new(working_set,
+                output.push(Expression::new(
+                    working_set,
                     Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
                     span,
                     Type::String,
@@ -1884,7 +1870,8 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
         }
     }
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::StringInterpolation(output),
         span,
         Type::String,
@@ -1895,19 +1882,22 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
     let contents = working_set.get_span_contents(span);
 
     if contents == b"$nu" {
-        return Expression::new(working_set,
+        return Expression::new(
+            working_set,
             Expr::Var(nu_protocol::NU_VARIABLE_ID),
             span,
             Type::Any,
         );
     } else if contents == b"$in" {
-        return Expression::new(working_set,
+        return Expression::new(
+            working_set,
             Expr::Var(nu_protocol::IN_VARIABLE_ID),
             span,
             Type::Any,
         );
     } else if contents == b"$env" {
-        return Expression::new(working_set,
+        return Expression::new(
+            working_set,
             Expr::Var(nu_protocol::ENV_VARIABLE_ID),
             span,
             Type::Any,
@@ -1921,7 +1911,8 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
     };
 
     if let Some(id) = parse_variable(working_set, span) {
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Var(id),
             span,
             working_set.get_variable(id).ty.clone(),
@@ -2046,7 +2037,8 @@ pub fn parse_simple_cell_path(working_set: &mut StateWorkingSet, span: Span) -> 
 
     let cell_path = parse_cell_path(working_set, tokens, false);
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::CellPath(CellPath { members: cell_path }),
         span,
         Type::CellPath,
@@ -2105,11 +2097,7 @@ pub fn parse_full_cell_path(
             tokens.next();
 
             (
-                Expression::new(working_set,
-                    Expr::Subexpression(block_id),
-                    head_span,
-                    ty,
-                ),
+                Expression::new(working_set, Expr::Subexpression(block_id), head_span, ty),
                 // Expression {
                 //     expr: Expr::Subexpression(block_id),
                 //     span: head_span,
@@ -2144,11 +2132,7 @@ pub fn parse_full_cell_path(
         } else if let Some(var_id) = implicit_head {
             trace!("parsing: implicit head of full cell path");
             (
-                Expression::new(working_set,
-                    Expr::Var(var_id),
-                    head.span,
-                    Type::Any,
-                ),
+                Expression::new(working_set, Expr::Var(var_id), head.span, Type::Any),
                 false,
             )
         } else {
@@ -2162,19 +2146,19 @@ pub fn parse_full_cell_path(
 
         let tail = parse_cell_path(working_set, tokens, expect_dot);
         // FIXME: Get the type of the data at the tail using follow_cell_path() (or something)
-        let ty =
-            if !tail.is_empty() {
-                // Until the aforementioned fix is implemented, this is necessary to allow mutable list upserts
-                // such as $a.1 = 2 to work correctly.
-                Type::Any
-            } else {
-                head.ty.clone()
-            };
+        let ty = if !tail.is_empty() {
+            // Until the aforementioned fix is implemented, this is necessary to allow mutable list upserts
+            // such as $a.1 = 2 to work correctly.
+            Type::Any
+        } else {
+            head.ty.clone()
+        };
 
-        Expression::new(working_set,
-                        Expr::FullCellPath(Box::new(FullCellPath { head, tail })),
-                        full_cell_span,
-            ty
+        Expression::new(
+            working_set,
+            Expr::FullCellPath(Box::new(FullCellPath { head, tail })),
+            full_cell_span,
+            ty,
         )
     } else {
         garbage(span)
@@ -2190,7 +2174,8 @@ pub fn parse_directory(working_set: &mut StateWorkingSet, span: Span) -> Express
     if err.is_none() {
         trace!("-- found {}", token);
 
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Directory(token, quoted),
             span,
             Type::String,
@@ -2211,7 +2196,8 @@ pub fn parse_filepath(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     if err.is_none() {
         trace!("-- found {}", token);
 
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Filepath(token, quoted),
             span,
             Type::String,
@@ -2243,31 +2229,19 @@ pub fn parse_datetime(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     let token = String::from_utf8_lossy(bytes).to_string();
 
     if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(&token) {
-        return Expression::new(working_set,
-            Expr::DateTime(datetime),
-            span,
-            Type::Date,
-        );
+        return Expression::new(working_set, Expr::DateTime(datetime), span, Type::Date);
     }
 
     // Just the date
     let just_date = token.clone() + "T00:00:00+00:00";
     if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(&just_date) {
-        return Expression::new(working_set,
-            Expr::DateTime(datetime),
-            span,
-            Type::Date,
-        );
+        return Expression::new(working_set, Expr::DateTime(datetime), span, Type::Date);
     }
 
     // Date and time, assume UTC
     let datetime = token + "+00:00";
     if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(&datetime) {
-        return Expression::new(working_set,
-            Expr::DateTime(datetime),
-            span,
-            Type::Date,
-        );
+        return Expression::new(working_set, Expr::DateTime(datetime), span, Type::Date);
     }
 
     working_set.error(ParseError::Expected("datetime", span));
@@ -2285,7 +2259,7 @@ pub fn parse_duration(working_set: &mut StateWorkingSet, span: Span) -> Expressi
         Some(Ok(expr)) => {
             let span_id = working_set.add_span(span);
             expr.with_span_id(span_id)
-        },
+        }
         Some(Err(mk_err_for)) => {
             working_set.error(mk_err_for("duration"));
             garbage(span)
@@ -2315,7 +2289,7 @@ pub fn parse_filesize(working_set: &mut StateWorkingSet, span: Span) -> Expressi
         Some(Ok(expr)) => {
             let span_id = working_set.add_span(span);
             expr.with_span_id(span_id)
-        },
+        }
         Some(Err(mk_err_for)) => {
             working_set.error(mk_err_for("filesize"));
             garbage(span)
@@ -2480,7 +2454,8 @@ pub fn parse_glob_pattern(working_set: &mut StateWorkingSet, span: Span) -> Expr
     if err.is_none() {
         trace!("-- found {}", token);
 
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::GlobPattern(token, quoted),
             span,
             Type::Glob,
@@ -2707,11 +2682,7 @@ pub fn parse_string(working_set: &mut StateWorkingSet, span: Span) -> Expression
         working_set.error(err);
     }
 
-    Expression::new(working_set,
-        Expr::String(s),
-        span,
-        Type::String,
-    )
+    Expression::new(working_set, Expr::String(s), span, Type::String)
 }
 
 fn is_quoted(bytes: &[u8]) -> bool {
@@ -2757,21 +2728,13 @@ pub fn parse_string_strict(working_set: &mut StateWorkingSet, span: Span) -> Exp
         trace!("-- found {}", token);
 
         if quoted {
-            Expression::new(working_set,
-                Expr::String(token),
-                span,
-                Type::String,
-            )
+            Expression::new(working_set, Expr::String(token), span, Type::String)
         } else if token.contains(' ') {
             working_set.error(ParseError::Expected("string", span));
 
             garbage(span)
         } else {
-            Expression::new(working_set,
-                Expr::String(token),
-                span,
-                Type::String,
-            )
+            Expression::new(working_set, Expr::String(token), span, Type::String)
         }
     } else {
         working_set.error(ParseError::Expected("string", span));
@@ -2832,7 +2795,8 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
                     ),
                     prev_span,
                 ));
-                return Expression::new(working_set,
+                return Expression::new(
+                    working_set,
                     Expr::ImportPattern(import_pattern),
                     prev_span,
                     Type::List(Box::new(Type::String)),
@@ -2867,7 +2831,8 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
                         .push(ImportPatternMember::List { names: output });
                 } else {
                     working_set.error(ParseError::ExportNotFound(result.span));
-                    return Expression::new(working_set,
+                    return Expression::new(
+                        working_set,
                         Expr::ImportPattern(import_pattern),
                         span(spans),
                         Type::List(Box::new(Type::String)),
@@ -2886,7 +2851,8 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
         }
     }
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::ImportPattern(import_pattern),
         span(&spans[1..]),
         Type::List(Box::new(Type::String)),
@@ -2953,7 +2919,8 @@ pub fn parse_var_with_opt_type(
                 //     ty: ty.clone(),
                 //     custom_completion: None,
                 // },
-                Expression::new(working_set,
+                Expression::new(
+                    working_set,
                     Expr::VarDecl(id),
                     span(&spans[span_beginning..*spans_idx + 1]),
                     ty.clone(),
@@ -2975,11 +2942,7 @@ pub fn parse_var_with_opt_type(
 
             working_set.error(ParseError::MissingType(spans[*spans_idx]));
             (
-                Expression::new(working_set,
-                    Expr::VarDecl(id),
-                    spans[*spans_idx],
-                    Type::Any,
-                ),
+                Expression::new(working_set, Expr::VarDecl(id), spans[*spans_idx], Type::Any),
                 // Expression {
                 //     expr: Expr::VarDecl(id),
                 //     span: spans[*spans_idx],
@@ -3167,11 +3130,7 @@ pub fn parse_row_condition(working_set: &mut StateWorkingSet, spans: &[Span]) ->
         }
     };
 
-    Expression::new(working_set,
-                    Expr::RowCondition(block_id),
-        span,
-                    Type::Bool,
-    )
+    Expression::new(working_set, Expr::RowCondition(block_id), span, Type::Bool)
 }
 
 pub fn parse_signature(working_set: &mut StateWorkingSet, span: Span) -> Expression {
@@ -3200,11 +3159,7 @@ pub fn parse_signature(working_set: &mut StateWorkingSet, span: Span) -> Express
 
     let sig = parse_signature_helper(working_set, Span::new(start, end));
 
-    Expression::new(working_set,
-        Expr::Signature(sig),
-        span,
-        Type::Signature,
-    )
+    Expression::new(working_set, Expr::Signature(sig), span, Type::Signature)
     // Expression {
     //     expr: Expr::Signature(sig),
     //     span,
@@ -3928,7 +3883,8 @@ pub fn parse_list_expression(
     //     custom_completion: None,
     // }
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::List(args),
         span,
         Type::List(Box::new(if let Some(ty) = contained_type {
@@ -4050,11 +4006,7 @@ fn parse_table_expression(working_set: &mut StateWorkingSet, span: Span) -> Expr
         Type::Table(vec![])
     };
 
-    Expression::new(working_set,
-        Expr::Table(head, rows),
-        span,
-        ty,
-    )
+    Expression::new(working_set, Expr::Table(head, rows), span, ty)
     // Expression {
     //     expr: Expr::Table(head, rows),
     //     span,
@@ -4174,11 +4126,7 @@ pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> 
 
     let block_id = working_set.add_block(Arc::new(output));
 
-    Expression::new(working_set,
-        Expr::Block(block_id),
-        span,
-        Type::Block,
-    )
+    Expression::new(working_set, Expr::Block(block_id), span, Type::Block)
     // Expression {
     //     expr: Expr::Block(block_id),
     //     span,
@@ -4377,7 +4325,8 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
         output_matches.push((pattern, result));
     }
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::MatchBlock(output_matches),
         span,
         Type::Any,
@@ -4525,11 +4474,7 @@ pub fn parse_closure_expression(
 
     let block_id = working_set.add_block(Arc::new(output));
 
-    Expression::new(working_set,
-        Expr::Closure(block_id),
-        span,
-        Type::Closure,
-    )
+    Expression::new(working_set, Expr::Closure(block_id), span, Type::Closure)
     // Expression {
     //     expr: Expr::Closure(block_id),
     //     span,
@@ -4562,11 +4507,7 @@ pub fn parse_value(
                 //     ty: Type::Bool,
                 //     custom_completion: None,
                 // };
-                return Expression::new(working_set,
-                    Expr::Bool(true),
-                    span,
-                    Type::Bool,
-                );
+                return Expression::new(working_set, Expr::Bool(true), span, Type::Bool);
             } else {
                 working_set.error(ParseError::Expected("non-boolean value", span));
                 return Expression::garbage(span);
@@ -4580,22 +4521,14 @@ pub fn parse_value(
                 //     ty: Type::Bool,
                 //     custom_completion: None,
                 // };
-                return Expression::new(working_set,
-                    Expr::Bool(false),
-                    span,
-                    Type::Bool,
-                );
+                return Expression::new(working_set, Expr::Bool(false), span, Type::Bool);
             } else {
                 working_set.error(ParseError::Expected("non-boolean value", span));
                 return Expression::garbage(span);
             }
         }
         b"null" => {
-            return Expression::new(working_set,
-                Expr::Nothing,
-                span,
-                Type::Nothing,
-            );
+            return Expression::new(working_set, Expr::Nothing, span, Type::Nothing);
             // return Expression {
             //     expr: Expr::Nothing,
             //     span,
@@ -4678,11 +4611,7 @@ pub fn parse_value(
         SyntaxShape::Boolean => {
             // Redundant, though we catch bad boolean parses here
             if bytes == b"true" || bytes == b"false" {
-                Expression::new(working_set,
-                    Expr::Bool(true),
-                    span,
-                    Type::Bool,
-                )
+                Expression::new(working_set, Expr::Bool(true), span, Type::Bool)
                 // Expression {
                 //     expr: Expr::Bool(true),
                 //     span,
@@ -4893,11 +4822,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     //     custom_completion: None,
     // }
 
-    Expression::new(working_set,
-        Expr::Operator(operator),
-        span,
-        Type::Any,
-    )
+    Expression::new(working_set, Expr::Operator(operator), span, Type::Any)
 }
 
 pub fn parse_math_expression(
@@ -4969,7 +4894,8 @@ pub fn parse_math_expression(
         //     ty: Type::Bool,
         //     custom_completion: None,
         // };
-        lhs = Expression::new(working_set,
+        lhs = Expression::new(
+            working_set,
             Expr::UnaryNot(Box::new(lhs)),
             Span::new(*not_start_span, spans[idx].end),
             Type::Bool,
@@ -5044,7 +4970,8 @@ pub fn parse_math_expression(
             //     ty: Type::Bool,
             //     custom_completion: None,
             // };
-            rhs = Expression::new(working_set,
+            rhs = Expression::new(
+                working_set,
                 Expr::UnaryNot(Box::new(rhs)),
                 Span::new(*not_start_span, spans[idx].end),
                 Type::Bool,
@@ -5085,17 +5012,17 @@ pub fn parse_math_expression(
 
             let op_span = span(&[lhs.span, rhs.span]);
             expr_stack.push(
-                Expression::new(working_set,
+                Expression::new(
+                    working_set,
                     Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
                     op_span,
                     result_ty,
-                )
-            //     Expression {
-            //     expr: Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
-            //     span: op_span,
-            //     ty: result_ty,
-            //     custom_completion: None,
-            // }
+                ), //     Expression {
+                   //     expr: Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
+                   //     span: op_span,
+                   //     ty: result_ty,
+                   //     custom_completion: None,
+                   // }
             );
         }
         expr_stack.push(op);
@@ -5128,17 +5055,17 @@ pub fn parse_math_expression(
 
         let binary_op_span = span(&[lhs.span, rhs.span]);
         expr_stack.push(
-            Expression::new(working_set,
+            Expression::new(
+                working_set,
                 Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
                 binary_op_span,
                 result_ty,
-            )
-        //     Expression {
-        //     expr: Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
-        //     span: binary_op_span,
-        //     ty: result_ty,
-        //     custom_completion: None,
-        // }
+            ), //     Expression {
+               //     expr: Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
+               //     span: binary_op_span,
+               //     ty: result_ty,
+               //     custom_completion: None,
+               // }
         );
     }
 
@@ -5182,7 +5109,8 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                     parse_string_strict(working_set, rhs_span)
                 }
             } else {
-                Expression::new(working_set,
+                Expression::new(
+                    working_set,
                     Expr::String(String::new()),
                     Span::unknown(),
                     Type::Nothing,
@@ -5286,20 +5214,18 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
             }
 
             let arguments = vec![
-                Argument::Positional(
-                    Expression::new(working_set,
+                Argument::Positional(Expression::new(
+                    working_set,
                     Expr::List(env_vars),
                     span(&spans[..pos]),
                     Type::Any,
-            )
-                ),
-                Argument::Positional(
-                    Expression::new(working_set,
+                )),
+                Argument::Positional(Expression::new(
+                    working_set,
                     Expr::Closure(block_id),
                     span(&spans[pos..]),
                     Type::Closure,
-            )
-                ),
+                )),
             ];
 
             let expr = Expr::Call(Box::new(Call {
@@ -5528,18 +5454,13 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
         }
     }
 
-    let ty =if let Some(fields) = field_types {
+    let ty = if let Some(fields) = field_types {
         Type::Record(fields)
     } else {
         Type::Any
     };
 
-
-    Expression::new(working_set,
-        Expr::Record(output),
-        span,
-        ty
-    )
+    Expression::new(working_set, Expr::Record(output), span, ty)
 }
 
 fn parse_redirection_target(
@@ -6277,13 +6198,12 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
 
         let block_id = working_set.add_block(Arc::new(block));
 
-        output.push(Argument::Positional(
-            Expression::new(working_set,
+        output.push(Argument::Positional(Expression::new(
+            working_set,
             Expr::Closure(block_id),
             span,
             Type::Any,
-            )
-       ));
+        )));
 
         output.push(Argument::Named((
             Spanned {
@@ -6297,14 +6217,17 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
         // The containing, synthetic call to `collect`.
         // We don't want to have a real span as it will confuse flattening
         // The args are where we'll get the real info
-        Expression::new(working_set, Expr::Call(Box::new(Call {
+        Expression::new(
+            working_set,
+            Expr::Call(Box::new(Call {
                 head: Span::new(0, 0),
                 arguments: output,
                 decl_id,
                 parser_info: HashMap::new(),
             })),
             span,
-        Type::Any,)
+            Type::Any,
+        )
     } else {
         Expression::garbage(span)
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -763,37 +763,6 @@ pub struct ParsedInternalCall {
     pub output: Type,
 }
 
-// fn attach_parser_info_builtin(working_set: &mut StateWorkingSet, name: &str, call: &mut Call) {
-//     match name {
-//         "use" | "overlay use" | "source-env" | "nu-check" => {
-//             if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
-//                 call.set_parser_info(
-//                     DIR_VAR_PARSER_INFO.to_owned(),
-//                     Expression::new(working_set,
-//                         Expr::Var(var_id),
-//                         call.head,
-//                         Type::Any,
-//                     ),
-//                 );
-//             }
-//         }
-//         _ => {}
-//     }
-// }
-
-// fn attach_parser_info_builtin(working_set: &StateWorkingSet, name: &str) -> Option<VarId> {
-//     match name {
-//         "use" | "overlay use" | "source-env" | "nu-check" => {
-//             if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
-//                 Some(var_id)
-//             } else {
-//                 None
-//             }
-//         }
-//         _ => None
-//     }
-// }
-
 pub fn parse_internal_call(
     working_set: &mut StateWorkingSet,
     command_span: Span,
@@ -811,16 +780,9 @@ pub fn parse_internal_call(
     let output = signature.get_output_type();
 
     let lib_dirs_var_id = if decl.is_builtin() {
-        // attach_parser_info_builtin(working_set, decl.name())
-        // attach_parser_info_builtin(working_set, decl.name(), &mut call);
-
         match decl.name() {
             "use" | "overlay use" | "source-env" | "nu-check" => {
-                if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
-                    Some(var_id)
-                } else {
-                    None
-                }
+                find_dirs_var(working_set, LIB_DIRS_VAR)
             }
             _ => None,
         }
@@ -1189,7 +1151,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
                 span: _,
                 span_id: _,
                 ty,
-                custom_completion,
+                custom_completion: _,
             } = &alias.clone().wrapped_call
             {
                 trace!("parsing: alias of external call");

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -774,6 +774,7 @@ pub fn parse_internal_call(
     let mut call = Call::new(command_span);
     call.decl_id = decl_id;
     call.head = command_span;
+    let _ = working_set.add_span(call.head);
 
     let decl = working_set.get_decl(decl_id);
     let signature = decl.signature();
@@ -893,6 +894,8 @@ pub fn parse_internal_call(
                 call.add_unknown(arg);
             } else {
                 for flag in short_flags {
+                    let _ = working_set.add_span(spans[spans_idx]);
+
                     if let Some(arg_shape) = flag.arg {
                         if let Some(arg) = spans.get(spans_idx + 1) {
                             let arg = parse_value(working_set, *arg, &arg_shape);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5137,13 +5137,11 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                     parse_string_strict(working_set, rhs_span)
                 }
             } else {
-                Expression::string(working_set, String::new(), Type::Nothing, Span::unknown())
-                // Expression {
-                //     expr: Expr::String(String::new()),
-                //     span: Span::unknown(),
-                //     ty: Type::Nothing,
-                //     custom_completion: None,
-                // }
+                Expression::new(working_set,
+                    Expr::String(String::new()),
+                    Span::unknown(),
+                    Type::Nothing,
+                )
             };
 
             if starting_error_count == working_set.parse_errors.len() {
@@ -5244,22 +5242,18 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
 
             let arguments = vec![
                 Argument::Positional(
-                    Expression::list(working_set, env_vars, Type::Any, span(&spans[..pos]))
-                //     Expression {
-                //     expr: Expr::List(env_vars),
-                //     span: span(&spans[..pos]),
-                //     ty: Type::Any,
-                //     custom_completion: None,
-                // }
+                    Expression::new(working_set,
+                    Expr::List(env_vars),
+                    span(&spans[..pos]),
+                    Type::Any,
+            )
                 ),
                 Argument::Positional(
-                    Expression::closure(working_set, block_id, Type::Closure, span(&spans[pos..]))
-                //     Expression {
-                //     expr: Expr::Closure(block_id),
-                //     span: span(&spans[pos..]),
-                //     ty: Type::Closure,
-                //     custom_completion: None,
-                // }
+                    Expression::new(working_set,
+                    Expr::Closure(block_id),
+                    span(&spans[pos..]),
+                    Type::Closure,
+            )
                 ),
             ];
 
@@ -5495,18 +5489,15 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
         Type::Any
     };
 
-    Expression::record(working_set, output, ty, span)
-
-    // Expression {
-    //     expr: Expr::Record(output),
-    //     span,
-    //     ty: (if let Some(fields) = field_types {
-    //         Type::Record(fields)
-    //     } else {
-    //         Type::Any
-    //     }),
-    //     custom_completion: None,
-    // }
+    Expression::new(working_set,
+        Expr::Record(output),
+        span,
+        if let Some(fields) = field_types {
+            Type::Record(fields)
+        } else {
+            Type::Any
+        },
+    )
 }
 
 fn parse_redirection_target(
@@ -6245,14 +6236,12 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
         let block_id = working_set.add_block(Arc::new(block));
 
         output.push(Argument::Positional(
-            Expression::closure(working_set, block_id, Type::Any, span)
-        //     Expression {
-        //     expr: Expr::Closure(block_id),
-        //     span,
-        //     ty: Type::Any,
-        //     custom_completion: None,
-        // }
-        ));
+            Expression::new(working_set,
+            Expr::Closure(block_id),
+            span,
+            Type::Any,
+            )
+       ));
 
         output.push(Argument::Named((
             Spanned {
@@ -6266,28 +6255,14 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
         // The containing, synthetic call to `collect`.
         // We don't want to have a real span as it will confuse flattening
         // The args are where we'll get the real info
-        Expression::call(working_set, Call {
+        Expression::new(working_set, Expr::Call(Box::new(Call {
                 head: Span::new(0, 0),
                 arguments: output,
                 decl_id,
                 parser_info: HashMap::new(),
-            },
-            Type::Any,
-            span)
-
-        // Expression {
-        //     expr: Expr::Call(Box::new(Call {
-        //         head: Span::new(0, 0),
-        //         arguments: output,
-        //         decl_id,
-        //         redirect_stdout: true,
-        //         redirect_stderr: false,
-        //         parser_info: HashMap::new(),
-        //     })),
-        //     span,
-        //     ty: Type::Any,
-        //     custom_completion: None,
-        // }
+            })),
+            span,
+        Type::Any,)
     } else {
         Expression::garbage(span)
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2308,7 +2308,6 @@ pub fn parse_unit_value<'res>(
             Expr::ValueWithUnit(
                 Box::new(Expression::new_unknown(
                     Expr::Int(num),
-                    lhs_span,
                     Type::Number,
                 )),
                 Spanned {
@@ -2316,7 +2315,6 @@ pub fn parse_unit_value<'res>(
                     span: unit_span,
                 },
             ),
-            span,
             ty,
         );
 

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -104,27 +104,27 @@ pub fn math_result_type(
                     | Type::Filesize,
                     _,
                 ) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "addition".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "addition".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -152,27 +152,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Date | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "subtraction".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "subtraction".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -209,27 +209,27 @@ pub fn math_result_type(
                 | (Type::Duration, _)
                 | (Type::Filesize, _)
                 | (Type::List(_), _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "multiplication".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "multiplication".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -252,27 +252,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "exponentiation".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "exponentiation".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -302,27 +302,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Filesize | Type::Duration, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "division".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "division".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -348,27 +348,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Filesize | Type::Duration, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "floor division".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "floor division".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -392,27 +392,27 @@ pub fn math_result_type(
                     // definitions. As soon as that syntax is added this should be removed
                     (a, b) if a == b => (Type::Bool, None),
                     (Type::Bool, _) => {
-                        *op = Expression::garbage(working_set, op.span);
+                        *op = Expression::garbage_existing(op.span_id);
                         (
                             Type::Any,
                             Some(ParseError::UnsupportedOperationRHS(
                                 "boolean operation".into(),
-                                op.span,
-                                lhs.span,
+                                op.get_span(&working_set),
+                                lhs.get_span(&working_set),
                                 lhs.ty.clone(),
-                                rhs.span,
+                                rhs.get_span(&working_set),
                                 rhs.ty.clone(),
                             )),
                         )
                     }
                     _ => {
-                        *op = Expression::garbage(working_set, op.span);
+                        *op = Expression::garbage_existing(op.span_id);
                         (
                             Type::Any,
                             Some(ParseError::UnsupportedOperationLHS(
                                 "boolean operation".into(),
-                                op.span,
-                                lhs.span,
+                                op.get_span(&working_set),
+                                lhs.get_span(&working_set),
                                 lhs.ty.clone(),
                             )),
                         )
@@ -443,27 +443,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "less-than comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "less-than comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -493,27 +493,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "less-than or equal comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "less-than or equal comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -543,27 +543,27 @@ pub fn math_result_type(
                 (Type::Nothing, _) => (Type::Nothing, None),
                 (_, Type::Nothing) => (Type::Nothing, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "greater-than comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "greater-than comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -593,27 +593,27 @@ pub fn math_result_type(
                 (Type::Nothing, _) => (Type::Nothing, None),
                 (_, Type::Nothing) => (Type::Nothing, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "greater-than or equal comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "greater-than or equal comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -640,27 +640,27 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "regex matching".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "regex matching".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -675,27 +675,27 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "regex matching".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "regex matching".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -710,27 +710,27 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "starts-with comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "starts-with comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -745,27 +745,27 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "ends-with comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "ends-with comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -783,27 +783,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::String, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "subset comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "subset comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -821,27 +821,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::String, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "subset comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "subset comparison".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -857,27 +857,27 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int, _) => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
                             "bit operations".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
-                            rhs.span,
+                            rhs.get_span(&working_set),
                             rhs.ty.clone(),
                         )),
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(working_set, op.span);
+                    *op = Expression::garbage_existing(op.span_id);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
                             "bit operations".into(),
-                            op.span,
-                            lhs.span,
+                            op.get_span(&working_set),
+                            lhs.get_span(&working_set),
                             lhs.ty.clone(),
                         )),
                     )
@@ -893,16 +893,22 @@ pub fn math_result_type(
                 (Type::List(_), Type::List(_)) => (Type::Nothing, None),
                 (x, y) => (
                     Type::Nothing,
-                    Some(ParseError::Mismatch(x.to_string(), y.to_string(), rhs.span)),
+                    Some(ParseError::Mismatch(
+                        x.to_string(),
+                        y.to_string(),
+                        rhs.get_span(&working_set),
+                    )),
                 ),
             },
         },
         _ => {
-            *op = Expression::garbage(working_set, op.span);
+            *op = Expression::garbage_existing(op.span_id);
 
             (
                 Type::Any,
-                Some(ParseError::IncompleteMathExpression(op.span)),
+                Some(ParseError::IncompleteMathExpression(
+                    op.get_span(&working_set),
+                )),
             )
         }
     }
@@ -1006,7 +1012,7 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
                     .last()
                     .expect("internal error: we should have elements")
                     .expr
-                    .span
+                    .get_span(&working_set)
             };
 
             output_errors.push(ParseError::OutputMismatch(output_type.clone(), span))
@@ -1055,27 +1061,27 @@ fn check_append(
         (Type::Binary, Type::Binary) => (Type::Binary, None),
         (Type::Any, _) | (_, Type::Any) => (Type::Any, None),
         (Type::Table(_) | Type::String | Type::Binary, _) => {
-            *op = Expression::garbage(working_set, op.span);
+            *op = Expression::garbage_existing(op.span_id);
             (
                 Type::Any,
                 Some(ParseError::UnsupportedOperationRHS(
                     "append".into(),
-                    op.span,
-                    lhs.span,
+                    op.get_span(&working_set),
+                    lhs.get_span(&working_set),
                     lhs.ty.clone(),
-                    rhs.span,
+                    rhs.get_span(&working_set),
                     rhs.ty.clone(),
                 )),
             )
         }
         _ => {
-            *op = Expression::garbage(working_set, op.span);
+            *op = Expression::garbage_existing(op.span_id);
             (
                 Type::Any,
                 Some(ParseError::UnsupportedOperationLHS(
                     "append".into(),
-                    op.span,
-                    lhs.span,
+                    op.get_span(&working_set),
+                    lhs.get_span(&working_set),
                     lhs.ty.clone(),
                 )),
             )

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -68,7 +68,7 @@ pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
 }
 
 pub fn math_result_type(
-    _working_set: &StateWorkingSet,
+    working_set: &mut StateWorkingSet,
     lhs: &mut Expression,
     op: &mut Expression,
     rhs: &mut Expression,
@@ -104,7 +104,7 @@ pub fn math_result_type(
                     | Type::Filesize,
                     _,
                 ) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -118,7 +118,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -130,7 +130,7 @@ pub fn math_result_type(
                     )
                 }
             },
-            Operator::Math(Math::Append) => check_append(lhs, rhs, op),
+            Operator::Math(Math::Append) => check_append(working_set, lhs, rhs, op),
             Operator::Math(Math::Minus) => match (&lhs.ty, &rhs.ty) {
                 (Type::Int, Type::Int) => (Type::Int, None),
                 (Type::Float, Type::Int) => (Type::Float, None),
@@ -152,7 +152,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Date | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -166,7 +166,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -209,7 +209,7 @@ pub fn math_result_type(
                 | (Type::Duration, _)
                 | (Type::Filesize, _)
                 | (Type::List(_), _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -223,7 +223,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -252,7 +252,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -266,7 +266,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -302,7 +302,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Filesize | Type::Duration, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -316,7 +316,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -348,7 +348,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Filesize | Type::Duration, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -362,7 +362,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -392,7 +392,7 @@ pub fn math_result_type(
                     // definitions. As soon as that syntax is added this should be removed
                     (a, b) if a == b => (Type::Bool, None),
                     (Type::Bool, _) => {
-                        *op = Expression::garbage(op.span);
+                        *op = Expression::garbage(working_set, op.span);
                         (
                             Type::Any,
                             Some(ParseError::UnsupportedOperationRHS(
@@ -406,7 +406,7 @@ pub fn math_result_type(
                         )
                     }
                     _ => {
-                        *op = Expression::garbage(op.span);
+                        *op = Expression::garbage(working_set, op.span);
                         (
                             Type::Any,
                             Some(ParseError::UnsupportedOperationLHS(
@@ -443,7 +443,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -457,7 +457,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -493,7 +493,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -507,7 +507,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -543,7 +543,7 @@ pub fn math_result_type(
                 (Type::Nothing, _) => (Type::Nothing, None),
                 (_, Type::Nothing) => (Type::Nothing, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -557,7 +557,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -593,7 +593,7 @@ pub fn math_result_type(
                 (Type::Nothing, _) => (Type::Nothing, None),
                 (_, Type::Nothing) => (Type::Nothing, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -607,7 +607,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -640,7 +640,7 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -654,7 +654,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -675,7 +675,7 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -689,7 +689,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -710,7 +710,7 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -724,7 +724,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -745,7 +745,7 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.to_string()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -759,7 +759,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -783,7 +783,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -797,7 +797,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -821,7 +821,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -835,7 +835,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -857,7 +857,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -871,7 +871,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -883,7 +883,9 @@ pub fn math_result_type(
                     )
                 }
             },
-            Operator::Assignment(Assignment::AppendAssign) => check_append(lhs, rhs, op),
+            Operator::Assignment(Assignment::AppendAssign) => {
+                check_append(working_set, lhs, rhs, op)
+            }
             Operator::Assignment(_) => match (&lhs.ty, &rhs.ty) {
                 (x, y) if x == y => (Type::Nothing, None),
                 (Type::Any, _) => (Type::Nothing, None),
@@ -896,7 +898,7 @@ pub fn math_result_type(
             },
         },
         _ => {
-            *op = Expression::garbage(op.span);
+            *op = Expression::garbage(working_set, op.span);
 
             (
                 Type::Any,
@@ -1028,6 +1030,7 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
 }
 
 fn check_append(
+    working_set: &mut StateWorkingSet,
     lhs: &Expression,
     rhs: &Expression,
     op: &mut Expression,
@@ -1052,7 +1055,7 @@ fn check_append(
         (Type::Binary, Type::Binary) => (Type::Binary, None),
         (Type::Any, _) | (_, Type::Any) => (Type::Any, None),
         (Type::Table(_) | Type::String | Type::Binary, _) => {
-            *op = Expression::garbage(op.span);
+            *op = Expression::garbage(working_set, op.span);
             (
                 Type::Any,
                 Some(ParseError::UnsupportedOperationRHS(
@@ -1066,7 +1069,7 @@ fn check_append(
             )
         }
         _ => {
-            *op = Expression::garbage(op.span);
+            *op = Expression::garbage(working_set, op.span);
             (
                 Type::Any,
                 Some(ParseError::UnsupportedOperationLHS(

--- a/crates/nu-plugin/src/plugin/context.rs
+++ b/crates/nu-plugin/src/plugin/context.rs
@@ -129,7 +129,7 @@ impl<'a> PluginExecutionContext for PluginExecutionCommandContext<'a> {
     fn get_current_dir(&self) -> Result<Spanned<String>, ShellError> {
         let cwd = nu_engine::env::current_dir_str(&self.engine_state, &self.stack)?;
         // The span is not really used, so just give it call.head
-        Ok(cwd.into_spanned(self.call.head))
+        Ok(cwd.into_spanned(self.call.head, self.call.head_id))
     }
 
     fn add_env_var(&mut self, name: String, value: Value) -> Result<(), ShellError> {
@@ -147,7 +147,7 @@ impl<'a> PluginExecutionContext for PluginExecutionCommandContext<'a> {
             &mut self.stack.clone(),
             false,
         )
-        .into_spanned(self.call.head))
+        .into_spanned(self.call.head, self.call.head_id))
     }
 
     fn eval_closure(

--- a/crates/nu-plugin/src/plugin/interface.rs
+++ b/crates/nu-plugin/src/plugin/interface.rs
@@ -192,10 +192,11 @@ pub trait InterfaceManager {
             PipelineDataHeader::ExternalStream(info) => {
                 let handle = self.stream_manager().get_handle();
                 let span = info.span;
+                let span_id = info.span_id;
                 let new_raw_stream = |raw_info: RawStreamInfo| {
                     let reader = handle.read_stream(raw_info.id, self.get_interface())?;
                     let mut stream =
-                        RawStream::new(Box::new(reader), ctrlc.cloned(), span, raw_info.known_size);
+                        RawStream::new(Box::new(reader), ctrlc.cloned(), span, span_id, raw_info.known_size);
                     stream.is_binary = raw_info.is_binary;
                     Ok::<_, ShellError>(stream)
                 };
@@ -211,6 +212,7 @@ pub trait InterfaceManager {
                         })
                         .transpose()?,
                     span: info.span,
+                    span_id: info.span_id,
                     metadata: None,
                     trim_end_newline: info.trim_end_newline,
                 }
@@ -286,6 +288,7 @@ pub trait Interface: Clone + Send {
                 stderr,
                 exit_code,
                 span,
+                span_id,
                 metadata: _,
                 trim_end_newline,
             } => {
@@ -305,6 +308,7 @@ pub trait Interface: Clone + Send {
                 // Generate the header, with the stream ids
                 let header = PipelineDataHeader::ExternalStream(ExternalStreamInfo {
                     span,
+                    span_id,
                     stdout: stdout
                         .as_ref()
                         .zip(stdout_stream.as_ref())

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -21,6 +21,7 @@ use std::{
     collections::{btree_map, BTreeMap},
     sync::{atomic::AtomicBool, mpsc, Arc, OnceLock},
 };
+use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
 #[cfg(test)]
 mod tests;
@@ -864,7 +865,7 @@ impl PluginInterface {
         // Note: the protocol is always designed to have a span with the custom value, but this
         // operation doesn't support one.
         let call = PluginCall::CustomValueOp(
-            value.into_spanned(Span::unknown()),
+            value.into_spanned(Span::unknown(), UNKNOWN_SPAN_ID),
             CustomValueOp::PartialCmp(other_value),
         );
         match self.plugin_call(call, None)? {
@@ -892,7 +893,7 @@ impl PluginInterface {
         // Note: the protocol is always designed to have a span with the custom value, but this
         // operation doesn't support one.
         self.custom_value_op_expecting_value(
-            value.into_spanned(Span::unknown()),
+            value.into_spanned(Span::unknown(), UNKNOWN_SPAN_ID),
             CustomValueOp::Dropped,
         )
         .map(|_| ())

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -298,7 +298,7 @@ pub trait Plugin: Sync {
         let _ = engine;
         custom_value
             .item
-            .to_base_value(custom_value.span)
+            .to_base_value(custom_value.span, custom_value.span_id)
             .map_err(LabeledError::from)
     }
 
@@ -315,7 +315,7 @@ pub trait Plugin: Sync {
         let _ = engine;
         custom_value
             .item
-            .follow_path_int(custom_value.span, index.item, index.span)
+            .follow_path_int(custom_value.span, custom_value.span_id, index.item, index.span, index.span_id)
             .map_err(LabeledError::from)
     }
 
@@ -332,7 +332,7 @@ pub trait Plugin: Sync {
         let _ = engine;
         custom_value
             .item
-            .follow_path_string(custom_value.span, column_name.item, column_name.span)
+            .follow_path_string(custom_value.span, custom_value.span_id, column_name.item, column_name.span, custom_value.span_id)
             .map_err(LabeledError::from)
     }
 
@@ -367,7 +367,7 @@ pub trait Plugin: Sync {
     ) -> Result<Value, LabeledError> {
         let _ = engine;
         left.item
-            .operation(left.span, operator.item, operator.span, &right)
+            .operation(left.span, left.span_id, operator.item, operator.span, operator.span_id, &right)
             .map_err(LabeledError::from)
     }
 
@@ -703,7 +703,7 @@ fn custom_value_op(
     let local_value = custom_value
         .item
         .deserialize_to_custom_value(custom_value.span)?
-        .into_spanned(custom_value.span);
+        .into_spanned(custom_value.span, custom_value.span_id);
     match op {
         CustomValueOp::ToBaseValue => {
             let result = plugin

--- a/crates/nu-plugin/src/protocol/evaluated_call.rs
+++ b/crates/nu-plugin/src/protocol/evaluated_call.rs
@@ -1,8 +1,4 @@
-use nu_protocol::{
-    ast::{Call, Expression},
-    engine::{EngineState, Stack},
-    FromValue, ShellError, Span, Spanned, Value,
-};
+use nu_protocol::{ast::{Call, Expression}, engine::{EngineState, Stack}, FromValue, ShellError, Span, SpanId, Spanned, Value};
 use serde::{Deserialize, Serialize};
 
 /// A representation of the plugin's invocation command including command line args
@@ -20,6 +16,8 @@ use serde::{Deserialize, Serialize};
 pub struct EvaluatedCall {
     /// Span of the command invocation
     pub head: Span,
+    /// Span ID of the command invocation
+    pub head_id: SpanId,
     /// Values of positional arguments
     pub positional: Vec<Value>,
     /// Names and values of named arguments
@@ -49,6 +47,7 @@ impl EvaluatedCall {
 
         Ok(Self {
             head: call.head,
+            head_id: call.head_id,
             positional,
             named,
         })
@@ -64,9 +63,11 @@ impl EvaluatedCall {
     /// ```
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let null_span = Span::new(0, 0);
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "foo".to_owned(), span: null_span},
@@ -81,8 +82,10 @@ impl EvaluatedCall {
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
     /// # let null_span = Span::new(0, 0);
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "bar".to_owned(), span: null_span},
@@ -97,12 +100,14 @@ impl EvaluatedCall {
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
     /// # let null_span = Span::new(0, 0);
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "foo".to_owned(), span: null_span},
-    /// #         Some(Value::bool(true, Span::unknown()))
+    /// #         Some(Value::bool(true, Span::unknown(), UNKNOWN_SPAN_ID))
     /// #     )],
     /// # };
     /// assert!(call.has_flag("foo").unwrap());
@@ -113,12 +118,14 @@ impl EvaluatedCall {
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
     /// # let null_span = Span::new(0, 0);
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "foo".to_owned(), span: null_span},
-    /// #         Some(Value::bool(false, Span::unknown()))
+    /// #         Some(Value::bool(false, Span::unknown(), UNKNOWN_SPAN_ID))
     /// #     )],
     /// # };
     /// assert!(!call.has_flag("foo").unwrap());
@@ -129,8 +136,10 @@ impl EvaluatedCall {
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
     /// # let null_span = Span::new(0, 0);
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "foo".to_owned(), span: null_span},
@@ -165,9 +174,11 @@ impl EvaluatedCall {
     /// ```
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let null_span = Span::new(0, 0);
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "foo".to_owned(), span: null_span},
@@ -186,9 +197,11 @@ impl EvaluatedCall {
     /// ```
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let null_span = Span::new(0, 0);
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![],
     /// # };
@@ -216,9 +229,11 @@ impl EvaluatedCall {
     /// ```
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let null_span = Span::new(0, 0);
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: vec![
     /// #         Value::string("a".to_owned(), null_span),
     /// #         Value::string("b".to_owned(), null_span),
@@ -246,9 +261,11 @@ impl EvaluatedCall {
     /// ```
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let null_span = Span::new(0, 0);
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "foo".to_owned(), span: null_span},
@@ -263,9 +280,11 @@ impl EvaluatedCall {
     /// ```
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let null_span = Span::new(0, 0);
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "bar".to_owned(), span: null_span},
@@ -280,9 +299,11 @@ impl EvaluatedCall {
     /// ```
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let null_span = Span::new(0, 0);
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: Vec::new(),
     /// #     named: vec![(
     /// #         Spanned { item: "foo".to_owned(), span: null_span},
@@ -307,9 +328,11 @@ impl EvaluatedCall {
     /// ```
     /// # use nu_protocol::{Spanned, Span, Value};
     /// # use nu_plugin::EvaluatedCall;
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let null_span = Span::new(0, 0);
     /// # let call = EvaluatedCall {
     /// #     head: null_span,
+    /// #     head_id: UNKNOWN_SPAN_ID,
     /// #     positional: vec![
     /// #         Value::string("zero".to_owned(), null_span),
     /// #         Value::string("one".to_owned(), null_span),
@@ -368,11 +391,13 @@ impl EvaluatedCall {
 mod test {
     use super::*;
     use nu_protocol::{Span, Spanned, Value};
+    use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
     #[test]
     fn call_to_value() {
         let call = EvaluatedCall {
             head: Span::new(0, 10),
+            head_id: UNKNOWN_SPAN_ID,
             positional: vec![
                 Value::float(1.0, Span::new(0, 10)),
                 Value::string("something", Span::new(0, 10)),

--- a/crates/nu-plugin/src/protocol/evaluated_call.rs
+++ b/crates/nu-plugin/src/protocol/evaluated_call.rs
@@ -33,8 +33,9 @@ impl EvaluatedCall {
         stack: &mut Stack,
         eval_expression_fn: fn(&EngineState, &mut Stack, &Expression) -> Result<Value, ShellError>,
     ) -> Result<Self, ShellError> {
-        let positional =
-            call.rest_iter_flattened(0, |expr| eval_expression_fn(engine_state, stack, expr))?;
+        let positional = call.rest_iter_flattened(&engine_state, 0, |expr| {
+            eval_expression_fn(engine_state, stack, expr)
+        })?;
 
         let mut named = Vec::with_capacity(call.named_len());
         for (string, _, expr) in call.named_iter() {

--- a/crates/nu-plugin/src/protocol/mod.rs
+++ b/crates/nu-plugin/src/protocol/mod.rs
@@ -8,10 +8,7 @@ mod tests;
 #[cfg(test)]
 pub(crate) mod test_util;
 
-use nu_protocol::{
-    ast::Operator, engine::Closure, Config, LabeledError, PipelineData, PluginSignature, RawStream,
-    ShellError, Span, Spanned, Value,
-};
+use nu_protocol::{ast::Operator, engine::Closure, Config, LabeledError, PipelineData, PluginSignature, RawStream, ShellError, Span, Spanned, Value, SpanId};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -110,6 +107,7 @@ pub struct ListStreamInfo {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ExternalStreamInfo {
     pub span: Span,
+    pub span_id: SpanId,
     pub stdout: Option<RawStreamInfo>,
     pub stderr: Option<RawStreamInfo>,
     pub exit_code: Option<ListStreamInfo>,

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -349,9 +349,13 @@ impl Call {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::engine::EngineState;
 
     #[test]
     fn argument_span_named() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
         let named = Spanned {
             item: "named".to_string(),
             span: Span::new(2, 3),
@@ -360,7 +364,7 @@ mod test {
             item: "short".to_string(),
             span: Span::new(5, 7),
         };
-        let expr = Expression::garbage(Span::new(11, 13));
+        let expr = Expression::garbage(&mut working_set, Span::new(11, 13));
 
         let arg = Argument::Named((named.clone(), None, None));
 
@@ -381,8 +385,11 @@ mod test {
 
     #[test]
     fn argument_span_positional() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
         let span = Span::new(2, 3);
-        let expr = Expression::garbage(span);
+        let expr = Expression::garbage(&mut working_set, span);
         let arg = Argument::Positional(expr);
 
         assert_eq!(span, arg.span());
@@ -390,8 +397,11 @@ mod test {
 
     #[test]
     fn argument_span_unknown() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
         let span = Span::new(2, 3);
-        let expr = Expression::garbage(span);
+        let expr = Expression::garbage(&mut working_set, span);
         let arg = Argument::Unknown(expr);
 
         assert_eq!(span, arg.span());
@@ -399,9 +409,12 @@ mod test {
 
     #[test]
     fn call_arguments_span() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
         let mut call = Call::new(Span::new(0, 1));
-        call.add_positional(Expression::garbage(Span::new(2, 3)));
-        call.add_positional(Expression::garbage(Span::new(5, 7)));
+        call.add_positional(Expression::garbage(&mut working_set, Span::new(2, 3)));
+        call.add_positional(Expression::garbage(&mut working_set, Span::new(5, 7)));
 
         assert_eq!(Span::new(2, 7), call.arguments_span());
     }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -16,11 +16,12 @@ pub struct Expression {
 }
 
 impl Expression {
-    pub fn garbage(span: Span) -> Expression {
+    pub fn garbage(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+        let span_id = working_set.add_span(span);
         Expression {
             expr: Expr::Garbage,
             span,
-            span_id: todo!("add span id to garbage"),
+            span_id,
             ty: Type::Any,
             custom_completion: None,
         }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, RecordItem},
-    engine::StateWorkingSet,
+    engine::{EngineState, StateWorkingSet},
     BlockId, DeclId, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
@@ -469,18 +469,23 @@ impl Expression {
             span,
             span_id,
             ty,
-            custom_completion: None
+            custom_completion: None,
         }
     }
 
-    pub fn new_existing(engine_state: &EngineState, expr: Expr, span: Span, ty: Type) -> Expression {
+    pub fn new_existing(
+        engine_state: &EngineState,
+        expr: Expr,
+        span: Span,
+        ty: Type,
+    ) -> Expression {
         let span_id = engine_state.get_span_id(span);
         Expression {
             expr,
             span,
             span_id,
             ty,
-            custom_completion: None
+            custom_completion: None,
         }
     }
 
@@ -490,7 +495,7 @@ impl Expression {
             span,
             span_id: SpanId(0),
             ty,
-            custom_completion: None
+            custom_completion: None,
         }
     }
 
@@ -500,8 +505,7 @@ impl Expression {
             span: self.span,
             span_id,
             ty: self.ty,
-            custom_completion: self.custom_completion
+            custom_completion: self.custom_completion,
         }
     }
 }
-

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -474,12 +474,7 @@ impl Expression {
         }
     }
 
-    pub fn new_existing(
-        expr: Expr,
-        span: Span,
-        span_id: SpanId,
-        ty: Type,
-    ) -> Expression {
+    pub fn new_existing(expr: Expr, span: Span, span_id: SpanId, ty: Type) -> Expression {
         Expression {
             expr,
             span,

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, RecordItem},
     engine::StateWorkingSet,
-    BlockId, DeclId, Signature, Span, Type, VarId, IN_VARIABLE_ID,
+    BlockId, DeclId, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -10,6 +10,7 @@ use std::sync::Arc;
 pub struct Expression {
     pub expr: Expr,
     pub span: Span,
+    pub span_id: SpanId,
     pub ty: Type,
     pub custom_completion: Option<DeclId>,
 }
@@ -19,6 +20,7 @@ impl Expression {
         Expression {
             expr: Expr::Garbage,
             span,
+            span_id: todo!("add span id to garbage"),
             ty: Type::Any,
             custom_completion: None,
         }
@@ -459,4 +461,27 @@ impl Expression {
             Expr::Spread(expr) => expr.replace_span(working_set, replaced, new_span),
         }
     }
+
+    pub fn new(working_set: &mut StateWorkingSet, expr: Expr, span: Span, ty: Type) -> Expression {
+        let span_id = working_set.add_span(span);
+        Expression {
+            expr,
+            span,
+            span_id,
+            ty,
+            custom_completion: None
+        }
+    }
+
+    pub fn new_existing(engine_state: &EngineState, expr: Expr, span: Span, ty: Type) -> Expression {
+        let span_id = engine_state.get_span_id(span);
+        Expression {
+            expr,
+            span,
+            span_id,
+            ty,
+            custom_completion: None
+        }
+    }
 }
+

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -504,6 +504,16 @@ impl Expression {
         }
     }
 
+    pub fn with_completion(self, custom_completion: Option<DeclId>) -> Self {
+        Expression {
+            expr: self.expr,
+            span: self.span,
+            span_id: self.span_id,
+            ty: self.ty,
+            custom_completion,
+        }
+    }
+
     pub fn span(&self, engine_state: &EngineState) -> Span {
         engine_state.get_span(self.span_id)
     }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, RecordItem},
-    engine::StateWorkingSet,
+    engine::{EngineState, StateWorkingSet},
     BlockId, DeclId, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
@@ -502,5 +502,9 @@ impl Expression {
             ty: self.ty,
             custom_completion: self.custom_completion,
         }
+    }
+
+    pub fn span(&self, engine_state: &EngineState) -> Span {
+        engine_state.get_span(self.span_id)
     }
 }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, RecordItem},
-    engine::{EngineState, StateWorkingSet},
+    engine::StateWorkingSet,
     BlockId, DeclId, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
@@ -475,12 +475,11 @@ impl Expression {
     }
 
     pub fn new_existing(
-        engine_state: &EngineState,
         expr: Expr,
         span: Span,
+        span_id: SpanId,
         ty: Type,
     ) -> Expression {
-        let span_id = engine_state.get_span_id(span);
         Expression {
             expr,
             span,

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, RecordItem},
-    engine::{EngineState, StateWorkingSet},
+    engine::StateWorkingSet,
     BlockId, DeclId, GetSpan, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
@@ -9,7 +9,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Expression {
     pub expr: Expr,
-    pub span: Span,
     pub span_id: SpanId,
     pub ty: Type,
     pub custom_completion: Option<DeclId>,
@@ -20,7 +19,6 @@ impl Expression {
         let span_id = working_set.add_span(span);
         Expression {
             expr: Expr::Garbage,
-            span: todo!(),
             span_id,
             ty: Type::Any,
             custom_completion: None,
@@ -467,7 +465,6 @@ impl Expression {
         let span_id = working_set.add_span(span);
         Expression {
             expr,
-            span: todo!(),
             span_id,
             ty,
             custom_completion: None,
@@ -477,9 +474,17 @@ impl Expression {
     pub fn new_existing(expr: Expr, span_id: SpanId, ty: Type) -> Expression {
         Expression {
             expr,
-            span: todo!(),
             span_id,
             ty,
+            custom_completion: None,
+        }
+    }
+
+    pub fn garbage_existing(span_id: SpanId) -> Expression {
+        Expression {
+            expr: Expr::Garbage,
+            span_id,
+            ty: Type::Any,
             custom_completion: None,
         }
     }
@@ -487,7 +492,6 @@ impl Expression {
     pub fn new_unknown(expr: Expr, ty: Type) -> Expression {
         Expression {
             expr,
-            span: todo!(),
             span_id: SpanId(0),
             ty,
             custom_completion: None,
@@ -497,7 +501,6 @@ impl Expression {
     pub fn with_span_id(self, span_id: SpanId) -> Expression {
         Expression {
             expr: self.expr,
-            span: todo!(),
             span_id,
             ty: self.ty,
             custom_completion: self.custom_completion,
@@ -507,14 +510,17 @@ impl Expression {
     pub fn with_completion(self, custom_completion: Option<DeclId>) -> Self {
         Expression {
             expr: self.expr,
-            span: self.span,
             span_id: self.span_id,
             ty: self.ty,
             custom_completion,
         }
     }
 
-    pub fn span(&self, engine_state: &EngineState) -> Span {
-        engine_state.get_span(self.span_id)
+    // pub fn span(&self, engine_state: &EngineState) -> Span {
+    //     engine_state.get_span(self.span_id)
+    // }
+
+    pub fn get_span(&self, state: &impl GetSpan) -> Span {
+        state.get_span(self.span_id)
     }
 }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -483,5 +483,25 @@ impl Expression {
             custom_completion: None
         }
     }
+
+    pub fn new_unknown(expr: Expr, span: Span, ty: Type) -> Expression {
+        Expression {
+            expr,
+            span,
+            span_id: SpanId(0),
+            ty,
+            custom_completion: None
+        }
+    }
+
+    pub fn with_span_id(self, span_id: SpanId) -> Expression {
+        Expression {
+            expr: self.expr,
+            span: self.span,
+            span_id,
+            ty: self.ty,
+            custom_completion: self.custom_completion
+        }
+    }
 }
 

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -1,4 +1,4 @@
-use crate::{ShellError, Span};
+use crate::{GetSpan, ShellError, Span};
 
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -131,15 +131,15 @@ impl Display for RangeOperator {
     }
 }
 
-pub fn eval_operator(op: &Expression) -> Result<Operator, ShellError> {
+pub fn eval_operator(state: &impl GetSpan, op: &Expression) -> Result<Operator, ShellError> {
     match op {
         Expression {
             expr: Expr::Operator(operator),
             ..
         } => Ok(operator.clone()),
-        Expression { span, expr, .. } => Err(ShellError::UnknownOperator {
+        Expression { span_id, expr, .. } => Err(ShellError::UnknownOperator {
             op_token: format!("{expr:?}"),
-            span: *span,
+            span: state.get_span(*span_id),
         }),
     }
 }

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -1,4 +1,4 @@
-use crate::{GetSpan, ShellError, Span};
+use crate::{GetSpan, ShellError, Span, SpanId};
 
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -119,7 +119,9 @@ pub enum RangeInclusion {
 pub struct RangeOperator {
     pub inclusion: RangeInclusion,
     pub span: Span,
+    pub span_id: SpanId,
     pub next_op_span: Span,
+    pub next_op_span_id: SpanId,
 }
 
 impl Display for RangeOperator {

--- a/crates/nu-protocol/src/ast/pipeline.rs
+++ b/crates/nu-protocol/src/ast/pipeline.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::Expression,
     engine::{EngineState, StateWorkingSet},
-    IoStream, Span,
+    IoStream, Span, SpanId,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -57,11 +57,11 @@ impl RedirectionTarget {
         &mut self,
         working_set: &mut StateWorkingSet,
         replaced: Span,
-        new_span: Span,
+        new_span_id: SpanId,
     ) {
         match self {
             RedirectionTarget::File { expr, .. } => {
-                expr.replace_span(working_set, replaced, new_span)
+                expr.replace_span(working_set, replaced, new_span_id)
             }
             RedirectionTarget::Pipe { .. } => {}
         }

--- a/crates/nu-protocol/src/ast/pipeline.rs
+++ b/crates/nu-protocol/src/ast/pipeline.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::Expression,
     engine::{EngineState, StateWorkingSet},
-    IoStream, Span, SpanId,
+    GetSpan, IoStream, Span, SpanId,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -143,13 +143,17 @@ impl Pipeline {
         Self { elements: vec![] }
     }
 
-    pub fn from_vec(expressions: Vec<Expression>) -> Pipeline {
+    pub fn from_vec(state: &impl GetSpan, expressions: Vec<Expression>) -> Pipeline {
         Self {
             elements: expressions
                 .into_iter()
                 .enumerate()
                 .map(|(idx, expr)| PipelineElement {
-                    pipe: if idx == 0 { None } else { Some(expr.span) },
+                    pipe: if idx == 0 {
+                        None
+                    } else {
+                        Some(expr.get_span(state))
+                    },
                     expr,
                     redirection: None,
                 })

--- a/crates/nu-protocol/src/ast/pipeline.rs
+++ b/crates/nu-protocol/src/ast/pipeline.rs
@@ -102,17 +102,18 @@ impl PipelineElement {
         &mut self,
         working_set: &mut StateWorkingSet,
         replaced: Span,
-        new_span: Span,
+        // new_span: Span,
+        new_span_id: SpanId,
     ) {
-        self.expr.replace_span(working_set, replaced, new_span);
+        self.expr.replace_span(working_set, replaced, new_span_id);
         if let Some(expr) = self.redirection.as_mut() {
             match expr {
                 PipelineRedirection::Single { target, .. } => {
-                    target.replace_span(working_set, replaced, new_span)
+                    target.replace_span(working_set, replaced, new_span_id)
                 }
                 PipelineRedirection::Separate { out, err } => {
-                    out.replace_span(working_set, replaced, new_span);
-                    err.replace_span(working_set, replaced, new_span);
+                    out.replace_span(working_set, replaced, new_span_id);
+                    err.replace_span(working_set, replaced, new_span_id);
                 }
             }
         }

--- a/crates/nu-protocol/src/config/completer.rs
+++ b/crates/nu-protocol/src/config/completer.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{record, Config, Span, Value};
+use crate::{record, Config, Span, Value, SpanId};
 
 use super::helper::ReconstructVal;
 
@@ -26,7 +26,7 @@ impl FromStr for CompletionAlgorithm {
 }
 
 impl ReconstructVal for CompletionAlgorithm {
-    fn reconstruct_value(&self, span: Span) -> Value {
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value {
         let str = match self {
             CompletionAlgorithm::Prefix => "prefix",
             CompletionAlgorithm::Fuzzy => "fuzzy",
@@ -43,12 +43,12 @@ pub(super) fn reconstruct_external_completer(config: &Config, span: Span) -> Val
     }
 }
 
-pub(super) fn reconstruct_external(config: &Config, span: Span) -> Value {
+pub(super) fn reconstruct_external(config: &Config, span: Span, span_id: SpanId) -> Value {
     Value::record(
         record! {
             "max_results" => Value::int(config.max_external_completion_results, span),
             "completer" => reconstruct_external_completer(config, span),
-            "enable" => Value::bool(config.enable_external_completion, span),
+            "enable" => Value::bool(config.enable_external_completion, span_id),
         },
         span,
     )

--- a/crates/nu-protocol/src/config/helper.rs
+++ b/crates/nu-protocol/src/config/helper.rs
@@ -1,8 +1,8 @@
-use crate::{Record, ShellError, Span, Value};
+use crate::{Record, ShellError, Span, SpanId, Value};
 use std::{collections::HashMap, fmt::Display, str::FromStr};
 
 pub(super) trait ReconstructVal {
-    fn reconstruct_value(&self, span: Span) -> Value;
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value;
 }
 
 pub(super) fn process_string_enum<T, E>(
@@ -15,6 +15,7 @@ pub(super) fn process_string_enum<T, E>(
     E: Display,
 {
     let span = value.span();
+    let span_id = value.span_id();
     if let Ok(v) = value.coerce_str() {
         match v.parse() {
             Ok(format) => {
@@ -32,7 +33,7 @@ pub(super) fn process_string_enum<T, E>(
                     inner: vec![],
                 });
                 // Reconstruct
-                *value = config_point.reconstruct_value(span);
+                *value = config_point.reconstruct_value(span, span_id);
             }
         }
     } else {
@@ -44,7 +45,7 @@ pub(super) fn process_string_enum<T, E>(
             inner: vec![],
         });
         // Reconstruct
-        *value = config_point.reconstruct_value(span);
+        *value = config_point.reconstruct_value(span, span_id);
     }
 }
 
@@ -64,7 +65,7 @@ pub(super) fn process_bool_config(
             inner: vec![],
         });
         // Reconstruct
-        *value = Value::bool(*config_point, value.span());
+        *value = Value::bool(*config_point, value.span_id());
     }
 }
 

--- a/crates/nu-protocol/src/config/mod.rs
+++ b/crates/nu-protocol/src/config/mod.rs
@@ -203,6 +203,7 @@ impl Value {
         if let Value::Record { val, .. } = self {
             val.retain_mut(|key, value| {
                 let span = value.span();
+                let span_id = value.span_id();
                 match key {
                     // Grouped options
                     "ls" => {
@@ -227,8 +228,8 @@ impl Value {
                             // Reconstruct
                             *value = Value::record(
                                 record! {
-                                    "use_ls_colors" => Value::bool(config.use_ls_colors, span),
-                                    "clickable_links" => Value::bool(config.show_clickable_links_in_ls, span),
+                                    "use_ls_colors" => Value::bool(config.use_ls_colors, span_id),
+                                    "clickable_links" => Value::bool(config.show_clickable_links_in_ls, span_id),
                                 },
                                 span,
                             );
@@ -254,7 +255,7 @@ impl Value {
                             // Reconstruct
                             *value = Value::record(
                                 record! {
-                                    "always_trash" => Value::bool(config.rm_always_trash, span),
+                                    "always_trash" => Value::bool(config.rm_always_trash, span_id),
                                 },
                                 span,
                             );
@@ -294,10 +295,10 @@ impl Value {
                             // Reconstruct
                             *value = Value::record(
                                 record! {
-                                    "sync_on_enter" => Value::bool(history.sync_on_enter, span),
+                                    "sync_on_enter" => Value::bool(history.sync_on_enter, span_id),
                                     "max_size" => Value::int(history.max_size, span),
-                                    "file_format" => history.file_format.reconstruct_value(span),
-                                    "isolation" => Value::bool(history.isolation, span),
+                                    "file_format" => history.file_format.reconstruct_value(span, span_id),
+                                    "isolation" => Value::bool(history.isolation, span_id),
                                 },
                                 span,
                             );
@@ -307,6 +308,7 @@ impl Value {
                         if let Value::Record { val, .. } = value {
                             val.retain_mut(|key2, value| {
                                 let span = value.span();
+                                let span_id  = value.span_id();
                                 match key2 {
                                     "quick" => {
                                         process_bool_config(value, &mut errors, &mut config.quick_completions);
@@ -362,7 +364,7 @@ impl Value {
                                         } else {
                                             report_invalid_value("should be a record", span, &mut errors);
                                             // Reconstruct
-                                            *value = reconstruct_external(&config, span);
+                                            *value = reconstruct_external(&config, span, span_id);
                                         }
                                     }
                                     "use_ls_colors" => {
@@ -380,12 +382,12 @@ impl Value {
                             // Reconstruct record
                             *value = Value::record(
                                 record! {
-                                    "quick" => Value::bool(config.quick_completions, span),
-                                    "partial" => Value::bool(config.partial_completions, span),
-                                    "algorithm" => config.completion_algorithm.reconstruct_value(span),
-                                    "case_sensitive" => Value::bool(config.case_sensitive_completions, span),
-                                    "external" => reconstruct_external(&config, span),
-                                    "use_ls_colors" => Value::bool(config.use_ls_colors_completions, span),
+                                    "quick" => Value::bool(config.quick_completions, span_id),
+                                    "partial" => Value::bool(config.partial_completions, span_id),
+                                    "algorithm" => config.completion_algorithm.reconstruct_value(span, span_id),
+                                    "case_sensitive" => Value::bool(config.case_sensitive_completions, span_id),
+                                    "external" => reconstruct_external(&config, span, span_id),
+                                    "use_ls_colors" => Value::bool(config.use_ls_colors_completions, span_id),
                                 },
                                 span,
                             );
@@ -416,9 +418,9 @@ impl Value {
                             // Reconstruct
                             *value = Value::record(
                                 record! {
-                                    "vi_insert" => config.cursor_shape_vi_insert.reconstruct_value(span),
-                                    "vi_normal" => config.cursor_shape_vi_normal.reconstruct_value(span),
-                                    "emacs" => config.cursor_shape_emacs.reconstruct_value(span),
+                                    "vi_insert" => config.cursor_shape_vi_insert.reconstruct_value(span, span_id),
+                                    "vi_normal" => config.cursor_shape_vi_normal.reconstruct_value(span, span_id),
+                                    "emacs" => config.cursor_shape_emacs.reconstruct_value(span, span_id),
                                 },
                                 span,
                             );
@@ -505,7 +507,7 @@ impl Value {
                                                 // try_parse_trim_strategy() already adds its own errors
                                                 errors.push(e);
                                                 *value =
-                                                    reconstruct_trim_strategy(&config, span);
+                                                    reconstruct_trim_strategy(&config, span, span_id);
                                             }
                                         }
                                     }
@@ -535,10 +537,10 @@ impl Value {
                             // Reconstruct
                             *value = Value::record(
                                 record! {
-                                    "mode" => config.table_mode.reconstruct_value(span),
-                                    "index_mode" => config.table_index_mode.reconstruct_value(span),
-                                    "trim" => reconstruct_trim_strategy(&config, span),
-                                    "show_empty" => Value::bool(config.table_show_empty, span),
+                                    "mode" => config.table_mode.reconstruct_value(span, span_id),
+                                    "index_mode" => config.table_index_mode.reconstruct_value(span, span_id),
+                                    "trim" => reconstruct_trim_strategy(&config, span, span_id),
+                                    "show_empty" => Value::bool(config.table_show_empty, span_id),
                                 },
                                 span,
                             );
@@ -574,7 +576,7 @@ impl Value {
                             // Reconstruct
                             *value = Value::record(
                                 record! {
-                                    "metric" => Value::bool(config.filesize_metric, span),
+                                    "metric" => Value::bool(config.filesize_metric, span_id),
                                     "format" => Value::string(config.filesize_format.clone(), span),
                                 },
                                 span,

--- a/crates/nu-protocol/src/config/output.rs
+++ b/crates/nu-protocol/src/config/output.rs
@@ -1,5 +1,5 @@
 use super::helper::ReconstructVal;
-use crate::{Config, Record, Span, Value};
+use crate::{Config, Record, Span, SpanId, Value};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -22,7 +22,7 @@ impl FromStr for ErrorStyle {
 }
 
 impl ReconstructVal for ErrorStyle {
-    fn reconstruct_value(&self, span: Span) -> Value {
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value {
         Value::string(
             match self {
                 ErrorStyle::Fancy => "fancy",

--- a/crates/nu-protocol/src/config/reedline.rs
+++ b/crates/nu-protocol/src/config/reedline.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use super::{extract_value, helper::ReconstructVal};
-use crate::{record, Config, ShellError, Span, Value};
+use crate::{record, Config, ShellError, Span, Value, SpanId};
 use serde::{Deserialize, Serialize};
 
 /// Definition of a parsed keybinding from the config object
@@ -55,7 +55,7 @@ impl FromStr for NuCursorShape {
 }
 
 impl ReconstructVal for NuCursorShape {
-    fn reconstruct_value(&self, span: Span) -> Value {
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value {
         Value::string(
             match self {
                 NuCursorShape::Line => "line",
@@ -92,7 +92,7 @@ impl FromStr for HistoryFileFormat {
 }
 
 impl ReconstructVal for HistoryFileFormat {
-    fn reconstruct_value(&self, span: Span) -> Value {
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value {
         Value::string(
             match self {
                 HistoryFileFormat::Sqlite => "sqlite",
@@ -123,7 +123,7 @@ impl FromStr for EditBindings {
 }
 
 impl ReconstructVal for EditBindings {
-    fn reconstruct_value(&self, span: Span) -> Value {
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value {
         Value::string(
             match self {
                 EditBindings::Vi => "vi",

--- a/crates/nu-protocol/src/config/table.rs
+++ b/crates/nu-protocol/src/config/table.rs
@@ -1,5 +1,5 @@
 use super::helper::ReconstructVal;
-use crate::{record, Config, ShellError, Span, Value};
+use crate::{record, Config, ShellError, Span, Value, SpanId};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -52,7 +52,7 @@ impl FromStr for TableMode {
 }
 
 impl ReconstructVal for TableMode {
-    fn reconstruct_value(&self, span: Span) -> Value {
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value {
         Value::string(
             match self {
                 TableMode::Basic => "basic",
@@ -109,7 +109,7 @@ impl FromStr for FooterMode {
 }
 
 impl ReconstructVal for FooterMode {
-    fn reconstruct_value(&self, span: Span) -> Value {
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value {
         Value::string(
             match self {
                 FooterMode::Always => "always".to_string(),
@@ -146,7 +146,7 @@ impl FromStr for TableIndexMode {
 }
 
 impl ReconstructVal for TableIndexMode {
-    fn reconstruct_value(&self, span: Span) -> Value {
+    fn reconstruct_value(&self, span: Span, span_id: SpanId) -> Value {
         Value::string(
             match self {
                 TableIndexMode::Always => "always",
@@ -289,12 +289,12 @@ fn try_parse_trim_methodology(value: &Value) -> Option<TrimStrategy> {
     None
 }
 
-pub(super) fn reconstruct_trim_strategy(config: &Config, span: Span) -> Value {
+pub(super) fn reconstruct_trim_strategy(config: &Config, span: Span, span_id: SpanId) -> Value {
     match &config.trim_strategy {
         TrimStrategy::Wrap { try_to_keep_words } => Value::record(
             record! {
                 "methodology" => Value::string("wrapping", span),
-                "wrapping_try_keep_words" => Value::bool(*try_to_keep_words, span),
+                "wrapping_try_keep_words" => Value::bool(*try_to_keep_words, span_id),
             },
             span,
         ),

--- a/crates/nu-protocol/src/debugger/profiler.rs
+++ b/crates/nu-protocol/src/debugger/profiler.rs
@@ -140,7 +140,7 @@ impl Debugger for Profiler {
 
         let new_id = ElementId(self.elements.len());
 
-        let mut new_element = ElementInfo::new(self.depth, element.expr.span);
+        let mut new_element = ElementInfo::new(self.depth, element.expr.get_span(engine_state));
         new_element.expr = expr_opt;
 
         self.elements.push(new_element);
@@ -156,7 +156,7 @@ impl Debugger for Profiler {
 
     fn leave_element(
         &mut self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         element: &PipelineElement,
         result: &Result<(PipelineData, bool), ShellError>,
     ) {
@@ -164,7 +164,7 @@ impl Debugger for Profiler {
             return;
         }
 
-        let element_span = element.expr.span;
+        let element_span = element.expr.get_span(engine_state);
 
         let out_opt = self.collect_values.then(|| match result {
             Ok((pipeline_data, _not_sure_what_this_is)) => match pipeline_data {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1051,6 +1051,16 @@ impl<'a> GetSpan for &'a EngineState {
     }
 }
 
+impl GetSpan for EngineState {
+    /// Get existing span
+    fn get_span(&self, span_id: SpanId) -> Span {
+        *self
+            .spans
+            .get(span_id.0)
+            .expect("internal error: missing span")
+    }
+}
+
 impl Default for EngineState {
     fn default() -> Self {
         Self::new()

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -6,8 +6,8 @@ use crate::{
         CachedFile, Command, CommandType, EnvVars, OverlayFrame, ScopeFrame, Stack, StateDelta,
         Variable, Visibility, DEFAULT_OVERLAY_NAME,
     },
-    BlockId, Category, Config, DeclId, Example, FileId, HistoryConfig, Module, ModuleId, OverlayId,
-    ShellError, Signature, Span, SpanId, Type, Value, VarId, VirtualPathId, GetSpan,
+    BlockId, Category, Config, DeclId, Example, FileId, GetSpan, HistoryConfig, Module, ModuleId,
+    OverlayId, ShellError, Signature, Span, SpanId, Type, Value, VarId, VirtualPathId,
 };
 use fancy_regex::Regex;
 use lru::LruCache;
@@ -1044,7 +1044,10 @@ impl EngineState {
 impl<'a> GetSpan for &'a EngineState {
     /// Get existing span
     fn get_span(&self, span_id: SpanId) -> Span {
-        *self.spans.get(span_id.0).expect("internal error: missing span")
+        *self
+            .spans
+            .get(span_id.0)
+            .expect("internal error: missing span")
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -117,6 +117,9 @@ pub const IN_VARIABLE_ID: usize = 1;
 pub const ENV_VARIABLE_ID: usize = 2;
 // NOTE: If you add more to this list, make sure to update the > checks based on the last in the list
 
+// The first span is unknown span
+pub const UNKNOWN_SPAN_ID: SpanId = SpanId(0);
+
 impl EngineState {
     pub fn new() -> Self {
         Self {
@@ -1030,13 +1033,11 @@ impl EngineState {
     }
 
     /// Find ID of a span
-    pub fn get_span_id(&self, span: Span) -> SpanId {
-        SpanId(
+    pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
             self.spans
                 .iter()
                 .position(|sp| sp == &span)
-                .expect("span not found"),
-        )
+                .map(SpanId)
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -7,7 +7,7 @@ use crate::{
         Variable, Visibility, DEFAULT_OVERLAY_NAME,
     },
     BlockId, Category, Config, DeclId, Example, FileId, HistoryConfig, Module, ModuleId, OverlayId,
-    ShellError, Signature, Span, SpanId, Type, Value, VarId, VirtualPathId,
+    ShellError, Signature, Span, SpanId, Type, Value, VarId, VirtualPathId, GetSpan,
 };
 use fancy_regex::Regex;
 use lru::LruCache;
@@ -1035,14 +1035,16 @@ impl EngineState {
         SpanId(self.num_spans() - 1)
     }
 
-    /// Get existing span
-    pub fn get_span(&self, span_id: SpanId) -> Span {
-        *self.spans.get(&span_id.0).expect("internal error: missing span")
-    }
-
     /// Find ID of a span (should be avoided if possible)
     pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
         self.spans.iter().position(|sp| sp == &span).map(SpanId)
+    }
+}
+
+impl<'a> GetSpan for &'a EngineState {
+    /// Get existing span
+    fn get_span(&self, span_id: SpanId) -> Span {
+        *self.spans.get(span_id.0).expect("internal error: missing span")
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -7,7 +7,7 @@ use crate::{
         Variable, Visibility, DEFAULT_OVERLAY_NAME,
     },
     BlockId, Category, Config, DeclId, Example, FileId, HistoryConfig, Module, ModuleId, OverlayId,
-    ShellError, Signature, Span, Type, Value, VarId, VirtualPathId,
+    ShellError, Signature, Span, SpanId, Type, Value, VarId, VirtualPathId,
 };
 use fancy_regex::Regex;
 use lru::LruCache;
@@ -1018,6 +1018,15 @@ impl EngineState {
                 NonZeroUsize::new(REGEX_CACHE_SIZE).expect("tried to create cache of size zero"),
             )));
         }
+    }
+
+    pub fn add_span(&mut self, span: Span) -> SpanId {
+        todo!("impl adding spans");
+        todo!("push first span unknown!")
+    }
+
+    pub fn get_span_id(&self, span: Span) -> SpanId {
+        todo!("impl span search")
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1032,7 +1032,12 @@ impl EngineState {
         SpanId(self.spans.len() - 1)
     }
 
-    /// Find ID of a span
+    /// Get existing span
+    pub fn get_span(&self, span_id: SpanId) -> Span {
+        self.spans[span_id.0]
+    }
+
+    /// Find ID of a span (should be avoided if possible)
     pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
         self.spans.iter().position(|sp| sp == &span).map(SpanId)
     }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -614,6 +614,9 @@ impl EngineState {
         self.modules.len()
     }
 
+    pub fn num_spans(&self) -> usize {
+        self.spans.len()
+    }
     pub fn print_vars(&self) {
         for var in self.vars.iter().enumerate() {
             println!("var{}: {:?}", var.0, var.1);
@@ -1029,12 +1032,12 @@ impl EngineState {
     /// Add new span and return its ID
     pub fn add_span(&mut self, span: Span) -> SpanId {
         self.spans.push(span);
-        SpanId(self.spans.len() - 1)
+        SpanId(self.num_spans() - 1)
     }
 
     /// Get existing span
     pub fn get_span(&self, span_id: SpanId) -> Span {
-        self.spans[span_id.0]
+        *self.spans.get(&span_id.0).expect("internal error: missing span")
     }
 
     /// Find ID of a span (should be avoided if possible)

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -82,6 +82,7 @@ pub struct EngineState {
     // especially long, so it helps
     pub(super) blocks: Arc<Vec<Arc<Block>>>,
     pub(super) modules: Arc<Vec<Arc<Module>>>,
+    pub spans: Vec<Span>,
     usage: Usage,
     pub scope: ScopeFrame,
     pub ctrlc: Option<Arc<AtomicBool>>,
@@ -133,6 +134,7 @@ impl EngineState {
             modules: Arc::new(vec![Arc::new(Module::new(
                 DEFAULT_OVERLAY_NAME.as_bytes().to_vec(),
             ))]),
+            spans: vec![Span::unknown()],
             usage: Usage::new(),
             // make sure we have some default overlay:
             scope: ScopeFrame::with_empty_overlay(
@@ -185,6 +187,7 @@ impl EngineState {
         self.files.extend(delta.files);
         self.virtual_paths.extend(delta.virtual_paths);
         self.vars.extend(delta.vars);
+        self.spans.extend(delta.spans);
         self.usage.merge_with(delta.usage);
 
         // Avoid potentially cloning the Arcs if we aren't adding anything
@@ -1020,13 +1023,20 @@ impl EngineState {
         }
     }
 
+    /// Add new span and return its ID
     pub fn add_span(&mut self, span: Span) -> SpanId {
-        todo!("impl adding spans");
-        todo!("push first span unknown!")
+        self.spans.push(span);
+        SpanId(self.spans.len() - 1)
     }
 
+    /// Find ID of a span
     pub fn get_span_id(&self, span: Span) -> SpanId {
-        todo!("impl span search")
+        SpanId(
+            self.spans
+                .iter()
+                .position(|sp| sp == &span)
+                .expect("span not found"),
+        )
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1034,10 +1034,7 @@ impl EngineState {
 
     /// Find ID of a span
     pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
-            self.spans
-                .iter()
-                .position(|sp| sp == &span)
-                .map(SpanId)
+        self.spans.iter().position(|sp| sp == &span).map(SpanId)
     }
 }
 

--- a/crates/nu-protocol/src/engine/state_delta.rs
+++ b/crates/nu-protocol/src/engine/state_delta.rs
@@ -4,7 +4,7 @@ use crate::{
         usage::Usage, CachedFile, Command, EngineState, OverlayFrame, ScopeFrame, Variable,
         VirtualPath,
     },
-    Module, Span
+    Module, Span,
 };
 use std::sync::Arc;
 

--- a/crates/nu-protocol/src/engine/state_delta.rs
+++ b/crates/nu-protocol/src/engine/state_delta.rs
@@ -4,7 +4,7 @@ use crate::{
         usage::Usage, CachedFile, Command, EngineState, OverlayFrame, ScopeFrame, Variable,
         VirtualPath,
     },
-    Module,
+    Module, Span
 };
 use std::sync::Arc;
 
@@ -21,6 +21,7 @@ pub struct StateDelta {
     pub(super) decls: Vec<Box<dyn Command>>, // indexed by DeclId
     pub blocks: Vec<Arc<Block>>,             // indexed by BlockId
     pub(super) modules: Vec<Arc<Module>>,    // indexed by ModuleId
+    pub spans: Vec<Span>,                    // indexed by SpanId
     pub(super) usage: Usage,
     pub scope: Vec<ScopeFrame>,
     #[cfg(feature = "plugin")]
@@ -45,6 +46,7 @@ impl StateDelta {
             decls: vec![],
             blocks: vec![],
             modules: vec![],
+            spans: vec![],
             scope: vec![scope_frame],
             usage: Usage::new(),
             #[cfg(feature = "plugin")]

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1023,6 +1023,18 @@ impl<'a> StateWorkingSet<'a> {
         self.delta.spans.push(span);
         SpanId(num_permanent_spans + self.delta.spans.len() - 1)
     }
+
+    pub fn get_span(&self, span_id: SpanId) -> Span {
+        let num_permanent_spans = self.permanent_state.num_spans();
+        if span_id.0 < num_permanent_spans {
+            self.permanent_state.get_span(span_id)
+        } else {
+            *self.delta
+                .spans
+                .get(&span_id.0 - &num_permanent_spans)
+                .expect("internal error: missing span")
+        }
+    }
 }
 
 impl<'a> miette::SourceCode for &StateWorkingSet<'a> {

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -5,7 +5,7 @@ use crate::{
         StateDelta, Variable, VirtualPath, Visibility, PWD_ENV,
     },
     BlockId, Category, Config, DeclId, FileId, Module, ModuleId, ParseError, ParseWarning, Span,
-    Type, Value, VarId, VirtualPathId,
+    SpanId, Type, Value, VarId, VirtualPathId,
 };
 use core::panic;
 use std::{
@@ -1016,6 +1016,10 @@ impl<'a> StateWorkingSet<'a> {
                 .get(virtual_path_id - num_permanent_virtual_paths)
                 .expect("internal error: missing virtual path")
         }
+    }
+
+    pub fn add_span(&mut self, span: Span) -> SpanId {
+        todo!("impl adding spans")
     }
 }
 

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -4,8 +4,8 @@ use crate::{
         usage::build_usage, CachedFile, Command, CommandType, EngineState, OverlayFrame,
         StateDelta, Variable, VirtualPath, Visibility, PWD_ENV,
     },
-    BlockId, Category, Config, DeclId, FileId, Module, ModuleId, ParseError, ParseWarning, Span,
-    SpanId, Type, Value, VarId, VirtualPathId, GetSpan
+    BlockId, Category, Config, DeclId, FileId, GetSpan, Module, ModuleId, ParseError, ParseWarning,
+    Span, SpanId, Type, Value, VarId, VirtualPathId,
 };
 use core::panic;
 use std::{
@@ -1027,13 +1027,13 @@ impl<'a> StateWorkingSet<'a> {
 
 impl<'a> GetSpan for StateWorkingSet<'a> {
     fn get_span(&self, span_id: SpanId) -> Span {
-        get_span(&self, span_id)
+        get_span(self, span_id)
     }
 }
 
 impl<'a> GetSpan for &'a StateWorkingSet<'a> {
     fn get_span(&self, span_id: SpanId) -> Span {
-        get_span(&self, span_id)
+        get_span(self, span_id)
     }
 }
 
@@ -1042,9 +1042,10 @@ fn get_span(working_set: &StateWorkingSet, span_id: SpanId) -> Span {
     if span_id.0 < num_permanent_spans {
         working_set.permanent_state.get_span(span_id)
     } else {
-        *working_set.delta
+        *working_set
+            .delta
             .spans
-            .get(&span_id.0 - &num_permanent_spans)
+            .get(span_id.0 - num_permanent_spans)
             .expect("internal error: missing span")
     }
 }

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1019,11 +1019,9 @@ impl<'a> StateWorkingSet<'a> {
     }
 
     pub fn add_span(&mut self, span: Span) -> SpanId {
-        todo!("impl adding spans")
-    }
-
-    pub fn get_span_id(&self, span: Span) -> SpanId {
-        todo!("impl span search")
+        let num_permanent_spans = self.permanent_state.spans.len();
+        self.delta.spans.push(span);
+        SpanId(num_permanent_spans + self.delta.spans.len() - 1)
     }
 }
 

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1037,6 +1037,12 @@ impl<'a> GetSpan for &'a StateWorkingSet<'a> {
     }
 }
 
+impl<'a, 'b> GetSpan for &'b mut StateWorkingSet<'a> {
+    fn get_span(&self, span_id: SpanId) -> Span {
+        get_span(self, span_id)
+    }
+}
+
 fn get_span(working_set: &StateWorkingSet, span_id: SpanId) -> Span {
     let num_permanent_spans = working_set.permanent_state.num_spans();
     if span_id.0 < num_permanent_spans {

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -5,7 +5,7 @@ use crate::{
         StateDelta, Variable, VirtualPath, Visibility, PWD_ENV,
     },
     BlockId, Category, Config, DeclId, FileId, Module, ModuleId, ParseError, ParseWarning, Span,
-    SpanId, Type, Value, VarId, VirtualPathId,
+    SpanId, Type, Value, VarId, VirtualPathId, GetSpan
 };
 use core::panic;
 use std::{
@@ -1023,17 +1023,29 @@ impl<'a> StateWorkingSet<'a> {
         self.delta.spans.push(span);
         SpanId(num_permanent_spans + self.delta.spans.len() - 1)
     }
+}
 
-    pub fn get_span(&self, span_id: SpanId) -> Span {
-        let num_permanent_spans = self.permanent_state.num_spans();
-        if span_id.0 < num_permanent_spans {
-            self.permanent_state.get_span(span_id)
-        } else {
-            *self.delta
-                .spans
-                .get(&span_id.0 - &num_permanent_spans)
-                .expect("internal error: missing span")
-        }
+impl<'a> GetSpan for StateWorkingSet<'a> {
+    fn get_span(&self, span_id: SpanId) -> Span {
+        get_span(&self, span_id)
+    }
+}
+
+impl<'a> GetSpan for &'a StateWorkingSet<'a> {
+    fn get_span(&self, span_id: SpanId) -> Span {
+        get_span(&self, span_id)
+    }
+}
+
+fn get_span(working_set: &StateWorkingSet, span_id: SpanId) -> Span {
+    let num_permanent_spans = working_set.permanent_state.num_spans();
+    if span_id.0 < num_permanent_spans {
+        working_set.permanent_state.get_span(span_id)
+    } else {
+        *working_set.delta
+            .spans
+            .get(&span_id.0 - &num_permanent_spans)
+            .expect("internal error: missing span")
     }
 }
 

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1021,6 +1021,10 @@ impl<'a> StateWorkingSet<'a> {
     pub fn add_span(&mut self, span: Span) -> SpanId {
         todo!("impl adding spans")
     }
+
+    pub fn get_span_id(&self, span: Span) -> SpanId {
+        todo!("impl span search")
+    }
 }
 
 impl<'a> miette::SourceCode for &StateWorkingSet<'a> {

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -4,7 +4,7 @@ use crate::{
         ExternalArgument, Math, Operator, RecordItem,
     },
     debugger::DebugContext,
-    Config, IntoInterruptiblePipelineData, Range, Record, ShellError, Span, Value, VarId,
+    Config, GetSpan, IntoInterruptiblePipelineData, Range, Record, ShellError, Span, Value, VarId,
 };
 use std::{borrow::Cow, collections::HashMap};
 
@@ -12,7 +12,7 @@ use std::{borrow::Cow, collections::HashMap};
 pub trait Eval {
     /// State that doesn't need to be mutated.
     /// EngineState for regular eval and StateWorkingSet for const eval
-    type State<'a>: Copy;
+    type State<'a>: Copy + GetSpan;
 
     /// State that needs to be mutated.
     /// This is the stack for regular eval, and unused by const eval
@@ -23,8 +23,10 @@ pub trait Eval {
         mut_state: &mut Self::MutState,
         expr: &Expression,
     ) -> Result<Value, ShellError> {
+        let expr_span = state.get_span(expr.span_id);
+
         match &expr.expr {
-            Expr::Bool(b) => Ok(Value::bool(*b, expr.span)),
+            Expr::Bool(b) => Ok(Value::bool(*b, expr_span)),
             Expr::Int(i) => Ok(Value::int(*i, expr.span)),
             Expr::Float(f) => Ok(Value::float(*f, expr.span)),
             Expr::Binary(b) => Ok(Value::binary(b.clone(), expr.span)),

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -28,32 +28,32 @@ pub trait Eval {
         match &expr.expr {
             Expr::Bool(b) => Ok(Value::bool(*b, expr_span)),
             Expr::Int(i) => Ok(Value::int(*i, expr.span)),
-            Expr::Float(f) => Ok(Value::float(*f, expr.span)),
-            Expr::Binary(b) => Ok(Value::binary(b.clone(), expr.span)),
-            Expr::Filepath(path, quoted) => Self::eval_filepath(state, mut_state, path.clone(), *quoted, expr.span),
+            Expr::Float(f) => Ok(Value::float(*f, expr_span)),
+            Expr::Binary(b) => Ok(Value::binary(b.clone(), expr_span)),
+            Expr::Filepath(path, quoted) => Self::eval_filepath(state, mut_state, path.clone(), *quoted, expr_span),
             Expr::Directory(path, quoted) => {
-                Self::eval_directory(state, mut_state, path.clone(), *quoted, expr.span)
+                Self::eval_directory(state, mut_state, path.clone(), *quoted, expr_span)
             }
-            Expr::Var(var_id) => Self::eval_var(state, mut_state, *var_id, expr.span),
-            Expr::CellPath(cell_path) => Ok(Value::cell_path(cell_path.clone(), expr.span)),
+            Expr::Var(var_id) => Self::eval_var(state, mut_state, *var_id, expr_span),
+            Expr::CellPath(cell_path) => Ok(Value::cell_path(cell_path.clone(), expr_span)),
             Expr::FullCellPath(cell_path) => {
                 let value = Self::eval::<D>(state, mut_state, &cell_path.head)?;
 
                 value.follow_cell_path(&cell_path.tail, false)
             }
-            Expr::DateTime(dt) => Ok(Value::date(*dt, expr.span)),
+            Expr::DateTime(dt) => Ok(Value::date(*dt, expr_span)),
             Expr::List(x) => {
                 let mut output = vec![];
                 for expr in x {
                     match &expr.expr {
                         Expr::Spread(expr) => match Self::eval::<D>(state, mut_state, expr)? {
                             Value::List { mut vals, .. } => output.append(&mut vals),
-                            _ => return Err(ShellError::CannotSpreadAsList { span: expr.span }),
+                            _ => return Err(ShellError::CannotSpreadAsList { span: expr_span }),
                         },
                         _ => output.push(Self::eval::<D>(state, mut_state, expr)?),
                     }
                 }
-                Ok(Value::list(output, expr.span))
+                Ok(Value::list(output, expr_span))
             }
             Expr::Record(items) => {
                 let mut record = Record::new();
@@ -100,7 +100,7 @@ pub trait Eval {
                     }
                 }
 
-                Ok(Value::record(record, expr.span))
+                Ok(Value::record(record, expr_span))
             }
             Expr::Table(headers, vals) => {
                 let mut output_headers = vec![];
@@ -112,7 +112,7 @@ pub trait Eval {
                     {
                         return Err(ShellError::ColumnDefinedTwice {
                             col_name: header,
-                            second_use: expr.span,
+                            second_use: expr_span,
                             first_use: headers[idx].span,
                         });
                     } else {
@@ -128,14 +128,14 @@ pub trait Eval {
 
                     output_rows.push(Value::record(
                         record,
-                        expr.span,
+                        expr_span,
                     ));
                 }
-                Ok(Value::list(output_rows, expr.span))
+                Ok(Value::list(output_rows, expr_span))
             }
             Expr::Keyword(_, _, expr) => Self::eval::<D>(state, mut_state, expr),
-            Expr::String(s) => Ok(Value::string(s.clone(), expr.span)),
-            Expr::Nothing => Ok(Value::nothing(expr.span)),
+            Expr::String(s) => Ok(Value::string(s.clone(), expr_span)),
+            Expr::Nothing => Ok(Value::nothing(expr_span)),
             Expr::ValueWithUnit(e, unit) => match Self::eval::<D>(state, mut_state, e)? {
                 Value::Int { val, .. } => unit.item.build_value(val, unit.span),
                 x => Err(ShellError::CantConvert {
@@ -145,43 +145,43 @@ pub trait Eval {
                     help: None,
                 }),
             },
-            Expr::Call(call) => Self::eval_call::<D>(state, mut_state, call, expr.span),
+            Expr::Call(call) => Self::eval_call::<D>(state, mut_state, call, expr_span),
             Expr::ExternalCall(head, args) => {
-                Self::eval_external_call(state, mut_state, head, args, expr.span)
+                Self::eval_external_call(state, mut_state, head, args, expr_span)
             }
             Expr::Subexpression(block_id) => {
-                Self::eval_subexpression::<D>(state, mut_state, *block_id, expr.span)
+                Self::eval_subexpression::<D>(state, mut_state, *block_id, expr_span)
             }
             Expr::Range(from, next, to, operator) => {
                 let from = if let Some(f) = from {
                     Self::eval::<D>(state, mut_state, f)?
                 } else {
-                    Value::nothing(expr.span)
+                    Value::nothing(expr_span)
                 };
 
                 let next = if let Some(s) = next {
                     Self::eval::<D>(state, mut_state, s)?
                 } else {
-                    Value::nothing(expr.span)
+                    Value::nothing(expr_span)
                 };
 
                 let to = if let Some(t) = to {
                     Self::eval::<D>(state, mut_state, t)?
                 } else {
-                    Value::nothing(expr.span)
+                    Value::nothing(expr_span)
                 };
                 Ok(Value::range(
-                    Range::new(expr.span, from, next, to, operator)?,
-                    expr.span,
+                    Range::new(expr_span, from, next, to, operator)?,
+                    expr_span,
                 ))
             }
             Expr::UnaryNot(expr) => {
                 let lhs = Self::eval::<D>(state, mut_state, expr)?;
                 match lhs {
-                    Value::Bool { val, .. } => Ok(Value::bool(!val, expr.span)),
+                    Value::Bool { val, .. } => Ok(Value::bool(!val, expr_span)),
                     other => Err(ShellError::TypeMismatch {
                         err_message: format!("expected bool, found {}", other.get_type()),
-                        span: expr.span,
+                        span: expr_span,
                     }),
                 }
             }
@@ -195,23 +195,23 @@ pub trait Eval {
                         match boolean {
                             Boolean::And => {
                                 if lhs.is_false() {
-                                    Ok(Value::bool(false, expr.span))
+                                    Ok(Value::bool(false, expr_span))
                                 } else {
                                     let rhs = Self::eval::<D>(state, mut_state, rhs)?;
-                                    lhs.and(op_span, &rhs, expr.span)
+                                    lhs.and(op_span, &rhs, expr_span)
                                 }
                             }
                             Boolean::Or => {
                                 if lhs.is_true() {
-                                    Ok(Value::bool(true, expr.span))
+                                    Ok(Value::bool(true, expr_span))
                                 } else {
                                     let rhs = Self::eval::<D>(state, mut_state, rhs)?;
-                                    lhs.or(op_span, &rhs, expr.span)
+                                    lhs.or(op_span, &rhs, expr_span)
                                 }
                             }
                             Boolean::Xor => {
                                 let rhs = Self::eval::<D>(state, mut_state, rhs)?;
-                                lhs.xor(op_span, &rhs, expr.span)
+                                lhs.xor(op_span, &rhs, expr_span)
                             }
                         }
                     }
@@ -220,35 +220,35 @@ pub trait Eval {
                         let rhs = Self::eval::<D>(state, mut_state, rhs)?;
 
                         match math {
-                            Math::Plus => lhs.add(op_span, &rhs, expr.span),
-                            Math::Minus => lhs.sub(op_span, &rhs, expr.span),
-                            Math::Multiply => lhs.mul(op_span, &rhs, expr.span),
-                            Math::Divide => lhs.div(op_span, &rhs, expr.span),
-                            Math::Append => lhs.append(op_span, &rhs, expr.span),
-                            Math::Modulo => lhs.modulo(op_span, &rhs, expr.span),
-                            Math::FloorDivision => lhs.floor_div(op_span, &rhs, expr.span),
-                            Math::Pow => lhs.pow(op_span, &rhs, expr.span),
+                            Math::Plus => lhs.add(op_span, &rhs, expr_span),
+                            Math::Minus => lhs.sub(op_span, &rhs, expr_span),
+                            Math::Multiply => lhs.mul(op_span, &rhs, expr_span),
+                            Math::Divide => lhs.div(op_span, &rhs, expr_span),
+                            Math::Append => lhs.append(op_span, &rhs, expr_span),
+                            Math::Modulo => lhs.modulo(op_span, &rhs, expr_span),
+                            Math::FloorDivision => lhs.floor_div(op_span, &rhs, expr_span),
+                            Math::Pow => lhs.pow(op_span, &rhs, expr_span),
                         }
                     }
                     Operator::Comparison(comparison) => {
                         let lhs = Self::eval::<D>(state, mut_state, lhs)?;
                         let rhs = Self::eval::<D>(state, mut_state, rhs)?;
                         match comparison {
-                            Comparison::LessThan => lhs.lt(op_span, &rhs, expr.span),
-                            Comparison::LessThanOrEqual => lhs.lte(op_span, &rhs, expr.span),
-                            Comparison::GreaterThan => lhs.gt(op_span, &rhs, expr.span),
-                            Comparison::GreaterThanOrEqual => lhs.gte(op_span, &rhs, expr.span),
-                            Comparison::Equal => lhs.eq(op_span, &rhs, expr.span),
-                            Comparison::NotEqual => lhs.ne(op_span, &rhs, expr.span),
-                            Comparison::In => lhs.r#in(op_span, &rhs, expr.span),
-                            Comparison::NotIn => lhs.not_in(op_span, &rhs, expr.span),
-                            Comparison::StartsWith => lhs.starts_with(op_span, &rhs, expr.span),
-                            Comparison::EndsWith => lhs.ends_with(op_span, &rhs, expr.span),
+                            Comparison::LessThan => lhs.lt(op_span, &rhs, expr_span),
+                            Comparison::LessThanOrEqual => lhs.lte(op_span, &rhs, expr_span),
+                            Comparison::GreaterThan => lhs.gt(op_span, &rhs, expr_span),
+                            Comparison::GreaterThanOrEqual => lhs.gte(op_span, &rhs, expr_span),
+                            Comparison::Equal => lhs.eq(op_span, &rhs, expr_span),
+                            Comparison::NotEqual => lhs.ne(op_span, &rhs, expr_span),
+                            Comparison::In => lhs.r#in(op_span, &rhs, expr_span),
+                            Comparison::NotIn => lhs.not_in(op_span, &rhs, expr_span),
+                            Comparison::StartsWith => lhs.starts_with(op_span, &rhs, expr_span),
+                            Comparison::EndsWith => lhs.ends_with(op_span, &rhs, expr_span),
                             Comparison::RegexMatch => {
-                                Self::regex_match(state, op_span, &lhs, &rhs, false, expr.span)
+                                Self::regex_match(state, op_span, &lhs, &rhs, false, expr_span)
                             }
                             Comparison::NotRegexMatch => {
-                                Self::regex_match(state, op_span, &lhs, &rhs, true, expr.span)
+                                Self::regex_match(state, op_span, &lhs, &rhs, true, expr_span)
                             }
                         }
                     }
@@ -256,21 +256,21 @@ pub trait Eval {
                         let lhs = Self::eval::<D>(state, mut_state, lhs)?;
                         let rhs = Self::eval::<D>(state, mut_state, rhs)?;
                         match bits {
-                            Bits::BitAnd => lhs.bit_and(op_span, &rhs, expr.span),
-                            Bits::BitOr => lhs.bit_or(op_span, &rhs, expr.span),
-                            Bits::BitXor => lhs.bit_xor(op_span, &rhs, expr.span),
-                            Bits::ShiftLeft => lhs.bit_shl(op_span, &rhs, expr.span),
-                            Bits::ShiftRight => lhs.bit_shr(op_span, &rhs, expr.span),
+                            Bits::BitAnd => lhs.bit_and(op_span, &rhs, expr_span),
+                            Bits::BitOr => lhs.bit_or(op_span, &rhs, expr_span),
+                            Bits::BitXor => lhs.bit_xor(op_span, &rhs, expr_span),
+                            Bits::ShiftLeft => lhs.bit_shl(op_span, &rhs, expr_span),
+                            Bits::ShiftRight => lhs.bit_shr(op_span, &rhs, expr_span),
                         }
                     }
                     Operator::Assignment(assignment) => Self::eval_assignment::<D>(
-                        state, mut_state, lhs, rhs, assignment, op_span, expr.span
+                        state, mut_state, lhs, rhs, assignment, op_span, expr_span
                     ),
                 }
             }
-            Expr::Block(block_id) => Ok(Value::block(*block_id, expr.span)),
+            Expr::Block(block_id) => Ok(Value::block(*block_id, expr_span)),
             Expr::RowCondition(block_id) | Expr::Closure(block_id) => {
-                Self::eval_row_condition_or_closure(state, mut_state, *block_id, expr.span)
+                Self::eval_row_condition_or_closure(state, mut_state, *block_id, expr_span)
             }
             Expr::StringInterpolation(exprs) => {
                 let mut parts = vec![];
@@ -284,13 +284,13 @@ pub trait Eval {
                     .into_iter()
                     .into_pipeline_data(None)
                     .collect_string("", &config)
-                    .map(|x| Value::string(x, expr.span))
+                    .map(|x| Value::string(x, expr_span))
             }
-            Expr::Overlay(_) => Self::eval_overlay(state, expr.span),
+            Expr::Overlay(_) => Self::eval_overlay(state, expr_span),
             Expr::GlobPattern(pattern, quoted) => {
                 // GlobPattern is similar to Filepath
                 // But we don't want to expand path during eval time, it's required for `nu_engine::glob_from` to run correctly
-                Ok(Value::glob(pattern, *quoted, expr.span))
+                Ok(Value::glob(pattern, *quoted, expr_span))
             }
             Expr::MatchBlock(_) // match blocks are handled by `match`
             | Expr::VarDecl(_)

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -27,7 +27,7 @@ pub trait Eval {
 
         match &expr.expr {
             Expr::Bool(b) => Ok(Value::bool(*b, expr_span)),
-            Expr::Int(i) => Ok(Value::int(*i, expr.span)),
+            Expr::Int(i) => Ok(Value::int(*i, expr_span)),
             Expr::Float(f) => Ok(Value::float(*f, expr_span)),
             Expr::Binary(b) => Ok(Value::binary(b.clone(), expr_span)),
             Expr::Filepath(path, quoted) => Self::eval_filepath(state, mut_state, path.clone(), *quoted, expr_span),
@@ -66,11 +66,11 @@ pub trait Eval {
                             if let Some(orig_span) = col_names.get(&col_name) {
                                 return Err(ShellError::ColumnDefinedTwice {
                                     col_name,
-                                    second_use: col.span,
+                                    second_use: state.get_span(col.span_id),
                                     first_use: *orig_span,
                                 });
                             } else {
-                                col_names.insert(col_name.clone(), col.span);
+                                col_names.insert(col_name.clone(), state.get_span(col.span_id));
                                 record.push(col_name, Self::eval::<D>(state, mut_state, val)?);
                             }
                         }
@@ -81,18 +81,18 @@ pub trait Eval {
                                         if let Some(orig_span) = col_names.get(&col_name) {
                                             return Err(ShellError::ColumnDefinedTwice {
                                                 col_name,
-                                                second_use: inner.span,
+                                                second_use: state.get_span(inner.span_id),
                                                 first_use: *orig_span,
                                             });
                                         } else {
-                                            col_names.insert(col_name.clone(), inner.span);
+                                            col_names.insert(col_name.clone(), state.get_span(inner.span_id));
                                             record.push(col_name, val);
                                         }
                                     }
                                 }
                                 _ => {
                                     return Err(ShellError::CannotSpreadAsRecord {
-                                        span: inner.span,
+                                        span: state.get_span(inner.span_id),
                                     })
                                 }
                             }
@@ -113,7 +113,7 @@ pub trait Eval {
                         return Err(ShellError::ColumnDefinedTwice {
                             col_name: header,
                             second_use: expr_span,
-                            first_use: headers[idx].span,
+                            first_use: state.get_span(headers[idx].span_id),
                         });
                     } else {
                         output_headers.push(header);
@@ -141,7 +141,7 @@ pub trait Eval {
                 x => Err(ShellError::CantConvert {
                     to_type: "unit value".into(),
                     from_type: x.get_type().to_string(),
-                    span: e.span,
+                    span: state.get_span(e.span_id),
                     help: None,
                 }),
             },
@@ -186,8 +186,8 @@ pub trait Eval {
                 }
             }
             Expr::BinaryOp(lhs, op, rhs) => {
-                let op_span = op.span;
-                let op = eval_operator(op)?;
+                let op_span = state.get_span(op.span_id);
+                let op = eval_operator(&state, op)?;
 
                 match op {
                     Operator::Boolean(boolean) => {
@@ -298,7 +298,7 @@ pub trait Eval {
             | Expr::Signature(_)
             | Expr::Spread(_)
             | Expr::Operator(_)
-            | Expr::Garbage => Self::unreachable(expr),
+            | Expr::Garbage => Self::unreachable(state, expr),
         }
     }
 
@@ -379,5 +379,5 @@ pub trait Eval {
     fn eval_overlay(state: Self::State<'_>, span: Span) -> Result<Value, ShellError>;
 
     /// For expressions that should never actually be evaluated
-    fn unreachable(expr: &Expression) -> Result<Value, ShellError>;
+    fn unreachable(state: Self::State<'_>, expr: &Expression) -> Result<Value, ShellError>;
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -249,7 +249,7 @@ pub fn eval_constant_with_input(
         Expr::Call(call) => eval_const_call(working_set, call, input),
         Expr::Subexpression(block_id) => {
             let block = working_set.get_block(*block_id);
-            eval_const_subexpression(working_set, block, input, expr.span)
+            eval_const_subexpression(working_set, block, input, expr.get_span(working_set))
         }
         _ => eval_constant(working_set, expr).map(|v| PipelineData::Value(v, None)),
     }
@@ -380,7 +380,9 @@ impl Eval for EvalConst {
         Err(ShellError::NotAConstant { span })
     }
 
-    fn unreachable(expr: &Expression) -> Result<Value, ShellError> {
-        Err(ShellError::NotAConstant { span: expr.span })
+    fn unreachable(working_set: &StateWorkingSet, expr: &Expression) -> Result<Value, ShellError> {
+        Err(ShellError::NotAConstant {
+            span: expr.get_span(working_set),
+        })
     }
 }

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -1,17 +1,11 @@
-use crate::{
-    ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument},
-    debugger::{DebugContext, WithoutDebug},
-    engine::{EngineState, StateWorkingSet},
-    eval_base::Eval,
-    record, Config, HistoryFileFormat, PipelineData, Record, ShellError, Span, Value, VarId,
-};
+use crate::{ast::{Assignment, Block, Call, Expr, Expression, ExternalArgument}, debugger::{DebugContext, WithoutDebug}, engine::{EngineState, StateWorkingSet}, eval_base::Eval, record, Config, HistoryFileFormat, PipelineData, Record, ShellError, Span, Value, VarId, SpanId};
 use nu_system::os_info::{get_kernel_version, get_os_arch, get_os_family, get_os_name};
 use std::{
     borrow::Cow,
     path::{Path, PathBuf},
 };
 
-pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Value, ShellError> {
+pub fn create_nu_constant(engine_state: &EngineState, span: Span, span_id: SpanId) -> Result<Value, ShellError> {
     fn canonicalize_path(engine_state: &EngineState, path: &Path) -> PathBuf {
         let cwd = engine_state.current_work_dir();
 
@@ -174,14 +168,14 @@ pub fn create_nu_constant(engine_state: &EngineState, span: Span) -> Result<Valu
 
     record.push(
         "is-interactive",
-        Value::bool(engine_state.is_interactive, span),
+        Value::bool(engine_state.is_interactive, span_id),
     );
 
-    record.push("is-login", Value::bool(engine_state.is_login, span));
+    record.push("is-login", Value::bool(engine_state.is_login, span_id));
 
     record.push(
         "history-enabled",
-        Value::bool(engine_state.history_enabled, span),
+        Value::bool(engine_state.history_enabled, span_id),
     );
 
     record.push(
@@ -346,10 +340,12 @@ impl Eval for EvalConst {
     fn regex_match(
         _: &StateWorkingSet,
         _op_span: Span,
+        _op_span_id: SpanId,
         _: &Value,
         _: &Value,
         _: bool,
         expr_span: Span,
+        _expr_span_id: SpanId,
     ) -> Result<Value, ShellError> {
         Err(ShellError::NotAConstant { span: expr_span })
     }
@@ -361,6 +357,7 @@ impl Eval for EvalConst {
         _: &Expression,
         _: Assignment,
         _op_span: Span,
+        _op_span_id: SpanId,
         expr_span: Span,
     ) -> Result<Value, ShellError> {
         // TODO: Allow debugging const eval

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 pub type VarId = usize;
 pub type DeclId = usize;
 pub type BlockId = usize;
@@ -5,3 +7,5 @@ pub type ModuleId = usize;
 pub type OverlayId = usize;
 pub type FileId = usize;
 pub type VirtualPathId = usize;
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SpanId(pub usize);  // more robust ID style used in the new parser

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -8,4 +8,4 @@ pub type OverlayId = usize;
 pub type FileId = usize;
 pub type VirtualPathId = usize;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct SpanId(pub usize);  // more robust ID style used in the new parser
+pub struct SpanId(pub usize); // more robust ID style used in the new parser

--- a/crates/nu-protocol/src/pipeline_data/stream.rs
+++ b/crates/nu-protocol/src/pipeline_data/stream.rs
@@ -10,6 +10,7 @@ pub struct RawStream {
     pub ctrlc: Option<Arc<AtomicBool>>,
     pub is_binary: bool,
     pub span: Span,
+    pub span_id: SpanId,
     pub known_size: Option<u64>, // (bytes)
 }
 
@@ -18,6 +19,7 @@ impl RawStream {
         stream: Box<dyn Iterator<Item = Result<Vec<u8>, ShellError>> + Send + 'static>,
         ctrlc: Option<Arc<AtomicBool>>,
         span: Span,
+        span_id: SpanId,
         known_size: Option<u64>,
     ) -> Self {
         Self {
@@ -26,6 +28,7 @@ impl RawStream {
             ctrlc,
             is_binary: false,
             span,
+            span_id,
             known_size,
         }
     }
@@ -43,12 +46,14 @@ impl RawStream {
         Ok(Spanned {
             item: output,
             span: self.span,
+            span_id: self.span_id,
         })
     }
 
     pub fn into_string(self) -> Result<Spanned<String>, ShellError> {
         let mut output = String::new();
         let span = self.span;
+        let span_id = self.span_id;
         let ctrlc = &self.ctrlc.clone();
 
         for item in self {
@@ -58,7 +63,7 @@ impl RawStream {
             output.push_str(&item?.coerce_into_string()?);
         }
 
-        Ok(Spanned { item: output, span })
+        Ok(Spanned { item: output, span, span_id })
     }
 
     pub fn chain(self, stream: RawStream) -> RawStream {
@@ -68,6 +73,7 @@ impl RawStream {
             ctrlc: self.ctrlc,
             is_binary: self.is_binary,
             span: self.span,
+            span_id: self.span_id,
             known_size: self.known_size,
         }
     }

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -1,6 +1,6 @@
+use crate::SpanId;
 use miette::SourceSpan;
 use serde::{Deserialize, Serialize};
-use crate::SpanId;
 
 pub trait GetSpan {
     fn get_span(&self, span_id: SpanId) -> Span;

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -1,5 +1,10 @@
 use miette::SourceSpan;
 use serde::{Deserialize, Serialize};
+use crate::SpanId;
+
+pub trait GetSpan {
+    fn get_span(&self, span_id: SpanId) -> Span;
+}
 
 /// A spanned area of interest, generic over what kind of thing is of interest
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/nu-protocol/src/span.rs
+++ b/crates/nu-protocol/src/span.rs
@@ -11,6 +11,7 @@ pub trait GetSpan {
 pub struct Spanned<T> {
     pub item: T,
     pub span: Span,
+    pub span_id: SpanId,
 }
 
 /// Helper trait to create [`Spanned`] more ergonomically.
@@ -21,17 +22,18 @@ pub trait IntoSpanned: Sized {
     ///
     /// ```
     /// # use nu_protocol::{Span, IntoSpanned};
+    /// # use nu_protocol::engine::UNKNOWN_SPAN_ID;
     /// # let span = Span::test_data();
-    /// let spanned = "Hello, world!".into_spanned(span);
+    /// let spanned = "Hello, world!".into_spanned(span, UNKNOWN_SPAN_ID);
     /// assert_eq!("Hello, world!", spanned.item);
     /// assert_eq!(span, spanned.span);
     /// ```
-    fn into_spanned(self, span: Span) -> Spanned<Self>;
+    fn into_spanned(self, span: Span, span: SpanId) -> Spanned<Self>;
 }
 
 impl<T> IntoSpanned for T {
-    fn into_spanned(self, span: Span) -> Spanned<Self> {
-        Spanned { item: self, span }
+    fn into_spanned(self, span: Span, span_id: SpanId) -> Spanned<Self> {
+        Spanned { item: self, span, span_id }
     }
 }
 

--- a/crates/nu-protocol/src/value/custom_value.rs
+++ b/crates/nu-protocol/src/value/custom_value.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, fmt};
 
-use crate::{ast::Operator, ShellError, Span, Value};
+use crate::{ast::Operator, ShellError, Span, SpanId, Value};
 
 /// Trait definition for a custom [`Value`](crate::Value) type
 #[typetag::serde(tag = "type")]
@@ -22,7 +22,7 @@ pub trait CustomValue: fmt::Debug + Send + Sync {
     ///
     /// This imposes the requirement that you can represent the custom value in some form using the
     /// Value representations that already exist in nushell
-    fn to_base_value(&self, span: Span) -> Result<Value, ShellError>;
+    fn to_base_value(&self, span: Span, span_id: SpanId) -> Result<Value, ShellError>;
 
     /// Any representation used to downcast object to its original type
     fn as_any(&self) -> &dyn std::any::Any;
@@ -31,8 +31,10 @@ pub trait CustomValue: fmt::Debug + Send + Sync {
     fn follow_path_int(
         &self,
         self_span: Span,
+        _self_span_id: SpanId,
         index: usize,
         path_span: Span,
+        _path_span_id: SpanId,
     ) -> Result<Value, ShellError> {
         let _ = (self_span, index);
         Err(ShellError::IncompatiblePathAccess {
@@ -45,8 +47,10 @@ pub trait CustomValue: fmt::Debug + Send + Sync {
     fn follow_path_string(
         &self,
         self_span: Span,
+        self_span_id: SpanId,
         column_name: String,
         path_span: Span,
+        path_span_id: SpanId,
     ) -> Result<Value, ShellError> {
         let _ = (self_span, column_name);
         Err(ShellError::IncompatiblePathAccess {
@@ -69,8 +73,10 @@ pub trait CustomValue: fmt::Debug + Send + Sync {
     fn operation(
         &self,
         lhs_span: Span,
+        _lhs_span_id: SpanId,
         operator: Operator,
         op: Span,
+        _op_id: SpanId,
         right: &Value,
     ) -> Result<Value, ShellError> {
         let _ = (lhs_span, right);

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -19,10 +19,12 @@ impl FromValue for Value {
 impl FromValue for Spanned<i64> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
-            Value::Int { val, .. } => Ok(Spanned { item: val, span }),
-            Value::Filesize { val, .. } => Ok(Spanned { item: val, span }),
-            Value::Duration { val, .. } => Ok(Spanned { item: val, span }),
+            Value::Int { val, .. } => Ok(Spanned { item: val, span, span_id }),
+            Value::Filesize { val, .. } => Ok(Spanned { item: val, span, span_id }),
+            Value::Duration { val, .. } => Ok(Spanned { item: val, span, span_id }),
 
             v => Err(ShellError::CantConvert {
                 to_type: "int".into(),
@@ -54,12 +56,15 @@ impl FromValue for i64 {
 impl FromValue for Spanned<f64> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
             Value::Int { val, .. } => Ok(Spanned {
                 item: val as f64,
                 span,
+                span_id,
             }),
-            Value::Float { val, .. } => Ok(Spanned { item: val, span }),
+            Value::Float { val, .. } => Ok(Spanned { item: val, span, span_id }),
 
             v => Err(ShellError::CantConvert {
                 to_type: "float".into(),
@@ -89,6 +94,8 @@ impl FromValue for f64 {
 impl FromValue for Spanned<usize> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
             Value::Int { val, .. } => {
                 if val.is_negative() {
@@ -97,6 +104,7 @@ impl FromValue for Spanned<usize> {
                     Ok(Spanned {
                         item: val as usize,
                         span,
+                        span_id,
                     })
                 }
             }
@@ -107,6 +115,7 @@ impl FromValue for Spanned<usize> {
                     Ok(Spanned {
                         item: val as usize,
                         span,
+                        span_id,
                     })
                 }
             }
@@ -117,6 +126,7 @@ impl FromValue for Spanned<usize> {
                     Ok(Spanned {
                         item: val as usize,
                         span,
+                        span_id,
                     })
                 }
             }
@@ -134,6 +144,8 @@ impl FromValue for Spanned<usize> {
 impl FromValue for usize {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
             Value::Int { val, .. } => {
                 if val.is_negative() {
@@ -186,6 +198,8 @@ impl FromValue for String {
 impl FromValue for Spanned<String> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         Ok(Spanned {
             item: match v {
                 Value::CellPath { val, .. } => val.to_string(),
@@ -200,6 +214,7 @@ impl FromValue for Spanned<String> {
                 }
             },
             span,
+            span_id,
         })
     }
 }
@@ -234,6 +249,8 @@ impl FromValue for NuGlob {
 impl FromValue for Spanned<NuGlob> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         Ok(Spanned {
             item: match v {
                 Value::CellPath { val, .. } => NuGlob::Expand(val.to_string()),
@@ -259,6 +276,7 @@ impl FromValue for Spanned<NuGlob> {
                 }
             },
             span,
+            span_id,
         })
     }
 }
@@ -297,10 +315,13 @@ impl FromValue for Vec<Spanned<String>> {
                 .into_iter()
                 .map(|val| {
                     let val_span = val.span();
+                    let val_span_id = val.span_id();
+
                     match val {
                         Value::String { val, .. } => Ok(Spanned {
                             item: val,
                             span: val_span,
+                            span_id: val_span_id,
                         }),
                         c => Err(ShellError::CantConvert {
                             to_type: "string".into(),
@@ -349,6 +370,8 @@ impl FromValue for Vec<bool> {
 impl FromValue for CellPath {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
             Value::CellPath { val, .. } => Ok(val),
             Value::String { val, .. } => Ok(CellPath {
@@ -398,8 +421,10 @@ impl FromValue for bool {
 impl FromValue for Spanned<bool> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
-            Value::Bool { val, .. } => Ok(Spanned { item: val, span }),
+            Value::Bool { val, .. } => Ok(Spanned { item: val, span, span_id}),
             v => Err(ShellError::CantConvert {
                 to_type: "bool".into(),
                 from_type: v.get_type().to_string(),
@@ -427,8 +452,10 @@ impl FromValue for DateTime<FixedOffset> {
 impl FromValue for Spanned<DateTime<FixedOffset>> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
-            Value::Date { val, .. } => Ok(Spanned { item: val, span }),
+            Value::Date { val, .. } => Ok(Spanned { item: val, span, span_id}),
             v => Err(ShellError::CantConvert {
                 to_type: "date".into(),
                 from_type: v.get_type().to_string(),
@@ -456,8 +483,10 @@ impl FromValue for Range {
 impl FromValue for Spanned<Range> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
-            Value::Range { val, .. } => Ok(Spanned { item: *val, span }),
+            Value::Range { val, .. } => Ok(Spanned { item: *val, span, span_id}),
             v => Err(ShellError::CantConvert {
                 to_type: "range".into(),
                 from_type: v.get_type().to_string(),
@@ -486,11 +515,14 @@ impl FromValue for Vec<u8> {
 impl FromValue for Spanned<Vec<u8>> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
-            Value::Binary { val, .. } => Ok(Spanned { item: val, span }),
+            Value::Binary { val, .. } => Ok(Spanned { item: val, span, span_id}),
             Value::String { val, .. } => Ok(Spanned {
                 item: val.into_bytes(),
                 span,
+                span_id
             }),
             v => Err(ShellError::CantConvert {
                 to_type: "binary data".into(),
@@ -505,10 +537,13 @@ impl FromValue for Spanned<Vec<u8>> {
 impl FromValue for Spanned<PathBuf> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
             Value::String { val, .. } => Ok(Spanned {
                 item: val.into(),
                 span,
+                span_id,
             }),
             v => Err(ShellError::CantConvert {
                 to_type: "range".into(),
@@ -584,8 +619,10 @@ impl FromValue for Block {
 impl FromValue for Spanned<Closure> {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         let span = v.span();
+        let span_id = v.span_id();
+
         match v {
-            Value::Closure { val, .. } => Ok(Spanned { item: val, span }),
+            Value::Closure { val, .. } => Ok(Spanned { item: val, span , span_id}),
             v => Err(ShellError::CantConvert {
                 to_type: "Closure".into(),
                 from_type: v.get_type().to_string(),

--- a/crates/nu_plugin_custom_values/src/cool_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/cool_custom_value.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{ast, CustomValue, ShellError, Span, Value};
+use nu_protocol::{ast, CustomValue, ShellError, Span, SpanId, Value};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
@@ -53,7 +53,7 @@ impl CustomValue for CoolCustomValue {
         self.typetag_name().to_string()
     }
 
-    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+    fn to_base_value(&self, span: Span, _span_id: SpanId) -> Result<Value, ShellError> {
         Ok(Value::string(
             format!("I used to be a custom value! My data was ({})", self.cool),
             span,
@@ -63,8 +63,10 @@ impl CustomValue for CoolCustomValue {
     fn follow_path_int(
         &self,
         _self_span: Span,
+        _self_span_id: SpanId,
         index: usize,
         path_span: Span,
+        _path_span_id: SpanId,
     ) -> Result<Value, ShellError> {
         if index == 0 {
             Ok(Value::string(&self.cool, path_span))
@@ -79,8 +81,10 @@ impl CustomValue for CoolCustomValue {
     fn follow_path_string(
         &self,
         self_span: Span,
+        _self_span_id: SpanId,
         column_name: String,
         path_span: Span,
+        _path_span_id: SpanId,
     ) -> Result<Value, ShellError> {
         if column_name == "cool" {
             Ok(Value::string(&self.cool, path_span))
@@ -106,8 +110,10 @@ impl CustomValue for CoolCustomValue {
     fn operation(
         &self,
         lhs_span: Span,
+        _lhs_span_id: SpanId,
         operator: ast::Operator,
         op_span: Span,
+        _op_span_id: SpanId,
         right: &Value,
     ) -> Result<Value, ShellError> {
         match operator {

--- a/crates/nu_plugin_custom_values/src/drop_check.rs
+++ b/crates/nu_plugin_custom_values/src/drop_check.rs
@@ -1,8 +1,6 @@
 use crate::CustomValuePlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, SimplePluginCommand};
-use nu_protocol::{
-    record, Category, CustomValue, LabeledError, ShellError, Signature, Span, SyntaxShape, Value,
-};
+use nu_protocol::{record, Category, CustomValue, LabeledError, ShellError, Signature, Span, SyntaxShape, Value, SpanId};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -34,7 +32,7 @@ impl CustomValue for DropCheckValue {
         "DropCheckValue".into()
     }
 
-    fn to_base_value(&self, span: Span) -> Result<Value, ShellError> {
+    fn to_base_value(&self, span: Span, span_id: SpanId) -> Result<Value, ShellError> {
         Ok(Value::record(
             record! {
                 "msg" => Value::string(&self.msg, span)

--- a/crates/nu_plugin_custom_values/src/second_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/second_custom_value.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use nu_protocol::{CustomValue, ShellError, Span, Value};
+use nu_protocol::{CustomValue, ShellError, Span, SpanId, Value};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -51,7 +51,7 @@ impl CustomValue for SecondCustomValue {
         self.typetag_name().to_string()
     }
 
-    fn to_base_value(&self, span: nu_protocol::Span) -> Result<Value, ShellError> {
+    fn to_base_value(&self, span: nu_protocol::Span, span_id: SpanId) -> Result<Value, ShellError> {
         Ok(Value::string(
             format!(
                 "I used to be a DIFFERENT custom value! ({})",

--- a/crates/nu_plugin_example/src/commands/collect_external.rs
+++ b/crates/nu_plugin_example/src/commands/collect_external.rs
@@ -55,10 +55,11 @@ impl PluginCommand for CollectExternal {
                 .map(|bin| bin.to_vec())
         });
         Ok(PipelineData::ExternalStream {
-            stdout: Some(RawStream::new(Box::new(stream), None, call.head, None)),
+            stdout: Some(RawStream::new(Box::new(stream), None, call.head, call.head_id, None)),
             stderr: None,
             exit_code: None,
             span: call.head,
+            span_id: call.head_id,
             metadata: None,
             trim_end_newline: false,
         })

--- a/crates/nu_plugin_gstat/src/gstat.rs
+++ b/crates/nu_plugin_gstat/src/gstat.rs
@@ -1,5 +1,5 @@
 use git2::{Branch, BranchType, DescribeOptions, Repository};
-use nu_protocol::{record, IntoSpanned, LabeledError, Span, Spanned, Value};
+use nu_protocol::{record, IntoSpanned, LabeledError, Span, Spanned, Value, SpanId};
 use std::{fmt::Write, ops::BitAnd, path::Path};
 
 // git status
@@ -26,6 +26,7 @@ impl GStat {
         current_dir: &str,
         path: Option<Spanned<String>>,
         span: Span,
+        span_id: SpanId,
     ) -> Result<Value, LabeledError> {
         // use std::any::Any;
         // eprintln!("input type: {:?} value: {:#?}", &value.type_id(), &value);
@@ -36,9 +37,9 @@ impl GStat {
             Some(path) => path,
             None => {
                 if !value.is_nothing() {
-                    value.coerce_string()?.into_spanned(value.span())
+                    value.coerce_string()?.into_spanned(value.span(), value.span_id())
                 } else {
-                    String::from(".").into_spanned(span)
+                    String::from(".").into_spanned(span, span_id)
                 }
             }
         };

--- a/crates/nu_plugin_gstat/src/nu/mod.rs
+++ b/crates/nu_plugin_gstat/src/nu/mod.rs
@@ -37,6 +37,6 @@ impl SimplePluginCommand for GStat {
         let repo_path: Option<Spanned<String>> = call.opt(0)?;
         // eprintln!("input value: {:#?}", &input);
         let current_dir = engine.get_current_dir()?;
-        self.gstat(input, &current_dir, repo_path, call.head)
+        self.gstat(input, &current_dir, repo_path, call.head, call.head_id)
     }
 }

--- a/crates/nu_plugin_query/src/query_xml.rs
+++ b/crates/nu_plugin_query/src/query_xml.rs
@@ -93,7 +93,7 @@ pub fn execute_xpath_query(
                     }
                 }
                 sxd_xpath::Value::Boolean(b) => {
-                    record.push(key, Value::bool(b, call.head));
+                    record.push(key, Value::bool(b, call.head_id));
                 }
                 sxd_xpath::Value::Number(n) => {
                     record.push(key, Value::float(n, call.head));
@@ -133,11 +133,13 @@ mod tests {
     use super::execute_xpath_query as query;
     use nu_plugin::EvaluatedCall;
     use nu_protocol::{record, Span, Spanned, Value};
+    use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
     #[test]
     fn position_function_in_predicate() {
         let call = EvaluatedCall {
             head: Span::test_data(),
+            head_id: UNKNOWN_SPAN_ID,
             positional: vec![],
             named: vec![],
         };
@@ -150,6 +152,7 @@ mod tests {
         let spanned_str: Spanned<String> = Spanned {
             item: "count(//a/*[position() = 2])".to_string(),
             span: Span::test_data(),
+            span_id: UNKNOWN_SPAN_ID,
         };
 
         let actual = query(&call, &text, Some(spanned_str)).expect("test should not fail");
@@ -167,6 +170,7 @@ mod tests {
     fn functions_implicitly_coerce_argument_types() {
         let call = EvaluatedCall {
             head: Span::test_data(),
+            head_id: UNKNOWN_SPAN_ID,
             positional: vec![],
             named: vec![],
         };
@@ -179,6 +183,7 @@ mod tests {
         let spanned_str: Spanned<String> = Spanned {
             item: "count(//*[contains(., true)])".to_string(),
             span: Span::test_data(),
+            span_id: UNKNOWN_SPAN_ID,
         };
 
         let actual = query(&call, &text, Some(spanned_str)).expect("test should not fail");

--- a/src/command.rs
+++ b/src/command.rs
@@ -110,6 +110,7 @@ pub(crate) fn parse_commandline_args(
             let ide_ast: Option<Spanned<String>> = call.get_named_arg("ide-ast");
 
             fn extract_contents(
+                engine_state: &EngineState,
                 expression: Option<&Expression>,
             ) -> Result<Option<Spanned<String>>, ShellError> {
                 if let Some(expr) = expression {
@@ -117,12 +118,12 @@ pub(crate) fn parse_commandline_args(
                     if let Some(str) = str {
                         Ok(Some(Spanned {
                             item: str,
-                            span: expr.span,
+                            span: expr.get_span(engine_state),
                         }))
                     } else {
                         Err(ShellError::TypeMismatch {
                             err_message: "string".into(),
-                            span: expr.span,
+                            span: expr.get_span(engine_state),
                         })
                     }
                 } else {
@@ -130,16 +131,16 @@ pub(crate) fn parse_commandline_args(
                 }
             }
 
-            let commands = extract_contents(commands)?;
-            let testbin = extract_contents(testbin)?;
+            let commands = extract_contents(engine_state, commands)?;
+            let testbin = extract_contents(engine_state, testbin)?;
             #[cfg(feature = "plugin")]
-            let plugin_file = extract_contents(plugin_file)?;
-            let config_file = extract_contents(config_file)?;
-            let env_file = extract_contents(env_file)?;
-            let log_level = extract_contents(log_level)?;
-            let log_target = extract_contents(log_target)?;
-            let execute = extract_contents(execute)?;
-            let include_path = extract_contents(include_path)?;
+            let plugin_file = extract_contents(engine_state, plugin_file)?;
+            let config_file = extract_contents(engine_state, config_file)?;
+            let env_file = extract_contents(engine_state, env_file)?;
+            let log_level = extract_contents(engine_state, log_level)?;
+            let log_target = extract_contents(engine_state, log_target)?;
+            let execute = extract_contents(engine_state, execute)?;
+            let include_path = extract_contents(engine_state, include_path)?;
 
             let help = call.has_flag(engine_state, &mut stack, "help")?;
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Starting a big refactor that will change Expressions and Values (and possibly other related types) to use Span IDs pointing at an array of spans instead of storing the spans manually.

This should save 8 bytes on every Expression/Value etc. Given how much overhead in Nushell is caused by memory (de)allocation, there is a high chance of positive performance impact.

The main motivation, though, is preparing for the new (WIP!) parser, which uses the array-based approach throughout. After this refactor, it should be much easier to adapt the evaluator to the output of the [new parser](https://github.com/sophiajt/new-nu-parser).

The plan is to finish up this PR before the next release and merge in the calm period after the release to avoid excessive merge conflicts piling up during normal operation.

## TODO:

- [ ] Re-enable `format pattern` 
- [ ] Rename `.get_span()` to `.span()`
- [ ] Remove span from Call
- [ ] Resolve `TODO span_id`
- [ ] Resolve `TODO SPAN`
- [ ] Check if `detect columns` still works

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Hopefully none, except possibly performance improvements.

Temporarily disabled `format pattern` because it was trying to do eval

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
