### PR TITLE
Use nightly clippy to kill dead code/fix style

### DIFF
--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -95,7 +95,6 @@ impl std::error::Error for InvalidMatchAlgorithm {}
 pub struct CompletionOptions {
     pub case_sensitive: bool,
     pub positional: bool,
-    pub sort_by: SortBy,
     pub match_algorithm: MatchAlgorithm,
 }
 
@@ -104,7 +103,6 @@ impl Default for CompletionOptions {
         Self {
             case_sensitive: true,
             positional: true,
-            sort_by: SortBy::Ascending,
             match_algorithm: MatchAlgorithm::Prefix,
         }
     }

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -108,11 +108,6 @@ impl Completer for CustomCompletion {
                                     .get("positional")
                                     .and_then(|val| val.as_bool().ok())
                                     .unwrap_or(true),
-                                sort_by: if should_sort {
-                                    SortBy::Ascending
-                                } else {
-                                    SortBy::None
-                                },
                                 match_algorithm: match options.get("completion_algorithm") {
                                     Some(option) => option
                                         .coerce_string()

--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -680,10 +680,9 @@ fn run_regexes(hash: &HashMap<u32, (&'static str, String)>, contents: &str) -> S
     let hash_count: u32 = hash.len() as u32;
     for n in 0..hash_count {
         let value = hash.get(&n).expect("error getting hash at index");
-        //println!("{},{}", value.0, value.1);
         let re = Regex::new(value.0).expect("problem with color regex");
         let after = re.replace_all(&working_string, &value.1[..]).to_string();
-        working_string = after.clone();
+        working_string = after;
     }
     working_string
 }

--- a/crates/nu-command/src/conversions/into/cell_path.rs
+++ b/crates/nu-command/src/conversions/into/cell_path.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::ast::{CellPath, PathMember};
+use nu_protocol::ast::PathMember;
 
 #[derive(Clone)]
 pub struct IntoCellPath;

--- a/crates/nu-command/src/conversions/into/duration.rs
+++ b/crates/nu-command/src/conversions/into/duration.rs
@@ -1,9 +1,6 @@
 use nu_engine::command_prelude::*;
 use nu_parser::{parse_unit_value, DURATION_UNIT_GROUPS};
-use nu_protocol::{
-    ast::{CellPath, Expr},
-    Unit,
-};
+use nu_protocol::{ast::Expr, Unit};
 
 const NS_PER_SEC: i64 = 1_000_000_000;
 #[derive(Clone)]

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -1,7 +1,4 @@
-use crate::{
-    help::{HelpAliases, HelpCommands, HelpEscapes, HelpExterns, HelpModules, HelpOperators},
-    *,
-};
+use crate::*;
 use nu_protocol::engine::{EngineState, StateWorkingSet};
 
 pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -6,9 +6,6 @@ use std::{io::BufReader, path::Path};
 #[cfg(feature = "sqlite")]
 use crate::database::SQLiteDatabase;
 
-#[cfg(feature = "sqlite")]
-use nu_protocol::IntoPipelineData;
-
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -368,10 +368,9 @@ fn find_with_rest_and_highlight(
     let highlight_style =
         style_computer.compute("search_result", &Value::string("search result", span));
 
-    let cols_to_search_in_map = match call.get_flag(&engine_state, stack, "columns")? {
-        Some(cols) => cols,
-        None => vec![],
-    };
+    let cols_to_search_in_map: Vec<_> = call
+        .get_flag(&engine_state, stack, "columns")?
+        .unwrap_or_default();
 
     let cols_to_search_in_filter = cols_to_search_in_map.clone();
 

--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -1,7 +1,5 @@
 use nu_engine::command_prelude::*;
 
-use std::convert::TryInto;
-
 #[derive(Clone)]
 pub struct Skip;
 

--- a/crates/nu-command/src/stor/delete.rs
+++ b/crates/nu-command/src/stor/delete.rs
@@ -85,24 +85,22 @@ impl Command for StorDelete {
         let db = Box::new(SQLiteDatabase::new(std::path::Path::new(MEMORY_DB), None));
 
         if let Some(new_table_name) = table_name_opt {
-            let where_clause = match where_clause_opt {
-                Some(where_stmt) => where_stmt,
-                None => String::new(),
-            };
-
             if let Ok(conn) = db.open_connection() {
-                let sql_stmt = if where_clause.is_empty() {
-                    // We're deleting an entire table
-                    format!("DROP TABLE {}", new_table_name)
-                } else {
-                    // We're just deleting some rows
-                    let mut delete_stmt = format!("DELETE FROM {} ", new_table_name);
+                let sql_stmt = match where_clause_opt {
+                    None => {
+                        // We're deleting an entire table
+                        format!("DROP TABLE {}", new_table_name)
+                    }
+                    Some(where_clause) => {
+                        // We're just deleting some rows
+                        let mut delete_stmt = format!("DELETE FROM {} ", new_table_name);
 
-                    // Yup, this is a bit janky, but I'm not sure a better way to do this without having
-                    // --and and --or flags as well as supporting ==, !=, <>, is null, is not null, etc.
-                    // and other sql syntax. So, for now, just type a sql where clause as a string.
-                    delete_stmt.push_str(&format!("WHERE {}", where_clause));
-                    delete_stmt
+                        // Yup, this is a bit janky, but I'm not sure a better way to do this without having
+                        // --and and --or flags as well as supporting ==, !=, <>, is null, is not null, etc.
+                        // and other sql syntax. So, for now, just type a sql where clause as a string.
+                        delete_stmt.push_str(&format!("WHERE {}", where_clause));
+                        delete_stmt
+                    }
                 };
 
                 // dbg!(&sql_stmt);

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -919,7 +919,7 @@ fn get_abbriviated_dummy(head: &[Value], tail: &VecDeque<Value>) -> Value {
     }
 }
 
-fn is_record_list<'a>(mut batch: impl Iterator<Item = &'a Value> + ExactSizeIterator) -> bool {
+fn is_record_list<'a>(mut batch: impl ExactSizeIterator<Item = &'a Value>) -> bool {
     batch.len() > 0 && batch.all(|value| matches!(value, Value::Record { .. }))
 }
 

--- a/crates/nu-json/src/ser.rs
+++ b/crates/nu-json/src/ser.rs
@@ -318,9 +318,9 @@ where
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         self.ser
             .formatter
@@ -345,9 +345,9 @@ where
     type Ok = ();
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -365,9 +365,9 @@ where
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -385,9 +385,9 @@ where
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -409,9 +409,9 @@ where
     type Ok = ();
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<()>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         self.ser
             .formatter
@@ -423,9 +423,9 @@ where
         self.ser.formatter.colon(&mut self.ser.writer)
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         value.serialize(&mut *self.ser)
     }
@@ -446,9 +446,9 @@ where
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         ser::SerializeMap::serialize_entry(self, key, value)
     }
@@ -466,9 +466,9 @@ where
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         ser::SerializeStruct::serialize_field(self, key, value)
     }

--- a/crates/nu-json/src/value.rs
+++ b/crates/nu-json/src/value.rs
@@ -1094,9 +1094,9 @@ impl<'de> de::MapAccess<'de> for MapDeserializer {
     }
 }
 
-pub fn to_value<T: ?Sized>(value: &T) -> Result<Value>
+pub fn to_value<T>(value: &T) -> Result<Value>
 where
-    T: ser::Serialize,
+    T: ser::Serialize + ?Sized,
 {
     value.serialize(Serializer)
 }

--- a/crates/nu-json/src/value.rs
+++ b/crates/nu-json/src/value.rs
@@ -2,7 +2,7 @@
 use std::collections::{btree_map, BTreeMap};
 
 #[cfg(feature = "preserve_order")]
-use linked_hash_map::{self, LinkedHashMap};
+use linked_hash_map::LinkedHashMap;
 
 use std::fmt;
 use std::io;

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2,7 +2,6 @@ use crate::{
     lex::{lex, lex_signature},
     lite_parser::{lite_parse, LiteCommand, LitePipeline, LiteRedirection, LiteRedirectionTarget},
     parse_keywords::*,
-    parse_mut,
     parse_patterns::parse_pattern,
     parse_shape_specs::{parse_shape_name, parse_type, ShapeDescriptorUse},
     type_check::{self, math_result_type, type_compatible},
@@ -13,8 +12,8 @@ use log::trace;
 use nu_engine::DIR_VAR_PARSER_INFO;
 use nu_protocol::{
     ast::*, engine::StateWorkingSet, eval_const::eval_constant, span, BlockId, DidYouMean, Flag,
-    ParseError, PositionalArg, Signature, Span, Spanned, SyntaxShape, Type, Unit, VarId,
-    ENV_VARIABLE_ID, IN_VARIABLE_ID,
+    ParseError, PositionalArg, Signature, Span, Spanned, SyntaxShape, Type, VarId, ENV_VARIABLE_ID,
+    IN_VARIABLE_ID,
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -22,9 +21,6 @@ use std::{
     str,
     sync::Arc,
 };
-
-#[cfg(feature = "plugin")]
-use crate::parse_keywords::parse_register;
 
 pub fn garbage(span: Span) -> Expression {
     Expression::garbage(span)

--- a/crates/nu-pretty-hex/src/pretty_hex.rs
+++ b/crates/nu-pretty-hex/src/pretty_hex.rs
@@ -1,5 +1,4 @@
-use core::primitive::str;
-use core::{default::Default, fmt};
+use core::fmt;
 use nu_ansi_term::{Color, Style};
 
 /// Returns a one-line hexdump of `source` grouped in default format without header

--- a/crates/nu-protocol/src/pipeline_data/mod.rs
+++ b/crates/nu-protocol/src/pipeline_data/mod.rs
@@ -595,14 +595,14 @@ impl PipelineData {
     }
 
     /// Simplified flatmapper. For full iterator support use `.into_iter()` instead
-    pub fn flat_map<U: 'static, F>(
+    pub fn flat_map<U, F>(
         self,
         mut f: F,
         ctrlc: Option<Arc<AtomicBool>>,
     ) -> Result<PipelineData, ShellError>
     where
         Self: Sized,
-        U: IntoIterator<Item = Value>,
+        U: IntoIterator<Item = Value> + 'static,
         <U as IntoIterator>::IntoIter: 'static + Send,
         F: FnMut(Value) -> U + 'static + Send,
     {

--- a/crates/nu-table/src/table.rs
+++ b/crates/nu-table/src/table.rs
@@ -457,17 +457,6 @@ fn load_theme(
     }
 }
 
-struct FooterStyle;
-
-impl<R: ExactRecords, D> TableOption<R, D, ColoredConfig> for FooterStyle {
-    fn change(self, records: &mut R, cfg: &mut ColoredConfig, _: &mut D) {
-        if let Some(line) = cfg.get_horizontal_line(1).cloned() {
-            let count_rows = records.count_rows();
-            cfg.insert_horizontal_line(count_rows - 1, line);
-        }
-    }
-}
-
 fn maybe_truncate_columns(
     data: &mut NuRecords,
     theme: &TableTheme,


### PR DESCRIPTION
- **Remove duplicated imports**
- **Remove unused field in `CompletionOptions`**
- **Remove unused struct in `nu-table`**
- **Clarify generic bounds**
- **Simplify a subtrait bound for `ExactSizeIterator`**
- **Use `unwrap_or_default`**
- **Use `Option` directly instead of empty string**
- **Elide unneeded clone in `to html`**
