### PR TITLE
Use safe `nix` API instead of `libc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,6 @@ dependencies = [
  "indexmap",
  "indicatif",
  "itertools 0.12.0",
- "libc",
  "log",
  "lscolors",
  "md-5",

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -106,9 +106,8 @@ winreg = { workspace = true }
 uucore = { workspace = true, features = ["mode"] }
 
 [target.'cfg(unix)'.dependencies]
-libc = { workspace = true }
 umask = { workspace = true }
-nix = { workspace = true, default-features = false, features = ["user", "resource"] }
+nix = { workspace = true, default-features = false, features = ["user", "resource", "pthread"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs = { workspace = true }

--- a/crates/nu-command/src/debug/info.rs
+++ b/crates/nu-command/src/debug/info.rs
@@ -268,6 +268,6 @@ fn get_thread_id() -> u64 {
     }
     #[cfg(unix)]
     {
-        nix::sys::pthread::pthread_self()
+        nix::sys::pthread::pthread_self() as u64
     }
 }

--- a/crates/nu-command/src/debug/info.rs
+++ b/crates/nu-command/src/debug/info.rs
@@ -71,7 +71,7 @@ impl LazySystemInfoRecord {
     ) -> Result<Value, ShellError> {
         let pid = Pid::from(std::process::id() as usize);
         match column {
-            "thread_id" => Ok(Value::int(get_thread_id(), self.span)),
+            "thread_id" => Ok(Value::int(get_thread_id() as i64, self.span)),
             "pid" => Ok(Value::int(pid.as_u32() as i64, self.span)),
             "ppid" => {
                 // only get information requested
@@ -261,13 +261,13 @@ impl<'a, F: Fn() -> RefreshKind> From<(Option<&'a System>, F)> for SystemOpt<'a>
     }
 }
 
-fn get_thread_id() -> i64 {
-    #[cfg(target_family = "windows")]
+fn get_thread_id() -> u64 {
+    #[cfg(windows)]
     {
-        unsafe { windows::Win32::System::Threading::GetCurrentThreadId() as i64 }
+        unsafe { windows::Win32::System::Threading::GetCurrentThreadId().into() }
     }
-    #[cfg(not(target_family = "windows"))]
+    #[cfg(unix)]
     {
-        unsafe { libc::pthread_self() as i64 }
+        nix::sys::pthread::pthread_self()
     }
 }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use {
     crate::filesystem::util::users,
     nix::{
-        sys::stat::Mode,
+        sys::stat::{mode_t, Mode},
         unistd::{Gid, Uid},
     },
     std::os::unix::fs::MetadataExt,
@@ -170,7 +170,7 @@ fn have_permission(dir: impl AsRef<Path>) -> PermissionResult<'static> {
 fn have_permission(dir: impl AsRef<Path>) -> PermissionResult<'static> {
     match dir.as_ref().metadata() {
         Ok(metadata) => {
-            let mode = Mode::from_bits_truncate(metadata.mode());
+            let mode = Mode::from_bits_truncate(metadata.mode() as mode_t);
             let current_user_uid = users::get_current_uid();
             if current_user_uid.is_root() {
                 return PermissionResult::PermissionOk;

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -511,6 +511,7 @@ pub(crate) fn dir_entry_dict(
             {
                 use crate::filesystem::util::users;
                 use std::os::unix::fs::MetadataExt;
+
                 let mode = md.permissions().mode();
                 record.push(
                     "mode",
@@ -525,19 +526,19 @@ pub(crate) fn dir_entry_dict(
 
                 record.push(
                     "user",
-                    if let Some(user) = users::get_user_by_uid(md.uid()) {
+                    if let Some(user) = users::get_user_by_uid(md.uid().into()) {
                         Value::string(user.name, span)
                     } else {
-                        Value::int(md.uid() as i64, span)
+                        Value::int(md.uid().into(), span)
                     },
                 );
 
                 record.push(
                     "group",
-                    if let Some(group) = users::get_group_by_gid(md.gid()) {
+                    if let Some(group) = users::get_group_by_gid(md.gid().into()) {
                         Value::string(group.name, span)
                     } else {
-                        Value::int(md.gid() as i64, span)
+                        Value::int(md.gid().into(), span)
                     },
                 );
             }

--- a/crates/nu-system/src/foreground.rs
+++ b/crates/nu-system/src/foreground.rs
@@ -120,7 +120,7 @@ mod foreground_pgroup {
     /// Currently only intended to access `tcsetpgrp` and `tcgetpgrp` with the I/O safe `nix`
     /// interface.
     pub unsafe fn stdin_fd() -> impl AsFd {
-        unsafe { BorrowedFd::borrow_raw(libc::STDIN_FILENO) }
+        unsafe { BorrowedFd::borrow_raw(nix::libc::STDIN_FILENO) }
     }
 
     pub fn prepare_command(external_command: &mut Command, existing_pgrp: u32) {


### PR DESCRIPTION
# Description
Where possible, this PR replaces usages of raw `libc` bindings to instead use safe interfaces from the `nix` crate. Where not possible,  the `libc` version reexported through `nix` was used instead of having a separate `libc` dependency.
