### PR TITLE
Improve safety of `get_unchecked_str` in `nu_system::macos`

### DIFF
--- a/crates/nu-system/src/macos.rs
+++ b/crates/nu-system/src/macos.rs
@@ -146,11 +146,9 @@ pub struct PathInfo {
 
 #[cfg_attr(tarpaulin, ignore)]
 unsafe fn get_unchecked_str(cp: *mut u8, start: *mut u8) -> String {
-    let len = cp as usize - start as usize;
-    let part = Vec::from_raw_parts(start, len, len);
-    let tmp = String::from_utf8_unchecked(part.clone());
-    ::std::mem::forget(part);
-    tmp
+    let len = (cp as usize).saturating_sub(start as usize);
+    let part = std::slice::from_raw_parts(start, len);
+    String::from_utf8_unchecked(part.to_vec())
 }
 
 #[cfg_attr(tarpaulin, ignore)]


### PR DESCRIPTION
# Description
The implementation of this function had a few issues before:

- It didn't check that the `cp` pointer is actually ahead of the `start` pointer, so `len` could potentially underflow and wrap around, which would be a violation of memory safety
- It used `Vec::from_raw_parts` even though the buffer is borrowed, not owned. Although `std::mem::forget` is used later to ensure the destructor doesn't run, there is a risk that the destructor would run if a panic happened during `String::from_utf8_unchecked`, which would lead to a `free()` of a pointer we don't own
