### PR TITLE
Remove dead `impl PluginEncoder for EncodingType`

### DIFF
--- a/crates/nu-plugin/src/serializers/mod.rs
+++ b/crates/nu-plugin/src/serializers/mod.rs
@@ -1,4 +1,4 @@
-use crate::plugin::{Encoder, PluginEncoder};
+use crate::plugin::Encoder;
 use nu_protocol::ShellError;
 
 pub mod json;
@@ -21,19 +21,6 @@ impl EncodingType {
             b"msgpack" => Some(Self::MsgPack(msgpack::MsgPackSerializer {})),
             _ => None,
         }
-    }
-
-    pub fn to_str(&self) -> &'static str {
-        match self {
-            Self::Json(_) => "json",
-            Self::MsgPack(_) => "msgpack",
-        }
-    }
-}
-
-impl PluginEncoder for EncodingType {
-    fn name(&self) -> &str {
-        self.to_str()
     }
 }
 


### PR DESCRIPTION
Detected due to `clippy::wrong_self_convention` for `to_str`

# Breaking change to plugin authors

seems to be implementation detail

cc @devyn 
