### PR TITLE
set the type of default NU_LIB_DIRS and NU_PLUGIN_DIRS to list<string>

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,14 +132,18 @@ fn main() -> Result<()> {
     default_nu_lib_dirs_path.push("scripts");
     engine_state.add_env_var(
         "NU_LIB_DIRS".to_string(),
-        Value::test_string(default_nu_lib_dirs_path.to_string_lossy()),
+        Value::test_list(vec![Value::test_string(
+            default_nu_lib_dirs_path.to_string_lossy(),
+        )]),
     );
 
     let mut default_nu_plugin_dirs_path = nushell_config_path;
     default_nu_plugin_dirs_path.push("plugins");
     engine_state.add_env_var(
         "NU_PLUGIN_DIRS".to_string(),
-        Value::test_string(default_nu_plugin_dirs_path.to_string_lossy()),
+        Value::test_list(vec![Value::test_string(
+            default_nu_plugin_dirs_path.to_string_lossy(),
+        )]),
     );
     // End: Default NU_LIB_DIRS, NU_PLUGIN_DIRS
 

--- a/src/tests/test_env.rs
+++ b/src/tests/test_env.rs
@@ -1,4 +1,5 @@
 use crate::tests::{fail_test, run_test, TestResult};
+use nu_test_support::nu;
 
 #[test]
 fn shorthand_env_1() -> TestResult {
@@ -13,4 +14,16 @@ fn shorthand_env_2() -> TestResult {
 #[test]
 fn shorthand_env_3() -> TestResult {
     run_test(r#"FOO=BAZ BAR=MOO $env.FOO"#, "BAZ")
+}
+
+#[test]
+fn default_nu_lib_dirs_type() {
+    let actual = nu!("$env.NU_LIB_DIRS | describe");
+    assert_eq!(actual.out, "list<string>");
+}
+
+#[test]
+fn default_nu_plugin_dirs_type() {
+    let actual = nu!("$env.NU_PLUGIN_DIRS | describe");
+    assert_eq!(actual.out, "list<string>");
 }


### PR DESCRIPTION
# Description
Fix: #12489

I believe the issue it's because the default value of `NU_LIB_DIRS` and `NU_PLUGIN_DIRS` is a string, but it should be a list.

So if users don't set up these values in `env.nu`, we will get a problem.