### PR TITLE
Fix testing.nu import of std log

### DIFF
--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -1,4 +1,4 @@
-use std/log.nu
+use std log
 
 def "nu-complete threads" [] {
     seq 1 (sys|get cpu|length)


### PR DESCRIPTION
# Description

`use std/log.nu` does not work, have to `use std log`

# User-Facing Changes

Fix the testing script. Bug fix.
