### PR TITLE
Box `ImportPattern` in `Expr`

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2431,7 +2431,7 @@ pub fn parse_use(
 
     // Create a new Use command call to pass the import pattern as parser info
     let import_pattern_expr = Expression {
-        expr: Expr::ImportPattern(import_pattern),
+        expr: Expr::ImportPattern(Box::new(import_pattern)),
         span: span(args_spans),
         ty: Type::Any,
         custom_completion: None,
@@ -2615,7 +2615,7 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
 
         // Create a new Use command call to pass the new import pattern
         let import_pattern_expr = Expression {
-            expr: Expr::ImportPattern(import_pattern),
+            expr: Expr::ImportPattern(Box::new(import_pattern)),
             span: span(args_spans),
             ty: Type::Any,
             custom_completion: None,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -2782,7 +2782,7 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
                     prev_span,
                 ));
                 return Expression {
-                    expr: Expr::ImportPattern(import_pattern),
+                    expr: Expr::ImportPattern(Box::new(import_pattern)),
                     span: prev_span,
                     ty: Type::List(Box::new(Type::String)),
                     custom_completion: None,
@@ -2818,7 +2818,7 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
                 } else {
                     working_set.error(ParseError::ExportNotFound(result.span));
                     return Expression {
-                        expr: Expr::ImportPattern(import_pattern),
+                        expr: Expr::ImportPattern(Box::new(import_pattern)),
                         span: span(spans),
                         ty: Type::List(Box::new(Type::String)),
                         custom_completion: None,
@@ -2838,7 +2838,7 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
     }
 
     Expression {
-        expr: Expr::ImportPattern(import_pattern),
+        expr: Expr::ImportPattern(Box::new(import_pattern)),
         span: span(&spans[1..]),
         ty: Type::List(Box::new(Type::String)),
         custom_completion: None,

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -46,7 +46,7 @@ pub enum Expr {
     String(String),
     CellPath(CellPath),
     FullCellPath(Box<FullCellPath>),
-    ImportPattern(ImportPattern),
+    ImportPattern(Box<ImportPattern>),
     Overlay(Option<BlockId>), // block ID of the overlay's origin module
     Signature(Box<Signature>),
     StringInterpolation(Vec<Expression>),

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -117,7 +117,7 @@ impl Expression {
 
     pub fn as_import_pattern(&self) -> Option<ImportPattern> {
         match &self.expr {
-            Expr::ImportPattern(pattern) => Some(pattern.clone()),
+            Expr::ImportPattern(pattern) => Some(*pattern.clone()),
             _ => None,
         }
     }


### PR DESCRIPTION
# Description
Adds a `Box` around the `ImportPattern` in `Expr` which decreases the size of `Expr` from 152 to 64 bytes (and `Expression` from 216 to 128 bytes). This seems to speed up parsing a little bit according to the benchmarks (main is top, PR is bottom):
```
benchmarks                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
benchmarks                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ parser_benchmarks                           │               │               │               │         │
├─ parser_benchmarks                           │               │               │               │         │
│  ├─ parse_default_config_file  2.287 ms      │ 4.532 ms      │ 2.311 ms      │ 2.437 ms      │ 100     │ 100
│  ├─ parse_default_config_file  2.255 ms      │ 2.781 ms      │ 2.281 ms      │ 2.312 ms      │ 100     │ 100
│  ╰─ parse_default_env_file     421.8 µs      │ 824.6 µs      │ 494.3 µs      │ 527.5 µs      │ 100     │ 100
│  ╰─ parse_default_env_file     402 µs        │ 486.6 µs      │ 414.8 µs      │ 416.2 µs      │ 100     │ 100

```