### PR TITLE
Return value instead of stream from `kill`

### DIFF
--- a/crates/nu-command/src/platform/kill.rs
+++ b/crates/nu-command/src/platform/kill.rs
@@ -147,23 +147,21 @@ impl Command for Kill {
             });
         }
 
-        let val = String::from(
-            String::from_utf8(output.stdout)
-                .map_err(|e| ShellError::GenericError {
-                    error: "failed to convert output to string".into(),
-                    msg: e.to_string(),
-                    span: Some(call.head),
-                    help: None,
-                    inner: vec![],
-                })?
-                .trim_end(),
-        );
-        if val.is_empty() {
+        let mut output =
+            String::from_utf8(output.stdout).map_err(|e| ShellError::GenericError {
+                error: "failed to convert output to string".into(),
+                msg: e.to_string(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            })?;
+
+        output.truncate(output.trim_end().len());
+
+        if output.is_empty() {
             Ok(Value::nothing(call.head).into_pipeline_data())
         } else {
-            Ok(vec![Value::string(val, call.head)]
-                .into_iter()
-                .into_pipeline_data(engine_state.ctrlc.clone()))
+            Ok(Value::string(output, call.head).into_pipeline_data())
         }
     }
 


### PR DESCRIPTION
# Description
The `kill` command returns a stream with a single value. This PR changes it to simply return the value. 

# User-Facing Changes
Technically a breaking change.