### PR TITLE
Avoid uses of `Record` internals again

### DIFF
--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -1,6 +1,7 @@
 use crate::database::values::sqlite::{open_sqlite_db, values_to_sql};
 use nu_engine::command_prelude::*;
 
+use itertools::Itertools;
 use std::{
     path::Path,
     sync::{
@@ -243,8 +244,8 @@ fn insert_in_transaction(
         let insert_statement = format!(
             "INSERT INTO [{}] ({}) VALUES ({})",
             table_name,
-            val.cols.join(", "),
-            ["?"].repeat(val.values().len()).join(", ")
+            Itertools::intersperse(val.columns().map(String::as_str), ", ").collect::<String>(),
+            Itertools::intersperse(itertools::repeat_n("?", val.len()), ", ").collect::<String>(),
         );
 
         let mut insert_statement =

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -269,8 +269,7 @@ impl Job {
     fn find_invalid_column(record: &Record) -> Option<&String> {
         const VALID_COLS: [&str; 3] = [COLUMN_TAG_NAME, COLUMN_ATTRS_NAME, COLUMN_CONTENT_NAME];
         record
-            .cols
-            .iter()
+            .columns()
             .find(|col| !VALID_COLS.contains(&col.as_str()))
     }
 


### PR DESCRIPTION
# Description
Again avoid uses of the `Record` internals, so we are free to change the data layout

- **Don't use internals of `Record` in `into sqlite`**
- **Don't use internals of `Record` in `to xml`**

Remaining: `rename`

# User-Facing Changes
None
