### PR TITLE
Add --no-newline option to `nu`

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -85,6 +85,7 @@ fn bench_command_with_custom_stack_and_engine(
                 &mut stack.clone(),
                 PipelineData::empty(),
                 None,
+                false,
             )
             .unwrap();
         })
@@ -104,6 +105,7 @@ fn setup_stack_and_engine_from_command(command: &str) -> (Stack, EngineState) {
         &mut stack,
         PipelineData::empty(),
         None,
+        false,
     )
     .unwrap();
 
@@ -263,6 +265,7 @@ mod eval_commands {
                     &mut nu_protocol::engine::Stack::new(),
                     PipelineData::empty(),
                     None,
+                    false,
                 )
                 .unwrap();
             })

--- a/crates/nu-cli/src/eval_cmds.rs
+++ b/crates/nu-cli/src/eval_cmds.rs
@@ -15,6 +15,7 @@ pub fn evaluate_commands(
     stack: &mut Stack,
     input: PipelineData,
     table_mode: Option<Value>,
+    no_newline: bool,
 ) -> Result<Option<i64>> {
     // Translate environment variables from Strings to Values
     if let Some(e) = convert_env_values(engine_state, stack) {
@@ -60,7 +61,13 @@ pub fn evaluate_commands(
             if let Some(t_mode) = table_mode {
                 config.table_mode = t_mode.coerce_str()?.parse().unwrap_or_default();
             }
-            crate::eval_file::print_table_or_error(engine_state, stack, pipeline_data, &mut config)
+            crate::eval_file::print_table_or_error(
+                engine_state,
+                stack,
+                pipeline_data,
+                &mut config,
+                no_newline,
+            )
         }
         Err(err) => {
             let working_set = StateWorkingSet::new(engine_state);

--- a/src/command.rs
+++ b/src/command.rs
@@ -97,6 +97,7 @@ pub(crate) fn parse_commandline_args(
             let execute = call.get_flag_expr("execute");
             let table_mode: Option<Value> =
                 call.get_flag(engine_state, &mut stack, "table-mode")?;
+            let no_newline = call.get_named_arg("no-newline");
 
             // ide flags
             let lsp = call.has_flag(engine_state, &mut stack, "lsp")?;
@@ -190,6 +191,7 @@ pub(crate) fn parse_commandline_args(
                 ide_check,
                 ide_ast,
                 table_mode,
+                no_newline,
             });
         }
     }
@@ -224,6 +226,7 @@ pub(crate) struct NushellCliArgs {
     pub(crate) log_target: Option<Spanned<String>>,
     pub(crate) execute: Option<Spanned<String>>,
     pub(crate) table_mode: Option<Value>,
+    pub(crate) no_newline: Option<Spanned<String>>,
     pub(crate) include_path: Option<Spanned<String>>,
     pub(crate) lsp: bool,
     pub(crate) ide_goto_def: Option<Value>,
@@ -270,6 +273,7 @@ impl Command for Nu {
                 "the table mode to use. rounded is default.",
                 Some('m'),
             )
+            .switch("no-newline", "print the result for --commands(-c) without a newline", None)
             .switch(
                 "no-config-file",
                 "start with no config file and no env file",

--- a/src/run.rs
+++ b/src/run.rs
@@ -118,6 +118,7 @@ pub(crate) fn run_commands(
         &mut stack,
         input,
         parsed_nu_cli_args.table_mode,
+        parsed_nu_cli_args.no_newline.is_some(),
     );
     perf(
         "evaluate_commands",

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -289,6 +289,22 @@ fn run_in_noninteractive_mode() {
 }
 
 #[test]
+#[cfg(not(windows))]
+fn run_with_no_newline() {
+    let child_output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "{:?} --no-newline -c '\"hello world\"'",
+            nu_test_support::fs::executable_path()
+        ))
+        .output()
+        .expect("failed to run nu");
+
+    assert_eq!(child_output.stdout, b"hello world"); // with no newline
+    assert!(child_output.stderr.is_empty());
+}
+
+#[test]
 fn main_script_can_have_subcommands1() {
     Playground::setup("main_subcommands", |dirs, sandbox| {
         sandbox.mkdir("main_subcommands");

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -289,18 +289,13 @@ fn run_in_noninteractive_mode() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn run_with_no_newline() {
-    let child_output = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(format!(
-            "{:?} --no-newline -c '\"hello world\"'",
-            nu_test_support::fs::executable_path()
-        ))
+    let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
+        .args(["--no-newline", "-c", "\"hello world\""])
         .output()
         .expect("failed to run nu");
 
-    assert_eq!(child_output.stdout, b"hello world"); // with no newline
+    assert_eq!("hello world", String::from_utf8_lossy(&child_output.stdout)); // with no newline
     assert!(child_output.stderr.is_empty());
 }
 


### PR DESCRIPTION
# Description
I have `nu` set as my shell in my editor, which allows me to easily pipe selections of text to things like `str pascal-case` or even more complex string operation pipelines, which I find super handy. However, the only annoying thing is that I pretty much always have to add `| print -n` at the end, because `nu` adds a newline when it prints the resulting value.

This adds a `--no-newline` option to stop that from happening, and then you don't need to pipe to `print -n` anymore, you can just have your shell command for your editor contain that flag.

# User-Facing Changes
- Add `--no-newline` command line option

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
