### PR TITLE
Add `Record::into_columns`

### DIFF
--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -391,6 +391,10 @@ impl Iterator for IntoIter {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl DoubleEndedIterator for IntoIter {
@@ -427,6 +431,10 @@ impl<'a> Iterator for Iter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(col, val): &(_, _)| (col, val))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
 
 impl<'a> DoubleEndedIterator for Iter<'a> {
@@ -462,6 +470,10 @@ impl<'a> Iterator for IterMut<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|(col, val)| (&*col, val))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }
 

--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -216,6 +216,12 @@ impl Record {
         }
     }
 
+    pub fn into_columns(self) -> IntoColumns {
+        IntoColumns {
+            iter: self.inner.into_iter(),
+        }
+    }
+
     pub fn values(&self) -> Values {
         Values {
             iter: self.inner.iter(),
@@ -506,6 +512,34 @@ impl<'a> DoubleEndedIterator for Columns<'a> {
 }
 
 impl<'a> ExactSizeIterator for Columns<'a> {
+    fn len(&self) -> usize {
+        self.iter.len()
+    }
+}
+
+pub struct IntoColumns {
+    iter: std::vec::IntoIter<(String, Value)>,
+}
+
+impl Iterator for IntoColumns {
+    type Item = String;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|(col, _)| col)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl DoubleEndedIterator for IntoColumns {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back().map(|(col, _)| col)
+    }
+}
+
+impl ExactSizeIterator for IntoColumns {
     fn len(&self) -> usize {
         self.iter.len()
     }


### PR DESCRIPTION
# Description
Add `Record::into_columns` to complement `Record::columns` and `Record::into_values`.