### PR TITLE
Make `view source` more robust

### DIFF
--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -68,7 +68,7 @@ impl Command for ViewSource {
                             };
                             if !vec_of_required.is_empty()
                                 || !vec_of_optional.is_empty()
-                                || vec_of_flags.len()!= 1
+                                || vec_of_flags.len() != 1
                                 || rest.is_some()
                             {
                                 final_contents.push(' ');

--- a/crates/nu-command/src/debug/view_source.rs
+++ b/crates/nu-command/src/debug/view_source.rs
@@ -61,17 +61,17 @@ impl Command for ViewSource {
                             let contents = engine_state.get_span_contents(block_span);
                             // name of function
                             let mut final_contents = String::new();
-                            if val.contains(" ") {
+                            if val.contains(' ') {
                                 let _ = write!(&mut final_contents, "def \"{val}\" [");
                             } else {
                                 let _ = write!(&mut final_contents, "def {val} [");
                             };
                             if !vec_of_required.is_empty()
                                 || !vec_of_optional.is_empty()
-                                || !(vec_of_flags.len() == 1)
+                                || vec_of_flags.len()!= 1
                                 || rest.is_some()
                             {
-                                final_contents.push_str(" ");
+                                final_contents.push(' ');
                             }
                             for n in vec_of_required {
                                 let _ = write!(&mut final_contents, "{}: {} ", n.name, n.shape);


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Resolves #11800.

```
~/CodingProjects/nushell> def "url expand" [$urls:any = []]: [string -> string, list -> table] {    
:::   let urls = ($in | default $urls)
:::   def expand-link [] {
:::     http head --redirect-mode manual $in | where name == location | get value.0
:::   }
:::   match ($urls | describe) {
:::     string => { $urls | expand-link }
:::     $type if ($type =~ list) => { $urls | wrap link | insert expanded {|url| $url.link | expand-link}}
:::   }
::: }; view source "url expand"
def "url expand" [ $urls: any = [] ]: [string -> string, list<any> -> table] {
  let urls = ($in | default $urls)
  def expand-link [] {
    http head --redirect-mode manual $in | where name == location | get value.0
  }
  match ($urls | describe) {
    string => { $urls | expand-link }
    $type if ($type =~ list) => { $urls | wrap link | insert expanded {|url| $url.link | expand-link}}
  }
}
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

`view source` now 
- adds quotes to commands with spaces
- shows default argument values
- shows type signatures

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
