### PR TITLE
Return a traditional exit code when core dumped

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -559,12 +559,11 @@ impl ExternalCommand {
                                         "{cause}: child process '{commandname}' core dumped"
                                     );
                                     eprintln!("{}", style.paint(&message));
-                                    let _ = exit_code_tx.send(Value::error(
-                                        ShellError::ExternalCommand {
-                                            label: "core dumped".into(),
-                                            help: message,
-                                            span: head,
-                                        },
+                                    let _ = exit_code_tx.send(Value::int(
+                                        // If we don't get a code (unlikely)
+                                        // assume the program aborted
+                                        // SIGABRT (6) + 0x80 (128) = 134
+                                        x.code().unwrap_or(nix::libc::SIGABRT & 0x80).into(),
                                         head,
                                     ));
                                     return Ok(());

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -563,7 +563,7 @@ impl ExternalCommand {
                                         // If we don't get a code (unlikely)
                                         // assume the program aborted
                                         // SIGABRT (6) + 0x80 (128) = 134
-                                        x.code().unwrap_or(nix::libc::SIGABRT & 0x80).into(),
+                                        x.code().unwrap_or(nix::libc::SIGABRT + 0x80).into(),
                                         head,
                                     ));
                                     return Ok(());


### PR DESCRIPTION
# Description
Attempt to fix #12369

running a program `fail` dumping its core with `fail | complete | get
exit_code` should return a `Value::Int` corresponding to its exit code.


# User-Facing Changes
Previously we sent a full `Value::Error(ShellError)` which was
incompatible with all other exit code logic.

Now get just the exit code but still print to STDERR.

