### PR TITLE
:recycle: rework some help strings

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/commands.rs
@@ -10,7 +10,7 @@ impl Command for ScopeCommands {
 
     fn signature(&self) -> Signature {
         Signature::build("scope commands")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::Any)))])
             .allow_variants_without_examples(true)
             .category(Category::Core)
     }

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -116,7 +116,7 @@ You can also learn more at https://www.nushell.sh/book/"#;
             },
             Example {
                 description: "show help for single sub-command, alias, or module",
-                example: "help str lpad",
+                example: "help str join",
                 result: None,
             },
             Example {

--- a/crates/nu-command/tests/main.rs
+++ b/crates/nu-command/tests/main.rs
@@ -233,7 +233,7 @@ fn usage_start_uppercase() {
 
         // Check lowercase to allow usage to contain syntax like:
         //
-        // "`let-env FOO = ...` …"
+        // "`$env.FOO = ...`"
         if usage.starts_with(|u: char| u.is_lowercase()) {
             failures.push(format!("{cmd_name}: \"{usage}\""));
         }

--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -715,7 +715,7 @@ def pretty-cmd [] {
 #   > help match
 #
 #   show help for single sub-command, alias, or module
-#   > help str lpad
+#   > help str join
 #
 #   search for string in command names, usage and search terms
 #   > help --find char


### PR DESCRIPTION
# Description

I changed some help outputs:

![image](https://github.com/nushell/nushell/assets/30557287/d25f0fbe-ffc3-43b3-93cf-b1793d2351b6)

![image](https://github.com/nushell/nushell/assets/30557287/acb5581c-8959-4916-8a55-d3ed6a2e1dcf)

I also checked with `rg` the commands deprecated in #9840 and found a help or a comment here and there.

# User-Facing Changes

same of above

# Tests + Formatting
