### PR TITLE
Bump reedline to 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,8 +4518,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.30.0"
-source = "git+https://github.com/nushell/reedline?branch=main#b7209b68721f9d33cc9c3f38ba7e7359e4b7c717"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65ebc241ed0ccea0bbbd775a55a76f0dd9971ef084589dea938751a03ffedc14"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ quickcheck_macros = "1.0"
 rand = "0.8"
 ratatui = "0.26"
 rayon = "1.10"
-reedline = "0.30.0"
+reedline = "0.31.0"
 regex = "1.9.5"
 ropey = "1.6.1"
 roxmltree = "0.19"
@@ -285,7 +285,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`


### PR DESCRIPTION
See changelog:
https://github.com/nushell/reedline/releases/tag/v0.31.0
