### PR TITLE
Fix hooks on 0.92.0

### DIFF
--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -125,9 +125,9 @@ impl Stack {
         unique_stack.env_vars = child.env_vars;
         unique_stack.env_hidden = child.env_hidden;
         unique_stack.active_overlays = child.active_overlays;
-        for item in child.parent_deletions.into_iter() {
-            unique_stack.vars.remove(item);
-        }
+        unique_stack
+            .vars
+            .retain(|(var, _)| !child.parent_deletions.contains(var));
         unique_stack
     }
     pub fn with_env(

--- a/tests/hooks/mod.rs
+++ b/tests/hooks/mod.rs
@@ -551,3 +551,16 @@ fn err_hook_parse_error() {
     assert!(actual_repl.err.contains("unsupported_config_value"));
     assert_eq!(actual_repl.out, "");
 }
+
+#[test]
+fn env_change_overlay() {
+    let inp = &[
+        "module test { export-env { $env.BAR = 2 } }",
+        &env_change_hook_code("FOO", "'overlay use test'"),
+        "$env.FOO = 1",
+        "$env.BAR",
+    ];
+
+    let actual_repl = nu!(nu_repl_code(inp));
+    assert_eq!(actual_repl.out, "2");
+}


### PR DESCRIPTION
# Description
Fixes #12382, where overlay changes from hooks were not preserved into the global state. This was due to creating child stacks for hooks, when the global stack should have been used instead.
