### PR TITLE
Switch plugin msgpack protocol to named format

### DIFF
--- a/crates/nu-plugin/src/serializers/msgpack.rs
+++ b/crates/nu-plugin/src/serializers/msgpack.rs
@@ -26,7 +26,7 @@ impl Encoder<PluginInput> for MsgPackSerializer {
         plugin_input: &PluginInput,
         writer: &mut impl std::io::Write,
     ) -> Result<(), nu_protocol::ShellError> {
-        rmp_serde::encode::write(writer, plugin_input).map_err(rmp_encode_err)
+        rmp_serde::encode::write_named(writer, plugin_input).map_err(rmp_encode_err)
     }
 
     fn decode(
@@ -46,7 +46,7 @@ impl Encoder<PluginOutput> for MsgPackSerializer {
         plugin_output: &PluginOutput,
         writer: &mut impl std::io::Write,
     ) -> Result<(), ShellError> {
-        rmp_serde::encode::write(writer, plugin_output).map_err(rmp_encode_err)
+        rmp_serde::encode::write_named(writer, plugin_output).map_err(rmp_encode_err)
     }
 
     fn decode(


### PR DESCRIPTION
# Description
In conflict with the documentation, the msgpack serializer for plugins is actually using the compact format, which doesn't name struct fields, and is instead dependent on their ordering, rendering them as tuples. This is not a good idea for a robust protocol even if it makes the serialization and deserialization faster.

I expect this to have some impact on performance, but I think the robustness is probably worth it.

Deserialization always accepts either format, so this shouldn't cause too many incompatibilities.

# User-Facing Changes
This does technically change the protocol, but it makes it reflect the documentation. It shouldn't break deserialization, so plugins shouldn't necessarily need a recompile.

Performance is likely worse and I should benchmark the difference.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
