### PR TITLE
Add BufWriter to ChildStdin on the plugin interface

### DIFF
--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -10,7 +10,7 @@ use std::{
     env,
     ffi::OsStr,
     fmt::Write,
-    io::{BufReader, Read, Write as WriteTrait},
+    io::{BufReader, BufWriter, Read, Write as WriteTrait},
     ops::Deref,
     path::Path,
     process::{Child, ChildStdout, Command as CommandSys, Stdio},
@@ -178,8 +178,9 @@ fn make_plugin_interface(
     let encoder = get_plugin_encoding(&mut stdout)?;
 
     let reader = BufReader::with_capacity(OUTPUT_BUFFER_SIZE, stdout);
+    let writer = BufWriter::with_capacity(OUTPUT_BUFFER_SIZE, stdin);
 
-    let mut manager = PluginInterfaceManager::new(source.clone(), (Mutex::new(stdin), encoder));
+    let mut manager = PluginInterfaceManager::new(source.clone(), (Mutex::new(writer), encoder));
     manager.set_garbage_collector(gc);
 
     let interface = manager.get_interface();


### PR DESCRIPTION
# Description
This speeds up writing messages to the plugin, because otherwise every individual piece of the messages (not even the entire message) is written with one syscall, leading to a lot of back and forth with the kernel.

I learned this by running `strace` to debug something and saw a ton of `write()` calls.

```nushell
# Before
1..10 | each { timeit { example seq 1 10000 | example sum } } | math avg
269ms 779µs 149ns
# After
> 1..10 | each { timeit { example seq 1 10000 | example sum } } | math avg
39ms 636µs 643ns
```

# User-Facing Changes
- Performance improvement

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
