### PR TITLE
Change default algorithm in `detect columns`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2951,6 +2951,7 @@ dependencies = [
  "trash",
  "umask",
  "unicode-segmentation",
+ "unicode-width",
  "ureq",
  "url",
  "uu_cp",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -96,6 +96,7 @@ wax = { version = "0.6" }
 which = { workspace = true, optional = true }
 bracoxide = "0.1.2"
 chardetng = "0.1.17"
+unicode-width = "0.1.11"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52"

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -96,7 +96,7 @@ uuid = { workspace = true, features = ["v4"] }
 v_htmlescape = { workspace = true }
 wax = { workspace = true }
 which = { workspace = true, optional = true }
-unicode-width = {workspace = true}
+unicode-width = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 winreg = { workspace = true }

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -105,7 +105,7 @@ fn guess_width(
     let mut input = input.collect_string("", engine_state.get_config())?;
     let num_rows_to_skip: Option<usize> = call.get_flag(engine_state, stack, "skip")?;
     if let Some(rows) = num_rows_to_skip {
-        input = input.lines().skip(rows).map(|x| x.to_string()).collect();
+        input = input.lines().skip(rows).map(|x| x.to_string()).join("\n");
     }
 
     let mut guess_width = GuessWidth::new_reader(Box::new(Cursor::new(input)));

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -35,7 +35,7 @@ impl Command for DetectColumns {
             .named(
                 "combine-columns",
                 SyntaxShape::Range,
-                "columns to be combined; listed as a range",
+                "columns to be combined; listed as a range, only useful if `--old` is active",
                 Some('c'),
             )
             .switch("old", "use another algorithm to detect columns, it may be useful if default one doesn't work", None)
@@ -68,10 +68,17 @@ impl Command for DetectColumns {
         vec![
             Example {
                 description: "detect columns by df output",
-                example: "'Filesystem     1K-blocks      Used Available Use% Mounted on
-none             8150224         4   8150220   1% /mnt/wsl
-none           146801624 125954264  20847360  86% /usr/lib/wsl/drivers' | detect columns",
-                result: None,
+                example: r"
+'Filesystem     1K-blocks      Used Available Use% Mounted on
+none             8150224         4   8150220   1% /mnt/c' | detect columns",
+                result: Some(Value::test_list(vec![Value::test_record(record!{
+                    "Filesystem" => Value::test_string("none"),
+                    "1K-blocks" => Value::test_string("8150224"),
+                    "Used" => Value::test_string("4"),
+                    "Available" => Value::test_string("8150220"),
+                    "Use%" => Value::test_string("1%"),
+                    "Mounted on" => Value::test_string("/mnt/c")
+                })])),
             },
             Example {
                 description: "Use --old parameter if you find default one does not work",

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -35,10 +35,10 @@ impl Command for DetectColumns {
             .named(
                 "combine-columns",
                 SyntaxShape::Range,
-                "columns to be combined; listed as a range, only useful if `--old` is active",
+                "columns to be combined; listed as a range, only useful if `--legacy` is active",
                 Some('c'),
             )
-            .switch("old", "use another algorithm to detect columns, it may be useful if default one doesn't work", None)
+            .switch("legacy", "use another algorithm to detect columns, it may be useful if default one doesn't work", None)
             .category(Category::Strings)
     }
 
@@ -57,7 +57,7 @@ impl Command for DetectColumns {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        if !call.has_flag(engine_state, stack, "old")? {
+        if !call.has_flag(engine_state, stack, "legacy")? {
             guess_width(engine_state, stack, call, input)
         } else {
             detect_columns_old(engine_state, stack, call, input)
@@ -81,8 +81,8 @@ none             8150224         4   8150220   1% /mnt/c' | detect columns",
                 })])),
             },
             Example {
-                description: "Use --old parameter if you find default one does not work",
-                example: "'a b c' | detect columns --old --no-headers",
+                description: "Use --legacy parameter if you find default one does not work",
+                example: "'a b c' | detect columns --legacy --no-headers",
                 result: Some(Value::test_list(vec![Value::test_record(record! {
                         "column0" => Value::test_string("a"),
                         "column1" => Value::test_string("b"),

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -485,9 +485,7 @@ fn process_range(
                 (r_idx as usize + 1).min(length),
             )))
         }
-        Err(processing_error) => {
-            return Err(processing_error("could not find range index", input_span))
-        }
+        Err(processing_error) => Err(processing_error("could not find range index", input_span)),
     }
 }
 

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -71,7 +71,7 @@ impl Command for DetectColumns {
                 example: r"
 'Filesystem     1K-blocks      Used Available Use% Mounted on
 none             8150224         4   8150220   1% /mnt/c' | detect columns",
-                result: Some(Value::test_list(vec![Value::test_record(record!{
+                result: Some(Value::test_list(vec![Value::test_record(record! {
                     "Filesystem" => Value::test_string("none"),
                     "1K-blocks" => Value::test_string("8150224"),
                     "Used" => Value::test_string("4"),

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -93,7 +93,7 @@ fn guess_width(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     use super::guess_width::GuessWidth;
-    let input_span = input.span().unwrap_or_else(|| call.head);
+    let input_span = input.span().unwrap_or(call.head);
 
     let mut input = input.collect_string("", engine_state.get_config())?;
     let num_rows_to_skip: Option<usize> = call.get_flag(engine_state, stack, "skip")?;

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -149,7 +149,7 @@ fn guess_width(
                     .into_iter()
                     .map(|v| Value::string(v, input_span))
                     .collect();
-                // somes rows may has less columns, fill it with ""
+                // some rows may has less columns, fill it with ""
                 for _ in values.len()..columns.len() {
                     values.push(Value::string("", input_span));
                 }

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -89,6 +89,29 @@ none             8150224         4   8150220   1% /mnt/c' | detect columns",
                         "column2" => Value::test_string("c"),
                 })])),
             },
+            Example {
+                description: "",
+                example:
+                    "$'c1 c2 c3 c4 c5(char nl)a b c d e' | detect columns --combine-columns 0..1 --legacy",
+                result: None,
+            },
+            Example {
+                description: "Splits a multi-line string into columns with headers detected",
+                example:
+                    "$'c1 c2 c3 c4 c5(char nl)a b c d e' | detect columns --combine-columns -2..-1 --legacy",
+                result: None,
+            },
+            Example {
+                description: "Splits a multi-line string into columns with headers detected",
+                example:
+                    "$'c1 c2 c3 c4 c5(char nl)a b c d e' | detect columns --combine-columns 2.. --legacy",
+                result: None,
+            },
+            Example {
+                description: "Parse external ls command and combine columns for datetime",
+                example: "^ls -lh | detect columns --no-headers --skip 1 --combine-columns 5..7 --legacy",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/strings/guess_width.rs
+++ b/crates/nu-command/src/strings/guess_width.rs
@@ -1,0 +1,469 @@
+/// Attribution: https://github.com/noborus/guesswidth/blob/main/guesswidth.go
+/// The MIT License (MIT) as of 2024-03-22
+///
+/// GuessWidth handles the format as formatted by printf.
+/// Spaces exist as delimiters, but spaces are not always delimiters.
+/// The width seems to be a fixed length, but it doesn't always fit.
+/// GuessWidth finds the column separation position
+/// from the reference line(header) and multiple lines(body).
+
+/// Briefly, the algorithm uses a histogram of spaces to find widths.
+/// blanks, lines, and pos are variables used in the algorithm. The other
+/// items names below are just for reference.
+/// blanks =  0000003000113333111100003000
+///  lines = "   PID TTY          TIME CMD"
+///          "302965 pts/3    00:00:11 zsh"
+///          "709737 pts/3    00:00:00 ps"
+///
+/// measure= "012345678901234567890123456789"
+/// spaces = "      ^        ^        ^"
+///    pos =  6 15 24 <- the carets show these positions
+/// the items in pos map to 3's in the blanks array
+
+/// Now that we have pos, we can let split() use this pos array to figure out
+/// how to split all lines by comparing each index to see if there's a space.
+/// So, it looks at position 6, 15, 24 and sees if it has a space in those
+/// positions. If it does, it splits the line there. If it doesn't, it wiggles
+/// around the position to find the next space and splits there.
+use std::io::{self, BufRead};
+use unicode_width::UnicodeWidthStr;
+
+/// the number to scan to analyze.
+const SCAN_NUM: u8 = 128;
+/// the minimum number of lines to recognize as a separator.
+/// 1 if only the header, 2 or more if there is a blank in the body.
+const MIN_LINES: usize = 2;
+/// whether to trim the space in the value.
+const TRIM_SPACE: bool = true;
+
+/// GuessWidth reads records from printf-like output.
+pub struct GuessWidth {
+    pub(crate) reader: io::BufReader<Box<dyn io::Read>>,
+    // a list of separator positions.
+    pub(crate) pos: Vec<usize>,
+    // stores the lines read for scan.
+    pub(crate) pre_lines: Vec<String>,
+    // the number returned by read.
+    pub(crate) pre_count: usize,
+    // the base line number. It starts from 0.
+    pub(crate) header: usize,
+    // the maximum number of columns to split.
+    pub(crate) limit_split: usize,
+}
+
+impl GuessWidth {
+    pub fn new_reader(r: Box<dyn io::Read>) -> GuessWidth {
+        let reader = io::BufReader::new(r);
+        GuessWidth {
+            reader,
+            pos: Vec::new(),
+            pre_lines: Vec::new(),
+            pre_count: 0,
+            header: 0,
+            limit_split: 0,
+        }
+    }
+
+    /// read_all reads all rows
+    /// and returns a two-dimensional slice of rows and columns.
+    pub fn read_all(&mut self) -> Vec<Vec<String>> {
+        if self.pre_lines.is_empty() {
+            self.scan(SCAN_NUM);
+        }
+
+        let mut rows = Vec::new();
+        while let Ok(columns) = self.read() {
+            rows.push(columns);
+        }
+        rows
+    }
+
+    /// scan preReads and parses the lines.
+    fn scan(&mut self, num: u8) {
+        for _ in 0..num {
+            let mut buf = String::new();
+            if self.reader.read_line(&mut buf).unwrap() == 0 {
+                break;
+            }
+
+            let line = buf.trim_end().to_string();
+            self.pre_lines.push(line);
+        }
+
+        self.pos = positions(&self.pre_lines, self.header, MIN_LINES);
+        if self.limit_split > 0 && self.pos.len() > self.limit_split {
+            self.pos.truncate(self.limit_split);
+        }
+    }
+
+    /// read reads one row and returns a slice of columns.
+    /// scan is executed first if it is not preRead.
+    fn read(&mut self) -> Result<Vec<String>, io::Error> {
+        if self.pre_lines.is_empty() {
+            self.scan(SCAN_NUM);
+        }
+
+        if self.pre_count < self.pre_lines.len() {
+            let line = &self.pre_lines[self.pre_count];
+            self.pre_count += 1;
+            Ok(split(line, &self.pos, TRIM_SPACE))
+        } else {
+            let mut buf = String::new();
+            if self.reader.read_line(&mut buf)? == 0 {
+                return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "End of file"));
+            }
+
+            let line = buf.trim_end().to_string();
+            Ok(split(&line, &self.pos, TRIM_SPACE))
+        }
+    }
+}
+
+// positions returns separator positions
+// from multiple lines and header line number.
+// Lines before the header line are ignored.
+fn positions(lines: &[String], header: usize, min_lines: usize) -> Vec<usize> {
+    let mut blanks = Vec::new();
+    for (n, line) in lines.iter().enumerate() {
+        if n < header {
+            continue;
+        }
+
+        if n == header {
+            blanks = lookup_blanks(line.trim_end_matches(' '));
+            continue;
+        }
+
+        count_blanks(&mut blanks, line.trim_end_matches(' '));
+    }
+
+    positions_helper(&blanks, min_lines)
+}
+
+fn separator_position(lr: &[char], p: usize, pos: &[usize], n: usize) -> usize {
+    if lr[p].is_whitespace() {
+        return p;
+    }
+
+    let mut f = p;
+    while f < lr.len() && !lr[f].is_whitespace() {
+        f += 1;
+    }
+
+    let mut b = p;
+    while b > 0 && !lr[b].is_whitespace() {
+        b -= 1;
+    }
+
+    if b == pos[n] {
+        return f;
+    }
+
+    if n < pos.len() - 1 {
+        if f == pos[n + 1] {
+            return b;
+        }
+        if b == pos[n] {
+            return f;
+        }
+        if b > pos[n] && b < pos[n + 1] {
+            return b;
+        }
+    }
+
+    f
+}
+
+fn split(line: &str, pos: &[usize], trim_space: bool) -> Vec<String> {
+    let mut n = 0;
+    let mut start = 0;
+    let mut columns = Vec::with_capacity(pos.len() + 1);
+    let lr: Vec<char> = line.chars().collect();
+    let mut w = 0;
+
+    for p in 0..lr.len() {
+        if n > pos.len() - 1 {
+            start = p;
+            break;
+        }
+
+        if pos[n] <= w {
+            let end = separator_position(&lr, p, pos, n);
+            if start > end {
+                break;
+            }
+            let col = &line[start..end];
+            let col = if trim_space { col.trim() } else { col };
+            columns.push(col.to_string());
+            n += 1;
+            start = end;
+        }
+
+        w += UnicodeWidthStr::width(lr[p].to_string().as_str());
+    }
+
+    // add last part.
+    let col = &line[start..];
+    let col = if trim_space { col.trim() } else { col };
+    columns.push(col.to_string());
+    columns
+}
+
+// Creates a blank(1) and non-blank(0) slice.
+// Execute for the base line (header line).
+fn lookup_blanks(line: &str) -> Vec<usize> {
+    let mut blanks = Vec::new();
+    let mut first = true;
+
+    for c in line.chars() {
+        if c == ' ' {
+            if first {
+                blanks.push(0);
+                continue;
+            }
+            blanks.push(1);
+            continue;
+        }
+
+        first = false;
+        blanks.push(0);
+        if UnicodeWidthStr::width(c.to_string().as_str()) == 2 {
+            blanks.push(0);
+        }
+    }
+
+    blanks
+}
+
+// count up if the line is blank where the reference line was blank.
+fn count_blanks(blanks: &mut [usize], line: &str) {
+    let mut n = 0;
+
+    for c in line.chars() {
+        if n >= blanks.len() {
+            break;
+        }
+
+        if c == ' ' && blanks[n] > 0 {
+            blanks[n] += 1;
+        }
+
+        n += 1;
+        if UnicodeWidthStr::width(c.to_string().as_str()) == 2 {
+            n += 1;
+        }
+    }
+}
+
+// Generates a list of separator positions from a blank slice.
+fn positions_helper(blanks: &[usize], min_lines: usize) -> Vec<usize> {
+    let mut max = min_lines;
+    let mut p = 0;
+    let mut pos = Vec::new();
+
+    for (n, v) in blanks.iter().enumerate() {
+        if *v >= max {
+            max = *v;
+            p = n;
+        }
+        if *v == 0 {
+            max = min_lines;
+            if p > 0 {
+                pos.push(p);
+                p = 0;
+            }
+        }
+    }
+    pos
+}
+
+// to_rows returns rows separated by columns.
+#[allow(dead_code)]
+fn to_rows(lines: Vec<String>, pos: Vec<usize>, trim_space: bool) -> Vec<Vec<String>> {
+    let mut rows: Vec<Vec<String>> = Vec::with_capacity(lines.len());
+    for line in lines {
+        let columns = split(&line, &pos, trim_space);
+        rows.push(columns);
+    }
+    rows
+}
+
+// to_table parses a slice of lines and returns a table.
+#[allow(dead_code)]
+pub fn to_table(lines: Vec<String>, header: usize, trim_space: bool) -> Vec<Vec<String>> {
+    let pos = positions(&lines, header, 2);
+    to_rows(lines, pos, trim_space)
+}
+
+// to_table_n parses a slice of lines and returns a table, but limits the number of splits.
+#[allow(dead_code)]
+pub fn to_table_n(
+    lines: Vec<String>,
+    header: usize,
+    num_split: usize,
+    trim_space: bool,
+) -> Vec<Vec<String>> {
+    let mut pos = positions(&lines, header, 2);
+    if pos.len() > num_split {
+        pos.truncate(num_split);
+    }
+    to_rows(lines, pos, trim_space)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::guess_width::{to_table, to_table_n, GuessWidth};
+
+    #[test]
+    fn test_guess_width_ps_trim() {
+        let input = "   PID TTY          TIME CMD
+302965 pts/3    00:00:11 zsh
+709737 pts/3    00:00:00 ps";
+
+        let r = Box::new(std::io::BufReader::new(input.as_bytes())) as Box<dyn std::io::Read>;
+        let reader = std::io::BufReader::new(r);
+
+        let mut guess_width = GuessWidth {
+            reader,
+            pos: Vec::new(),
+            pre_lines: Vec::new(),
+            pre_count: 0,
+            header: 0,
+            limit_split: 0,
+        };
+
+        #[rustfmt::skip]
+        let want = vec![
+            vec!["PID", "TTY", "TIME", "CMD"],
+            vec!["302965", "pts/3", "00:00:11", "zsh"],
+            vec!["709737", "pts/3", "00:00:00", "ps"],
+        ];
+        let got = guess_width.read_all();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_guess_width_ps_overflow_trim() {
+        let input = "USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+root           1  0.0  0.0 168576 13788 ?        Ss   Mar11   0:49 /sbin/init splash
+noborus   703052  2.1  0.7 1184814400 230920 ?   Sl   10:03   0:45 /opt/google/chrome/chrome
+noborus   721971  0.0  0.0  13716  3524 pts/3    R+   10:39   0:00 ps aux";
+
+        let r = Box::new(std::io::BufReader::new(input.as_bytes())) as Box<dyn std::io::Read>;
+        let reader = std::io::BufReader::new(r);
+
+        let mut guess_width = GuessWidth {
+            reader,
+            pos: Vec::new(),
+            pre_lines: Vec::new(),
+            pre_count: 0,
+            header: 0,
+            limit_split: 0,
+        };
+
+        #[rustfmt::skip]
+        let want = vec![
+            vec!["USER", "PID", "%CPU", "%MEM", "VSZ", "RSS", "TTY", "STAT", "START", "TIME", "COMMAND"],
+            vec!["root", "1", "0.0", "0.0", "168576", "13788", "?", "Ss", "Mar11", "0:49", "/sbin/init splash"],
+            vec!["noborus", "703052", "2.1", "0.7", "1184814400", "230920", "?", "Sl", "10:03", "0:45", "/opt/google/chrome/chrome"],
+            vec!["noborus", "721971", "0.0", "0.0", "13716", "3524", "pts/3", "R+", "10:39", "0:00", "ps aux"],
+        ];
+        let got = guess_width.read_all();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_guess_width_ps_limit_trim() {
+        let input = "   PID TTY          TIME CMD
+302965 pts/3    00:00:11 zsh
+709737 pts/3    00:00:00 ps";
+
+        let r = Box::new(std::io::BufReader::new(input.as_bytes())) as Box<dyn std::io::Read>;
+        let reader = std::io::BufReader::new(r);
+
+        let mut guess_width = GuessWidth {
+            reader,
+            pos: Vec::new(),
+            pre_lines: Vec::new(),
+            pre_count: 0,
+            header: 0,
+            limit_split: 2,
+        };
+
+        #[rustfmt::skip]
+        let want = vec![
+            vec!["PID", "TTY", "TIME CMD"],
+            vec!["302965", "pts/3", "00:00:11 zsh"],
+            vec!["709737", "pts/3", "00:00:00 ps"],
+        ];
+        let got = guess_width.read_all();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_guess_width_windows_df_trim() {
+        let input = "Filesystem     1K-blocks      Used Available Use% Mounted on
+C:/Apps/Git    998797308 869007000 129790308  88% /
+D:             104792064  17042676  87749388  17% /d";
+
+        let r = Box::new(std::io::BufReader::new(input.as_bytes())) as Box<dyn std::io::Read>;
+        let reader = std::io::BufReader::new(r);
+
+        let mut guess_width = GuessWidth {
+            reader,
+            pos: Vec::new(),
+            pre_lines: Vec::new(),
+            pre_count: 0,
+            header: 0,
+            limit_split: 0,
+        };
+
+        #[rustfmt::skip]
+        let want = vec![
+            vec!["Filesystem","1K-blocks","Used","Available","Use%","Mounted on"],
+            vec!["C:/Apps/Git","998797308","869007000","129790308","88%","/"],
+            vec!["D:","104792064","17042676","87749388","17%","/d"],
+        ];
+        let got = guess_width.read_all();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_to_table() {
+        let lines = vec![
+            "   PID TTY          TIME CMD".to_string(),
+            "302965 pts/3    00:00:11 zsh".to_string(),
+            "709737 pts/3    00:00:00 ps".to_string(),
+        ];
+
+        let want = vec![
+            vec!["PID", "TTY", "TIME", "CMD"],
+            vec!["302965", "pts/3", "00:00:11", "zsh"],
+            vec!["709737", "pts/3", "00:00:00", "ps"],
+        ];
+
+        let header = 0;
+        let trim_space = true;
+        let table = to_table(lines, header, trim_space);
+        assert_eq!(table, want);
+    }
+
+    #[test]
+    fn test_to_table_n() {
+        let lines = vec![
+            "2022-12-21T09:50:16+0000 WARN A warning that should be ignored is usually at this level and should be actionable.".to_string(),
+    		"2022-12-21T09:50:17+0000 INFO This is less important than debug log and is often used to provide context in the current task.".to_string(),
+        ];
+
+        let want = vec![
+            vec!["2022-12-21T09:50:16+0000", "WARN", "A warning that should be ignored is usually at this level and should be actionable."],
+            vec!["2022-12-21T09:50:17+0000", "INFO", "This is less important than debug log and is often used to provide context in the current task."],
+        ];
+
+        let header = 0;
+        let trim_space = true;
+        let num_split = 2;
+        let table = to_table_n(lines, header, num_split, trim_space);
+        assert_eq!(table, want);
+    }
+}

--- a/crates/nu-command/src/strings/guess_width.rs
+++ b/crates/nu-command/src/strings/guess_width.rs
@@ -35,6 +35,8 @@ const SCAN_NUM: u8 = 128;
 const MIN_LINES: usize = 2;
 /// whether to trim the space in the value.
 const TRIM_SPACE: bool = true;
+/// the base line number.  It starts from 0.
+const HEADER: usize = 0;
 
 /// GuessWidth reads records from printf-like output.
 pub struct GuessWidth {
@@ -45,8 +47,6 @@ pub struct GuessWidth {
     pub(crate) pre_lines: Vec<String>,
     // the number returned by read.
     pub(crate) pre_count: usize,
-    // the base line number. It starts from 0.
-    pub(crate) header: usize,
     // the maximum number of columns to split.
     pub(crate) limit_split: usize,
 }
@@ -59,7 +59,6 @@ impl GuessWidth {
             pos: Vec::new(),
             pre_lines: Vec::new(),
             pre_count: 0,
-            header: 0,
             limit_split: 0,
         }
     }
@@ -82,7 +81,7 @@ impl GuessWidth {
     fn scan(&mut self, num: u8) {
         for _ in 0..num {
             let mut buf = String::new();
-            if self.reader.read_line(&mut buf).unwrap_or(0) == 0 {
+            if self.reader.read_line(&mut buf).unwrap() == 0 {
                 break;
             }
 
@@ -90,7 +89,7 @@ impl GuessWidth {
             self.pre_lines.push(line);
         }
 
-        self.pos = positions(&self.pre_lines, self.header, MIN_LINES);
+        self.pos = positions(&self.pre_lines, HEADER, MIN_LINES);
         if self.limit_split > 0 && self.pos.len() > self.limit_split {
             self.pos.truncate(self.limit_split);
         }
@@ -175,7 +174,7 @@ fn separator_position(lr: &[char], p: usize, pos: &[usize], n: usize) -> usize {
 }
 
 fn split(line: &str, pos: &[usize], trim_space: bool) -> Vec<String> {
-    let mut n: usize = 0;
+    let mut n = 0;
     let mut start = 0;
     let mut columns = Vec::with_capacity(pos.len() + 1);
     let lr: Vec<char> = line.chars().collect();
@@ -312,7 +311,7 @@ pub fn to_table_n(
 
 #[cfg(test)]
 mod tests {
-    use super::{to_table, to_table_n, GuessWidth};
+    use crate::guess_width::{to_table, to_table_n, GuessWidth};
 
     #[test]
     fn test_guess_width_ps_trim() {
@@ -328,7 +327,6 @@ mod tests {
             pos: Vec::new(),
             pre_lines: Vec::new(),
             pre_count: 0,
-            header: 0,
             limit_split: 0,
         };
 
@@ -357,7 +355,6 @@ noborus   721971  0.0  0.0  13716  3524 pts/3    R+   10:39   0:00 ps aux";
             pos: Vec::new(),
             pre_lines: Vec::new(),
             pre_count: 0,
-            header: 0,
             limit_split: 0,
         };
 
@@ -386,7 +383,6 @@ noborus   721971  0.0  0.0  13716  3524 pts/3    R+   10:39   0:00 ps aux";
             pos: Vec::new(),
             pre_lines: Vec::new(),
             pre_count: 0,
-            header: 0,
             limit_split: 2,
         };
 
@@ -414,7 +410,6 @@ D:             104792064  17042676  87749388  17% /d";
             pos: Vec::new(),
             pre_lines: Vec::new(),
             pre_count: 0,
-            header: 0,
             limit_split: 0,
         };
 

--- a/crates/nu-command/src/strings/guess_width.rs
+++ b/crates/nu-command/src/strings/guess_width.rs
@@ -82,7 +82,7 @@ impl GuessWidth {
     fn scan(&mut self, num: u8) {
         for _ in 0..num {
             let mut buf = String::new();
-            if self.reader.read_line(&mut buf).unwrap() == 0 {
+            if self.reader.read_line(&mut buf).unwrap_or(0) == 0 {
                 break;
             }
 
@@ -175,14 +175,14 @@ fn separator_position(lr: &[char], p: usize, pos: &[usize], n: usize) -> usize {
 }
 
 fn split(line: &str, pos: &[usize], trim_space: bool) -> Vec<String> {
-    let mut n = 0;
+    let mut n: usize = 0;
     let mut start = 0;
     let mut columns = Vec::with_capacity(pos.len() + 1);
     let lr: Vec<char> = line.chars().collect();
     let mut w = 0;
 
     for p in 0..lr.len() {
-        if n > pos.len() - 1 {
+        if pos.is_empty() || n > pos.len() - 1 {
             start = p;
             break;
         }
@@ -312,7 +312,7 @@ pub fn to_table_n(
 
 #[cfg(test)]
 mod tests {
-    use crate::guess_width::{to_table, to_table_n, GuessWidth};
+    use super::{to_table, to_table_n, GuessWidth};
 
     #[test]
     fn test_guess_width_ps_trim() {

--- a/crates/nu-command/src/strings/guess_width.rs
+++ b/crates/nu-command/src/strings/guess_width.rs
@@ -81,7 +81,7 @@ impl GuessWidth {
     fn scan(&mut self, num: u8) {
         for _ in 0..num {
             let mut buf = String::new();
-            if self.reader.read_line(&mut buf).unwrap() == 0 {
+            if self.reader.read_line(&mut buf).unwrap_or(0) == 0 {
                 break;
             }
 

--- a/crates/nu-command/src/strings/guess_width.rs
+++ b/crates/nu-command/src/strings/guess_width.rs
@@ -311,7 +311,7 @@ pub fn to_table_n(
 
 #[cfg(test)]
 mod tests {
-    use crate::guess_width::{to_table, to_table_n, GuessWidth};
+    use super::{to_table, to_table_n, GuessWidth};
 
     #[test]
     fn test_guess_width_ps_trim() {

--- a/crates/nu-command/src/strings/mod.rs
+++ b/crates/nu-command/src/strings/mod.rs
@@ -2,6 +2,7 @@ mod char_;
 mod detect_columns;
 mod encode_decode;
 mod format;
+mod guess_width;
 mod parse;
 mod split;
 mod str_;

--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -1,7 +1,7 @@
-use nu_test_support::{nu, playground::Playground};
+use nu_test_support::{nu, pipeline, playground::Playground};
 
 #[test]
-fn detect_columns_with_old() {
+fn detect_columns_with_legacy() {
     let cases = [(
         "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
         "[[c1,c2,c3,c4,c5]; [a,b,c,d,e]]",
@@ -26,7 +26,7 @@ fn detect_columns_with_old() {
 }
 
 #[test]
-fn detect_columns_with_old_and_flag_c() {
+fn detect_columns_with_legacy_and_flag_c() {
     let cases = [
         (
             "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
@@ -62,4 +62,35 @@ fn detect_columns_with_old_and_flag_c() {
             );
         }
     });
+}
+
+#[test]
+fn detect_columns_with_flag_c() {
+    let body = "$\"
+total 284K(char nl)
+drwxr-xr-x  2 root root 4.0K Mar 20 08:28 =(char nl)
+drwxr-xr-x  4 root root 4.0K Mar 20 08:18 ~(char nl)
+-rw-r--r--  1 root root 3.0K Mar 20 07:23 ~asdf(char nl)\"";
+    let expected = "[
+['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column8'];
+['drwxr-xr-x', '2', 'root', 'root', '4.0K', 'Mar 20 08:28', '='],
+['drwxr-xr-x', '4', 'root', 'root', '4.0K', 'Mar 20 08:18', '~'],
+['-rw-r--r--',  '1', 'root', 'root', '3.0K', 'Mar 20 07:23', '~asdf']
+]";
+    let range = "5..7";
+    let cmd = format!(
+        "({} | detect columns -c {} -s 1 --no-headers) == {}",
+        pipeline(body),
+        range,
+        pipeline(expected),
+    );
+    println!("debug cmd: {cmd}");
+    Playground::setup("detect_columns_test_1", |dirs, _| {
+        let out = nu!(
+            cwd: dirs.test(),
+            cmd,
+        );
+        println!("{}", out.out);
+        assert_eq!(out.out, "true");
+    })
 }

--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -1,7 +1,7 @@
 use nu_test_support::{nu, playground::Playground};
 
 #[test]
-fn detect_columns() {
+fn detect_columns_with_old() {
     let cases = [(
         "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
         "[[c1,c2,c3,c4,c5]; [a,b,c,d,e]]",
@@ -11,14 +11,14 @@ fn detect_columns() {
         for case in cases.into_iter() {
             let out = nu!(
                 cwd: dirs.test(),
-                "({} | detect columns) == {}",
+                "({} | detect columns --old) == {}",
                 case.0,
                 case.1
             );
 
             assert_eq!(
                 out.out, "true",
-                "({} | detect columns) == {}",
+                "({} | detect columns --old) == {}",
                 case.0, case.1
             );
         }
@@ -26,7 +26,7 @@ fn detect_columns() {
 }
 
 #[test]
-fn detect_columns_with_flag_c() {
+fn detect_columns_with_old_and_flag_c() {
     let cases = [
         (
             "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
@@ -49,7 +49,7 @@ fn detect_columns_with_flag_c() {
         for case in cases.into_iter() {
             let out = nu!(
                 cwd: dirs.test(),
-                "({} | detect columns --combine-columns {}) == {}",
+                "({} | detect columns --old --combine-columns {}) == {}",
                 case.0,
                 case.2,
                 case.1,
@@ -57,7 +57,7 @@ fn detect_columns_with_flag_c() {
 
             assert_eq!(
                 out.out, "true",
-                "({} | detect columns --combine-columns {}) == {}",
+                "({} | detect columns --old --combine-columns {}) == {}",
                 case.0, case.2, case.1
             );
         }

--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -11,14 +11,14 @@ fn detect_columns_with_old() {
         for case in cases.into_iter() {
             let out = nu!(
                 cwd: dirs.test(),
-                "({} | detect columns --old) == {}",
+                "({} | detect columns --legacy) == {}",
                 case.0,
                 case.1
             );
 
             assert_eq!(
                 out.out, "true",
-                "({} | detect columns --old) == {}",
+                "({} | detect columns --legacy) == {}",
                 case.0, case.1
             );
         }
@@ -49,7 +49,7 @@ fn detect_columns_with_old_and_flag_c() {
         for case in cases.into_iter() {
             let out = nu!(
                 cwd: dirs.test(),
-                "({} | detect columns --old --combine-columns {}) == {}",
+                "({} | detect columns --legacy --combine-columns {}) == {}",
                 case.0,
                 case.2,
                 case.1,
@@ -57,7 +57,7 @@ fn detect_columns_with_old_and_flag_c() {
 
             assert_eq!(
                 out.out, "true",
-                "({} | detect columns --old --combine-columns {}) == {}",
+                "({} | detect columns --legacy --combine-columns {}) == {}",
                 case.0, case.2, case.1
             );
         }


### PR DESCRIPTION
# Description
@fdncred found another histogram based algorithm to detect columns, and rewrite it in rust: https://github.com/fdncred/guess-width

I have tested it manually, and it works good with `df`, `docker ps`, `^ps`.  This pr is going to use the algorithm in `detect columns`

Fix: #4183

The pitfall of new algorithm:
1. it may not works well if there isn't too much rows of input
2. it may not works well if the length of value is less than the header to value, e.g:
```
c1 c2 c3 c4 c5
a b c d e
g h i j k
g a a q d
a v c q q | detect columns
```
In this case, users might need to use ~~`--old`~~ `--legacy` to make it works well.

# User-Facing Changes
User might need to add ~~`--old`~~  `--legacy` to scripts if they find `detect columns` in their scripts broken.

# Tests + Formatting
Done

# After Submitting
NaN