### PR TITLE
Enhance benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,8 @@ dependencies = [
 [[package]]
 name = "divan"
 version = "0.1.14"
-source = "git+https://github.com/OliverKillane/divan.git?rev=c54ac74#c54ac74a8b85e3862a4bcbaea9e08d9e5095caa5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d567df2c9c2870a43f3f2bd65aaeb18dbce1c18f217c3e564b4fbaeb3ee56c"
 dependencies = [
  "cfg-if",
  "clap",
@@ -1149,13 +1150,13 @@ dependencies = [
  "divan-macros",
  "libc",
  "regex-lite",
- "serde_json",
 ]
 
 [[package]]
 name = "divan-macros"
 version = "0.1.14"
-source = "git+https://github.com/OliverKillane/divan.git?rev=c54ac74#c54ac74a8b85e3862a4bcbaea9e08d9e5095caa5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,8 +1141,7 @@ dependencies = [
 [[package]]
 name = "divan"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d567df2c9c2870a43f3f2bd65aaeb18dbce1c18f217c3e564b4fbaeb3ee56c"
+source = "git+https://github.com/OliverKillane/divan.git?rev=c54ac74#c54ac74a8b85e3862a4bcbaea9e08d9e5095caa5"
 dependencies = [
  "cfg-if",
  "clap",
@@ -1150,13 +1149,13 @@ dependencies = [
  "divan-macros",
  "libc",
  "regex-lite",
+ "serde_json",
 ]
 
 [[package]]
 name = "divan-macros"
 version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27540baf49be0d484d8f0130d7d8da3011c32a44d4fc873368154f1510e574a2"
+source = "git+https://github.com/OliverKillane/divan.git?rev=c54ac74#c54ac74a8b85e3862a4bcbaea9e08d9e5095caa5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,7 +211,7 @@ nix = { workspace = true, default-features = false, features = [
 nu-test-support = { path = "./crates/nu-test-support", version = "0.91.1" }
 assert_cmd = "2.0"
 dirs-next = { workspace = true }
-divan = { git = "https://github.com/OliverKillane/divan.git", rev = "c54ac74" }
+divan = "0.1.14"
 pretty_assertions = "1.4"
 rstest = { workspace = true, default-features = false }
 serial_test = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ lscolors = { version = "0.17", default-features = false }
 lsp-server = "0.7.5"
 lsp-types = "0.95.0"
 mach2 = "0.4"
-md5 = { version = "0.10", package = "md-5"}
+md5 = { version = "0.10", package = "md-5" }
 miette = "7.2"
 mime = "0.3"
 mime_guess = "2.0"
@@ -211,7 +211,7 @@ nix = { workspace = true, default-features = false, features = [
 nu-test-support = { path = "./crates/nu-test-support", version = "0.91.1" }
 assert_cmd = "2.0"
 dirs-next = { workspace = true }
-divan = "0.1.14"
+divan = { git = "https://github.com/OliverKillane/divan.git", rev = "c54ac74" }
 pretty_assertions = "1.4"
 rstest = { workspace = true, default-features = false }
 serial_test = "3.0"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -115,7 +115,7 @@ fn setup_stack_and_engine_from_command(command: &str) -> (Stack, EngineState) {
 // an executable for every single one - incredibly slowly. Would be nice to figure out
 // a way to split things up again.
 
-#[divan::bench]
+#[divan::bench(min_time = 1)]
 fn load_standard_lib(bencher: divan::Bencher) {
     let engine = setup_engine();
     bencher
@@ -155,12 +155,12 @@ mod record {
         s
     }
 
-    #[divan::bench(args = [1, 10, 100, 1000])]
+    #[divan::bench(min_time = 1, args = [1, 10, 100, 1000])]
     fn create(bencher: divan::Bencher, n: i32) {
         bench_command(bencher, create_flat_record_string(n));
     }
 
-    #[divan::bench(args = [1, 10, 100, 1000])]
+    #[divan::bench(min_time = 1, args = [1, 10, 100, 1000])]
     fn flat_access(bencher: divan::Bencher, n: i32) {
         let (stack, engine) = setup_stack_and_engine_from_command(&create_flat_record_string(n));
         bench_command_with_custom_stack_and_engine(
@@ -171,7 +171,7 @@ mod record {
         );
     }
 
-    #[divan::bench(args = [1, 2, 4, 8, 16, 32, 64, 128])]
+    #[divan::bench(min_time = 1, args = [1, 2, 4, 8, 16, 32, 64, 128])]
     fn nest_access(bencher: divan::Bencher, depth: i32) {
         let (stack, engine) =
             setup_stack_and_engine_from_command(&create_nested_record_string(depth));
@@ -202,12 +202,12 @@ mod table {
         s
     }
 
-    #[divan::bench(args = [1, 10, 100, 1000])]
+    #[divan::bench(min_time = 1, args = [1, 10, 100, 1000])]
     fn create(bencher: divan::Bencher, n: i32) {
         bench_command(bencher, create_example_table_nrows(n));
     }
 
-    #[divan::bench(args = [1, 10, 100, 1000])]
+    #[divan::bench(min_time = 1, args = [1, 10, 100, 1000])]
     fn get(bencher: divan::Bencher, n: i32) {
         let (stack, engine) = setup_stack_and_engine_from_command(&create_example_table_nrows(n));
         bench_command_with_custom_stack_and_engine(
@@ -218,7 +218,7 @@ mod table {
         );
     }
 
-    #[divan::bench(args = [1, 10, 100, 1000])]
+    #[divan::bench(min_time = 1, args = [1, 10, 100, 1000])]
     fn select(bencher: divan::Bencher, n: i32) {
         let (stack, engine) = setup_stack_and_engine_from_command(&create_example_table_nrows(n));
         bench_command_with_custom_stack_and_engine(
@@ -234,7 +234,7 @@ mod table {
 mod eval_commands {
     use super::*;
 
-    #[divan::bench(args = [100, 1_000, 10_000])]
+    #[divan::bench(min_time = 1, args = [100, 1_000, 10_000])]
     fn interleave(bencher: divan::Bencher, n: i32) {
         bench_command(
             bencher,
@@ -242,7 +242,7 @@ mod eval_commands {
         )
     }
 
-    #[divan::bench(args = [100, 1_000, 10_000])]
+    #[divan::bench(min_time = 1, args = [100, 1_000, 10_000])]
     fn interleave_with_ctrlc(bencher: divan::Bencher, n: i32) {
         let mut engine = setup_engine();
         engine.ctrlc = Some(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
@@ -268,12 +268,12 @@ mod eval_commands {
             })
     }
 
-    #[divan::bench(args = [1, 5, 10, 100, 1_000])]
+    #[divan::bench(min_time = 1, args = [1, 5, 10, 100, 1_000])]
     fn for_range(bencher: divan::Bencher, n: i32) {
         bench_command(bencher, format!("(for $x in (1..{}) {{ sleep 50ns }})", n))
     }
 
-    #[divan::bench(args = [1, 5, 10, 100, 1_000])]
+    #[divan::bench(min_time = 1, args = [1, 5, 10, 100, 1_000])]
     fn each(bencher: divan::Bencher, n: i32) {
         bench_command(
             bencher,
@@ -281,7 +281,7 @@ mod eval_commands {
         )
     }
 
-    #[divan::bench(args = [1, 5, 10, 100, 1_000])]
+    #[divan::bench(min_time = 1, args = [1, 5, 10, 100, 1_000])]
     fn par_each_1t(bencher: divan::Bencher, n: i32) {
         bench_command(
             bencher,
@@ -289,7 +289,7 @@ mod eval_commands {
         )
     }
 
-    #[divan::bench(args = [1, 5, 10, 100, 1_000])]
+    #[divan::bench(min_time = 1, args = [1, 5, 10, 100, 1_000])]
     fn par_each_2t(bencher: divan::Bencher, n: i32) {
         bench_command(
             bencher,
@@ -302,7 +302,7 @@ mod eval_commands {
 mod parser_benchmarks {
     use super::*;
 
-    #[divan::bench()]
+    #[divan::bench(min_time = 1)]
     fn parse_default_config_file(bencher: divan::Bencher) {
         let engine_state = setup_engine();
         let default_env = get_default_config().as_bytes();
@@ -312,7 +312,7 @@ mod parser_benchmarks {
             .bench_refs(|working_set| parse(working_set, None, default_env, false))
     }
 
-    #[divan::bench()]
+    #[divan::bench(min_time = 1)]
     fn parse_default_env_file(bencher: divan::Bencher) {
         let engine_state = setup_engine();
         let default_env = get_default_env().as_bytes();
@@ -327,7 +327,7 @@ mod parser_benchmarks {
 mod eval_benchmarks {
     use super::*;
 
-    #[divan::bench()]
+    #[divan::bench(min_time = 1)]
     fn eval_default_env(bencher: divan::Bencher) {
         let default_env = get_default_env().as_bytes();
         let fname = "default_env.nu";
@@ -345,7 +345,7 @@ mod eval_benchmarks {
             })
     }
 
-    #[divan::bench()]
+    #[divan::bench(min_time = 1)]
     fn eval_default_config(bencher: divan::Bencher) {
         let default_env = get_default_config().as_bytes();
         let fname = "default_config.nu";
@@ -379,7 +379,7 @@ fn encoding_test_data(row_cnt: usize, col_cnt: usize) -> Value {
 mod encoding_benchmarks {
     use super::*;
 
-    #[divan::bench(args = [(100, 5), (10000, 15)])]
+    #[divan::bench(min_time = 1, args = [(100, 5), (10000, 15)])]
     fn json_encode(bencher: divan::Bencher, (row_cnt, col_cnt): (usize, usize)) {
         let test_data = PluginOutput::CallResponse(
             0,
@@ -391,7 +391,7 @@ mod encoding_benchmarks {
             .bench_values(|mut res| encoder.encode(&test_data, &mut res))
     }
 
-    #[divan::bench(args = [(100, 5), (10000, 15)])]
+    #[divan::bench(min_time = 1, args = [(100, 5), (10000, 15)])]
     fn msgpack_encode(bencher: divan::Bencher, (row_cnt, col_cnt): (usize, usize)) {
         let test_data = PluginOutput::CallResponse(
             0,
@@ -408,7 +408,7 @@ mod encoding_benchmarks {
 mod decoding_benchmarks {
     use super::*;
 
-    #[divan::bench(args = [(100, 5), (10000, 15)])]
+    #[divan::bench(min_time = 1, args = [(100, 5), (10000, 15)])]
     fn json_decode(bencher: divan::Bencher, (row_cnt, col_cnt): (usize, usize)) {
         let test_data = PluginOutput::CallResponse(
             0,
@@ -428,7 +428,7 @@ mod decoding_benchmarks {
             })
     }
 
-    #[divan::bench(args = [(100, 5), (10000, 15)])]
+    #[divan::bench(min_time = 1, args = [(100, 5), (10000, 15)])]
     fn msgpack_decode(bencher: divan::Bencher, (row_cnt, col_cnt): (usize, usize)) {
         let test_data = PluginOutput::CallResponse(
             0,

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -517,7 +517,7 @@ def generate_benchmark_comparison [old_data: string, new_data: string, md_tabs:b
     let new_report =  cleanup_benchmark_report $new_data $md_tabs
     
     let combined_report = ($old_report | zip $new_report)
-    let comparason_report = ($combined_report | each { |it|
+    let comparison_report = ($combined_report | each { |it|
         let old = $it.0
         let new = $it.1
         
@@ -548,10 +548,10 @@ def generate_benchmark_comparison [old_data: string, new_data: string, md_tabs:b
     })
 
     if $into_md {
-        # Not sure why convertion has to be done to make it work.
-        return ($comparason_report| to csv | from csv | to md)
+        # Not sure why conversion has to be done to make it work.
+        return ($comparison_report| to csv | from csv | to md)
     } else {
-        return $comparason_report
+        return $comparison_report
     }
 }
 

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -533,7 +533,7 @@ def compare-benchmarks [old: string, new: string] {
     return (($old | zip $new) | each { |it|
         let old = $it.0
         let new = $it.1
-        let relative = ($old.median / $new.median) | math round -p 2
+        let relative = ($old.fastest / $new.fastest) | math round -p 2
 
         # Notes are based on the relative performance of the two runs
         # Indicates significant performance improvements or regressions
@@ -546,8 +546,8 @@ def compare-benchmarks [old: string, new: string] {
             else {" "})
         {
             "Name": $old.name,
-            "Old": (($old.median / 1000) | math round | into duration),
-            "New": (($new.median / 1000) | math round | into duration),
+            "Old": (($old.fastest / 1000) | math round | into duration),
+            "New": (($new.fastest / 1000) | math round | into duration),
             "Relative": $relative,
             "Note": $note
         }


### PR DESCRIPTION
# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

closes #12331

This PR does 3 things
- changes divan to a specific commit to enable file exports.
- sets a min_time for each current bench, this to reduce noise for fast benches.
- Adds a few new commands to toolkit.nu,
  - format-benchmark-data: convert the benchmark data from divan to a simple flat table.
  - compare-benchmarks: takes 2 different benchmarks and try to generate a simple report comparing them.

![image](https://github.com/nushell/nushell/assets/17986183/34ea0b0a-ccdd-401a-a279-8e8d44260948)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
