### PR TITLE
Cleaning up to_pipe_line_data and cache_and_to_value, making them part of CustomValueSupport

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/eager/append.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/append.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
 };
 
 use crate::{
-    values::{to_pipeline_data, Axis, Column, CustomValueSupport, NuDataFrame},
+    values::{Axis, Column, CustomValueSupport, NuDataFrame},
     PolarsPlugin,
 };
 
@@ -129,7 +129,7 @@ fn command(
     let df = NuDataFrame::try_from_pipeline(plugin, input, call.head)?;
     let df = df.append_df(&df_other, axis, call.head)?;
 
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/cast.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/cast.rs
@@ -1,6 +1,6 @@
 use crate::{
-    dataframe::values::{str_to_dtype, to_pipeline_data, NuExpression, NuLazyFrame},
-    values::{cant_convert_err, PolarsPluginObject, PolarsPluginType},
+    dataframe::values::{str_to_dtype, NuExpression, NuLazyFrame},
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 
@@ -105,7 +105,7 @@ impl PluginCommand for CastDF {
                 let dtype: String = call.req(0)?;
                 let dtype = str_to_dtype(&dtype, call.head)?;
                 let expr: NuExpression = expr.to_polars().cast(dtype).into();
-                to_pipeline_data(plugin, engine, call.head, expr)
+                expr.to_pipeline_data(plugin, engine, call.head)
             }
             _ => Err(cant_convert_err(
                 &value,
@@ -145,7 +145,7 @@ fn command_lazy(
     let column = col(&column_nm).cast(dtype);
     let lazy = lazy.to_polars().with_columns(&[column]);
     let lazy = NuLazyFrame::new(false, lazy);
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 fn command_eager(
@@ -186,7 +186,7 @@ fn command_eager(
         })?;
 
     let df = NuDataFrame::new(false, df);
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/drop.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/drop.rs
@@ -1,4 +1,3 @@
-use crate::values::to_pipeline_data;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, SyntaxShape, Type,
@@ -112,7 +111,7 @@ fn command(
 
     let final_df = NuDataFrame::new(df.from_lazy, polars_df);
 
-    to_pipeline_data(plugin, engine, call.head, final_df)
+    final_df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/drop_duplicates.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/drop_duplicates.rs
@@ -5,7 +5,7 @@ use nu_protocol::{
 };
 use polars::prelude::UniqueKeepStrategy;
 
-use crate::values::{to_pipeline_data, CustomValueSupport};
+use crate::values::CustomValueSupport;
 use crate::PolarsPlugin;
 
 use super::super::values::utils::convert_columns_string;
@@ -117,7 +117,7 @@ fn command(
         })?;
 
     let df = NuDataFrame::new(df.from_lazy, polars_df);
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/drop_nulls.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/drop_nulls.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     Value,
 };
 
-use crate::values::{to_pipeline_data, CustomValueSupport};
+use crate::values::CustomValueSupport;
 use crate::PolarsPlugin;
 
 use super::super::values::utils::convert_columns_string;
@@ -134,7 +134,7 @@ fn command(
             inner: vec![],
         })?;
     let df = NuDataFrame::new(df.from_lazy, polars_df);
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/dtypes.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/dtypes.rs
@@ -1,6 +1,6 @@
 use crate::PolarsPlugin;
 
-use super::super::values::{to_pipeline_data, Column, CustomValueSupport, NuDataFrame};
+use super::super::values::{Column, CustomValueSupport, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type, Value,
@@ -96,7 +96,7 @@ fn command(
     let dtypes_col = Column::new("dtype".to_string(), dtypes);
 
     let df = NuDataFrame::try_from_columns(vec![names_col, dtypes_col], None)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/dummies.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/dummies.rs
@@ -1,8 +1,5 @@
 use super::super::values::NuDataFrame;
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type,
@@ -103,7 +100,7 @@ fn command(
             })?;
 
     let df: NuDataFrame = polars_df.into();
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/filter_with.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/filter_with.rs
@@ -7,10 +7,7 @@ use polars::prelude::LazyFrame;
 
 use crate::{
     dataframe::values::{NuExpression, NuLazyFrame},
-    values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, PolarsPluginObject,
-        PolarsPluginType,
-    },
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 
@@ -114,7 +111,7 @@ fn command_eager(
         let lazy = df.lazy();
         let lazy = lazy.apply_with_expr(expression, LazyFrame::filter);
 
-        to_pipeline_data(plugin, engine, call.head, lazy)
+        lazy.to_pipeline_data(plugin, engine, call.head)
     } else {
         let mask = NuDataFrame::try_from_value_coerce(plugin, &mask_value, mask_span)?
             .as_series(mask_span)?;
@@ -137,7 +134,7 @@ fn command_eager(
                 inner: vec![],
             })?;
         let df = NuDataFrame::new(df.from_lazy, polars_df);
-        to_pipeline_data(plugin, engine, call.head, df)
+        df.to_pipeline_data(plugin, engine, call.head)
     }
 }
 
@@ -150,7 +147,7 @@ fn command_lazy(
     let expr: Value = call.req(0)?;
     let expr = NuExpression::try_from_value(plugin, &expr)?;
     let lazy = lazy.apply_with_expr(expr, LazyFrame::filter);
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/first.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/first.rs
@@ -1,5 +1,5 @@
 use crate::{
-    values::{to_pipeline_data, Column, CustomValueSupport},
+    values::{Column, CustomValueSupport},
     PolarsPlugin,
 };
 
@@ -105,7 +105,8 @@ impl PluginCommand for FirstDF {
             let expr = NuExpression::try_from_value(plugin, &value)?;
             let expr: NuExpression = expr.to_polars().first().into();
 
-            to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+            expr.to_pipeline_data(plugin, engine, call.head)
+                .map_err(LabeledError::from)
         }
     }
 }
@@ -122,7 +123,7 @@ fn command(
     let res = df.as_ref().head(Some(rows));
     let res = NuDataFrame::new(false, res);
 
-    to_pipeline_data(plugin, engine, call.head, res)
+    res.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/get.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/get.rs
@@ -5,9 +5,7 @@ use nu_protocol::{
 };
 
 use crate::{
-    dataframe::values::utils::convert_columns_string,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
+    dataframe::values::utils::convert_columns_string, values::CustomValueSupport, PolarsPlugin,
 };
 
 use super::super::values::{Column, NuDataFrame};
@@ -87,7 +85,7 @@ fn command(
             inner: vec![],
         })?;
     let df = NuDataFrame::new(false, df);
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/last.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/last.rs
@@ -1,5 +1,5 @@
 use crate::{
-    values::{to_pipeline_data, Column, CustomValueSupport},
+    values::{Column, CustomValueSupport},
     PolarsPlugin,
 };
 
@@ -80,7 +80,8 @@ impl PluginCommand for LastDF {
             let expr = NuExpression::try_from_value(plugin, &value)?;
             let expr: NuExpression = expr.to_polars().last().into();
 
-            to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+            expr.to_pipeline_data(plugin, engine, call.head)
+                .map_err(LabeledError::from)
         }
     }
 }
@@ -96,7 +97,7 @@ fn command(
 
     let res = df.as_ref().tail(Some(rows));
     let res = NuDataFrame::new(false, res);
-    to_pipeline_data(plugin, engine, call.head, res)
+    res.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/melt.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/melt.rs
@@ -5,9 +5,7 @@ use nu_protocol::{
 };
 
 use crate::{
-    dataframe::values::utils::convert_columns_string,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
+    dataframe::values::utils::convert_columns_string, values::CustomValueSupport, PolarsPlugin,
 };
 
 use super::super::values::{Column, NuDataFrame};
@@ -182,7 +180,7 @@ fn command(
     }
 
     let res = NuDataFrame::new(false, res);
-    to_pipeline_data(plugin, engine, call.head, res)
+    res.to_pipeline_data(plugin, engine, call.head)
 }
 
 fn check_column_datatypes<T: AsRef<str>>(

--- a/crates/nu_plugin_polars/src/dataframe/eager/open.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/open.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::NuSchema,
-    values::{cache_and_to_value, NuLazyFrame},
+    values::{CustomValueSupport, NuLazyFrame},
     PolarsPlugin,
 };
 use nu_path::expand_path_with;
@@ -187,7 +187,7 @@ fn from_parquet(
             })?
             .into();
 
-        cache_and_to_value(plugin, engine, call.head, df)
+        df.cache_and_to_value(plugin, engine, call.head)
     } else {
         let columns: Option<Vec<String>> = call.get_flag("columns")?;
 
@@ -216,7 +216,7 @@ fn from_parquet(
             })?
             .into();
 
-        cache_and_to_value(plugin, engine, call.head, df)
+        df.cache_and_to_value(plugin, engine, call.head)
     }
 }
 
@@ -254,7 +254,7 @@ fn from_avro(
         })?
         .into();
 
-    cache_and_to_value(plugin, engine, call.head, df)
+    df.cache_and_to_value(plugin, engine, call.head)
 }
 
 fn from_ipc(
@@ -284,7 +284,7 @@ fn from_ipc(
             })?
             .into();
 
-        cache_and_to_value(plugin, engine, call.head, df)
+        df.cache_and_to_value(plugin, engine, call.head)
     } else {
         let columns: Option<Vec<String>> = call.get_flag("columns")?;
 
@@ -313,7 +313,7 @@ fn from_ipc(
             })?
             .into();
 
-        cache_and_to_value(plugin, engine, call.head, df)
+        df.cache_and_to_value(plugin, engine, call.head)
     }
 }
 
@@ -355,7 +355,7 @@ fn from_json(
         })?
         .into();
 
-    cache_and_to_value(plugin, engine, call.head, df)
+    df.cache_and_to_value(plugin, engine, call.head)
 }
 
 fn from_jsonl(
@@ -399,7 +399,7 @@ fn from_jsonl(
         })?
         .into();
 
-    cache_and_to_value(plugin, engine, call.head, df)
+    df.cache_and_to_value(plugin, engine, call.head)
 }
 
 fn from_csv(
@@ -472,7 +472,7 @@ fn from_csv(
             })?
             .into();
 
-        cache_and_to_value(plugin, engine, call.head, df)
+        df.cache_and_to_value(plugin, engine, call.head)
     } else {
         let csv_reader = CsvReader::from_path(file_path)
             .map_err(|e| ShellError::GenericError {
@@ -538,6 +538,6 @@ fn from_csv(
             })?
             .into();
 
-        cache_and_to_value(plugin, engine, call.head, df)
+        df.cache_and_to_value(plugin, engine, call.head)
     }
 }

--- a/crates/nu_plugin_polars/src/dataframe/eager/query_df.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/query_df.rs
@@ -1,7 +1,7 @@
 use super::super::values::NuDataFrame;
 use crate::dataframe::values::Column;
 use crate::dataframe::{eager::SQLContext, values::NuLazyFrame};
-use crate::values::{to_pipeline_data, CustomValueSupport};
+use crate::values::CustomValueSupport;
 use crate::PolarsPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
@@ -92,7 +92,7 @@ fn command(
             inner: vec![],
         })?;
     let lazy = NuLazyFrame::new(!df.from_lazy, df_sql);
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/rename.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/rename.rs
@@ -6,7 +6,7 @@ use nu_protocol::{
 
 use crate::{
     dataframe::{utils::extract_strings, values::NuLazyFrame},
-    values::{to_pipeline_data, CustomValueSupport, PolarsPluginObject},
+    values::{CustomValueSupport, PolarsPluginObject},
     PolarsPlugin,
 };
 
@@ -161,7 +161,7 @@ fn command_eager(
     }
 
     let df = NuDataFrame::new(false, polars_df);
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 fn command_lazy(
@@ -187,7 +187,7 @@ fn command_lazy(
     let lazy = lazy.to_polars();
     let lazy: NuLazyFrame = lazy.rename(&columns, &new_names).into();
 
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/sample.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/sample.rs
@@ -6,10 +6,7 @@ use nu_protocol::{
 use polars::prelude::NamedFrom;
 use polars::series::Series;
 
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::NuDataFrame;
 
@@ -134,5 +131,5 @@ fn command(
         }),
     };
     let df = NuDataFrame::new(false, df?);
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }

--- a/crates/nu_plugin_polars/src/dataframe/eager/shape.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/shape.rs
@@ -3,11 +3,7 @@ use nu_protocol::{
     Category, Example, LabeledError, PipelineData, ShellError, Signature, Span, Type, Value,
 };
 
-use crate::{
-    dataframe::values::Column,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{dataframe::values::Column, values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::NuDataFrame;
 
@@ -79,7 +75,7 @@ fn command(
     let cols_col = Column::new("columns".to_string(), vec![cols]);
 
     let df = NuDataFrame::try_from_columns(vec![rows_col, cols_col], None)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/slice.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/slice.rs
@@ -4,11 +4,7 @@ use nu_protocol::{
     Value,
 };
 
-use crate::{
-    dataframe::values::Column,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{dataframe::values::Column, values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::NuDataFrame;
 
@@ -80,7 +76,7 @@ fn command(
     let res = df.as_ref().slice(offset, size);
     let res = NuDataFrame::new(false, res);
 
-    to_pipeline_data(plugin, engine, call.head, res)
+    res.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/summary.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/summary.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -277,7 +274,7 @@ fn command(
 
     let df = NuDataFrame::new(df.from_lazy, polars_df);
 
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/take.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/take.rs
@@ -5,11 +5,7 @@ use nu_protocol::{
 };
 use polars::prelude::DataType;
 
-use crate::{
-    dataframe::values::Column,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{dataframe::values::Column, values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::NuDataFrame;
 
@@ -147,7 +143,7 @@ fn command(
         })?;
 
     let df = NuDataFrame::new(df.from_lazy, polars_df);
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/eager/to_df.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/to_df.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::NuSchema,
-    values::{to_pipeline_data, Column, CustomValueSupport},
+    values::{Column, CustomValueSupport},
     PolarsPlugin,
 };
 
@@ -183,7 +183,8 @@ impl PluginCommand for ToDataFrame {
             .transpose()?;
 
         let df = NuDataFrame::try_from_iter(plugin, input.into_iter(), maybe_schema.clone())?;
-        to_pipeline_data(plugin, engine, call.head, df).map_err(LabeledError::from)
+        df.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/eager/with_column.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/with_column.rs
@@ -1,7 +1,7 @@
 use super::super::values::{Column, NuDataFrame};
 use crate::{
     dataframe::values::{NuExpression, NuLazyFrame},
-    values::{to_pipeline_data, CustomValueSupport, PolarsPluginObject},
+    values::{CustomValueSupport, PolarsPluginObject},
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -143,7 +143,7 @@ fn command_eager(
         let expressions = NuExpression::extract_exprs(plugin, value)?;
         let lazy = NuLazyFrame::new(true, df.lazy().to_polars().with_columns(&expressions));
         let df = lazy.collect(call.head)?;
-        to_pipeline_data(plugin, engine, call.head, df)
+        df.to_pipeline_data(plugin, engine, call.head)
     } else {
         let mut other = NuDataFrame::try_from_value(plugin, &new_column)?.as_series(column_span)?;
 
@@ -166,7 +166,7 @@ fn command_eager(
             })?;
 
         let df = NuDataFrame::new(df.from_lazy, polars_df);
-        to_pipeline_data(plugin, engine, call.head, df)
+        df.to_pipeline_data(plugin, engine, call.head)
     }
 }
 
@@ -180,7 +180,7 @@ fn command_lazy(
     let value = Value::list(vals, call.head);
     let expressions = NuExpression::extract_exprs(plugin, value)?;
     let lazy: NuLazyFrame = lazy.to_polars().with_columns(&expressions).into();
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/expressions/alias.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/alias.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::NuExpression;
 
@@ -72,7 +69,8 @@ impl PluginCommand for ExprAlias {
         let expr = NuExpression::try_from_pipeline(plugin, input, call.head)?;
         let expr: NuExpression = expr.to_polars().alias(alias.as_str()).into();
 
-        to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+        expr.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/expressions/arg_where.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/arg_where.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -63,7 +63,8 @@ impl PluginCommand for ExprArgWhere {
         let value: Value = call.req(0)?;
         let expr = NuExpression::try_from_value(plugin, &value)?;
         let expr: NuExpression = arg_where(expr.to_polars()).into();
-        to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+        expr.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/expressions/col.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/col.rs
@@ -1,4 +1,4 @@
-use crate::{dataframe::values::NuExpression, values::to_pipeline_data, PolarsPlugin};
+use crate::{dataframe::values::NuExpression, values::CustomValueSupport, PolarsPlugin};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     record, Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type, Value,
@@ -54,7 +54,8 @@ impl PluginCommand for ExprCol {
     ) -> Result<PipelineData, LabeledError> {
         let name: String = call.req(0)?;
         let expr: NuExpression = col(name.as_str()).into();
-        to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+        expr.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/expressions/concat_str.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/concat_str.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -92,7 +92,8 @@ impl PluginCommand for ExprConcatStr {
         let expressions = NuExpression::extract_exprs(plugin, value)?;
         let expr: NuExpression = concat_str(expressions, &separator, false).into();
 
-        to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+        expr.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/expressions/datepart.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/datepart.rs
@@ -2,7 +2,7 @@ use super::super::values::NuExpression;
 
 use crate::{
     dataframe::values::{Column, NuDataFrame},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 use chrono::{DateTime, FixedOffset};
@@ -149,7 +149,8 @@ impl PluginCommand for ExprDatePart {
                 }))
             }
         }.into();
-        to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+        expr.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/expressions/expressions_macro.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/expressions_macro.rs
@@ -2,7 +2,7 @@
 /// All of these expressions have an identical body and only require
 /// to have a change in the name, description and expression function
 use crate::dataframe::values::{Column, NuDataFrame, NuExpression, NuLazyFrame};
-use crate::values::{to_pipeline_data, CustomValueSupport};
+use crate::values::CustomValueSupport;
 use crate::PolarsPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
@@ -51,7 +51,8 @@ macro_rules! expr_command {
                 let expr = NuExpression::try_from_pipeline(plugin, input, call.head)
                     .map_err(LabeledError::from)?;
                 let expr: NuExpression = expr.to_polars().$func().into();
-                to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+                expr.to_pipeline_data(plugin, engine, call.head)
+                    .map_err(LabeledError::from)
             }
         }
 
@@ -95,7 +96,8 @@ macro_rules! expr_command {
                 let expr = NuExpression::try_from_pipeline(input, call.head)
                     .map_err(LabeledError::from)?;
                 let expr: NuExpression = expr.into_polars().$func($ddof).into();
-                to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+                expr.to_pipeline_data(plugin, engine, call.head)
+                    .map_err(LabeledError::from)
             }
         }
 
@@ -174,12 +176,14 @@ macro_rules! lazy_expr_command {
                             })
                             .map_err(LabeledError::from)?,
                     );
-                    to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+                    lazy.to_pipeline_data(plugin, engine, call.head)
+                        .map_err(LabeledError::from)
                 } else {
                     let expr =
                         NuExpression::try_from_value(plugin, &value).map_err(LabeledError::from)?;
                     let expr: NuExpression = expr.to_polars().$func().into();
-                    to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+                    expr.to_pipeline_data(plugin, engine, call.head)
+                        .map_err(LabeledError::from)
                 }
             }
         }
@@ -253,11 +257,13 @@ macro_rules! lazy_expr_command {
                             })
                             .map_err(LabeledError::from)?,
                     );
-                    to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+                    lazy.to_pipeline_data(plugin, engine, call.head)
+                        .map_err(LabeledError::from)
                 } else {
                     let expr = NuExpression::try_from_value(plugin, &value)?;
                     let expr: NuExpression = expr.to_polars().$func($ddof).into();
-                    to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+                    expr.to_pipeline_data(plugin, engine, call.head)
+                        .map_err(LabeledError::from)
                 }
             }
         }

--- a/crates/nu_plugin_polars/src/dataframe/expressions/is_in.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/is_in.rs
@@ -1,9 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression},
-    values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, PolarsPluginObject,
-        PolarsPluginType,
-    },
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -157,7 +154,7 @@ fn command_expr(
     }
 
     let expr: NuExpression = expr.to_polars().is_in(lit(list)).into();
-    to_pipeline_data(plugin, engine, call.head, expr)
+    expr.to_pipeline_data(plugin, engine, call.head)
 }
 
 fn command_df(
@@ -185,7 +182,7 @@ fn command_df(
     res.rename("is_in");
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/expressions/lit.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/lit.rs
@@ -1,8 +1,4 @@
-use crate::{
-    dataframe::values::NuExpression,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{dataframe::values::NuExpression, values::CustomValueSupport, PolarsPlugin};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
     record, Category, Example, LabeledError, PipelineData, Signature, SyntaxShape, Type, Value,
@@ -57,7 +53,8 @@ impl PluginCommand for ExprLit {
     ) -> Result<PipelineData, LabeledError> {
         let literal: Value = call.req(0)?;
         let expr = NuExpression::try_from_value(plugin, &literal)?;
-        to_pipeline_data(plugin, engine, call.head, expr).map_err(LabeledError::from)
+        expr.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/expressions/otherwise.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/otherwise.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression, NuWhen, NuWhenType},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -106,7 +106,9 @@ impl PluginCommand for ExprOtherwise {
                 .otherwise(otherwise_predicate.to_polars())
                 .into(),
         };
-        to_pipeline_data(plugin, engine, call.head, complete).map_err(LabeledError::from)
+        complete
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/expressions/when.rs
+++ b/crates/nu_plugin_polars/src/dataframe/expressions/when.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression, NuWhen},
-    values::{to_pipeline_data, CustomValueSupport, NuWhenType},
+    values::{CustomValueSupport, NuWhenType},
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -128,7 +128,9 @@ impl PluginCommand for ExprWhen {
             },
         };
 
-        to_pipeline_data(plugin, engine, call.head, when_then).map_err(LabeledError::from)
+        when_then
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/lazy/aggregate.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/aggregate.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{NuExpression, NuLazyFrame, NuLazyGroupBy},
-    values::{to_pipeline_data, Column, CustomValueSupport, NuDataFrame},
+    values::{Column, CustomValueSupport, NuDataFrame},
     PolarsPlugin,
 };
 
@@ -148,7 +148,8 @@ impl PluginCommand for LazyAggregate {
 
         let polars = group_by.to_polars();
         let lazy = NuLazyFrame::new(false, polars.agg(&expressions));
-        to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+        lazy.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/lazy/explode.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/explode.rs
@@ -1,5 +1,5 @@
 use crate::dataframe::values::{Column, NuDataFrame, NuExpression, NuLazyFrame};
-use crate::values::{to_pipeline_data, CustomValueSupport, PolarsPluginObject};
+use crate::values::{CustomValueSupport, PolarsPluginObject};
 use crate::PolarsPlugin;
 
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -151,7 +151,7 @@ pub(crate) fn explode_lazy(
         .explode(columns.iter().map(AsRef::as_ref).collect::<Vec<&str>>());
     let lazy = NuLazyFrame::from(exploded);
 
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 pub(crate) fn explode_expr(
@@ -161,8 +161,9 @@ pub(crate) fn explode_expr(
     expr: NuExpression,
 ) -> Result<PipelineData, ShellError> {
     let expr: NuExpression = expr.to_polars().explode().into();
-    to_pipeline_data(plugin, engine, call.head, expr)
+    expr.to_pipeline_data(plugin, engine, call.head)
 }
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/nu_plugin_polars/src/dataframe/lazy/fetch.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/fetch.rs
@@ -1,5 +1,5 @@
 use crate::dataframe::values::{Column, NuDataFrame};
-use crate::values::{to_pipeline_data, CustomValueSupport, NuLazyFrame};
+use crate::values::{CustomValueSupport, NuLazyFrame};
 use crate::PolarsPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{
@@ -84,7 +84,9 @@ impl PluginCommand for LazyFetch {
 
         // mark this as not from lazy so it doesn't get converted back to a lazy frame
         eager.from_lazy = false;
-        to_pipeline_data(plugin, engine, call.head, eager).map_err(LabeledError::from)
+        eager
+            .to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/lazy/fill_nan.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/fill_nan.rs
@@ -1,9 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression},
-    values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, PolarsPluginObject,
-        PolarsPluginType,
-    },
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -161,7 +158,7 @@ fn cmd_df(
         })
         .collect::<Vec<Column>>();
     let df = NuDataFrame::try_from_columns(dataframe, None)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 fn cmd_expr(
@@ -173,8 +170,7 @@ fn cmd_expr(
 ) -> Result<PipelineData, ShellError> {
     let fill = NuExpression::try_from_value(plugin, &fill)?.to_polars();
     let expr: NuExpression = expr.to_polars().fill_nan(fill).into();
-
-    to_pipeline_data(plugin, engine, call.head, expr)
+    expr.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/lazy/fill_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/fill_null.rs
@@ -1,9 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression, NuLazyFrame},
-    values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, PolarsPluginObject,
-        PolarsPluginType,
-    },
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -100,7 +97,7 @@ fn cmd_lazy(
 ) -> Result<PipelineData, ShellError> {
     let expr = NuExpression::try_from_value(plugin, &fill)?.to_polars();
     let lazy = NuLazyFrame::new(lazy.from_eager, lazy.to_polars().fill_null(expr));
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 fn cmd_expr(
@@ -112,7 +109,7 @@ fn cmd_expr(
 ) -> Result<PipelineData, ShellError> {
     let fill = NuExpression::try_from_value(plugin, &fill)?.to_polars();
     let expr: NuExpression = expr.to_polars().fill_null(fill).into();
-    to_pipeline_data(plugin, engine, call.head, expr)
+    expr.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/lazy/filter.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression, NuLazyFrame},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 
@@ -89,7 +89,7 @@ fn command(
         lazy.from_eager,
         lazy.to_polars().filter(filter_expr.to_polars()),
     );
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/lazy/groupby.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/groupby.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression, NuLazyFrame, NuLazyGroupBy},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -153,7 +153,7 @@ fn command(
 ) -> Result<PipelineData, ShellError> {
     let group_by = lazy.to_polars().group_by(expressions);
     let group_by = NuLazyGroupBy::new(group_by, lazy.from_eager, lazy.schema()?);
-    to_pipeline_data(plugin, engine, call.head, group_by)
+    group_by.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/lazy/join.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/join.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression, NuLazyFrame},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -244,7 +244,8 @@ impl PluginCommand for LazyJoin {
             .finish();
 
         let lazy = NuLazyFrame::new(from_eager, lazy);
-        to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+        lazy.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/lazy/macro_commands.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/macro_commands.rs
@@ -2,7 +2,7 @@
 /// All of these commands have an identical body and only require
 /// to have a change in the name, description and function
 use crate::dataframe::values::{Column, NuDataFrame, NuLazyFrame};
-use crate::values::{to_pipeline_data, CustomValueSupport};
+use crate::values::CustomValueSupport;
 use crate::PolarsPlugin;
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
 use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Span, Type, Value};
@@ -47,7 +47,8 @@ macro_rules! lazy_command {
                 let lazy = NuLazyFrame::try_from_pipeline_coerce(plugin, input, call.head)
                     .map_err(LabeledError::from)?;
                 let lazy = NuLazyFrame::new(lazy.from_eager, lazy.to_polars().$func());
-                to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+                lazy.to_pipeline_data(plugin, engine, call.head)
+                    .map_err(LabeledError::from)
             }
         }
 
@@ -92,7 +93,8 @@ macro_rules! lazy_command {
                 let lazy = NuLazyFrame::try_from_pipeline_coerce(plugin, input, call.head)
                     .map_err(LabeledError::from)?;
                 let lazy = NuLazyFrame::new(lazy.from_eager, lazy.into_polars().$func($ddot));
-                to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+                lazy.to_pipeline_data(plugin, engine, call.head)
+                    .map_err(LabeledError::from)
             }
         }
 
@@ -160,7 +162,8 @@ macro_rules! lazy_command {
                         .map_err(LabeledError::from)?,
                 );
 
-                to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+                lazy.to_pipeline_data(plugin, engine, call.head)
+                    .map_err(LabeledError::from)
             }
         }
 

--- a/crates/nu_plugin_polars/src/dataframe/lazy/median.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/median.rs
@@ -1,8 +1,7 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuLazyFrame},
     values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, NuExpression, PolarsPluginObject,
-        PolarsPluginType,
+        cant_convert_err, CustomValueSupport, NuExpression, PolarsPluginObject, PolarsPluginType,
     },
     PolarsPlugin,
 };
@@ -96,7 +95,7 @@ impl PluginCommand for LazyMedian {
             PolarsPluginObject::NuLazyFrame(lazy) => command(plugin, engine, call, lazy),
             PolarsPluginObject::NuExpression(expr) => {
                 let expr: NuExpression = expr.to_polars().median().into();
-                to_pipeline_data(plugin, engine, call.head, expr)
+                expr.to_pipeline_data(plugin, engine, call.head)
             }
             _ => Err(cant_convert_err(
                 &value,
@@ -128,7 +127,7 @@ fn command(
             inner: vec![],
         })?;
     let lazy = NuLazyFrame::new(lazy.from_eager, polars_lazy);
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/lazy/quantile.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/quantile.rs
@@ -1,8 +1,7 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuLazyFrame},
     values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, NuExpression, PolarsPluginObject,
-        PolarsPluginType,
+        cant_convert_err, CustomValueSupport, NuExpression, PolarsPluginObject, PolarsPluginType,
     },
     PolarsPlugin,
 };
@@ -110,7 +109,7 @@ impl PluginCommand for LazyQuantile {
                     .to_polars()
                     .quantile(lit(quantile), QuantileInterpolOptions::default())
                     .into();
-                to_pipeline_data(plugin, engine, call.head, expr)
+                expr.to_pipeline_data(plugin, engine, call.head)
             }
             _ => Err(cant_convert_err(
                 &value,
@@ -145,7 +144,7 @@ fn command(
             })?,
     );
 
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/lazy/select.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/select.rs
@@ -1,6 +1,6 @@
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression, NuLazyFrame},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 
@@ -68,7 +68,8 @@ impl PluginCommand for LazySelect {
         let pipeline_value = input.into_value(call.head);
         let lazy = NuLazyFrame::try_from_value_coerce(plugin, &pipeline_value)?;
         let lazy = NuLazyFrame::new(lazy.from_eager, lazy.to_polars().select(&expressions));
-        to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+        lazy.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/lazy/sort_by_expr.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/sort_by_expr.rs
@@ -1,7 +1,7 @@
 use super::super::values::NuLazyFrame;
 use crate::{
     dataframe::values::{Column, NuDataFrame, NuExpression},
-    values::{to_pipeline_data, CustomValueSupport},
+    values::CustomValueSupport,
     PolarsPlugin,
 };
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -144,7 +144,8 @@ impl PluginCommand for LazySortBy {
             lazy.to_polars()
                 .sort_by_exprs(&expressions, reverse, nulls_last, maintain_order),
         );
-        to_pipeline_data(plugin, engine, call.head, lazy).map_err(LabeledError::from)
+        lazy.to_pipeline_data(plugin, engine, call.head)
+            .map_err(LabeledError::from)
     }
 }
 

--- a/crates/nu_plugin_polars/src/dataframe/series/all_false.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/all_false.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -104,7 +101,7 @@ fn command(
         vec![Column::new("all_false".to_string(), vec![value])],
         None,
     )?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/all_true.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/all_true.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -104,7 +101,7 @@ fn command(
         vec![Column::new("all_true".to_string(), vec![value])],
         None,
     )?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/arg_max.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/arg_max.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -81,7 +78,7 @@ fn command(
 
     let res = chunked.into_series();
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/arg_min.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/arg_min.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -81,7 +78,7 @@ fn command(
 
     let res = chunked.into_series();
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/cumulative.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/cumulative.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -144,7 +141,7 @@ fn command(
     res.rename(&name);
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/as_date.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/as_date.rs
@@ -1,4 +1,4 @@
-use crate::{values::to_pipeline_data, PolarsPlugin};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -97,5 +97,5 @@ fn command(
     res.rename("date");
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }

--- a/crates/nu_plugin_polars/src/dataframe/series/date/as_datetime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/as_datetime.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -183,7 +180,7 @@ fn command(
 
     res.rename("datetime");
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_day.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_day.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -90,7 +87,7 @@ fn command(
     let res = casted.day().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_hour.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_hour.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -82,7 +79,7 @@ fn command(
     let res = casted.hour().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_minute.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_minute.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 use polars::{prelude::NamedFrom, series::Series};
 
 use super::super::super::values::NuDataFrame;
@@ -80,7 +77,7 @@ fn command(
     let res = casted.minute().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_month.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_month.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -82,7 +79,7 @@ fn command(
     let res = casted.month().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_nanosecond.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_nanosecond.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -82,7 +79,7 @@ fn command(
     let res = casted.nanosecond().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_ordinal.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_ordinal.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -82,7 +79,7 @@ fn command(
     let res = casted.ordinal().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_second.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_second.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -82,7 +79,7 @@ fn command(
     let res = casted.second().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_week.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_week.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -82,7 +79,7 @@ fn command(
     let res = casted.week().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_weekday.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_weekday.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -82,7 +79,7 @@ fn command(
     let res = casted.weekday().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/date/get_year.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/date/get_year.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::NuDataFrame;
 
@@ -82,7 +79,7 @@ fn command(
     let res = casted.year().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/indexes/arg_sort.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/indexes/arg_sort.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -125,7 +122,7 @@ fn command(
     res.rename("arg_sort");
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/indexes/arg_true.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/indexes/arg_true.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -103,7 +100,7 @@ fn command(
                 })?
                 .into();
 
-            to_pipeline_data(plugin, engine, call.head, res)
+            res.to_pipeline_data(plugin, engine, call.head)
         }
         _ => Err(ShellError::UnsupportedInput {
             msg: "Expected the dataframe to have a column".to_string(),

--- a/crates/nu_plugin_polars/src/dataframe/series/indexes/arg_unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/indexes/arg_unique.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -89,7 +86,7 @@ fn command(
     res.rename("arg_unique");
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/indexes/set_with_idx.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/indexes/set_with_idx.rs
@@ -1,8 +1,4 @@
-use crate::{
-    missing_flag_error,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{missing_flag_error, values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -212,7 +208,7 @@ fn command(
         }),
     }?;
 
-    to_pipeline_data(plugin, engine, call.head, res)
+    res.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/masks/is_duplicated.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/masks/is_duplicated.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -118,7 +115,7 @@ fn command(
     res.rename("is_duplicated");
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/masks/is_not_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/masks/is_not_null.rs
@@ -1,8 +1,5 @@
 use crate::{
-    values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, PolarsPluginObject,
-        PolarsPluginType,
-    },
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 
@@ -90,7 +87,7 @@ impl PluginCommand for IsNotNull {
             }
             PolarsPluginObject::NuExpression(expr) => {
                 let expr: NuExpression = expr.to_polars().is_not_null().into();
-                to_pipeline_data(plugin, engine, call.head, expr)
+                expr.to_pipeline_data(plugin, engine, call.head)
             }
             _ => Err(cant_convert_err(
                 &value,
@@ -115,7 +112,7 @@ fn command(
     res.rename("is_not_null");
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/masks/is_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/masks/is_null.rs
@@ -1,7 +1,6 @@
 use crate::{
     values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, NuExpression, PolarsPluginObject,
-        PolarsPluginType,
+        cant_convert_err, CustomValueSupport, NuExpression, PolarsPluginObject, PolarsPluginType,
     },
     PolarsPlugin,
 };
@@ -90,7 +89,7 @@ impl PluginCommand for IsNull {
             }
             PolarsPluginObject::NuExpression(expr) => {
                 let expr: NuExpression = expr.to_polars().is_null().into();
-                to_pipeline_data(plugin, engine, call.head, expr)
+                expr.to_pipeline_data(plugin, engine, call.head)
             }
             _ => Err(cant_convert_err(
                 &value,
@@ -115,7 +114,7 @@ fn command(
     res.rename("is_null");
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/masks/is_unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/masks/is_unique.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -118,7 +115,7 @@ fn command(
     res.rename("is_unique");
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/masks/not.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/masks/not.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
@@ -88,7 +85,7 @@ fn command(
     let res = bool.not();
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/masks/set.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/masks/set.rs
@@ -1,8 +1,4 @@
-use crate::{
-    missing_flag_error,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{missing_flag_error, values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -195,7 +191,7 @@ fn command(
         }),
     }?;
 
-    to_pipeline_data(plugin, engine, call.head, res)
+    res.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/n_null.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/n_null.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -78,7 +75,7 @@ fn command(
         vec![Column::new("count_null".to_string(), vec![value])],
         None,
     )?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/n_unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/n_unique.rs
@@ -1,8 +1,5 @@
 use crate::{
-    values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, PolarsPluginObject,
-        PolarsPluginType,
-    },
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 
@@ -82,7 +79,7 @@ impl PluginCommand for NUnique {
             }
             PolarsPluginObject::NuExpression(expr) => {
                 let expr: NuExpression = expr.to_polars().n_unique().into();
-                to_pipeline_data(plugin, engine, call.head, expr)
+                expr.to_pipeline_data(plugin, engine, call.head)
             }
             _ => Err(cant_convert_err(
                 &value,
@@ -120,7 +117,7 @@ fn command(
         vec![Column::new("count_unique".to_string(), vec![value])],
         None,
     )?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/rolling.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/rolling.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -181,7 +178,7 @@ fn command(
     res.rename(&name);
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/shift.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/shift.rs
@@ -1,9 +1,6 @@
 use crate::{
     dataframe::values::{NuExpression, NuLazyFrame},
-    values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, PolarsPluginObject,
-        PolarsPluginType,
-    },
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 
@@ -99,7 +96,7 @@ fn command_eager(
     let series = df.as_series(call.head)?.shift(period);
 
     let df = NuDataFrame::try_from_series_vec(vec![series], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 fn command_lazy(
@@ -121,7 +118,7 @@ fn command_lazy(
         None => lazy.shift(shift).into(),
     };
 
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/concatenate.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/concatenate.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -109,7 +106,7 @@ fn command(
     res.rename(series.name());
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/contains.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/contains.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -102,7 +99,7 @@ fn command(
         })?;
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/replace.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/replace.rs
@@ -1,8 +1,4 @@
-use crate::{
-    missing_flag_error,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{missing_flag_error, values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -117,7 +113,7 @@ fn command(
     res.rename(series.name());
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/replace_all.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/replace_all.rs
@@ -1,8 +1,4 @@
-use crate::{
-    missing_flag_error,
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{missing_flag_error, values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -119,7 +115,7 @@ fn command(
     res.rename(series.name());
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine_state, call.head, df)
+    df.to_pipeline_data(plugin, engine_state, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/str_lengths.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/str_lengths.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -83,7 +80,7 @@ fn command(
     let res = chunked.as_ref().str_len_bytes().into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/str_slice.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/str_slice.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -132,7 +129,7 @@ fn command(
         .with_name(series.name());
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/strftime.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/strftime.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -101,7 +98,7 @@ fn command(
         .into_series();
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/to_lowercase.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/to_lowercase.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -88,7 +85,7 @@ fn command(
     res.rename(series.name());
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/string/to_uppercase.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/string/to_uppercase.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::super::values::{Column, NuDataFrame};
 
@@ -92,7 +89,7 @@ fn command(
     res.rename(series.name());
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/unique.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/unique.rs
@@ -1,9 +1,6 @@
 use crate::{
     dataframe::{utils::extract_strings, values::NuLazyFrame},
-    values::{
-        cant_convert_err, to_pipeline_data, CustomValueSupport, PolarsPluginObject,
-        PolarsPluginType,
-    },
+    values::{cant_convert_err, CustomValueSupport, PolarsPluginObject, PolarsPluginType},
     PolarsPlugin,
 };
 
@@ -118,7 +115,7 @@ fn command_eager(
     })?;
 
     let df = NuDataFrame::try_from_series_vec(vec![res.into_series()], call.head)?;
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 fn command_lazy(
@@ -148,7 +145,7 @@ fn command_lazy(
     } else {
         lazy.unique_stable(subset, strategy).into()
     };
-    to_pipeline_data(plugin, engine, call.head, lazy)
+    lazy.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/series/value_counts.rs
+++ b/crates/nu_plugin_polars/src/dataframe/series/value_counts.rs
@@ -1,7 +1,4 @@
-use crate::{
-    values::{to_pipeline_data, CustomValueSupport},
-    PolarsPlugin,
-};
+use crate::{values::CustomValueSupport, PolarsPlugin};
 
 use super::super::values::{Column, NuDataFrame};
 
@@ -90,7 +87,7 @@ fn command(
         })?;
 
     let df: NuDataFrame = res.into();
-    to_pipeline_data(plugin, engine, call.head, df)
+    df.to_pipeline_data(plugin, engine, call.head)
 }
 
 #[cfg(test)]

--- a/crates/nu_plugin_polars/src/dataframe/values/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/mod.rs
@@ -302,44 +302,44 @@ pub trait CustomValueSupport: Cacheable {
             false
         }
     }
-}
 
-/// Wraps the cache and into_value calls.
-/// This function also does mapping back and forth
-/// between lazy and eager values and makes sure they
-/// are cached appropriately.
-pub fn cache_and_to_value(
-    plugin: &PolarsPlugin,
-    engine: &EngineInterface,
-    span: Span,
-    cv: impl CustomValueSupport,
-) -> Result<Value, ShellError> {
-    match cv.to_cache_value()? {
-        // if it was from a lazy value, make it lazy again
-        PolarsPluginObject::NuDataFrame(df) if df.from_lazy => {
-            let df = df.lazy();
-            Ok(df.cache(plugin, engine, span)?.into_value(span))
+    /// Wraps the cache and into_value calls.
+    /// This function also does mapping back and forth
+    /// between lazy and eager values and makes sure they
+    /// are cached appropriately.
+    fn cache_and_to_value(
+        self,
+        plugin: &PolarsPlugin,
+        engine: &EngineInterface,
+        span: Span,
+    ) -> Result<Value, ShellError> {
+        match self.to_cache_value()? {
+            // if it was from a lazy value, make it lazy again
+            PolarsPluginObject::NuDataFrame(df) if df.from_lazy => {
+                let df = df.lazy();
+                Ok(df.cache(plugin, engine, span)?.into_value(span))
+            }
+            // if it was from an eager value, make it eager again
+            PolarsPluginObject::NuLazyFrame(lf) if lf.from_eager => {
+                let lf = lf.collect(span)?;
+                Ok(lf.cache(plugin, engine, span)?.into_value(span))
+            }
+            _ => Ok(self.cache(plugin, engine, span)?.into_value(span)),
         }
-        // if it was from an eager value, make it eager again
-        PolarsPluginObject::NuLazyFrame(lf) if lf.from_eager => {
-            let lf = lf.collect(span)?;
-            Ok(lf.cache(plugin, engine, span)?.into_value(span))
-        }
-        _ => Ok(cv.cache(plugin, engine, span)?.into_value(span)),
     }
-}
 
-/// Caches the object, converts it to a it's CustomValue counterpart
-/// And creates a pipeline data object out of it
-#[inline]
-pub fn to_pipeline_data(
-    plugin: &PolarsPlugin,
-    engine: &EngineInterface,
-    span: Span,
-    cv: impl CustomValueSupport,
-) -> Result<PipelineData, ShellError> {
-    Ok(PipelineData::Value(
-        cache_and_to_value(plugin, engine, span, cv)?,
-        None,
-    ))
+    /// Caches the object, converts it to a it's CustomValue counterpart
+    /// And creates a pipeline data object out of it
+    #[inline]
+    fn to_pipeline_data(
+        self,
+        plugin: &PolarsPlugin,
+        engine: &EngineInterface,
+        span: Span,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(PipelineData::Value(
+            self.cache_and_to_value(plugin, engine, span)?,
+            None,
+        ))
+    }
 }


### PR DESCRIPTION
# Description

This is just some cleanup. I moved to_pipeline_data and to_cache_value to the CustomValueSupport trait, where I should've put them to begin with.
