### PR TITLE
Refactor `first` and `last`

### DIFF
--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -101,7 +101,7 @@ fn first_helper(
 
     // early exit for `first 0`
     if rows == 0 {
-        return Ok(Vec::<Value>::new().into_pipeline_data_with_metadata(metadata, ctrlc));
+        return Ok(Value::list(Vec::new(), head).into_pipeline_data_with_metadata(metadata));
     }
 
     match input {

--- a/crates/nu-command/src/filters/first.rs
+++ b/crates/nu-command/src/filters/first.rs
@@ -96,7 +96,6 @@ fn first_helper(
         1
     };
 
-    let ctrlc = engine_state.ctrlc.clone();
     let metadata = input.metadata();
 
     // early exit for `first 0`
@@ -133,6 +132,7 @@ fn first_helper(
                     }
                 }
                 Value::Range { val, .. } => {
+                    let ctrlc = engine_state.ctrlc.clone();
                     let mut iter = val.into_range_iter(span, ctrlc.clone());
                     if return_single_element {
                         if let Some(v) = iter.next() {
@@ -166,7 +166,7 @@ fn first_helper(
             } else {
                 Ok(ls
                     .take(rows)
-                    .into_pipeline_data_with_metadata(metadata, ctrlc))
+                    .into_pipeline_data_with_metadata(metadata, engine_state.ctrlc.clone()))
             }
         }
         PipelineData::ExternalStream { span, .. } => Err(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -98,7 +98,7 @@ impl Command for Last {
                 let iterator = input.into_iter_strict(head)?;
 
                 // only keep last `rows_desired` rows in memory
-                let mut buf = VecDeque::<_>::new();
+                let mut buf = VecDeque::new();
 
                 for row in iterator {
                     if buf.len() == rows {
@@ -110,12 +110,12 @@ impl Command for Last {
 
                 if return_single_element {
                     if let Some(last) = buf.pop_back() {
-                        Ok(last.into_pipeline_data_with_metadata(metadata))
+                        Ok(last.into_pipeline_data())
                     } else {
-                        Ok(PipelineData::empty().set_metadata(metadata))
+                        Err(ShellError::AccessEmptyContent { span: head })
                     }
                 } else {
-                    Ok(buf.into_pipeline_data_with_metadata(metadata, ctrlc))
+                    Ok(Value::list(buf.into(), head).into_pipeline_data_with_metadata(metadata))
                 }
             }
             PipelineData::Value(val, _) => {

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -126,8 +126,8 @@ impl Command for Last {
                 match val {
                     Value::List { mut vals, .. } => {
                         if return_single_element {
-                            if let Some(v) = vals.last_mut() {
-                                Ok(std::mem::take(v).into_pipeline_data())
+                            if let Some(v) = vals.pop() {
+                                Ok(v.into_pipeline_data())
                             } else {
                                 Err(ShellError::AccessEmptyContent { span: head })
                             }
@@ -139,7 +139,7 @@ impl Command for Last {
                     }
                     Value::Binary { mut val, .. } => {
                         if return_single_element {
-                            if let Some(&val) = val.last() {
+                            if let Some(val) = val.pop() {
                                 Ok(Value::int(val.into(), span).into_pipeline_data())
                             } else {
                                 Err(ShellError::AccessEmptyContent { span: head })

--- a/crates/nu-command/src/filters/last.rs
+++ b/crates/nu-command/src/filters/last.rs
@@ -90,7 +90,7 @@ impl Command for Last {
 
         // early exit for `last 0`
         if rows == 0 {
-            return Ok(Vec::<Value>::new().into_pipeline_data_with_metadata(metadata, ctrlc));
+            return Ok(Value::list(Vec::new(), head).into_pipeline_data_with_metadata(metadata));
         }
 
         match input {

--- a/crates/nu-command/tests/commands/default.rs
+++ b/crates/nu-command/tests/commands/default.rs
@@ -28,7 +28,7 @@ fn adds_row_data_if_column_missing() {
 
 #[test]
 fn default_after_empty_filter() {
-    let actual = nu!("[a b] | where $it == 'c' | last | default 'd'");
+    let actual = nu!("[a b] | where $it == 'c' | get -i 0 | default 'd'");
 
     assert_eq!(actual.out, "d");
 }

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -51,7 +51,7 @@ fn gets_first_row_when_no_amount_given() {
 fn gets_first_row_as_list_when_amount_given() {
     let actual = nu!("[1, 2, 3] | first 1 | describe");
 
-    assert_eq!(actual.out, "list<int> (stream)");
+    assert_eq!(actual.out, "list<int>");
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -51,7 +51,7 @@ fn requests_more_rows_than_table_has() {
 fn gets_last_row_as_list_when_amount_given() {
     let actual = nu!("[1, 2, 3] | last 1 | describe");
 
-    assert_eq!(actual.out, "list<int> (stream)");
+    assert_eq!(actual.out, "list<int>");
 }
 
 #[test]


### PR DESCRIPTION
# Description

- Refactors `first` and `last` using `Vec::truncate` and `Vec::drain`.
- `std::mem::take` was also used to eliminate a few `Value` clones.
- The `NeedsPositiveValue` error now uses the span of the `rows` argument instead of the call head span.
- `last` now errors on an empty stream to match `first` which does error.
-  Made metadata preservation more consistent.

# User-Facing Changes
Breaking change: `last` now errors on an empty stream to match `first` which does error.
Maybe this should be the other way around?
