### PR TITLE
fix std log

### DIFF
--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -135,7 +135,7 @@ def parse-int-level [
 }
 
 def current-log-level [] {
-    let env_level = ($env.NU_log-level? | default (log-level).INFO)
+    let env_level = ($env.NU_LOG_LEVEL? | default (log-level).INFO)
 
     try {
         $env_level | into int

--- a/crates/nu-std/std/log.nu
+++ b/crates/nu-std/std/log.nu
@@ -44,34 +44,34 @@ def log-types [] {
     (
         {
             "CRITICAL": {
-                "ansi": ((log-ansi).CRITICAL),
-                "level": ((log-level).CRITICAL),
-                "prefix": ((log-prefix).CRITICAL),
-                "short_prefix": ((log-short-prefix).CRITICAL)
+                "ansi": (log-ansi).CRITICAL,
+                "level": (log-level).CRITICAL,
+                "prefix": (log-prefix).CRITICAL,
+                "short_prefix": (log-short-prefix).CRITICAL
             },
             "ERROR": {
-                "ansi": ((log-ansi).ERROR),
-                "level": ((log-level).ERROR),
-                "prefix": ((log-prefix).ERROR),
-                "short_prefix": ((log-short-prefix).ERROR)
+                "ansi": (log-ansi).ERROR,
+                "level": (log-level).ERROR,
+                "prefix": (log-prefix).ERROR,
+                "short_prefix": (log-short-prefix).ERROR
             },
             "WARNING": {
-                "ansi": ((log-ansi).WARNING),
-                "level": ((log-level).WARNING),
-                "prefix": ((log-prefix).WARNING),
-                "short_prefix": ((log-short-prefix).WARNING)
+                "ansi": (log-ansi).WARNING,
+                "level": (log-level).WARNING,
+                "prefix": (log-prefix).WARNING,
+                "short_prefix": (log-short-prefix).WARNING
             },
             "INFO": {
-                "ansi": ((log-ansi).INFO),
-                "level": ((log-level).INFO),
-                "prefix": ((log-prefix).INFO),
-                "short_prefix": ((log-short-prefix).INFO)
+                "ansi": (log-ansi).INFO,
+                "level": (log-level).INFO,
+                "prefix": (log-prefix).INFO,
+                "short_prefix": (log-short-prefix).INFO
             },
             "DEBUG": {
-                "ansi": ((log-ansi).DEBUG),
-                "level": ((log-level).DEBUG),
-                "prefix": ((log-prefix).DEBUG),
-                "short_prefix": ((log-short-prefix).DEBUG)
+                "ansi": (log-ansi).DEBUG,
+                "level": (log-level).DEBUG,
+                "prefix": (log-prefix).DEBUG,
+                "short_prefix": (log-short-prefix).DEBUG
             }
         }
     )
@@ -83,16 +83,16 @@ def parse-string-level [
 ] {
     let level = ($level | str upcase)
 
-    if $level in [((log-prefix).CRITICAL) ((log-short-prefix).CRITICAL) "CRIT" "CRITICAL"] {
-        ((log-level).CRITICAL)
-    } else if $level in [((log-prefix).ERROR) ((log-short-prefix).ERROR) "ERROR"] {
-        ((log-level).ERROR)
-    } else if $level in [((log-prefix).WARNING) ((log-short-prefix).WARNING) "WARN" "WARNING"] {
-        ((log-level).WARNING)
-    } else if $level in [((log-prefix).DEBUG) ((log-short-prefix).DEBUG) "DEBUG"] {
-        ((log-level).DEBUG)
+    if $level in [(log-prefix).CRITICAL (log-short-prefix).CRITICAL "CRIT" "CRITICAL"] {
+        (log-level).CRITICAL
+    } else if $level in [(log-prefix).ERROR (log-short-prefix).ERROR "ERROR"] {
+        (log-level).ERROR
+    } else if $level in [(log-prefix).WARNING (log-short-prefix).WARNING "WARN" "WARNING"] {
+        (log-level).WARNING
+    } else if $level in [(log-prefix).DEBUG (log-short-prefix).DEBUG "DEBUG"] {
+        (log-level).DEBUG
     } else {
-        ((log-level).INFO)
+        (log-level).INFO
     }
 }
 
@@ -101,41 +101,41 @@ def parse-int-level [
     level: int,
     --short (-s)
 ] {
-    if $level >= ((log-level).CRITICAL) {
+    if $level >= (log-level).CRITICAL {
         if $short {
-            ((log-short-prefix).CRITICAL)
+            (log-short-prefix).CRITICAL
         } else {
-            ((log-prefix).CRITICAL)
+            (log-prefix).CRITICAL
         }
-    } else if $level >= ((log-level).ERROR) {
+    } else if $level >= (log-level).ERROR {
         if $short {
-            ((log-short-prefix).ERROR)
+            (log-short-prefix).ERROR
         } else {
-            ((log-prefix).ERROR)
+            (log-prefix).ERROR
         }
-    } else if $level >= ((log-level).WARNING) {
+    } else if $level >= (log-level).WARNING {
         if $short {
-            ((log-short-prefix).WARNING)
+            (log-short-prefix).WARNING
         } else {
-            ((log-prefix).WARNING)
+            (log-prefix).WARNING
         }
-    } else if $level >= ((log-level).INFO) {
+    } else if $level >= (log-level).INFO {
         if $short {
-            ((log-short-prefix).INFO)
+            (log-short-prefix).INFO
         } else {
-            ((log-prefix).INFO)
+            (log-prefix).INFO
         }
     } else {
         if $short {
-            ((log-short-prefix).DEBUG)
+            (log-short-prefix).DEBUG
         } else {
-            ((log-prefix).DEBUG)
+            (log-prefix).DEBUG
         }
     }
 }
 
 def current-log-level [] {
-    let env_level = ($env.NU_log-level? | default (((log-level).INFO)))
+    let env_level = ($env.NU_log-level? | default (log-level).INFO)
 
     try {
         $env_level | into int
@@ -264,11 +264,11 @@ export def custom [
     }
 
     let valid_levels_for_defaulting = [
-        ((log-level).CRITICAL)
-        ((log-level).ERROR)
-        ((log-level).WARNING)
-        ((log-level).INFO)
-        ((log-level).DEBUG)
+        (log-level).CRITICAL
+        (log-level).ERROR
+        (log-level).WARNING
+        (log-level).INFO
+        (log-level).DEBUG
     ]
 
     let prefix = if ($level_prefix | is-empty) {

--- a/crates/nu-std/tests/logger_tests/test_basic_commands.nu
+++ b/crates/nu-std/tests/logger_tests/test_basic_commands.nu
@@ -6,9 +6,9 @@ def run [
     --short
 ] {
     if $short {
-        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log ($message_level) --short "test message"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) --short "test message"'
     } else {
-        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log ($message_level) "test message"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) "test message"'
     }
     | complete | get --ignore-errors stderr
 }

--- a/crates/nu-std/tests/logger_tests/test_log_custom.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_custom.nu
@@ -12,12 +12,12 @@ def run-command [
 ] {
     if ($level_prefix | is-empty) {
         if ($ansi | is-empty) {
-            ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level)'
+            ^$nu.current-exe --no-config-file --commands $'use std; NU_LOG_LEVEL=($system_level) std log custom "($message)" "($format)" ($log_level)'
         } else {
-            ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level) --ansi "($ansi)"'
+            ^$nu.current-exe --no-config-file --commands $'use std; NU_LOG_LEVEL=($system_level) std log custom "($message)" "($format)" ($log_level) --ansi "($ansi)"'
         }
     } else {
-        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log custom "($message)" "($format)" ($log_level) --level-prefix "($level_prefix)" --ansi "($ansi)"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_LOG_LEVEL=($system_level) std log custom "($message)" "($format)" ($log_level) --level-prefix "($level_prefix)" --ansi "($ansi)"'
     }
     | complete | get --ignore-errors stderr
 }

--- a/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
+++ b/crates/nu-std/tests/logger_tests/test_log_format_flag.nu
@@ -10,9 +10,9 @@ def run-command [
     --short
 ] {
     if $short {
-        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log ($message_level) --format "($format)" --short "($message)"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) --format "($format)" --short "($message)"'
     } else {
-        ^$nu.current-exe --no-config-file --commands $'use std; NU_log-level=($system_level) std log ($message_level) --format "($format)" "($message)"'
+        ^$nu.current-exe --no-config-file --commands $'use std; NU_LOG_LEVEL=($system_level) std log ($message_level) --format "($format)" "($message)"'
     }
     | complete | get --ignore-errors stderr
 }

--- a/crates/nu-std/tests/logger_tests/test_logger_env.nu
+++ b/crates/nu-std/tests/logger_tests/test_logger_env.nu
@@ -3,38 +3,38 @@ use std log *
 
 #[test]
 def env_log-ansi [] {
-    assert equal ((log-ansi).CRITICAL) (ansi red_bold)
-    assert equal ((log-ansi).ERROR) (ansi red)
-    assert equal ((log-ansi).WARNING) (ansi yellow)
-    assert equal ((log-ansi).INFO) (ansi default)
-    assert equal ((log-ansi).DEBUG) (ansi default_dimmed)
+    assert equal (log-ansi).CRITICAL (ansi red_bold)
+    assert equal (log-ansi).ERROR (ansi red)
+    assert equal (log-ansi).WARNING (ansi yellow)
+    assert equal (log-ansi).INFO (ansi default)
+    assert equal (log-ansi).DEBUG (ansi default_dimmed)
 }
 
 #[test]
 def env_log-level [] {
-    assert equal ((log-level).CRITICAL) 50
-    assert equal ((log-level).ERROR) 40
-    assert equal ((log-level).WARNING) 30
-    assert equal ((log-level).INFO) 20
-    assert equal ((log-level).DEBUG) 10
+    assert equal (log-level).CRITICAL 50
+    assert equal (log-level).ERROR 40
+    assert equal (log-level).WARNING 30
+    assert equal (log-level).INFO 20
+    assert equal (log-level).DEBUG 10
 }
 
 #[test]
 def env_log-prefix [] {
-    assert equal ((log-prefix).CRITICAL) "CRT"
-    assert equal ((log-prefix).ERROR) "ERR"
-    assert equal ((log-prefix).WARNING) "WRN"
-    assert equal ((log-prefix).INFO) "INF"
-    assert equal ((log-prefix).DEBUG) "DBG"
+    assert equal (log-prefix).CRITICAL "CRT"
+    assert equal (log-prefix).ERROR "ERR"
+    assert equal (log-prefix).WARNING "WRN"
+    assert equal (log-prefix).INFO "INF"
+    assert equal (log-prefix).DEBUG "DBG"
 }
 
 #[test]
 def env_log-short-prefix [] {
-    assert equal ((log-short-prefix).CRITICAL) "C"
-    assert equal ((log-short-prefix).ERROR) "E"
-    assert equal ((log-short-prefix).WARNING) "W"
-    assert equal ((log-short-prefix).INFO) "I"
-    assert equal ((log-short-prefix).DEBUG) "D"
+    assert equal (log-short-prefix).CRITICAL "C"
+    assert equal (log-short-prefix).ERROR "E"
+    assert equal (log-short-prefix).WARNING "W"
+    assert equal (log-short-prefix).INFO "I"
+    assert equal (log-short-prefix).DEBUG "D"
 }
 
 #[test]


### PR DESCRIPTION
related to
- https://github.com/nushell/nushell/pull/12196

# Description
while i'm 100% okey with the original intent behind https://github.com/nushell/nushell/pull/12196, i think the PR did introduce two unintended things:
- extra parentheses that make the `log.nu` module look like Lisp lol
- a renaming of the `NU_LOG_LEVEL` environment variable to `NU_log-level`. this breaks previous usage of `std log` and, as it's not mentionned at all in the PR, i thought it was not intentional :yum: 

# User-Facing Changes
users can now control `std log` with `$env.NU_LOG_LEVEL`

# Tests + Formatting
the "log" tests have been fixed as well.

# After Submitting