### PR TITLE
ensure negative numbers aren't parsed as short flags

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -453,7 +453,10 @@ fn parse_short_flags(
     let arg_contents = working_set.get_span_contents(arg_span);
 
     if let Ok(arg_contents_uft8_ref) = str::from_utf8(arg_contents) {
-        if arg_contents_uft8_ref.starts_with('-') && arg_contents_uft8_ref.len() > 1 {
+        if arg_contents_uft8_ref.starts_with('-')
+            && arg_contents_uft8_ref.len() > 1
+            && arg_contents_uft8_ref.parse::<f64>().is_err()
+        {
             let short_flags = &arg_contents_uft8_ref[1..];
             let num_chars = short_flags.chars().count();
             let mut found_short_flags = vec![];


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Resolves #11930, the main cause of which was the `-1` float argument being parsed as a short flag instead of a positional argument. 

I am slightly concerned that this might cause issues I don't realise right now, although I don't recall any nushell flags being interpretable as negative numbers... 


# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Disallow `def`s from having negative numbers as flags?