### PR TITLE
fix typo in the documentation of `nuon::ToStyle`

### DIFF
--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -12,7 +12,7 @@ use std::ops::Bound;
 pub enum ToStyle {
     /// no indentation at all
     ///
-    /// `{ a: 1, b: 2 }` will be converted to `{: 1, b: 2}`
+    /// `{ a: 1, b: 2 }` will be converted to `{a: 1, b: 2}`
     Raw,
     #[allow(clippy::tabs_in_doc_comments)]
     /// tabulation-based indentation


### PR DESCRIPTION
follow-up to
- https://github.com/nushell/nushell/pull/12591

cc/ @fdncred 

# Description
there was a typo in the doc of `nuon::ToStyle`.

# User-Facing Changes

# Tests + Formatting

# After Submitting