### PR TITLE
Deprecate `register` and add `plugin use`

### DIFF
--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -54,7 +54,7 @@ apparent the next time `nu` is next launched with that plugin cache file.
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["add", "load", "plugin", "register", "signature"]
+        vec!["load", "register", "signature"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -54,7 +54,7 @@ apparent the next time `nu` is next launched with that plugin cache file.
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["plugin", "add", "register", "load", "signature"]
+        vec!["add", "load", "plugin", "register", "signature"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-plugin/src/commands/plugin/list.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/list.rs
@@ -29,6 +29,10 @@ impl Command for PluginList {
         "List installed plugins."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["scope"]
+    }
+
     fn examples(&self) -> Vec<nu_protocol::Example> {
         vec![
             Example {

--- a/crates/nu-cmd-plugin/src/commands/plugin/mod.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/mod.rs
@@ -4,11 +4,13 @@ mod add;
 mod list;
 mod rm;
 mod stop;
+mod use_;
 
 pub use add::PluginAdd;
 pub use list::PluginList;
 pub use rm::PluginRm;
 pub use stop::PluginStop;
+pub use use_::PluginUse;
 
 #[derive(Clone)]
 pub struct PluginCommand;
@@ -67,6 +69,15 @@ impl Command for PluginCommand {
             Example {
                 example: "plugin add nu_plugin_inc",
                 description: "Run the `nu_plugin_inc` plugin from the current directory and install its signatures.",
+                result: None,
+            },
+            Example {
+                example: "plugin use inc",
+                description: "
+Load (or reload) the `inc` plugin from the plugin cache file and put its commands in scope.
+The plugin must already be in the cache file at parse time.
+"
+                .trim(),
                 result: None,
             },
             Example {

--- a/crates/nu-cmd-plugin/src/commands/plugin/mod.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/mod.rs
@@ -30,10 +30,6 @@ impl Command for PluginCommand {
         "Commands for managing plugins."
     }
 
-    fn extra_usage(&self) -> &str {
-        "To load a plugin, see `register`."
-    }
-
     fn run(
         &self,
         engine_state: &EngineState,
@@ -57,16 +53,6 @@ impl Command for PluginCommand {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                example: "plugin list",
-                description: "List installed plugins",
-                result: None,
-            },
-            Example {
-                example: "plugin stop inc",
-                description: "Stop the plugin named `inc`.",
-                result: None,
-            },
-            Example {
                 example: "plugin add nu_plugin_inc",
                 description: "Run the `nu_plugin_inc` plugin from the current directory and install its signatures.",
                 result: None,
@@ -78,6 +64,16 @@ Load (or reload) the `inc` plugin from the plugin cache file and put its command
 The plugin must already be in the cache file at parse time.
 "
                 .trim(),
+                result: None,
+            },
+            Example {
+                example: "plugin list",
+                description: "List installed plugins",
+                result: None,
+            },
+            Example {
+                example: "plugin stop inc",
+                description: "Stop the plugin named `inc`.",
                 result: None,
             },
             Example {

--- a/crates/nu-cmd-plugin/src/commands/plugin/rm.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/rm.rs
@@ -51,7 +51,7 @@ fixed with `plugin add`.
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["plugin", "rm", "remove", "delete", "signature"]
+        vec!["remove", "delete", "signature"]
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-plugin/src/commands/plugin/use_.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/use_.rs
@@ -1,0 +1,81 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct PluginUse;
+
+impl Command for PluginUse {
+    fn name(&self) -> &str {
+        "plugin use"
+    }
+
+    fn usage(&self) -> &str {
+        "Load a plugin from the plugin cache file into scope."
+    }
+
+    fn signature(&self) -> nu_protocol::Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::Nothing, Type::Nothing)])
+            .named(
+                "plugin-config",
+                SyntaxShape::Filepath,
+                "Use a plugin cache file other than the one set in `$nu.plugin-path`",
+                None,
+            )
+            .required(
+                "name",
+                SyntaxShape::String,
+                "The name of the plugin to load (not the filename)",
+            )
+            .category(Category::Plugin)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"
+This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html
+
+The plugin definition must be available in the plugin cache file at parse time.
+Run `plugin add` first in the REPL to do this, or from a script consider
+preparing a plugin cache file and passing `--plugin-config`, or using the
+`--plugin` option to `nu` instead.
+
+If the plugin was already loaded, this will reload the latest definition from
+the cache file into scope.
+"#
+        .trim()
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["add", "plugin", "register", "scope", "use"]
+    }
+
+    fn is_parser_keyword(&self) -> bool {
+        true
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        _call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(PipelineData::empty())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Load the commands for the `query` plugin from $nu.plugin-path",
+                example: r#"plugin use query"#,
+                result: None,
+            },
+            Example {
+                description:
+                    "Load the commands for the `query` plugin from a custom plugin cache file",
+                example: r#"plugin use --plugin-config local-plugins.msgpackz query"#,
+                result: None,
+            },
+        ]
+    }
+}

--- a/crates/nu-cmd-plugin/src/commands/plugin/use_.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/use_.rs
@@ -46,7 +46,7 @@ the cache file into scope.
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["add", "plugin", "register", "scope", "use"]
+        vec!["add", "register", "scope"]
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-cmd-plugin/src/commands/register.rs
+++ b/crates/nu-cmd-plugin/src/commands/register.rs
@@ -35,8 +35,13 @@ impl Command for Register {
     }
 
     fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nu.html"#
+        r#"
+Deprecated in favor of `plugin add` and `plugin use`.
+
+This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html
+"#
+        .trim()
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-cmd-plugin/src/commands/register.rs
+++ b/crates/nu-cmd-plugin/src/commands/register.rs
@@ -45,7 +45,7 @@ This command is a parser keyword. For details, check:
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["plugin", "add", "register"]
+        vec!["add"]
     }
 
     fn is_parser_keyword(&self) -> bool {

--- a/crates/nu-cmd-plugin/src/default_context.rs
+++ b/crates/nu-cmd-plugin/src/default_context.rs
@@ -12,11 +12,12 @@ pub fn add_plugin_command_context(mut engine_state: EngineState) -> EngineState 
         }
 
         bind_command!(
-            PluginCommand,
             PluginAdd,
+            PluginCommand,
             PluginList,
             PluginRm,
             PluginStop,
+            PluginUse,
             Register,
         );
 

--- a/crates/nu-command/tests/format_conversions/nuon.rs
+++ b/crates/nu-command/tests/format_conversions/nuon.rs
@@ -479,5 +479,5 @@ fn read_code_should_fail_rather_than_panic() {
     let actual = nu!(cwd: "tests/fixtures/formats", pipeline(
         r#"open code.nu | from nuon"#
     ));
-    assert!(actual.err.contains("error when parsing"))
+    assert!(actual.err.contains("Error when loading"))
 }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -94,11 +94,14 @@ pub fn is_unaliasable_parser_keyword(working_set: &StateWorkingSet, spans: &[Spa
 /// This is a new more compact method of calling parse_xxx() functions without repeating the
 /// parse_call() in each function. Remaining keywords can be moved here.
 pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
+    let orig_parse_errors_len = working_set.parse_errors.len();
+
     let call_expr = parse_call(working_set, &lite_command.parts, lite_command.parts[0]);
 
-    // if err.is_some() {
-    //     return (Pipeline::from_vec(vec![call_expr]), err);
-    // }
+    // If an error occurred, don't invoke the keyword-specific functionality
+    if working_set.parse_errors.len() > orig_parse_errors_len {
+        return Pipeline::from_vec(vec![call_expr]);
+    }
 
     if let Expression {
         expr: Expr::Call(call),

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -71,6 +71,7 @@ pub const UNALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[
     b"source",
     b"where",
     b"register",
+    b"plugin use",
 ];
 
 /// Check whether spans start with a parser keyword that can be aliased
@@ -121,6 +122,7 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
             "overlay hide" => parse_overlay_hide(working_set, call),
             "overlay new" => parse_overlay_new(working_set, call),
             "overlay use" => parse_overlay_use(working_set, call),
+            "plugin use" => parse_plugin_use(working_set, call),
             _ => Pipeline::from_vec(vec![call_expr]),
         }
     } else {
@@ -1946,7 +1948,7 @@ pub fn parse_module_file_or_dir(
     let cwd = working_set.get_cwd();
 
     let module_path =
-        if let Some(path) = find_in_dirs(&module_path_str, working_set, &cwd, LIB_DIRS_VAR) {
+        if let Some(path) = find_in_dirs(&module_path_str, working_set, &cwd, Some(LIB_DIRS_VAR)) {
             path
         } else {
             working_set.error(ParseError::ModuleNotFound(path_span, module_path_str));
@@ -3402,7 +3404,7 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     }
                 };
 
-                if let Some(path) = find_in_dirs(&filename, working_set, &cwd, LIB_DIRS_VAR) {
+                if let Some(path) = find_in_dirs(&filename, working_set, &cwd, Some(LIB_DIRS_VAR)) {
                     if let Some(contents) = path.read(working_set) {
                         // Add the file to the stack of files being processed.
                         if let Err(e) = working_set.files.push(path.clone().path_buf(), spans[1]) {
@@ -3562,7 +3564,7 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
     // Maybe this is not necessary but it is a sanity check
     if working_set.get_span_contents(spans[0]) != b"register" {
         working_set.error(ParseError::UnknownState(
-            "internal error: Wrong call name for parse plugin function".into(),
+            "internal error: Wrong call name for 'register' function".into(),
             span(spans),
         ));
         return garbage_pipeline(spans);
@@ -3620,7 +3622,8 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
                 .coerce_into_string()
                 .map_err(|err| err.wrap(working_set, call.head))?;
 
-            let Some(path) = find_in_dirs(&filename, working_set, &cwd, PLUGIN_DIRS_VAR) else {
+            let Some(path) = find_in_dirs(&filename, working_set, &cwd, Some(PLUGIN_DIRS_VAR))
+            else {
                 return Err(ParseError::RegisteredFileNotFound(filename, expr.span));
             };
 
@@ -3778,6 +3781,100 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
     }])
 }
 
+#[cfg(feature = "plugin")]
+pub fn parse_plugin_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
+    use nu_protocol::{FromValue, PluginCacheFile};
+
+    let cwd = working_set.get_cwd();
+
+    if let Err(err) = (|| {
+        let name = call
+            .positional_nth(0)
+            .map(|expr| {
+                eval_constant(working_set, expr)
+                    .and_then(Spanned::<String>::from_value)
+                    .map_err(|err| err.wrap(working_set, call.head))
+            })
+            .expect("required positional should have been checked")?;
+
+        let plugin_config = call
+            .named_iter()
+            .find(|(arg_name, _, _)| arg_name.item == "plugin-config")
+            .map(|(_, _, expr)| {
+                let expr = expr
+                    .as_ref()
+                    .expect("--plugin-config arg should have been checked already");
+                eval_constant(working_set, expr)
+                    .and_then(Spanned::<String>::from_value)
+                    .map_err(|err| err.wrap(working_set, call.head))
+            })
+            .transpose()?;
+
+        // Find the actual plugin config path location. We don't have a const/env variable for this,
+        // it either lives in the current working directory or in the script's directory
+        let plugin_config_path = if let Some(custom_path) = &plugin_config {
+            find_in_dirs(&custom_path.item, working_set, &cwd, None).ok_or_else(|| {
+                ParseError::FileNotFound(custom_path.item.clone(), custom_path.span)
+            })?
+        } else {
+            ParserPath::RealPath(
+                working_set
+                    .permanent_state
+                    .plugin_path
+                    .as_ref()
+                    .ok_or_else(|| ParseError::LabeledErrorWithHelp {
+                        error: "Plugin cache file not set".into(),
+                        label: "can't load plugin without cache file".into(),
+                        span: call.head,
+                        help:
+                            "pass --plugin-config to `plugin use` when $nu.plugin-path is not set"
+                                .into(),
+                    })?
+                    .to_owned(),
+            )
+        };
+
+        let file = plugin_config_path.open(working_set).map_err(|err| {
+            ParseError::LabeledError(
+                "Plugin cache file can't be opened".into(),
+                err.to_string(),
+                plugin_config.as_ref().map(|p| p.span).unwrap_or(call.head),
+            )
+        })?;
+
+        // The file is now open, so we just have to parse the contents and find the plugin
+        let contents = PluginCacheFile::read_from(file, Some(call.head))
+            .map_err(|err| err.wrap(working_set, call.head))?;
+
+        let plugin_item = contents
+            .plugins
+            .iter()
+            .find(|plugin| plugin.name == name.item)
+            .ok_or_else(|| ParseError::PluginNotFound {
+                name: name.item.clone(),
+                name_span: name.span,
+                plugin_config_span: plugin_config.as_ref().map(|p| p.span),
+            })?;
+
+        // Now add the signatures to the working set
+        nu_plugin::load_plugin_cache_item(working_set, plugin_item, Some(call.head))
+            .map_err(|err| err.wrap(working_set, call.head))?;
+
+        Ok(())
+    })() {
+        working_set.error(err);
+    }
+
+    let call_span = call.span();
+
+    Pipeline::from_vec(vec![Expression {
+        expr: Expr::Call(call),
+        span: call_span,
+        ty: Type::Nothing,
+        custom_completion: None,
+    }])
+}
+
 pub fn find_dirs_var(working_set: &StateWorkingSet, var_name: &str) -> Option<VarId> {
     working_set
         .find_variable(format!("${}", var_name).as_bytes())
@@ -3801,13 +3898,13 @@ pub fn find_in_dirs(
     filename: &str,
     working_set: &StateWorkingSet,
     cwd: &str,
-    dirs_var_name: &str,
+    dirs_var_name: Option<&str>,
 ) -> Option<ParserPath> {
     pub fn find_in_dirs_with_id(
         filename: &str,
         working_set: &StateWorkingSet,
         cwd: &str,
-        dirs_var_name: &str,
+        dirs_var_name: Option<&str>,
     ) -> Option<ParserPath> {
         // Choose whether to use file-relative or PWD-relative path
         let actual_cwd = working_set
@@ -3847,8 +3944,10 @@ pub fn find_in_dirs(
         }
 
         // Look up relative path from NU_LIB_DIRS
-        working_set
-            .get_variable(find_dirs_var(working_set, dirs_var_name)?)
+        dirs_var_name
+            .as_ref()
+            .and_then(|dirs_var_name| find_dirs_var(working_set, dirs_var_name))
+            .map(|var_id| working_set.get_variable(var_id))?
             .const_val
             .as_ref()?
             .as_list()
@@ -3870,7 +3969,7 @@ pub fn find_in_dirs(
         filename: &str,
         working_set: &StateWorkingSet,
         cwd: &str,
-        dirs_env: &str,
+        dirs_env: Option<&str>,
     ) -> Option<PathBuf> {
         // Choose whether to use file-relative or PWD-relative path
         let actual_cwd = working_set
@@ -3884,7 +3983,9 @@ pub fn find_in_dirs(
             let path = Path::new(filename);
 
             if path.is_relative() {
-                if let Some(lib_dirs) = working_set.get_env_var(dirs_env) {
+                if let Some(lib_dirs) =
+                    dirs_env.and_then(|dirs_env| working_set.get_env_var(dirs_env))
+                {
                     if let Ok(dirs) = lib_dirs.as_list() {
                         for lib_dir in dirs {
                             if let Ok(dir) = lib_dir.to_path() {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -125,6 +125,7 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
             "overlay hide" => parse_overlay_hide(working_set, call),
             "overlay new" => parse_overlay_new(working_set, call),
             "overlay use" => parse_overlay_use(working_set, call),
+            #[cfg(feature = "plugin")]
             "plugin use" => parse_plugin_use(working_set, call),
             _ => Pipeline::from_vec(vec![call_expr]),
         }

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -3548,11 +3548,12 @@ pub fn parse_where(working_set: &mut StateWorkingSet, lite_command: &LiteCommand
     }
 }
 
+/// `register` is deprecated and will be removed in 0.94. Use `plugin add` and `plugin use` instead.
 #[cfg(feature = "plugin")]
 pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
     use nu_plugin::{get_signature, PersistentPlugin, PluginDeclaration};
     use nu_protocol::{
-        engine::Stack, IntoSpanned, PluginCacheItem, PluginIdentity, PluginSignature,
+        engine::Stack, IntoSpanned, ParseWarning, PluginCacheItem, PluginIdentity, PluginSignature,
         RegisteredPlugin,
     };
 
@@ -3611,6 +3612,16 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             (call, call_span)
         }
     };
+
+    // Now that the call is parsed, add the deprecation warning
+    working_set
+        .parse_warnings
+        .push(ParseWarning::DeprecatedWarning {
+            old_command: "register".into(),
+            new_suggestion: "use `plugin add` and `plugin use`".into(),
+            span: call.head,
+            url: "https://www.nushell.sh/book/plugins.html".into(),
+        });
 
     // Extracting the required arguments from the call and keeping them together in a tuple
     let arguments = call

--- a/crates/nu-parser/src/parser_path.rs
+++ b/crates/nu-parser/src/parser_path.rs
@@ -103,15 +103,31 @@ impl ParserPath {
         }
     }
 
-    pub fn read<'a>(&'a self, working_set: &'a StateWorkingSet) -> Option<Vec<u8>> {
+    pub fn open<'a>(
+        &'a self,
+        working_set: &'a StateWorkingSet,
+    ) -> std::io::Result<Box<dyn std::io::Read + 'a>> {
         match self {
-            ParserPath::RealPath(p) => std::fs::read(p).ok(),
+            ParserPath::RealPath(p) => {
+                std::fs::File::open(p).map(|f| Box::new(f) as Box<dyn std::io::Read>)
+            }
             ParserPath::VirtualFile(_, file_id) => working_set
                 .get_contents_of_file(*file_id)
-                .map(|bytes| bytes.to_vec()),
+                .map(|bytes| Box::new(bytes) as Box<dyn std::io::Read>)
+                .ok_or(std::io::ErrorKind::NotFound.into()),
 
-            ParserPath::VirtualDir(..) => None,
+            ParserPath::VirtualDir(..) => Err(std::io::ErrorKind::NotFound.into()),
         }
+    }
+
+    pub fn read<'a>(&'a self, working_set: &'a StateWorkingSet) -> Option<Vec<u8>> {
+        self.open(working_set)
+            .and_then(|mut reader| {
+                let mut vec = vec![];
+                reader.read_to_end(&mut vec)?;
+                Ok(vec)
+            })
+            .ok()
     }
 
     pub fn from_virtual_path(

--- a/crates/nu-plugin/src/lib.rs
+++ b/crates/nu-plugin/src/lib.rs
@@ -78,10 +78,11 @@ pub use serializers::{json::JsonSerializer, msgpack::MsgPackSerializer};
 // Used by other nu crates.
 #[doc(hidden)]
 pub use plugin::{
-    create_plugin_signature, get_signature, load_plugin_cache_item, load_plugin_file,
-    serve_plugin_io, EngineInterfaceManager, GetPlugin, Interface, InterfaceManager,
-    PersistentPlugin, PluginDeclaration, PluginExecutionCommandContext, PluginExecutionContext,
-    PluginInterface, PluginInterfaceManager, PluginSource, ServePluginError,
+    add_plugin_to_working_set, create_plugin_signature, get_signature, load_plugin_cache_item,
+    load_plugin_file, serve_plugin_io, EngineInterfaceManager, GetPlugin, Interface,
+    InterfaceManager, PersistentPlugin, PluginDeclaration, PluginExecutionCommandContext,
+    PluginExecutionContext, PluginInterface, PluginInterfaceManager, PluginSource,
+    ServePluginError,
 };
 #[doc(hidden)]
 pub use protocol::{PluginCustomValue, PluginInput, PluginOutput};

--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -748,9 +748,9 @@ impl PluginInterface {
                     PluginCall::CustomValueOp(val, _) => Some(val.span),
                 },
                 help: Some(format!(
-                    "the plugin may have experienced an error. Try registering the plugin again \
+                    "the plugin may have experienced an error. Try loading the plugin again \
                         with `{}`",
-                    self.state.source.identity.register_command(),
+                    self.state.source.identity.use_command(),
                 )),
                 inner: vec![],
             })?;

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -992,7 +992,8 @@ pub fn load_plugin_cache_item(
         }
         PluginCacheItemData::Invalid => Err(ShellError::PluginCacheDataInvalid {
             plugin_name: identity.name().to_owned(),
-            register_command: identity.register_command(),
+            span,
+            add_command: identity.add_command(),
         }),
     }
 }

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -990,7 +990,7 @@ pub fn add_plugin_to_working_set(
         .clone();
 
     // Add it to / get it from the working set
-    let plugin = working_set.find_or_create_plugin(&identity, || {
+    let plugin = working_set.find_or_create_plugin(identity, || {
         Arc::new(PersistentPlugin::new(identity.clone(), gc_config.clone()))
     });
 

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -108,6 +108,13 @@ impl Expression {
         }
     }
 
+    pub fn as_filepath(&self) -> Option<(String, bool)> {
+        match &self.expr {
+            Expr::Filepath(string, quoted) => Some((string.clone(), *quoted)),
+            _ => None,
+        }
+    }
+
     pub fn as_import_pattern(&self) -> Option<ImportPattern> {
         match &self.expr {
             Expr::ImportPattern(pattern) => Some(*pattern.clone()),

--- a/crates/nu-protocol/src/errors/parse_error.rs
+++ b/crates/nu-protocol/src/errors/parse_error.rs
@@ -439,6 +439,19 @@ pub enum ParseError {
     #[diagnostic(code(nu::parser::file_not_found))]
     FileNotFound(String, #[label("File not found: {0}")] Span),
 
+    #[error("Plugin not found")]
+    #[diagnostic(
+        code(nu::parser::plugin_not_found),
+        help("plugins need to be added to the plugin cache file before your script is run (see `plugin add`)"),
+    )]
+    PluginNotFound {
+        name: String,
+        #[label("Plugin not found: {name}")]
+        name_span: Span,
+        #[label("in this cache file")]
+        plugin_config_span: Option<Span>,
+    },
+
     #[error("Invalid literal")] // <problem> in <entity>.
     #[diagnostic()]
     InvalidLiteral(String, String, #[label("{0} in {1}")] Span),
@@ -544,6 +557,7 @@ impl ParseError {
             ParseError::SourcedFileNotFound(_, s) => *s,
             ParseError::RegisteredFileNotFound(_, s) => *s,
             ParseError::FileNotFound(_, s) => *s,
+            ParseError::PluginNotFound { name_span, .. } => *name_span,
             ParseError::LabeledError(_, _, s) => *s,
             ParseError::ShellAndAnd(s) => *s,
             ParseError::ShellOrOr(s) => *s,

--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -5,19 +5,21 @@ use thiserror::Error;
 
 #[derive(Clone, Debug, Error, Diagnostic, Serialize, Deserialize)]
 pub enum ParseWarning {
-    #[error("Deprecated: {0}")]
-    DeprecatedWarning(
-        String,
-        String,
-        #[label = "`{0}` is deprecated and will be removed in 0.90. Please use `{1}` instead, more info: https://www.nushell.sh/book/custom_commands.html"]
-        Span,
-    ),
+    #[error("Deprecated: {old_command}")]
+    #[diagnostic(help("for more info: {url}"))]
+    DeprecatedWarning {
+        old_command: String,
+        new_suggestion: String,
+        #[label("`{old_command}` is deprecated and will be removed in 0.94. Please {new_suggestion} instead")]
+        span: Span,
+        url: String,
+    },
 }
 
 impl ParseWarning {
     pub fn span(&self) -> Span {
         match self {
-            ParseWarning::DeprecatedWarning(_, _, s) => *s,
+            ParseWarning::DeprecatedWarning { span, .. } => *span,
         }
     }
 }

--- a/crates/nu-protocol/src/errors/shell_error.rs
+++ b/crates/nu-protocol/src/errors/shell_error.rs
@@ -750,17 +750,19 @@ pub enum ShellError {
         span: Span,
     },
 
-    /// The cached plugin data (in `$nu.plugin-path`) for a plugin is invalid.
+    /// The cached plugin data for a plugin is invalid.
     ///
     /// ## Resolution
     ///
-    /// `register` the plugin again to update the data, or remove it.
+    /// `plugin add` the plugin again to update the data, or remove it with `plugin rm`.
     #[error("The cached plugin data for `{plugin_name}` is invalid")]
     #[diagnostic(code(nu::shell::plugin_cache_data_invalid))]
     PluginCacheDataInvalid {
         plugin_name: String,
-        #[help("try registering the plugin again with `{}`")]
-        register_command: String,
+        #[label("plugin `{plugin_name}` loaded here")]
+        span: Option<Span>,
+        #[help("the format in the plugin cache file is not compatible with this version of Nushell.\n\nTry adding the plugin again with `{}`")]
+        add_command: String,
     },
 
     /// A plugin failed to load.

--- a/crates/nu-protocol/src/plugin/identity.rs
+++ b/crates/nu-protocol/src/plugin/identity.rs
@@ -89,17 +89,22 @@ impl PluginIdentity {
             .expect("fake plugin identity path is invalid")
     }
 
-    /// A command that could be used to register the plugin, for suggesting in errors.
-    pub fn register_command(&self) -> String {
+    /// A command that could be used to add the plugin, for suggesting in errors.
+    pub fn add_command(&self) -> String {
         if let Some(shell) = self.shell() {
             format!(
-                "register --shell '{}' '{}'",
+                "plugin add --shell '{}' '{}'",
                 shell.display(),
                 self.filename().display(),
             )
         } else {
-            format!("register '{}'", self.filename().display())
+            format!("plugin add '{}'", self.filename().display())
         }
+    }
+
+    /// A command that could be used to reload the plugin, for suggesting in errors.
+    pub fn use_command(&self) -> String {
+        format!("plugin use '{}'", self.name())
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -324,13 +324,13 @@ impl Command for Nu {
             .switch("version", "print the version", Some('v'))
             .named(
                 "config",
-                SyntaxShape::Filepath,
+                SyntaxShape::String,
                 "start with an alternate config file",
                 None,
             )
             .named(
                 "env-config",
-                SyntaxShape::Filepath,
+                SyntaxShape::String,
                 "start with an alternate environment config file",
                 None,
             )

--- a/src/command.rs
+++ b/src/command.rs
@@ -324,13 +324,13 @@ impl Command for Nu {
             .switch("version", "print the version", Some('v'))
             .named(
                 "config",
-                SyntaxShape::String,
+                SyntaxShape::Filepath,
                 "start with an alternate config file",
                 None,
             )
             .named(
                 "env-config",
-                SyntaxShape::String,
+                SyntaxShape::Filepath,
                 "start with an alternate environment config file",
                 None,
             )
@@ -370,14 +370,14 @@ impl Command for Nu {
             signature = signature
                 .named(
                     "plugin-config",
-                    SyntaxShape::String,
+                    SyntaxShape::Filepath,
                     "start with an alternate plugin cache file",
                     None,
                 )
                 .named(
                     "plugins",
-                    SyntaxShape::List(Box::new(SyntaxShape::String)),
-                    "list of plugin executables to load, separately from the cache file",
+                    SyntaxShape::List(Box::new(SyntaxShape::Filepath)),
+                    "list of plugin executable files to load, separately from the cache file",
                     None,
                 )
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -400,7 +400,7 @@ fn main() -> Result<()> {
         let mut working_set = StateWorkingSet::new(&engine_state);
         for plugin_filename in plugins {
             // Make sure the plugin filenames are canonicalized
-            let filename = nu_path::canonicalize_with(&plugin_filename.item, &init_cwd)
+            let filename = canonicalize_with(&plugin_filename.item, &init_cwd)
                 .map_err(|err| ShellError::from(err.into_spanned(plugin_filename.span)))?;
 
             let identity = PluginIdentity::new(&filename, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -392,7 +392,7 @@ fn main() -> Result<()> {
     #[cfg(feature = "plugin")]
     if let Some(plugins) = &parsed_nu_cli_args.plugins {
         use nu_plugin::{GetPlugin, PluginDeclaration};
-        use nu_protocol::{engine::StateWorkingSet, IntoSpanned, PluginIdentity};
+        use nu_protocol::{engine::StateWorkingSet, ErrSpan, PluginIdentity};
 
         // Load any plugins specified with --plugins
         start_time = std::time::Instant::now();
@@ -401,10 +401,12 @@ fn main() -> Result<()> {
         for plugin_filename in plugins {
             // Make sure the plugin filenames are canonicalized
             let filename = canonicalize_with(&plugin_filename.item, &init_cwd)
-                .map_err(|err| ShellError::from(err.into_spanned(plugin_filename.span)))?;
+                .err_span(plugin_filename.span)
+                .map_err(ShellError::from)?;
 
             let identity = PluginIdentity::new(&filename, None)
-                .map_err(|err| ShellError::from(err.into_spanned(plugin_filename.span)))?;
+                .err_span(plugin_filename.span)
+                .map_err(ShellError::from)?;
 
             // Create the plugin and add it to the working set
             let plugin = nu_plugin::add_plugin_to_working_set(&mut working_set, &identity)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,7 +399,11 @@ fn main() -> Result<()> {
 
         let mut working_set = StateWorkingSet::new(&engine_state);
         for plugin_filename in plugins {
-            let identity = PluginIdentity::new(&plugin_filename.item, None)
+            // Make sure the plugin filenames are canonicalized
+            let filename = nu_path::canonicalize_with(&plugin_filename.item, &init_cwd)
+                .map_err(|err| ShellError::from(err.into_spanned(plugin_filename.span)))?;
+
+            let identity = PluginIdentity::new(&filename, None)
                 .map_err(|err| ShellError::from(err.into_spanned(plugin_filename.span)))?;
 
             // Create the plugin and add it to the working set

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,6 +389,40 @@ fn main() -> Result<()> {
         use_color,
     );
 
+    #[cfg(feature = "plugin")]
+    if let Some(plugins) = &parsed_nu_cli_args.plugins {
+        use nu_plugin::{GetPlugin, PluginDeclaration};
+        use nu_protocol::{engine::StateWorkingSet, IntoSpanned, PluginIdentity};
+
+        // Load any plugins specified with --plugins
+        start_time = std::time::Instant::now();
+
+        let mut working_set = StateWorkingSet::new(&engine_state);
+        for plugin_filename in plugins {
+            let identity = PluginIdentity::new(&plugin_filename.item, None)
+                .map_err(|err| ShellError::from(err.into_spanned(plugin_filename.span)))?;
+
+            // Create the plugin and add it to the working set
+            let plugin = nu_plugin::add_plugin_to_working_set(&mut working_set, &identity)?;
+
+            // Spawn the plugin to get its signatures, and then add the commands to the working set
+            for signature in plugin.clone().get_plugin(None)?.get_signature()? {
+                let decl = PluginDeclaration::new(plugin.clone(), signature);
+                working_set.add_decl(Box::new(decl));
+            }
+        }
+        engine_state.merge_delta(working_set.render())?;
+
+        perf(
+            "load plugins specified in --plugins",
+            start_time,
+            file!(),
+            line!(),
+            column!(),
+            use_color,
+        )
+    }
+
     start_time = std::time::Instant::now();
     if parsed_nu_cli_args.lsp {
         perf(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,6 +39,7 @@ pub fn run_test_with_env(input: &str, expected: &str, env: &HashMap<&str, &str>)
     let name = file.path();
 
     let mut cmd = Command::cargo_bin("nu")?;
+    cmd.arg("--no-config-file");
     cmd.arg(name).envs(env);
 
     writeln!(file, "{input}")?;
@@ -53,6 +54,7 @@ pub fn run_test(input: &str, expected: &str) -> TestResult {
 
     let mut cmd = Command::cargo_bin("nu")?;
     cmd.arg("--no-std-lib");
+    cmd.arg("--no-config-file");
     cmd.arg(name);
     cmd.env(
         "PWD",
@@ -70,6 +72,7 @@ pub fn run_test_std(input: &str, expected: &str) -> TestResult {
     let name = file.path();
 
     let mut cmd = Command::cargo_bin("nu")?;
+    cmd.arg("--no-config-file");
     cmd.arg(name);
     cmd.env(
         "PWD",
@@ -105,6 +108,7 @@ pub fn run_test_contains(input: &str, expected: &str) -> TestResult {
 
     let mut cmd = Command::cargo_bin("nu")?;
     cmd.arg("--no-std-lib");
+    cmd.arg("--no-config-file");
     cmd.arg(name);
 
     writeln!(file, "{input}")?;
@@ -132,6 +136,7 @@ pub fn test_ide_contains(input: &str, ide_commands: &[&str], expected: &str) -> 
 
     let mut cmd = Command::cargo_bin("nu")?;
     cmd.arg("--no-std-lib");
+    cmd.arg("--no-config-file");
     for ide_command in ide_commands {
         cmd.arg(ide_command);
     }
@@ -162,6 +167,7 @@ pub fn fail_test(input: &str, expected: &str) -> TestResult {
 
     let mut cmd = Command::cargo_bin("nu")?;
     cmd.arg("--no-std-lib");
+    cmd.arg("--no-config-file");
     cmd.arg(name);
     cmd.env(
         "PWD",

--- a/src/tests/test_parser.rs
+++ b/src/tests/test_parser.rs
@@ -594,6 +594,42 @@ register $file
 }
 
 #[test]
+fn plugin_use_with_string_literal() -> TestResult {
+    fail_test(
+        r#"plugin use 'nu-plugin-math'"#,
+        "Plugin cache file not set",
+    )
+}
+
+#[test]
+fn plugin_use_with_string_constant() -> TestResult {
+    let input = "\
+const file = 'nu-plugin-math'
+plugin use $file
+";
+    // should not fail with `not a constant`
+    fail_test(input, "Plugin cache file not set")
+}
+
+#[test]
+fn plugin_use_with_string_variable() -> TestResult {
+    let input = "\
+let file = 'nu-plugin-math'
+plugin use $file
+";
+    fail_test(input, "Value is not a parse-time constant")
+}
+
+#[test]
+fn plugin_use_with_non_string_constant() -> TestResult {
+    let input = "\
+const file = 6
+plugin use $file
+";
+    fail_test(input, "expected string, found int")
+}
+
+#[test]
 fn extern_errors_with_no_space_between_params_and_name_1() -> TestResult {
     fail_test("extern cmd[]", "expected space")
 }

--- a/tests/fixtures/formats/code.nu
+++ b/tests/fixtures/formats/code.nu
@@ -1,1 +1,1 @@
-register
+plugin use

--- a/tests/plugins/nu_plugin_nu_example.rs
+++ b/tests/plugins/nu_plugin_nu_example.rs
@@ -1,14 +1,7 @@
 use assert_cmd::Command;
-use nu_parser::escape_quote_string;
 
 #[test]
 fn call() {
-    let path = nu_path::canonicalize_with(
-        "crates/nu_plugin_nu_example/nu_plugin_nu_example.nu",
-        nu_test_support::fs::root(),
-    )
-    .expect("failed to find nu_plugin_nu_example.nu");
-
     // Add the `nu` binaries to the path env
     let path_env = std::env::join_paths(
         std::iter::once(nu_test_support::fs::binaries()).chain(
@@ -27,7 +20,10 @@ fn call() {
             "--no-config-file",
             "--no-std-lib",
             "--plugins",
-            &format!("[{}]", escape_quote_string(&path.to_string_lossy())),
+            &format!(
+                "[crates{0}nu_plugin_nu_example{0}nu_plugin_nu_example.nu]",
+                std::path::MAIN_SEPARATOR
+            ),
             "--commands",
             "nu_plugin_nu_example 4242 teststring",
         ])

--- a/tests/plugins/nu_plugin_nu_example.rs
+++ b/tests/plugins/nu_plugin_nu_example.rs
@@ -9,7 +9,20 @@ fn call() {
     )
     .expect("failed to find nu_plugin_nu_example.nu");
 
+    // Add the `nu` binaries to the path env
+    let path_env = std::env::join_paths(
+        std::iter::once(nu_test_support::fs::binaries()).chain(
+            std::env::var_os(nu_test_support::NATIVE_PATH_ENV_VAR)
+                .as_deref()
+                .map(std::env::split_paths)
+                .into_iter()
+                .flatten(),
+        ),
+    )
+    .expect("failed to make path var");
+
     let assert = Command::new(nu_test_support::fs::executable_path())
+        .env(nu_test_support::NATIVE_PATH_ENV_VAR, path_env)
         .args([
             "--no-config-file",
             "--no-std-lib",


### PR DESCRIPTION
# Description

Adds a new keyword, `plugin use`. Unlike `register`, this merely loads the signatures from the plugin cache file. The file is configurable with the `--plugin-config` option either to `nu` or to `plugin use` itself, just like the other `plugin` family of commands. At the REPL, one might do this to replace `register`:

```nushell
> plugin add ~/.cargo/bin/nu_plugin_foo
> plugin use foo
```

This will not work in a script, because `plugin use` is a keyword and `plugin add` does not evaluate at parse time (intentionally). This means we no longer run random binaries during parse.

The `--plugins` option has been added to allow running `nu` with certain plugins in one step. This is used especially for the `nu_with_plugins!` test macro, but I'd imagine is generally useful. The only weird quirk is that it has to be a list, and we don't really do this for any of our other CLI args at the moment.

`register` now prints a deprecation parse warning.

This should fix #11923, as we now have a complete alternative to `register`.

# User-Facing Changes

- Add `plugin use` command
- Deprecate `register`
- Add `--plugins` option to `nu` to replace a common use of `register`

# Tests + Formatting

I think I've tested it thoroughly enough and every existing test passes. Testing nu CLI options and alternate config files is a little hairy and I wish there were some more generic helpers for this, so this will go on my TODO list for refactoring.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

- [ ] Update plugins sections of book
- [ ] Release notes
