### PR TITLE
Fix negative value file size for "into filesize" (issue #12396)

### DIFF
--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -110,7 +110,7 @@ impl Command for SubCommand {
             Example {
                 description: "Convert negative file size to filesize",
                 example: "-1KB | into filesize",
-                result: Some(Value::test_filesize(-1000))
+                result: Some(Value::test_filesize(-1000)),
             },
         ]
     }

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -107,6 +107,11 @@ impl Command for SubCommand {
                 example: "4KB | into filesize",
                 result: Some(Value::test_filesize(4000)),
             },
+            Example {
+                description: "Convert negative file size to filesize",
+                example: "-1KB | into filesize",
+                result: Some(Value::test_filesize(-1000))
+            },
         ]
     }
 }
@@ -140,14 +145,28 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
     // Now that we know the locale, get the thousands separator and remove it
     // so strings like 1,123,456 can be parsed as 1123456
     let no_comma_string = a_string.replace(locale.separator(), "");
-    match no_comma_string.trim().parse::<bytesize::ByteSize>() {
-        Ok(n) => Ok(n.0 as i64),
-        Err(_) => Err(ShellError::CantConvert {
-            to_type: "int".into(),
-            from_type: "string".into(),
-            span,
-            help: None,
-        }),
+
+    // Hadle negative file size
+    if no_comma_string.starts_with('-') {
+        match no_comma_string[1..].trim().parse::<bytesize::ByteSize>() {
+            Ok(n) => Ok(-(n.as_u64() as i64)),
+            Err(_) => Err(ShellError::CantConvert {
+                to_type: "int".into(),
+                from_type: "string".into(),
+                span,
+                help: None,
+            }),
+        }
+    } else {
+        match no_comma_string.trim().parse::<bytesize::ByteSize>() {
+            Ok(n) => Ok(n.0 as i64),
+            Err(_) => Err(ShellError::CantConvert {
+                to_type: "int".into(),
+                from_type: "string".into(),
+                span,
+                help: None,
+            }),
+        }
     }
 }
 

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -109,7 +109,7 @@ impl Command for SubCommand {
             },
             Example {
                 description: "Convert string with unit to filesize",
-                example: "-1KB | into filesize",
+                example: "'-1KB' | into filesize",
                 result: Some(Value::test_filesize(-1000)),
             },
         ]

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -108,7 +108,7 @@ impl Command for SubCommand {
                 result: Some(Value::test_filesize(4000)),
             },
             Example {
-                description: "Convert negative file size to filesize",
+                description: "Convert string with unit to filesize",
                 example: "-1KB | into filesize",
                 result: Some(Value::test_filesize(-1000)),
             },
@@ -145,10 +145,11 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
     // Now that we know the locale, get the thousands separator and remove it
     // so strings like 1,123,456 can be parsed as 1123456
     let no_comma_string = a_string.replace(locale.separator(), "");
+    let clean_string = no_comma_string.trim();
 
     // Hadle negative file size
-    if no_comma_string.starts_with('-') {
-        match no_comma_string[1..].trim().parse::<bytesize::ByteSize>() {
+    if let Some(stripped_string) = clean_string.strip_prefix('-') {
+        match stripped_string.parse::<bytesize::ByteSize>() {
             Ok(n) => Ok(-(n.as_u64() as i64)),
             Err(_) => Err(ShellError::CantConvert {
                 to_type: "int".into(),
@@ -158,7 +159,7 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
             }),
         }
     } else {
-        match no_comma_string.trim().parse::<bytesize::ByteSize>() {
+        match clean_string.parse::<bytesize::ByteSize>() {
             Ok(n) => Ok(n.0 as i64),
             Err(_) => Err(ShellError::CantConvert {
                 to_type: "int".into(),

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline, Outcome};
+use nu_test_support::{nu, pipeline};
 
 #[test]
 fn into_filesize_int() {

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -1,4 +1,4 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::{nu, pipeline, Outcome};
 
 #[test]
 fn into_filesize_int() {
@@ -60,4 +60,11 @@ fn into_filesize_negative_filesize() {
     let actual = nu!("-3kib | into filesize");
 
     assert!(actual.out.contains("-3.0 KiB"));
+}
+
+#[test]
+fn into_negative_filesize() {
+    let actual: Outcome = nu!("-1 | into filesize");
+
+    assert!(actual.out.contains("-1 B"));
 }

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -64,7 +64,7 @@ fn into_filesize_negative_filesize() {
 
 #[test]
 fn into_negative_filesize() {
-    let actual = nu!("-1 | into filesize");
+    let actual = nu!("'-1' | into filesize");
 
     assert!(actual.out.contains("-1 B"));
 }

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -64,7 +64,7 @@ fn into_filesize_negative_filesize() {
 
 #[test]
 fn into_negative_filesize() {
-    let actual: Outcome = nu!("-1 | into filesize");
+    let actual = nu!("-1 | into filesize");
 
     assert!(actual.out.contains("-1 B"));
 }


### PR DESCRIPTION

# Description
Add support for using negative values file size for `into filesize`. This will help in sorting the file size if negative values are also passed.

**Before**
![image](https://github.com/nushell/nushell/assets/43441496/e115b4b3-7526-4379-8dc0-f4f4e44839a1)
**After**
![image](https://github.com/nushell/nushell/assets/43441496/4a75fb40-ebe6-46eb-b9d2-55f37db7a6fa)

# User-Facing Changes
- User can now sort negative filesize also

# Tests + Formatting
- 🟢 toolkit fmt
- 🟢 toolkit clippy
- 🟢 toolkit test
- 🟢 toolkit test stdlib



# After Submitting
