### PR TITLE
Bump our Rust version to stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://www.nushell.sh"
 license = "MIT"
 name = "nu"
 repository = "https://github.com/nushell/nushell"
-rust-version = "1.75.0"
+rust-version = "1.77.2"
 version = "0.92.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -16,4 +16,4 @@ profile = "default"
 # use in nushell, we may opt to use the bleeding edge stable version of rust.
 # I believe rust is on a 6 week release cycle and nushell is on a 4 week release cycle.
 # So, every two nushell releases, this version number should be bumped by one.
-channel = "1.75.0"
+channel = "1.77.2"


### PR DESCRIPTION
This was prompted by CVE-2024-24576

- https://nvd.nist.gov/vuln/detail/CVE-2024-24576
- https://blog.rust-lang.org/2024/04/09/cve-2024-24576.html
- https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/

Affected is launching commands on Windows with arbitrary arguments, which is the case for Nushell's external invocation on Windows

Rust has fixed this quoting vulnerability in 1.77.2 (latest stable at time of commit)

We will thus use this version for our builds and recommend all our packaging/distribution maintainers to use this version of Rust when building Nushell.
