### PR TITLE
Fix build of nu-protocol without plugin feature enabled

### DIFF
--- a/crates/nu-protocol/src/example.rs
+++ b/crates/nu-protocol/src/example.rs
@@ -20,6 +20,7 @@ pub struct PluginExample {
     pub result: Option<Value>,
 }
 
+#[cfg(feature = "plugin")]
 impl From<Example<'_>> for PluginExample {
     fn from(value: Example) -> Self {
         PluginExample {


### PR DESCRIPTION
# Description

I broke this, I think in #12279, because I forgot a `#[cfg(plugin)]`
