### PR TITLE
Fix nushell#10591: encode returns error with utf-16le and utf-16be encodings (nushell#10591)

### DIFF
--- a/crates/nu-command/src/strings/encode_decode/encode.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode.rs
@@ -37,6 +37,7 @@ impl Command for Encode {
 big5, euc-jp, euc-kr, gbk, iso-8859-1, cp1252, latin5
 
 Note that since the Encoding Standard doesn't specify encoders for utf-16le and utf-16be, these are not yet supported.
+More information can be found here: https://docs.rs/encoding_rs/latest/encoding_rs/#utf-16le-utf-16be-and-unicode-encoding-schemes
 
 For a more complete list of encodings, please refer to the encoding_rs
 documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#


### PR DESCRIPTION
# Description

This closes (nushell#10591)

The Command encode's help text says that utf-16le and utf-16be encodings are not supported, however you could still use these encodings and they didn't work properly, since they returned the bytes UTF-8 encoded:
```bash
"䆺ש" | encode utf-16
Length: 5 (0x5) bytes | printable whitespace ascii_other non_ascii
00000000: e4 86 ba d7 a9 ×××××
 ```
# User-Facing Changes

The Command encode's help text was updated and now when trying to encode with utf-16le and utf-16be returns an error:
![screenshot](https://github.com/nushell/nushell/assets/119532691/c346dc57-8b42-4dfc-93d5-638b0041d89f)

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`