### PR TITLE
Fix path normalization

### DIFF
--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -274,8 +274,8 @@ mod tests {
     }
 
     #[test]
-    fn expand_dots_multi_single_dots_no_change() {
-        assert_path_eq!("././.", expand_dots("././."));
+    fn expand_dots_multi_single_dots() {
+        assert_path_eq!(".", expand_dots("././."));
     }
 
     #[test]

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -108,17 +108,12 @@ pub fn expand_ndots(path: impl AsRef<Path>) -> PathBuf {
     expanded.into()
 }
 
-/// Expand "." and ".." into nothing and parent directory, respectively.
+/// Normalize the path, expanding occurances of "." and "..".
+///
+/// It performs the same normalization as `Path::components()`, except it also expands ".."
+/// when its preceding component is a normal component, ignoring the possibility of symlinks.
 pub fn expand_dots(path: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
-
-    // Early-exit if path does not contain '.' or '..'
-    if !path
-        .components()
-        .any(|c| std::matches!(c, Component::CurDir | Component::ParentDir))
-    {
-        return path.into();
-    }
 
     let mut result = PathBuf::with_capacity(path.as_os_str().len());
 

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -187,26 +187,21 @@ mod tests {
     #[test]
     fn expand_two_dots() {
         let path = Path::new("/foo/bar/..");
-
-        assert_eq!(
-            PathBuf::from("/foo"), // missing path
-            expand_dots(path)
-        );
+        assert_path_eq!("/foo", expand_dots(path));
     }
 
     #[test]
     fn expand_dots_with_curdir() {
         let path = Path::new("/foo/./bar/./baz");
-
-        assert_eq!(PathBuf::from("/foo/bar/baz"), expand_dots(path));
+        assert_path_eq!("/foo/bar/baz", expand_dots(path));
     }
 
     // track_caller refers, in the panic-message, to the line of the function call and not
     // inside of the function, which is nice for a test-helper-function
     #[track_caller]
     fn check_ndots_expansion(expected: &str, s: &str) {
-        let expanded = expand_ndots(Path::new(s));
-        assert_eq!(Path::new(expected), &expanded);
+        let expanded = expand_ndots(s);
+        assert_path_eq!(expected, expanded);
     }
 
     // common tests
@@ -269,45 +264,39 @@ mod tests {
     #[test]
     fn expand_dots_double_dots_no_change() {
         // Can't resolve this as we don't know our parent dir
-        assert_eq!(Path::new(".."), expand_dots(Path::new("..")));
+        assert_path_eq!("..", expand_dots(".."));
     }
 
     #[test]
     fn expand_dots_single_dot_no_change() {
         // Can't resolve this as we don't know our current dir
-        assert_eq!(Path::new("."), expand_dots(Path::new(".")));
+        assert_path_eq!(".", expand_dots("."));
     }
 
     #[test]
     fn expand_dots_multi_single_dots_no_change() {
-        assert_eq!(Path::new("././."), expand_dots(Path::new("././.")));
+        assert_path_eq!("././.", expand_dots("././."));
     }
 
     #[test]
     fn expand_multi_double_dots_no_change() {
-        assert_eq!(Path::new("../../../"), expand_dots(Path::new("../../../")));
+        assert_path_eq!("../../../", expand_dots("../../../"));
     }
 
     #[test]
     fn expand_dots_no_change_with_dirs() {
         // Can't resolve this as we don't know our parent dir
-        assert_eq!(
-            Path::new("../../../dir1/dir2/"),
-            expand_dots(Path::new("../../../dir1/dir2"))
-        );
+        assert_path_eq!("../../../dir1/dir2/", expand_dots("../../../dir1/dir2"));
     }
 
     #[test]
     fn expand_dots_simple() {
-        assert_eq!(Path::new("/foo"), expand_dots(Path::new("/foo/bar/..")));
+        assert_path_eq!("/foo", expand_dots("/foo/bar/.."));
     }
 
     #[test]
     fn expand_dots_complex() {
-        assert_eq!(
-            Path::new("/test"),
-            expand_dots(Path::new("/foo/./bar/../../test/././test2/../"))
-        );
+        assert_path_eq!("/test", expand_dots("/foo/./bar/../../test/././test2/../"));
     }
 
     #[cfg(windows)]

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -2,7 +2,7 @@ use std::path::{Component, Path, PathBuf};
 
 use super::helpers;
 
-/// Normalize the path, expanding occurances of n-dots.
+/// Normalize the path, expanding occurrences of n-dots.
 ///
 /// It performs the same normalization as `Path::components()`, except it also expands n-dots,
 /// such as "..." and "....", into multiple "..".
@@ -33,7 +33,7 @@ pub fn expand_ndots(path: impl AsRef<Path>) -> PathBuf {
     result
 }
 
-/// Normalize the path, expanding occurances of "." and "..".
+/// Normalize the path, expanding occurrences of "." and "..".
 ///
 /// It performs the same normalization as `Path::components()`, except it also expands ".."
 /// when its preceding component is a normal component, ignoring the possibility of symlinks.
@@ -70,7 +70,7 @@ mod tests {
 
     /// Path equality in Rust is defined by comparing their `components()`.
     /// However, `components()` will perform its own normalization, which is not ideal for testing.
-    /// Avoid `assert_eq!` in tests; use `assert_path_eq!` instead, which converts path to string before comparision.
+    /// Avoid `assert_eq!` in tests; use `assert_path_eq!` instead, which converts path to string before comparison.
     /// It accepts PathBuf, Path, String, and &str.
     macro_rules! assert_path_eq {
         ($left:expr, $right:expr $(,)?) => {
@@ -94,11 +94,11 @@ mod tests {
     /// For example, "./foo\bar" is converted to ".\foo\bar" on Windows, and "./foo/bar" on other platforms.
     #[cfg(windows)]
     fn platform_path(path: &str) -> String {
-        path.replace(r"/", r"\")
+        path.replace('/', "\\")
     }
     #[cfg(not(windows))]
     fn platform_path(path: &str) -> String {
-        path.replace(r"\", r"/")
+        path.replace('\\', "/")
     }
 
     #[test]

--- a/crates/nu-path/src/dots.rs
+++ b/crates/nu-path/src/dots.rs
@@ -161,6 +161,18 @@ mod tests {
         };
     }
 
+    /// Fixes the path separator for test cases, so that you don't need to write the same test case twice.
+    ///
+    /// For example, "./foo\bar" is converted to ".\foo\bar" on Windows, and "./foo/bar" on other platforms.
+    #[cfg(windows)]
+    fn platform_path(path: &str) -> String {
+        path.replace(r"/", r"\")
+    }
+    #[cfg(not(windows))]
+    fn platform_path(path: &str) -> String {
+        path.replace(r"\", r"/")
+    }
+
     #[test]
     fn assert_path_eq_works() {
         assert_path_eq!(PathBuf::from("/foo/bar"), Path::new("/foo/bar"));
@@ -177,6 +189,21 @@ mod tests {
         assert_path_ne!(Path::new("/foo/./bar"), "/foo/bar");
         assert_path_ne!(Path::new(r"\foo\bar"), r"/foo/bar");
         assert_path_ne!(Path::new(r"/foo/bar"), r"\foo\bar");
+    }
+
+    #[test]
+    fn platform_path_works() {
+        #[cfg(windows)]
+        {
+            assert_eq!(platform_path(r"/foo/bar"), r"\foo\bar");
+            assert_eq!(platform_path(r"C:\foo\bar"), r"C:\foo\bar");
+        }
+
+        #[cfg(not(windows))]
+        {
+            assert_eq!(platform_path(r"/foo/bar"), r"/foo/bar");
+            assert_eq!(platform_path(r"C:\foo\bar"), r"C:/foo/bar");
+        }
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes a bug in `nu_path::expand_dots()` (Issue #12602). It introduces a path comparision macro `assert_path_eq!` so that path can be tested without normalization.

The now-working tests exposed several other incorrect behavior, which this PR fixed:

* A test case (`expand_dots_multi_single_dots_no_change()` said that `././.` should expands to itself, which is incorrect, because `././.` should expand to `.`. The test case is now fixed.
* `nu_path::expand_dots()` always uses platform-specific path separators (`\` on Windows, `/` everywhere else), but test cases were written with `/` only. A helper function `platform_path()` is introduced to help with that.
* `expand_ndots()` operates on strings instead of path components, which causes some strange behavior. For example, a path like `/tmp/foo/...` on Windows will be expanded into `/tmp/foo/..\..`. It is rewritten to operate on components, just like `expand_dots()`.

---

That was all good news, but here comes the bad news. Fixing the bug in `nu_path::expand_dots()` actually broke the test somewhere in the `mv` command (`errors_if_destination_doesnt_exist()` in `nu-command/tests/command/move_/umv.rs`).

What happened is that `mv` actually cares if a path has an ending slash or not. For example, `mv foo bar` is interpretered as "renaming the file `foo` to `bar`, or if `bar` already exists and is a directory, then move `foo` into `bar` instead". On the other hand, `mv foo bar/` always means "move `foo` into `bar`, and if `bar` doesn't exist or is not a directory, throw an error".

I cannot proceed unless I know whether Nushell wants to care about trailing slashes or not. The original `nu_path::expand_dots()` was written so that trailing slashes are normalized away, but I'm not sure if that's intentional.