### PR TITLE
[WIP] Create "substring" match type

### DIFF
--- a/crates/nu-cli/src/completions/completion_options.rs
+++ b/crates/nu-cli/src/completions/completion_options.rs
@@ -24,6 +24,12 @@ pub enum MatchAlgorithm {
     /// Example:
     /// "git checkout" is matched by "gco"
     Fuzzy,
+
+    /// Only show suggestions which contain the substring starting at any place
+    /// 
+    /// Example:
+    /// "git checkout" is matched by "check"
+    Substring
 }
 
 impl MatchAlgorithm {
@@ -37,6 +43,7 @@ impl MatchAlgorithm {
                 let matcher = SkimMatcherV2::default();
                 matcher.fuzzy_match(haystack, needle).is_some()
             }
+            MatchAlgorithm::Substring => haystack.contains(needle),
         }
     }
 
@@ -51,6 +58,7 @@ impl MatchAlgorithm {
                 let matcher = SkimMatcherV2::default();
                 matcher.fuzzy_match(&haystack_str, &needle_str).is_some()
             }
+            MatchAlgorithm::Substring => haystack.windows(needle.len()).any(|window| window == needle),
         }
     }
 }
@@ -60,6 +68,7 @@ impl From<CompletionAlgorithm> for MatchAlgorithm {
         match value {
             CompletionAlgorithm::Prefix => MatchAlgorithm::Prefix,
             CompletionAlgorithm::Fuzzy => MatchAlgorithm::Fuzzy,
+            CompletionAlgorithm::Substring => MatchAlgorithm::Substring,
         }
     }
 }
@@ -71,6 +80,7 @@ impl TryFrom<String> for MatchAlgorithm {
         match value.as_str() {
             "prefix" => Ok(Self::Prefix),
             "fuzzy" => Ok(Self::Fuzzy),
+            "substring" => Ok(Self::Substring),
             _ => Err(InvalidMatchAlgorithm::Unknown),
         }
     }

--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -163,7 +163,7 @@ fn filter(
                     }
                 }
             },
-            MatchAlgorithm::Fuzzy => options
+            MatchAlgorithm::Fuzzy | MatchAlgorithm::Substring => options
                 .match_algorithm
                 .matches_u8(it.suggestion.value.as_bytes(), prefix),
         })

--- a/crates/nu-protocol/src/config/completer.rs
+++ b/crates/nu-protocol/src/config/completer.rs
@@ -11,6 +11,7 @@ pub enum CompletionAlgorithm {
     #[default]
     Prefix,
     Fuzzy,
+    Substring,
 }
 
 impl FromStr for CompletionAlgorithm {
@@ -20,6 +21,7 @@ impl FromStr for CompletionAlgorithm {
         match s.to_ascii_lowercase().as_str() {
             "prefix" => Ok(Self::Prefix),
             "fuzzy" => Ok(Self::Fuzzy),
+            "substring" => Ok(Self::Substring),
             _ => Err("expected either 'prefix' or 'fuzzy'"),
         }
     }
@@ -30,6 +32,7 @@ impl ReconstructVal for CompletionAlgorithm {
         let str = match self {
             CompletionAlgorithm::Prefix => "prefix",
             CompletionAlgorithm::Fuzzy => "fuzzy",
+            CompletionAlgorithm::Substring => "substring",
         };
         Value::string(str, span)
     }

--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -206,7 +206,7 @@ $env.config = {
         case_sensitive: false # set to true to enable case-sensitive completions
         quick: true    # set this to false to prevent auto-selecting completions when only one remains
         partial: true    # set this to false to prevent partial filling of the prompt
-        algorithm: "prefix"    # prefix or fuzzy
+        algorithm: "prefix"    # prefix or fuzzy or substring
         external: {
             enable: true # set to false to prevent nushell looking into $env.PATH to find more suggestions, `false` recommended for WSL users as this look up may be very slow
             max_results: 100 # setting it lower can improve completion performance at the cost of omitting some options


### PR DESCRIPTION
**This is a WIP.** It does not yet seem to trigger the desired behavior so I am trying to debug this.

# Description
Similar behavior to zsh's history-substring-search method, this matching algorithm will check if a given string is contained within the other, regardless of position.

- The zsh version of this: https://github.com/zsh-users/zsh-history-substring-search
- This PR should close https://github.com/nushell/nushell/discussions/7968

# User-Facing Changes

- This adds the "substring" match type, so users can turn on a history-substring-search

# Tests + Formatting

- These need to be implemented. I wanted to get people's thoughts first as it might change how I need to write the test.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
