### PR TITLE
better logging for shell_integration ansi escapes + better plugin perf logging

### DIFF
--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -24,17 +24,35 @@ pub fn read_plugin_file(
     plugin_file: Option<Spanned<String>>,
     storage_path: &str,
 ) {
-    let start_time = std::time::Instant::now();
-    let mut plug_path = String::new();
+    let mut start_time = std::time::Instant::now();
     // Reading signatures from signature file
     // The plugin.nu file stores the parsed signature collected from each registered plugin
     add_plugin_file(engine_state, plugin_file, storage_path);
+    perf(
+        "add plugin file to engine_state",
+        start_time,
+        file!(),
+        line!(),
+        column!(),
+        engine_state.get_config().use_ansi_coloring,
+    );
 
+    start_time = std::time::Instant::now();
     let plugin_path = engine_state.plugin_signatures.clone();
     if let Some(plugin_path) = plugin_path {
         let plugin_filename = plugin_path.to_string_lossy();
-        plug_path = plugin_filename.to_string();
+        let plug_path = plugin_filename.to_string();
+
         if let Ok(contents) = std::fs::read(&plugin_path) {
+            perf(
+                &format!("read plugin file {}", &plug_path),
+                start_time,
+                file!(),
+                line!(),
+                column!(),
+                engine_state.get_config().use_ansi_coloring,
+            );
+            start_time = std::time::Instant::now();
             eval_source(
                 engine_state,
                 stack,
@@ -43,17 +61,16 @@ pub fn read_plugin_file(
                 PipelineData::empty(),
                 false,
             );
+            perf(
+                &format!("eval_source plugin file {}", &plug_path),
+                start_time,
+                file!(),
+                line!(),
+                column!(),
+                engine_state.get_config().use_ansi_coloring,
+            );
         }
     }
-
-    perf(
-        &format!("read_plugin_file {}", &plug_path),
-        start_time,
-        file!(),
-        line!(),
-        column!(),
-        engine_state.get_config().use_ansi_coloring,
-    );
 }
 
 #[cfg(feature = "plugin")]


### PR DESCRIPTION
# Description

This PR just adds better logging for shell_integration and tweaks the ansi escapes so they're closer to where the action happens. I also added some perf log entries to help better understand plugin file load and eval performance.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
