### PR TITLE
Don't allow skip on external stream

### DIFF
--- a/crates/nu-command/src/filters/skip/skip_.rs
+++ b/crates/nu-command/src/filters/skip/skip_.rs
@@ -87,43 +87,12 @@ impl Command for Skip {
         let ctrlc = engine_state.ctrlc.clone();
         let input_span = input.span().unwrap_or(call.head);
         match input {
-            PipelineData::ExternalStream {
-                stdout: Some(stream),
-                span: bytes_span,
-                metadata,
-                ..
-            } => {
-                let mut remaining = n;
-                let mut output = vec![];
-
-                for frame in stream {
-                    let frame = frame?;
-
-                    match frame {
-                        Value::String { val, .. } => {
-                            let bytes = val.as_bytes();
-                            if bytes.len() < remaining {
-                                remaining -= bytes.len();
-                                //output.extend_from_slice(bytes)
-                            } else {
-                                output.extend_from_slice(&bytes[remaining..]);
-                                break;
-                            }
-                        }
-                        Value::Binary { val: bytes, .. } => {
-                            if bytes.len() < remaining {
-                                remaining -= bytes.len();
-                            } else {
-                                output.extend_from_slice(&bytes[remaining..]);
-                                break;
-                            }
-                        }
-                        _ => unreachable!("Raw streams are either bytes or strings"),
-                    }
-                }
-
-                Ok(Value::binary(output, bytes_span).into_pipeline_data_with_metadata(metadata))
-            }
+            PipelineData::ExternalStream { .. } => Err(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "list, binary or range".into(),
+                wrong_type: "raw data".into(),
+                dst_span: call.head,
+                src_span: input_span,
+            }),
             PipelineData::Value(Value::Binary { val, .. }, metadata) => {
                 let bytes = val.into_iter().skip(n).collect::<Vec<_>>();
 

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -7,7 +7,7 @@ fn binary_skip_will_raise_error() {
         "open sample_data.ods --raw | skip 2"
     );
 
-    assert!(actual.out.contains("only_supports_this_input_type"));
+    assert!(actual.err.contains("only_supports_this_input_type"));
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/skip/skip_.rs
+++ b/crates/nu-command/tests/commands/skip/skip_.rs
@@ -1,18 +1,13 @@
-use nu_test_support::{nu, pipeline};
+use nu_test_support::nu;
 
 #[test]
-fn binary_skip() {
+fn binary_skip_will_raise_error() {
     let actual = nu!(
-        cwd: "tests/fixtures/formats", pipeline(
-        r#"
-            open sample_data.ods --raw |
-            skip 2 |
-            take 2 |
-            into int --endian big
-        "#
-    ));
+        cwd: "tests/fixtures/formats",
+        "open sample_data.ods --raw | skip 2"
+    );
 
-    assert_eq!(actual.out, "772");
+    assert!(actual.out.contains("only_supports_this_input_type"));
 }
 
 #[test]


### PR DESCRIPTION
# Description
Close: #12514

# User-Facing Changes
`^ls | skip 1` will raise an error
```nushell
❯ ^ls | skip 1
Error: nu::shell::only_supports_this_input_type

  × Input type not supported.
   ╭─[entry #1:1:2]
 1 │ ^ls | skip 1
   ·  ─┬   ──┬─
   ·   │     ╰── only list, binary or range input data is supported
   ·   ╰── input type: raw data
   ╰────
```

# Tests + Formatting
Sorry I can't add it because of the issue: https://github.com/nushell/nushell/issues/12558

# After Submitting
Nan
