### PR TITLE
Reuse existing small allocations if possible

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -663,7 +663,7 @@ fn prepare_history_metadata(
         let result = line_editor
             .update_last_command_context(&|mut c| {
                 c.start_timestamp = Some(chrono::Utc::now());
-                c.hostname = hostname.clone();
+                c.hostname.clone_from(hostname);
 
                 c.cwd = Some(StateWorkingSet::new(engine_state).get_cwd());
                 c

--- a/crates/nu-explore/src/commands/help.rs
+++ b/crates/nu-explore/src/commands/help.rs
@@ -104,7 +104,7 @@ impl ViewCommand for HelpCmd {
     }
 
     fn parse(&mut self, args: &str) -> Result<()> {
-        self.input_command = args.trim().to_owned();
+        args.trim().clone_into(&mut self.input_command);
 
         Ok(())
     }

--- a/crates/nu-explore/src/commands/nu.rs
+++ b/crates/nu-explore/src/commands/nu.rs
@@ -62,7 +62,7 @@ impl ViewCommand for NuCmd {
     }
 
     fn parse(&mut self, args: &str) -> Result<()> {
-        self.command = args.trim().to_owned();
+        args.trim().clone_into(&mut self.command);
 
         Ok(())
     }

--- a/crates/nu-explore/src/commands/try.rs
+++ b/crates/nu-explore/src/commands/try.rs
@@ -64,7 +64,7 @@ impl ViewCommand for TryCmd {
     }
 
     fn parse(&mut self, args: &str) -> Result<()> {
-        self.command = args.trim().to_owned();
+        args.trim().clone_into(&mut self.command);
 
         Ok(())
     }

--- a/crates/nu-explore/src/pager/mod.rs
+++ b/crates/nu-explore/src/pager/mod.rs
@@ -295,7 +295,7 @@ fn render_ui(
         if pager.cmd_buf.run_cmd {
             let args = pager.cmd_buf.buf_cmd2.clone();
             pager.cmd_buf.run_cmd = false;
-            pager.cmd_buf.buf_cmd2 = String::new();
+            pager.cmd_buf.buf_cmd2.clear();
 
             let out =
                 pager_run_command(engine_state, stack, pager, &mut view_stack, &commands, args);
@@ -814,21 +814,21 @@ fn handle_general_key_events2<V>(
 {
     match key.code {
         KeyCode::Char('?') => {
-            search.buf_cmd_input = String::new();
+            search.buf_cmd_input.clear();
             search.is_search_input = true;
             search.is_reversed = true;
 
             info.report = None;
         }
         KeyCode::Char('/') => {
-            search.buf_cmd_input = String::new();
+            search.buf_cmd_input.clear();
             search.is_search_input = true;
             search.is_reversed = false;
 
             info.report = None;
         }
         KeyCode::Char(':') => {
-            command.buf_cmd2 = String::new();
+            command.buf_cmd2.clear();
             command.is_cmd_input = true;
             command.cmd_exec_info = None;
 
@@ -837,7 +837,7 @@ fn handle_general_key_events2<V>(
         KeyCode::Char('n') => {
             if !search.search_results.is_empty() {
                 if search.buf_cmd_input.is_empty() {
-                    search.buf_cmd_input = search.buf_cmd.clone();
+                    search.buf_cmd_input.clone_from(&search.buf_cmd);
                 }
 
                 if search.search_index + 1 == search.search_results.len() {
@@ -863,7 +863,7 @@ fn search_input_key_event(
 ) -> bool {
     match &key.code {
         KeyCode::Esc => {
-            buf.buf_cmd_input = String::new();
+            buf.buf_cmd_input.clear();
 
             if let Some(view) = view {
                 if !buf.buf_cmd.is_empty() {
@@ -878,7 +878,7 @@ fn search_input_key_event(
             true
         }
         KeyCode::Enter => {
-            buf.buf_cmd = buf.buf_cmd_input.clone();
+            buf.buf_cmd.clone_from(&buf.buf_cmd_input);
             buf.is_search_input = false;
 
             true
@@ -982,7 +982,8 @@ fn cmd_input_key_event(buf: &mut CommandBuf, key: &KeyEvent) -> bool {
                     buf.cmd_history_pos + 1,
                     buf.cmd_history.len().saturating_sub(1),
                 );
-                buf.buf_cmd2 = buf.cmd_history[buf.cmd_history_pos].clone();
+                buf.buf_cmd2
+                    .clone_from(&buf.cmd_history[buf.cmd_history_pos]);
             }
 
             true
@@ -991,7 +992,8 @@ fn cmd_input_key_event(buf: &mut CommandBuf, key: &KeyEvent) -> bool {
             if !buf.cmd_history.is_empty() {
                 buf.cmd_history_allow = true;
                 buf.cmd_history_pos = buf.cmd_history_pos.saturating_sub(1);
-                buf.buf_cmd2 = buf.cmd_history[buf.cmd_history_pos].clone();
+                buf.buf_cmd2
+                    .clone_from(&buf.cmd_history[buf.cmd_history_pos]);
             }
 
             true

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -812,7 +812,7 @@ fn _transpose_table(
     let mut data = vec![vec![Value::default(); count_rows]; count_columns];
     for (row, values) in values.iter().enumerate() {
         for (column, value) in values.iter().enumerate() {
-            data[column][row] = value.to_owned();
+            data[column][row].clone_from(value);
         }
     }
 

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -592,7 +592,7 @@ pub fn parse_def(
         if let Some(decl_id) = working_set.find_predecl(name.as_bytes()) {
             let declaration = working_set.get_decl_mut(decl_id);
 
-            signature.name = name.clone();
+            signature.name.clone_from(&name);
             if !has_wrapped {
                 *signature = signature.add_help();
             }
@@ -751,9 +751,9 @@ pub fn parse_extern(
                     name.clone()
                 };
 
-                signature.name = external_name.clone();
-                signature.usage = usage.clone();
-                signature.extra_usage = extra_usage.clone();
+                signature.name.clone_from(&external_name);
+                signature.usage.clone_from(&usage);
+                signature.extra_usage.clone_from(&extra_usage);
                 signature.allows_unknown_args = true;
 
                 if let Some(block_id) = body.and_then(|x| x.as_block()) {
@@ -1233,7 +1233,7 @@ pub fn parse_export_in_module(
                 // Trying to warp the 'def' call into the 'export def' in a very clumsy way
                 if let Some(Expr::Call(def_call)) = pipeline.elements.first().map(|e| &e.expr.expr)
                 {
-                    call = def_call.clone();
+                    call.clone_from(def_call);
                     call.head = span(&spans[0..=1]);
                     call.decl_id = export_def_decl_id;
                 } else {
@@ -1269,7 +1269,7 @@ pub fn parse_export_in_module(
                 // Trying to warp the 'def' call into the 'export def' in a very clumsy way
                 if let Some(Expr::Call(def_call)) = pipeline.elements.first().map(|e| &e.expr.expr)
                 {
-                    call = def_call.clone();
+                    call.clone_from(def_call);
                     call.head = span(&spans[0..=1]);
                     call.decl_id = export_def_decl_id;
                 } else {
@@ -1325,7 +1325,7 @@ pub fn parse_export_in_module(
                 if let Some(Expr::Call(alias_call)) =
                     pipeline.elements.first().map(|e| &e.expr.expr)
                 {
-                    call = alias_call.clone();
+                    call.clone_from(alias_call);
 
                     call.head = span(&spans[0..=1]);
                     call.decl_id = export_alias_decl_id;
@@ -1380,7 +1380,7 @@ pub fn parse_export_in_module(
                 // Trying to warp the 'use' call into the 'export use' in a very clumsy way
                 if let Some(Expr::Call(use_call)) = pipeline.elements.first().map(|e| &e.expr.expr)
                 {
-                    call = use_call.clone();
+                    call.clone_from(use_call);
 
                     call.head = span(&spans[0..=1]);
                     call.decl_id = export_use_decl_id;
@@ -1412,7 +1412,7 @@ pub fn parse_export_in_module(
                 if let Some(Expr::Call(module_call)) =
                     pipeline.elements.first().map(|e| &e.expr.expr)
                 {
-                    call = module_call.clone();
+                    call.clone_from(module_call);
 
                     call.head = span(&spans[0..=1]);
                     call.decl_id = export_module_decl_id;
@@ -1463,7 +1463,7 @@ pub fn parse_export_in_module(
                 // Trying to warp the 'const' call into the 'export const' in a very clumsy way
                 if let Some(Expr::Call(def_call)) = pipeline.elements.first().map(|e| &e.expr.expr)
                 {
-                    call = def_call.clone();
+                    call.clone_from(def_call);
 
                     call.head = span(&spans[0..=1]);
                     call.decl_id = export_const_decl_id;

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -137,11 +137,11 @@ impl Stack {
     ) {
         // Do not clone the environment if it hasn't changed
         if self.env_vars.iter().any(|scope| !scope.is_empty()) {
-            self.env_vars = env_vars.to_owned();
+            env_vars.clone_into(&mut self.env_vars);
         }
 
         if !self.env_hidden.is_empty() {
-            self.env_hidden = env_hidden.to_owned();
+            self.env_hidden.clone_from(env_hidden);
         }
     }
 


### PR DESCRIPTION
Those allocations are all small and insignificant in the grand scheme of things and the optimizer may be able to resolve some of those but better to be nice anyways.

Primarily inspired by the new [`clippy::assigning_clones`](https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones)

- **Avoid reallocs with `clone_from` in `nu-parser`**
- **Avoid realloc on assignment in `Stack`**
- **Fix `clippy::assigning_clones` in `nu-cli`**
- **Reuse allocations in `nu-explore` if possible**
