### PR TITLE
Move more dependencies to workspace level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3077,7 +3077,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "typetag",
- "windows 0.52.0",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -5984,9 +5984,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uu_cp"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8e090cfcfa51cb224d247e05938d25718a7203c6f8c0f0de7b3b031d99dcea"
+checksum = "927869e2df48ac2f09ebc083459e96efc97028863a41dce96cfe8164c5c722ba"
 dependencies = [
  "clap",
  "filetime",
@@ -6000,9 +6000,9 @@ dependencies = [
 
 [[package]]
 name = "uu_mkdir"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbf657c9e738d16ebc5c161a611ff25327c1fb599645afb2831062efb23c851"
+checksum = "9d303b73c3a1ede83101c4a01c7f2f72f000ec9241a5d788ceba6a91a9ce1cb3"
 dependencies = [
  "clap",
  "uucore",
@@ -6010,9 +6010,9 @@ dependencies = [
 
 [[package]]
 name = "uu_mktemp"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154531208d9ec160629bf9545a56ad9df38e964e547e0a17ee9d75aeec9831cb"
+checksum = "c7e25b0928c96297836d3400c049d7c772073d0534720e4d13dd0e4a6ed52349"
 dependencies = [
  "clap",
  "rand",
@@ -6022,9 +6022,9 @@ dependencies = [
 
 [[package]]
 name = "uu_mv"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e307e61d34d2e1dba0659ef443ada8340ec3b788bd6c8fc7fdfe0e02c6b4cfc"
+checksum = "8ec472139edb0e91d9706779bfdf45814b139d8b23bea2ad0feaaac1fb6c1523"
 dependencies = [
  "clap",
  "fs_extra",
@@ -6034,9 +6034,9 @@ dependencies = [
 
 [[package]]
 name = "uu_whoami"
-version = "0.0.23"
+version = "0.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70589dc3b41f34cbfe1fb22b8f20fcac233fa4565409905f12dd06780b18374d"
+checksum = "521f16cb67ba9f55341e00cd6b806556cefef430e9d80ea425607628da3a40e5"
 dependencies = [
  "clap",
  "libc",
@@ -6062,6 +6062,7 @@ dependencies = [
  "wild",
  "winapi-util",
  "windows-sys 0.48.0",
+ "xattr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,25 +55,110 @@ members = [
 ]
 
 [workspace.dependencies]
+alphanumeric-sort = "1.5"
+ansi-str = "0.8"
+base64 = "0.22"
+bracoxide = "0.1.2"
+byteorder = "1.5"
+bytesize = "1.3"
+calamine = "0.24.0"
+chardetng = "0.1.17"
 chrono = { default-features = false, version = "0.4" }
+chrono-humanize = "0.2.3"
+chrono-tz = "0.8"
+crossbeam-channel = "0.5.8"
 crossterm = "0.27"
+csv = "1.3"
 ctrlc = "3.4"
+dialoguer = { default-features = false, version = "0.11" }
+digest = { default-features = false, version = "0.10" }
+dirs-next = "2.0"
+dtparse = "2.0"
+encoding_rs = "0.8"
 fancy-regex = "0.13"
+filesize = "0.2"
+filetime = "0.2"
+fs_extra = "1.3"
+fuzzy-matcher = "0.3"
+hamcrest2 = "0.3"
+heck = "0.5.0"
+human-date-parser = "0.1.1"
+indexmap = "2.2"
+indicatif = "0.17"
+is_executable = "1.0"
+itertools = "0.12"
+libc = "0.2"
+libproc = "0.14"
 log = "0.4"
+lru = "0.12"
+lscolors = { version = "0.17", default-features = false }
+lsp-server = "0.7.5"
+lsp-types = "0.95.0"
+mach2 = "0.4"
+md5 = { version = "0.10", package = "md-5"}
 miette = "7.2"
+mime = "0.3"
+mime_guess = "2.0"
+mockito = { version = "1.4", default-features = false }
+native-tls = "0.2"
 nix = { version = "0.27", default-features = false }
+notify-debouncer-full = { version = "0.3", default-features = false }
 nu-ansi-term = "0.50.0"
+num-format = "0.4"
+num-traits = "0.2"
+omnipath = "0.1"
 once_cell = "1.18"
+open = "5.1"
+os_pipe = "1.1"
 pathdiff = "0.2"
 percent-encoding = "2"
+print-positions = "0.6"
+procfs = "0.16.0"
+pwd = "1.3"
+quick-xml = "0.31.0"
+quickcheck = "1.0"
+quickcheck_macros = "1.0"
+rand = "0.8"
+ratatui = "0.26"
+rayon = "1.9"
 reedline = "0.30.0"
+regex = "1.9.5"
+ropey = "1.6.1"
+roxmltree = "0.19"
 rstest = { version = "0.18", default-features = false }
+rusqlite = "0.31"
+rust-embed = "8.2.0"
+same-file = "1.0"
+serde = { version = "1.0", default-features = false }
 serde_json = "1.0"
+serde_urlencoded = "0.7.1"
+serde_yaml = "0.9"
+sha2 = "0.10"
+strip-ansi-escapes = "0.2.0"
 sysinfo = "0.30"
+tabled = { version = "0.14.0", default-features = false }
 tempfile = "3.10"
+terminal_size = "0.3"
+titlecase = "2.0"
+toml = "0.8"
+trash = "3.3"
+umask = "2.1"
 unicode-segmentation = "1.11"
+unicode-width = "0.1"
+ureq = { version = "2.9", default-features = false }
+url = "2.2"
+uu_cp = "0.0.24"
+uu_mkdir = "0.0.24"
+uu_mktemp = "0.0.24"
+uu_mv = "0.0.24"
+uu_whoami = "0.0.24"
+uucore = "0.0.24"
 uuid = "1.8.0"
+v_htmlescape = "0.15.0"
+wax = "0.6"
 which = "6.0.0"
+windows = "0.54"
+winreg = "0.52"
 
 [dependencies]
 nu-cli = { path = "./crates/nu-cli", version = "0.91.1" }
@@ -123,7 +208,7 @@ nix = { workspace = true, default-features = false, features = [
 [dev-dependencies]
 nu-test-support = { path = "./crates/nu-test-support", version = "0.91.1" }
 assert_cmd = "2.0"
-dirs-next = "2.0"
+dirs-next = { workspace = true }
 divan = "0.1.14"
 pretty_assertions = "1.4"
 rstest = { workspace = true, default-features = false }

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -30,11 +30,11 @@ reedline = { workspace = true, features = ["bashisms", "sqlite"] }
 chrono = { default-features = false, features = ["std"], workspace = true }
 crossterm = { workspace = true }
 fancy-regex = { workspace = true }
-fuzzy-matcher = "0.3"
-is_executable = "1.0"
+fuzzy-matcher = { workspace = true }
+is_executable = { workspace = true }
 log = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
-lscolors = { version = "0.17", default-features = false, features = ["nu-ansi-term"] }
+lscolors = { workspace = true, default-features = false, features = ["nu-ansi-term"] }
 once_cell = { workspace = true }
 percent-encoding = { workspace = true }
 pathdiff = { workspace = true }

--- a/crates/nu-cmd-base/Cargo.toml
+++ b/crates/nu-cmd-base/Cargo.toml
@@ -15,7 +15,7 @@ nu-parser = { path = "../nu-parser", version = "0.91.1" }
 nu-path = { path = "../nu-path", version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
-indexmap = "2.2"
+indexmap = { workspace = true }
 miette = { workspace = true }
 
 [dev-dependencies]

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -19,11 +19,11 @@ nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
 # Potential dependencies for extras
 chrono = { workspace = true, features = ["std", "unstable-locales"], default-features = false }
-chrono-tz = "0.8"
+chrono-tz = { workspace = true }
 fancy-regex = { workspace = true }
-indexmap = { version = "2.2" }
+indexmap = { workspace = true }
 num = { version = "0.4", optional = true }
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 sqlparser = { version = "0.43", optional = true }
 polars-io = { version = "0.37", features = ["avro"], optional = true }
 polars-arrow = { version = "0.37", optional = true }

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -13,24 +13,24 @@ version = "0.91.1"
 bench = false
 
 [dependencies]
-nu-engine = { path = "../nu-engine", version = "0.91.1" }
-nu-parser = { path = "../nu-parser", version = "0.91.1" }
-nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 nu-cmd-base = { path = "../nu-cmd-base", version = "0.91.1" }
+nu-engine = { path = "../nu-engine", version = "0.91.1" }
+nu-json = { version = "0.91.1", path = "../nu-json" }
+nu-parser = { path = "../nu-parser", version = "0.91.1" }
+nu-pretty-hex = { version = "0.91.1", path = "../nu-pretty-hex" }
+nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 
 # Potential dependencies for extras
-heck = "0.5.0"
-num-traits = "0.2"
+heck = { workspace = true }
+num-traits = { workspace = true }
 nu-ansi-term = { workspace = true }
 fancy-regex = { workspace = true }
-rust-embed = "8.2.0"
-serde = "1.0.164"
-nu-pretty-hex = { version = "0.91.1", path = "../nu-pretty-hex" }
-nu-json = { version = "0.91.1", path = "../nu-json" }
-serde_urlencoded = "0.7.1"
-v_htmlescape = "0.15.0"
-itertools = "0.12"
+rust-embed = { workspace = true }
+serde = { workspace = true }
+serde_urlencoded = { workspace = true }
+v_htmlescape = { workspace = true }
+itertools = { workspace = true }
 
 [features]
 extra = ["default"]

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -17,7 +17,7 @@ nu-parser = { path = "../nu-parser", version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 
-itertools = "0.12"
+itertools = { workspace = true }
 shadow-rs = { version = "0.26", default-features = false }
 
 [build-dependencies]

--- a/crates/nu-color-config/Cargo.toml
+++ b/crates/nu-color-config/Cargo.toml
@@ -16,7 +16,7 @@ nu-engine = { path = "../nu-engine", version = "0.91.1" }
 nu-json = { path = "../nu-json", version = "0.91.1" }
 nu-ansi-term = { workspace = true }
 
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 nu-test-support = { path = "../nu-test-support", version = "0.91.1" }

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -28,92 +28,92 @@ nu-term-grid = { path = "../nu-term-grid", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 nu-ansi-term = { workspace = true }
 
-alphanumeric-sort = "1.5"
-base64 = "0.22"
-byteorder = "1.5"
-bytesize = "1.3"
-calamine = { version = "0.24.0", features = ["dates"] }
+alphanumeric-sort = { workspace = true }
+base64 = { workspace = true }
+bracoxide = { workspace = true }
+byteorder = { workspace = true }
+bytesize = { workspace = true }
+calamine = { workspace = true, features = ["dates"] }
+chardetng = { workspace = true }
 chrono = { workspace = true, features = ["std", "unstable-locales", "clock"], default-features = false }
-chrono-humanize = "0.2.3"
-chrono-tz = "0.8"
+chrono-humanize = { workspace = true }
+chrono-tz = { workspace = true }
 crossterm = { workspace = true }
-csv = "1.3"
-dialoguer = { default-features = false, features = ["fuzzy-select"], version = "0.11" }
-digest = { default-features = false, version = "0.10" }
-dtparse = "2.0"
-encoding_rs = "0.8"
+csv = { workspace = true }
+dialoguer = { workspace = true, default-features = false, features = ["fuzzy-select"] }
+digest = { workspace = true, default-features = false }
+dtparse = { workspace = true }
+encoding_rs = { workspace = true }
 fancy-regex = { workspace = true }
-filesize = "0.2"
-filetime = "0.2"
-fs_extra = "1.3"
-human-date-parser = "0.1.1"
-indexmap = "2.2"
-indicatif = "0.17"
-itertools = "0.12"
-lscolors = { version = "0.17", default-features = false, features = ["nu-ansi-term"] }
+filesize = { workspace = true }
+filetime = { workspace = true }
+fs_extra = { workspace =  true }
+human-date-parser = { workspace = true }
+indexmap = { workspace = true }
+indicatif = { workspace = true }
+itertools = { workspace = true }
 log = { workspace = true }
-md5 = { package = "md-5", version = "0.10" }
-mime = "0.3"
-mime_guess = "2.0"
-native-tls = "0.2"
-notify-debouncer-full = { version = "0.3", default-features = false }
-num-format = { version = "0.4" }
-num-traits = "0.2"
-open = "5.1"
+lscolors = { workspace = true, default-features = false, features = ["nu-ansi-term"] }
+md5 = { workspace = true }
+mime = { workspace = true }
+mime_guess = { workspace = true }
+native-tls = { workspace = true }
+notify-debouncer-full = { workspace = true, default-features = false }
+num-format = { workspace = true }
+num-traits = { workspace = true }
 once_cell = { workspace = true }
-os_pipe = "1.1"
+open = { workspace = true }
+os_pipe = { workspace = true }
 pathdiff = { workspace = true }
 percent-encoding = { workspace = true }
-print-positions = "0.6"
-quick-xml = "0.31.0"
-rand = "0.8"
-rayon = "1.9"
-regex = "1.9.5"
-roxmltree = "0.19"
-rusqlite = { version = "0.31", features = ["bundled", "backup", "chrono"], optional = true }
-same-file = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+print-positions = { workspace = true }
+quick-xml = { workspace = true }
+rand = { workspace = true }
+rayon = { workspace = true }
+regex = { workspace = true }
+roxmltree = { workspace = true }
+rusqlite = { workspace = true, features = ["bundled", "backup", "chrono"], optional = true }
+same-file = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
-serde_urlencoded = "0.7"
-serde_yaml = "0.9"
-sha2 = "0.10"
+serde_urlencoded = { workspace = true }
+serde_yaml = { workspace = true }
+sha2 = { workspace = true }
 sysinfo = { workspace = true }
-tabled = { version = "0.14.0", features = ["color"], default-features = false }
-terminal_size = "0.3"
-titlecase = "2.0"
-toml = "0.8"
+tabled = { workspace = true, features = ["color"], default-features = false }
+terminal_size = { workspace = true }
+titlecase = { workspace = true }
+toml = { workspace = true }
 unicode-segmentation = { workspace = true }
-ureq = { version = "2.9", default-features = false, features = ["charset", "gzip", "json", "native-tls"] }
-url = "2.2"
-uu_mv = "0.0.23"
-uu_cp = "0.0.23"
-uu_whoami = "0.0.23"
-uu_mkdir = "0.0.23"
-uu_mktemp = "0.0.23"
+ureq = { workspace = true, default-features = false, features = ["charset", "gzip", "json", "native-tls"] }
+url = { workspace = true }
+uu_cp = { workspace = true }
+uu_mkdir = { workspace = true }
+uu_mktemp = { workspace = true }
+uu_mv = { workspace = true }
+uu_whoami = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-v_htmlescape = "0.15.0"
-wax = { version = "0.6" }
+v_htmlescape = { workspace = true }
+wax = { workspace = true }
 which = { workspace = true, optional = true }
-bracoxide = "0.1.2"
-chardetng = "0.1.17"
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.52"
+winreg = { workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]
-uucore = { version = "0.0.24", features = ["mode"] }
+uucore = { workspace = true, features = ["mode"] }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
-umask = "2.1"
+libc = { workspace = true }
+umask = { workspace = true }
 nix = { workspace = true, default-features = false, features = ["user", "resource"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-procfs = "0.16.0"
+procfs = { workspace = true }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies.trash]
 optional = true
-version = "3.3"
+workspace = true
 
 [target.'cfg(windows)'.dependencies.windows]
 features = [
@@ -124,7 +124,7 @@ features = [
 	"Win32_Security",
 	"Win32_System_Threading",
 ]
-version = "0.54"
+workspace = true
 
 [features]
 plugin = ["nu-parser/plugin"]
@@ -136,8 +136,8 @@ which-support = ["which"]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.91.1" }
 nu-test-support = { path = "../nu-test-support", version = "0.91.1" }
 
-dirs-next = "2.0"
-mockito = { version = "1.4", default-features = false }
-quickcheck = "1.0"
-quickcheck_macros = "1.0"
+dirs-next = { workspace = true }
+mockito = { workspace = true, default-features = false }
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
 rstest = { workspace = true, default-features = false }

--- a/crates/nu-explore/Cargo.toml
+++ b/crates/nu-explore/Cargo.toml
@@ -21,12 +21,12 @@ nu-utils = { path = "../nu-utils", version = "0.91.1" }
 nu-ansi-term = { workspace = true }
 nu-pretty-hex = { path = "../nu-pretty-hex", version = "0.91.1" }
 
-terminal_size = "0.3"
-strip-ansi-escapes = "0.2.0"
+terminal_size = { workspace = true }
+strip-ansi-escapes = { workspace = true }
 crossterm = { workspace = true }
-ratatui = "0.26"
-ansi-str = "0.8"
-unicode-width = "0.1"
-lscolors = { version = "0.17", default-features = false, features = [
+ratatui = { workspace = true }
+ansi-str = { workspace = true }
+unicode-width = { workspace = true }
+lscolors = { workspace = true, default-features = false, features = [
   "nu-ansi-term",
 ] }

--- a/crates/nu-json/Cargo.toml
+++ b/crates/nu-json/Cargo.toml
@@ -18,9 +18,9 @@ default = ["preserve_order"]
 
 [dependencies]
 linked-hash-map = { version = "0.5", optional = true }
-num-traits = "0.2"
-serde = "1.0"
-serde_json = "1.0.114"
+num-traits = { workspace = true }
+serde = { workspace =  true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 # nu-path = { path="../nu-path", version = "0.91.1" }

--- a/crates/nu-lsp/Cargo.toml
+++ b/crates/nu-lsp/Cargo.toml
@@ -14,12 +14,12 @@ nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
 reedline = { workspace = true }
 
-crossbeam-channel = "0.5.8"
-lsp-types = "0.95.0"
-lsp-server = "0.7.5"
+crossbeam-channel = { workspace = true }
+lsp-types = { workspace = true }
+lsp-server = { workspace = true }
 miette = { workspace = true }
-ropey = "1.6.1"
-serde = "1.0"
+ropey = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/nu-parser/Cargo.toml
+++ b/crates/nu-parser/Cargo.toml
@@ -17,9 +17,9 @@ nu-path = { path = "../nu-path", version = "0.91.1" }
 nu-plugin = { path = "../nu-plugin", optional = true, version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
-bytesize = "1.3"
+bytesize = { workspace = true }
 chrono = { default-features = false, features = ['std'], workspace = true }
-itertools = "0.12"
+itertools = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/nu-path/Cargo.toml
+++ b/crates/nu-path/Cargo.toml
@@ -12,10 +12,10 @@ exclude = ["/fuzz"]
 bench = false
 
 [dependencies]
-dirs-next = "2.0"
+dirs-next = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-omnipath = "0.1"
+omnipath = { workspace = true }
 
 [target.'cfg(all(unix, not(target_os = "macos"), not(target_os = "android")))'.dependencies]
-pwd = "1.3"
+pwd = { workspace = true }

--- a/crates/nu-plugin/Cargo.toml
+++ b/crates/nu-plugin/Cargo.toml
@@ -16,7 +16,7 @@ nu-protocol = { path = "../nu-protocol", version = "0.91.1" }
 
 bincode = "1.3"
 rmp-serde = "1.1"
-serde = "1.0"
+serde = { workspace = true }
 serde_json = { workspace = true }
 log = "0.4"
 miette = { workspace = true }
@@ -25,7 +25,7 @@ typetag = "0.2"
 thiserror = "1.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.52", features = [
+windows = { workspace = true, features = [
   # For setting process creation flags
   "Win32_System_Threading",
 ] }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -19,13 +19,13 @@ nu-system = { path = "../nu-system", version = "0.91.1" }
 
 byte-unit = { version = "5.1", features = [ "serde" ] }
 chrono = { workspace = true, features = [ "serde", "std", "unstable-locales" ], default-features = false }
-chrono-humanize = "0.2"
+chrono-humanize = { workspace = true }
 fancy-regex = { workspace = true }
-indexmap = "2.2"
-lru = "0.12"
+indexmap = { workspace = true }
+lru = { workspace = true }
 miette = { workspace = true, features = ["fancy-no-backtrace"] }
-num-format = "0.4"
-serde = { version = "1.0", default-features = false }
+num-format = { workspace = true }
+serde = { workspace = true, default-features = false }
 serde_json = { workspace = true, optional = true }
 thiserror = "1.0"
 typetag = "0.2"

--- a/crates/nu-system/Cargo.toml
+++ b/crates/nu-system/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 bench = false
 
 [dependencies]
-libc = "0.2"
+libc = { workspace = true }
 log = { workspace = true }
 sysinfo = { workspace = true }
 
@@ -21,17 +21,17 @@ sysinfo = { workspace = true }
 nix = { workspace = true, default-features = false, features = ["fs", "term", "process", "signal"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
-procfs = "0.16"
+procfs = { workspace = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-libproc = "0.14"
-mach2 = "0.4"
+libproc = { workspace = true }
+mach2 = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 chrono = { workspace = true, default-features = false, features = ["clock"] }
 ntapi = "0.4"
 once_cell = { workspace = true }
-windows = { version = "0.54", features = [
+windows = { workspace = true, features = [
   "Wdk_System_SystemServices",
   "Wdk_System_Threading",
   "Win32_Foundation",

--- a/crates/nu-table/Cargo.toml
+++ b/crates/nu-table/Cargo.toml
@@ -18,7 +18,7 @@ nu-color-config = { path = "../nu-color-config", version = "0.91.1" }
 nu-ansi-term = { workspace = true }
 once_cell = { workspace = true }
 fancy-regex = { workspace = true }
-tabled = { version = "0.14.0", features = ["color"], default-features = false }
+tabled = { workspace = true, features = ["color"], default-features = false }
 
 [dev-dependencies]
 # nu-test-support = { path="../nu-test-support", version = "0.91.1"  }

--- a/crates/nu-term-grid/Cargo.toml
+++ b/crates/nu-term-grid/Cargo.toml
@@ -13,4 +13,4 @@ bench = false
 [dependencies]
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 
-unicode-width = "0.1"
+unicode-width = { workspace = true }

--- a/crates/nu-test-support/Cargo.toml
+++ b/crates/nu-test-support/Cargo.toml
@@ -16,6 +16,6 @@ nu-path = { path = "../nu-path", version = "0.91.1" }
 nu-glob = { path = "../nu-glob", version = "0.91.1" }
 nu-utils = { path = "../nu-utils", version = "0.91.1" }
 
-num-format = "0.4"
+num-format = { workspace = true }
 which = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -17,10 +17,10 @@ bench = false
 bench = false
 
 [dependencies]
-lscolors = { version = "0.17", default-features = false, features = ["nu-ansi-term"] }
+lscolors = { workspace = true, default-features = false, features = ["nu-ansi-term"] }
 log = { workspace = true }
-num-format = { version = "0.4" }
-strip-ansi-escapes = "0.2.0"
+num-format = { workspace = true }
+strip-ansi-escapes = { workspace = true }
 sys-locale = "0.3"
 unicase = "2.7.0"
 

--- a/crates/nu_plugin_custom_values/Cargo.toml
+++ b/crates/nu_plugin_custom_values/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 [dependencies]
 nu-plugin = { path = "../nu-plugin", version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1", features = ["plugin"] }
-serde = { version = "1.0", default-features = false }
+serde = { workspace = true, default-features = false }
 typetag = "0.2"

--- a/crates/nu_plugin_formats/Cargo.toml
+++ b/crates/nu_plugin_formats/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.91.1"
 nu-plugin = { path = "../nu-plugin", version = "0.91.1" }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1", features = ["plugin"] }
 
-indexmap = "2.2"
+indexmap = { workspace = true }
 eml-parser = "0.1"
 ical = "0.10"
 rust-ini = "0.20.0"


### PR DESCRIPTION
# Description
This is a followup to #12043 that moves more dependency versions to workspace dependencies.

# User-Facing Changes
N/A

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`