### PR TITLE
Also use old mac workers for `plugins` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        platform: [windows-latest, macos-latest, ubuntu-20.04]
+        # Using macOS 13 runner because 14 is based on the M1 and has half as much RAM (7 GB,
+        # instead of 14 GB) which is too little for us right now.
+        #
+        # Failure occuring with clippy for rust 1.77.2
+        platform: [windows-latest, macos-13, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
Repeat from #12493

Now we see failures on main
