### PR TITLE
Fix #12416 by canonicalizing XDG_CONFIG_HOME before comparing to config_dir()

### DIFF
--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -234,10 +234,10 @@ fn test_xdg_config_empty() {
     Playground::setup("xdg_config_empty", |_, playground| {
         playground.with_env("XDG_CONFIG_HOME", "");
 
-        let actual = nu!("$nu.default-config-dir");
+        let actual = run(playground, "$nu.default-config-dir");
         let expected = dirs_next::config_dir().unwrap().join("nushell");
         assert_eq!(
-            actual.out,
+            actual,
             adjust_canonicalization(expected.canonicalize().unwrap_or(expected))
         );
     });
@@ -249,10 +249,10 @@ fn test_xdg_config_bad() {
         let xdg_config_home = r#"mn2''6t\/k*((*&^//k//: "#;
         playground.with_env("XDG_CONFIG_HOME", xdg_config_home);
 
-        let actual = nu!("$nu.default-config-dir");
+        let actual = run(playground, "$nu.default-config-dir");
         let expected = dirs_next::config_dir().unwrap().join("nushell");
         assert_eq!(
-            actual.out,
+            actual,
             adjust_canonicalization(expected.canonicalize().unwrap_or(expected))
         );
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes #12416. Turns out that in src/main.rs, `XDG_CONFIG_HOME` wasn't being canonicalized before being compared to `nu_path::config_dir()` to check if `XDG_CONFIG_HOME` was set to an invalid value. This has been rectified now.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Setting `XDG_CONFIG_HOME` to a symlink should work now.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

I manually tested it and the error has disappeared:

New behavior (this branch):
![image](https://github.com/nushell/nushell/assets/45539777/062d1cc5-551c-431c-b138-d3da8de018bd)

Old behavior (main):
![image](https://github.com/nushell/nushell/assets/45539777/22c4b5a3-3fd0-4ab6-9cf0-ae25488645ba)

Thanks to a pointer from Devyn, I've now added tests to make sure the `xdg_config_home_invalid` error doesn't pop up when `XDG_CONFIG_HOME` is a symlink (and does when it's actually invalid).

Turns out two of the tests in `test_config_path` tried modifying `XDG_CONFIG_HOME` using `playground.with_env` but used `nu!`, so the subprocess didn't actually use the modified value of `XDG_CONFIG_HOME`. When I added them, I was unaware that the `.with_env` didn't actually modify the environment. This has now been rectified.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
