### PR TITLE
add search_term "str extract" to `parse` command

### DIFF
--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -19,7 +19,7 @@ impl Command for Parse {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["pattern", "match", "regex"]
+        vec!["pattern", "match", "regex", "str extract"]
     }
 
     fn signature(&self) -> nu_protocol::Signature {


### PR DESCRIPTION
# Description

For a long time, I was searching for the `str extract` command to extract regexes from strings. I often painfully used `str replace -r '(.*)(pattern_to_find)(.*)' '$2'` for such purposes.
Only this morning did I realize that `parse` is what I needed for so many times, which I had only used for parsing data in tables.