### PR TITLE
Lex whitespace in input-output types.

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3036,7 +3036,8 @@ pub fn parse_input_output_types(
         full_span.end -= 1;
     }
 
-    let (tokens, parse_error) = lex_signature(bytes, full_span.start, &[b','], &[], true);
+    let (tokens, parse_error) =
+        lex_signature(bytes, full_span.start, &[b'\n', b'\r', b','], &[], true);
 
     if let Some(parse_error) = parse_error {
         working_set.parse_errors.push(parse_error);

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -657,12 +657,41 @@ fn let_variable_disallows_completer() -> TestResult {
 }
 
 #[test]
-fn def_with_input_output_1() -> TestResult {
+fn def_with_input_output() -> TestResult {
     run_test(r#"def foo []: nothing -> int { 3 }; foo"#, "3")
 }
 
 #[test]
-fn def_with_input_output_2() -> TestResult {
+fn def_with_input_output_with_line_breaks() -> TestResult {
+    run_test(
+        r#"def foo []: [
+          nothing -> int
+        ] { 3 }; foo"#,
+        "3",
+    )
+}
+
+#[test]
+fn def_with_multi_input_output_with_line_breaks() -> TestResult {
+    run_test(
+        r#"def foo []: [
+          nothing -> int
+          string -> int
+        ] { 3 }; foo"#,
+        "3",
+    )
+}
+
+#[test]
+fn def_with_multi_input_output_without_commas() -> TestResult {
+    run_test(
+        r#"def foo []: [nothing -> int string -> int] { 3 }; foo"#,
+        "3",
+    )
+}
+
+#[test]
+fn def_with_multi_input_output_called_with_first_sig() -> TestResult {
     run_test(
         r#"def foo []: [int -> int, string -> int] { 3 }; 10 | foo"#,
         "3",
@@ -670,7 +699,7 @@ fn def_with_input_output_2() -> TestResult {
 }
 
 #[test]
-fn def_with_input_output_3() -> TestResult {
+fn def_with_multi_input_output_called_with_second_sig() -> TestResult {
     run_test(
         r#"def foo []: [int -> int, string -> int] { 3 }; "bob" | foo"#,
         "3",


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes #12264.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Multiple input-output types can break across lines like command params.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

✅ E2E parser tests

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
