### PR TITLE
use abbreviated string instead of debug string for `DatetimeParseError`s

### DIFF
--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -332,7 +332,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                         }
                         None => Value::error(
                             ShellError::DatetimeParseError {
-                                msg: input.to_debug_string(),
+                                msg: input.to_abbreviated_string(&nu_protocol::Config::default()),
                                 span: *span,
                             },
                             *span,
@@ -345,7 +345,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                         }
                         None => Value::error(
                             ShellError::DatetimeParseError {
-                                msg: input.to_debug_string(),
+                                msg: input.to_abbreviated_string(&nu_protocol::Config::default()),
                                 span: *span,
                             },
                             *span,

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -78,9 +78,11 @@ fn helper(value: Value, head: Span) -> Value {
         }
         Value::Date { val, .. } => Value::string(humanize_date(val), head),
         _ => Value::error(
-            ShellError::DatetimeParseError {
-                msg: value.to_abbreviated_string(&nu_protocol::Config::default()),
-                span: head,
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "date, string (that represents datetime), or nothing".into(),
+                wrong_type: value.get_type().to_string(),
+                dst_span: head,
+                src_span: span,
             },
             head,
         ),

--- a/crates/nu-command/src/date/humanize.rs
+++ b/crates/nu-command/src/date/humanize.rs
@@ -79,7 +79,7 @@ fn helper(value: Value, head: Span) -> Value {
         Value::Date { val, .. } => Value::string(humanize_date(val), head),
         _ => Value::error(
             ShellError::DatetimeParseError {
-                msg: value.to_debug_string(),
+                msg: value.to_abbreviated_string(&nu_protocol::Config::default()),
                 span: head,
             },
             head,

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -112,9 +112,11 @@ fn helper(val: Value, head: Span) -> Value {
         }
         Value::Date { val, .. } => parse_date_into_table(val, head),
         _ => Value::error(
-            ShellError::DatetimeParseError {
-                msg: val.to_abbreviated_string(&nu_protocol::Config::default()),
-                span: head,
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "date, string (that represents datetime), or nothing".into(),
+                wrong_type: val.get_type().to_string(),
+                dst_span: head,
+                src_span: span,
             },
             head,
         ),

--- a/crates/nu-command/src/date/to_record.rs
+++ b/crates/nu-command/src/date/to_record.rs
@@ -113,7 +113,7 @@ fn helper(val: Value, head: Span) -> Value {
         Value::Date { val, .. } => parse_date_into_table(val, head),
         _ => Value::error(
             ShellError::DatetimeParseError {
-                msg: val.to_debug_string(),
+                msg: val.to_abbreviated_string(&nu_protocol::Config::default()),
                 span: head,
             },
             head,

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -111,9 +111,11 @@ fn helper(val: Value, head: Span) -> Value {
         }
         Value::Date { val, .. } => parse_date_into_table(val, head),
         _ => Value::error(
-            ShellError::DatetimeParseError {
-                msg: val.to_abbreviated_string(&nu_protocol::Config::default()),
-                span: head,
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "date, string (that represents datetime), or nothing".into(),
+                wrong_type: val.get_type().to_string(),
+                dst_span: head,
+                src_span: val_span,
             },
             head,
         ),

--- a/crates/nu-command/src/date/to_table.rs
+++ b/crates/nu-command/src/date/to_table.rs
@@ -112,7 +112,7 @@ fn helper(val: Value, head: Span) -> Value {
         Value::Date { val, .. } => parse_date_into_table(val, head),
         _ => Value::error(
             ShellError::DatetimeParseError {
-                msg: val.to_debug_string(),
+                msg: val.to_abbreviated_string(&nu_protocol::Config::default()),
                 span: head,
             },
             head,

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -116,7 +116,7 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
         }
         _ => Value::error(
             ShellError::DatetimeParseError {
-                msg: value.to_debug_string(),
+                msg: value.to_abbreviated_string(&nu_protocol::Config::default()),
                 span: head,
             },
             head,

--- a/crates/nu-command/src/date/to_timezone.rs
+++ b/crates/nu-command/src/date/to_timezone.rs
@@ -115,9 +115,11 @@ fn helper(value: Value, head: Span, timezone: &Spanned<String>) -> Value {
             _to_timezone(dt.with_timezone(dt.offset()), timezone, head)
         }
         _ => Value::error(
-            ShellError::DatetimeParseError {
-                msg: value.to_abbreviated_string(&nu_protocol::Config::default()),
-                span: head,
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "date, string (that represents datetime), or nothing".into(),
+                wrong_type: value.get_type().to_string(),
+                dst_span: head,
+                src_span: val_span,
             },
             head,
         ),

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -153,9 +153,11 @@ fn format_helper(value: Value, formatter: &str, formatter_span: Span, head_span:
             }
         }
         _ => Value::error(
-            ShellError::DatetimeParseError {
-                msg: value.to_abbreviated_string(&nu_protocol::Config::default()),
-                span: head_span,
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "date, string (that represents datetime)".into(),
+                wrong_type: value.get_type().to_string(),
+                dst_span: head_span,
+                src_span: value.span(),
             },
             head_span,
         ),
@@ -174,9 +176,11 @@ fn format_helper_rfc2822(value: Value, span: Span) -> Value {
             }
         }
         _ => Value::error(
-            ShellError::DatetimeParseError {
-                msg: value.to_abbreviated_string(&nu_protocol::Config::default()),
-                span,
+            ShellError::OnlySupportsThisInputType {
+                exp_input_type: "date, string (that represents datetime)".into(),
+                wrong_type: value.get_type().to_string(),
+                dst_span: span,
+                src_span: val_span,
             },
             span,
         ),

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -154,7 +154,7 @@ fn format_helper(value: Value, formatter: &str, formatter_span: Span, head_span:
         }
         _ => Value::error(
             ShellError::DatetimeParseError {
-                msg: value.to_debug_string(),
+                msg: value.to_abbreviated_string(&nu_protocol::Config::default()),
                 span: head_span,
             },
             head_span,
@@ -175,7 +175,7 @@ fn format_helper_rfc2822(value: Value, span: Span) -> Value {
         }
         _ => Value::error(
             ShellError::DatetimeParseError {
-                msg: value.to_debug_string(),
+                msg: value.to_abbreviated_string(&nu_protocol::Config::default()),
                 span,
             },
             span,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Resolves #12444. Prevents debug string from being printed out.

