### PR TITLE
Fix #12280: replace `difference` crate with `similar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,7 +3078,7 @@ dependencies = [
 name = "nu-plugin-test-support"
 version = "0.91.1"
 dependencies = [
- "crossterm",
+ "nu-ansi-term",
  "nu-engine",
  "nu-parser",
  "nu-plugin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,12 +1102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
-name = "difference"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
-
-[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,12 +3078,13 @@ dependencies = [
 name = "nu-plugin-test-support"
 version = "0.91.1"
 dependencies = [
- "difference",
+ "crossterm",
  "nu-engine",
  "nu-parser",
  "nu-plugin",
  "nu-protocol",
  "serde",
+ "similar",
  "typetag",
 ]
 

--- a/crates/nu-plugin-test-support/Cargo.toml
+++ b/crates/nu-plugin-test-support/Cargo.toml
@@ -12,7 +12,8 @@ nu-engine = { path = "../nu-engine", version = "0.91.1", features = ["plugin"] }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1", features = ["plugin"] }
 nu-parser = { path = "../nu-parser", version = "0.91.1", features = ["plugin"] }
 nu-plugin = { path = "../nu-plugin", version = "0.91.1" }
-difference = "2.0"
+similar = "2.4"
+crossterm = { workspace = true }
 
 [dev-dependencies]
 typetag = "0.2"

--- a/crates/nu-plugin-test-support/Cargo.toml
+++ b/crates/nu-plugin-test-support/Cargo.toml
@@ -12,8 +12,8 @@ nu-engine = { path = "../nu-engine", version = "0.91.1", features = ["plugin"] }
 nu-protocol = { path = "../nu-protocol", version = "0.91.1", features = ["plugin"] }
 nu-parser = { path = "../nu-parser", version = "0.91.1", features = ["plugin"] }
 nu-plugin = { path = "../nu-plugin", version = "0.91.1" }
+nu-ansi-term = { workspace = true }
 similar = "2.4"
-crossterm = { workspace = true }
 
 [dev-dependencies]
 typetag = "0.2"

--- a/crates/nu-plugin-test-support/src/diff.rs
+++ b/crates/nu-plugin-test-support/src/diff.rs
@@ -1,0 +1,27 @@
+use std::fmt::Write;
+
+use crossterm::style::{Color, Stylize};
+use similar::{ChangeTag, TextDiff};
+
+/// Generate a stylized diff of different lines between two strings
+pub(crate) fn diff_by_line(old: &str, new: &str) -> String {
+    let mut out = String::new();
+
+    let diff = TextDiff::from_lines(old, new);
+
+    for change in diff.iter_all_changes() {
+        let color = match change.tag() {
+            ChangeTag::Equal => Color::Reset,
+            ChangeTag::Delete => Color::Red,
+            ChangeTag::Insert => Color::Green,
+        };
+        let _ = write!(
+            out,
+            "{}{}",
+            change.tag().to_string().with(color),
+            change.value_ref().with(color)
+        );
+    }
+
+    out
+}

--- a/crates/nu-plugin-test-support/src/diff.rs
+++ b/crates/nu-plugin-test-support/src/diff.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use crossterm::style::{Color, Stylize};
+use nu_ansi_term::{Color, Style};
 use similar::{ChangeTag, TextDiff};
 
 /// Generate a stylized diff of different lines between two strings
@@ -10,16 +10,16 @@ pub(crate) fn diff_by_line(old: &str, new: &str) -> String {
     let diff = TextDiff::from_lines(old, new);
 
     for change in diff.iter_all_changes() {
-        let color = match change.tag() {
-            ChangeTag::Equal => Color::Reset,
-            ChangeTag::Delete => Color::Red,
-            ChangeTag::Insert => Color::Green,
+        let style = match change.tag() {
+            ChangeTag::Equal => Style::new(),
+            ChangeTag::Delete => Color::Red.into(),
+            ChangeTag::Insert => Color::Green.into(),
         };
         let _ = write!(
             out,
             "{}{}",
-            change.tag().to_string().with(color),
-            change.value_ref().with(color)
+            style.paint(change.tag().to_string()),
+            style.paint(change.value()),
         );
     }
 

--- a/crates/nu-plugin-test-support/src/lib.rs
+++ b/crates/nu-plugin-test-support/src/lib.rs
@@ -63,6 +63,7 @@
 //! # test_lowercase().unwrap();
 //! ```
 
+mod diff;
 mod fake_persistent_plugin;
 mod fake_register;
 mod plugin_test;

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -1,6 +1,6 @@
 use std::{convert::Infallible, sync::Arc};
 
-use crossterm::style::Stylize;
+use nu_ansi_term::Style;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_plugin::{Plugin, PluginCommand, PluginCustomValue, PluginSource};
@@ -190,10 +190,11 @@ impl PluginTest {
         let mut failed = false;
 
         for example in examples {
+            let bold = Style::new().bold();
             let mut failed_header = || {
                 failed = true;
-                eprintln!("{} {}", "Example:".bold(), example.example);
-                eprintln!("{} {}", "Description:".bold(), example.description);
+                eprintln!("{} {}", bold.paint("Example:"), example.example);
+                eprintln!("{} {}", bold.paint("Description:"), example.description);
             };
             if let Some(expectation) = &example.result {
                 match self.eval(&example.example) {
@@ -214,7 +215,7 @@ impl PluginTest {
                             let value_formatted = format!("{:#?}", value);
                             let diff = diff_by_line(&expectation_formatted, &value_formatted);
                             failed_header();
-                            eprintln!("{} {}", "Result:".bold(), diff);
+                            eprintln!("{} {}", bold.paint("Result:"), diff);
                         }
                     }
                     Err(err) => {


### PR DESCRIPTION
Fixes #12280.

# Description

This removes the dependency on the `difference` crate, which is unmaintained, for `nu-plugin-test-support`. The `similar` crate (Apache-2.0) is used instead, which is a bit larger and more complex, but still suitable for a dev dep for tests. Also switched to use `crossterm` for colors, since `similar` doesn't come with any terminal pretty printing functionality.

# User-Facing Changes

None - output should be identical.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
