### PR TITLE
Don't check if stderr empty in test_xdg_config_symlink

### DIFF
--- a/src/tests/test_config_path.rs
+++ b/src/tests/test_config_path.rs
@@ -278,6 +278,10 @@ fn test_xdg_config_symlink() {
         playground.symlink("real", config_link);
 
         let stderr = run_interactive_stderr(playground.cwd().join(config_link));
-        assert!(stderr.is_empty(), "stderr was {}", stderr);
+        assert!(
+            !stderr.contains("xdg_config_home_invalid"),
+            "stderr was {}",
+            stderr
+        );
     });
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Fixes a problem introduced in https://github.com/nushell/nushell/pull/12420 where one of the config path tests (`test_xdg_config_symlink`) fails if, on MacOS, a developer already has config files in the default location for that platform.

This happened because the test is making sure the `xdg_config_home_invalid` error isn't reported, but to do that, it asserts that stderr is empty, which it is not if in the case mentioned above, because Nushell warns that the default location (`~/.config`/`~/Library/Application Support`) is not empty but `XDG_CONFIG_HOME` is empty.

If someone with a Mac could test this, that'd be great.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

None, this is for contributors.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
