### PR TITLE
Refactor `Record` to use a single backing `Vec`

### DIFF
--- a/crates/nu-protocol/src/value/record.rs
+++ b/crates/nu-protocol/src/value/record.rs
@@ -6,8 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Record {
-    cols: Vec<String>,
-    vals: Vec<Value>,
+    inner: Vec<(String, Value)>,
 }
 
 impl Record {
@@ -17,8 +16,7 @@ impl Record {
 
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            cols: Vec::with_capacity(capacity),
-            vals: Vec::with_capacity(capacity),
+            inner: Vec::with_capacity(capacity),
         }
     }
 
@@ -35,7 +33,8 @@ impl Record {
         creation_site_span: Span,
     ) -> Result<Self, ShellError> {
         if cols.len() == vals.len() {
-            Ok(Self { cols, vals })
+            let inner = cols.into_iter().zip(vals).collect();
+            Ok(Self { inner })
         } else {
             Err(ShellError::RecordColsValsMismatch {
                 bad_value: input_span,
@@ -53,13 +52,11 @@ impl Record {
     }
 
     pub fn is_empty(&self) -> bool {
-        debug_assert_eq!(self.cols.len(), self.vals.len());
-        self.cols.is_empty()
+        self.inner.is_empty()
     }
 
     pub fn len(&self) -> usize {
-        debug_assert_eq!(self.cols.len(), self.vals.len());
-        self.cols.len()
+        self.inner.len()
     }
 
     /// Naive push to the end of the datastructure.
@@ -68,8 +65,7 @@ impl Record {
     ///
     /// Consider to use [`Record::insert`] instead
     pub fn push(&mut self, col: impl Into<String>, val: Value) {
-        self.cols.push(col.into());
-        self.vals.push(val);
+        self.inner.push((col.into(), val));
     }
 
     /// Insert into the record, replacing preexisting value if found.
@@ -79,9 +75,7 @@ impl Record {
     where
         K: AsRef<str> + Into<String>,
     {
-        if let Some(idx) = self.index_of(&col) {
-            // Can panic if vals.len() < cols.len()
-            let curr_val = &mut self.vals[idx];
+        if let Some(curr_val) = self.get_mut(&col) {
             Some(std::mem::replace(curr_val, val))
         } else {
             self.push(col, val);
@@ -98,15 +92,19 @@ impl Record {
     }
 
     pub fn get(&self, col: impl AsRef<str>) -> Option<&Value> {
-        self.index_of(col).and_then(|idx| self.vals.get(idx))
+        self.inner
+            .iter()
+            .find_map(|(k, v)| if k == col.as_ref() { Some(v) } else { None })
     }
 
     pub fn get_mut(&mut self, col: impl AsRef<str>) -> Option<&mut Value> {
-        self.index_of(col).and_then(|idx| self.vals.get_mut(idx))
+        self.inner
+            .iter_mut()
+            .find_map(|(k, v)| if k == col.as_ref() { Some(v) } else { None })
     }
 
     pub fn get_index(&self, idx: usize) -> Option<(&String, &Value)> {
-        Some((self.cols.get(idx)?, self.vals.get(idx)?))
+        self.inner.get(idx).map(|(col, val): &(_, _)| (col, val))
     }
 
     /// Remove single value by key
@@ -116,8 +114,8 @@ impl Record {
     /// Note: makes strong assumption that keys are unique
     pub fn remove(&mut self, col: impl AsRef<str>) -> Option<Value> {
         let idx = self.index_of(col)?;
-        self.cols.remove(idx);
-        Some(self.vals.remove(idx))
+        let (_, val) = self.inner.remove(idx);
+        Some(val)
     }
 
     /// Remove elements in-place that do not satisfy `keep`
@@ -185,33 +183,7 @@ impl Record {
     where
         F: FnMut(&str, &mut Value) -> bool,
     {
-        // `Vec::retain` is able to optimize memcopies internally.
-        // For maximum benefit, `retain` is used on `vals`,
-        // as `Value` is a larger struct than `String`.
-        //
-        // To do a simultaneous retain on the `cols`, three portions of it are tracked:
-        //     [..retained, ..dropped, ..unvisited]
-
-        // number of elements keep so far, start of ..dropped and length of ..retained
-        let mut retained = 0;
-        // current index of element being checked, start of ..unvisited
-        let mut idx = 0;
-
-        self.vals.retain_mut(|val| {
-            if keep(&self.cols[idx], val) {
-                // skip swaps for first consecutive run of kept elements
-                if idx != retained {
-                    self.cols.swap(idx, retained);
-                }
-                retained += 1;
-                idx += 1;
-                true
-            } else {
-                idx += 1;
-                false
-            }
-        });
-        self.cols.truncate(retained);
+        self.inner.retain_mut(|(col, val)| keep(col, val));
     }
 
     /// Truncate record to the first `len` elements.
@@ -235,25 +207,24 @@ impl Record {
     /// assert_eq!(rec.len(), 0);
     /// ```
     pub fn truncate(&mut self, len: usize) {
-        self.cols.truncate(len);
-        self.vals.truncate(len);
+        self.inner.truncate(len);
     }
 
     pub fn columns(&self) -> Columns {
         Columns {
-            iter: self.cols.iter(),
+            iter: self.inner.iter(),
         }
     }
 
     pub fn values(&self) -> Values {
         Values {
-            iter: self.vals.iter(),
+            iter: self.inner.iter(),
         }
     }
 
     pub fn into_values(self) -> IntoValues {
         IntoValues {
-            iter: self.vals.into_iter(),
+            iter: self.inner.into_iter(),
         }
     }
 
@@ -282,19 +253,18 @@ impl Record {
     where
         R: RangeBounds<usize> + Clone,
     {
-        debug_assert_eq!(self.cols.len(), self.vals.len());
         Drain {
-            keys: self.cols.drain(range.clone()),
-            values: self.vals.drain(range),
+            iter: self.inner.drain(range),
         }
     }
 }
 
 impl FromIterator<(String, Value)> for Record {
     fn from_iter<T: IntoIterator<Item = (String, Value)>>(iter: T) -> Self {
-        let (cols, vals) = iter.into_iter().unzip();
         // TODO: should this check for duplicate keys/columns?
-        Self { cols, vals }
+        Self {
+            inner: iter.into_iter().collect(),
+        }
     }
 }
 
@@ -308,7 +278,7 @@ impl Extend<(String, Value)> for Record {
 }
 
 pub struct IntoIter {
-    iter: std::iter::Zip<std::vec::IntoIter<String>, std::vec::IntoIter<Value>>,
+    iter: std::vec::IntoIter<(String, Value)>,
 }
 
 impl Iterator for IntoIter {
@@ -338,26 +308,26 @@ impl IntoIterator for Record {
 
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
-            iter: self.cols.into_iter().zip(self.vals),
+            iter: self.inner.into_iter(),
         }
     }
 }
 
 pub struct Iter<'a> {
-    iter: std::iter::Zip<std::slice::Iter<'a, String>, std::slice::Iter<'a, Value>>,
+    iter: std::slice::Iter<'a, (String, Value)>,
 }
 
 impl<'a> Iterator for Iter<'a> {
     type Item = (&'a String, &'a Value);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.iter.next().map(|(col, val): &(_, _)| (col, val))
     }
 }
 
 impl<'a> DoubleEndedIterator for Iter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
+        self.iter.next_back().map(|(col, val): &(_, _)| (col, val))
     }
 }
 
@@ -374,26 +344,26 @@ impl<'a> IntoIterator for &'a Record {
 
     fn into_iter(self) -> Self::IntoIter {
         Iter {
-            iter: self.cols.iter().zip(&self.vals),
+            iter: self.inner.iter(),
         }
     }
 }
 
 pub struct IterMut<'a> {
-    iter: std::iter::Zip<std::slice::Iter<'a, String>, std::slice::IterMut<'a, Value>>,
+    iter: std::slice::IterMut<'a, (String, Value)>,
 }
 
 impl<'a> Iterator for IterMut<'a> {
     type Item = (&'a String, &'a mut Value);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.iter.next().map(|(col, val)| (&*col, val))
     }
 }
 
 impl<'a> DoubleEndedIterator for IterMut<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
+        self.iter.next_back().map(|(col, val)| (&*col, val))
     }
 }
 
@@ -410,20 +380,20 @@ impl<'a> IntoIterator for &'a mut Record {
 
     fn into_iter(self) -> Self::IntoIter {
         IterMut {
-            iter: self.cols.iter().zip(&mut self.vals),
+            iter: self.inner.iter_mut(),
         }
     }
 }
 
 pub struct Columns<'a> {
-    iter: std::slice::Iter<'a, String>,
+    iter: std::slice::Iter<'a, (String, Value)>,
 }
 
 impl<'a> Iterator for Columns<'a> {
     type Item = &'a String;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.iter.next().map(|(col, _)| col)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -433,7 +403,7 @@ impl<'a> Iterator for Columns<'a> {
 
 impl<'a> DoubleEndedIterator for Columns<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
+        self.iter.next_back().map(|(col, _)| col)
     }
 }
 
@@ -444,14 +414,14 @@ impl<'a> ExactSizeIterator for Columns<'a> {
 }
 
 pub struct Values<'a> {
-    iter: std::slice::Iter<'a, Value>,
+    iter: std::slice::Iter<'a, (String, Value)>,
 }
 
 impl<'a> Iterator for Values<'a> {
     type Item = &'a Value;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.iter.next().map(|(_, val)| val)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -461,7 +431,7 @@ impl<'a> Iterator for Values<'a> {
 
 impl<'a> DoubleEndedIterator for Values<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
+        self.iter.next_back().map(|(_, val)| val)
     }
 }
 
@@ -472,14 +442,14 @@ impl<'a> ExactSizeIterator for Values<'a> {
 }
 
 pub struct IntoValues {
-    iter: std::vec::IntoIter<Value>,
+    iter: std::vec::IntoIter<(String, Value)>,
 }
 
 impl Iterator for IntoValues {
     type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
+        self.iter.next().map(|(_, val)| val)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -489,7 +459,7 @@ impl Iterator for IntoValues {
 
 impl DoubleEndedIterator for IntoValues {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.iter.next_back()
+        self.iter.next_back().map(|(_, val)| val)
     }
 }
 
@@ -500,31 +470,30 @@ impl ExactSizeIterator for IntoValues {
 }
 
 pub struct Drain<'a> {
-    keys: std::vec::Drain<'a, String>,
-    values: std::vec::Drain<'a, Value>,
+    iter: std::vec::Drain<'a, (String, Value)>,
 }
 
 impl Iterator for Drain<'_> {
     type Item = (String, Value);
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some((self.keys.next()?, self.values.next()?))
+        self.iter.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.keys.size_hint()
+        self.iter.size_hint()
     }
 }
 
 impl DoubleEndedIterator for Drain<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        Some((self.keys.next_back()?, self.values.next_back()?))
+        self.iter.next_back()
     }
 }
 
 impl ExactSizeIterator for Drain<'_> {
     fn len(&self) -> usize {
-        self.keys.len()
+        self.iter.len()
     }
 }
 


### PR DESCRIPTION
# Description
This shrinks `Record`'s size in half and and allows you to include it in `Value` without growing the size.

Changing the `Record` internals may have slightly different performance characteristics as the cache locality changes on lookups (if you directly need the value, it should be closer, but in other cases may blow up the cache line budget)

Also different perf characteristics on creation expected. 
`Record::from_raw_cols_vals` now probably worse.

## Benchmarking

Comparison with the main branch (boxed Record) revealed no significant change to the creation but an improvement when accessing larger N.
The fact that this was more pronounced for nested access (still cloning before nushell/nushell#12325) leads to the conclusion that this may still be dominated by the smaller clone necessary for a 24-byte `Record` over the previous 48 bytes.

### Highlights

The `cargo bench` output is interleaved

First line `main` branch
Second line `record-switcheroo`

```
├─ eval_benchmarks                             │               │               │               │         │
├─ eval_benchmarks                             │               │               │               │         │
│  ├─ eval_default_config        3.093 ms      │ 7.452 ms      │ 3.138 ms      │ 3.191 ms      │ 100     │ 100
│  ├─ eval_default_config        2.974 ms      │ 3.374 ms      │ 3.041 ms      │ 3.051 ms      │ 100     │ 100
│  ╰─ eval_default_env           507.3 µs      │ 585.6 µs      │ 515.2 µs      │ 525.1 µs      │ 100     │ 100
│  ╰─ eval_default_env           496.9 µs      │ 626 µs        │ 506.7 µs      │ 514.4 µs      │ 100     │ 100
...

├─ record                                      │               │               │               │         │
├─ record                                      │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  │  ├─ 1                       33.56 µs      │ 58.74 µs      │ 34.25 µs      │ 35.18 µs      │ 100     │ 100
│  │  ├─ 1                       33.6 µs       │ 63.57 µs      │ 34.33 µs      │ 35.86 µs      │ 100     │ 100
│  │  ├─ 10                      48.33 µs      │ 91.74 µs      │ 49.34 µs      │ 50.41 µs      │ 100     │ 100
│  │  ├─ 10                      48.38 µs      │ 72.86 µs      │ 49.36 µs      │ 50.87 µs      │ 100     │ 100
│  │  ├─ 100                     194.6 µs      │ 242.1 µs      │ 197.7 µs      │ 201.7 µs      │ 100     │ 100
│  │  ├─ 100                     196.6 µs      │ 251.1 µs      │ 199.9 µs      │ 203.3 µs      │ 100     │ 100
│  │  ╰─ 1000                    1.693 ms      │ 1.793 ms      │ 1.735 ms      │ 1.736 ms      │ 100     │ 100
│  │  ╰─ 1000                    1.703 ms      │ 1.81 ms       │ 1.734 ms      │ 1.739 ms      │ 100     │ 100
│  ├─ flat_access                              │               │               │               │         │
│  ├─ flat_access                              │               │               │               │         │
│  │  ├─ 1                       21.94 µs      │ 45.51 µs      │ 22.45 µs      │ 23.5 µs       │ 100     │ 100
│  │  ├─ 1                       19.76 µs      │ 37.99 µs      │ 20.14 µs      │ 20.5 µs       │ 100     │ 100
│  │  ├─ 10                      20.13 µs      │ 51.62 µs      │ 21.03 µs      │ 22.06 µs      │ 100     │ 100
│  │  ├─ 10                      20.45 µs      │ 37.88 µs      │ 20.76 µs      │ 21.02 µs      │ 100     │ 100
│  │  ├─ 100                     29.66 µs      │ 77.59 µs      │ 30.27 µs      │ 31.6 µs       │ 100     │ 100
│  │  ├─ 100                     28.91 µs      │ 52.54 µs      │ 29.59 µs      │ 31.16 µs      │ 100     │ 100
│  │  ╰─ 1000                    135.3 µs      │ 196.1 µs      │ 145.3 µs      │ 147.3 µs      │ 100     │ 100
│  │  ╰─ 1000                    128 µs        │ 176.4 µs      │ 141.1 µs      │ 141 µs        │ 100     │ 100
│  ╰─ nest_access                              │               │               │               │         │
│  ╰─ nest_access                              │               │               │               │         │
│     ├─ 1                       20.66 µs      │ 55.76 µs      │ 21.15 µs      │ 22.2 µs       │ 100     │ 100
│     ├─ 1                       21.98 µs      │ 47.54 µs      │ 22.38 µs      │ 23.48 µs      │ 100     │ 100
...

│     ├─ 16                      45.71 µs      │ 72.62 µs      │ 46.99 µs      │ 48.94 µs      │ 100     │ 100
│     ├─ 16                      36.6 µs       │ 88.51 µs      │ 37.14 µs      │ 38.59 µs      │ 100     │ 100
│     ├─ 32                      89.55 µs      │ 108.3 µs      │ 90.86 µs      │ 92 µs         │ 100     │ 100
│     ├─ 32                      75.59 µs      │ 102.5 µs      │ 76.89 µs      │ 78.41 µs      │ 100     │ 100
│     ├─ 64                      245.2 µs      │ 298.2 µs      │ 250.6 µs      │ 253.2 µs      │ 100     │ 100
│     ├─ 64                      187.3 µs      │ 266.5 µs      │ 192.1 µs      │ 195.7 µs      │ 100     │ 100
│     ╰─ 128                     857.2 µs      │ 921.6 µs      │ 880.9 µs      │ 883.2 µs      │ 100     │ 100
│     ╰─ 128                     647.6 µs      │ 739.8 µs      │ 677 µs        │ 681.5 µs      │ 100     │ 100
╰─ table                                       │               │               │               │         │
╰─ table                                       │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   │  ├─ 1                       38.35 µs      │ 95.52 µs      │ 39.19 µs      │ 40.94 µs      │ 100     │ 100
   │  ├─ 1                       38.44 µs      │ 67.72 µs      │ 39.36 µs      │ 40.72 µs      │ 100     │ 100
   │  ├─ 10                      56.51 µs      │ 91.34 µs      │ 57.53 µs      │ 59.52 µs      │ 100     │ 100
   │  ├─ 10                      54.45 µs      │ 91.64 µs      │ 55.79 µs      │ 57.89 µs      │ 100     │ 100
   │  ├─ 100                     219.4 µs      │ 282.7 µs      │ 222.2 µs      │ 226.3 µs      │ 100     │ 100
   │  ├─ 100                     217.5 µs      │ 263.9 µs      │ 220.6 µs      │ 224.3 µs      │ 100     │ 100
   │  ╰─ 1000                    1.871 ms      │ 1.979 ms      │ 1.916 ms      │ 1.92 ms       │ 100     │ 100
   │  ╰─ 1000                    1.887 ms      │ 2.006 ms      │ 1.917 ms      │ 1.92 ms       │ 100     │ 100
   ├─ get                                      │               │               │               │         │
   ├─ get                                      │               │               │               │         │
   │  ├─ 1                       27.56 µs      │ 64.49 µs      │ 27.94 µs      │ 28.63 µs      │ 100     │ 100
   │  ├─ 1                       27.87 µs      │ 55.48 µs      │ 28.49 µs      │ 29.47 µs      │ 100     │ 100
   │  ├─ 10                      31.47 µs      │ 57.22 µs      │ 32.28 µs      │ 33.47 µs      │ 100     │ 100
   │  ├─ 10                      32.97 µs      │ 57.07 µs      │ 33.76 µs      │ 34.7 µs       │ 100     │ 100
   │  ├─ 100                     72.11 µs      │ 131.4 µs      │ 73.44 µs      │ 76.66 µs      │ 100     │ 100
   │  ├─ 100                     67 µs         │ 99.95 µs      │ 68.27 µs      │ 70.25 µs      │ 100     │ 100
   │  ╰─ 1000                    450.5 µs      │ 525 µs        │ 461.9 µs      │ 469.9 µs      │ 100     │ 100
   │  ╰─ 1000                    400 µs        │ 450.3 µs      │ 408.5 µs      │ 412.3 µs      │ 100     │ 100
   ╰─ select                                   │               │               │               │         │
   ╰─ select                                   │               │               │               │         │
      ├─ 1                       27.03 µs      │ 64.04 µs      │ 27.59 µs      │ 28.9 µs       │ 100     │ 100
      ├─ 1                       26.66 µs      │ 52.26 µs      │ 27.39 µs      │ 28.34 µs      │ 100     │ 100
      ├─ 10                      35.66 µs      │ 78.04 µs      │ 36.46 µs      │ 37.99 µs      │ 100     │ 100
      ├─ 10                      34.11 µs      │ 61.27 µs      │ 34.73 µs      │ 36.46 µs      │ 100     │ 100
      ├─ 100                     114.2 µs      │ 171 µs        │ 116.5 µs      │ 119.6 µs      │ 100     │ 100
      ├─ 100                     100.9 µs      │ 147 µs        │ 102.3 µs      │ 104.4 µs      │ 100     │ 100
      ╰─ 1000                    879.8 µs      │ 958 µs        │ 902.4 µs      │ 905 µs        │ 100     │ 100
      ╰─ 1000                    748.2 µs      │ 864.6 µs      │ 783.1 µs      │ 785.1 µs      │ 100     │ 100
```

<details>
<summary>Full benchmark run</summary>

```
benchmarks                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
benchmarks                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ load_standard_lib             12.21 ms      │ 17.25 ms      │ 12.4 ms       │ 12.58 ms      │ 100     │ 100
├─ load_standard_lib             12.77 ms      │ 19.52 ms      │ 14.12 ms      │ 14.55 ms      │ 100     │ 100
├─ decoding_benchmarks                         │               │               │               │         │
├─ decoding_benchmarks                         │               │               │               │         │
│  ├─ json_decode                              │               │               │               │         │
│  ├─ json_decode                              │               │               │               │         │
│  │  ├─ (100, 5)                548.9 µs      │ 1.459 ms      │ 567.5 µs      │ 581.5 µs      │ 100     │ 100
│  │  ├─ (100, 5)                571.5 µs      │ 805.8 µs      │ 595.4 µs      │ 604.4 µs      │ 100     │ 100
│  │  ╰─ (10000, 15)             202.9 ms      │ 209.7 ms      │ 204.5 ms      │ 204.9 ms      │ 100     │ 100
│  │  ╰─ (10000, 15)             228.9 ms      │ 289.5 ms      │ 261.4 ms      │ 262.1 ms      │ 100     │ 100
│  ╰─ msgpack_decode                           │               │               │               │         │
│  ╰─ msgpack_decode                           │               │               │               │         │
│     ├─ (100, 5)                241.6 µs      │ 294.8 µs      │ 244.1 µs      │ 246 µs        │ 100     │ 100
│     ├─ (100, 5)                269.9 µs      │ 312.4 µs      │ 272.5 µs      │ 275.3 µs      │ 100     │ 100
│     ╰─ (10000, 15)             84.62 ms      │ 86.32 ms      │ 84.89 ms      │ 84.97 ms      │ 100     │ 100
│     ╰─ (10000, 15)             110.2 ms      │ 114.7 ms      │ 110.8 ms      │ 111 ms        │ 100     │ 100
├─ encoding_benchmarks                         │               │               │               │         │
├─ encoding_benchmarks                         │               │               │               │         │
│  ├─ json_encode                              │               │               │               │         │
│  ├─ json_encode                              │               │               │               │         │
│  │  ├─ (100, 5)                116.1 µs      │ 184.4 µs      │ 117 µs        │ 118.7 µs      │ 100     │ 100
│  │  ├─ (100, 5)                114.4 µs      │ 134.5 µs      │ 115.1 µs      │ 116.2 µs      │ 100     │ 100
│  │  ╰─ (10000, 15)             30.29 ms      │ 30.84 ms      │ 30.41 ms      │ 30.44 ms      │ 100     │ 100
│  │  ╰─ (10000, 15)             30.09 ms      │ 31.99 ms      │ 30.23 ms      │ 30.26 ms      │ 100     │ 100
│  ╰─ msgpack_encode                           │               │               │               │         │
│  ╰─ msgpack_encode                           │               │               │               │         │
│     ├─ (100, 5)                43.22 µs      │ 49.36 µs      │ 43.42 µs      │ 43.73 µs      │ 100     │ 100
│     ├─ (100, 5)                40.88 µs      │ 57.71 µs      │ 41.84 µs      │ 42.28 µs      │ 100     │ 100
│     ╰─ (10000, 15)             11.12 ms      │ 11.39 ms      │ 11.29 ms      │ 11.29 ms      │ 100     │ 100
│     ╰─ (10000, 15)             11.59 ms      │ 12.09 ms      │ 11.78 ms      │ 11.79 ms      │ 100     │ 100
├─ eval_benchmarks                             │               │               │               │         │
├─ eval_benchmarks                             │               │               │               │         │
│  ├─ eval_default_config        3.093 ms      │ 7.452 ms      │ 3.138 ms      │ 3.191 ms      │ 100     │ 100
│  ├─ eval_default_config        2.974 ms      │ 3.374 ms      │ 3.041 ms      │ 3.051 ms      │ 100     │ 100
│  ╰─ eval_default_env           507.3 µs      │ 585.6 µs      │ 515.2 µs      │ 525.1 µs      │ 100     │ 100
│  ╰─ eval_default_env           496.9 µs      │ 626 µs        │ 506.7 µs      │ 514.4 µs      │ 100     │ 100
├─ eval_commands                               │               │               │               │         │
├─ eval_commands                               │               │               │               │         │
│  ├─ each                                     │               │               │               │         │
│  ├─ each                                     │               │               │               │         │
│  │  ├─ 1                       88.51 µs      │ 199.5 µs      │ 130.3 µs      │ 126.2 µs      │ 100     │ 100
│  │  ├─ 1                       73.73 µs      │ 189.8 µs      │ 76.88 µs      │ 84.09 µs      │ 100     │ 100
│  │  ├─ 5                       220.4 µs      │ 398.6 µs      │ 283.3 µs      │ 301.2 µs      │ 100     │ 100
│  │  ├─ 5                       274.8 µs      │ 340.3 µs      │ 279.3 µs      │ 295.4 µs      │ 100     │ 100
│  │  ├─ 10                      470.8 µs      │ 699 µs        │ 580 µs        │ 587 µs        │ 100     │ 100
│  │  ├─ 10                      526.9 µs      │ 1.056 ms      │ 583 µs        │ 606.2 µs      │ 100     │ 100
│  │  ├─ 100                     3.719 ms      │ 6.12 ms       │ 4.729 ms      │ 4.895 ms      │ 100     │ 100
│  │  ├─ 100                     5.625 ms      │ 6.543 ms      │ 6.162 ms      │ 6.149 ms      │ 100     │ 100
│  │  ╰─ 1000                    51.48 ms      │ 61.48 ms      │ 57.4 ms       │ 57.18 ms      │ 100     │ 100
│  │  ╰─ 1000                    41.54 ms      │ 62.62 ms      │ 61.49 ms      │ 60.53 ms      │ 100     │ 100
│  ├─ for_range                                │               │               │               │         │
│  ├─ for_range                                │               │               │               │         │
│  │  ├─ 1                       87.06 µs      │ 185.8 µs      │ 109.7 µs      │ 122.5 µs      │ 100     │ 100
│  │  ├─ 1                       71.7 µs       │ 204.8 µs      │ 75.54 µs      │ 86.34 µs      │ 100     │ 100
│  │  ├─ 5                       276.8 µs      │ 402.9 µs      │ 281 µs        │ 302.3 µs      │ 100     │ 100
│  │  ├─ 5                       273.1 µs      │ 410.4 µs      │ 279.4 µs      │ 305.9 µs      │ 100     │ 100
│  │  ├─ 10                      531 µs        │ 701.9 µs      │ 595.4 µs      │ 606.9 µs      │ 100     │ 100
│  │  ├─ 10                      545.7 µs      │ 1.073 ms      │ 603.8 µs      │ 613.8 µs      │ 100     │ 100
│  │  ├─ 100                     5.786 ms      │ 6.829 ms      │ 6.113 ms      │ 6.118 ms      │ 100     │ 100
│  │  ├─ 100                     5.665 ms      │ 6.503 ms      │ 6.124 ms      │ 6.105 ms      │ 100     │ 100
│  │  ╰─ 1000                    55.23 ms      │ 61.62 ms      │ 60.48 ms      │ 60.19 ms      │ 100     │ 100
│  │  ╰─ 1000                    51.16 ms      │ 62.02 ms      │ 58.09 ms      │ 58.12 ms      │ 100     │ 100
│  ├─ interleave                               │               │               │               │         │
│  ├─ interleave                               │               │               │               │         │
│  │  ├─ 100                     1.326 ms      │ 2.588 ms      │ 1.665 ms      │ 1.699 ms      │ 100     │ 100
│  │  ├─ 100                     1.386 ms      │ 2.333 ms      │ 1.741 ms      │ 1.753 ms      │ 100     │ 100
│  │  ├─ 1000                    12.4 ms       │ 17.03 ms      │ 14.19 ms      │ 14.28 ms      │ 100     │ 100
│  │  ├─ 1000                    13.19 ms      │ 17.75 ms      │ 14.41 ms      │ 14.76 ms      │ 100     │ 100
│  │  ╰─ 10000                   127.8 ms      │ 168.9 ms      │ 145.2 ms      │ 144.9 ms      │ 100     │ 100
│  │  ╰─ 10000                   137.8 ms      │ 177.2 ms      │ 156.8 ms      │ 157.7 ms      │ 100     │ 100
│  ├─ interleave_with_ctrlc                    │               │               │               │         │
│  ├─ interleave_with_ctrlc                    │               │               │               │         │
│  │  ├─ 100                     1.289 ms      │ 2.238 ms      │ 1.611 ms      │ 1.646 ms      │ 100     │ 100
│  │  ├─ 100                     1.354 ms      │ 2.336 ms      │ 1.597 ms      │ 1.633 ms      │ 100     │ 100
│  │  ├─ 1000                    11.9 ms       │ 17.6 ms       │ 13.52 ms      │ 13.79 ms      │ 100     │ 100
│  │  ├─ 1000                    13.16 ms      │ 19.39 ms      │ 14.72 ms      │ 15.17 ms      │ 100     │ 100
│  │  ╰─ 10000                   124.5 ms      │ 166.4 ms      │ 138.4 ms      │ 139.8 ms      │ 100     │ 100
│  │  ╰─ 10000                   141.1 ms      │ 178.6 ms      │ 154.4 ms      │ 155.9 ms      │ 100     │ 100
│  ├─ par_each_1t                              │               │               │               │         │
│  ├─ par_each_1t                              │               │               │               │         │
│  │  ├─ 1                       152.7 µs      │ 585.8 µs      │ 159.8 µs      │ 169.6 µs      │ 100     │ 100
│  │  ├─ 1                       152.7 µs      │ 228.9 µs      │ 156.8 µs      │ 160.2 µs      │ 100     │ 100
│  │  ├─ 5                       289.7 µs      │ 508.1 µs      │ 349.7 µs      │ 345.9 µs      │ 100     │ 100
│  │  ├─ 5                       284.3 µs      │ 492.4 µs      │ 350.3 µs      │ 342.3 µs      │ 100     │ 100
│  │  ├─ 10                      502.1 µs      │ 991.9 µs      │ 585.7 µs      │ 595 µs        │ 100     │ 100
│  │  ├─ 10                      530.5 µs      │ 724.8 µs      │ 648.7 µs      │ 637.1 µs      │ 100     │ 100
│  │  ├─ 100                     3.307 ms      │ 6.337 ms      │ 3.974 ms      │ 4.151 ms      │ 100     │ 100
│  │  ├─ 100                     3.466 ms      │ 6.709 ms      │ 5.861 ms      │ 5.637 ms      │ 100     │ 100
│  │  ╰─ 1000                    35.21 ms      │ 55.26 ms      │ 39.25 ms      │ 40.76 ms      │ 100     │ 100
│  │  ╰─ 1000                    42.33 ms      │ 61.34 ms      │ 58.07 ms      │ 56.81 ms      │ 100     │ 100
│  ╰─ par_each_2t                              │               │               │               │         │
│  ╰─ par_each_2t                              │               │               │               │         │
│     ├─ 1                       175.5 µs      │ 411.2 µs      │ 193.5 µs      │ 201.1 µs      │ 100     │ 100
│     ├─ 1                       186.4 µs      │ 1.113 ms      │ 194 µs        │ 210.5 µs      │ 100     │ 100
│     ├─ 5                       256.8 µs      │ 1.137 ms      │ 330.5 µs      │ 326.4 µs      │ 100     │ 100
│     ├─ 5                       260.5 µs      │ 774.1 µs      │ 274.5 µs      │ 302.4 µs      │ 100     │ 100
│     ├─ 10                      373.8 µs      │ 1.198 ms      │ 400.8 µs      │ 424.5 µs      │ 100     │ 100
│     ├─ 10                      343.3 µs      │ 831.6 µs      │ 399.5 µs      │ 414.4 µs      │ 100     │ 100
│     ├─ 100                     2.111 ms      │ 3.182 ms      │ 2.79 ms       │ 2.744 ms      │ 100     │ 100
│     ├─ 100                     1.997 ms      │ 3.21 ms       │ 2.616 ms      │ 2.642 ms      │ 100     │ 100
│     ╰─ 1000                    18.01 ms      │ 29.91 ms      │ 26.51 ms      │ 25.72 ms      │ 100     │ 100
│     ╰─ 1000                    17.82 ms      │ 30.43 ms      │ 21.3 ms       │ 22.54 ms      │ 100     │ 100
├─ parser_benchmarks                           │               │               │               │         │
├─ parser_benchmarks                           │               │               │               │         │
│  ├─ parse_default_config_file  2.14 ms       │ 2.293 ms      │ 2.199 ms      │ 2.205 ms      │ 100     │ 100
│  ├─ parse_default_config_file  2.091 ms      │ 2.227 ms      │ 2.136 ms      │ 2.142 ms      │ 100     │ 100
│  ╰─ parse_default_env_file     379.3 µs      │ 474.3 µs      │ 387.9 µs      │ 395.3 µs      │ 100     │ 100
│  ╰─ parse_default_env_file     380 µs        │ 476.5 µs      │ 387.8 µs      │ 395.7 µs      │ 100     │ 100
├─ record                                      │               │               │               │         │
├─ record                                      │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  │  ├─ 1                       33.56 µs      │ 58.74 µs      │ 34.25 µs      │ 35.18 µs      │ 100     │ 100
│  │  ├─ 1                       33.6 µs       │ 63.57 µs      │ 34.33 µs      │ 35.86 µs      │ 100     │ 100
│  │  ├─ 10                      48.33 µs      │ 91.74 µs      │ 49.34 µs      │ 50.41 µs      │ 100     │ 100
│  │  ├─ 10                      48.38 µs      │ 72.86 µs      │ 49.36 µs      │ 50.87 µs      │ 100     │ 100
│  │  ├─ 100                     194.6 µs      │ 242.1 µs      │ 197.7 µs      │ 201.7 µs      │ 100     │ 100
│  │  ├─ 100                     196.6 µs      │ 251.1 µs      │ 199.9 µs      │ 203.3 µs      │ 100     │ 100
│  │  ╰─ 1000                    1.693 ms      │ 1.793 ms      │ 1.735 ms      │ 1.736 ms      │ 100     │ 100
│  │  ╰─ 1000                    1.703 ms      │ 1.81 ms       │ 1.734 ms      │ 1.739 ms      │ 100     │ 100
│  ├─ flat_access                              │               │               │               │         │
│  ├─ flat_access                              │               │               │               │         │
│  │  ├─ 1                       21.94 µs      │ 45.51 µs      │ 22.45 µs      │ 23.5 µs       │ 100     │ 100
│  │  ├─ 1                       19.76 µs      │ 37.99 µs      │ 20.14 µs      │ 20.5 µs       │ 100     │ 100
│  │  ├─ 10                      20.13 µs      │ 51.62 µs      │ 21.03 µs      │ 22.06 µs      │ 100     │ 100
│  │  ├─ 10                      20.45 µs      │ 37.88 µs      │ 20.76 µs      │ 21.02 µs      │ 100     │ 100
│  │  ├─ 100                     29.66 µs      │ 77.59 µs      │ 30.27 µs      │ 31.6 µs       │ 100     │ 100
│  │  ├─ 100                     28.91 µs      │ 52.54 µs      │ 29.59 µs      │ 31.16 µs      │ 100     │ 100
│  │  ╰─ 1000                    135.3 µs      │ 196.1 µs      │ 145.3 µs      │ 147.3 µs      │ 100     │ 100
│  │  ╰─ 1000                    128 µs        │ 176.4 µs      │ 141.1 µs      │ 141 µs        │ 100     │ 100
│  ╰─ nest_access                              │               │               │               │         │
│  ╰─ nest_access                              │               │               │               │         │
│     ├─ 1                       20.66 µs      │ 55.76 µs      │ 21.15 µs      │ 22.2 µs       │ 100     │ 100
│     ├─ 1                       21.98 µs      │ 47.54 µs      │ 22.38 µs      │ 23.48 µs      │ 100     │ 100
│     ├─ 2                       20.94 µs      │ 49.89 µs      │ 21.42 µs      │ 22.28 µs      │ 100     │ 100
│     ├─ 2                       19.71 µs      │ 43.7 µs       │ 20.64 µs      │ 21.27 µs      │ 100     │ 100
│     ├─ 4                       22.69 µs      │ 46.06 µs      │ 23.19 µs      │ 23.91 µs      │ 100     │ 100
│     ├─ 4                       24.4 µs       │ 43.51 µs      │ 24.87 µs      │ 25.35 µs      │ 100     │ 100
│     ├─ 8                       29.08 µs      │ 51.93 µs      │ 29.62 µs      │ 30.76 µs      │ 100     │ 100
│     ├─ 8                       25.45 µs      │ 67.51 µs      │ 25.88 µs      │ 26.99 µs      │ 100     │ 100
│     ├─ 16                      45.71 µs      │ 72.62 µs      │ 46.99 µs      │ 48.94 µs      │ 100     │ 100
│     ├─ 16                      36.6 µs       │ 88.51 µs      │ 37.14 µs      │ 38.59 µs      │ 100     │ 100
│     ├─ 32                      89.55 µs      │ 108.3 µs      │ 90.86 µs      │ 92 µs         │ 100     │ 100
│     ├─ 32                      75.59 µs      │ 102.5 µs      │ 76.89 µs      │ 78.41 µs      │ 100     │ 100
│     ├─ 64                      245.2 µs      │ 298.2 µs      │ 250.6 µs      │ 253.2 µs      │ 100     │ 100
│     ├─ 64                      187.3 µs      │ 266.5 µs      │ 192.1 µs      │ 195.7 µs      │ 100     │ 100
│     ╰─ 128                     857.2 µs      │ 921.6 µs      │ 880.9 µs      │ 883.2 µs      │ 100     │ 100
│     ╰─ 128                     647.6 µs      │ 739.8 µs      │ 677 µs        │ 681.5 µs      │ 100     │ 100
╰─ table                                       │               │               │               │         │
╰─ table                                       │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   │  ├─ 1                       38.35 µs      │ 95.52 µs      │ 39.19 µs      │ 40.94 µs      │ 100     │ 100
   │  ├─ 1                       38.44 µs      │ 67.72 µs      │ 39.36 µs      │ 40.72 µs      │ 100     │ 100
   │  ├─ 10                      56.51 µs      │ 91.34 µs      │ 57.53 µs      │ 59.52 µs      │ 100     │ 100
   │  ├─ 10                      54.45 µs      │ 91.64 µs      │ 55.79 µs      │ 57.89 µs      │ 100     │ 100
   │  ├─ 100                     219.4 µs      │ 282.7 µs      │ 222.2 µs      │ 226.3 µs      │ 100     │ 100
   │  ├─ 100                     217.5 µs      │ 263.9 µs      │ 220.6 µs      │ 224.3 µs      │ 100     │ 100
   │  ╰─ 1000                    1.871 ms      │ 1.979 ms      │ 1.916 ms      │ 1.92 ms       │ 100     │ 100
   │  ╰─ 1000                    1.887 ms      │ 2.006 ms      │ 1.917 ms      │ 1.92 ms       │ 100     │ 100
   ├─ get                                      │               │               │               │         │
   ├─ get                                      │               │               │               │         │
   │  ├─ 1                       27.56 µs      │ 64.49 µs      │ 27.94 µs      │ 28.63 µs      │ 100     │ 100
   │  ├─ 1                       27.87 µs      │ 55.48 µs      │ 28.49 µs      │ 29.47 µs      │ 100     │ 100
   │  ├─ 10                      31.47 µs      │ 57.22 µs      │ 32.28 µs      │ 33.47 µs      │ 100     │ 100
   │  ├─ 10                      32.97 µs      │ 57.07 µs      │ 33.76 µs      │ 34.7 µs       │ 100     │ 100
   │  ├─ 100                     72.11 µs      │ 131.4 µs      │ 73.44 µs      │ 76.66 µs      │ 100     │ 100
   │  ├─ 100                     67 µs         │ 99.95 µs      │ 68.27 µs      │ 70.25 µs      │ 100     │ 100
   │  ╰─ 1000                    450.5 µs      │ 525 µs        │ 461.9 µs      │ 469.9 µs      │ 100     │ 100
   │  ╰─ 1000                    400 µs        │ 450.3 µs      │ 408.5 µs      │ 412.3 µs      │ 100     │ 100
   ╰─ select                                   │               │               │               │         │
   ╰─ select                                   │               │               │               │         │
      ├─ 1                       27.03 µs      │ 64.04 µs      │ 27.59 µs      │ 28.9 µs       │ 100     │ 100
      ├─ 1                       26.66 µs      │ 52.26 µs      │ 27.39 µs      │ 28.34 µs      │ 100     │ 100
      ├─ 10                      35.66 µs      │ 78.04 µs      │ 36.46 µs      │ 37.99 µs      │ 100     │ 100
      ├─ 10                      34.11 µs      │ 61.27 µs      │ 34.73 µs      │ 36.46 µs      │ 100     │ 100
      ├─ 100                     114.2 µs      │ 171 µs        │ 116.5 µs      │ 119.6 µs      │ 100     │ 100
      ├─ 100                     100.9 µs      │ 147 µs        │ 102.3 µs      │ 104.4 µs      │ 100     │ 100
      ╰─ 1000                    879.8 µs      │ 958 µs        │ 902.4 µs      │ 905 µs        │ 100     │ 100
      ╰─ 1000                    748.2 µs      │ 864.6 µs      │ 783.1 µs      │ 785.1 µs      │ 100     │ 100


```

</details>


# User-Facing Changes

Reduced memory usage
