### PR TITLE
Added let command to PluginTest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,6 +3060,7 @@ name = "nu-plugin-test-support"
 version = "0.92.2"
 dependencies = [
  "nu-ansi-term",
+ "nu-cmd-lang",
  "nu-engine",
  "nu-parser",
  "nu-plugin",

--- a/crates/nu-plugin-test-support/Cargo.toml
+++ b/crates/nu-plugin-test-support/Cargo.toml
@@ -13,6 +13,7 @@ nu-engine = { path = "../nu-engine", version = "0.92.2", features = ["plugin"] }
 nu-protocol = { path = "../nu-protocol", version = "0.92.2", features = ["plugin"] }
 nu-parser = { path = "../nu-parser", version = "0.92.2", features = ["plugin"] }
 nu-plugin = { path = "../nu-plugin", version = "0.92.2" }
+nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.92.2" }
 nu-ansi-term = { workspace = true }
 similar = "2.4"
 

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -1,6 +1,7 @@
 use std::{cmp::Ordering, convert::Infallible, sync::Arc};
 
 use nu_ansi_term::Style;
+use nu_cmd_lang::Let;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_plugin::{Plugin, PluginCommand, PluginCustomValue, PluginSource};
@@ -38,6 +39,7 @@ impl PluginTest {
     ) -> Result<PluginTest, ShellError> {
         let mut engine_state = EngineState::new();
         let mut working_set = StateWorkingSet::new(&engine_state);
+        working_set.add_decl(Box::new(Let));
 
         let reg_plugin = fake_register(&mut working_set, name, plugin)?;
         let source = Arc::new(PluginSource::new(reg_plugin));


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
The `let` command is needed for many example tests. This pull request adds the `let` command to the EngineState of Test Plugin.

cc: @devyn 


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No user changes. Plugin tests can now have examples with the let keyword.