### PR TITLE
fix(shell_integration): set window title on startup

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -1046,7 +1046,7 @@ fn shell_integration_osc_7_633_2(
                     run_ansi_sequence(&format!(
                         "\x1b]7;file://{}{}{}\x1b\\",
                         percent_encoding::utf8_percent_encode(
-                            hostname.unwrap_or_else(|| "localhost"),
+                            hostname.unwrap_or("localhost"),
                             percent_encoding::CONTROLS
                         ),
                         if path.starts_with('/') { "" } else { "/" },

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -117,7 +117,7 @@ pub fn evaluate_repl(
 
     let hostname = System::host_name();
     if shell_integration {
-        do_shell_integration(hostname.as_deref(), engine_state, &mut unique_stack);
+        shell_integration_osc_7_633_2(hostname.as_deref(), engine_state, &mut unique_stack);
     }
 
     engine_state.set_startup_time(entire_start_time.elapsed().as_nanos() as i64);
@@ -666,7 +666,7 @@ fn loop_iteration(ctx: LoopContext) -> (bool, Stack, Reedline) {
             if shell_integration {
                 start_time = Instant::now();
 
-                do_shell_integration(hostname, engine_state, &mut stack);
+                shell_integration_osc_7_633_2(hostname, engine_state, &mut stack);
 
                 perf(
                     "shell_integration_finalize ansi escape sequences",
@@ -1025,7 +1025,11 @@ fn do_run_cmd(
 /// can have more information about what is going on (both on startup and after we have
 /// run a command)
 ///
-fn do_shell_integration(hostname: Option<&str>, engine_state: &EngineState, stack: &mut Stack) {
+fn shell_integration_osc_7_633_2(
+    hostname: Option<&str>,
+    engine_state: &EngineState,
+    stack: &mut Stack,
+) {
     if let Some(cwd) = stack.get_env_var(engine_state, "PWD") {
         match cwd.coerce_into_string() {
             Ok(path) => {


### PR DESCRIPTION
Should close #10833 — though I'd imagine that should have already been closed.

# Description

Very minor tweak, but it was quite noticeable when using Zellij which relies on OSC 2 to set pane titles. Before the change:
![image](https://github.com/nushell/nushell/assets/6251883/b944bbce-2040-4886-9955-3c5b57d368e9)

Note that the default `Pane #1` is still showing for the untouched shell, but running a command like `htop` or `ls` correctly sets the title during / afterwards.

After this PR:
![image](https://github.com/nushell/nushell/assets/6251883/dd513cfe-923c-450f-b0f2-c66938b0d6f0)

There are now no-longer any unset titles — even if the shell hasn't been touched.

**As an aside:** I feel quite strongly that (at least OSC 2) shell integration should be enabled by default, as it is for every other Linux shell I've used, but I'm not sure which issues that caused that the default config refers to? Which terminals are broken by shell integration, and could some of the shell integrations be turned on by default after splitting things into sub-options as suggested in #11301 ?

# User-Facing Changes

You'll just have shell integrations working from right after the shell has been launched, instead of needing to run something first.

# Tests + Formatting

Not quite sure how to test this one? Are there any other tests that currently exist for shell integration? I couldn't quite track them down...

# After Submitting

Let me know if you think this needs any user-facing docs changes!
