### PR TITLE
Python plugin: remove unnecessary fields from signature

### DIFF
--- a/crates/nu_plugin_python/nu_plugin_python_example.py
+++ b/crates/nu_plugin_python/nu_plugin_python_example.py
@@ -45,20 +45,16 @@ def signatures():
                     "name": "nu-python",
                     "usage": "Signature test for Python",
                     "extra_usage": "",
-                    "input_type": "Any",
-                    "output_type": "Any",
                     "required_positional": [
                         {
                             "name": "a",
                             "desc": "required integer value",
                             "shape": "Int",
-                            "var_id": None,
                         },
                         {
                             "name": "b",
                             "desc": "required string value",
                             "shape": "String",
-                            "var_id": None,
                         },
                     ],
                     "optional_positional": [
@@ -66,14 +62,12 @@ def signatures():
                             "name": "opt",
                             "desc": "Optional number",
                             "shape": "Int",
-                            "var_id": None,
                         }
                     ],
                     "rest_positional": {
                         "name": "rest",
                         "desc": "rest value string",
                         "shape": "String",
-                        "var_id": None,
                     },
                     "named": [
                         {
@@ -82,7 +76,6 @@ def signatures():
                             "arg": None,
                             "required": False,
                             "desc": "Display the help message for this command",
-                            "var_id": None,
                         },
                         {
                             "long": "flag",
@@ -90,7 +83,6 @@ def signatures():
                             "arg": None,
                             "required": False,
                             "desc": "a flag for the signature",
-                            "var_id": None,
                         },
                         {
                             "long": "named",
@@ -98,7 +90,6 @@ def signatures():
                             "arg": "String",
                             "required": False,
                             "desc": "named string",
-                            "var_id": None,
                         },
                     ],
                     "input_output_types": [["Any", "Any"]],


### PR DESCRIPTION
# Description
Remove a couple of legacy fields (`input_type`, `output_type`), and
`var_id` which is optional and not required for deserialization.

I think until I document this in the plugin protocol ref, most people
will probably be using this example to get started, so it should be as
correct as possible

# After Submitting
- [ ] TODO: document `Signature` in plugin protocol reference
