### PR TITLE
Avoid panic when pipe a variable to a custom command which have recursive call

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6302,7 +6302,7 @@ pub fn parse(
         // to avoid mutate a block that is in the permanent state.
         // this can happened if user defines a function with recursive call
         // and pipe a variable to the command, e.g:
-        // def px [] { if { true } else { px } };    # the block px is saved in permanent state.
+        // def px [] { if true { 42 } else { px } };    # the block px is saved in permanent state.
         // let x = 3
         // $x | px
         // If we don't guard for `block_id`, it will change captures of `px`, which is

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5904,7 +5904,6 @@ pub fn discover_captures_in_expr(
             if let Some(block_id) = decl.get_block_id() {
                 match seen_blocks.get(&block_id) {
                     Some(capture_list) => {
-                        log::warn!("success capture list");
                         // Push captures onto the outer closure that aren't created by that outer closure
                         for capture in capture_list {
                             if !seen.contains(&capture.0) {
@@ -5915,7 +5914,6 @@ pub fn discover_captures_in_expr(
                     None => {
                         let block = working_set.get_block(block_id);
                         if !block.captures.is_empty() {
-                            log::warn!("not empty?");
                             for capture in &block.captures {
                                 if !seen.contains(capture) {
                                     output.push((*capture, call.head));
@@ -5937,7 +5935,6 @@ pub fn discover_captures_in_expr(
 
                                 result
                             };
-                            log::warn!("result for sub call block: {result:?}");
                             // Push captures onto the outer closure that aren't created by that outer closure
                             for capture in &result {
                                 if !seen.contains(&capture.0) {
@@ -6303,8 +6300,8 @@ pub fn parse(
         let block_captures_empty = block.captures.is_empty();
         // need to check block_id >= working_set.permanent_state.num_blocks()
         // to avoid mutate a block that is in the permanent state.
-        // this can happened if user defines a function with recursive call, and
-        // use it as global variable, e.g:
+        // this can happened if user defines a function with recursive call
+        // and pipe a variable to the comand, e.g:
         // def px [] { if { true } else { px } };    # the block px is saved in permanent state.
         // let x = 3
         // $x | px

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6302,7 +6302,6 @@ pub fn parse(
         // to avoid mutate a block that is in the permanent state.
         // this can happened if user defines a function with recursive call
         // and pipe a variable to the command, e.g:
-        :xa
         // def px [] { if { true } else { px } };    # the block px is saved in permanent state.
         // let x = 3
         // $x | px

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5765,7 +5765,9 @@ fn discover_captures_in_pipeline(
     output: &mut Vec<(VarId, Span)>,
 ) -> Result<(), ParseError> {
     for element in &pipeline.elements {
+        log::warn!("before discover pipeline element: {element:?}, output: {output:?}");
         discover_captures_in_pipeline_element(working_set, element, seen, seen_blocks, output)?;
+        log::warn!("after discover pipeline element: {element:?}, output: {output:?}");
     }
 
     Ok(())
@@ -5904,6 +5906,7 @@ pub fn discover_captures_in_expr(
             if let Some(block_id) = decl.get_block_id() {
                 match seen_blocks.get(&block_id) {
                     Some(capture_list) => {
+                        log::warn!("success capture list");
                         // Push captures onto the outer closure that aren't created by that outer closure
                         for capture in capture_list {
                             if !seen.contains(&capture.0) {
@@ -5914,6 +5917,7 @@ pub fn discover_captures_in_expr(
                     None => {
                         let block = working_set.get_block(block_id);
                         if !block.captures.is_empty() {
+                            log::warn!("not empty?");
                             for capture in &block.captures {
                                 if !seen.contains(capture) {
                                     output.push((*capture, call.head));
@@ -5935,6 +5939,7 @@ pub fn discover_captures_in_expr(
 
                                 result
                             };
+                            log::warn!("result for sub call block: {result:?}");
                             // Push captures onto the outer closure that aren't created by that outer closure
                             for capture in &result {
                                 if !seen.contains(&capture.0) {
@@ -6297,6 +6302,11 @@ pub fn parse(
         // by our working set delta. If we ever tried to modify the permanent state, we'd
         // panic (again, in theory, this shouldn't be possible)
         let block = working_set.get_block(block_id);
+        log::warn!(
+            "more info: {captures:?}, {:?}, {:?}",
+            block.span,
+            block.captures
+        );
         let block_captures_empty = block.captures.is_empty();
         if !captures.is_empty() && block_captures_empty {
             let block = working_set.get_block_mut(block_id);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -6301,7 +6301,8 @@ pub fn parse(
         // need to check block_id >= working_set.permanent_state.num_blocks()
         // to avoid mutate a block that is in the permanent state.
         // this can happened if user defines a function with recursive call
-        // and pipe a variable to the comand, e.g:
+        // and pipe a variable to the command, e.g:
+        :xa
         // def px [] { if { true } else { px } };    # the block px is saved in permanent state.
         // let x = 3
         // $x | px

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -828,4 +828,26 @@ fn not_panic_with_recursive_call() {
         "$x | px",
     ]));
     assert_eq!(result.out, "3");
+
+    let result = nu!(nu_repl_code(&[
+        "def px [n=0] { let l = $in; if $n == 0 { return false } else { $l | px ($n - 1) } }",
+        "let x = 1",
+        "$x | px"
+    ]));
+    assert_eq!(result.out, "false");
+
+    let result = nu!(nu_repl_code(&[
+        "def px [n=0] { let l = $in; if $n == 0 { return false } else { $l | px ($n - 1) } }",
+        "let x = 1",
+        "def foo [] { $x }",
+        "foo | px"
+    ]));
+    assert_eq!(result.out, "false");
+
+    let result = nu!(nu_repl_code(&[
+        "def px [n=0] { let l = $in; if $n == 0 { return false } else { $l | px ($n - 1) } }",
+        "let x = 1",
+        "do {|| $x } | px"
+    ]));
+    assert_eq!(result.out, "false");
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -1,4 +1,5 @@
 use crate::tests::{fail_test, run_test, run_test_with_env, TestResult};
+use nu_test_support::{nu, nu_repl_code};
 use std::collections::HashMap;
 
 use super::run_test_contains;
@@ -817,4 +818,14 @@ fn record_missing_value() -> TestResult {
 #[test]
 fn def_requires_body_closure() -> TestResult {
     fail_test("def a [] (echo 4)", "expected definition body closure")
+}
+
+#[test]
+fn not_panic_with_recursive_call() {
+    let result = nu!(nu_repl_code(&[
+        "def px [] { if true { 3 } else { px } }",
+        "let x = 1",
+        "$x | px",
+    ]));
+    assert_eq!(result.out, "3");
 }

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -850,4 +850,10 @@ fn not_panic_with_recursive_call() {
         "do {|| $x } | px"
     ]));
     assert_eq!(result.out, "false");
+
+    let result = nu!(
+        cwd: "tests/parsing/samples",
+        "nu recursive_func_with_alias.nu"
+    );
+    assert!(result.status.success());
 }

--- a/tests/parsing/samples/recursive_func_with_alias.nu
+++ b/tests/parsing/samples/recursive_func_with_alias.nu
@@ -1,0 +1,22 @@
+alias "orig update" = update
+
+# Update a column to have a new value if it exists.
+#
+# If the column exists with the value `null` it will be skipped.
+export def "update" [
+    field: cell-path # The name of the column to maybe update.
+    value: any # The new value to give the cell(s), or a closure to create the value.
+]: [record -> record, table -> table, list<any> -> list<any>] {
+    let input = $in
+    match ($input | describe | str replace --regex '<.*' '') {
+        record => {
+            if ($input | get -i $field) != null {
+                $input | orig update $field $value
+            } else { $input }
+        }
+        table|list => {
+            $input | each {|| update $field $value }
+        }
+        _ => { $input | orig update $field $value }
+    }
+}


### PR DESCRIPTION
# Description
Fixes: #11351

And comment here is also fixed: https://github.com/nushell/nushell/issues/11351#issuecomment-1996191537

The panic can happened if we pipe a variable to a custom command which recursively called itself inside another block.

TBH, I think I figure out how it works to panic, but I'm not sure if there is a potention issue if nushell don't mutate a block in such case.

# User-Facing Changes
Nan

# Tests + Formatting
Done

# After Submitting
Done
