### PR TITLE
Throw error with circular source

### DIFF
--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -326,3 +326,27 @@ fn source_respects_early_return() {
 
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn source_catches_recursion() {
+    Playground::setup("source_catches_recursion", |dirs, sandbox| {
+        sandbox.with_files(vec![
+            FileWithContentToBeTrimmed(
+                "foo.nu",
+                r#"
+                source bar.nu
+            "#,
+            ),
+            FileWithContentToBeTrimmed(
+                "bar.nu",
+                r#"
+                source foo.nu
+            "#,
+            ),
+        ]);
+
+        let actual = nu!(cwd: dirs.test(), "source foo.nu");
+
+        assert!(actual.err.contains("recursion_limit_reached"));
+    })
+}

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3317,6 +3317,16 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
 pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
     let spans = &lite_command.parts;
+
+    if working_set.source_recursions > working_set.permanent_state.config.recursion_limit {
+        working_set.error(ParseError::RecursionLimitReached(
+            working_set.permanent_state.config.recursion_limit,
+            spans[0],
+        ));
+        return garbage_pipeline(spans);
+    }
+    working_set.source_recursions += 1;
+
     let name = working_set.get_span_contents(spans[0]);
 
     if name == b"source" || name == b"source-env" {

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -34,6 +34,7 @@ pub struct StateWorkingSet<'a> {
     pub search_predecls: bool,
     pub parse_errors: Vec<ParseError>,
     pub parse_warnings: Vec<ParseWarning>,
+    pub source_recursions: i64,
 }
 
 impl<'a> StateWorkingSet<'a> {
@@ -47,6 +48,7 @@ impl<'a> StateWorkingSet<'a> {
             search_predecls: true,
             parse_errors: vec![],
             parse_warnings: vec![],
+            source_recursions: 0,
         }
     }
 

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -465,6 +465,10 @@ pub enum ParseError {
         #[label("...and here")] Option<Span>,
     ),
 
+    #[error("Recursion limit ({0}) reached")]
+    #[diagnostic(code(nu::shell::recursion_limit_reached))]
+    RecursionLimitReached(i64, #[label("This called itself too many times")] Span),
+
     #[error("This command does not have a ...rest parameter")]
     #[diagnostic(
         code(nu::parser::unexpected_spread_arg),
@@ -554,6 +558,7 @@ impl ParseError {
             ParseError::InvalidLiteral(_, _, s) => *s,
             ParseError::LabeledErrorWithHelp { span: s, .. } => *s,
             ParseError::RedirectingBuiltinCommand(_, s, _) => *s,
+            ParseError::RecursionLimitReached(_, s) => *s,
             ParseError::UnexpectedSpreadArg(_, s) => *s,
         }
     }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Resolves #12267

Prevents stack overflow with circular source; throws error instead, similar to a recursive function.

```
# foo.nu
source bar.nu
```
```
# bar.nu
source foo.nu
```

```
/home/gabriel> source foo.nu                                                                               
Error: nu::shell::recursion_limit_reached

  × Recursion limit (50) reached
   ╭─[/home/gabriel/foo.nu:1:1]
 1 │ source bar.nu
   · ───┬──
   ·    ╰── This called itself too many times
   ╰────

```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
You can no longer source indefinitely. 

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added test `source_catches_recursion`.