### PR TITLE
Make `echo` printing more consistent

### DIFF
--- a/crates/nu-command/tests/commands/echo.rs
+++ b/crates/nu-command/tests/commands/echo.rs
@@ -34,3 +34,9 @@ fn echo_range_handles_exclusive_down() {
 
     assert_eq!(actual.out, "[3,2]");
 }
+
+#[test]
+fn echo_prints_if_last_command_in_pipeline() {
+    let actual = nu!("(echo a; echo b)");
+    assert_eq!(actual.out, "ab"); // testing framework deletes newlines...
+}


### PR DESCRIPTION
# Description
Reverts changes to `echo` from #11934 so that `echo` will always print values if the output stream is the terminal. Printing should also hopefully be more consistent compared to before #11934. For example, take:
```nushell
(echo a; echo b)
```
Before this used to only print `b` , but it now prints both `a` and `b`.
