### PR TITLE
Elide clone in `V::follow_cell_path` for record

### DIFF
--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1160,16 +1160,16 @@ impl Value {
                     let span = current.span();
 
                     match current {
-                        Value::Record { val, .. } => {
+                        Value::Record { mut val, .. } => {
                             // Make reverse iterate to avoid duplicate column leads to first value, actually last value is expected.
-                            if let Some(found) = val.iter().rev().find(|x| {
+                            if let Some(found) = val.iter_mut().rev().find(|x| {
                                 if insensitive {
                                     x.0.eq_ignore_case(column_name)
                                 } else {
                                     x.0 == column_name
                                 }
                             }) {
-                                current = found.1.clone(); // TODO: avoid clone here
+                                current = std::mem::take(found.1);
                             } else if *optional {
                                 return Ok(Value::nothing(*origin_span)); // short-circuit
                             } else if let Some(suggestion) =
@@ -1222,15 +1222,15 @@ impl Value {
                                 .map(|val| {
                                     let val_span = val.span();
                                     match val {
-                                        Value::Record { val, .. } => {
-                                            if let Some(found) = val.iter().rev().find(|x| {
+                                        Value::Record { mut val, .. } => {
+                                            if let Some(found) = val.iter_mut().rev().find(|x| {
                                                 if insensitive {
                                                     x.0.eq_ignore_case(column_name)
                                                 } else {
                                                     x.0 == column_name
                                                 }
                                             }) {
-                                                Ok(found.1.clone()) // TODO: avoid clone here
+                                                Ok(std::mem::take(found.1))
                                             } else if *optional {
                                                 Ok(Value::nothing(*origin_span))
                                             } else if let Some(suggestion) =


### PR DESCRIPTION
# Description
This clone is not necessary and tanks the performance of deep nested access.
As soon as we found the value we now we discard the old value so can `std::mem::take` the inner (`impl Default for Value` to the rescue)

We may be able to further optimize this but not having to clone the value is vital.

# Benchmarking

I basically took @Devyn 's benchmark script from #12305 and ran it with default setting (no change to the time, potential thermal rampup/slowdown)

<details>
<summary><code>devynbench.nu</code></summary>

```nu
git checkout main
cargo bench | tee { save before.txt }
git checkout -
cargo bench | tee { save after.txt }
open before.txt | lines | zip { open after.txt | lines } | flatten | save combined.txt
```

</details>

## Results

### highlight `nest_access`

first line `main`
second line `i-follow-records-deep-nest-baby`

```
│  ╰─ nest_access                              │               │               │               │         │
│  ╰─ nest_access                              │               │               │               │         │
│     ├─ 1                       18.9 µs       │ 45.59 µs      │ 19.28 µs      │ 20.07 µs      │ 100     │ 100
│     ├─ 1                       21.82 µs      │ 58.9 µs       │ 22.34 µs      │ 23.18 µs      │ 100     │ 100
│     ├─ 2                       20.86 µs      │ 58.99 µs      │ 21.49 µs      │ 22.62 µs      │ 100     │ 100
│     ├─ 2                       20.06 µs      │ 100.5 µs      │ 20.52 µs      │ 21.84 µs      │ 100     │ 100
│     ├─ 4                       22.05 µs      │ 48.13 µs      │ 22.62 µs      │ 23.86 µs      │ 100     │ 100
│     ├─ 4                       24.63 µs      │ 50.97 µs      │ 25.03 µs      │ 25.79 µs      │ 100     │ 100
│     ├─ 8                       27.02 µs      │ 50.55 µs      │ 28.75 µs      │ 29.7 µs       │ 100     │ 100
│     ├─ 8                       23.79 µs      │ 48.44 µs      │ 24.43 µs      │ 25.17 µs      │ 100     │ 100
│     ├─ 16                      40.08 µs      │ 76.74 µs      │ 40.82 µs      │ 41.88 µs      │ 100     │ 100
│     ├─ 16                      28.44 µs      │ 72.42 µs      │ 29.1 µs       │ 30.09 µs      │ 100     │ 100
│     ├─ 32                      88.85 µs      │ 119.5 µs      │ 90.29 µs      │ 92.23 µs      │ 100     │ 100
│     ├─ 32                      40.34 µs      │ 138.2 µs      │ 41.31 µs      │ 43.33 µs      │ 100     │ 100
│     ├─ 64                      243.9 µs      │ 302.6 µs      │ 248.9 µs      │ 251.8 µs      │ 100     │ 100
│     ├─ 64                      53.77 µs      │ 143.2 µs      │ 60.86 µs      │ 61.33 µs      │ 100     │ 100
│     ╰─ 128                     862.4 µs      │ 927.7 µs      │ 878.5 µs      │ 880.6 µs      │ 100     │ 100
│     ╰─ 128                     84.36 µs      │ 140 µs        │ 86.39 µs      │ 88.79 µs      │ 100     │ 100
```


<details>
<summary>Full output</summary>

```
benchmarks                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
benchmarks                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ load_standard_lib             12.97 ms      │ 15.78 ms      │ 13.61 ms      │ 13.69 ms      │ 100     │ 100
├─ load_standard_lib             12.28 ms      │ 16.72 ms      │ 12.45 ms      │ 12.52 ms      │ 100     │ 100
├─ decoding_benchmarks                         │               │               │               │         │
├─ decoding_benchmarks                         │               │               │               │         │
│  ├─ json_decode                              │               │               │               │         │
│  ├─ json_decode                              │               │               │               │         │
│  │  ├─ (100, 5)                542.1 µs      │ 710.5 µs      │ 548.3 µs      │ 558.8 µs      │ 100     │ 100
│  │  ├─ (100, 5)                522.8 µs      │ 645.7 µs      │ 550.3 µs      │ 557.1 µs      │ 100     │ 100
│  │  ╰─ (10000, 15)             199.7 ms      │ 247 ms        │ 202.9 ms      │ 204.7 ms      │ 100     │ 100
│  │  ╰─ (10000, 15)             198.5 ms      │ 208.4 ms      │ 200.7 ms      │ 201.1 ms      │ 100     │ 100
│  ╰─ msgpack_decode                           │               │               │               │         │
│  ╰─ msgpack_decode                           │               │               │               │         │
│     ├─ (100, 5)                239.9 µs      │ 297.1 µs      │ 241.6 µs      │ 244.2 µs      │ 100     │ 100
│     ├─ (100, 5)                243.4 µs      │ 293.9 µs      │ 245.9 µs      │ 249.3 µs      │ 100     │ 100
│     ╰─ (10000, 15)             81.26 ms      │ 83.07 ms      │ 81.73 ms      │ 81.78 ms      │ 100     │ 100
│     ╰─ (10000, 15)             84.22 ms      │ 102 ms        │ 85.65 ms      │ 86.71 ms      │ 100     │ 100
├─ encoding_benchmarks                         │               │               │               │         │
├─ encoding_benchmarks                         │               │               │               │         │
│  ├─ json_encode                              │               │               │               │         │
│  ├─ json_encode                              │               │               │               │         │
│  │  ├─ (100, 5)                111.1 µs      │ 139.6 µs      │ 112.3 µs      │ 113.4 µs      │ 100     │ 100
│  │  ├─ (100, 5)                111.3 µs      │ 179.9 µs      │ 113.3 µs      │ 117.2 µs      │ 100     │ 100
│  │  ╰─ (10000, 15)             30.23 ms      │ 30.68 ms      │ 30.35 ms      │ 30.38 ms      │ 100     │ 100
│  │  ╰─ (10000, 15)             28.24 ms      │ 29.95 ms      │ 29.29 ms      │ 29.34 ms      │ 100     │ 100
│  ╰─ msgpack_encode                           │               │               │               │         │
│  ╰─ msgpack_encode                           │               │               │               │         │
│     ├─ (100, 5)                43.49 µs      │ 79.3 µs       │ 44.04 µs      │ 44.74 µs      │ 100     │ 100
│     ├─ (100, 5)                42.25 µs      │ 56.58 µs      │ 43.12 µs      │ 43.43 µs      │ 100     │ 100
│     ╰─ (10000, 15)             11.12 ms      │ 11.51 ms      │ 11.32 ms      │ 11.32 ms      │ 100     │ 100
│     ╰─ (10000, 15)             10.65 ms      │ 11.35 ms      │ 10.97 ms      │ 10.97 ms      │ 100     │ 100
├─ eval_benchmarks                             │               │               │               │         │
├─ eval_benchmarks                             │               │               │               │         │
│  ├─ eval_default_config        3.093 ms      │ 6.066 ms      │ 3.132 ms      │ 3.172 ms      │ 100     │ 100
│  ├─ eval_default_config        3.054 ms      │ 8.281 ms      │ 3.118 ms      │ 3.179 ms      │ 100     │ 100
│  ╰─ eval_default_env           506 µs        │ 600.1 µs      │ 516.8 µs      │ 523.5 µs      │ 100     │ 100
│  ╰─ eval_default_env           503.8 µs      │ 612.1 µs      │ 516.4 µs      │ 524.8 µs      │ 100     │ 100
├─ eval_commands                               │               │               │               │         │
├─ eval_commands                               │               │               │               │         │
│  ├─ each                                     │               │               │               │         │
│  ├─ each                                     │               │               │               │         │
│  │  ├─ 1                       75.18 µs      │ 215.1 µs      │ 135.1 µs      │ 124.9 µs      │ 100     │ 100
│  │  ├─ 1                       90.79 µs      │ 200.7 µs      │ 150.3 µs      │ 132.2 µs      │ 100     │ 100
│  │  ├─ 5                       273.5 µs      │ 804.1 µs      │ 336.9 µs      │ 330.2 µs      │ 100     │ 100
│  │  ├─ 5                       280.8 µs      │ 1.099 ms      │ 342.6 µs      │ 360.3 µs      │ 100     │ 100
│  │  ├─ 10                      545.8 µs      │ 696.8 µs      │ 635.2 µs      │ 623.9 µs      │ 100     │ 100
│  │  ├─ 10                      497.6 µs      │ 781.2 µs      │ 635.5 µs      │ 641.3 µs      │ 100     │ 100
│  │  ├─ 100                     5.397 ms      │ 7.019 ms      │ 6.135 ms      │ 6.126 ms      │ 100     │ 100
│  │  ├─ 100                     5.139 ms      │ 6.635 ms      │ 6.159 ms      │ 6.094 ms      │ 100     │ 100
│  │  ╰─ 1000                    51.69 ms      │ 62.94 ms      │ 60.34 ms      │ 59.65 ms      │ 100     │ 100
│  │  ╰─ 1000                    55.59 ms      │ 62.87 ms      │ 61.35 ms      │ 61.02 ms      │ 100     │ 100
│  ├─ for_range                                │               │               │               │         │
│  ├─ for_range                                │               │               │               │         │
│  │  ├─ 1                       83.85 µs      │ 178.5 µs      │ 105.8 µs      │ 116.9 µs      │ 100     │ 100
│  │  ├─ 1                       88.35 µs      │ 193.5 µs      │ 148.1 µs      │ 127.5 µs      │ 100     │ 100
│  │  ├─ 5                       273.1 µs      │ 659.9 µs      │ 333.4 µs      │ 322.2 µs      │ 100     │ 100
│  │  ├─ 5                       277.4 µs      │ 434.3 µs      │ 340 µs        │ 344.4 µs      │ 100     │ 100
│  │  ├─ 10                      549.9 µs      │ 1.045 ms      │ 608 µs        │ 625.6 µs      │ 100     │ 100
│  │  ├─ 10                      515.6 µs      │ 902.5 µs      │ 636.1 µs      │ 630.6 µs      │ 100     │ 100
│  │  ├─ 100                     5.794 ms      │ 6.439 ms      │ 6.116 ms      │ 6.107 ms      │ 100     │ 100
│  │  ├─ 100                     4.942 ms      │ 6.884 ms      │ 6.058 ms      │ 6.054 ms      │ 100     │ 100
│  │  ╰─ 1000                    55.49 ms      │ 62.59 ms      │ 60.86 ms      │ 60.61 ms      │ 100     │ 100
│  │  ╰─ 1000                    50.74 ms      │ 61.49 ms      │ 59.63 ms      │ 59.38 ms      │ 100     │ 100
│  ├─ interleave                               │               │               │               │         │
│  ├─ interleave                               │               │               │               │         │
│  │  ├─ 100                     1.39 ms       │ 2.409 ms      │ 1.729 ms      │ 1.747 ms      │ 100     │ 100
│  │  ├─ 100                     1.403 ms      │ 2.4 ms        │ 1.81 ms       │ 1.801 ms      │ 100     │ 100
│  │  ├─ 1000                    11.47 ms      │ 18 ms         │ 13.56 ms      │ 13.92 ms      │ 100     │ 100
│  │  ├─ 1000                    11.5 ms       │ 16.94 ms      │ 13.13 ms      │ 13.33 ms      │ 100     │ 100
│  │  ╰─ 10000                   124.6 ms      │ 166.8 ms      │ 146.4 ms      │ 145.9 ms      │ 100     │ 100
│  │  ╰─ 10000                   124.1 ms      │ 184 ms        │ 147.5 ms      │ 147.2 ms      │ 100     │ 100
│  ├─ interleave_with_ctrlc                    │               │               │               │         │
│  ├─ interleave_with_ctrlc                    │               │               │               │         │
│  │  ├─ 100                     1.36 ms       │ 2.067 ms      │ 1.559 ms      │ 1.577 ms      │ 100     │ 100
│  │  ├─ 100                     1.358 ms      │ 2.124 ms      │ 1.578 ms      │ 1.609 ms      │ 100     │ 100
│  │  ├─ 1000                    12.1 ms       │ 18.63 ms      │ 13.66 ms      │ 13.86 ms      │ 100     │ 100
│  │  ├─ 1000                    12.47 ms      │ 18.86 ms      │ 14.28 ms      │ 14.53 ms      │ 100     │ 100
│  │  ╰─ 10000                   117.8 ms      │ 154.4 ms      │ 136.4 ms      │ 137.4 ms      │ 100     │ 100
│  │  ╰─ 10000                   122.8 ms      │ 166.6 ms      │ 137.2 ms      │ 138.2 ms      │ 100     │ 100
│  ├─ par_each_1t                              │               │               │               │         │
│  ├─ par_each_1t                              │               │               │               │         │
│  │  ├─ 1                       152.1 µs      │ 232.7 µs      │ 161 µs        │ 163.4 µs      │ 100     │ 100
│  │  ├─ 1                       161.2 µs      │ 293.2 µs      │ 164 µs        │ 168.6 µs      │ 100     │ 100
│  │  ├─ 5                       334.5 µs      │ 502 µs        │ 351.5 µs      │ 358.2 µs      │ 100     │ 100
│  │  ├─ 5                       328.4 µs      │ 444.7 µs      │ 353.5 µs      │ 360.3 µs      │ 100     │ 100
│  │  ├─ 10                      519.2 µs      │ 778.3 µs      │ 665.2 µs      │ 674.1 µs      │ 100     │ 100
│  │  ├─ 10                      478.6 µs      │ 802.4 µs      │ 662.7 µs      │ 672.2 µs      │ 100     │ 100
│  │  ├─ 100                     5.274 ms      │ 6.812 ms      │ 6.183 ms      │ 6.147 ms      │ 100     │ 100
│  │  ├─ 100                     3.962 ms      │ 7.034 ms      │ 5.661 ms      │ 5.662 ms      │ 100     │ 100
│  │  ╰─ 1000                    34.37 ms      │ 64.17 ms      │ 61.22 ms      │ 60.19 ms      │ 100     │ 100
│  │  ╰─ 1000                    39.87 ms      │ 62.59 ms      │ 57.52 ms      │ 56.23 ms      │ 100     │ 100
│  ╰─ par_each_2t                              │               │               │               │         │
│  ╰─ par_each_2t                              │               │               │               │         │
│     ├─ 1                       181.5 µs      │ 413.3 µs      │ 195.5 µs      │ 203.1 µs      │ 100     │ 100
│     ├─ 1                       179.5 µs      │ 662.8 µs      │ 194.5 µs      │ 203.9 µs      │ 100     │ 100
│     ├─ 5                       266.7 µs      │ 400.1 µs      │ 329.8 µs      │ 315.3 µs      │ 100     │ 100
│     ├─ 5                       262.2 µs      │ 695.9 µs      │ 326.7 µs      │ 317.3 µs      │ 100     │ 100
│     ├─ 10                      381.1 µs      │ 844.2 µs      │ 399.8 µs      │ 411.2 µs      │ 100     │ 100
│     ├─ 10                      357.1 µs      │ 559.3 µs      │ 443.2 µs      │ 442.1 µs      │ 100     │ 100
│     ├─ 100                     2.673 ms      │ 3.483 ms      │ 3.115 ms      │ 3.094 ms      │ 100     │ 100
│     ├─ 100                     2.335 ms      │ 3.407 ms      │ 3.091 ms      │ 3.042 ms      │ 100     │ 100
│     ╰─ 1000                    19.02 ms      │ 36 ms         │ 30.07 ms      │ 29.81 ms      │ 100     │ 100
│     ╰─ 1000                    25.96 ms      │ 30.32 ms      │ 28.73 ms      │ 28.72 ms      │ 100     │ 100
├─ parser_benchmarks                           │               │               │               │         │
├─ parser_benchmarks                           │               │               │               │         │
│  ├─ parse_default_config_file  2.146 ms      │ 2.275 ms      │ 2.2 ms        │ 2.203 ms      │ 100     │ 100
│  ├─ parse_default_config_file  2.165 ms      │ 3.008 ms      │ 2.283 ms      │ 2.335 ms      │ 100     │ 100
│  ╰─ parse_default_env_file     380.3 µs      │ 477.1 µs      │ 389.4 µs      │ 396.1 µs      │ 100     │ 100
│  ╰─ parse_default_env_file     390.2 µs      │ 828.2 µs      │ 422 µs        │ 442.6 µs      │ 100     │ 100
├─ record                                      │               │               │               │         │
├─ record                                      │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  │  ├─ 1                       33.05 µs      │ 59.78 µs      │ 33.69 µs      │ 34.6 µs       │ 100     │ 100
│  │  ├─ 1                       36.59 µs      │ 160.9 µs      │ 38.55 µs      │ 42.95 µs      │ 100     │ 100
│  │  ├─ 10                      48.34 µs      │ 77.92 µs      │ 49.09 µs      │ 50.32 µs      │ 100     │ 100
│  │  ├─ 10                      51.87 µs      │ 128 µs        │ 55.57 µs      │ 60.66 µs      │ 100     │ 100
│  │  ├─ 100                     196.4 µs      │ 246 µs        │ 199.4 µs      │ 202.2 µs      │ 100     │ 100
│  │  ├─ 100                     197.8 µs      │ 364.3 µs      │ 204.4 µs      │ 216.3 µs      │ 100     │ 100
│  │  ╰─ 1000                    1.704 ms      │ 1.882 ms      │ 1.75 ms       │ 1.752 ms      │ 100     │ 100
│  │  ╰─ 1000                    1.732 ms      │ 2.72 ms       │ 1.792 ms      │ 1.834 ms      │ 100     │ 100
│  ├─ flat_access                              │               │               │               │         │
│  ├─ flat_access                              │               │               │               │         │
│  │  ├─ 1                       19.13 µs      │ 37.36 µs      │ 19.51 µs      │ 19.94 µs      │ 100     │ 100
│  │  ├─ 1                       19.37 µs      │ 52.85 µs      │ 19.91 µs      │ 21.19 µs      │ 100     │ 100
│  │  ├─ 10                      19.74 µs      │ 43.43 µs      │ 20.44 µs      │ 20.97 µs      │ 100     │ 100
│  │  ├─ 10                      19.91 µs      │ 96.53 µs      │ 20.42 µs      │ 22.44 µs      │ 100     │ 100
│  │  ├─ 100                     30 µs         │ 68.33 µs      │ 30.54 µs      │ 32.39 µs      │ 100     │ 100
│  │  ├─ 100                     32.92 µs      │ 81.06 µs      │ 33.59 µs      │ 35.59 µs      │ 100     │ 100
│  │  ╰─ 1000                    125.9 µs      │ 196.4 µs      │ 140.8 µs      │ 140.6 µs      │ 100     │ 100
│  │  ╰─ 1000                    121.3 µs      │ 226.7 µs      │ 137.9 µs      │ 141.1 µs      │ 100     │ 100
│  ╰─ nest_access                              │               │               │               │         │
│  ╰─ nest_access                              │               │               │               │         │
│     ├─ 1                       18.9 µs       │ 45.59 µs      │ 19.28 µs      │ 20.07 µs      │ 100     │ 100
│     ├─ 1                       21.82 µs      │ 58.9 µs       │ 22.34 µs      │ 23.18 µs      │ 100     │ 100
│     ├─ 2                       20.86 µs      │ 58.99 µs      │ 21.49 µs      │ 22.62 µs      │ 100     │ 100
│     ├─ 2                       20.06 µs      │ 100.5 µs      │ 20.52 µs      │ 21.84 µs      │ 100     │ 100
│     ├─ 4                       22.05 µs      │ 48.13 µs      │ 22.62 µs      │ 23.86 µs      │ 100     │ 100
│     ├─ 4                       24.63 µs      │ 50.97 µs      │ 25.03 µs      │ 25.79 µs      │ 100     │ 100
│     ├─ 8                       27.02 µs      │ 50.55 µs      │ 28.75 µs      │ 29.7 µs       │ 100     │ 100
│     ├─ 8                       23.79 µs      │ 48.44 µs      │ 24.43 µs      │ 25.17 µs      │ 100     │ 100
│     ├─ 16                      40.08 µs      │ 76.74 µs      │ 40.82 µs      │ 41.88 µs      │ 100     │ 100
│     ├─ 16                      28.44 µs      │ 72.42 µs      │ 29.1 µs       │ 30.09 µs      │ 100     │ 100
│     ├─ 32                      88.85 µs      │ 119.5 µs      │ 90.29 µs      │ 92.23 µs      │ 100     │ 100
│     ├─ 32                      40.34 µs      │ 138.2 µs      │ 41.31 µs      │ 43.33 µs      │ 100     │ 100
│     ├─ 64                      243.9 µs      │ 302.6 µs      │ 248.9 µs      │ 251.8 µs      │ 100     │ 100
│     ├─ 64                      53.77 µs      │ 143.2 µs      │ 60.86 µs      │ 61.33 µs      │ 100     │ 100
│     ╰─ 128                     862.4 µs      │ 927.7 µs      │ 878.5 µs      │ 880.6 µs      │ 100     │ 100
│     ╰─ 128                     84.36 µs      │ 140 µs        │ 86.39 µs      │ 88.79 µs      │ 100     │ 100
╰─ table                                       │               │               │               │         │
╰─ table                                       │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   │  ├─ 1                       38.88 µs      │ 65.92 µs      │ 39.62 µs      │ 40.53 µs      │ 100     │ 100
   │  ├─ 1                       41.41 µs      │ 109.4 µs      │ 42.83 µs      │ 45.94 µs      │ 100     │ 100
   │  ├─ 10                      55.14 µs      │ 117.8 µs      │ 56.46 µs      │ 58.04 µs      │ 100     │ 100
   │  ├─ 10                      55.94 µs      │ 106.3 µs      │ 56.78 µs      │ 60.61 µs      │ 100     │ 100
   │  ├─ 100                     223.4 µs      │ 278.9 µs      │ 226.7 µs      │ 230.6 µs      │ 100     │ 100
   │  ├─ 100                     220.9 µs      │ 368.7 µs      │ 224.8 µs      │ 235.8 µs      │ 100     │ 100
   │  ╰─ 1000                    1.917 ms      │ 2.85 ms       │ 1.971 ms      │ 1.994 ms      │ 100     │ 100
   │  ╰─ 1000                    1.897 ms      │ 2.137 ms      │ 1.972 ms      │ 1.976 ms      │ 100     │ 100
   ├─ get                                      │               │               │               │         │
   ├─ get                                      │               │               │               │         │
   │  ├─ 1                       30.11 µs      │ 71.25 µs      │ 30.8 µs       │ 32.42 µs      │ 100     │ 100
   │  ├─ 1                       28.4 µs       │ 66.65 µs      │ 29.18 µs      │ 31.75 µs      │ 100     │ 100
   │  ├─ 10                      31.91 µs      │ 77.51 µs      │ 32.7 µs       │ 34.45 µs      │ 100     │ 100
   │  ├─ 10                      32.37 µs      │ 78.59 µs      │ 33.33 µs      │ 35.28 µs      │ 100     │ 100
   │  ├─ 100                     72.43 µs      │ 152.7 µs      │ 73.74 µs      │ 76.51 µs      │ 100     │ 100
   │  ├─ 100                     73.09 µs      │ 161.5 µs      │ 78.64 µs      │ 82.4 µs       │ 100     │ 100
   │  ╰─ 1000                    459.3 µs      │ 554.4 µs      │ 475 µs        │ 485.2 µs      │ 100     │ 100
   │  ╰─ 1000                    457.9 µs      │ 1.151 ms      │ 469.7 µs      │ 487.7 µs      │ 100     │ 100
   ╰─ select                                   │               │               │               │         │
   ╰─ select                                   │               │               │               │         │
      ├─ 1                       25.97 µs      │ 53.22 µs      │ 26.87 µs      │ 28.37 µs      │ 100     │ 100
      ├─ 1                       27.59 µs      │ 95.58 µs      │ 28.31 µs      │ 30.81 µs      │ 100     │ 100
      ├─ 10                      35.13 µs      │ 91.36 µs      │ 35.72 µs      │ 37.6 µs       │ 100     │ 100
      ├─ 10                      35.94 µs      │ 87 µs         │ 36.5 µs       │ 38.66 µs      │ 100     │ 100
      ├─ 100                     114.3 µs      │ 556 µs        │ 116.2 µs      │ 123.3 µs      │ 100     │ 100
      ├─ 100                     115.8 µs      │ 186.8 µs      │ 117.3 µs      │ 121.2 µs      │ 100     │ 100
      ╰─ 1000                    878.4 µs      │ 968.2 µs      │ 897.3 µs      │ 906.9 µs      │ 100     │ 100
      ╰─ 1000                    878.6 µs      │ 1.006 ms      │ 915.7 µs      │ 921.4 µs      │ 100     │ 100
```
</details>

# User-Facing Changes
MOAR speed
