### PR TITLE
Fix stop suggesting `--trash` when already enabled (issue #12361)

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -382,7 +382,10 @@ fn rm(
                         ))]
                         {
                             trash::delete(&f).map_err(|e: trash::Error| {
-                                Error::new(ErrorKind::Other, format!("{e:?}\nTry '--trash' flag"))
+                                Error::new(
+                                    ErrorKind::Other,
+                                    format!("{e:?}\nTry '--permanent' flag"),
+                                )
                             })
                         }
 


### PR DESCRIPTION
fixes #12361

Looking at the condition, `TRASH_SUPPORTED && (trash || (rm_always_trash && !permanent))`, this code path seems only to run when `--trash` is enabled and `--permanent` is disabled.

This suggests that the `--trash` suggestion is a mistake and should have suggested `--permanent`.

