### PR TITLE
Update MSRV following `rust-toolchain.toml`

### DIFF
--- a/.github/workflows/check-msrv.nu
+++ b/.github/workflows/check-msrv.nu
@@ -1,0 +1,12 @@
+let toolchain_spec = open rust-toolchain.toml | get toolchain.channel
+let msrv_spec = open Cargo.toml | get package.rust-version
+
+# This check is conservative in the sense that we use `rust-toolchain.toml`'s
+# override to ensure that this is the upper-bound for the minimum supported
+# rust version
+if $toolchain_spec != $msrv_spec {
+    print -e "Mismatching rust compiler versions specified in `Cargo.toml` and `rust-toolchain.toml`"
+    print -e $"Cargo.toml:          ($msrv_spec)"
+    print -e $"rust-toolchain.toml: ($toolchain_spec)"
+    exit 1
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Standard library tests
         run: nu -c 'use crates/nu-std/testing.nu; testing run-tests --path crates/nu-std'
 
+      - name: Ensure that Cargo.toml MSRV and rust-toolchain.toml use the same version
+        run: nu .github/workflows/check-msrv.nu
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.74.1"
+rust-version = "1.75.0"
 version = "0.92.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Also update the `rust-version` in `Cargo.toml` following the update to `rust-toolchain.toml` in #12258

# Testing

Added a CI check to verify any future PRs trying to update one will also have to update the other. (using `std-lib-and-python-virtualenv` job as this already includes a fresh `nu` binary for a little toml munching script)
