### PR TITLE
add "to nuon" enumeration of possible styles

### DIFF
--- a/crates/nu-command/src/filters/uniq.rs
+++ b/crates/nu-command/src/filters/uniq.rs
@@ -215,7 +215,7 @@ fn sort_attributes(val: Value) -> Value {
 
 fn generate_key(item: &ValueCounter) -> Result<String, ShellError> {
     let value = sort_attributes(item.val_to_compare.clone()); //otherwise, keys could be different for Records
-    nuon::to_nuon(&value, true, None, None, Some(Span::unknown()))
+    nuon::to_nuon(&value, nuon::ToStyle::Raw, Some(Span::unknown()))
 }
 
 fn generate_results_with_count(head: Span, uniq_values: Vec<ValueCounter>) -> Vec<Value> {

--- a/crates/nu-command/tests/commands/database/into_sqlite.rs
+++ b/crates/nu-command/tests/commands/database/into_sqlite.rs
@@ -330,7 +330,8 @@ fn into_sqlite_big_insert() {
                 )
                 .unwrap();
 
-            let nuon = nuon::to_nuon(&value, true, None, None, Some(Span::unknown())).unwrap()
+            let nuon = nuon::to_nuon(&value, nuon::ToStyle::Raw, Some(Span::unknown()))
+                .unwrap()
                 + &line_ending();
 
             nuon_file.write_all(nuon.as_bytes()).unwrap();

--- a/crates/nu-command/tests/commands/database/into_sqlite.rs
+++ b/crates/nu-command/tests/commands/database/into_sqlite.rs
@@ -330,8 +330,7 @@ fn into_sqlite_big_insert() {
                 )
                 .unwrap();
 
-            let nuon = nuon::to_nuon(&value, nuon::ToStyle::Raw, Some(Span::unknown()))
-                .unwrap()
+            let nuon = nuon::to_nuon(&value, nuon::ToStyle::Raw, Some(Span::unknown())).unwrap()
                 + &line_ending();
 
             nuon_file.write_all(nuon.as_bytes()).unwrap();

--- a/crates/nuon/src/lib.rs
+++ b/crates/nuon/src/lib.rs
@@ -9,13 +9,14 @@ mod to;
 
 pub use from::from_nuon;
 pub use to::to_nuon;
+pub use to::ToStyle;
 
 #[cfg(test)]
 mod tests {
     use chrono::DateTime;
     use nu_protocol::{ast::RangeInclusion, engine::Closure, record, IntRange, Range, Span, Value};
 
-    use crate::{from_nuon, to_nuon};
+    use crate::{from_nuon, to_nuon, ToStyle};
 
     /// test something of the form
     /// ```nushell
@@ -29,7 +30,7 @@ mod tests {
         if let Some(m) = middle {
             assert_eq!(val, m);
         }
-        assert_eq!(to_nuon(&val, true, None, None, None).unwrap(), input);
+        assert_eq!(to_nuon(&val, ToStyle::Raw, None).unwrap(), input);
     }
 
     #[test]
@@ -178,9 +179,7 @@ mod tests {
                 block_id: 0,
                 captures: vec![]
             }),
-            true,
-            None,
-            None,
+            ToStyle::Raw,
             None,
         )
         .unwrap_err()
@@ -199,14 +198,7 @@ mod tests {
     #[test]
     fn binary_roundtrip() {
         assert_eq!(
-            to_nuon(
-                &from_nuon("0x[1f ff]", None).unwrap(),
-                true,
-                None,
-                None,
-                None
-            )
-            .unwrap(),
+            to_nuon(&from_nuon("0x[1f ff]", None).unwrap(), ToStyle::Raw, None).unwrap(),
             "0x[1FFF]"
         );
     }
@@ -247,7 +239,7 @@ mod tests {
     #[test]
     fn float_doesnt_become_int() {
         assert_eq!(
-            to_nuon(&Value::test_float(1.0), true, None, None, None).unwrap(),
+            to_nuon(&Value::test_float(1.0), ToStyle::Raw, None).unwrap(),
             "1.0"
         );
     }
@@ -255,7 +247,7 @@ mod tests {
     #[test]
     fn float_inf_parsed_properly() {
         assert_eq!(
-            to_nuon(&Value::test_float(f64::INFINITY), true, None, None, None).unwrap(),
+            to_nuon(&Value::test_float(f64::INFINITY), ToStyle::Raw, None).unwrap(),
             "inf"
         );
     }
@@ -263,14 +255,7 @@ mod tests {
     #[test]
     fn float_neg_inf_parsed_properly() {
         assert_eq!(
-            to_nuon(
-                &Value::test_float(f64::NEG_INFINITY),
-                true,
-                None,
-                None,
-                None
-            )
-            .unwrap(),
+            to_nuon(&Value::test_float(f64::NEG_INFINITY), ToStyle::Raw, None).unwrap(),
             "-inf"
         );
     }
@@ -278,7 +263,7 @@ mod tests {
     #[test]
     fn float_nan_parsed_properly() {
         assert_eq!(
-            to_nuon(&Value::test_float(-f64::NAN), true, None, None, None).unwrap(),
+            to_nuon(&Value::test_float(-f64::NAN), ToStyle::Raw, None).unwrap(),
             "NaN"
         );
     }
@@ -299,9 +284,7 @@ mod tests {
                         "c d" => Value::test_int(6)
                     ))
                 ]),
-                true,
-                None,
-                None,
+                ToStyle::Raw,
                 None
             )
             .unwrap(),
@@ -312,7 +295,7 @@ mod tests {
 
     #[test]
     fn to_nuon_quotes_empty_string() {
-        let res = to_nuon(&Value::test_string(""), true, None, None, None);
+        let res = to_nuon(&Value::test_string(""), ToStyle::Raw, None);
         assert!(res.is_ok());
         assert_eq!(res.unwrap(), r#""""#);
     }
@@ -358,9 +341,7 @@ mod tests {
                         "c d" => Value::test_int(6)
                     ))
                 ]),
-                true,
-                None,
-                None,
+                ToStyle::Raw,
                 None
             )
             .unwrap(),
@@ -373,9 +354,7 @@ mod tests {
                     "ro name" => Value::test_string("sam"),
                     "rank" => Value::test_int(10)
                 )),
-                true,
-                None,
-                None,
+                ToStyle::Raw,
                 None
             )
             .unwrap(),

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -18,7 +18,7 @@ pub enum ToStyle {
     /// tabulation-based indentation
     ///
     /// using 2 as the variant value, `{ a: 1, b: 2 }` will be converted to
-    /// ```
+    /// ```text
     /// {
     /// 		a: 1,
     /// 		b: 2
@@ -28,7 +28,7 @@ pub enum ToStyle {
     /// space-based indentation
     ///
     /// using 3 as the variant value, `{ a: 1, b: 2 }` will be converted to
-    /// ```
+    /// ```text
     /// {
     ///    a: 1,
     ///    b: 2

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -14,6 +14,7 @@ pub enum ToStyle {
     ///
     /// `{ a: 1, b: 2 }` will be converted to `{: 1, b: 2}`
     Raw,
+    #[allow(clippy::tabs_in_doc_comments)]
     /// tabulation-based indentation
     ///
     /// using 2 as the variant value, `{ a: 1, b: 2 }` will be converted to

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -8,10 +8,31 @@ use nu_protocol::{Range, ShellError, Span, Value};
 
 use std::ops::Bound;
 
-/// TODO: documentation
+/// control the way Nushell [`Value`] is converted to NUON data
 pub enum ToStyle {
+    /// no indentation at all
+    ///
+    /// `{ a: 1, b: 2 }` will be converted to `{: 1, b: 2}`
     Raw,
+    /// tabulation-based indentation
+    ///
+    /// using 2 as the variant value, `{ a: 1, b: 2 }` will be converted to
+    /// ```
+    /// {
+    /// 		a: 1,
+    /// 		b: 2
+    /// }
+    /// ```
     Tabs(usize),
+    /// space-based indentation
+    ///
+    /// using 3 as the variant value, `{ a: 1, b: 2 }` will be converted to
+    /// ```
+    /// {
+    ///    a: 1,
+    ///    b: 2
+    /// }
+    /// ```
     Spaces(usize),
 }
 


### PR DESCRIPTION
# Description
in order to change the style of the _serialized_ NUON data, `nuon::to_nuon` takes three mutually exclusive arguments, `raw: bool`, `tabs: Option<usize>` and `indent: Option<usize>` :thinking: 
this begs to use an enumeration with all possible alternatives, right?

this PR changes the signature of `nuon::to_nuon` to use `nuon::ToStyle` which has three variants
- `Raw`: no newlines
- `Tabs(n: usize)`: newlines and `n` tabulations as indent
- `Spaces(n: usize)`: newlines and `n` spaces as indent

# User-Facing Changes
the signature of `nuon::to_nuon` changes from
```rust
to_nuon(
    input: &Value,
    raw: bool,
    tabs: Option<usize>,
    indent: Option<usize>,
    span: Option<Span>,
) -> Result<String, ShellError>
```
to
```rust
to_nuon(
    input: &Value,
    style: ToStyle,
    span: Option<Span>
) -> Result<String, ShellError>
```

# Tests + Formatting

# After Submitting