### PR TITLE
Don't strip ANSI escapes before fs commands

### DIFF
--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -39,17 +39,6 @@ impl Command for Cd {
         let path_val: Option<Spanned<String>> = call.opt(engine_state, stack, 0)?;
         let cwd = current_dir(engine_state, stack)?;
 
-        let path_val = {
-            if let Some(path) = path_val {
-                Some(Spanned {
-                    item: nu_utils::strip_ansi_string_unlikely(path.item),
-                    span: path.span,
-                })
-            } else {
-                path_val
-            }
-        };
-
         let (path, span) = match path_val {
             Some(v) => {
                 if v.item == "-" {

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -207,27 +207,13 @@ fn ls_for_one_pattern(
         use_mime_type,
         call_span,
     } = args;
-    let pattern_arg = {
-        if let Some(path) = pattern_arg {
-            // it makes no sense to list an empty string.
-            if path.item.as_ref().is_empty() {
-                return Err(ShellError::FileNotFoundCustom {
-                    msg: "empty string('') directory or file does not exist".to_string(),
-                    span: path.span,
-                });
-            }
-            match path.item {
-                NuGlob::DoNotExpand(p) => Some(Spanned {
-                    item: NuGlob::DoNotExpand(nu_utils::strip_ansi_string_unlikely(p)),
-                    span: path.span,
-                }),
-                NuGlob::Expand(p) => Some(Spanned {
-                    item: NuGlob::Expand(nu_utils::strip_ansi_string_unlikely(p)),
-                    span: path.span,
-                }),
-            }
-        } else {
-            pattern_arg
+    if let Some(path) = &pattern_arg {
+        // it makes no sense to list an empty string.
+        if path.item.as_ref().is_empty() {
+            return Err(ShellError::FileNotFoundCustom {
+                msg: "empty string('') directory or file does not exist".to_string(),
+                span: path.span,
+            });
         }
     };
 

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -79,7 +79,6 @@ impl Command for Open {
         let mut output = vec![];
 
         for path in paths {
-
             let arg_span = path.span;
             // let path_no_whitespace = &path.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
 

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -78,9 +78,7 @@ impl Command for Open {
 
         let mut output = vec![];
 
-        for mut path in paths {
-            //FIXME: `open` should not have to do this
-            path.item = path.item.strip_ansi_string_unlikely();
+        for path in paths {
 
             let arg_span = path.span;
             // let path_no_whitespace = &path.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));

--- a/crates/nu-command/src/filesystem/start.rs
+++ b/crates/nu-command/src/filesystem/start.rs
@@ -38,10 +38,6 @@ impl Command for Start {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let path = call.req::<Spanned<String>>(engine_state, stack, 0)?;
-        let path = Spanned {
-            item: nu_utils::strip_ansi_string_unlikely(path.item),
-            span: path.span,
-        };
         let path_no_whitespace = &path.item.trim_end_matches(|x| matches!(x, '\x09'..='\x0d'));
         // only check if file exists in current current directory
         let file_path = Path::new(path_no_whitespace);

--- a/crates/nu-command/src/filesystem/ucp.rs
+++ b/crates/nu-command/src/filesystem/ucp.rs
@@ -174,9 +174,7 @@ impl Command for UCp {
             });
         }
         let target = paths.pop().expect("Should not be reached?");
-        let target_path = PathBuf::from(&nu_utils::strip_ansi_string_unlikely(
-            target.item.to_string(),
-        ));
+        let target_path = PathBuf::from(target.item.to_string());
         let cwd = current_dir(engine_state, stack)?;
         let target_path = nu_path::expand_path_with(target_path, &cwd, target.item.is_expand());
         if target.item.as_ref().ends_with(PATH_SEPARATOR) && !target_path.is_dir() {
@@ -193,8 +191,7 @@ impl Command for UCp {
 
         let mut sources: Vec<(Vec<PathBuf>, bool)> = Vec::new();
 
-        for mut p in paths {
-            p.item = p.item.strip_ansi_string_unlikely();
+        for p in paths {
             let exp_files: Vec<Result<PathBuf, ShellError>> =
                 nu_engine::glob_from(&p, &cwd, call.head, None)
                     .map(|f| f.1)?

--- a/crates/nu-command/src/filesystem/umv.rs
+++ b/crates/nu-command/src/filesystem/umv.rs
@@ -110,8 +110,7 @@ impl Command for UMv {
             span: call.head,
         })?;
         let mut files: Vec<(Vec<PathBuf>, bool)> = Vec::new();
-        for mut p in paths {
-            p.item = p.item.strip_ansi_string_unlikely();
+        for p in paths {
             let exp_files: Vec<Result<PathBuf, ShellError>> =
                 nu_engine::glob_from(&p, &cwd, call.head, None)
                     .map(|f| f.1)?
@@ -147,7 +146,7 @@ impl Command for UMv {
 
         // Add back the target after globbing
         let abs_target_path = expand_path_with(
-            nu_utils::strip_ansi_string_unlikely(spanned_target.item.to_string()),
+            spanned_target.item.to_string(),
             &cwd,
             matches!(spanned_target.item, NuGlob::Expand(..)),
         );

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -629,27 +629,6 @@ fn list_directory_contains_invalid_utf8() {
 }
 
 #[test]
-fn list_ignores_ansi() {
-    Playground::setup("ls_test_ansi", |dirs, sandbox| {
-        sandbox.with_files(vec![
-            EmptyFile("los.txt"),
-            EmptyFile("tres.txt"),
-            EmptyFile("amigos.txt"),
-            EmptyFile("arepas.clu"),
-        ]);
-
-        let actual = nu!(
-            cwd: dirs.test(), pipeline(
-            "
-                ls | find .txt | each {|| ls $in.name } 
-            "
-        ));
-
-        assert!(actual.err.is_empty());
-    })
-}
-
-#[test]
 fn list_unknown_flag() {
     let actual = nu!("ls -r");
 

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -378,21 +378,6 @@ fn does_not_error_when_some_file_is_moving_into_itself() {
 }
 
 #[test]
-fn mv_ignores_ansi() {
-    Playground::setup("umv_test_ansi", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
-        let actual = nu!(
-             cwd: sandbox.cwd(),
-            r#"
-                 ls | find test | mv $in.0.name success.txt; ls | $in.0.name
-            "#
-        );
-
-        assert_eq!(actual.out, "success.txt");
-    })
-}
-
-#[test]
 fn mv_directory_with_same_name() {
     Playground::setup("umv_test_directory_with_same_name", |_dirs, sandbox| {
         sandbox.mkdir("testdir");

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -341,19 +341,6 @@ fn removes_files_with_case_sensitive_glob_matches_by_default() {
 }
 
 #[test]
-fn remove_ignores_ansi() {
-    Playground::setup("rm_test_ansi", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
-
-        let actual = nu!(
-            cwd: sandbox.cwd(),
-            "ls | find test | get name | rm $in.0; ls | is-empty",
-        );
-        assert_eq!(actual.out, "true");
-    });
-}
-
-#[test]
 fn removes_symlink() {
     let symlink_target = "symlink_target";
     let symlink = "symlink";

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -529,28 +529,6 @@ fn copy_identical_file_impl(progress: bool) {
     });
 }
 
-#[test]
-#[ignore = "File name in progress bar not on uutils impl"]
-fn copy_ignores_ansi() {
-    copy_ignores_ansi_impl(false);
-    copy_ignores_ansi_impl(true);
-}
-
-fn copy_ignores_ansi_impl(progress: bool) {
-    Playground::setup("ucp_test_16", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
-
-        let progress_flag = if progress { "-p" } else { "" };
-
-        let actual = nu!(
-            cwd: sandbox.cwd(),
-            "ls | find test | get name | cp {} $in.0 success.txt; ls | find success | get name | ansi strip | get 0",
-            progress_flag,
-        );
-        assert_eq!(actual.out, "success.txt");
-    });
-}
-
 //apparently on windows error msg is different, but linux(where i test) is fine.
 //fix later FIXME
 #[cfg(unix)]

--- a/crates/nu-protocol/src/value/glob.rs
+++ b/crates/nu-protocol/src/value/glob.rs
@@ -14,13 +14,6 @@ pub enum NuGlob {
 }
 
 impl NuGlob {
-    pub fn strip_ansi_string_unlikely(self) -> Self {
-        match self {
-            NuGlob::DoNotExpand(s) => NuGlob::DoNotExpand(nu_utils::strip_ansi_string_unlikely(s)),
-            NuGlob::Expand(s) => NuGlob::Expand(nu_utils::strip_ansi_string_unlikely(s)),
-        }
-    }
-
     pub fn is_expand(&self) -> bool {
         matches!(self, NuGlob::Expand(..))
     }


### PR DESCRIPTION
# Description
Don't strip ANSI escapes before executing file-sytem commands

Previously all our file system operations tried to remove ANSI escape
codes from their input (as well as other characters like `\t`).

- This is bad if you want to deal with files that are allowed arbitrary names in the bounds of the OS/FS
- This was done as we had `ls` inserting colors before we had the working `PipelineMetadata` system.
- Currently `find` will still insert ANSI coloring into its result and messing with downstream commands (see #11899)

Closes #6315


# User-Facing Changes
The following commands will faithfully accept their paths as is:
- `mv`
- `cp`
- `ls`
- `rm`

You should not pipe the output of `find` into file-system commands until we change `find` to not emit ANSI in stream

```nushell
ls | find bla | each {|entry| rm $entry.name }
```


# Tests + Formatting
Drop tests that pipe `find` output into fs cmds
