### PR TITLE
Reject incombatible flag combinations in `to nuon`

### DIFF
--- a/crates/nu-command/src/formats/to/nuon.rs
+++ b/crates/nu-command/src/formats/to/nuon.rs
@@ -109,11 +109,6 @@ impl Command for ToNuon {
                 result: Some(Value::test_string("[\n  1,\n  2,\n  3\n]")),
             },
             Example {
-                description: "Overwrite any set option with --raw",
-                example: "[1 2 3] | to nuon --indent 2 --raw",
-                result: Some(Value::test_string("[1, 2, 3]"))
-            },
-            Example {
                 description: "A more complex record with multiple data types",
                 example: "{date: 2000-01-01, data: [1 [2 3] 4.56]} | to nuon --indent 2",
                 result: Some(Value::test_string("{\n  date: 2000-01-01T00:00:00+00:00,\n  data: [\n    1,\n    [\n      2,\n      3\n    ],\n    4.56\n  ]\n}"))


### PR DESCRIPTION
# Description
Follow up to #12591

Ensure an error is shown.

`.expect` is fine here as the precondition of reaching each branch is
explicitly that this flag has been found. Only extra care has to be
taken when changing the flag name. But that is the general risk of this
stringly typed API.


# User-Facing Changes
Ineffective combinations of flags will now return a `ShellError::IncompatibleParameters` instead of returning output for which the exact behavior was previously undefined.

