### PR TITLE
Ensure that two columns named index don't exist when converting a Dataframe to a nu Value.

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
@@ -154,12 +154,16 @@ pub fn create_column(
 
 // Adds a separator to the vector of values using the column names from the
 // dataframe to create the Values Row
-pub fn add_separator(values: &mut Vec<Value>, df: &DataFrame, span: Span) {
+// returns true if there is an index column contained in the dataframe
+pub fn add_separator(values: &mut Vec<Value>, df: &DataFrame, has_index: bool, span: Span) {
     let mut record = Record::new();
 
-    record.push("index", Value::string("...", span));
+    if !has_index {
+        record.push("index", Value::string("...", span));
+    }
 
     for name in df.get_column_names() {
+        // there should only be one index field
         record.push(name, Value::string("...", span))
     }
 

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
@@ -300,8 +300,7 @@ impl NuDataFrame {
         self.columns(Span::unknown())
             .unwrap_or_default() // just assume there isn't an index
             .iter()
-            .find(|col| col.name() == "index")
-            .is_some()
+            .any(|col| col.name() == "index")
     }
 
     // Print is made out a head and if the dataframe is too large, then a tail


### PR DESCRIPTION
# Description
@maxim-uvarov discovered an issue with the current implementation. When executing [[index a]; [1 1]] | polars into-df, a plugin_failed_to_decode error occurs. This happens because a Record is created with two columns named "index" as an index column is added during conversion. This pull request addresses the problem by not adding an index column if there is already a column named "index" in the dataframe.