### PR TITLE
Two consecutive calls to into-lazy should not fail

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/mod.rs
@@ -147,7 +147,9 @@ impl NuDataFrame {
 
         for value in iter {
             match value {
-                Value::Custom { .. } => return Self::try_from_value(plugin, &value),
+                Value::Custom { .. } => {
+                    return Self::try_from_value_coerce(plugin, &value, value.span());
+                }
                 Value::List { vals, .. } => {
                     let record = vals
                         .into_iter()


### PR DESCRIPTION
# Description

From @maxim-uvarov's [post](https://discord.com/channels/601130461678272522/1227612017171501136/1228656319704203375).

When calling `to-lazy` back to back in a pipeline, an error should not occur:

```
> [[a b]; [6 2] [1 4] [4 1]] | polars into-lazy | polars into-lazy
Error: nu::shell::cant_convert

  × Can't convert to NuDataFrame.
   ╭─[entry #1:1:30]
 1 │ [[a b]; [6 2] [1 4] [4 1]] | polars into-lazy | polars into-lazy
   ·                              ────────┬───────
   ·                                      ╰── can't convert NuLazyFrameCustomValue to NuDataFrame
   ╰────
 ```

This pull request ensures that custom value's of NuLazyFrameCustomValue are properly converted when passed in.
