### PR TITLE
Isolate tests from user config

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -47,7 +47,7 @@ fn ignore_shell_errors_works_for_external_with_semicolon() {
 
 #[test]
 fn ignore_program_errors_works_for_external_with_semicolon() {
-    let actual = nu!(r#"do -p { nu -c 'exit 1' }; "text""#);
+    let actual = nu!(r#"do -p { nu -n -c 'exit 1' }; "text""#);
 
     assert_eq!(actual.err, "");
     assert_eq!(actual.out, "text");

--- a/crates/nu-command/tests/commands/exec.rs
+++ b/crates/nu-command/tests/commands/exec.rs
@@ -7,7 +7,7 @@ fn basic_exec() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu -c 'exec nu --testbin cococo a b c'
+                nu -n -c 'exec nu --testbin cococo a b c'
             "#
         ));
 
@@ -21,7 +21,7 @@ fn exec_complex_args() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu -c 'exec nu --testbin cococo b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --'
+                nu -n -c 'exec nu --testbin cococo b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --'
             "#
         ));
 
@@ -35,7 +35,7 @@ fn exec_fail_batched_short_args() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu -c 'exec nu --testbin cococo -ab 10'
+                nu -n -c 'exec nu --testbin cococo -ab 10'
             "#
         ));
 
@@ -49,7 +49,7 @@ fn exec_misc_values() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu -c 'let x = "abc"; exec nu --testbin cococo $x ...[ a b c ]'
+                nu -n -c 'let x = "abc"; exec nu --testbin cococo $x ...[ a b c ]'
             "#
         ));
 

--- a/crates/nu-command/tests/commands/interleave.rs
+++ b/crates/nu-command/tests/commands/interleave.rs
@@ -3,8 +3,8 @@ use nu_test_support::nu;
 #[test]
 fn interleave_external_commands() {
     let result = nu!("interleave \
-        { nu -c 'print hello; print world' | lines | each { 'greeter: ' ++ $in } } \
-        { nu -c 'print nushell; print rocks' | lines | each { 'evangelist: ' ++ $in } } | \
+        { nu -n -c 'print hello; print world' | lines | each { 'greeter: ' ++ $in } } \
+        { nu -n -c 'print nushell; print rocks' | lines | each { 'evangelist: ' ++ $in } } | \
         each { print }; null");
     assert!(result.out.contains("greeter: hello"), "{}", result.out);
     assert!(result.out.contains("greeter: world"), "{}", result.out);

--- a/crates/nu-command/tests/commands/return_.rs
+++ b/crates/nu-command/tests/commands/return_.rs
@@ -18,7 +18,7 @@ fn early_return_if_false() {
 fn return_works_in_script_without_def_main() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
-        "nu early_return.nu"
+        "nu -n early_return.nu"
     ));
 
     assert!(actual.err.is_empty());
@@ -28,7 +28,7 @@ fn return_works_in_script_without_def_main() {
 fn return_works_in_script_with_def_main() {
     let actual = nu!(
         cwd: "tests/fixtures/formats",
-        pipeline("nu early_return_outside_main.nu")
+        pipeline("nu -n early_return_outside_main.nu")
     );
     assert!(actual.err.is_empty());
 }

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -93,7 +93,7 @@ fn save_stderr_and_stdout_to_afame_file() {
             r#"
             $env.FOO = "bar";
             $env.BAZ = "ZZZ";
-            do -c {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_5/new-file.txt --stderr save_test_5/new-file.txt
+            do -c {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_5/new-file.txt --stderr save_test_5/new-file.txt
             "#,
         );
         assert!(actual
@@ -115,7 +115,7 @@ fn save_stderr_and_stdout_to_diff_file() {
             r#"
             $env.FOO = "bar";
             $env.BAZ = "ZZZ";
-            do -c {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_6/log.txt --stderr save_test_6/err.txt
+            do -c {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_6/log.txt --stderr save_test_6/err.txt
             "#,
         );
 
@@ -208,7 +208,7 @@ fn save_append_works_on_stderr() {
             r#"
             $env.FOO = " New";
             $env.BAZ = " New Err";
-            do -i {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -a -r save_test_11/log.txt --stderr save_test_11/err.txt"#,
+            do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -a -r save_test_11/log.txt --stderr save_test_11/err.txt"#,
         );
 
         let actual = file_contents(expected_file);
@@ -229,7 +229,7 @@ fn save_not_overrides_err_by_default() {
             r#"
             $env.FOO = " New";
             $env.BAZ = " New Err";
-            do -i {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_12/log.txt --stderr save_test_12/err.txt"#,
+            do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_12/log.txt --stderr save_test_12/err.txt"#,
         );
 
         assert!(actual.err.contains("Destination file already exists"));
@@ -252,7 +252,7 @@ fn save_override_works_stderr() {
             r#"
             $env.FOO = "New";
             $env.BAZ = "New Err";
-            do -i {nu -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -f -r save_test_13/log.txt --stderr save_test_13/err.txt"#,
+            do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -f -r save_test_13/log.txt --stderr save_test_13/err.txt"#,
         );
 
         let actual = file_contents(expected_file);

--- a/crates/nu-std/tests/logger_tests/test_basic_commands.nu
+++ b/crates/nu-std/tests/logger_tests/test_basic_commands.nu
@@ -6,9 +6,9 @@ def run [
     --short
 ] {
     if $short {
-        ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log ($message_level) --short "test message"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log ($message_level) --short "test message"'
     } else {
-        ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log ($message_level) "test message"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log ($message_level) "test message"'
     }
     | complete | get --ignore-errors stderr
 }

--- a/crates/nu-std/tests/logger_tests/test_log_custom.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_custom.nu
@@ -12,12 +12,12 @@ def run-command [
 ] {
     if ($level_prefix | is-empty) {
         if ($ansi | is-empty) {
-            ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level)'
+            ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level)'
         } else {
-            ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level) --ansi "($ansi)"'
+            ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level) --ansi "($ansi)"'
         }
     } else {
-        ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level) --level-prefix "($level_prefix)" --ansi "($ansi)"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level) --level-prefix "($level_prefix)" --ansi "($ansi)"'
     }
     | complete | get --ignore-errors stderr
 }

--- a/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
@@ -10,9 +10,9 @@ def run-command [
     --short
 ] {
     if $short {
-        ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log ($message_level) --format "($format)" --short "($message)"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log ($message_level) --format "($format)" --short "($message)"'
     } else {
-        ^$nu.current-exe --commands $'use std; NU_log-level=($system_level) std log ($message_level) --format "($format)" "($message)"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log ($message_level) --format "($format)" "($message)"'
     }
     | complete | get --ignore-errors stderr
 }

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -243,7 +243,7 @@ fn run_in_login_mode() {
 #[test]
 fn run_in_not_login_mode() {
     let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
-        .args(["-c", "echo $nu.is-login"])
+        .args(["-n", "-c", "echo $nu.is-login"])
         .output()
         .expect("failed to run nu");
 
@@ -254,7 +254,7 @@ fn run_in_not_login_mode() {
 #[test]
 fn run_in_interactive_mode() {
     let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
-        .args(["-i", "-c", "echo $nu.is-interactive"])
+        .args(["-n", "-i", "-c", "echo $nu.is-interactive"])
         .output()
         .expect("failed to run nu");
 
@@ -265,7 +265,7 @@ fn run_in_interactive_mode() {
 #[test]
 fn run_in_noninteractive_mode() {
     let child_output = std::process::Command::new(nu_test_support::fs::executable_path())
-        .args(["-c", "echo $nu.is-interactive"])
+        .args(["-n", "-c", "echo $nu.is-interactive"])
         .output()
         .expect("failed to run nu");
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -375,7 +375,7 @@ mod nu_commands {
     #[test]
     fn echo_internally_externally() {
         let actual = nu!(r#"
-        nu -c "echo 'foo'"
+        nu -n -c "echo 'foo'"
         "#);
 
         assert_eq!(actual.out, "foo");
@@ -385,7 +385,7 @@ mod nu_commands {
     fn failed_with_proper_exit_code() {
         Playground::setup("external failed", |dirs, _sandbox| {
             let actual = nu!(cwd: dirs.test(), r#"
-            nu -c "cargo build | complete | get exit_code"
+            nu -n -c "cargo build | complete | get exit_code"
             "#);
 
             // cargo for non rust project's exit code is 101.
@@ -396,7 +396,7 @@ mod nu_commands {
     #[test]
     fn better_arg_quoting() {
         let actual = nu!(r#"
-        nu -c "\# '"
+        nu -n -c "\# '"
         "#);
 
         assert_eq!(actual.out, "");
@@ -405,7 +405,7 @@ mod nu_commands {
     #[test]
     fn command_list_arg_test() {
         let actual = nu!("
-        nu ...['-c' 'version']
+        nu ...['-n' '-c' 'version']
         ");
 
         assert!(actual.out.contains("version"));
@@ -416,7 +416,7 @@ mod nu_commands {
     #[test]
     fn command_cell_path_arg_test() {
         let actual = nu!("
-        nu ...([ '-c' 'version' ])
+        nu ...([ '-n' '-c' 'version' ])
         ");
 
         assert!(actual.out.contains("version"));
@@ -431,7 +431,7 @@ mod nu_script {
     #[test]
     fn run_nu_script() {
         let actual = nu!(cwd: "tests/fixtures/formats", "
-        nu script.nu
+        nu -n script.nu
         ");
 
         assert_eq!(actual.out, "done");
@@ -440,7 +440,7 @@ mod nu_script {
     #[test]
     fn run_nu_script_multiline() {
         let actual = nu!(cwd: "tests/fixtures/formats", "
-        nu script_multiline.nu
+        nu -n script_multiline.nu
         ");
 
         assert_eq!(actual.out, "23");

--- a/toolkit.nu
+++ b/toolkit.nu
@@ -107,7 +107,7 @@ export def test [
 export def "test stdlib" [
     --extra-args: string = ''
 ] {
-    cargo run -- -c $"
+    cargo run -- --no-config-file -c $"
         use crates/nu-std/testing.nu
         testing run-tests --path crates/nu-std ($extra_args)
     "


### PR DESCRIPTION
# Description
This is an attempt to isolate the unit tests from whatever might be in the user's config. If the
user's config is broken in some way or incompatible with this version (for example, especially if
there are plugins that aren't built for this version), tests can spuriously fail.

This makes tests more reliably pass the same way they would on CI even if the user has config, and
should also make them run faster.

I think this is _good enough_, but I still think we should have a specific config dir env variable for nushell specifically (rather than having to use `XDG_CONFIG_HOME`, which would mess with other things) and then we can just have `nu-test-support` set that to a temporary dir containing the shipped default config files.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

