### PR TITLE
Ab/version details

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -58,11 +58,12 @@ impl Command for Version {
 }
 
 pub fn version(engine_state: &EngineState, call: &Call) -> Result<PipelineData, ShellError> {
-    // Pre-allocate the arrays in the worst case (16 items):
+    // Pre-allocate the arrays in the worst case (17 items):
     // - version
     // - major
     // - minor
     // - patch
+    // - pre
     // - branch
     // - commit_hash
     // - build_os
@@ -74,7 +75,7 @@ pub fn version(engine_state: &EngineState, call: &Call) -> Result<PipelineData, 
     // - allocator
     // - features
     // - installed_plugins
-    let mut record = Record::with_capacity(16);
+    let mut record = Record::with_capacity(17);
 
     record.push(
         "version",
@@ -82,6 +83,11 @@ pub fn version(engine_state: &EngineState, call: &Call) -> Result<PipelineData, 
     );
 
     push_version_numbers(&mut record, call.head);
+
+    let version_pre = Some(build::PKG_VERSION_PRE).filter(|x| !x.is_empty());
+    if let Some(version_pre) = version_pre {
+        record.push("pre", Value::string(version_pre, call.head));
+    }
 
     record.push("branch", Value::string(build::BRANCH, call.head));
 

--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -56,7 +56,7 @@ impl Command for Version {
 }
 
 pub fn version(engine_state: &EngineState, call: &Call) -> Result<PipelineData, ShellError> {
-    // Pre-allocate the arrays in the worst case (12 items):
+    // Pre-allocate the arrays in the worst case (13 items):
     // - version
     // - branch
     // - commit_hash
@@ -66,9 +66,10 @@ pub fn version(engine_state: &EngineState, call: &Call) -> Result<PipelineData, 
     // - cargo_version
     // - build_time
     // - build_rust_channel
+    // - allocator
     // - features
     // - installed_plugins
-    let mut record = Record::with_capacity(12);
+    let mut record = Record::with_capacity(13);
 
     record.push(
         "version",


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->
Closes #12561

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Add version details in `version`'s output. The intended use is for third-party tools to be able to quickly check version numbers without having to the parsing from `(version).version` or `$env.NU_VERSION`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

This adds 4 new values to the record from `version`:

```
...
│ major              │ 0                                               │
│ minor              │ 92                                              │
│ patch              │ 3                                               │
│ pre                │ a-value                                         │
...
```

`pre` is optional and won't be present most of the time I think.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

I ran the new command using `cargo run -- -c version`:

```
╭────────────────────┬─────────────────────────────────────────────────╮
│ version            │ 0.92.3                                          │
│ major              │ 0                                               │
│ minor              │ 92                                              │
│ patch              │ 3                                               │
│ branch             │                                                 │
│ commit_hash        │                                                 │
│ build_os           │ macos-aarch64                                   │
│ build_target       │ aarch64-apple-darwin                            │
│ rust_version       │ rustc 1.77.2 (25ef9e3d8 2024-04-09)             │
│ rust_channel       │ 1.77.2-aarch64-apple-darwin                     │
│ cargo_version      │ cargo 1.77.2 (e52e36006 2024-03-26)             │
│ build_time         │ 2024-04-20 15:09:36 +02:00                      │
│ build_rust_channel │ release                                         │
│ allocator          │ mimalloc                                        │
│ features           │ default, sqlite, system-clipboard, trash, which │
│ installed_plugins  │                                                 │
╰────────────────────┴─────────────────────────────────────────────────╯
```

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

After this is merged I would like to write docs somewhere for scripts writer to advise using these members instead of the string values. Where should I put said docs ? 