### PR TITLE
Fix usage of --tabs flag while converting to json (#12115)

### DIFF
--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -45,7 +45,8 @@ impl Command for ToJson {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let raw = call.has_flag(engine_state, stack, "raw")?;
-        let use_tabs = call.has_flag(engine_state, stack, "tabs")?;
+        let use_tabs = call.get_flag(engine_state, stack, "tabs")?;
+        let indent = call.get_flag(engine_state, stack, "indent")?;
 
         let span = call.head;
         // allow ranges to expand and turn into array
@@ -55,12 +56,12 @@ impl Command for ToJson {
 
         let json_result = if raw {
             nu_json::to_string_raw(&json_value)
-        } else if use_tabs {
-            let tab_count: usize = call.get_flag(engine_state, stack, "tabs")?.unwrap_or(1);
+        } else if let Some(tab_count) = use_tabs {
             nu_json::to_string_with_tab_indentation(&json_value, tab_count)
-        } else {
-            let indent: usize = call.get_flag(engine_state, stack, "indent")?.unwrap_or(2);
+        } else if let Some(indent) = indent {
             nu_json::to_string_with_indent(&json_value, indent)
+        } else {
+            nu_json::to_string(&json_value)
         };
 
         match json_result {

--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -235,3 +235,35 @@ fn inf_in_range_fails() {
     let actual = nu!(r#"-inf..inf | to json"#);
     assert!(actual.err.contains("Cannot create range"));
 }
+
+#[test]
+fn test_indent_flag() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+            r#"
+                echo '{ "a": 1, "b": 2, "c": 3 }'
+                | from json
+                | to json --indent 3
+            "#
+        ));
+
+        let expected_output = "{   \"a\": 1,   \"b\": 2,   \"c\": 3}";
+
+        assert_eq!(actual.out, expected_output);
+}
+
+#[test]
+fn test_tabs_indent_flag() {
+    let actual = nu!(
+        cwd: "tests/fixtures/formats", pipeline(
+            r#"
+                echo '{ "a": 1, "b": 2, "c": 3 }'
+                | from json
+                | to json --tabs 2
+            "#
+        ));
+
+        let expected_output = "{\t\t\"a\": 1,\t\t\"b\": 2,\t\t\"c\": 3}";
+
+        assert_eq!(actual.out, expected_output);
+}


### PR DESCRIPTION
# Description
This fix addresses a bug (#12115 ) where the --tabs flag couldn't be utilized due to improper handling of the tab quantity provided by the user. Previously, the code mistakenly attempted to convert the tab quantity to a boolean value, leading to a conversion error. The resolution involves adjusting the condition clauses to properly validate the presence of the flag's value. Now, the code checks whether the get_flag() function returns a value or None associated with the --tabs flag. This adjustment enables the --tabs flag to function correctly, triggering the appropriate condition and allowing the conversion to proceed as expected. Similarly, the fix applies to the --indent flag. Additionally, a default case was added, and the conversion now works properly without flags. Two tests were added to validate the corrected behavior of these flags.

# User-Facing Changes
Now the conversion should work just fine, instead of displaying a conversion error.

# Tests + Formatting
-🟢 toolkit fmt
-🟢 toolkit clippy
-🟢 toolkit test
-🟢 toolkit test stdlib

To run added tests:
- cargo test --package nu-command --test main -- format_conversions::json::test_tabs_indent_flag
- cargo test --package nu-command --test main -- format_conversions::json::test_indent_flag