### PR TITLE
Revert boxing of `Record` (undo #12252)

### DIFF
--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -317,7 +317,7 @@ fn recursive_value(val: Value, sublevels: Vec<Vec<u8>>) -> Value {
         let span = val.span();
         match val {
             Value::Record { val, .. } => {
-                for item in *val {
+                for item in val {
                     // Check if index matches with sublevel
                     if item.0.as_bytes().to_vec() == next_sublevel {
                         // If matches try to fetch recursively the next

--- a/crates/nu-cmd-base/src/hook.rs
+++ b/crates/nu-cmd-base/src/hook.rs
@@ -18,7 +18,7 @@ pub fn eval_env_change_hook(
     if let Some(hook) = env_change_hook {
         match hook {
             Value::Record { val, .. } => {
-                for (env_name, hook_value) in &*val {
+                for (env_name, hook_value) in &val {
                     let before = engine_state
                         .previous_env_vars
                         .get(env_name)

--- a/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/values/nu_dataframe/mod.rs
@@ -163,7 +163,7 @@ impl NuDataFrame {
                     conversion::insert_record(&mut column_values, record, &maybe_schema)?
                 }
                 Value::Record { val: record, .. } => {
-                    conversion::insert_record(&mut column_values, *record, &maybe_schema)?
+                    conversion::insert_record(&mut column_values, record, &maybe_schema)?
                 }
                 _ => {
                     let key = "0".to_string();

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -317,7 +317,7 @@ fn describe_value(
                 record!(
                     "type" => Value::string("record", head),
                     "lazy" => Value::bool(false, head),
-                    "columns" => Value::record(*val, head),
+                    "columns" => Value::record(val, head),
                 ),
                 head,
             )
@@ -408,7 +408,7 @@ fn describe_value(
                         )?);
                     }
 
-                    record.push("columns", Value::record(*val, head));
+                    record.push("columns", Value::record(val, head));
                 } else {
                     let cols = val.column_names();
                     record.push("length", Value::int(cols.len() as i64, head));

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -237,7 +237,7 @@ impl<'a> std::fmt::Debug for DebuggableValue<'a> {
             Value::Record { val, .. } => {
                 write!(f, "{{")?;
                 let mut first = true;
-                for (col, value) in (&**val).into_iter() {
+                for (col, value) in val.into_iter() {
                     if !first {
                         write!(f, ", ")?;
                     }

--- a/crates/nu-command/src/charting/histogram.rs
+++ b/crates/nu-command/src/charting/histogram.rs
@@ -177,7 +177,7 @@ fn run_histogram(
                 match v {
                     // parse record, and fill valid value to actual input.
                     Value::Record { val, .. } => {
-                        for (c, v) in *val {
+                        for (c, v) in val {
                             if &c == col_name {
                                 if let Ok(v) = HashableValue::from_value(v, head_span) {
                                     inputs.push(v);

--- a/crates/nu-command/src/conversions/into/record.rs
+++ b/crates/nu-command/src/conversions/into/record.rs
@@ -131,7 +131,7 @@ fn into_record(
                 .collect(),
             span,
         ),
-        Value::Record { val, .. } => Value::record(*val, span),
+        Value::Record { val, .. } => Value::record(val, span),
         Value::Error { .. } => input,
         other => Value::error(
             ShellError::TypeMismatch {

--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -53,7 +53,7 @@ impl Command for LoadEnv {
             }
             None => match input {
                 PipelineData::Value(Value::Record { val, .. }, ..) => {
-                    for (env_var, rhs) in *val {
+                    for (env_var, rhs) in val {
                         let env_var_ = env_var.as_str();
                         if ["FILE_PWD", "CURRENT_FILE"].contains(&env_var_) {
                             return Err(ShellError::AutomaticEnvVarSetManually {

--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -89,7 +89,7 @@ fn with_env(
                 // single row([[X W]; [Y Z]])
                 match &table[0] {
                     Value::Record { val, .. } => {
-                        for (k, v) in &**val {
+                        for (k, v) in val {
                             env.insert(k.to_string(), v.clone());
                         }
                     }
@@ -117,7 +117,7 @@ fn with_env(
         }
         // when get object by `open x.json` or `from json`
         Value::Record { val, .. } => {
-            for (k, v) in &**val {
+            for (k, v) in val {
                 env.insert(k.clone(), v.clone());
             }
         }

--- a/crates/nu-command/src/filters/default.rs
+++ b/crates/nu-command/src/filters/default.rs
@@ -106,7 +106,7 @@ fn default(
                                 record.push(column.item.clone(), value.clone());
                             }
 
-                            Value::record(*record, span)
+                            Value::record(record, span)
                         }
                         _ => item,
                     }

--- a/crates/nu-command/src/filters/drop/column.rs
+++ b/crates/nu-command/src/filters/drop/column.rs
@@ -123,7 +123,7 @@ fn drop_cols(
                 } => {
                     let len = record.len().saturating_sub(columns);
                     record.truncate(len);
-                    Ok(Value::record(*record, span).into_pipeline_data_with_metadata(metadata))
+                    Ok(Value::record(record, span).into_pipeline_data_with_metadata(metadata))
                 }
                 // Propagate errors
                 Value::Error { error, .. } => Err(*error),

--- a/crates/nu-command/src/filters/flatten.rs
+++ b/crates/nu-command/src/filters/flatten.rs
@@ -164,7 +164,7 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                 match value {
                     Value::Record { val, .. } => {
                         if need_flatten {
-                            for (col, val) in *val {
+                            for (col, val) in val {
                                 if out.contains_key(&col) {
                                     out.insert(format!("{column}_{col}"), val);
                                 } else {
@@ -172,9 +172,9 @@ fn flat_value(columns: &[CellPath], item: Value, all: bool) -> Vec<Value> {
                                 }
                             }
                         } else if out.contains_key(&column) {
-                            out.insert(format!("{column}_{column}"), Value::record(*val, span));
+                            out.insert(format!("{column}_{column}"), Value::record(val, span));
                         } else {
-                            out.insert(column, Value::record(*val, span));
+                            out.insert(column, Value::record(val, span));
                         }
                     }
                     Value::List { vals, .. } => {

--- a/crates/nu-command/src/filters/sort.rs
+++ b/crates/nu-command/src/filters/sort.rs
@@ -144,7 +144,7 @@ impl Command for Sort {
             // Records have two sorting methods, toggled by presence or absence of -v
             PipelineData::Value(Value::Record { val, .. }, ..) => {
                 let sort_by_value = call.has_flag(engine_state, stack, "values")?;
-                let record = sort_record(*val, span, sort_by_value, reverse, insensitive, natural);
+                let record = sort_record(val, span, sort_by_value, reverse, insensitive, natural);
                 Ok(record.into_pipeline_data())
             }
             // Other values are sorted here

--- a/crates/nu-command/src/filters/values.rs
+++ b/crates/nu-command/src/filters/values.rs
@@ -106,7 +106,7 @@ pub fn get_values<'a>(
     for item in input {
         match item {
             Value::Record { val, .. } => {
-                for (k, v) in &**val {
+                for (k, v) in val {
                     if let Some(vec) = output.get_mut(k) {
                         vec.push(v.clone());
                     } else {

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -130,7 +130,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
         }
         Value::Record { val, .. } => {
             let mut m = nu_json::Map::new();
-            for (k, v) in &**val {
+            for (k, v) in val {
                 m.insert(k.clone(), value_to_json_value(v)?);
             }
             nu_json::Value::Object(m)

--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -246,7 +246,7 @@ pub fn value_to_string(
         )),
         Value::Record { val, .. } => {
             let mut collection = vec![];
-            for (col, val) in &**val {
+            for (col, val) in val {
                 collection.push(if needs_quotes(col) {
                     format!(
                         "{idt_po}\"{}\": {}",

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -57,7 +57,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
         Value::String { val, .. } | Value::Glob { val, .. } => toml::Value::String(val.clone()),
         Value::Record { val, .. } => {
             let mut m = toml::map::Map::new();
-            for (k, v) in &**val {
+            for (k, v) in val {
                 m.insert(k.clone(), helper(engine_state, v)?);
             }
             toml::Value::Table(m)

--- a/crates/nu-command/src/formats/to/xml.rs
+++ b/crates/nu-command/src/formats/to/xml.rs
@@ -326,7 +326,7 @@ impl Job {
             // content: null}, {tag: a}. See to_xml_entry for more
             let attrs = match attrs {
                 Value::Record { val, .. } => val,
-                Value::Nothing { .. } => Box::new(Record::new()),
+                Value::Nothing { .. } => Record::new(),
                 _ => {
                     return Err(ShellError::CantConvert {
                         to_type: "XML".into(),
@@ -350,7 +350,7 @@ impl Job {
                 }
             };
 
-            self.write_tag(entry_span, tag, tag_span, *attrs, content)
+            self.write_tag(entry_span, tag, tag_span, attrs, content)
         }
     }
 

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -54,7 +54,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
         }
         Value::Record { val, .. } => {
             let mut m = serde_yaml::Mapping::new();
-            for (k, v) in &**val {
+            for (k, v) in val {
                 m.insert(
                     serde_yaml::Value::String(k.clone()),
                     value_to_yaml_value(v)?,

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -180,7 +180,7 @@ pub fn highlight_search_in_table(
         )?;
 
         if has_match {
-            matches.push(Value::record(*record, record_span));
+            matches.push(Value::record(record, record_span));
         }
     }
 

--- a/crates/nu-command/src/math/utils.rs
+++ b/crates/nu-command/src/math/utils.rs
@@ -27,7 +27,7 @@ fn helper_for_tables(
     for val in values {
         match val {
             Value::Record { val, .. } => {
-                for (key, value) in &**val {
+                for (key, value) in val {
                     column_values
                         .entry(key.clone())
                         .and_modify(|v: &mut Vec<Value>| v.push(value.clone()))
@@ -88,7 +88,7 @@ pub fn calculate(
                     *val = mf(slice::from_ref(val), span, name)?;
                     Ok(())
                 })?;
-            Ok(Value::record(*record, span))
+            Ok(Value::record(record, span))
         }
         PipelineData::Value(Value::Range { val, .. }, ..) => {
             let new_vals: Result<Vec<Value>, ShellError> = val

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -222,7 +222,7 @@ pub fn send_request(
         Value::Record { val, .. } if body_type == BodyType::Form => {
             let mut data: Vec<(String, String)> = Vec::with_capacity(val.len());
 
-            for (col, val) in *val {
+            for (col, val) in val {
                 data.push((col, val.coerce_into_string()?))
             }
 
@@ -336,7 +336,7 @@ pub fn request_add_custom_headers(
 
         match &headers {
             Value::Record { val, .. } => {
-                for (k, v) in &**val {
+                for (k, v) in val {
                     custom_headers.insert(k.to_string(), v.clone());
                 }
             }
@@ -346,7 +346,7 @@ pub fn request_add_custom_headers(
                     // single row([key1 key2]; [val1 val2])
                     match &table[0] {
                         Value::Record { val, .. } => {
-                            for (k, v) in &**val {
+                            for (k, v) in val {
                                 custom_headers.insert(k.to_string(), v.clone());
                             }
                         }

--- a/crates/nu-command/src/network/url/build_query.rs
+++ b/crates/nu-command/src/network/url/build_query.rs
@@ -65,7 +65,7 @@ fn to_url(input: PipelineData, head: Span) -> Result<PipelineData, ShellError> {
             match value {
                 Value::Record { ref val, .. } => {
                     let mut row_vec = vec![];
-                    for (k, v) in &**val {
+                    for (k, v) in val {
                         match v.coerce_string() {
                             Ok(s) => {
                                 row_vec.push((k.clone(), s));

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -392,7 +392,7 @@ fn handle_table_command(
         }
         PipelineData::Value(Value::Record { val, .. }, ..) => {
             input.data = PipelineData::Empty;
-            handle_record(input, cfg, *val)
+            handle_record(input, cfg, val)
         }
         PipelineData::Value(Value::LazyRecord { val, .. }, ..) => {
             input.data = val.collect()?.into_pipeline_data();

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -376,8 +376,8 @@ fn get_argument_for_color_value(
 ) -> Option<Argument> {
     match color {
         Value::Record { val, .. } => {
-            let record_exp: Vec<RecordItem> = (**val)
-                .iter()
+            let record_exp: Vec<RecordItem> = val
+                .into_iter()
                 .map(|(k, v)| {
                     RecordItem::Pair(
                         Expression {

--- a/crates/nu-explore/src/nu_common/table.rs
+++ b/crates/nu-explore/src/nu_common/table.rs
@@ -16,7 +16,7 @@ pub fn try_build_table(
     let span = value.span();
     match value {
         Value::List { vals, .. } => try_build_list(vals, ctrlc, config, span, style_computer),
-        Value::Record { val, .. } => try_build_map(*val, span, style_computer, ctrlc, config),
+        Value::Record { val, .. } => try_build_map(val, span, style_computer, ctrlc, config),
         val if matches!(val, Value::String { .. }) => {
             nu_value_to_string_clean(&val, config, style_computer).0
         }

--- a/crates/nu-protocol/src/config/hooks.rs
+++ b/crates/nu-protocol/src/config/hooks.rs
@@ -39,7 +39,7 @@ pub(super) fn create_hooks(value: &Value) -> Result<Hooks, ShellError> {
         Value::Record { val, .. } => {
             let mut hooks = Hooks::new();
 
-            for (col, val) in &**val {
+            for (col, val) in val {
                 match col.as_str() {
                     "pre_prompt" => hooks.pre_prompt = Some(val.clone()),
                     "pre_execution" => hooks.pre_execution = Some(val.clone()),

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -23,7 +23,7 @@ impl Matcher for Pattern {
             Pattern::Record(field_patterns) => match value {
                 Value::Record { val, .. } => {
                     'top: for field_pattern in field_patterns {
-                        for (col, val) in &**val {
+                        for (col, val) in val {
                             if col == &field_pattern.0 {
                                 // We have found the field
                                 let result = field_pattern.1.match_value(val, matches);

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -75,7 +75,7 @@ pub trait Eval {
                         RecordItem::Spread(_, inner) => {
                             match Self::eval::<D>(state, mut_state, inner)? {
                                 Value::Record { val: inner_val, .. } => {
-                                    for (col_name, val) in *inner_val {
+                                    for (col_name, val) in inner_val {
                                         if let Some(orig_span) = col_names.get(&col_name) {
                                             return Err(ShellError::ColumnDefinedTwice {
                                                 col_name,

--- a/crates/nu-protocol/src/value/from_value.rs
+++ b/crates/nu-protocol/src/value/from_value.rs
@@ -538,7 +538,7 @@ impl FromValue for Vec<Value> {
 impl FromValue for Record {
     fn from_value(v: Value) -> Result<Self, ShellError> {
         match v {
-            Value::Record { val, .. } => Ok(*val),
+            Value::Record { val, .. } => Ok(val),
             v => Err(ShellError::CantConvert {
                 to_type: "Record".into(),
                 from_type: v.get_type().to_string(),

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -109,7 +109,7 @@ pub enum Value {
         internal_span: Span,
     },
     Record {
-        val: Box<Record>,
+        val: Record,
         // note: spans are being refactored out of Value
         // please use .span() instead of matching this span value
         #[serde(rename = "span")]
@@ -537,7 +537,7 @@ impl Value {
     /// Unwraps the inner [`Record`] value or returns an error if this `Value` is not a record
     pub fn into_record(self) -> Result<Record, ShellError> {
         if let Value::Record { val, .. } = self {
-            Ok(*val)
+            Ok(val)
         } else {
             self.cant_convert_to("record")
         }
@@ -1997,7 +1997,7 @@ impl Value {
 
     pub fn record(val: Record, span: Span) -> Value {
         Value::Record {
-            val: Box::new(val),
+            val,
             internal_span: span,
         }
     }

--- a/crates/nu-table/src/types/collapse.rs
+++ b/crates/nu-table/src/types/collapse.rs
@@ -48,19 +48,17 @@ fn colorize_value(value: &mut Value, config: &Config, style_computer: &StyleComp
             // Take ownership of the record and reassign to &mut
             // We do this to have owned keys through `.into_iter`
             let record = std::mem::take(val);
-            *val = Box::new(
-                record
-                    .into_iter()
-                    .map(|(mut header, mut val)| {
-                        colorize_value(&mut val, config, style_computer);
+            *val = record
+                .into_iter()
+                .map(|(mut header, mut val)| {
+                    colorize_value(&mut val, config, style_computer);
 
-                        if let Some(color) = style.color_style {
-                            header = color.paint(header).to_string();
-                        }
-                        (header, val)
-                    })
-                    .collect::<Record>(),
-            );
+                    if let Some(color) = style.color_style {
+                        header = color.paint(header).to_string();
+                    }
+                    (header, val)
+                })
+                .collect::<Record>();
         }
         Value::List { vals, .. } => {
             for val in vals {

--- a/crates/nu-table/src/unstructured_table.rs
+++ b/crates/nu-table/src/unstructured_table.rs
@@ -89,7 +89,7 @@ fn build_table(
 
 fn convert_nu_value_to_table_value(value: Value, config: &Config) -> TableValue {
     match value {
-        Value::Record { val, .. } => build_vertical_map(*val, config),
+        Value::Record { val, .. } => build_vertical_map(val, config),
         Value::List { vals, .. } => {
             let rebuild_array_as_map = is_valid_record(&vals) && count_columns_in_record(&vals) > 0;
             if rebuild_array_as_map {


### PR DESCRIPTION
# Description
Depends on `Record` after #12326 to maintain reduced size of `Value`

Only short-term solution

Competes with #12305

## Benchmarking: Removing the `Box` indirection again

(assumes #12326)
Even better performance on `table` benchmarks and small additional gains in the `record` benchmarks.

### Hightlights

```
├─ eval_benchmarks                             │               │               │               │         │
├─ eval_benchmarks                             │               │               │               │         │
│  ├─ eval_default_config        3.118 ms      │ 7.512 ms      │ 3.173 ms      │ 3.22 ms       │ 100     │ 100
│  ├─ eval_default_config        2.982 ms      │ 3.366 ms      │ 3.037 ms      │ 3.047 ms      │ 100     │ 100
│  ╰─ eval_default_env           505.7 µs      │ 617.5 µs      │ 515.6 µs      │ 524.3 µs      │ 100     │ 100
│  ╰─ eval_default_env           501.9 µs      │ 614 µs        │ 513.5 µs      │ 522.3 µs      │ 100     │ 100
...
...
├─ record                                      │               │               │               │         │
├─ record                                      │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  │  ├─ 1                       33.34 µs      │ 96.94 µs      │ 34.14 µs      │ 36.21 µs      │ 100     │ 100
│  │  ├─ 1                       32.75 µs      │ 74.75 µs      │ 33.47 µs      │ 34.46 µs      │ 100     │ 100
│  │  ├─ 10                      48.84 µs      │ 80.79 µs      │ 49.9 µs       │ 51.35 µs      │ 100     │ 100
│  │  ├─ 10                      48.05 µs      │ 99.41 µs      │ 48.75 µs      │ 50.26 µs      │ 100     │ 100
│  │  ├─ 100                     198 µs        │ 270.8 µs      │ 201.2 µs      │ 205.7 µs      │ 100     │ 100
│  │  ├─ 100                     196.5 µs      │ 1.089 ms      │ 201.3 µs      │ 213.8 µs      │ 100     │ 100
│  │  ╰─ 1000                    1.732 ms      │ 2.244 ms      │ 1.778 ms      │ 1.783 ms      │ 100     │ 100
│  │  ╰─ 1000                    1.713 ms      │ 2.107 ms      │ 1.755 ms      │ 1.761 ms      │ 100     │ 100
│  ├─ flat_access                              │               │               │               │         │
│  ├─ flat_access                              │               │               │               │         │
│  │  ├─ 1                       18.35 µs      │ 39.73 µs      │ 18.83 µs      │ 19.93 µs      │ 100     │ 100
│  │  ├─ 1                       18.53 µs      │ 42.97 µs      │ 18.89 µs      │ 19.67 µs      │ 100     │ 100
│  │  ├─ 10                      19.41 µs      │ 52.46 µs      │ 19.86 µs      │ 20.93 µs      │ 100     │ 100
│  │  ├─ 10                      19.64 µs      │ 47.79 µs      │ 19.96 µs      │ 20.87 µs      │ 100     │ 100
│  │  ├─ 100                     29.1 µs       │ 96.08 µs      │ 29.48 µs      │ 31.37 µs      │ 100     │ 100
│  │  ├─ 100                     29.49 µs      │ 56.19 µs      │ 30.67 µs      │ 31.7 µs       │ 100     │ 100
│  │  ╰─ 1000                    120.9 µs      │ 197.2 µs      │ 134.8 µs      │ 136.2 µs      │ 100     │ 100
│  │  ╰─ 1000                    121.4 µs      │ 184.4 µs      │ 132.9 µs      │ 135.5 µs      │ 100     │ 100
│  ╰─ nest_access                              │               │               │               │         │
│  ╰─ nest_access                              │               │               │               │         │
│     ├─ 1                       19.09 µs      │ 52.58 µs      │ 19.57 µs      │ 20.53 µs      │ 100     │ 100
│     ├─ 1                       22.15 µs      │ 44.97 µs      │ 22.56 µs      │ 23.36 µs      │ 100     │ 100
│     ├─ 2                       22.46 µs      │ 40.65 µs      │ 23.16 µs      │ 23.83 µs      │ 100     │ 100
│     ├─ 2                       20.78 µs      │ 63.08 µs      │ 21.3 µs       │ 22.92 µs      │ 100     │ 100
...
...
│     ├─ 32                      89.78 µs      │ 146.2 µs      │ 91.06 µs      │ 93.95 µs      │ 100     │ 100
│     ├─ 32                      60.78 µs      │ 94.25 µs      │ 62.96 µs      │ 63.85 µs      │ 100     │ 100
│     ├─ 64                      242.7 µs      │ 314 µs        │ 248.5 µs      │ 252.9 µs      │ 100     │ 100
│     ├─ 64                      155.6 µs      │ 212.9 µs      │ 159.7 µs      │ 162.1 µs      │ 100     │ 100
│     ╰─ 128                     853.6 µs      │ 954.7 µs      │ 876.5 µs      │ 882.2 µs      │ 100     │ 100
│     ╰─ 128                     497.9 µs      │ 581.1 µs      │ 520.2 µs      │ 525.4 µs      │ 100     │ 100
...
...
╰─ table                                       │               │               │               │         │
╰─ table                                       │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   │  ├─ 1                       38.22 µs      │ 79.16 µs      │ 38.91 µs      │ 39.91 µs      │ 100     │ 100
   │  ├─ 1                       38.53 µs      │ 80.69 µs      │ 39.38 µs      │ 41.41 µs      │ 100     │ 100
   │  ├─ 10                      69.33 µs      │ 121.5 µs      │ 70.41 µs      │ 72.17 µs      │ 100     │ 100
   │  ├─ 10                      56.72 µs      │ 105.6 µs      │ 58.13 µs      │ 60.21 µs      │ 100     │ 100
   │  ├─ 100                     220.3 µs      │ 298.6 µs      │ 223.7 µs      │ 228.3 µs      │ 100     │ 100
   │  ├─ 100                     215.4 µs      │ 282 µs        │ 218.1 µs      │ 222.9 µs      │ 100     │ 100
   │  ╰─ 1000                    1.894 ms      │ 2.279 ms      │ 1.956 ms      │ 1.963 ms      │ 100     │ 100
   │  ╰─ 1000                    1.863 ms      │ 2.772 ms      │ 1.902 ms      │ 1.915 ms      │ 100     │ 100
   ├─ get                                      │               │               │               │         │
   ├─ get                                      │               │               │               │         │
   │  ├─ 1                       29.98 µs      │ 62.94 µs      │ 30.56 µs      │ 31.91 µs      │ 100     │ 100
   │  ├─ 1                       30.41 µs      │ 74.9 µs       │ 31.1 µs       │ 33.14 µs      │ 100     │ 100
   │  ├─ 10                      35.69 µs      │ 109.3 µs      │ 36.52 µs      │ 38.7 µs       │ 100     │ 100
   │  ├─ 10                      30.8 µs       │ 53.98 µs      │ 31.51 µs      │ 33.46 µs      │ 100     │ 100
   │  ├─ 100                     71.86 µs      │ 137.2 µs      │ 73.51 µs      │ 75.72 µs      │ 100     │ 100
   │  ├─ 100                     59.73 µs      │ 90.05 µs      │ 61.16 µs      │ 62.54 µs      │ 100     │ 100
   │  ╰─ 1000                    454.7 µs      │ 537.3 µs      │ 466.3 µs      │ 474 µs        │ 100     │ 100
   │  ╰─ 1000                    333 µs        │ 438.9 µs      │ 344.8 µs      │ 351 µs        │ 100     │ 100
   ╰─ select                                   │               │               │               │         │
   ╰─ select                                   │               │               │               │         │
      ├─ 1                       26.91 µs      │ 60.62 µs      │ 27.71 µs      │ 29.62 µs      │ 100     │ 100
      ├─ 1                       27.27 µs      │ 54.34 µs      │ 27.81 µs      │ 28.83 µs      │ 100     │ 100
      ├─ 10                      34.87 µs      │ 72.37 µs      │ 35.56 µs      │ 37.26 µs      │ 100     │ 100
      ├─ 10                      33.21 µs      │ 75.13 µs      │ 34.16 µs      │ 36.4 µs       │ 100     │ 100
      ├─ 100                     111.3 µs      │ 147.9 µs      │ 112.8 µs      │ 115 µs        │ 100     │ 100
      ├─ 100                     94.66 µs      │ 139.4 µs      │ 96.15 µs      │ 98.8 µs       │ 100     │ 100
      ╰─ 1000                    873.2 µs      │ 977.1 µs      │ 896.9 µs      │ 903.9 µs      │ 100     │ 100
      ╰─ 1000                    678.8 µs      │ 838.6 µs      │ 707.7 µs      │ 710.5 µs      │ 100     │ 100

```

<details>
<summary>Full benchmark run</summary>

```

benchmarks                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
benchmarks                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ load_standard_lib             12.25 ms      │ 15.18 ms      │ 12.48 ms      │ 12.58 ms      │ 100     │ 100
├─ load_standard_lib             12.47 ms      │ 16.21 ms      │ 12.65 ms      │ 12.74 ms      │ 100     │ 100
├─ decoding_benchmarks                         │               │               │               │         │
├─ decoding_benchmarks                         │               │               │               │         │
│  ├─ json_decode                              │               │               │               │         │
│  ├─ json_decode                              │               │               │               │         │
│  │  ├─ (100, 5)                526 µs        │ 594 µs        │ 534.9 µs      │ 540.3 µs      │ 100     │ 100
│  │  ├─ (100, 5)                562.8 µs      │ 643.2 µs      │ 570 µs        │ 575.3 µs      │ 100     │ 100
│  │  ╰─ (10000, 15)             197.1 ms      │ 207.9 ms      │ 200.4 ms      │ 200.3 ms      │ 100     │ 100
│  │  ╰─ (10000, 15)             222.6 ms      │ 276 ms        │ 264.5 ms      │ 264.5 ms      │ 100     │ 100
│  ╰─ msgpack_decode                           │               │               │               │         │
│  ╰─ msgpack_decode                           │               │               │               │         │
│     ├─ (100, 5)                240.3 µs      │ 315 µs        │ 242.1 µs      │ 244.8 µs      │ 100     │ 100
│     ├─ (100, 5)                271.2 µs      │ 325.3 µs      │ 273.8 µs      │ 276.6 µs      │ 100     │ 100
│     ╰─ (10000, 15)             82.92 ms      │ 88.21 ms      │ 83.42 ms      │ 83.7 ms       │ 100     │ 100
│     ╰─ (10000, 15)             112.7 ms      │ 114.7 ms      │ 113.3 ms      │ 113.3 ms      │ 100     │ 100
├─ encoding_benchmarks                         │               │               │               │         │
├─ encoding_benchmarks                         │               │               │               │         │
│  ├─ json_encode                              │               │               │               │         │
│  ├─ json_encode                              │               │               │               │         │
│  │  ├─ (100, 5)                111.1 µs      │ 130.9 µs      │ 112.1 µs      │ 113.2 µs      │ 100     │ 100
│  │  ├─ (100, 5)                115.2 µs      │ 144.3 µs      │ 116.4 µs      │ 117.5 µs      │ 100     │ 100
│  │  ╰─ (10000, 15)             29.87 ms      │ 30.38 ms      │ 30.18 ms      │ 30.18 ms      │ 100     │ 100
│  │  ╰─ (10000, 15)             32.71 ms      │ 35.19 ms      │ 32.94 ms      │ 33 ms         │ 100     │ 100
│  ╰─ msgpack_encode                           │               │               │               │         │
│  ╰─ msgpack_encode                           │               │               │               │         │
│     ├─ (100, 5)                43.11 µs      │ 55.19 µs      │ 43.61 µs      │ 44.09 µs      │ 100     │ 100
│     ├─ (100, 5)                45.44 µs      │ 66.08 µs      │ 46.01 µs      │ 46.57 µs      │ 100     │ 100
│     ╰─ (10000, 15)             11.17 ms      │ 11.4 ms       │ 11.28 ms      │ 11.28 ms      │ 100     │ 100
│     ╰─ (10000, 15)             12.56 ms      │ 12.98 ms      │ 12.76 ms      │ 12.76 ms      │ 100     │ 100
├─ eval_benchmarks                             │               │               │               │         │
├─ eval_benchmarks                             │               │               │               │         │
│  ├─ eval_default_config        3.118 ms      │ 7.512 ms      │ 3.173 ms      │ 3.22 ms       │ 100     │ 100
│  ├─ eval_default_config        2.982 ms      │ 3.366 ms      │ 3.037 ms      │ 3.047 ms      │ 100     │ 100
│  ╰─ eval_default_env           505.7 µs      │ 617.5 µs      │ 515.6 µs      │ 524.3 µs      │ 100     │ 100
│  ╰─ eval_default_env           501.9 µs      │ 614 µs        │ 513.5 µs      │ 522.3 µs      │ 100     │ 100
├─ eval_commands                               │               │               │               │         │
├─ eval_commands                               │               │               │               │         │
│  ├─ each                                     │               │               │               │         │
│  ├─ each                                     │               │               │               │         │
│  │  ├─ 1                       80.91 µs      │ 227.8 µs      │ 146.4 µs      │ 133.8 µs      │ 100     │ 100
│  │  ├─ 1                       85.31 µs      │ 568.1 µs      │ 145.3 µs      │ 135.4 µs      │ 100     │ 100
│  │  ├─ 5                       278.2 µs      │ 556.2 µs      │ 339.6 µs      │ 342.1 µs      │ 100     │ 100
│  │  ├─ 5                       277.2 µs      │ 580.5 µs      │ 338.1 µs      │ 336.2 µs      │ 100     │ 100
│  │  ├─ 10                      582.8 µs      │ 911 µs        │ 647.2 µs      │ 655.5 µs      │ 100     │ 100
│  │  ├─ 10                      554.5 µs      │ 883.2 µs      │ 631.2 µs      │ 640.4 µs      │ 100     │ 100
│  │  ├─ 100                     5.884 ms      │ 6.67 ms       │ 6.217 ms      │ 6.235 ms      │ 100     │ 100
│  │  ├─ 100                     5.866 ms      │ 6.467 ms      │ 6.191 ms      │ 6.171 ms      │ 100     │ 100
│  │  ╰─ 1000                    60.24 ms      │ 63.37 ms      │ 61.85 ms      │ 61.89 ms      │ 100     │ 100
│  │  ╰─ 1000                    53.65 ms      │ 62.89 ms      │ 60.62 ms      │ 60.4 ms       │ 100     │ 100
│  ├─ for_range                                │               │               │               │         │
│  ├─ for_range                                │               │               │               │         │
│  │  ├─ 1                       86.05 µs      │ 222.1 µs      │ 145.3 µs      │ 126.8 µs      │ 100     │ 100
│  │  ├─ 1                       76.05 µs      │ 229.1 µs      │ 87.46 µs      │ 104.8 µs      │ 100     │ 100
│  │  ├─ 5                       275.3 µs      │ 612.9 µs      │ 339.4 µs      │ 356.2 µs      │ 100     │ 100
│  │  ├─ 5                       274.3 µs      │ 440 µs        │ 336.6 µs      │ 342.5 µs      │ 100     │ 100
│  │  ├─ 10                      517.6 µs      │ 956.7 µs      │ 614.1 µs      │ 637.5 µs      │ 100     │ 100
│  │  ├─ 10                      439.7 µs      │ 714 µs        │ 635.8 µs      │ 634.8 µs      │ 100     │ 100
│  │  ├─ 100                     5.744 ms      │ 6.933 ms      │ 6.142 ms      │ 6.154 ms      │ 100     │ 100
│  │  ├─ 100                     5.51 ms       │ 6.11 ms       │ 5.976 ms      │ 5.952 ms      │ 100     │ 100
│  │  ╰─ 1000                    60.3 ms       │ 62.38 ms      │ 61.35 ms      │ 61.37 ms      │ 100     │ 100
│  │  ╰─ 1000                    58.28 ms      │ 61.95 ms      │ 60.91 ms      │ 60.56 ms      │ 100     │ 100
│  ├─ interleave                               │               │               │               │         │
│  ├─ interleave                               │               │               │               │         │
│  │  ├─ 100                     1.48 ms       │ 2.387 ms      │ 1.827 ms      │ 1.822 ms      │ 100     │ 100
│  │  ├─ 100                     1.456 ms      │ 2.215 ms      │ 1.731 ms      │ 1.76 ms       │ 100     │ 100
│  │  ├─ 1000                    11.97 ms      │ 19.11 ms      │ 13.69 ms      │ 13.97 ms      │ 100     │ 100
│  │  ├─ 1000                    13.22 ms      │ 19.45 ms      │ 14.7 ms       │ 15.03 ms      │ 100     │ 100
│  │  ╰─ 10000                   128.6 ms      │ 169 ms        │ 148.6 ms      │ 148.5 ms      │ 100     │ 100
│  │  ╰─ 10000                   145.1 ms      │ 186.3 ms      │ 163.1 ms      │ 163.4 ms      │ 100     │ 100
│  ├─ interleave_with_ctrlc                    │               │               │               │         │
│  ├─ interleave_with_ctrlc                    │               │               │               │         │
│  │  ├─ 100                     1.369 ms      │ 2.592 ms      │ 1.614 ms      │ 1.648 ms      │ 100     │ 100
│  │  ├─ 100                     1.44 ms       │ 2.249 ms      │ 1.77 ms       │ 1.811 ms      │ 100     │ 100
│  │  ├─ 1000                    11.72 ms      │ 19.43 ms      │ 13.55 ms      │ 13.9 ms       │ 100     │ 100
│  │  ├─ 1000                    13.37 ms      │ 19.14 ms      │ 14.59 ms      │ 14.9 ms       │ 100     │ 100
│  │  ╰─ 10000                   130.3 ms      │ 175.8 ms      │ 149.3 ms      │ 148.9 ms      │ 100     │ 100
│  │  ╰─ 10000                   144.7 ms      │ 190.5 ms      │ 160.2 ms      │ 161.1 ms      │ 100     │ 100
│  ├─ par_each_1t                              │               │               │               │         │
│  ├─ par_each_1t                              │               │               │               │         │
│  │  ├─ 1                       154.4 µs      │ 533.3 µs      │ 162.2 µs      │ 171.2 µs      │ 100     │ 100
│  │  ├─ 1                       159.4 µs      │ 272.9 µs      │ 162.2 µs      │ 168.6 µs      │ 100     │ 100
│  │  ├─ 5                       337.7 µs      │ 418.2 µs      │ 357.2 µs      │ 363.4 µs      │ 100     │ 100
│  │  ├─ 5                       293.5 µs      │ 447.4 µs      │ 354.9 µs      │ 356.2 µs      │ 100     │ 100
│  │  ├─ 10                      581.4 µs      │ 861.9 µs      │ 689.4 µs      │ 684.6 µs      │ 100     │ 100
│  │  ├─ 10                      526.6 µs      │ 752.9 µs      │ 667.1 µs      │ 662.5 µs      │ 100     │ 100
│  │  ├─ 100                     4.994 ms      │ 7.122 ms      │ 6.171 ms      │ 6.11 ms       │ 100     │ 100
│  │  ├─ 100                     3.378 ms      │ 6.788 ms      │ 3.969 ms      │ 4.184 ms      │ 100     │ 100
│  │  ╰─ 1000                    46.5 ms       │ 63.42 ms      │ 60.36 ms      │ 58.41 ms      │ 100     │ 100
│  │  ╰─ 1000                    31.98 ms      │ 46.68 ms      │ 33.65 ms      │ 35.67 ms      │ 100     │ 100
│  ╰─ par_each_2t                              │               │               │               │         │
│  ╰─ par_each_2t                              │               │               │               │         │
│     ├─ 1                       178.4 µs      │ 520.6 µs      │ 194.6 µs      │ 201.8 µs      │ 100     │ 100
│     ├─ 1                       175.8 µs      │ 651.4 µs      │ 193.4 µs      │ 202.2 µs      │ 100     │ 100
│     ├─ 5                       260.3 µs      │ 374.4 µs      │ 329.5 µs      │ 310.7 µs      │ 100     │ 100
│     ├─ 5                       263 µs        │ 399.8 µs      │ 330.2 µs      │ 316.2 µs      │ 100     │ 100
│     ├─ 10                      385.4 µs      │ 1.097 ms      │ 452.5 µs      │ 447.9 µs      │ 100     │ 100
│     ├─ 10                      335.3 µs      │ 982 µs        │ 392.7 µs      │ 402.1 µs      │ 100     │ 100
│     ├─ 100                     2.333 ms      │ 3.278 ms      │ 3.095 ms      │ 3.068 ms      │ 100     │ 100
│     ├─ 100                     1.82 ms       │ 3.15 ms       │ 2.521 ms      │ 2.539 ms      │ 100     │ 100
│     ╰─ 1000                    22.74 ms      │ 30.74 ms      │ 30.07 ms      │ 29.8 ms       │ 100     │ 100
│     ╰─ 1000                    17.33 ms      │ 30.7 ms       │ 23.62 ms      │ 24.29 ms      │ 100     │ 100
├─ parser_benchmarks                           │               │               │               │         │
├─ parser_benchmarks                           │               │               │               │         │
│  ├─ parse_default_config_file  2.155 ms      │ 2.696 ms      │ 2.216 ms      │ 2.232 ms      │ 100     │ 100
│  ├─ parse_default_config_file  2.152 ms      │ 2.314 ms      │ 2.214 ms      │ 2.219 ms      │ 100     │ 100
│  ╰─ parse_default_env_file     381.6 µs      │ 513.5 µs      │ 392.1 µs      │ 403.6 µs      │ 100     │ 100
│  ╰─ parse_default_env_file     381.5 µs      │ 484 µs        │ 391 µs        │ 399.6 µs      │ 100     │ 100
├─ record                                      │               │               │               │         │
├─ record                                      │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  ├─ create                                   │               │               │               │         │
│  │  ├─ 1                       33.34 µs      │ 96.94 µs      │ 34.14 µs      │ 36.21 µs      │ 100     │ 100
│  │  ├─ 1                       32.75 µs      │ 74.75 µs      │ 33.47 µs      │ 34.46 µs      │ 100     │ 100
│  │  ├─ 10                      48.84 µs      │ 80.79 µs      │ 49.9 µs       │ 51.35 µs      │ 100     │ 100
│  │  ├─ 10                      48.05 µs      │ 99.41 µs      │ 48.75 µs      │ 50.26 µs      │ 100     │ 100
│  │  ├─ 100                     198 µs        │ 270.8 µs      │ 201.2 µs      │ 205.7 µs      │ 100     │ 100
│  │  ├─ 100                     196.5 µs      │ 1.089 ms      │ 201.3 µs      │ 213.8 µs      │ 100     │ 100
│  │  ╰─ 1000                    1.732 ms      │ 2.244 ms      │ 1.778 ms      │ 1.783 ms      │ 100     │ 100
│  │  ╰─ 1000                    1.713 ms      │ 2.107 ms      │ 1.755 ms      │ 1.761 ms      │ 100     │ 100
│  ├─ flat_access                              │               │               │               │         │
│  ├─ flat_access                              │               │               │               │         │
│  │  ├─ 1                       18.35 µs      │ 39.73 µs      │ 18.83 µs      │ 19.93 µs      │ 100     │ 100
│  │  ├─ 1                       18.53 µs      │ 42.97 µs      │ 18.89 µs      │ 19.67 µs      │ 100     │ 100
│  │  ├─ 10                      19.41 µs      │ 52.46 µs      │ 19.86 µs      │ 20.93 µs      │ 100     │ 100
│  │  ├─ 10                      19.64 µs      │ 47.79 µs      │ 19.96 µs      │ 20.87 µs      │ 100     │ 100
│  │  ├─ 100                     29.1 µs       │ 96.08 µs      │ 29.48 µs      │ 31.37 µs      │ 100     │ 100
│  │  ├─ 100                     29.49 µs      │ 56.19 µs      │ 30.67 µs      │ 31.7 µs       │ 100     │ 100
│  │  ╰─ 1000                    120.9 µs      │ 197.2 µs      │ 134.8 µs      │ 136.2 µs      │ 100     │ 100
│  │  ╰─ 1000                    121.4 µs      │ 184.4 µs      │ 132.9 µs      │ 135.5 µs      │ 100     │ 100
│  ╰─ nest_access                              │               │               │               │         │
│  ╰─ nest_access                              │               │               │               │         │
│     ├─ 1                       19.09 µs      │ 52.58 µs      │ 19.57 µs      │ 20.53 µs      │ 100     │ 100
│     ├─ 1                       22.15 µs      │ 44.97 µs      │ 22.56 µs      │ 23.36 µs      │ 100     │ 100
│     ├─ 2                       22.46 µs      │ 40.65 µs      │ 23.16 µs      │ 23.83 µs      │ 100     │ 100
│     ├─ 2                       20.78 µs      │ 63.08 µs      │ 21.3 µs       │ 22.92 µs      │ 100     │ 100
│     ├─ 4                       21.67 µs      │ 57.42 µs      │ 22.29 µs      │ 23.24 µs      │ 100     │ 100
│     ├─ 4                       21.56 µs      │ 42.42 µs      │ 22.13 µs      │ 22.84 µs      │ 100     │ 100
│     ├─ 8                       26.9 µs       │ 91.01 µs      │ 27.61 µs      │ 29.36 µs      │ 100     │ 100
│     ├─ 8                       24.94 µs      │ 43.3 µs       │ 25.51 µs      │ 25.95 µs      │ 100     │ 100
│     ├─ 16                      39.98 µs      │ 123 µs        │ 40.64 µs      │ 42.87 µs      │ 100     │ 100
│     ├─ 16                      37.11 µs      │ 60.03 µs      │ 38.11 µs      │ 39.09 µs      │ 100     │ 100
│     ├─ 32                      89.78 µs      │ 146.2 µs      │ 91.06 µs      │ 93.95 µs      │ 100     │ 100
│     ├─ 32                      60.78 µs      │ 94.25 µs      │ 62.96 µs      │ 63.85 µs      │ 100     │ 100
│     ├─ 64                      242.7 µs      │ 314 µs        │ 248.5 µs      │ 252.9 µs      │ 100     │ 100
│     ├─ 64                      155.6 µs      │ 212.9 µs      │ 159.7 µs      │ 162.1 µs      │ 100     │ 100
│     ╰─ 128                     853.6 µs      │ 954.7 µs      │ 876.5 µs      │ 882.2 µs      │ 100     │ 100
│     ╰─ 128                     497.9 µs      │ 581.1 µs      │ 520.2 µs      │ 525.4 µs      │ 100     │ 100
╰─ table                                       │               │               │               │         │
╰─ table                                       │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   ├─ create                                   │               │               │               │         │
   │  ├─ 1                       38.22 µs      │ 79.16 µs      │ 38.91 µs      │ 39.91 µs      │ 100     │ 100
   │  ├─ 1                       38.53 µs      │ 80.69 µs      │ 39.38 µs      │ 41.41 µs      │ 100     │ 100
   │  ├─ 10                      69.33 µs      │ 121.5 µs      │ 70.41 µs      │ 72.17 µs      │ 100     │ 100
   │  ├─ 10                      56.72 µs      │ 105.6 µs      │ 58.13 µs      │ 60.21 µs      │ 100     │ 100
   │  ├─ 100                     220.3 µs      │ 298.6 µs      │ 223.7 µs      │ 228.3 µs      │ 100     │ 100
   │  ├─ 100                     215.4 µs      │ 282 µs        │ 218.1 µs      │ 222.9 µs      │ 100     │ 100
   │  ╰─ 1000                    1.894 ms      │ 2.279 ms      │ 1.956 ms      │ 1.963 ms      │ 100     │ 100
   │  ╰─ 1000                    1.863 ms      │ 2.772 ms      │ 1.902 ms      │ 1.915 ms      │ 100     │ 100
   ├─ get                                      │               │               │               │         │
   ├─ get                                      │               │               │               │         │
   │  ├─ 1                       29.98 µs      │ 62.94 µs      │ 30.56 µs      │ 31.91 µs      │ 100     │ 100
   │  ├─ 1                       30.41 µs      │ 74.9 µs       │ 31.1 µs       │ 33.14 µs      │ 100     │ 100
   │  ├─ 10                      35.69 µs      │ 109.3 µs      │ 36.52 µs      │ 38.7 µs       │ 100     │ 100
   │  ├─ 10                      30.8 µs       │ 53.98 µs      │ 31.51 µs      │ 33.46 µs      │ 100     │ 100
   │  ├─ 100                     71.86 µs      │ 137.2 µs      │ 73.51 µs      │ 75.72 µs      │ 100     │ 100
   │  ├─ 100                     59.73 µs      │ 90.05 µs      │ 61.16 µs      │ 62.54 µs      │ 100     │ 100
   │  ╰─ 1000                    454.7 µs      │ 537.3 µs      │ 466.3 µs      │ 474 µs        │ 100     │ 100
   │  ╰─ 1000                    333 µs        │ 438.9 µs      │ 344.8 µs      │ 351 µs        │ 100     │ 100
   ╰─ select                                   │               │               │               │         │
   ╰─ select                                   │               │               │               │         │
      ├─ 1                       26.91 µs      │ 60.62 µs      │ 27.71 µs      │ 29.62 µs      │ 100     │ 100
      ├─ 1                       27.27 µs      │ 54.34 µs      │ 27.81 µs      │ 28.83 µs      │ 100     │ 100
      ├─ 10                      34.87 µs      │ 72.37 µs      │ 35.56 µs      │ 37.26 µs      │ 100     │ 100
      ├─ 10                      33.21 µs      │ 75.13 µs      │ 34.16 µs      │ 36.4 µs       │ 100     │ 100
      ├─ 100                     111.3 µs      │ 147.9 µs      │ 112.8 µs      │ 115 µs        │ 100     │ 100
      ├─ 100                     94.66 µs      │ 139.4 µs      │ 96.15 µs      │ 98.8 µs       │ 100     │ 100
      ╰─ 1000                    873.2 µs      │ 977.1 µs      │ 896.9 µs      │ 903.9 µs      │ 100     │ 100
      ╰─ 1000                    678.8 µs      │ 838.6 µs      │ 707.7 µs      │ 710.5 µs      │ 100     │ 100


```

</details>

