### PR TITLE
feat: Commands mode supports arguments

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -81,6 +81,7 @@ fn bench_command_with_custom_stack_and_engine(
         .bench_values(|mut engine| {
             evaluate_commands(
                 &commands,
+                Vec::new(),
                 &mut engine,
                 &mut stack.clone(),
                 PipelineData::empty(),
@@ -101,6 +102,7 @@ fn setup_stack_and_engine_from_command(command: &str) -> (Stack, EngineState) {
     let mut stack = Stack::new();
     evaluate_commands(
         &commands,
+        Vec::new(),
         &mut engine,
         &mut stack,
         PipelineData::empty(),
@@ -261,6 +263,7 @@ mod eval_commands {
             .bench_values(|mut engine| {
                 evaluate_commands(
                     &commands,
+                    Vec::new(),
                     &mut engine,
                     &mut nu_protocol::engine::Stack::new(),
                     PipelineData::empty(),

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -1,7 +1,7 @@
 use log::info;
 use miette::Result;
 use nu_engine::{convert_env_values, eval_block};
-use nu_parser::parse;
+use nu_parser::{parse, escape_for_script_arg};
 use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
@@ -37,10 +37,12 @@ pub fn evaluate_commands(
 
         let mut commands = commands.item.clone();
         if !args_to_commands.is_empty() {
-            // Should args_to_commands be escaped in case some of them have spaces??
-            // It would be easier if https://github.com/nushell/nushell/issues/12343 could be addressed first.
+             let args_to_commands: Vec<String> = args_to_commands
+                .into_iter()
+                .map(|a| escape_for_script_arg(&a))
+                .collect();
             commands = format!(
-                "def --wrapped wrapped_commands [...args] {{ {} }}; wrapped_commands {}",
+                "def --wrapped main [...args] {{ {} }}; main {}",
                 commands,
                 args_to_commands.join(" "),
             )

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -1,3 +1,4 @@
+
 use log::info;
 use miette::Result;
 use nu_engine::{convert_env_values, eval_block};
@@ -35,10 +36,17 @@ pub fn evaluate_commands(
 
         let mut working_set = StateWorkingSet::new(engine_state);
 
+        let mut commands = commands.item.clone();
         if !args_to_commands.is_empty() {
-            // Command args support: maybe wrap the commands inside a wrapped function and call it with args_to_commands
+            // Should args_to_commands be escaped in case some of them have spaces??
+            // It would be easier if https://github.com/nushell/nushell/issues/12343 could be addressed first.
+            commands = format!(
+                "def --wrapped wrapped_commands [...args] {{ {} }}; wrapped_commands {}",
+                commands,
+                args_to_commands.join(" "),
+            )
         }
-        let output = parse(&mut working_set, None, commands.item.as_bytes(), false);
+        let output = parse(&mut working_set, None, commands.as_bytes(), false);
         if let Some(warning) = working_set.parse_warnings.first() {
             report_error(&working_set, warning);
         }

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -11,6 +11,7 @@ use nu_protocol::{
 /// Run a command (or commands) given to us by the user
 pub fn evaluate_commands(
     commands: &Spanned<String>,
+    args_to_commands: Vec<String>,
     engine_state: &mut EngineState,
     stack: &mut Stack,
     input: PipelineData,
@@ -34,6 +35,9 @@ pub fn evaluate_commands(
 
         let mut working_set = StateWorkingSet::new(engine_state);
 
+        if !args_to_commands.is_empty() {
+            // Command args support: maybe wrap the commands inside a wrapped function and call it with args_to_commands
+        }
         let output = parse(&mut working_set, None, commands.item.as_bytes(), false);
         if let Some(warning) = working_set.parse_warnings.first() {
             report_error(&working_set, warning);

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -1,4 +1,3 @@
-
 use log::info;
 use miette::Result;
 use nu_engine::{convert_env_values, eval_block};

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -1,7 +1,7 @@
 use log::info;
 use miette::Result;
 use nu_engine::{convert_env_values, eval_block};
-use nu_parser::{parse, escape_for_script_arg};
+use nu_parser::{escape_for_script_arg, parse};
 use nu_protocol::{
     debugger::WithoutDebug,
     engine::{EngineState, Stack, StateWorkingSet},
@@ -37,7 +37,7 @@ pub fn evaluate_commands(
 
         let mut commands = commands.item.clone();
         if !args_to_commands.is_empty() {
-             let args_to_commands: Vec<String> = args_to_commands
+            let args_to_commands: Vec<String> = args_to_commands
                 .into_iter()
                 .map(|a| escape_for_script_arg(&a))
                 .collect();

--- a/src/command.rs
+++ b/src/command.rs
@@ -61,7 +61,12 @@ pub(crate) fn gather_commandline_args() -> (Vec<String>, String, Vec<String>, Ve
     } else {
         Vec::default()
     };
-    (args_to_nushell, script_name, args_to_script, args_to_commands)
+    (
+        args_to_nushell,
+        script_name,
+        args_to_script,
+        args_to_commands,
+    )
 }
 
 pub(crate) fn parse_commandline_args(

--- a/src/command.rs
+++ b/src/command.rs
@@ -68,12 +68,12 @@ pub(crate) fn gather_commandline_args() -> CommandlineArgs {
     } else {
         Vec::default()
     };
-    return CommandlineArgs { 
+    CommandlineArgs {
         args_to_nushell,
         script_name,
         args_to_script,
         args_to_commands,
-     }
+    }
 }
 
 pub(crate) fn parse_commandline_args(

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,7 +7,14 @@ use nu_protocol::{
 };
 use nu_utils::stdout_write_all_and_flush;
 
-pub(crate) fn gather_commandline_args() -> (Vec<String>, String, Vec<String>, Vec<String>) {
+pub struct CommandlineArgs {
+    pub args_to_nushell: Vec<String>,
+    pub script_name: String,
+    pub args_to_script: Vec<String>,
+    pub args_to_commands: Vec<String>,
+}
+
+pub(crate) fn gather_commandline_args() -> CommandlineArgs {
     // Would be nice if we had a way to parse this. The first flags we see will be going to nushell
     // then it'll be the script name
     // then the args to the script
@@ -61,12 +68,12 @@ pub(crate) fn gather_commandline_args() -> (Vec<String>, String, Vec<String>, Ve
     } else {
         Vec::default()
     };
-    (
+    return CommandlineArgs { 
         args_to_nushell,
         script_name,
         args_to_script,
         args_to_commands,
-    )
+     }
 }
 
 pub(crate) fn parse_commandline_args(

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,9 +152,12 @@ fn main() -> Result<()> {
     let db = nu_command::open_connection_in_memory_custom()?;
     #[cfg(feature = "sqlite")]
     db.last_insert_rowid();
-
-    let (args_to_nushell, script_name, args_to_script, args_to_commands) =
-        gather_commandline_args();
+// ( script_name, args_to_script, args_to_commands)
+    let commandline_args = gather_commandline_args();
+    let args_to_nushell = commandline_args.args_to_nushell;
+    let script_name = commandline_args.script_name;
+    let args_to_script = commandline_args.args_to_script;
+    let args_to_commands = commandline_args.args_to_commands;
     let parsed_nu_cli_args = parse_commandline_args(&args_to_nushell.join(" "), &mut engine_state)
         .unwrap_or_else(|_| std::process::exit(1));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,6 @@ fn main() -> Result<()> {
     let db = nu_command::open_connection_in_memory_custom()?;
     #[cfg(feature = "sqlite")]
     db.last_insert_rowid();
-// ( script_name, args_to_script, args_to_commands)
     let commandline_args = gather_commandline_args();
     let args_to_nushell = commandline_args.args_to_nushell;
     let script_name = commandline_args.script_name;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use crate::{
     config_files::set_config_path,
     logger::{configure, logger},
 };
-use command::gather_commandline_args;
+use command::{gather_commandline_args, CommandlineArgs};
 use log::{trace, Level};
 use miette::Result;
 use nu_cli::gather_parent_env_vars;
@@ -152,11 +152,12 @@ fn main() -> Result<()> {
     let db = nu_command::open_connection_in_memory_custom()?;
     #[cfg(feature = "sqlite")]
     db.last_insert_rowid();
-    let commandline_args = gather_commandline_args();
-    let args_to_nushell = commandline_args.args_to_nushell;
-    let script_name = commandline_args.script_name;
-    let args_to_script = commandline_args.args_to_script;
-    let args_to_commands = commandline_args.args_to_commands;
+    let CommandlineArgs {
+        args_to_nushell,
+        script_name,
+        args_to_script,
+        args_to_commands,
+    } = gather_commandline_args();
     let parsed_nu_cli_args = parse_commandline_args(&args_to_nushell.join(" "), &mut engine_state)
         .unwrap_or_else(|_| std::process::exit(1));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
     #[cfg(feature = "sqlite")]
     db.last_insert_rowid();
 
-    let (args_to_nushell, script_name, args_to_script) = gather_commandline_args();
+    let (args_to_nushell, script_name, args_to_script, args_to_commands) = gather_commandline_args();
     let parsed_nu_cli_args = parse_commandline_args(&args_to_nushell.join(" "), &mut engine_state)
         .unwrap_or_else(|_| std::process::exit(1));
 
@@ -402,6 +402,7 @@ fn main() -> Result<()> {
             parsed_nu_cli_args,
             use_color,
             &commands,
+            args_to_commands,
             input,
             entire_start_time,
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,8 @@ fn main() -> Result<()> {
     #[cfg(feature = "sqlite")]
     db.last_insert_rowid();
 
-    let (args_to_nushell, script_name, args_to_script, args_to_commands) = gather_commandline_args();
+    let (args_to_nushell, script_name, args_to_script, args_to_commands) =
+        gather_commandline_args();
     let parsed_nu_cli_args = parse_commandline_args(&args_to_nushell.join(" "), &mut engine_state)
         .unwrap_or_else(|_| std::process::exit(1));
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -16,6 +16,7 @@ pub(crate) fn run_commands(
     parsed_nu_cli_args: command::NushellCliArgs,
     use_color: bool,
     commands: &nu_protocol::Spanned<String>,
+    args_to_commands: Vec<String>,
     input: PipelineData,
     entire_start_time: std::time::Instant,
 ) -> Result<(), miette::ErrReport> {
@@ -114,6 +115,7 @@ pub(crate) fn run_commands(
     let start_time = std::time::Instant::now();
     let ret_val = evaluate_commands(
         commands,
+        args_to_commands,
         engine_state,
         &mut stack,
         input,


### PR DESCRIPTION
# Description

Implementation of #11897 to support CLI tools like `lf`.

## Use case

This use case demonstrates how Nushell can seamlessly integrate with CLI tools like lf that support user-defined custom scripts.

`lf` Custom Script Execution with Nushell

`lf` allows defining custom commands that are executed using the given default shell. Here's how Nushell can be used within an `lf` script:

### Example: Creating Executable Nushell Scripts

Imagine an `lf` command named `mk-nu-scripts` that creates executable Nushell scripts:
```
cmd mk-nu-scripts &{{
  for x in $args {
    "#!/usr/bin/env nu" | save $x
    chmod +x $x
  }
}}
```
This command iterates over provided arguments (`$args`) and generates new files with the shebang line `#!/usr/bin/env nu`, effectively turning them into executable Nushell scripts.

### Usage within lf:

Simply execute the command with desired filenames as arguments:
```
:mk-nu-scripts foo bar
```

### Behind the Scenes:

`lf` automatically separates arguments. The `--` symbol ensures any arguments following it are passed to the Nushell script itself (specified by `-c`) and not interpreted by the shell.

### Benefits:

- Enhanced Workflow: Automate repetitive tasks within lf using powerful Nushell scripting.
- Extended Functionality: Leverage Nushell's capabilities to create custom lf features.
- Improved Developer Experience: Utilize existing Nushell knowledge within lf.

### Nushell Integration Potential:

This example showcases the potential of Nushell's integration with lf and similar CLI tools. Imagine building complex workflows and extending functionality seamlessly across different tools.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
Be able to use `nu` shell as the **default shell**

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
