### PR TITLE
cleanup coreutils tagging

### DIFF
--- a/crates/nu-command/src/filesystem/mktemp.rs
+++ b/crates/nu-command/src/filesystem/mktemp.rs
@@ -21,12 +21,12 @@ impl Command for Mktemp {
 
     fn search_terms(&self) -> Vec<&str> {
         vec![
-            "coreutils",
             "create",
             "directory",
             "file",
             "folder",
             "temporary",
+            "coreutils",
         ]
     }
 

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -43,7 +43,7 @@ impl Command for UMv {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["move"]
+        vec!["move", "file", "files", "coreutils"]
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-command/src/system/uname.rs
+++ b/crates/nu-command/src/system/uname.rs
@@ -21,12 +21,12 @@ impl Command for UName {
     }
 
     fn usage(&self) -> &str {
-        "Print certain system information."
+        "Print certain system information using uutils/coreutils uname."
     }
 
     fn search_terms(&self) -> Vec<&str> {
         // add other terms?
-        vec!["system"]
+        vec!["system", "coreutils"]
     }
 
     fn run(


### PR DESCRIPTION
# Description

Cleanup search terms and help usage to be consistent and include coreutils so people can easily find out which commands are coreutils.

![image](https://github.com/nushell/nushell/assets/343840/09b03b11-19ce-49ec-b0b5-9b8455d1b676)

or
```nushell
help commands | where usage =~ coreutils | reject params input_output
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
