### PR TITLE
`mkdir` umask fix

### DIFF
--- a/crates/nu-command/src/filesystem/umkdir.rs
+++ b/crates/nu-command/src/filesystem/umkdir.rs
@@ -13,7 +13,7 @@ const DEFAULT_MODE: u32 = 0o777;
 
 #[cfg(not(windows))]
 fn get_mode() -> u32 {
-    DEFAULT_MODE - mode::get_umask()
+    !mode::get_umask() & DEFAULT_MODE
 }
 
 #[cfg(windows)]

--- a/crates/nu-command/tests/commands/umkdir.rs
+++ b/crates/nu-command/tests/commands/umkdir.rs
@@ -141,7 +141,7 @@ fn mkdir_umask_permission() {
         assert_eq!(
             actual, 0o40755,
             "Most *nix systems have 0o00022 as the umask. \
-            So directory permission should be 0o40755 = 0o40777 - 0o00022"
+            So directory permission should be 0o40755 = 0o40777 & (!0o00022)"
         );
     })
 }


### PR DESCRIPTION
# Description
Fixes how the directory permissions are calculated in `mkdir`. Instead of subtraction, the umask is actually used as a mask via negation followed by bitwise and with the default mode. This matches how [uucore calculates](https://github.com/uutils/coreutils/blob/cac7155fba4260763ecd48894ca3be3ef087a2d9/src/uu/mkdir/src/mkdir.rs#L61) the mode.