### PR TITLE
Force timeit to not capture stdout

### DIFF
--- a/crates/nu-command/src/debug/timeit.rs
+++ b/crates/nu-command/src/debug/timeit.rs
@@ -44,14 +44,16 @@ impl Command for TimeIt {
         // Get the start time after all other computation has been done.
         let start_time = Instant::now();
 
+        // reset outdest, so the command can write to stdout and stderr.
+        let mut eval_stack = stack.clone().reset_out_dest();
         if let Some(command_to_run) = command_to_run {
             if let Some(block_id) = command_to_run.as_block() {
                 let eval_block = get_eval_block(engine_state);
                 let block = engine_state.get_block(block_id);
-                eval_block(engine_state, stack, block, input)?
+                eval_block(engine_state, &mut eval_stack, block, input)?
             } else {
                 let eval_expression_with_input = get_eval_expression_with_input(engine_state);
-                eval_expression_with_input(engine_state, stack, command_to_run, input)
+                eval_expression_with_input(engine_state, &mut eval_stack, command_to_run, input)
                     .map(|res| res.0)?
             }
         } else {

--- a/crates/nu-command/src/debug/timeit.rs
+++ b/crates/nu-command/src/debug/timeit.rs
@@ -45,16 +45,15 @@ impl Command for TimeIt {
         let start_time = Instant::now();
 
         // reset outdest, so the command can write to stdout and stderr.
-        let mut eval_stack = stack.clone().reset_out_dest();
+        let stack = &mut stack.push_redirection(None, None);
         if let Some(command_to_run) = command_to_run {
-            let stack = &mut stack.push_redirection(None, None);
             if let Some(block_id) = command_to_run.as_block() {
                 let eval_block = get_eval_block(engine_state);
                 let block = engine_state.get_block(block_id);
-                eval_block(engine_state, &mut eval_stack, block, input)?
+                eval_block(engine_state, stack, block, input)?
             } else {
                 let eval_expression_with_input = get_eval_expression_with_input(engine_state);
-                eval_expression_with_input(engine_state, &mut eval_stack, command_to_run, input)
+                eval_expression_with_input(engine_state, stack, command_to_run, input)
                     .map(|res| res.0)?
             }
         } else {

--- a/crates/nu-command/src/debug/timeit.rs
+++ b/crates/nu-command/src/debug/timeit.rs
@@ -47,6 +47,7 @@ impl Command for TimeIt {
         // reset outdest, so the command can write to stdout and stderr.
         let mut eval_stack = stack.clone().reset_out_dest();
         if let Some(command_to_run) = command_to_run {
+            let stack = &mut stack.push_redirection(None, None);
             if let Some(block_id) = command_to_run.as_block() {
                 let eval_block = get_eval_block(engine_state);
                 let block = engine_state.get_block(block_id);

--- a/crates/nu-command/tests/commands/debug/mod.rs
+++ b/crates/nu-command/tests/commands/debug/mod.rs
@@ -1,0 +1,1 @@
+mod timeit;

--- a/crates/nu-command/tests/commands/debug/timeit.rs
+++ b/crates/nu-command/tests/commands/debug/timeit.rs
@@ -8,7 +8,7 @@ fn timeit_show_stdout() {
 
 #[test]
 fn timeit_show_stderr() {
-    let actual = nu!(" with-env {FOO: bar, FOO2: baz} { let t = timeit { timeit nu --testbin echo_env_mixed out-err FOO FOO2} }");
+    let actual = nu!(" with-env {FOO: bar, FOO2: baz} { let t = timeit { nu --testbin echo_env_mixed out-err FOO FOO2 } }");
     assert!(actual.out.contains("bar"));
     assert!(actual.out.contains("baz"));
 }

--- a/crates/nu-command/tests/commands/debug/timeit.rs
+++ b/crates/nu-command/tests/commands/debug/timeit.rs
@@ -10,5 +10,5 @@ fn timeit_show_stdout() {
 fn timeit_show_stderr() {
     let actual = nu!(" with-env {FOO: bar, FOO2: baz} { let t = timeit { nu --testbin echo_env_mixed out-err FOO FOO2 } }");
     assert!(actual.out.contains("bar"));
-    assert!(actual.out.contains("baz"));
+    assert!(actual.err.contains("baz"));
 }

--- a/crates/nu-command/tests/commands/debug/timeit.rs
+++ b/crates/nu-command/tests/commands/debug/timeit.rs
@@ -1,0 +1,14 @@
+use nu_test_support::nu;
+
+#[test]
+fn timeit_show_stdout() {
+    let actual = nu!("let t = timeit nu --testbin cococo abcdefg");
+    assert_eq!(actual.out, "abcdefg");
+}
+
+#[test]
+fn timeit_show_stderr() {
+    let actual = nu!(" with-env {FOO: bar, FOO2: baz} { let t = timeit { timeit nu --testbin echo_env_mixed out-err FOO FOO2} }");
+    assert!(actual.out.contains("bar"));
+    assert!(actual.out.contains("baz"));
+}

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -113,6 +113,7 @@ mod ucp;
 #[cfg(unix)]
 mod ulimit;
 
+mod debug;
 mod umkdir;
 mod uname;
 mod uniq;

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -70,7 +70,7 @@ pub fn echo_env_mixed() {
 }
 
 /// Cross platform echo using println!()
-/// Example: nu --testbin echo a b c
+/// Example: nu --testbin cococo a b c
 /// a b c
 pub fn cococo() {
     let args: Vec<String> = args();


### PR DESCRIPTION
# Description
Fixes:  #11996

After this change `let t = timeit ^ls` will list current directory to stdout.
```
❯ let t = timeit ^ls
CODE_OF_CONDUCT.md      Cargo.lock              Cross.toml              README.md               aaa                     benches                 devdocs                 here11                  scripts                 target                  toolkit.nu              wix
CONTRIBUTING.md         Cargo.toml              LICENSE                 a.txt                   assets                  crates                  docker                  rust-toolchain.toml     src                     tests                   typos.toml
```

If user don't want such behavior, he can redirect the stdout to `std null-stream` easily
```
> use std
> let t = timeit { ^ls o> (std null-device) }
```

# User-Facing Changes
NaN

# Tests + Formatting
Done

# After Submitting
Nan
