### PR TITLE
Unify `working_set.error` usage.

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -459,7 +459,7 @@ pub fn parse_def(
                         let block = working_set.get_block_mut(*block_id);
                         block.signature = Box::new(sig.clone());
                     }
-                    _ => working_set.parse_errors.push(ParseError::Expected(
+                    _ => working_set.error(ParseError::Expected(
                         "definition body closure { ... }",
                         arg.span,
                     )),
@@ -2957,7 +2957,7 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                     );
 
                     if let Some(parse_error) = parse_error {
-                        working_set.parse_errors.push(parse_error)
+                        working_set.error(parse_error)
                     }
 
                     let rvalue_span = nu_protocol::span(&spans[(span.0 + 1)..]);
@@ -3221,7 +3221,7 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                     );
 
                     if let Some(parse_error) = parse_error {
-                        working_set.parse_errors.push(parse_error)
+                        working_set.error(parse_error);
                     }
 
                     let rvalue_span = nu_protocol::span(&spans[(span.0 + 1)..]);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2915,7 +2915,7 @@ pub fn parse_var_with_opt_type(
                 lex_signature(&type_bytes, full_span.start, &[b','], &[], true);
 
             if let Some(parse_error) = parse_error {
-                working_set.parse_errors.push(parse_error);
+                working_set.error(parse_error);
             }
 
             let ty = parse_type(working_set, &type_bytes, tokens[0].span);
@@ -3045,7 +3045,7 @@ pub fn parse_input_output_types(
         lex_signature(bytes, full_span.start, &[b'\n', b'\r', b','], &[], true);
 
     if let Some(parse_error) = parse_error {
-        working_set.parse_errors.push(parse_error);
+        working_set.error(parse_error);
     }
 
     let mut output = vec![];


### PR DESCRIPTION
# Description
A little refactor that use `working_set.error` rather than `working_set.parse_errors.push`, which is reported here: https://github.com/nushell/nushell/pull/12238

> Inconsistent error reporting. Usage of both working_set.error() and working_set.parse_errors.push(). Using ParseError::Expected for an invalid variable name when there's ParseError::VariableNotValid (from parser.rs:5237). Checking variable names manually when there's is_variable() (from parser.rs:2905).

# User-Facing Changes
NaN

# Tests + Formatting
Done
