### PR TITLE
keep sqlparser at 39 until polars is upgraded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,7 +2786,7 @@ dependencies = [
  "polars-plan",
  "polars-utils",
  "serde",
- "sqlparser 0.44.0",
+ "sqlparser",
 ]
 
 [[package]]
@@ -4117,7 +4117,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "sqlparser 0.39.0",
+ "sqlparser",
 ]
 
 [[package]]
@@ -5224,15 +5224,6 @@ name = "sqlparser"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743b4dc2cbde11890ccb254a8fc9d537fa41b36da00de2a1c5e9848c9bc42bd7"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf9c7ff146298ffda83a200f8d5084f08dcee1edfc135fcc1d646a45d50ffd6"
 dependencies = [
  "log",
 ]

--- a/crates/nu-cmd-dataframe/Cargo.toml
+++ b/crates/nu-cmd-dataframe/Cargo.toml
@@ -24,7 +24,8 @@ fancy-regex = { workspace = true }
 indexmap = { workspace = true }
 num = { version = "0.4", optional = true }
 serde = { workspace = true, features = ["derive"] }
-sqlparser = { version = "0.44", optional = true }
+# keep sqlparser at 0.39.0 until we can update polars
+sqlparser = { version = "0.39.0", optional = true }
 polars-io = { version = "0.37", features = ["avro"], optional = true }
 polars-arrow = { version = "0.37", optional = true }
 polars-ops = { version = "0.37", optional = true }


### PR DESCRIPTION
# Description

This PR reverts sqlparser to 0.39.0. It should stay here until we can get polars updated so that we don't have to have two versions of sqlparser.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
