### PR TITLE
Disallow setting the `PWD` via `load-env` input

### DIFF
--- a/crates/nu-command/src/env/load_env.rs
+++ b/crates/nu-command/src/env/load_env.rs
@@ -52,14 +52,16 @@ impl Command for LoadEnv {
             },
         };
 
-        for (env_var, rhs) in record {
-            let env_var_ = env_var.as_str();
-            if ["FILE_PWD", "CURRENT_FILE", "PWD"].contains(&env_var_) {
+        for prohibited in ["FILE_PWD", "CURRENT_FILE", "PWD"] {
+            if record.contains(prohibited) {
                 return Err(ShellError::AutomaticEnvVarSetManually {
-                    envvar_name: env_var,
+                    envvar_name: prohibited.to_string(),
                     span: call.head,
                 });
             }
+        }
+
+        for (env_var, rhs) in record {
             stack.add_env_var(env_var, rhs);
         }
         Ok(PipelineData::empty())


### PR DESCRIPTION
# Description
Fixes #12520


# User-Facing Changes
Breaking change:

Any operation parsing input with `PWD` to set the environment will now
fail with `ShellError::AutomaticEnvVarSetManually`

Furthermore transactions containing the special env-vars will be rejected before executing any modifications. Prevoiusly this was changing valid variables before while leaving valid variables after the violation untouched.

## `PWD` handling.

Now failing

```
{PWD: "/trolling"} | load-env
``` 

already failing 

```
load-env {PWD: "/trolling"}
``` 

## Error management



```
> load-env {MY_VAR1: foo, PWD: "/trolling", MY_VAR2: bar}
Error: nu::shell::automatic_env_var_set_manually

  × PWD cannot be set manually.
   ╭─[entry #1:1:2]
 1 │  load-env {MY_VAR1: foo, PWD: "/trolling", MY_VAR2: bar}
   ·  ────┬───
   ·      ╰── cannot set 'PWD' manually
   ╰────
  help: The environment variable 'PWD' is set automatically by Nushell and cannot be set manually.
```

### Before:
```
> $env.MY_VAR1
foo
> $env.MY_VAR2
Error: nu::shell::name_not_found
....
```
### After:
```
> $env.MY_VAR1
Error: nu::shell::name_not_found
....
> $env.MY_VAR2
Error: nu::shell::name_not_found
....
```

# After Submitting
We need to check if any integrations rely on this hack.

