### PR TITLE
prevent `select` (negative number) from hanging shell

### DIFF
--- a/crates/nu-command/src/filters/select.rs
+++ b/crates/nu-command/src/filters/select.rs
@@ -71,7 +71,15 @@ produce a table, a list will produce a list, and a record will produce a record.
                     };
                     new_columns.push(cv.clone());
                 }
-                Value::Int { val, .. } => {
+                Value::Int { val, internal_span } => {
+                    if val < 0 {
+                        return Err(ShellError::CantConvert {
+                            to_type: "cell path".into(),
+                            from_type: "negative number".into(),
+                            span: internal_span,
+                            help: None,
+                        });
+                    }
                     let cv = CellPath {
                         members: vec![PathMember::Int {
                             val: val as usize,

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -275,3 +275,9 @@ fn select_single_row_with_variable() {
     assert_eq!(actual.out, "[[a]; [3]]".to_string());
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn select_with_negative_number_errors_out() {
+    let actual = nu!("[1 2 3] | select (-2)");
+    assert!(actual.err.contains("negative number"));
+}


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
Resolves #11756.
Resolves #12346. 

As per description, shell no longer hangs:
```
~/CodingProjects/nushell> [1 2 3] | select (-2) 
Error: nu::shell::cant_convert

  × Can't convert to cell path.
   ╭─[entry #1:1:18]
 1 │ [1 2 3] | select (-2)
   ·                  ──┬─
   ·                    ╰── can't convert negative number to cell path
   ╰────
```


<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added relevant test :rocket: 

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Possibly support `get` `get`ting negative numbers, as per #12346 discussion. Alternatively, we can consider adding a cellpath for negative indexing?