### PR TITLE
Use nu-cmd-lang default context for plugin tests

### DIFF
--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, convert::Infallible, sync::Arc};
 
 use nu_ansi_term::Style;
-use nu_cmd_lang::Let;
+use nu_cmd_lang::create_default_context;
 use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_plugin::{Plugin, PluginCommand, PluginCustomValue, PluginSource};
@@ -37,9 +37,8 @@ impl PluginTest {
         name: &str,
         plugin: Arc<impl Plugin + Send + 'static>,
     ) -> Result<PluginTest, ShellError> {
-        let mut engine_state = EngineState::new();
+        let mut engine_state = create_default_context();
         let mut working_set = StateWorkingSet::new(&engine_state);
-        working_set.add_decl(Box::new(Let));
 
         let reg_plugin = fake_register(&mut working_set, name, plugin)?;
         let source = Arc::new(PluginSource::new(reg_plugin));

--- a/crates/nu-plugin-test-support/tests/hello/mod.rs
+++ b/crates/nu-plugin-test-support/tests/hello/mod.rs
@@ -73,3 +73,16 @@ fn test_an_example_with_the_wrong_result() -> Result<(), ShellError> {
     assert!(result.is_err());
     Ok(())
 }
+
+#[test]
+fn test_requiring_nu_cmd_lang_commands() -> Result<(), ShellError> {
+    use nu_protocol::Span;
+
+    let result = PluginTest::new("hello", HelloPlugin.into())?
+        .eval("do { let greeting = hello; $greeting }")?
+        .into_value(Span::test_data());
+
+    assert_eq!(Value::test_string("Hello, World!"), result);
+
+    Ok(())
+}


### PR DESCRIPTION
# Description
@ayax79 added `nu-cmd-lang` as a dep for `nu-plugin-test-support` in order to get access to `let`. Since we have the dep anyway now, we might as well just add all of the lang commands - there aren't very many of them and it would be less confusing than only `let` working.

# User-Facing Changes
- Can use some more core nu language features in plugin tests, like loops and `do`

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
- [ ] Might need to change something about the plugin testing section of the book, since I think it says something about there only being the plugin command itself available
