### PR TITLE
stress_internals: exit(1) on io error

### DIFF
--- a/crates/nu_plugin_stress_internals/src/main.rs
+++ b/crates/nu_plugin_stress_internals/src/main.rs
@@ -114,6 +114,8 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             Err(err) => {
                 if err.is_eof() {
                     break;
+                } else if err.is_io() {
+                    std::process::exit(1);
                 } else {
                     return Err(err.into());
                 }


### PR DESCRIPTION
# Description

The `stress_internals` tests can fail sometimes, but usually not on the CI, because Nushell exits while the plugin is still trying to read or maybe write something, leading to a broken pipe.

`nu-plugin` already exits with 1 without printing a message on a protocol-level I/O error, so this just doing the same thing.

I think there's probably a way to correct the plugin handling so that we wait for plugins to shut down before exiting and this doesn't happen, but this is the quick fix in the meantime.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

