### PR TITLE
bump python plugin nushell version

### DIFF
--- a/crates/nu_plugin_python/nu_plugin_python_example.py
+++ b/crates/nu_plugin_python/nu_plugin_python_example.py
@@ -27,7 +27,7 @@ import sys
 import json
 
 
-NUSHELL_VERSION = "0.91.1"
+NUSHELL_VERSION = "0.92.0"
 
 
 def signatures():


### PR DESCRIPTION
# Description

This PR bumps the python plugin to keep it in sync with the nushell version.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
