### PR TITLE
bump rust-toolchain to 1.75.0

### DIFF
--- a/crates/nu-protocol/src/errors/labeled_error.rs
+++ b/crates/nu-protocol/src/errors/labeled_error.rs
@@ -191,7 +191,7 @@ impl fmt::Display for LabeledError {
 
 impl std::error::Error for LabeledError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.inner.get(0).map(|r| r as _)
+        self.inner.first().map(|r| r as _)
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.74.1"
+channel = "1.75.0"


### PR DESCRIPTION
# Description

With the release of Rust 1.77.0 today we're able to bump the rust-toolchain for nushell to 1.75.0.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
