### PR TITLE
JSON format plugin tracing

### DIFF
--- a/crates/nu-plugin/src/serializers/json.rs
+++ b/crates/nu-plugin/src/serializers/json.rs
@@ -29,7 +29,23 @@ impl Encoder<PluginInput> for JsonSerializer {
         serde_json::to_writer(&mut *writer, plugin_input).map_err(json_encode_err)?;
         writer.write_all(b"\n").map_err(|err| ShellError::IOError {
             msg: err.to_string(),
-        })
+        })?;
+
+        if let Some(mut f) = std::env::var("NU_PLUGIN_INPUT_JSON").ok().and_then(|path| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .ok()
+        }) {
+            // If this environment variable is set to a writable file, append the JSON format plugin input.
+            use std::io::Write;
+
+            _ = serde_json::to_writer(&mut f, plugin_input).map_err(json_encode_err);
+            _ = f.write_all(b"\n\n");
+        };
+
+        Ok(())
     }
 
     fn decode(
@@ -37,45 +53,9 @@ impl Encoder<PluginInput> for JsonSerializer {
         reader: &mut impl std::io::BufRead,
     ) -> Result<Option<PluginInput>, nu_protocol::ShellError> {
         let mut de = serde_json::Deserializer::from_reader(reader);
-        let plugin_input = PluginInput::deserialize(&mut de)
+        PluginInput::deserialize(&mut de)
             .map(Some)
-            .or_else(json_decode_err);
-
-        if let Some((mut f, path)) = std::env::var("NU_PLUGIN_INPUT_JSON").ok().and_then(|path| {
-            std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&path)
-                .ok()
-                .map(|f| (f, path))
-        }) {
-            // If this environment variable is set to a writable file, append the JSON format plugin input.
-            // This is pretty much essential information when writing a plugin by hand, as opposed to using
-            // the Rust crate.
-
-            use std::io::Write;
-
-            match plugin_input {
-                Ok(Some(ref plugin_input)) => {
-                    serde_json::to_writer(&mut f, plugin_input)
-                        .unwrap_or_else(|e| panic!("dump plugin input JSON to {}: {}", &path, e));
-                    f.write_all(b"\n\n").unwrap_or_else(|e| {
-                        panic!("write terminating newline to {}: {}", &path, e)
-                    });
-                }
-                Ok(None) => {
-                    f.write_all(b"\n\n").unwrap_or_else(|e| {
-                        panic!("write terminating newline to {}: {}", &path, e)
-                    });
-                }
-                Err(ref e) => {
-                    writeln!(f, "{}\n", e)
-                        .unwrap_or_else(|e| panic!("write error to {}: {}", &path, e));
-                }
-            }
-        };
-
-        plugin_input
+            .or_else(json_decode_err)
     }
 }
 
@@ -88,7 +68,17 @@ impl Encoder<PluginOutput> for JsonSerializer {
         serde_json::to_writer(&mut *writer, plugin_output).map_err(json_encode_err)?;
         writer.write_all(b"\n").map_err(|err| ShellError::IOError {
             msg: err.to_string(),
-        })?;
+        })
+    }
+
+    fn decode(
+        &self,
+        reader: &mut impl std::io::BufRead,
+    ) -> Result<Option<PluginOutput>, ShellError> {
+        let mut de = serde_json::Deserializer::from_reader(reader);
+        let plugin_output = PluginOutput::deserialize(&mut de)
+            .map(Some)
+            .or_else(json_decode_err)?;
 
         if let Some((mut f, path)) = std::env::var("NU_PLUGIN_OUTPUT_JSON")
             .ok()
@@ -102,27 +92,25 @@ impl Encoder<PluginOutput> for JsonSerializer {
             })
         {
             // If this environment variable is set to a writable file, append the JSON format plugin output.
-            // This is pretty much essential information when writing a plugin by hand, as opposed to using
-            // the Rust crate.
-
             use std::io::Write;
-            serde_json::to_writer(&mut f, plugin_output)
-                .unwrap_or_else(|e| panic!("dump plugin output JSON to {}: {}", &path, e));
-            f.write_all(b"\n\n")
-                .unwrap_or_else(|e| panic!("write terminating newline to {}: {}", &path, e));
+
+            match plugin_output {
+                Some(ref plugin_output) => {
+                    serde_json::to_writer(&mut f, plugin_output)
+                        .unwrap_or_else(|e| panic!("dump plugin output JSON to {}: {}", &path, e));
+                    f.write_all(b"\n\n").unwrap_or_else(|e| {
+                        panic!("write terminating newline to {}: {}", &path, e)
+                    });
+                }
+                None => {
+                    f.write_all(b"\n\n").unwrap_or_else(|e| {
+                        panic!("write terminating newline to {}: {}", &path, e)
+                    });
+                }
+            }
         }
 
-        Ok(())
-    }
-
-    fn decode(
-        &self,
-        reader: &mut impl std::io::BufRead,
-    ) -> Result<Option<PluginOutput>, ShellError> {
-        let mut de = serde_json::Deserializer::from_reader(reader);
-        PluginOutput::deserialize(&mut de)
-            .map(Some)
-            .or_else(json_decode_err)
+        Ok(plugin_output)
     }
 }
 


### PR DESCRIPTION
# Description

Adds optional tracing of JSON format plugin protocol messages, dumping input and output messages in JSON format to separate files if enabled.

The tracing is enabled by environment variables
* `NU_PLUGIN_INPUT_JSON`
* `NU_PLUGIN_OUTPUT_JSON`

If either or both of these are set to a writable path in the filesystem, Nushell will append plugin messages sent to and received from any JSON format plugin.

Note that the tracing is implemented on the Nushell side of the plugin interface, rather than the plugin side, so that any JSON format plugin may be traced regardless of whether it uses the nu-plugin crate.

Any failure to write to the file is ignored, so it is not possible to compromise plugin behaviour with a badly set environment variable.

MessagePack format plugins are not affected.

## Rationale

So why is this useful?

I maintain the Nu plugin [bash-env](https://github.com/tesujimath/nu_plugin_bash_env), which provides environment import from Bash format.  It is written in Bash, because anything else would be infeasible.  So the plugin protocol is implemented by hand, making use of `jq` and carefully formatted JSON output.

This broke with the recent plugin protocol changes, in both Nu 0.91.0 and 0.92.0.  While fixing it up for 0.91.0 was not too hard, I found it not really possible to work out what was required for 0.92.0 without being able to trace the plugin messaging.

This tracing allowed me to write a dummy Rust plugin with the same interface for the purpose of working out what JSON format messages were required.

# User-Facing Changes

No visible change unless the environment variables above are defined, in which case, those files accumulate all JSON format plugin protocol messages.

# Tests + Formatting

These tests and checks all passed with no issues:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass

This one failed, but nothing to do with my changes:
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

```
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/nu -c 'use std testing; testing run-tests --path crates/nu-std'`
Error: nu::parser::export_not_found

  × Export not found.
   ╭─[source:1:9]
 1 │ use std testing; testing run-tests --path crates/nu-std
   ·         ───┬───
   ·            ╰── could not find imports
   ╰────
```

# After Submitting

The plugin contributors guide ought to be updated to reflect these changes.  I am happy to make a PR there at the right time.