### PR TITLE
Only mark collected dataframes as from_lazy=false when collect is called from the collect command.

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/lazy/collect.rs
+++ b/crates/nu_plugin_polars/src/dataframe/lazy/collect.rs
@@ -64,7 +64,9 @@ impl PluginCommand for LazyCollect {
         let value = input.into_value(call.head);
         match PolarsPluginObject::try_from_value(plugin, &value)? {
             PolarsPluginObject::NuLazyFrame(lazy) => {
-                let eager = lazy.collect(call.head)?;
+                let mut eager = lazy.collect(call.head)?;
+                // We don't want this converted back to a lazy frame
+                eager.from_lazy = true;
                 Ok(PipelineData::Value(
                     eager
                         .cache(plugin, engine, call.head)?

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
@@ -64,7 +64,7 @@ impl NuLazyFrame {
                 help: None,
                 inner: vec![],
             })
-            .map(|df| NuDataFrame::new(false, df))
+            .map(|df| NuDataFrame::new(true, df))
     }
 
     pub fn apply_with_expr<F>(self, expr: NuExpression, f: F) -> Self


### PR DESCRIPTION
I had previously changed NuLazyFrame::collect to set the NuDataFrame's from_lazy field to false to prevent conversion back to a lazy frame. It appears there are cases where this should happen. Instead, I am only setting from_lazy=false inside the `polars collect` command.

[Related discord message](https://discord.com/channels/601130461678272522/1227612017171501136/1230600465159421993)