### PR TITLE
Reorder parameters of `evaluate_{commands,file}` for consistency

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -85,9 +85,9 @@ mod eval_commands {
             .with_inputs(|| engine.clone())
             .bench_values(|mut engine| {
                 evaluate_commands(
-                    &commands,
                     &mut engine,
                     &mut nu_protocol::engine::Stack::new(),
+                    &commands,
                     PipelineData::empty(),
                     None,
                 )
@@ -119,9 +119,9 @@ mod eval_commands {
             .with_inputs(|| engine.clone())
             .bench_values(|mut engine| {
                 evaluate_commands(
-                    &commands,
                     &mut engine,
                     &mut nu_protocol::engine::Stack::new(),
+                    &commands,
                     PipelineData::empty(),
                     None,
                 )

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -12,9 +12,9 @@ use nu_protocol::{
 
 /// Run a command (or commands) given to us by the user
 pub fn evaluate_commands(
-    commands: &Spanned<String>,
     engine_state: &mut EngineState,
     stack: &mut Stack,
+    commands: &Spanned<String>,
     input: PipelineData,
     table_mode: Option<Value>,
 ) -> Result<Option<i64>> {

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -19,10 +19,10 @@ use nu_utils::stdout_write_all_and_flush;
 
 /// Main function used when a file path is found as argument for nu
 pub fn evaluate_file(
-    path: String,
-    args: &[String],
     engine_state: &mut EngineState,
     stack: &mut Stack,
+    path: String,
+    args: &[String],
     input: PipelineData,
 ) -> Result<()> {
     // Translate environment variables from Strings to Values

--- a/src/run.rs
+++ b/src/run.rs
@@ -112,9 +112,9 @@ pub(crate) fn run_commands(
 
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_commands(
-        commands,
         engine_state,
         &mut stack,
+        commands,
         input,
         parsed_nu_cli_args.table_mode,
     );
@@ -201,10 +201,10 @@ pub(crate) fn run_file(
 
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_file(
-        script_name,
-        &args_to_script,
         engine_state,
         &mut stack,
+        script_name,
+        &args_to_script,
         input,
     );
     perf(


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Reorder parameters of `evaluate_commands` and `evaluate_file`, so that `engine_state` is always the first parameter.