### PR TITLE
detect columns: intruduce a --guess flag, remove --legacy

### DIFF
--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -11,14 +11,14 @@ fn detect_columns_with_legacy() {
         for case in cases.into_iter() {
             let out = nu!(
                 cwd: dirs.test(),
-                "({} | detect columns --legacy) == {}",
+                "({} | detect columns) == {}",
                 case.0,
                 case.1
             );
 
             assert_eq!(
                 out.out, "true",
-                "({} | detect columns --legacy) == {}",
+                "({} | detect columns) == {}",
                 case.0, case.1
             );
         }
@@ -49,7 +49,7 @@ fn detect_columns_with_legacy_and_flag_c() {
         for case in cases.into_iter() {
             let out = nu!(
                 cwd: dirs.test(),
-                "({} | detect columns --legacy --combine-columns {}) == {}",
+                "({} | detect columns --combine-columns {}) == {}",
                 case.0,
                 case.2,
                 case.1,
@@ -57,7 +57,7 @@ fn detect_columns_with_legacy_and_flag_c() {
 
             assert_eq!(
                 out.out, "true",
-                "({} | detect columns --legacy --combine-columns {}) == {}",
+                "({} | detect columns --combine-columns {}) == {}",
                 case.0, case.2, case.1
             );
         }


### PR DESCRIPTION
# Description
This pr is addressing feedback from https://github.com/nushell/nushell/pull/12277#issuecomment-2027246752

Currently I think it's fine to replace `--legacy` flag with `--guess` one.  Only use `guess_width` algorithm if `--guess` is provided.

# User-Facing Changes
So it won't be a breaking change to previous version.
