### PR TITLE
Make default config conservative about clipboard

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -825,36 +825,42 @@ $env.config = {
             mode: emacs
             event: { edit: capitalizechar }
         }
-        # The *_system keybindings require terminal support to pass these
-        # keybindings through to nushell and nushell compiled with the
-        # `system-clipboard` feature
+        # The following bindings with `*system` events require that Nushell has
+        # been compiled with the `system-clipboard` feature.
+        # This should be the case for Windows, macOS, and most Linux distributions
+        # Not available for example on Android (termux)
+        # If you want to use the system clipboard for visual selection or to
+        # paste directly, uncomment the respective lines and replace the version
+        # using the internal clipboard.
         {
-            name: copy_selection_system
+            name: copy_selection
             modifier: control_shift
             keycode: char_c
             mode: emacs
-            event: { edit: copyselectionsystem }
+            event: { edit: copyselection }
+            # event: { edit: copyselectionsystem }
         }
         {
-            name: cut_selection_system
+            name: cut_selection
             modifier: control_shift
             keycode: char_x
             mode: emacs
-            event: { edit: cutselectionsystem }
+            event: { edit: cutselection }
+            # event: { edit: cutselectionsystem }
         }
+        # {
+        #     name: paste_system
+        #     modifier: control_shift
+        #     keycode: char_v
+        #     mode: emacs
+        #     event: { edit: pastesystem }
+        # }
         {
             name: select_all
             modifier: control_shift
             keycode: char_a
             mode: emacs
             event: { edit: selectall }
-        }
-        {
-            name: paste_system
-            modifier: control_shift
-            keycode: char_v
-            mode: emacs
-            event: { edit: pastesystem }
         }
     ]
 }


### PR DESCRIPTION
Some platforms don't support the `system-clipboard` feature, notably termux on android. 
The default config currently contained references to `reedline` events that are only available with the feature enabled (#12179). This thus broke the out of the box config for those users. 

For now be more defensive about this and only enable default events. Add the alternative as commented out code you can quickly enable.

## Tested with:

```
cargo run --no-default-features --features default-no-clipboard -- --config crates/nu-utils/src/sample_config/default_config.nu
```
