### PR TITLE
Switch the CI to use macos-13 instead of macos-latest, due to failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [windows-latest, macos-13, ubuntu-20.04]
+        platform: [windows-latest, macos-latest, ubuntu-20.04]
         feature: [default, dataframe]
         include:
           # linux CI cannot handle clipboard feature
@@ -83,7 +83,7 @@ jobs:
         exclude:
           - platform: windows-latest
             feature: dataframe
-          - platform: macos-13
+          - platform: macos-latest
             feature: dataframe
 
     runs-on: ${{ matrix.platform }}
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ubuntu-20.04, macos-13, windows-latest]
+        platform: [ubuntu-20.04, macos-latest, windows-latest]
         py:
           - py
 
@@ -165,7 +165,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [windows-latest, macos-13, ubuntu-20.04]
+        platform: [windows-latest, macos-latest, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,11 @@ jobs:
         # Pinning to Ubuntu 20.04 because building on newer Ubuntu versions causes linux-gnu
         # builds to link against a too-new-for-many-Linux-installs glibc version. Consider
         # revisiting this when 20.04 is closer to EOL (April 2025)
-        platform: [windows-latest, macos-latest, ubuntu-20.04]
+        #
+        # Using macOS 13 runner because 14 is based on the M1 and has half as much RAM (7 GB,
+        # instead of 14 GB) which is too little for us right now. Revisit when `dfr` commands are
+        # removed and we're only building the `polars` plugin instead
+        platform: [windows-latest, macos-13, ubuntu-20.04]
         feature: [default, dataframe]
         include:
           - feature: default
@@ -34,7 +38,7 @@ jobs:
         exclude:
           - platform: windows-latest
             feature: dataframe
-          - platform: macos-latest
+          - platform: macos-13
             feature: dataframe
 
     runs-on: ${{ matrix.platform }}
@@ -65,7 +69,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-20.04]
+        platform: [windows-latest, macos-13, ubuntu-20.04]
         feature: [default, dataframe]
         include:
           # linux CI cannot handle clipboard feature
@@ -79,7 +83,7 @@ jobs:
         exclude:
           - platform: windows-latest
             feature: dataframe
-          - platform: macos-latest
+          - platform: macos-13
             feature: dataframe
 
     runs-on: ${{ matrix.platform }}
@@ -110,7 +114,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [ubuntu-20.04, macos-latest, windows-latest]
+        platform: [ubuntu-20.04, macos-13, windows-latest]
         py:
           - py
 
@@ -161,7 +165,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-20.04]
+        platform: [windows-latest, macos-13, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
# Description

The CI has been failing lately on macOS, most likely because it's running out of memory now that
the `polars` plugin has been included and it's quite large on top of `dfr`.

This PR just makes use use the `macos-13` runner instead of `macos-latest` because the latter has
only half as much RAM because it's running on the Apple M1 platform.
