### PR TITLE
Rename `Value::CustomValue` to `Value::Custom`

### DIFF
--- a/crates/nu-cmd-dataframe/src/dataframe/eager/query_df.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/eager/query_df.rs
@@ -87,7 +87,7 @@ fn command(
     let lazy = NuLazyFrame::new(false, df_sql);
 
     let eager = lazy.collect(call.head)?;
-    let value = Value::custom_value(Box::new(eager), call.head);
+    let value = Value::custom(Box::new(eager), call.head);
 
     Ok(PipelineData::Value(value, None))
 }

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/collect.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/collect.rs
@@ -55,7 +55,7 @@ impl Command for LazyCollect {
     ) -> Result<PipelineData, ShellError> {
         let lazy = NuLazyFrame::try_from_pipeline(input, call.head)?;
         let eager = lazy.collect(call.head)?;
-        let value = Value::custom_value(Box::new(eager), call.head);
+        let value = Value::custom(Box::new(eager), call.head);
 
         Ok(PipelineData::Value(value, None))
     }

--- a/crates/nu-cmd-dataframe/src/dataframe/lazy/to_lazy.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/lazy/to_lazy.rs
@@ -47,7 +47,7 @@ impl Command for ToLazyFrame {
 
         let df = NuDataFrame::try_from_iter(input.into_iter(), maybe_schema)?;
         let lazy = NuLazyFrame::from_dataframe(df);
-        let value = Value::custom_value(Box::new(lazy), call.head);
+        let value = Value::custom(Box::new(lazy), call.head);
 
         Ok(PipelineData::Value(value, None))
     }

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/custom_value.rs
@@ -17,7 +17,7 @@ impl CustomValue for NuDataFrame {
             from_lazy: false,
         };
 
-        Value::custom_value(Box::new(cloned), span)
+        Value::custom(Box::new(cloned), span)
     }
 
     fn type_name(&self) -> String {

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/custom_value.rs
@@ -55,7 +55,7 @@ impl CustomValue for NuDataFrame {
 
     fn partial_cmp(&self, other: &Value) -> Option<std::cmp::Ordering> {
         match other {
-            Value::CustomValue { val, .. } => val
+            Value::Custom { val, .. } => val
                 .as_any()
                 .downcast_ref::<Self>()
                 .and_then(|other| self.is_equal(other)),

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
@@ -152,7 +152,7 @@ impl NuDataFrame {
 
         for value in iter {
             match value {
-                Value::CustomValue { .. } => return Self::try_from_value(value),
+                Value::Custom { .. } => return Self::try_from_value(value),
                 Value::List { vals, .. } => {
                     let record = vals
                         .into_iter()
@@ -256,7 +256,7 @@ impl NuDataFrame {
     pub fn get_df(value: Value) -> Result<Self, ShellError> {
         let span = value.span();
         match value {
-            Value::CustomValue { val, .. } => match val.as_any().downcast_ref::<Self>() {
+            Value::Custom { val, .. } => match val.as_any().downcast_ref::<Self>() {
                 Some(df) => Ok(NuDataFrame {
                     df: df.df.clone(),
                     from_lazy: false,
@@ -283,7 +283,7 @@ impl NuDataFrame {
     }
 
     pub fn can_downcast(value: &Value) -> bool {
-        if let Value::CustomValue { val, .. } = value {
+        if let Value::Custom { val, .. } = value {
             val.as_any().downcast_ref::<Self>().is_some()
         } else {
             false

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
@@ -116,15 +116,15 @@ impl NuDataFrame {
     }
 
     pub fn dataframe_into_value(dataframe: DataFrame, span: Span) -> Value {
-        Value::custom_value(Box::new(Self::new(false, dataframe)), span)
+        Value::custom(Box::new(Self::new(false, dataframe)), span)
     }
 
     pub fn into_value(self, span: Span) -> Value {
         if self.from_lazy {
             let lazy = NuLazyFrame::from_dataframe(self);
-            Value::custom_value(Box::new(lazy), span)
+            Value::custom(Box::new(lazy), span)
         } else {
-            Value::custom_value(Box::new(self), span)
+            Value::custom(Box::new(self), span)
         }
     }
 

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/operations.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/operations.rs
@@ -20,7 +20,7 @@ impl NuDataFrame {
     ) -> Result<Value, ShellError> {
         let rhs_span = right.span();
         match right {
-            Value::CustomValue { val: rhs, .. } => {
+            Value::Custom { val: rhs, .. } => {
                 let rhs = rhs.as_any().downcast_ref::<NuDataFrame>().ok_or_else(|| {
                     ShellError::DowncastNotPossible {
                         msg: "Unable to create dataframe".to_string(),

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/custom_value.rs
@@ -19,7 +19,7 @@ impl CustomValue for NuExpression {
     fn clone_value(&self, span: nu_protocol::Span) -> Value {
         let cloned = NuExpression(self.0.clone());
 
-        Value::custom_value(Box::new(cloned), span)
+        Value::custom(Box::new(cloned), span)
     }
 
     fn type_name(&self) -> String {

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/custom_value.rs
@@ -54,7 +54,7 @@ fn compute_with_value(
 ) -> Result<Value, ShellError> {
     let rhs_span = right.span();
     match right {
-        Value::CustomValue { val: rhs, .. } => {
+        Value::Custom { val: rhs, .. } => {
             let rhs = rhs.as_any().downcast_ref::<NuExpression>().ok_or_else(|| {
                 ShellError::DowncastNotPossible {
                     msg: "Unable to create expression".into(),

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/mod.rs
@@ -55,7 +55,7 @@ impl From<Expr> for NuExpression {
 
 impl NuExpression {
     pub fn into_value(self, span: Span) -> Value {
-        Value::custom_value(Box::new(self), span)
+        Value::custom(Box::new(self), span)
     }
 
     pub fn try_from_value(value: Value) -> Result<Self, ShellError> {

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_expression/mod.rs
@@ -61,7 +61,7 @@ impl NuExpression {
     pub fn try_from_value(value: Value) -> Result<Self, ShellError> {
         let span = value.span();
         match value {
-            Value::CustomValue { val, .. } => match val.as_any().downcast_ref::<Self>() {
+            Value::Custom { val, .. } => match val.as_any().downcast_ref::<Self>() {
                 Some(expr) => Ok(NuExpression(expr.0.clone())),
                 None => Err(ShellError::CantConvert {
                     to_type: "lazy expression".into(),
@@ -90,7 +90,7 @@ impl NuExpression {
 
     pub fn can_downcast(value: &Value) -> bool {
         match value {
-            Value::CustomValue { val, .. } => val.as_any().downcast_ref::<Self>().is_some(),
+            Value::Custom { val, .. } => val.as_any().downcast_ref::<Self>().is_some(),
             Value::List { vals, .. } => vals.iter().all(Self::can_downcast),
             Value::String { .. } | Value::Int { .. } | Value::Bool { .. } | Value::Float { .. } => {
                 true
@@ -144,7 +144,7 @@ impl ExtractedExpr {
     fn extract_exprs(value: Value) -> Result<ExtractedExpr, ShellError> {
         match value {
             Value::String { val, .. } => Ok(ExtractedExpr::Single(col(val.as_str()))),
-            Value::CustomValue { .. } => NuExpression::try_from_value(value)
+            Value::Custom { .. } => NuExpression::try_from_value(value)
                 .map(NuExpression::into_polars)
                 .map(ExtractedExpr::Single),
             Value::List { vals, .. } => vals

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/custom_value.rs
@@ -18,7 +18,7 @@ impl CustomValue for NuLazyFrame {
             schema: self.schema.clone(),
         };
 
-        Value::custom_value(Box::new(cloned), span)
+        Value::custom(Box::new(cloned), span)
     }
 
     fn type_name(&self) -> String {

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/mod.rs
@@ -141,7 +141,7 @@ impl NuLazyFrame {
     pub fn get_lazy_df(value: Value) -> Result<Self, ShellError> {
         let span = value.span();
         match value {
-            Value::CustomValue { val, .. } => match val.as_any().downcast_ref::<Self>() {
+            Value::Custom { val, .. } => match val.as_any().downcast_ref::<Self>() {
                 Some(expr) => Ok(Self {
                     lazy: expr.lazy.clone(),
                     from_eager: false,
@@ -164,7 +164,7 @@ impl NuLazyFrame {
     }
 
     pub fn can_downcast(value: &Value) -> bool {
-        if let Value::CustomValue { val, .. } = value {
+        if let Value::Custom { val, .. } = value {
             val.as_any().downcast_ref::<Self>().is_some()
         } else {
             false

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazyframe/mod.rs
@@ -90,9 +90,9 @@ impl NuLazyFrame {
     pub fn into_value(self, span: Span) -> Result<Value, ShellError> {
         if self.from_eager {
             let df = self.collect(span)?;
-            Ok(Value::custom_value(Box::new(df), span))
+            Ok(Value::custom(Box::new(df), span))
         } else {
-            Ok(Value::custom_value(Box::new(self), span))
+            Ok(Value::custom(Box::new(self), span))
         }
     }
 

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazygroupby/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazygroupby/custom_value.rs
@@ -18,7 +18,7 @@ impl CustomValue for NuLazyGroupBy {
             from_eager: self.from_eager,
         };
 
-        Value::custom_value(Box::new(cloned), span)
+        Value::custom(Box::new(cloned), span)
     }
 
     fn type_name(&self) -> String {

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazygroupby/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazygroupby/mod.rs
@@ -74,7 +74,7 @@ impl From<LazyGroupBy> for NuLazyGroupBy {
 
 impl NuLazyGroupBy {
     pub fn into_value(self, span: Span) -> Value {
-        Value::custom_value(Box::new(self), span)
+        Value::custom(Box::new(self), span)
     }
 
     pub fn into_polars(self) -> LazyGroupBy {

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazygroupby/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_lazygroupby/mod.rs
@@ -84,7 +84,7 @@ impl NuLazyGroupBy {
     pub fn try_from_value(value: Value) -> Result<Self, ShellError> {
         let span = value.span();
         match value {
-            Value::CustomValue { val, .. } => match val.as_any().downcast_ref::<NuLazyGroupBy>() {
+            Value::Custom { val, .. } => match val.as_any().downcast_ref::<NuLazyGroupBy>() {
                 Some(group) => Ok(Self {
                     group_by: group.group_by.clone(),
                     schema: group.schema.clone(),

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_when/custom_value.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_when/custom_value.rs
@@ -14,7 +14,7 @@ impl CustomValue for NuWhen {
     fn clone_value(&self, span: nu_protocol::Span) -> Value {
         let cloned = self.clone();
 
-        Value::custom_value(Box::new(cloned), span)
+        Value::custom(Box::new(cloned), span)
     }
 
     fn type_name(&self) -> String {

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_when/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_when/mod.rs
@@ -57,7 +57,7 @@ impl NuWhen {
     pub fn try_from_value(value: Value) -> Result<Self, ShellError> {
         let span = value.span();
         match value {
-            Value::CustomValue { val, .. } => match val.as_any().downcast_ref::<Self>() {
+            Value::Custom { val, .. } => match val.as_any().downcast_ref::<Self>() {
                 Some(expr) => Ok(expr.clone()),
                 None => Err(ShellError::CantConvert {
                     to_type: "when expression".into(),

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_when/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_when/mod.rs
@@ -51,7 +51,7 @@ impl From<ChainedThen> for NuWhen {
 
 impl NuWhen {
     pub fn into_value(self, span: Span) -> Value {
-        Value::custom_value(Box::new(self), span)
+        Value::custom(Box::new(self), span)
     }
 
     pub fn try_from_value(value: Value) -> Result<Self, ShellError> {

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -281,7 +281,7 @@ fn describe_value(
     options: Options,
 ) -> Result<Value, ShellError> {
     Ok(match value {
-        Value::CustomValue { val, .. } => Value::record(
+        Value::Custom { val, .. } => Value::record(
             record!(
                 "type" => Value::string("custom", head),
                 "subtype" => Value::string(val.type_name(), head),

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -274,7 +274,7 @@ impl<'a> std::fmt::Debug for DebuggableValue<'a> {
             Value::CellPath { val, .. } => {
                 write!(f, "CellPath({:?})", val.to_string())
             }
-            Value::CustomValue { val, .. } => {
+            Value::Custom { val, .. } => {
                 write!(f, "CustomValue({:?})", val)
             }
             Value::LazyRecord { val, .. } => {

--- a/crates/nu-color-config/src/style_computer.rs
+++ b/crates/nu-color-config/src/style_computer.rs
@@ -130,7 +130,7 @@ impl<'a> StyleComputer<'a> {
                 TextStyle::with_style(Left, s)
             }
             Value::Closure { .. }
-            | Value::CustomValue { .. }
+            | Value::Custom { .. }
             | Value::Error { .. }
             | Value::LazyRecord { .. } => TextStyle::basic_left(),
         }

--- a/crates/nu-command/src/conversions/into/string.rs
+++ b/crates/nu-command/src/conversions/into/string.rs
@@ -226,7 +226,7 @@ fn action(input: &Value, args: &Arguments, span: Span) -> Value {
             },
             span,
         ),
-        Value::CustomValue { val, .. } => {
+        Value::Custom { val, .. } => {
             // Only custom values that have a base value that can be converted to string are
             // accepted.
             val.to_base_value(input.span())

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -97,7 +97,7 @@ impl SQLiteDatabase {
 
     pub fn into_value(self, span: Span) -> Value {
         let db = Box::new(self);
-        Value::custom_value(db, span)
+        Value::custom(db, span)
     }
 
     pub fn query(
@@ -357,7 +357,7 @@ impl CustomValue for SQLiteDatabase {
             ctrlc: self.ctrlc.clone(),
         };
 
-        Value::custom_value(Box::new(cloned), span)
+        Value::custom(Box::new(cloned), span)
     }
 
     fn type_name(&self) -> String {

--- a/crates/nu-command/src/database/values/sqlite.rs
+++ b/crates/nu-command/src/database/values/sqlite.rs
@@ -69,7 +69,7 @@ impl SQLiteDatabase {
     pub fn try_from_value(value: Value) -> Result<Self, ShellError> {
         let span = value.span();
         match value {
-            Value::CustomValue { val, .. } => match val.as_any().downcast_ref::<Self>() {
+            Value::Custom { val, .. } => match val.as_any().downcast_ref::<Self>() {
                 Some(db) => Ok(Self {
                     path: db.path.clone(),
                     ctrlc: db.ctrlc.clone(),

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -293,7 +293,7 @@ pub fn debug_string_without_formatting(value: &Value) -> String {
         Value::CellPath { val, .. } => val.to_string(),
         // If we fail to collapse the custom value, just print <{type_name}> - failure is not
         // that critical here
-        Value::CustomValue { val, .. } => val
+        Value::Custom { val, .. } => val
             .to_base_value(value.span())
             .map(|val| debug_string_without_formatting(&val))
             .unwrap_or_else(|_| format!("<{}>", val.type_name())),

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -94,7 +94,7 @@ fn getcol(
                         .into_pipeline_data(ctrlc)
                         .set_metadata(metadata))
                 }
-                Value::CustomValue { val, .. } => {
+                Value::Custom { val, .. } => {
                     // TODO: should we get CustomValue to expose columns in a more efficient way?
                     // Would be nice to be able to get columns without generating the whole value
                     let input_as_base_value = val.to_base_value(span)?;

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -531,7 +531,7 @@ fn value_should_be_printed(
         | Value::Glob { .. }
         | Value::List { .. }
         | Value::CellPath { .. }
-        | Value::CustomValue { .. } => term_contains_value(term, &lower_value, span),
+        | Value::Custom { .. } => term_contains_value(term, &lower_value, span),
         Value::Record { val, .. } => {
             record_matches_term(val, columns_to_search, filter_config, term, span)
         }

--- a/crates/nu-command/src/filters/values.rs
+++ b/crates/nu-command/src/filters/values.rs
@@ -147,7 +147,7 @@ fn values(
                         .into_pipeline_data_with_metadata(metadata, ctrlc)),
                     Err(err) => Err(err),
                 },
-                Value::CustomValue { val, .. } => {
+                Value::Custom { val, .. } => {
                     let input_as_base_value = val.to_base_value(span)?;
                     match get_values(&[input_as_base_value], head, span) {
                         Ok(cols) => Ok(cols

--- a/crates/nu-command/src/formats/to/delimited.rs
+++ b/crates/nu-command/src/formats/to/delimited.rs
@@ -115,7 +115,7 @@ fn to_string_tagged_value(
         | Value::Int { .. }
         | Value::Duration { .. }
         | Value::Binary { .. }
-        | Value::CustomValue { .. }
+        | Value::Custom { .. }
         | Value::Filesize { .. }
         | Value::CellPath { .. }
         | Value::Float { .. } => Ok(v.clone().to_abbreviated_string(config)),

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -139,7 +139,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
             let collected = val.collect()?;
             value_to_json_value(&collected)?
         }
-        Value::CustomValue { val, .. } => {
+        Value::Custom { val, .. } => {
             let collected = val.to_base_value(span)?;
             value_to_json_value(&collected)?
         }

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -158,7 +158,7 @@ pub fn value_to_string(
             msg_span: span,
             input_span: v.span(),
         }),
-        Value::CustomValue { .. } => Err(ShellError::UnsupportedInput {
+        Value::Custom { .. } => Err(ShellError::UnsupportedInput {
             msg: "custom values are currently not nuon-compatible".to_string(),
             input: "value originates from here".into(),
             msg_span: span,

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -147,7 +147,7 @@ fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
         Value::CellPath { val, .. } => val.to_string(),
         // If we fail to collapse the custom value, just print <{type_name}> - failure is not
         // that critical here
-        Value::CustomValue { val, .. } => val
+        Value::Custom { val, .. } => val
             .to_base_value(span)
             .map(|val| local_into_string(val, separator, config))
             .unwrap_or_else(|_| format!("<{}>", val.type_name())),

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -93,7 +93,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
                 })
                 .collect::<Result<Vec<toml::Value>, ShellError>>()?,
         ),
-        Value::CustomValue { .. } => toml::Value::String("<Custom Value>".to_string()),
+        Value::Custom { .. } => toml::Value::String("<Custom Value>".to_string()),
     })
 }
 

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -95,7 +95,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
                 })
                 .collect::<Result<Vec<serde_yaml::Value>, ShellError>>()?,
         ),
-        Value::CustomValue { .. } => serde_yaml::Value::Null,
+        Value::Custom { .. } => serde_yaml::Value::Null,
     })
 }
 

--- a/crates/nu-command/src/sort_utils.rs
+++ b/crates/nu-command/src/sort_utils.rs
@@ -30,7 +30,7 @@ pub fn sort_value(
 
             Ok(Value::list(vals, span))
         }
-        Value::CustomValue { val, .. } => {
+        Value::Custom { val, .. } => {
             let base_val = val.to_base_value(span)?;
             sort_value(&base_val, sort_columns, ascending, insensitive, natural)
         }

--- a/crates/nu-command/src/stor/create.rs
+++ b/crates/nu-command/src/stor/create.rs
@@ -58,7 +58,7 @@ impl Command for StorCreate {
 
         process(table_name, span, &db, columns)?;
         // dbg!(db.clone());
-        Ok(Value::custom_value(db, span).into_pipeline_data())
+        Ok(Value::custom(db, span).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/stor/delete.rs
+++ b/crates/nu-command/src/stor/delete.rs
@@ -117,7 +117,7 @@ impl Command for StorDelete {
             }
         }
         // dbg!(db.clone());
-        Ok(Value::custom_value(db, span).into_pipeline_data())
+        Ok(Value::custom(db, span).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/stor/export.rs
+++ b/crates/nu-command/src/stor/export.rs
@@ -73,7 +73,7 @@ impl Command for StorExport {
                 })?;
         }
         // dbg!(db.clone());
-        Ok(Value::custom_value(db, span).into_pipeline_data())
+        Ok(Value::custom(db, span).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/stor/import.rs
+++ b/crates/nu-command/src/stor/import.rs
@@ -71,7 +71,7 @@ impl Command for StorImport {
                 })?;
         }
         // dbg!(db.clone());
-        Ok(Value::custom_value(db, span).into_pipeline_data())
+        Ok(Value::custom(db, span).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/stor/insert.rs
+++ b/crates/nu-command/src/stor/insert.rs
@@ -131,7 +131,7 @@ impl Command for StorInsert {
             };
         }
         // dbg!(db.clone());
-        Ok(Value::custom_value(db, span).into_pipeline_data())
+        Ok(Value::custom(db, span).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/stor/reset.rs
+++ b/crates/nu-command/src/stor/reset.rs
@@ -55,7 +55,7 @@ impl Command for StorReset {
                 })?;
         }
         // dbg!(db.clone());
-        Ok(Value::custom_value(db, span).into_pipeline_data())
+        Ok(Value::custom(db, span).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/stor/update.rs
+++ b/crates/nu-command/src/stor/update.rs
@@ -143,7 +143,7 @@ impl Command for StorUpdate {
             };
         }
         // dbg!(db.clone());
-        Ok(Value::custom_value(db, span).into_pipeline_data())
+        Ok(Value::custom(db, span).into_pipeline_data())
     }
 }
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -403,7 +403,7 @@ fn handle_table_command(
             // instead of stdout.
             Err(*error)
         }
-        PipelineData::Value(Value::CustomValue { val, .. }, ..) => {
+        PipelineData::Value(Value::Custom { val, .. }, ..) => {
             let base_pipeline = val.to_base_value(span)?.into_pipeline_data();
             Table.run(input.engine_state, input.stack, input.call, base_pipeline)
         }

--- a/crates/nu-plugin-test-support/tests/custom_value/mod.rs
+++ b/crates/nu-plugin-test-support/tests/custom_value/mod.rs
@@ -13,7 +13,7 @@ struct CustomU32(u32);
 
 impl CustomU32 {
     pub fn into_value(self, span: Span) -> Value {
-        Value::custom_value(Box::new(self), span)
+        Value::custom(Box::new(self), span)
     }
 }
 

--- a/crates/nu-plugin/src/plugin/interface/engine/tests.rs
+++ b/crates/nu-plugin/src/plugin/interface/engine/tests.rs
@@ -609,7 +609,7 @@ fn manager_prepare_pipeline_data_embeds_deserialization_errors_in_streams() -> R
 
     let span = Span::new(20, 30);
     let data = manager.prepare_pipeline_data(
-        [Value::custom_value(Box::new(invalid_custom_value), span)].into_pipeline_data(None),
+        [Value::custom(Box::new(invalid_custom_value), span)].into_pipeline_data(None),
     )?;
 
     let value = data
@@ -1147,7 +1147,7 @@ enum CantSerialize {
 #[typetag::serde]
 impl CustomValue for CantSerialize {
     fn clone_value(&self, span: Span) -> Value {
-        Value::custom_value(Box::new(self.clone()), span)
+        Value::custom(Box::new(self.clone()), span)
     }
 
     fn type_name(&self) -> String {
@@ -1170,11 +1170,7 @@ fn interface_prepare_pipeline_data_embeds_serialization_errors_in_streams() -> R
 
     let span = Span::new(40, 60);
     let data = interface.prepare_pipeline_data(
-        [Value::custom_value(
-            Box::new(CantSerialize::BadVariant),
-            span,
-        )]
-        .into_pipeline_data(None),
+        [Value::custom(Box::new(CantSerialize::BadVariant), span)].into_pipeline_data(None),
     )?;
 
     let value = data

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -241,7 +241,7 @@ impl PluginCustomValue {
             let span = value.span();
             match value {
                 // Set source on custom value
-                Value::CustomValue { ref val, .. } => {
+                Value::Custom { ref val, .. } => {
                     if let Some(custom_value) = val.as_any().downcast_ref::<PluginCustomValue>() {
                         // Since there's no `as_mut_any()`, we have to copy the whole thing
                         let mut custom_value = custom_value.clone();
@@ -272,7 +272,7 @@ impl PluginCustomValue {
             let span = value.span();
             match value {
                 // Set source on custom value
-                Value::CustomValue { val, .. } => {
+                Value::Custom { val, .. } => {
                     if let Some(custom_value) = val.as_any().downcast_ref::<PluginCustomValue>() {
                         if custom_value
                             .source
@@ -320,7 +320,7 @@ impl PluginCustomValue {
         value.recurse_mut(&mut |value| {
             let span = value.span();
             match value {
-                Value::CustomValue { ref val, .. } => {
+                Value::Custom { ref val, .. } => {
                     if val.as_any().downcast_ref::<PluginCustomValue>().is_some() {
                         // Already a PluginCustomValue
                         Ok(())
@@ -346,7 +346,7 @@ impl PluginCustomValue {
         value.recurse_mut(&mut |value| {
             let span = value.span();
             match value {
-                Value::CustomValue { ref val, .. } => {
+                Value::Custom { ref val, .. } => {
                     if let Some(val) = val.as_any().downcast_ref::<PluginCustomValue>() {
                         let deserialized = val.deserialize_to_custom_value(span)?;
                         *value = Value::custom_value(deserialized, span);
@@ -371,7 +371,7 @@ impl PluginCustomValue {
         value.recurse_mut(&mut |value| {
             let span = value.span();
             match value {
-                Value::CustomValue { ref val, .. } => {
+                Value::Custom { ref val, .. } => {
                     *value = val.to_base_value(span)?;
                     Ok(())
                 }

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -53,7 +53,7 @@ fn is_false(b: &bool) -> bool {
 #[typetag::serde]
 impl CustomValue for PluginCustomValue {
     fn clone_value(&self, span: Span) -> Value {
-        Value::custom_value(Box::new(self.clone()), span)
+        Value::custom(Box::new(self.clone()), span)
     }
 
     fn type_name(&self) -> String {
@@ -246,7 +246,7 @@ impl PluginCustomValue {
                         // Since there's no `as_mut_any()`, we have to copy the whole thing
                         let mut custom_value = custom_value.clone();
                         custom_value.source = Some(source.clone());
-                        *value = Value::custom_value(Box::new(custom_value), span);
+                        *value = Value::custom(Box::new(custom_value), span);
                     }
                     Ok(())
                 }
@@ -326,7 +326,7 @@ impl PluginCustomValue {
                         Ok(())
                     } else {
                         let serialized = Self::serialize_from_custom_value(&**val, span)?;
-                        *value = Value::custom_value(Box::new(serialized), span);
+                        *value = Value::custom(Box::new(serialized), span);
                         Ok(())
                     }
                 }
@@ -349,7 +349,7 @@ impl PluginCustomValue {
                 Value::Custom { ref val, .. } => {
                     if let Some(val) = val.as_any().downcast_ref::<PluginCustomValue>() {
                         let deserialized = val.deserialize_to_custom_value(span)?;
-                        *value = Value::custom_value(deserialized, span);
+                        *value = Value::custom(deserialized, span);
                         Ok(())
                     } else {
                         // Already not a PluginCustomValue

--- a/crates/nu-plugin/src/protocol/plugin_custom_value/tests.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value/tests.rs
@@ -231,12 +231,12 @@ fn add_source_nested_closure() -> Result<(), ShellError> {
 #[test]
 fn verify_source_error_message() -> Result<(), ShellError> {
     let span = Span::new(5, 7);
-    let mut ok_val = Value::custom_value(Box::new(test_plugin_custom_value_with_source()), span);
-    let mut native_val = Value::custom_value(Box::new(TestCustomValue(32)), span);
+    let mut ok_val = Value::custom(Box::new(test_plugin_custom_value_with_source()), span);
+    let mut native_val = Value::custom(Box::new(TestCustomValue(32)), span);
     let mut foreign_val = {
         let mut val = test_plugin_custom_value();
         val.source = Some(Arc::new(PluginSource::new_fake("other")));
-        Value::custom_value(Box::new(val), span)
+        Value::custom(Box::new(val), span)
     };
     let source = PluginSource::new_fake("test");
 
@@ -407,7 +407,7 @@ fn verify_source_nested_closure() -> Result<(), ShellError> {
 #[test]
 fn serialize_in_root() -> Result<(), ShellError> {
     let span = Span::new(4, 10);
-    let mut val = Value::custom_value(Box::new(expected_test_custom_value()), span);
+    let mut val = Value::custom(Box::new(expected_test_custom_value()), span);
     PluginCustomValue::serialize_custom_values_in(&mut val)?;
 
     assert_eq!(span, val.span());
@@ -520,7 +520,7 @@ fn serialize_in_closure() -> Result<(), ShellError> {
 #[test]
 fn deserialize_in_root() -> Result<(), ShellError> {
     let span = Span::new(4, 10);
-    let mut val = Value::custom_value(Box::new(test_plugin_custom_value()), span);
+    let mut val = Value::custom(Box::new(test_plugin_custom_value()), span);
     PluginCustomValue::deserialize_custom_values_in(&mut val)?;
 
     assert_eq!(span, val.span());

--- a/crates/nu-plugin/src/protocol/test_util.rs
+++ b/crates/nu-plugin/src/protocol/test_util.rs
@@ -9,7 +9,7 @@ pub(crate) struct TestCustomValue(pub i32);
 #[typetag::serde]
 impl CustomValue for TestCustomValue {
     fn clone_value(&self, span: Span) -> Value {
-        Value::custom_value(Box::new(self.clone()), span)
+        Value::custom(Box::new(self.clone()), span)
     }
 
     fn type_name(&self) -> String {

--- a/crates/nu-plugin/src/serializers/tests.rs
+++ b/crates/nu-plugin/src/serializers/tests.rs
@@ -320,7 +320,7 @@ macro_rules! generate_tests {
             let data = vec![1, 2, 3, 4, 5];
             let span = Span::new(2, 30);
 
-            let value = Value::custom_value(
+            let value = Value::custom(
                 Box::new(PluginCustomValue::new(
                     name.into(),
                     data.clone(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2051,7 +2051,7 @@ impl Value {
         }
     }
 
-    pub fn custom_value(val: Box<dyn CustomValue>, span: Span) -> Value {
+    pub fn custom(val: Box<dyn CustomValue>, span: Span) -> Value {
         Value::Custom {
             val,
             internal_span: span,
@@ -2164,7 +2164,7 @@ impl Value {
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
     /// when used in errors.
     pub fn test_custom_value(val: Box<dyn CustomValue>) -> Value {
-        Value::custom_value(val, Span::test_data())
+        Value::custom(val, Span::test_data())
     }
 
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source

--- a/crates/nu_plugin_custom_values/src/cool_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/cool_custom_value.rs
@@ -21,7 +21,7 @@ impl CoolCustomValue {
     pub fn try_from_value(value: &Value) -> Result<Self, ShellError> {
         let span = value.span();
         match value {
-            Value::CustomValue { val, .. } => {
+            Value::Custom { val, .. } => {
                 if let Some(cool) = val.as_any().downcast_ref::<Self>() {
                     Ok(cool.clone())
                 } else {
@@ -94,7 +94,7 @@ impl CustomValue for CoolCustomValue {
     }
 
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
-        if let Value::CustomValue { val, .. } = other {
+        if let Value::Custom { val, .. } = other {
             val.as_any()
                 .downcast_ref()
                 .and_then(|other: &CoolCustomValue| PartialOrd::partial_cmp(self, other))

--- a/crates/nu_plugin_custom_values/src/cool_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/cool_custom_value.rs
@@ -15,7 +15,7 @@ impl CoolCustomValue {
     }
 
     pub fn into_value(self, span: Span) -> Value {
-        Value::custom_value(Box::new(self), span)
+        Value::custom(Box::new(self), span)
     }
 
     pub fn try_from_value(value: &Value) -> Result<Self, ShellError> {
@@ -46,7 +46,7 @@ impl CoolCustomValue {
 #[typetag::serde]
 impl CustomValue for CoolCustomValue {
     fn clone_value(&self, span: Span) -> Value {
-        Value::custom_value(Box::new(self.clone()), span)
+        Value::custom(Box::new(self.clone()), span)
     }
 
     fn type_name(&self) -> String {
@@ -118,7 +118,7 @@ impl CustomValue for CoolCustomValue {
                     .ok()
                     .and_then(|c| c.as_any().downcast_ref::<CoolCustomValue>())
                 {
-                    Ok(Value::custom_value(
+                    Ok(Value::custom(
                         Box::new(CoolCustomValue {
                             cool: format!("{}{}", self.cool, right.cool),
                         }),

--- a/crates/nu_plugin_custom_values/src/drop_check.rs
+++ b/crates/nu_plugin_custom_values/src/drop_check.rs
@@ -16,7 +16,7 @@ impl DropCheckValue {
     }
 
     pub(crate) fn into_value(self, span: Span) -> Value {
-        Value::custom_value(Box::new(self), span)
+        Value::custom(Box::new(self), span)
     }
 
     pub(crate) fn notify(&self) {

--- a/crates/nu_plugin_custom_values/src/second_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/second_custom_value.rs
@@ -22,7 +22,7 @@ impl SecondCustomValue {
     pub fn try_from_value(value: &Value) -> Result<Self, ShellError> {
         let span = value.span();
         match value {
-            Value::CustomValue { val, .. } => match val.as_any().downcast_ref::<Self>() {
+            Value::Custom { val, .. } => match val.as_any().downcast_ref::<Self>() {
                 Some(value) => Ok(value.clone()),
                 None => Err(ShellError::CantConvert {
                     to_type: "cool".into(),
@@ -62,7 +62,7 @@ impl CustomValue for SecondCustomValue {
     }
 
     fn partial_cmp(&self, other: &Value) -> Option<Ordering> {
-        if let Value::CustomValue { val, .. } = other {
+        if let Value::Custom { val, .. } = other {
             val.as_any()
                 .downcast_ref()
                 .and_then(|other: &SecondCustomValue| PartialOrd::partial_cmp(self, other))

--- a/crates/nu_plugin_custom_values/src/second_custom_value.rs
+++ b/crates/nu_plugin_custom_values/src/second_custom_value.rs
@@ -16,7 +16,7 @@ impl SecondCustomValue {
     }
 
     pub fn into_value(self, span: Span) -> Value {
-        Value::custom_value(Box::new(self), span)
+        Value::custom(Box::new(self), span)
     }
 
     pub fn try_from_value(value: &Value) -> Result<Self, ShellError> {
@@ -44,7 +44,7 @@ impl SecondCustomValue {
 #[typetag::serde]
 impl CustomValue for SecondCustomValue {
     fn clone_value(&self, span: nu_protocol::Span) -> Value {
-        Value::custom_value(Box::new(self.clone()), span)
+        Value::custom(Box::new(self.clone()), span)
     }
 
     fn type_name(&self) -> String {


### PR DESCRIPTION

# Description
The second `Value` is redundant and will consume five extra bytes on each transmission of a custom value to/from a plugin.

# User-Facing Changes
This is a breaking change to the plugin protocol.

The [example in the protocol reference](https://www.nushell.sh/contributor-book/plugin_protocol_reference.html#value) becomes

```json
{
  "Custom": {
    "val": {
      "type": "PluginCustomValue",
      "name": "database",
      "data": [36, 190, 127, 40, 12, 3, 46, 83],
      "notify_on_drop": true
    },
    "span": {
      "start": 320,
      "end": 340
    }
  }
}
```

instead of 

```json
{
  "CustomValue": {
    ...
  }
}
```


# After Submitting
Update plugin protocol reference
