### PR TITLE
Refactor source cache into `CachedFile` struct

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -94,8 +94,8 @@ fn gather_env_vars(
     let span_offset = engine_state.next_span_start();
 
     engine_state.add_file(
-        "Host Environment Variables".to_string(),
-        fake_env_file.as_bytes().to_vec(),
+        "Host Environment Variables".into(),
+        fake_env_file.as_bytes().into(),
     );
 
     let (tokens, _) = lex(fake_env_file.as_bytes(), span_offset, &[], &[], true);

--- a/crates/nu-command/src/debug/view_files.rs
+++ b/crates/nu-command/src/debug/view_files.rs
@@ -43,13 +43,15 @@ impl Command for ViewFiles {
     ) -> Result<PipelineData, ShellError> {
         let mut records = vec![];
 
-        for (file, start, end) in engine_state.files() {
+        for file in engine_state.files() {
+            let start = file.covered_span.start;
+            let end = file.covered_span.end;
             records.push(Value::record(
                 record! {
-                    "filename" => Value::string(&**file, call.head),
-                    "start" => Value::int(*start as i64, call.head),
-                    "end" => Value::int(*end as i64, call.head),
-                    "size" => Value::int(*end as i64 - *start as i64, call.head),
+                    "filename" => Value::string(&*file.name, call.head),
+                    "start" => Value::int(start as i64, call.head),
+                    "end" => Value::int(end as i64, call.head),
+                    "size" => Value::int(end as i64 - start as i64, call.head),
                 },
                 call.head,
             ));

--- a/crates/nu-protocol/src/engine/cached_file.rs
+++ b/crates/nu-protocol/src/engine/cached_file.rs
@@ -1,0 +1,12 @@
+use crate::Span;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct CachedFile {
+    // Could possibly become an `Arc<PathBuf>`
+    pub name: Arc<str>,
+    // Use Arcs of slice types for more compact representation (capacity less)
+    pub content: Arc<[u8]>,
+    // TODO: when refactoring `Span` to IDs this needs to remain an interval
+    pub covered_span: Span,
+}

--- a/crates/nu-protocol/src/engine/cached_file.rs
+++ b/crates/nu-protocol/src/engine/cached_file.rs
@@ -1,12 +1,15 @@
 use crate::Span;
 use std::sync::Arc;
 
+/// Unit of cached source code
 #[derive(Clone)]
 pub struct CachedFile {
-    // Could possibly become an `Arc<PathBuf>`
-    pub name: Arc<str>,
     // Use Arcs of slice types for more compact representation (capacity less)
+    // Could possibly become an `Arc<PathBuf>`
+    /// The file name with which the code is associated (also includes REPL input)
+    pub name: Arc<str>,
+    /// Source code as raw bytes
     pub content: Arc<[u8]>,
-    // TODO: when refactoring `Span` to IDs this needs to remain an interval
+    /// global span coordinates that are covered by this [`CachedFile`]
     pub covered_span: Span,
 }

--- a/crates/nu-protocol/src/engine/mod.rs
+++ b/crates/nu-protocol/src/engine/mod.rs
@@ -1,3 +1,4 @@
+mod cached_file;
 mod call_info;
 mod capture_block;
 mod command;
@@ -10,6 +11,8 @@ mod state_working_set;
 mod stdio;
 mod usage;
 mod variable;
+
+pub use cached_file::CachedFile;
 
 pub use call_info::*;
 pub use capture_block::*;

--- a/crates/nu-protocol/src/engine/state_delta.rs
+++ b/crates/nu-protocol/src/engine/state_delta.rs
@@ -1,3 +1,4 @@
+use super::cached_file::CachedFile;
 use super::{usage::Usage, Command, EngineState, OverlayFrame, ScopeFrame, Variable, VirtualPath};
 use crate::ast::Block;
 use crate::Module;
@@ -12,8 +13,7 @@ use crate::RegisteredPlugin;
 /// can be applied to the global state to update it to contain both previous state and the state held
 /// within the delta.
 pub struct StateDelta {
-    pub(super) files: Vec<(Arc<String>, usize, usize)>,
-    pub(crate) file_contents: Vec<(Arc<Vec<u8>>, usize, usize)>,
+    pub(super) files: Vec<CachedFile>,
     pub(super) virtual_paths: Vec<(String, VirtualPath)>,
     pub(super) vars: Vec<Variable>,          // indexed by VarId
     pub(super) decls: Vec<Box<dyn Command>>, // indexed by DeclId
@@ -38,7 +38,6 @@ impl StateDelta {
 
         StateDelta {
             files: vec![],
-            file_contents: vec![],
             virtual_paths: vec![],
             vars: vec![],
             decls: vec![],
@@ -131,7 +130,7 @@ impl StateDelta {
         self.scope.pop();
     }
 
-    pub fn get_file_contents(&self) -> &[(Arc<Vec<u8>>, usize, usize)] {
-        &self.file_contents
+    pub fn get_file_contents(&self) -> &[CachedFile] {
+        &self.files
     }
 }

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -301,7 +301,7 @@ impl<'a> StateWorkingSet<'a> {
         self.permanent_state.files().chain(self.delta.files.iter())
     }
 
-    pub fn get_contents_of_file(&self, file_id: usize) -> Option<&[u8]> {
+    pub fn get_contents_of_file(&self, file_id: FileId) -> Option<&[u8]> {
         if let Some(cached_file) = self.permanent_state.get_file_contents().get(file_id) {
             return Some(&cached_file.content);
         }

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -160,14 +160,14 @@ pub fn goto_def(engine_state: &mut EngineState, file_path: &str, location: &Valu
                 let block = working_set.get_block(block_id);
                 if let Some(span) = &block.span {
                     for file in working_set.files() {
-                        if span.start >= file.1 && span.start < file.2 {
+                        if file.covered_span.contains(span.start) {
                             println!(
                                 "{}",
                                 json!(
                                     {
-                                        "file": &**file.0,
-                                        "start": span.start - file.1,
-                                        "end": span.end - file.1
+                                        "file": &*file.name,
+                                        "start": span.start - file.covered_span.start,
+                                        "end": span.end - file.covered_span.start,
                                     }
                                 )
                             );
@@ -180,14 +180,14 @@ pub fn goto_def(engine_state: &mut EngineState, file_path: &str, location: &Valu
         Some((Id::Variable(var_id), ..)) => {
             let var = working_set.get_variable(var_id);
             for file in working_set.files() {
-                if var.declaration_span.start >= file.1 && var.declaration_span.start < file.2 {
+                if file.covered_span.contains(var.declaration_span.start) {
                     println!(
                         "{}",
                         json!(
                             {
-                                "file": &**file.0,
-                                "start": var.declaration_span.start - file.1,
-                                "end": var.declaration_span.end - file.1
+                                "file": &*file.name,
+                                "start": var.declaration_span.start - file.covered_span.start,
+                                "end": var.declaration_span.end - file.covered_span.start,
                             }
                         )
                     );


### PR DESCRIPTION
# Description
Get rid of two parallel `Vec`s in `StateDelta` and `EngineState`, that also duplicated span information. Use a struct with documenting fields.

Also use `Arc<str>` and `Arc<[u8]>` for the allocations as they are never modified and cloned often (see #12229 for the first improvement). This also makes the representation more compact as no capacity is necessary.

# User-Facing Changes
API breakage on `EngineState`/`StateWorkingSet`/`StateDelta` that should not really affect plugin authors.
