### PR TITLE
:bug: remove 3 backticks messing the `hover`

### DIFF
--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -964,7 +964,7 @@ mod tests {
     }
 
     #[test]
-    fn hover_on_command() {
+    fn hover_on_custom_command() {
         let (client_connection, _recv) = initialize_language_server();
 
         let mut script = fixtures();
@@ -988,6 +988,36 @@ mod tests {
                 "contents": {
                     "kind": "markdown",
                     "value": "Renders some greeting message\n### Usage \n```\n  hello {flags}\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn hover_on_str_join() {
+        let (client_connection, _recv) = initialize_language_server();
+
+        let mut script = fixtures();
+        script.push("lsp");
+        script.push("hover");
+        script.push("command.nu");
+        let script = Url::from_file_path(script).unwrap();
+
+        open_unchecked(&client_connection, script.clone());
+
+        let resp = hover(&client_connection, script.clone(), 5, 8);
+        let result = if let Message::Response(response) = resp {
+            response.result
+        } else {
+            panic!()
+        };
+
+        assert_json_eq!(
+            result,
+            serde_json::json!({
+                "contents": {
+                    "kind": "markdown",
+                    "value": "Concatenate multiple strings into a single string, with an optional separator between each.\n### Usage \n```\n  str join {flags} <separator?>\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n\n### Parameters\n\n  `separator: string` - Optional separator to use when creating string.\n\n\n### Input/output types\n\n```\n list<any> | string\n string | string\n\n```\n### Example(s)\n  Create a string from input\n```\n  ['nu', 'shell'] | str join\n```\n  Create a string from input with a separator\n```\n  ['nu', 'shell'] | str join '-'\n```\n"
                 }
             })
         );

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -211,8 +211,7 @@ pub fn hover(engine_state: &mut EngineState, file_path: &str, location: &Value) 
         Some((Id::Declaration(decl_id), offset, span)) => {
             let decl = working_set.get_decl(decl_id);
 
-            //let mut description = "```\n### Signature\n```\n".to_string();
-            let mut description = "```\n".to_string();
+            let mut description = String::new();
 
             // first description
             description.push_str(&format!("{}\n", decl.usage()));

--- a/tests/fixtures/lsp/hover/command.nu
+++ b/tests/fixtures/lsp/hover/command.nu
@@ -2,3 +2,5 @@
 def hello [] {}
 
 hello
+
+[""] | str join


### PR DESCRIPTION
# Description

The hover was bugged with 3 backticks. I don't understand how it worked before, but this apparently now works correctly on my machine. This is really puzzling. My next step is to make a test to assert this will break a little less. I fixed it 3 times in the past

# Tests + Formatting

Added a test to be sure this doesn't breaks again 😄 (at least from nushell/nushell side)
