### PR TITLE
Prevent panic on date overflow

### DIFF
--- a/crates/nu-command/src/generators/seq_date.rs
+++ b/crates/nu-command/src/generators/seq_date.rs
@@ -336,7 +336,17 @@ pub fn run_seq_dates(
             }
         }
         ret.push(Value::string(date_string, call_span));
-        next += step_size;
+        if let Some(n) = next.checked_add_signed(step_size) {
+            next = n;
+        } else {
+            return Err(ShellError::GenericError {
+                error: "date overflow".into(),
+                msg: "adding the increment overflowed".into(),
+                span: Some(call_span),
+                help: None,
+                inner: vec![],
+            });
+        }
 
         if is_out_of_range(next) {
             break;


### PR DESCRIPTION
# Description
Fixes #12095 where date math using `chrono` can panic on overflow. It looks like there's only one place that needed fixing.
