### PR TITLE
Remove stepped ranges

### DIFF
--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -225,42 +225,14 @@ impl<'a> std::fmt::Debug for DebuggableValue<'a> {
             }
             Value::Range { val, .. } => match val {
                 Range::IntRange(range) => match range.end() {
-                    Bound::Included(end) => write!(
-                        f,
-                        "Range({:?}..{:?}, step: {:?})",
-                        range.start(),
-                        end,
-                        range.step(),
-                    ),
-                    Bound::Excluded(end) => write!(
-                        f,
-                        "Range({:?}..<{:?}, step: {:?})",
-                        range.start(),
-                        end,
-                        range.step(),
-                    ),
-                    Bound::Unbounded => {
-                        write!(f, "Range({:?}.., step: {:?})", range.start(), range.step())
-                    }
+                    Bound::Included(end) => write!(f, "Range({:?}..{:?})", range.start(), end),
+                    Bound::Excluded(end) => write!(f, "Range({:?}..<{:?})", range.start(), end),
+                    Bound::Unbounded => write!(f, "Range({:?}..)", range.start()),
                 },
                 Range::FloatRange(range) => match range.end() {
-                    Bound::Included(end) => write!(
-                        f,
-                        "Range({:?}..{:?}, step: {:?})",
-                        range.start(),
-                        end,
-                        range.step(),
-                    ),
-                    Bound::Excluded(end) => write!(
-                        f,
-                        "Range({:?}..<{:?}, step: {:?})",
-                        range.start(),
-                        end,
-                        range.step(),
-                    ),
-                    Bound::Unbounded => {
-                        write!(f, "Range({:?}.., step: {:?})", range.start(), range.step())
-                    }
+                    Bound::Included(end) => write!(f, "Range({:?}..{:?})", range.start(), end,),
+                    Bound::Excluded(end) => write!(f, "Range({:?}..<{:?})", range.start(), end,),
+                    Bound::Unbounded => write!(f, "Range({:?}..)", range.start()),
                 },
             },
             Value::String { val, .. } | Value::Glob { val, .. } => {

--- a/crates/nu-command/src/filters/drop/nth.rs
+++ b/crates/nu-command/src/filters/drop/nth.rs
@@ -134,7 +134,7 @@ impl Command for DropNth {
                     });
                 }
                 // check if the upper bound is smaller than the lower bound, e.g., do not accept 4..2
-                if range.step() < 0 {
+                if !range.is_ascending() {
                     return Err(ShellError::UnsupportedInput {
                         msg: "The upper bound needs to be equal or larger to the lower bound"
                             .into(),

--- a/crates/nu-command/src/filters/range.rs
+++ b/crates/nu-command/src/filters/range.rs
@@ -74,10 +74,10 @@ impl Command for Range {
                     Bound::Included(end) => end,
                     Bound::Excluded(end) => end - 1,
                     Bound::Unbounded => {
-                        if range.step() < 0 {
-                            i64::MIN
-                        } else {
+                        if range.is_ascending() {
                             i64::MAX
+                        } else {
+                            i64::MIN
                         }
                     }
                 };

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -272,7 +272,7 @@ fn convert_to_value(
             msg: "operators not supported in nuon".into(),
             span: expr.span,
         }),
-        Expr::Range(from, to, operator) => {
+        Expr::Range(from, op, to) => {
             let from = if let Some(f) = from {
                 convert_to_value(*f, span, original_text)?
             } else {
@@ -285,10 +285,7 @@ fn convert_to_value(
                 Value::nothing(expr.span)
             };
 
-            Ok(Value::range(
-                Range::new(from, to, operator.inclusion)?,
-                expr.span,
-            ))
+            Ok(Value::range(Range::new(from, op.inclusion, to)?, expr.span))
         }
         Expr::Record(key_vals) => {
             let mut record = Record::with_capacity(key_vals.len());

--- a/crates/nu-command/src/formats/from/nuon.rs
+++ b/crates/nu-command/src/formats/from/nuon.rs
@@ -272,15 +272,9 @@ fn convert_to_value(
             msg: "operators not supported in nuon".into(),
             span: expr.span,
         }),
-        Expr::Range(from, next, to, operator) => {
+        Expr::Range(from, to, operator) => {
             let from = if let Some(f) = from {
                 convert_to_value(*f, span, original_text)?
-            } else {
-                Value::nothing(expr.span)
-            };
-
-            let next = if let Some(s) = next {
-                convert_to_value(*s, span, original_text)?
             } else {
                 Value::nothing(expr.span)
             };
@@ -292,7 +286,7 @@ fn convert_to_value(
             };
 
             Ok(Value::range(
-                Range::new(from, next, to, operator.inclusion, expr.span)?,
+                Range::new(from, to, operator.inclusion)?,
                 expr.span,
             ))
         }

--- a/crates/nu-command/src/random/float.rs
+++ b/crates/nu-command/src/random/float.rs
@@ -78,7 +78,7 @@ fn float(
             let range_span = range.span;
             let range = FloatRange::from(range.item);
 
-            if range.step() < 0.0 {
+            if !range.is_ascending() {
                 return Err(ShellError::InvalidRange {
                     left_flank: range.start().to_string(),
                     right_flank: match range.end() {

--- a/crates/nu-command/src/random/int.rs
+++ b/crates/nu-command/src/random/int.rs
@@ -78,7 +78,7 @@ fn integer(
             let range_span = range.span;
             match range.item {
                 Range::IntRange(range) => {
-                    if range.step() < 0 {
+                    if !range.is_ascending() {
                         return Err(ShellError::InvalidRange {
                             left_flank: range.start().to_string(),
                             right_flank: match range.end() {

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -267,8 +267,8 @@ mod tests {
         let word = Value::test_string("Cargo.Cargo");
         let range = Range::new(
             Value::int(1, Span::test_data()),
-            Value::nothing(Span::test_data()),
             RangeInclusion::Inclusive,
+            Value::nothing(Span::test_data()),
         )
         .expect("valid range");
 
@@ -295,8 +295,8 @@ mod tests {
         let word = Value::test_string("Cargo.Banana");
         let range = Range::new(
             Value::nothing(Span::test_data()),
-            Value::int(5, Span::test_data()),
             RangeInclusion::Inclusive,
+            Value::int(5, Span::test_data()),
         )
         .expect("valid range");
 
@@ -323,8 +323,8 @@ mod tests {
         let word = Value::test_string("123123123");
         let range = Range::new(
             Value::int(2, Span::test_data()),
-            Value::int(6, Span::test_data()),
             RangeInclusion::Inclusive,
+            Value::int(6, Span::test_data()),
         )
         .expect("valid range");
 
@@ -351,8 +351,8 @@ mod tests {
         let word = Value::test_string("123456");
         let range = Range::new(
             Value::int(2, Span::test_data()),
-            Value::int(5, Span::test_data()),
             RangeInclusion::RightExclusive,
+            Value::int(5, Span::test_data()),
         )
         .expect("valid range");
 
@@ -396,8 +396,8 @@ mod tests {
 
         let range = Range::new(
             Value::int(0, Span::test_data()),
-            Value::int(3, Span::test_data()),
             RangeInclusion::Inclusive,
+            Value::int(3, Span::test_data()),
         )
         .expect("valid range");
 
@@ -425,8 +425,8 @@ mod tests {
 
         let range = Range::new(
             Value::int(-1, Span::test_data()),
-            Value::int(3, Span::test_data()),
             RangeInclusion::Inclusive,
+            Value::int(3, Span::test_data()),
         )
         .expect("valid range");
 

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -268,9 +268,7 @@ mod tests {
         let range = Range::new(
             Value::int(1, Span::test_data()),
             Value::nothing(Span::test_data()),
-            Value::nothing(Span::test_data()),
             RangeInclusion::Inclusive,
-            Span::test_data(),
         )
         .expect("valid range");
 
@@ -297,10 +295,8 @@ mod tests {
         let word = Value::test_string("Cargo.Banana");
         let range = Range::new(
             Value::nothing(Span::test_data()),
-            Value::nothing(Span::test_data()),
             Value::int(5, Span::test_data()),
             RangeInclusion::Inclusive,
-            Span::test_data(),
         )
         .expect("valid range");
 
@@ -327,10 +323,8 @@ mod tests {
         let word = Value::test_string("123123123");
         let range = Range::new(
             Value::int(2, Span::test_data()),
-            Value::nothing(Span::test_data()),
             Value::int(6, Span::test_data()),
             RangeInclusion::Inclusive,
-            Span::test_data(),
         )
         .expect("valid range");
 
@@ -357,10 +351,8 @@ mod tests {
         let word = Value::test_string("123456");
         let range = Range::new(
             Value::int(2, Span::test_data()),
-            Value::nothing(Span::test_data()),
             Value::int(5, Span::test_data()),
             RangeInclusion::RightExclusive,
-            Span::test_data(),
         )
         .expect("valid range");
 
@@ -404,10 +396,8 @@ mod tests {
 
         let range = Range::new(
             Value::int(0, Span::test_data()),
-            Value::int(1, Span::test_data()),
             Value::int(3, Span::test_data()),
             RangeInclusion::Inclusive,
-            Span::test_data(),
         )
         .expect("valid range");
 
@@ -435,10 +425,8 @@ mod tests {
 
         let range = Range::new(
             Value::int(-1, Span::test_data()),
-            Value::int(1, Span::test_data()),
             Value::int(3, Span::test_data()),
             RangeInclusion::Inclusive,
-            Span::test_data(),
         )
         .expect("valid range");
 

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -345,14 +345,10 @@ pub fn flatten_expression(
         Expr::Overlay(_) => {
             vec![(expr.span, FlatShape::String)]
         }
-        Expr::Range(from, next, to, op) => {
+        Expr::Range(from, to, op) => {
             let mut output = vec![];
             if let Some(f) = from {
                 output.extend(flatten_expression(working_set, f));
-            }
-            if let Some(s) = next {
-                output.extend(vec![(op.next_op_span, FlatShape::Operator)]);
-                output.extend(flatten_expression(working_set, s));
             }
             output.extend(vec![(op.span, FlatShape::Operator)]);
             if let Some(t) = to {

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -345,7 +345,7 @@ pub fn flatten_expression(
         Expr::Overlay(_) => {
             vec![(expr.span, FlatShape::String)]
         }
-        Expr::Range(from, to, op) => {
+        Expr::Range(from, op, to) => {
             let mut output = vec![];
             if let Some(f) = from {
                 output.extend(flatten_expression(working_set, f));

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1445,9 +1445,8 @@ pub fn parse_number(working_set: &mut StateWorkingSet, span: Span) -> Expression
 pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     trace!("parsing: range");
 
-    // Range follows the following syntax: [<from>][<next_operator><next>]<range_operator>[<to>]
-    //   where <next_operator> is ".."
-    //   and  <range_operator> is "..", "..=" or "..<"
+    // Range follows the following syntax: [<from>]<range_operator>[<to>]
+    //   where <range_operator> is "..", "..=" or "..<"
     //   and one of the <from> or <to> bounds must be present (just '..' is not allowed since it
     //     looks like parent directory)
     //bugbug range cannot be [..] because that looks like parent directory
@@ -1576,7 +1575,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression 
     };
 
     Expression {
-        expr: Expr::Range(from, next, to, range_op),
+        expr: Expr::Range(from, to, range_op),
         span,
         ty: Type::Range,
         custom_completion: None,
@@ -5991,14 +5990,11 @@ pub fn discover_captures_in_expr(
             }
         }
         Expr::Operator(_) => {}
-        Expr::Range(expr1, expr2, expr3, _) => {
-            if let Some(expr) = expr1 {
+        Expr::Range(from, to, _) => {
+            if let Some(expr) = from {
                 discover_captures_in_expr(working_set, expr, seen, seen_blocks, output)?;
             }
-            if let Some(expr) = expr2 {
-                discover_captures_in_expr(working_set, expr, seen, seen_blocks, output)?;
-            }
-            if let Some(expr) = expr3 {
+            if let Some(expr) = to {
                 discover_captures_in_expr(working_set, expr, seen, seen_blocks, output)?;
             }
         }

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -988,7 +988,6 @@ mod range {
         assert!(element.redirection.is_none());
         if let Expr::Range(
             Some(_),
-            None,
             Some(_),
             RangeOperator {
                 inclusion: the_inclusion,
@@ -1042,7 +1041,6 @@ mod range {
         assert!(element.redirection.is_none());
         if let Expr::Range(
             Some(_),
-            None,
             Some(_),
             RangeOperator {
                 inclusion: the_inclusion,
@@ -1084,7 +1082,6 @@ mod range {
         if let Expr::Range(
             Some(_),
             None,
-            None,
             RangeOperator {
                 inclusion: the_inclusion,
                 ..
@@ -1124,7 +1121,6 @@ mod range {
         assert!(element.redirection.is_none());
         if let Expr::Range(
             None,
-            None,
             Some(_),
             RangeOperator {
                 inclusion: the_inclusion,
@@ -1142,9 +1138,9 @@ mod range {
     }
 
     #[rstest]
-    #[case(b"2.0..4.0..10.0", RangeInclusion::Inclusive, "float inclusive")]
-    #[case(b"2.0..4.0..=10.0", RangeInclusion::Inclusive, "float =inclusive")]
-    #[case(b"2.0..4.0..<10.0", RangeInclusion::RightExclusive, "float exclusive")]
+    #[case(b"2.0..10.0", RangeInclusion::Inclusive, "float inclusive")]
+    #[case(b"2.0..=10.0", RangeInclusion::Inclusive, "float =inclusive")]
+    #[case(b"2.0..<10.0", RangeInclusion::RightExclusive, "float exclusive")]
 
     fn parse_float_range(
         #[case] phrase: &[u8],
@@ -1164,7 +1160,6 @@ mod range {
         let element = &pipeline.elements[0];
         assert!(element.redirection.is_none());
         if let Expr::Range(
-            Some(_),
             Some(_),
             Some(_),
             RangeOperator {

--- a/crates/nu-parser/tests/test_parser.rs
+++ b/crates/nu-parser/tests/test_parser.rs
@@ -988,11 +988,11 @@ mod range {
         assert!(element.redirection.is_none());
         if let Expr::Range(
             Some(_),
-            Some(_),
             RangeOperator {
                 inclusion: the_inclusion,
                 ..
             },
+            Some(_),
         ) = element.expr.expr
         {
             assert_eq!(
@@ -1041,11 +1041,11 @@ mod range {
         assert!(element.redirection.is_none());
         if let Expr::Range(
             Some(_),
-            Some(_),
             RangeOperator {
                 inclusion: the_inclusion,
                 ..
             },
+            Some(_),
         ) = element.expr.expr
         {
             assert_eq!(
@@ -1081,11 +1081,11 @@ mod range {
         assert!(element.redirection.is_none());
         if let Expr::Range(
             Some(_),
-            None,
             RangeOperator {
                 inclusion: the_inclusion,
                 ..
             },
+            None,
         ) = element.expr.expr
         {
             assert_eq!(
@@ -1121,11 +1121,11 @@ mod range {
         assert!(element.redirection.is_none());
         if let Expr::Range(
             None,
-            Some(_),
             RangeOperator {
                 inclusion: the_inclusion,
                 ..
             },
+            Some(_),
         ) = element.expr.expr
         {
             assert_eq!(
@@ -1161,11 +1161,11 @@ mod range {
         assert!(element.redirection.is_none());
         if let Expr::Range(
             Some(_),
-            Some(_),
             RangeOperator {
                 inclusion: the_inclusion,
                 ..
             },
+            Some(_),
         ) = element.expr.expr
         {
             assert_eq!(

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -18,8 +18,8 @@ pub enum Expr {
     Binary(Vec<u8>),
     Range(
         Option<Box<Expression>>, // from
-        Option<Box<Expression>>, // to
         RangeOperator,
+        Option<Box<Expression>>, // to
     ),
     Var(VarId),
     VarDecl(VarId),

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -18,7 +18,6 @@ pub enum Expr {
     Binary(Vec<u8>),
     Range(
         Option<Box<Expression>>, // from
-        Option<Box<Expression>>, // next value after "from"
         Option<Box<Expression>>, // to
         RangeOperator,
     ),
@@ -73,7 +72,7 @@ impl Expr {
             | Expr::Int(_)
             | Expr::Float(_)
             | Expr::Binary(_)
-            | Expr::Range(_, _, _, _)
+            | Expr::Range(_, _, _)
             | Expr::Var(_)
             | Expr::UnaryNot(_)
             | Expr::BinaryOp(_, _, _)

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -230,14 +230,9 @@ impl Expression {
             }
             Expr::Operator(_) => false,
             Expr::MatchBlock(_) => false,
-            Expr::Range(left, middle, right, ..) => {
+            Expr::Range(left, right, ..) => {
                 if let Some(left) = &left {
                     if left.has_in_variable(working_set) {
-                        return true;
-                    }
-                }
-                if let Some(middle) = &middle {
-                    if middle.has_in_variable(working_set) {
                         return true;
                     }
                 }
@@ -399,12 +394,9 @@ impl Expression {
                 }
             }
             Expr::Operator(_) => {}
-            Expr::Range(left, middle, right, ..) => {
+            Expr::Range(left, right, ..) => {
                 if let Some(left) = left {
                     left.replace_span(working_set, replaced, new_span)
-                }
-                if let Some(middle) = middle {
-                    middle.replace_span(working_set, replaced, new_span)
                 }
                 if let Some(right) = right {
                     right.replace_span(working_set, replaced, new_span)

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -230,7 +230,7 @@ impl Expression {
             }
             Expr::Operator(_) => false,
             Expr::MatchBlock(_) => false,
-            Expr::Range(left, right, ..) => {
+            Expr::Range(left, _, right) => {
                 if let Some(left) = &left {
                     if left.has_in_variable(working_set) {
                         return true;
@@ -394,7 +394,7 @@ impl Expression {
                 }
             }
             Expr::Operator(_) => {}
-            Expr::Range(left, right, ..) => {
+            Expr::Range(left, _, right) => {
                 if let Some(left) = left {
                     left.replace_span(working_set, replaced, new_span)
                 }

--- a/crates/nu-protocol/src/ast/operator.rs
+++ b/crates/nu-protocol/src/ast/operator.rs
@@ -109,7 +109,7 @@ impl Display for Operator {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RangeInclusion {
     Inclusive,
     RightExclusive,
@@ -119,7 +119,6 @@ pub enum RangeInclusion {
 pub struct RangeOperator {
     pub inclusion: RangeInclusion,
     pub span: Span,
-    pub next_op_span: Span,
 }
 
 impl Display for RangeOperator {

--- a/crates/nu-protocol/src/debugger/profiler.rs
+++ b/crates/nu-protocol/src/debugger/profiler.rs
@@ -249,7 +249,7 @@ fn expr_to_string(engine_state: &EngineState, expr: &Expr) -> String {
         Expr::Nothing => "nothing".to_string(),
         Expr::Operator(_) => "operator".to_string(),
         Expr::Overlay(_) => "overlay".to_string(),
-        Expr::Range(_, _, _, _) => "range".to_string(),
+        Expr::Range(_, _, _) => "range".to_string(),
         Expr::Record(_) => "record".to_string(),
         Expr::RowCondition(_) => "row condition".to_string(),
         Expr::Signature(_) => "signature".to_string(),

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -153,7 +153,7 @@ impl Matcher for Pattern {
                             false
                         }
                     }
-                    Expr::Range(start, step, end, inclusion) => {
+                    Expr::Range(start, end, inclusion) => {
                         // TODO: Add support for floats
 
                         let start = if let Some(start) = &start {
@@ -174,17 +174,6 @@ impl Matcher for Pattern {
                             i64::MAX
                         };
 
-                        let step = if let Some(step) = step {
-                            match &step.expr {
-                                Expr::Int(step) => *step - start,
-                                _ => return false,
-                            }
-                        } else if end < start {
-                            -1
-                        } else {
-                            1
-                        };
-
                         let (start, end) = if end < start {
                             (end, start)
                         } else {
@@ -193,9 +182,9 @@ impl Matcher for Pattern {
 
                         if let Value::Int { val, .. } = &value {
                             if matches!(inclusion.inclusion, RangeInclusion::RightExclusive) {
-                                *val >= start && *val < end && ((*val - start) % step) == 0
+                                *val >= start && *val < end
                             } else {
-                                *val >= start && *val <= end && ((*val - start) % step) == 0
+                                *val >= start && *val <= end
                             }
                         } else {
                             false

--- a/crates/nu-protocol/src/engine/pattern_match.rs
+++ b/crates/nu-protocol/src/engine/pattern_match.rs
@@ -153,7 +153,7 @@ impl Matcher for Pattern {
                             false
                         }
                     }
-                    Expr::Range(start, end, inclusion) => {
+                    Expr::Range(start, op, end) => {
                         // TODO: Add support for floats
 
                         let start = if let Some(start) = &start {
@@ -181,7 +181,7 @@ impl Matcher for Pattern {
                         };
 
                         if let Value::Int { val, .. } = &value {
-                            if matches!(inclusion.inclusion, RangeInclusion::RightExclusive) {
+                            if matches!(op.inclusion, RangeInclusion::RightExclusive) {
                                 *val >= start && *val < end
                             } else {
                                 *val >= start && *val <= end

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -150,15 +150,9 @@ pub trait Eval {
             Expr::Subexpression(block_id) => {
                 Self::eval_subexpression::<D>(state, mut_state, *block_id, expr.span)
             }
-            Expr::Range(from, next, to, operator) => {
+            Expr::Range(from, to, operator) => {
                 let from = if let Some(f) = from {
                     Self::eval::<D>(state, mut_state, f)?
-                } else {
-                    Value::nothing(expr.span)
-                };
-
-                let next = if let Some(s) = next {
-                    Self::eval::<D>(state, mut_state, s)?
                 } else {
                     Value::nothing(expr.span)
                 };
@@ -170,7 +164,7 @@ pub trait Eval {
                 };
 
                 Ok(Value::range(
-                    Range::new(from, next, to, operator.inclusion, expr.span)?,
+                    Range::new(from, to, operator.inclusion)?,
                     expr.span,
                 ))
             }

--- a/crates/nu-protocol/src/eval_base.rs
+++ b/crates/nu-protocol/src/eval_base.rs
@@ -150,7 +150,7 @@ pub trait Eval {
             Expr::Subexpression(block_id) => {
                 Self::eval_subexpression::<D>(state, mut_state, *block_id, expr.span)
             }
-            Expr::Range(from, to, operator) => {
+            Expr::Range(from, op, to) => {
                 let from = if let Some(f) = from {
                     Self::eval::<D>(state, mut_state, f)?
                 } else {
@@ -164,7 +164,7 @@ pub trait Eval {
                 };
 
                 Ok(Value::range(
-                    Range::new(from, to, operator.inclusion)?,
+                    Range::new(from, op.inclusion, to)?,
                     expr.span,
                 ))
             }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2182,7 +2182,6 @@ impl Value {
             Value::test_date(DateTime::UNIX_EPOCH.into()),
             Value::test_range(Range::IntRange(IntRange {
                 start: 0,
-                step: 1,
                 end: Bound::Excluded(0),
             })),
             Value::test_float(0.0),

--- a/crates/nu-protocol/src/value/range.rs
+++ b/crates/nu-protocol/src/value/range.rs
@@ -27,8 +27,8 @@ mod int_range {
     impl IntRange {
         pub fn new(
             start: Value,
-            end: Value,
             inclusion: RangeInclusion,
+            end: Value,
         ) -> Result<Self, ShellError> {
             fn to_int(value: Value) -> Result<Option<i64>, ShellError> {
                 match value {
@@ -218,8 +218,8 @@ mod float_range {
     impl FloatRange {
         pub fn new(
             start: Value,
-            end: Value,
             inclusion: RangeInclusion,
+            end: Value,
         ) -> Result<Self, ShellError> {
             fn to_float(value: Value) -> Result<Option<f64>, ShellError> {
                 match value {
@@ -451,12 +451,12 @@ pub enum Range {
 }
 
 impl Range {
-    pub fn new(start: Value, end: Value, inclusion: RangeInclusion) -> Result<Self, ShellError> {
+    pub fn new(start: Value, inclusion: RangeInclusion, end: Value) -> Result<Self, ShellError> {
         // promote to float range if any Value is float
         if matches!(start, Value::Float { .. }) || matches!(end, Value::Float { .. }) {
-            FloatRange::new(start, end, inclusion).map(Self::FloatRange)
+            FloatRange::new(start, inclusion, end).map(Self::FloatRange)
         } else {
-            IntRange::new(start, end, inclusion).map(Self::IntRange)
+            IntRange::new(start, inclusion, end).map(Self::IntRange)
         }
     }
 

--- a/src/tests/test_ranges.rs
+++ b/src/tests/test_ranges.rs
@@ -27,7 +27,7 @@ fn float_not_in_inc_range() -> TestResult {
 
 #[test]
 fn range_and_reduction() -> TestResult {
-    run_test(r#"1..6..36 | math sum"#, "148")
+    run_test(r#"1..36 | math sum"#, "666")
 }
 
 #[test]


### PR DESCRIPTION
# Description

This PR removes stepped ranges from the language (e.g., `0..5..20`). Why?

1. Simplifies the language. Supporting stepped ranges potentially makes commands more complex or makes handling arguments more annoying. E.g., `range 0..2..` should either error or actually select every other row. (Either way, the `every` command already covers this use case.)
2. Related to / because of `1.` stepped ranges have limited support. In the process of writing this PR, I didn't find a single command that handled, let alone even used the step value (#11521).
3. Stepped ranges have a potentially confusing syntax (#11086).
4. Stepped ranges have limited use cases / add little value. I think the main use case is simply to create a sequence of values. But the `seq` command already exists, and it should have all the same functionality.
   Edit: stepped ranges would allow for stepped slicing (e.g., like `arr[start:end:2]` in python). Not sure what the common use case for this is, but I'm guessing 2d arrays and images where a row stride is desired. However, I'm not sure how applicable or useful this would be for nushell. E.g., operations are usually over streams, and the `every` command already covers stepping behavior for streams.

As a side effect, this PR fixes #9417 (panic while parsing ranges).

# User-Facing Changes
This will break existing code that uses stepped ranges. Users will have to switch to using `seq`.

# After Submitting
Update the book and language guide. Language grammars will also need to be updated.