### PR TITLE
Fix some of the tests in `tests::shell`

### DIFF
--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -231,7 +231,7 @@ fn run_export_extern() {
 #[test]
 fn run_in_login_mode() {
     let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
-        .args(["-l", "-c", "echo $nu.is-login"])
+        .args(["-n", "-l", "-c", "echo $nu.is-login"])
         .output()
         .expect("failed to run nu");
 

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -229,62 +229,46 @@ fn run_export_extern() {
 }
 
 #[test]
-#[cfg(not(windows))]
 fn run_in_login_mode() {
-    let child_output = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(format!(
-            "{:?} --no-config-file --login --commands 'echo $nu.is-login'",
-            nu_test_support::fs::executable_path()
-        ))
+    let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
+        .args(["-l", "-c", "echo $nu.is-login"])
         .output()
-        .expect("true");
+        .expect("failed to run nu");
 
+    assert_eq!("true\n", String::from_utf8_lossy(&child_output.stdout));
     assert!(child_output.stderr.is_empty());
 }
 
 #[test]
-#[cfg(not(windows))]
 fn run_in_not_login_mode() {
-    let child_output = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(format!(
-            "{:?} -c 'echo $nu.is-login'",
-            nu_test_support::fs::executable_path()
-        ))
+    let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
+        .args(["-c", "echo $nu.is-login"])
         .output()
-        .expect("false");
+        .expect("failed to run nu");
 
+    assert_eq!("false\n", String::from_utf8_lossy(&child_output.stdout));
     assert!(child_output.stderr.is_empty());
 }
 
 #[test]
-#[cfg(not(windows))]
 fn run_in_interactive_mode() {
-    let child_output = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(format!(
-            "{:?} -i -c 'echo $nu.is-interactive'",
-            nu_test_support::fs::executable_path()
-        ))
+    let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
+        .args(["-i", "-c", "echo $nu.is-interactive"])
         .output()
-        .expect("true");
+        .expect("failed to run nu");
 
+    assert_eq!("true\n", String::from_utf8_lossy(&child_output.stdout));
     assert!(child_output.stderr.is_empty());
 }
 
 #[test]
-#[cfg(not(windows))]
 fn run_in_noninteractive_mode() {
-    let child_output = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(format!(
-            "{:?} -c 'echo $nu.is-interactive'",
-            nu_test_support::fs::executable_path()
-        ))
+    let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
+        .args(["-c", "echo $nu.is-interactive"])
         .output()
-        .expect("false");
+        .expect("failed to run nu");
 
+    assert_eq!("false\n", String::from_utf8_lossy(&child_output.stdout));
     assert!(child_output.stderr.is_empty());
 }
 


### PR DESCRIPTION
# Description
Some of the tests in `tests::shell` were using `sh` unnecessarily, and had `#[cfg(not(windows))]` when they should be testable on Windows if `sh` is not used.

I also found that they were using `.expect()` incorrectly, under the assumption that that would check their output, when really an `assert_eq!` on the output is needed to do that. So these tests weren't even really working properly before.

# User-Facing Changes
None

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

