### PR TITLE
`LazyRecord` fixup

### DIFF
--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -269,7 +269,7 @@ fn nested_suggestions(
         }
         Value::LazyRecord { val, .. } => {
             // Add all the columns as completion
-            for column_name in val.column_names() {
+            for column_name in val.columns() {
                 output.push(SemanticSuggestion {
                     suggestion: Suggestion {
                         value: column_name.to_string(),
@@ -322,9 +322,9 @@ fn recursive_value(val: &Value, sublevels: &[Vec<u8>]) -> Result<Value, Span> {
                 }
             }
             Value::LazyRecord { val, .. } => {
-                for col in val.column_names() {
+                for col in val.columns() {
                     if col.as_bytes() == *sublevel {
-                        let val = val.get_column_value(col).map_err(|_| span)?;
+                        let val = val.get(col).map_err(|_| span)?;
                         return recursive_value(&val, next_sublevels);
                     }
                 }

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -388,27 +388,19 @@ fn describe_value(
             record.push("lazy", Value::bool(true, head));
 
             if options.collect_lazyrecords {
-                let collected = val.collect()?;
-                if let Value::Record { val, .. } =
-                    describe_value(collected, head, engine_state, options)?
-                {
-                    let mut val = Record::clone(&val);
+                let mut val = val.to_record()?;
 
-                    for (_k, v) in val.iter_mut() {
-                        *v = compact_primitive_description(describe_value(
-                            std::mem::take(v),
-                            head,
-                            engine_state,
-                            options,
-                        )?);
-                    }
-
-                    record.push("length", Value::int(val.len() as i64, head));
-                    record.push("columns", Value::record(val, head));
-                } else {
-                    let cols = val.column_names();
-                    record.push("length", Value::int(cols.len() as i64, head));
+                for (_k, v) in val.iter_mut() {
+                    *v = compact_primitive_description(describe_value(
+                        std::mem::take(v),
+                        head,
+                        engine_state,
+                        options,
+                    )?);
                 }
+
+                record.push("length", Value::int(val.len() as i64, head));
+                record.push("columns", Value::record(val, head));
             } else {
                 let cols = val.column_names();
                 record.push("length", Value::int(cols.len() as i64, head));

--- a/crates/nu-cmd-lang/src/core_commands/describe.rs
+++ b/crates/nu-cmd-lang/src/core_commands/describe.rs
@@ -402,7 +402,7 @@ fn describe_value(
                 record.push("length", Value::int(val.len() as i64, head));
                 record.push("columns", Value::record(val, head));
             } else {
-                let cols = val.column_names();
+                let cols = val.columns();
                 record.push("length", Value::int(cols.len() as i64, head));
             }
 

--- a/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
@@ -128,11 +128,11 @@ impl std::fmt::Debug for NuLazyRecord {
 }
 
 impl LazyRecord for NuLazyRecord {
-    fn column_names(&self) -> Vec<&str> {
+    fn columns(&self) -> Vec<&str> {
         self.columns.iter().map(|column| column.as_str()).collect()
     }
 
-    fn get_column_value(&self, column: &str) -> Result<Value, ShellError> {
+    fn get(&self, column: &str) -> Result<Value, ShellError> {
         let block = self.engine_state.get_block(self.get_value.block_id);
         let mut stack = self.stack.lock().expect("lock must not be poisoned");
         let column_value = Value::string(column, self.span);

--- a/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
@@ -127,8 +127,8 @@ impl std::fmt::Debug for NuLazyRecord {
     }
 }
 
-impl<'a> LazyRecord<'a> for NuLazyRecord {
-    fn column_names(&'a self) -> Vec<&'a str> {
+impl LazyRecord for NuLazyRecord {
+    fn column_names(&self) -> Vec<&str> {
         self.columns.iter().map(|column| column.as_str()).collect()
     }
 

--- a/crates/nu-cmd-lang/src/example_support.rs
+++ b/crates/nu-cmd-lang/src/example_support.rs
@@ -307,7 +307,7 @@ impl<'a> std::fmt::Debug for DebuggableValue<'a> {
                 write!(f, "CustomValue({:?})", val)
             }
             Value::LazyRecord { val, .. } => {
-                let rec = val.collect().map_err(|_| std::fmt::Error)?;
+                let rec = val.to_value().map_err(|_| std::fmt::Error)?;
                 write!(f, "LazyRecord({:?})", DebuggableValue(&rec))
             }
         }

--- a/crates/nu-command/src/debug/explain.rs
+++ b/crates/nu-command/src/debug/explain.rs
@@ -272,7 +272,7 @@ pub fn debug_string_without_formatting(value: &Value) -> String {
                 .collect::<Vec<_>>()
                 .join(" ")
         ),
-        Value::LazyRecord { val, .. } => match val.collect() {
+        Value::LazyRecord { val, .. } => match val.to_value() {
             Ok(val) => debug_string_without_formatting(&val),
             Err(error) => format!("{error:?}"),
         },

--- a/crates/nu-command/src/debug/info.rs
+++ b/crates/nu-command/src/debug/info.rs
@@ -203,8 +203,8 @@ impl LazySystemInfoRecord {
     }
 }
 
-impl<'a> LazyRecord<'a> for LazySystemInfoRecord {
-    fn column_names(&'a self) -> Vec<&'a str> {
+impl LazyRecord for LazySystemInfoRecord {
+    fn column_names(&self) -> Vec<&str> {
         vec!["thread_id", "pid", "ppid", "process", "system"]
     }
 
@@ -220,7 +220,7 @@ impl<'a> LazyRecord<'a> for LazySystemInfoRecord {
         Value::lazy_record(Box::new(LazySystemInfoRecord { span }), span)
     }
 
-    fn to_record(&'a self) -> Result<Record, ShellError> {
+    fn to_record(&self) -> Result<Record, ShellError> {
         let rk = RefreshKind::new()
             .with_processes(ProcessRefreshKind::everything())
             .with_memory(MemoryRefreshKind::everything());

--- a/crates/nu-command/src/debug/info.rs
+++ b/crates/nu-command/src/debug/info.rs
@@ -220,7 +220,7 @@ impl<'a> LazyRecord<'a> for LazySystemInfoRecord {
         Value::lazy_record(Box::new(LazySystemInfoRecord { span }), span)
     }
 
-    fn collect(&'a self) -> Result<Value, ShellError> {
+    fn to_record(&'a self) -> Result<Record, ShellError> {
         let rk = RefreshKind::new()
             .with_processes(ProcessRefreshKind::everything())
             .with_memory(MemoryRefreshKind::everything());
@@ -233,8 +233,7 @@ impl<'a> LazyRecord<'a> for LazySystemInfoRecord {
                 let val = self.get_column_value_with_system(col, Some(&system))?;
                 Ok((col.to_owned(), val))
             })
-            .collect::<Result<Record, _>>()
-            .map(|record| Value::record(record, self.span()))
+            .collect()
     }
 }
 

--- a/crates/nu-command/src/debug/info.rs
+++ b/crates/nu-command/src/debug/info.rs
@@ -204,11 +204,11 @@ impl LazySystemInfoRecord {
 }
 
 impl LazyRecord for LazySystemInfoRecord {
-    fn column_names(&self) -> Vec<&str> {
+    fn columns(&self) -> Vec<&str> {
         vec!["thread_id", "pid", "ppid", "process", "system"]
     }
 
-    fn get_column_value(&self, column: &str) -> Result<Value, ShellError> {
+    fn get(&self, column: &str) -> Result<Value, ShellError> {
         self.get_column_value_with_system(column, None)
     }
 
@@ -227,7 +227,7 @@ impl LazyRecord for LazySystemInfoRecord {
         // only get information requested
         let system = System::new_with_specifics(rk);
 
-        self.column_names()
+        self.columns()
             .into_iter()
             .map(|col| {
                 let val = self.get_column_value_with_system(col, Some(&system))?;

--- a/crates/nu-command/src/filters/columns.rs
+++ b/crates/nu-command/src/filters/columns.rs
@@ -108,8 +108,7 @@ fn getcol(
                 Value::LazyRecord { val, .. } => {
                     Ok({
                         // Unfortunate casualty to LazyRecord's column_names not generating 'static strs
-                        let cols: Vec<_> =
-                            val.column_names().iter().map(|s| s.to_string()).collect();
+                        let cols: Vec<_> = val.columns().iter().map(|s| s.to_string()).collect();
 
                         cols.into_iter()
                             .map(move |x| Value::string(x, head))

--- a/crates/nu-command/src/filters/find.rs
+++ b/crates/nu-command/src/filters/find.rs
@@ -533,15 +533,10 @@ fn value_should_be_printed(
         Value::Record { val, .. } => {
             record_matches_term(val, columns_to_search, filter_config, term, span)
         }
-        Value::LazyRecord { val, .. } => match val.collect() {
-            Ok(val) => match val {
-                Value::Record { val, .. } => {
-                    record_matches_term(&val, columns_to_search, filter_config, term, span)
-                }
-                _ => false,
-            },
-            Err(_) => false,
-        },
+        Value::LazyRecord { val, .. } => val
+            .to_record()
+            .map(|val| record_matches_term(&val, columns_to_search, filter_config, term, span))
+            .unwrap_or(false),
         Value::Binary { .. } => false,
     });
     if invert {

--- a/crates/nu-command/src/filters/items.rs
+++ b/crates/nu-command/src/filters/items.rs
@@ -45,7 +45,7 @@ impl Command for Items {
             PipelineData::Empty => Ok(PipelineData::Empty),
             PipelineData::Value(value, ..) => {
                 let value = if let Value::LazyRecord { val, .. } = value {
-                    val.collect()?
+                    val.to_value()?
                 } else {
                     value
                 };

--- a/crates/nu-command/src/filters/values.rs
+++ b/crates/nu-command/src/filters/values.rs
@@ -161,20 +161,10 @@ fn values(
                     .cloned()
                     .collect::<Vec<_>>()
                     .into_pipeline_data_with_metadata(metadata, ctrlc)),
-                Value::LazyRecord { val, .. } => {
-                    let record = match val.collect()? {
-                        Value::Record { val, .. } => val,
-                        _ => Err(ShellError::NushellFailedSpanned {
-                            msg: "`LazyRecord::collect()` promises `Value::Record`".into(),
-                            label: "Violating lazy record found here".into(),
-                            span,
-                        })?,
-                    };
-                    Ok(record
-                        .into_owned()
-                        .into_values()
-                        .into_pipeline_data_with_metadata(metadata, ctrlc))
-                }
+                Value::LazyRecord { val, .. } => Ok(val
+                    .to_record()?
+                    .into_values()
+                    .into_pipeline_data_with_metadata(metadata, ctrlc)),
                 // Propagate errors
                 Value::Error { error, .. } => Err(*error),
                 other => Err(ShellError::OnlySupportsThisInputType {

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -136,7 +136,7 @@ pub fn value_to_json_value(v: &Value) -> Result<nu_json::Value, ShellError> {
             nu_json::Value::Object(m)
         }
         Value::LazyRecord { val, .. } => {
-            let collected = val.collect()?;
+            let collected = val.to_value()?;
             value_to_json_value(&collected)?
         }
         Value::Custom { val, .. } => {

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -130,7 +130,7 @@ fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
             .map(|(x, y)| format!("{}: {}", x, local_into_string(y, ", ", config)))
             .collect::<Vec<_>>()
             .join(separator),
-        Value::LazyRecord { val, .. } => match val.collect() {
+        Value::LazyRecord { val, .. } => match val.to_value() {
             Ok(val) => local_into_string(val, separator, config),
             Err(error) => format!("{error:?}"),
         },

--- a/crates/nu-command/src/formats/to/toml.rs
+++ b/crates/nu-command/src/formats/to/toml.rs
@@ -63,7 +63,7 @@ fn helper(engine_state: &EngineState, v: &Value) -> Result<toml::Value, ShellErr
             toml::Value::Table(m)
         }
         Value::LazyRecord { val, .. } => {
-            let collected = val.collect()?;
+            let collected = val.to_value()?;
             helper(engine_state, &collected)?
         }
         Value::List { vals, .. } => toml::Value::Array(toml_list(engine_state, vals)?),

--- a/crates/nu-command/src/formats/to/yaml.rs
+++ b/crates/nu-command/src/formats/to/yaml.rs
@@ -63,7 +63,7 @@ pub fn value_to_yaml_value(v: &Value) -> Result<serde_yaml::Value, ShellError> {
             serde_yaml::Value::Mapping(m)
         }
         Value::LazyRecord { val, .. } => {
-            let collected = val.collect()?;
+            let collected = val.to_value()?;
             value_to_yaml_value(&collected)?
         }
         Value::List { vals, .. } => {

--- a/crates/nu-command/src/system/sys.rs
+++ b/crates/nu-command/src/system/sys.rs
@@ -65,11 +65,11 @@ pub struct SysResult {
 }
 
 impl LazyRecord for SysResult {
-    fn column_names(&self) -> Vec<&str> {
+    fn columns(&self) -> Vec<&str> {
         vec!["host", "cpu", "disks", "mem", "temp", "net"]
     }
 
-    fn get_column_value(&self, column: &str) -> Result<Value, ShellError> {
+    fn get(&self, column: &str) -> Result<Value, ShellError> {
         let span = self.span;
 
         match column {

--- a/crates/nu-command/src/system/sys.rs
+++ b/crates/nu-command/src/system/sys.rs
@@ -64,8 +64,8 @@ pub struct SysResult {
     pub span: Span,
 }
 
-impl LazyRecord<'_> for SysResult {
-    fn column_names(&self) -> Vec<&'static str> {
+impl LazyRecord for SysResult {
+    fn column_names(&self) -> Vec<&str> {
         vec!["host", "cpu", "disks", "mem", "temp", "net"]
     }
 

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -395,7 +395,7 @@ fn handle_table_command(
             handle_record(input, cfg, val.into_owned())
         }
         PipelineData::Value(Value::LazyRecord { val, .. }, ..) => {
-            input.data = val.collect()?.into_pipeline_data();
+            input.data = val.to_value()?.into_pipeline_data();
             handle_table_command(input, cfg)
         }
         PipelineData::Value(Value::Error { error, .. }, ..) => {

--- a/crates/nu-explore/src/nu_common/value.rs
+++ b/crates/nu-explore/src/nu_common/value.rs
@@ -109,13 +109,12 @@ pub fn collect_input(value: Value) -> (Vec<String>, Vec<Vec<Value>>) {
 
             (vec![String::from("")], lines)
         }
-        Value::LazyRecord { val, .. } => match val.collect() {
-            Ok(value) => collect_input(value),
-            Err(_) => (
+        Value::LazyRecord { val, .. } => val.to_value().map(collect_input).unwrap_or_else(|_| {
+            (
                 vec![String::from("")],
                 vec![vec![Value::lazy_record(val, span)]],
-            ),
-        },
+            )
+        }),
         Value::Nothing { .. } => (vec![], vec![]),
         value => (vec![String::from("")], vec![vec![value]]),
     }

--- a/crates/nu-plugin-test-support/src/plugin_test.rs
+++ b/crates/nu-plugin-test-support/src/plugin_test.rs
@@ -340,8 +340,8 @@ impl PluginTest {
                 Ok(true)
             }
             // Must collect lazy records to compare.
-            (Value::LazyRecord { val: a_val, .. }, _) => self.value_eq(&a_val.collect()?, b),
-            (_, Value::LazyRecord { val: b_val, .. }) => self.value_eq(a, &b_val.collect()?),
+            (Value::LazyRecord { val: a_val, .. }, _) => self.value_eq(&a_val.to_value()?, b),
+            (_, Value::LazyRecord { val: b_val, .. }) => self.value_eq(a, &b_val.to_value()?),
             // Fall back to regular eq.
             _ => Ok(a == b),
         }

--- a/crates/nu-plugin/src/plugin/command.rs
+++ b/crates/nu-plugin/src/plugin/command.rs
@@ -383,7 +383,7 @@ pub(crate) fn render_examples(
                     }
                     // Collect LazyRecord before proceeding
                     Value::LazyRecord { ref val, .. } => {
-                        *value = val.collect()?;
+                        *value = val.to_value()?;
                         Ok(())
                     }
                     _ => Ok(()),

--- a/crates/nu-plugin/src/protocol/plugin_custom_value.rs
+++ b/crates/nu-plugin/src/protocol/plugin_custom_value.rs
@@ -324,7 +324,7 @@ impl PluginCustomValue {
                 }
                 // Collect LazyRecord before proceeding
                 Value::LazyRecord { ref val, .. } => {
-                    *value = val.collect()?;
+                    *value = val.to_value()?;
                     Ok(())
                 }
                 _ => Ok(()),
@@ -350,7 +350,7 @@ impl PluginCustomValue {
                 }
                 // Collect LazyRecord before proceeding
                 Value::LazyRecord { ref val, .. } => {
-                    *value = val.collect()?;
+                    *value = val.to_value()?;
                     Ok(())
                 }
                 _ => Ok(()),
@@ -369,7 +369,7 @@ impl PluginCustomValue {
                 }
                 // Collect LazyRecord before proceeding
                 Value::LazyRecord { ref val, .. } => {
-                    *value = val.collect()?;
+                    *value = val.to_value()?;
                     Ok(())
                 }
                 _ => Ok(()),

--- a/crates/nu-plugin/src/util/with_custom_values_in.rs
+++ b/crates/nu-plugin/src/util/with_custom_values_in.rs
@@ -22,7 +22,7 @@ where
             // next time, and we have to collect it anyway to serialize it. Collect it in place,
             // and then use the result
             Value::LazyRecord { val, .. } => {
-                *value = val.collect()?;
+                *value = val.to_value()?;
                 Ok(())
             }
             _ => Ok(()),

--- a/crates/nu-plugin/src/util/with_custom_values_in.rs
+++ b/crates/nu-plugin/src/util/with_custom_values_in.rs
@@ -37,8 +37,8 @@ fn find_custom_values() {
 
     #[derive(Debug, Clone)]
     struct Lazy;
-    impl<'a> LazyRecord<'a> for Lazy {
-        fn column_names(&'a self) -> Vec<&'a str> {
+    impl LazyRecord for Lazy {
+        fn column_names(&self) -> Vec<&str> {
             vec!["custom", "plain"]
         }
 

--- a/crates/nu-plugin/src/util/with_custom_values_in.rs
+++ b/crates/nu-plugin/src/util/with_custom_values_in.rs
@@ -38,11 +38,11 @@ fn find_custom_values() {
     #[derive(Debug, Clone)]
     struct Lazy;
     impl LazyRecord for Lazy {
-        fn column_names(&self) -> Vec<&str> {
+        fn columns(&self) -> Vec<&str> {
             vec!["custom", "plain"]
         }
 
-        fn get_column_value(&self, column: &str) -> Result<Value, ShellError> {
+        fn get(&self, column: &str) -> Result<Value, ShellError> {
             Ok(match column {
                 "custom" => Value::test_custom_value(Box::new(test_plugin_custom_value())),
                 "plain" => Value::test_int(42),

--- a/crates/nu-protocol/src/value/lazy_record.rs
+++ b/crates/nu-protocol/src/value/lazy_record.rs
@@ -6,19 +6,19 @@ use std::fmt;
 /// or into a [`Record`] with [`to_record`](LazyRecord::to_record).
 pub trait LazyRecord: fmt::Debug + Send + Sync {
     /// All column names
-    fn column_names(&self) -> Vec<&str>;
+    fn columns(&self) -> Vec<&str>;
 
     /// Get the value for a specific column
-    fn get_column_value(&self, column: &str) -> Result<Value, ShellError>;
+    fn get(&self, column: &str) -> Result<Value, ShellError>;
 
     fn span(&self) -> Span;
 
     /// Convert this [`LazyRecord`] into a [`Record`] by evaluating all of its columns
     fn to_record(&self) -> Result<Record, ShellError> {
-        self.column_names()
+        self.columns()
             .into_iter()
             .map(|col| {
-                let val = self.get_column_value(col)?;
+                let val = self.get(col)?;
                 Ok((col.to_owned(), val))
             })
             .collect()

--- a/crates/nu-protocol/src/value/lazy_record.rs
+++ b/crates/nu-protocol/src/value/lazy_record.rs
@@ -1,27 +1,32 @@
 use crate::{Record, ShellError, Span, Value};
 use std::fmt;
 
-// Trait definition for a lazy record (where columns are evaluated on-demand)
-// typetag is needed to make this implement Serialize+Deserialize... even though we should never actually serialize a LazyRecord.
-// To serialize a LazyRecord, collect it into a Value::Record with collect() first.
+/// Trait definition for a lazy record (where columns are evaluated on-demand)
+/// To serialize a LazyRecord, convert it into a [`Value`] with [`to_value`](LazyRecord::to_value)
+/// or into a [`Record`] with [`to_record`](LazyRecord::to_record).
 pub trait LazyRecord<'a>: fmt::Debug + Send + Sync {
-    // All column names
+    /// All column names
     fn column_names(&'a self) -> Vec<&'a str>;
 
-    // Get 1 specific column value
+    /// Get the value for a specific column
     fn get_column_value(&self, column: &str) -> Result<Value, ShellError>;
 
     fn span(&self) -> Span;
 
-    // Convert the lazy record into a regular Value::Record by collecting all its columns
-    fn collect(&'a self) -> Result<Value, ShellError> {
+    /// Convert this [`LazyRecord`] into a [`Record`] by evaluating all of its columns
+    fn to_record(&'a self) -> Result<Record, ShellError> {
         self.column_names()
             .into_iter()
             .map(|col| {
                 let val = self.get_column_value(col)?;
                 Ok((col.to_owned(), val))
             })
-            .collect::<Result<Record, _>>()
+            .collect()
+    }
+
+    /// Convert this [`LazyRecord`] into a [`Value`] by evaluating all of its columns
+    fn to_value(&'a self) -> Result<Value, ShellError> {
+        self.to_record()
             .map(|record| Value::record(record, self.span()))
     }
 

--- a/crates/nu-protocol/src/value/lazy_record.rs
+++ b/crates/nu-protocol/src/value/lazy_record.rs
@@ -4,9 +4,9 @@ use std::fmt;
 /// Trait definition for a lazy record (where columns are evaluated on-demand)
 /// To serialize a LazyRecord, convert it into a [`Value`] with [`to_value`](LazyRecord::to_value)
 /// or into a [`Record`] with [`to_record`](LazyRecord::to_record).
-pub trait LazyRecord<'a>: fmt::Debug + Send + Sync {
+pub trait LazyRecord: fmt::Debug + Send + Sync {
     /// All column names
-    fn column_names(&'a self) -> Vec<&'a str>;
+    fn column_names(&self) -> Vec<&str>;
 
     /// Get the value for a specific column
     fn get_column_value(&self, column: &str) -> Result<Value, ShellError>;
@@ -14,7 +14,7 @@ pub trait LazyRecord<'a>: fmt::Debug + Send + Sync {
     fn span(&self) -> Span;
 
     /// Convert this [`LazyRecord`] into a [`Record`] by evaluating all of its columns
-    fn to_record(&'a self) -> Result<Record, ShellError> {
+    fn to_record(&self) -> Result<Record, ShellError> {
         self.column_names()
             .into_iter()
             .map(|col| {
@@ -25,7 +25,7 @@ pub trait LazyRecord<'a>: fmt::Debug + Send + Sync {
     }
 
     /// Convert this [`LazyRecord`] into a [`Value`] by evaluating all of its columns
-    fn to_value(&'a self) -> Result<Value, ShellError> {
+    fn to_value(&self) -> Result<Value, ShellError> {
         self.to_record()
             .map(|record| Value::record(record, self.span()))
     }

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -166,7 +166,7 @@ pub enum Value {
     },
     #[serde(skip)]
     LazyRecord {
-        val: Box<dyn for<'a> LazyRecord<'a>>,
+        val: Box<dyn LazyRecord>,
         // note: spans are being refactored out of Value
         // please use .span() instead of matching this span value
         internal_span: Span,
@@ -673,7 +673,7 @@ impl Value {
     }
 
     /// Returns a reference to the inner [`LazyRecord`] trait object or an error if this `Value` is not a lazy record
-    pub fn as_lazy_record(&self) -> Result<&dyn for<'a> LazyRecord<'a>, ShellError> {
+    pub fn as_lazy_record(&self) -> Result<&dyn LazyRecord, ShellError> {
         if let Value::LazyRecord { val, .. } = self {
             Ok(val.as_ref())
         } else {
@@ -682,7 +682,7 @@ impl Value {
     }
 
     /// Unwraps the inner [`LazyRecord`] trait object or returns an error if this `Value` is not a lazy record
-    pub fn into_lazy_record(self) -> Result<Box<dyn for<'a> LazyRecord<'a>>, ShellError> {
+    pub fn into_lazy_record(self) -> Result<Box<dyn LazyRecord>, ShellError> {
         if let Value::LazyRecord { val, .. } = self {
             Ok(val)
         } else {
@@ -1998,7 +1998,7 @@ impl Value {
         }
     }
 
-    pub fn lazy_record(val: Box<dyn for<'a> LazyRecord<'a>>, span: Span) -> Value {
+    pub fn lazy_record(val: Box<dyn LazyRecord>, span: Span) -> Value {
         Value::LazyRecord {
             val,
             internal_span: span,
@@ -2103,7 +2103,7 @@ impl Value {
 
     /// Note: Only use this for test data, *not* live data, as it will point into unknown source
     /// when used in errors.
-    pub fn test_lazy_record(val: Box<dyn for<'a> LazyRecord<'a>>) -> Value {
+    pub fn test_lazy_record(val: Box<dyn LazyRecord>) -> Value {
         Value::lazy_record(val, Span::test_data())
     }
 

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -1138,7 +1138,7 @@ impl Value {
                             }
                         }
                         Value::LazyRecord { val, .. } => {
-                            let columns = val.column_names();
+                            let columns = val.columns();
 
                             if let Some(col) = columns.iter().rev().find(|&col| {
                                 if insensitive {
@@ -1147,7 +1147,7 @@ impl Value {
                                     col == column_name
                                 }
                             }) {
-                                current = val.get_column_value(col)?;
+                                current = val.get(col)?;
                             } else if *optional {
                                 return Ok(Value::nothing(*origin_span)); // short-circuit
                             } else if let Some(suggestion) = did_you_mean(&columns, column_name) {

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -222,7 +222,7 @@ fn value_to_string(
             ))
         }
         Value::LazyRecord { val, .. } => {
-            let collected = val.collect()?;
+            let collected = val.to_value()?;
             value_to_string(&collected, span, depth + 1, indent)
         }
         // All strings outside data structures are quoted because they are in 'command position'


### PR DESCRIPTION
# Description
Since `LazyRecord` was created before the introduction of the `Record` type, the API can be improved a little bit. This PR:
- adds a `to_record` trait method to turn a `LazyRecord` into a `Record`.
- renames `collect` to `to_value` for consistency.
- renames the other methods to match the `Record` API.
  - `column_names` => `columns`
  - `get_column_value` => `get`

The last major change is to remove the lifetime parameter from the `LazyRecord` trait. If my Rust understanding is correct, we shouldn't need to have a lifetime parameter on the trait. A lifetime might be added to a trait, if for example, a lifetime appears on an argument in one of the trait methods. E.g.:
```rust
trait TraitLife<'a> {
    fn consume_lifetime(&self, thing: &'a Thing);
}
```
This would allow a trait implementer to have the same lifetime as the one specified by the trait. In this example, it makes it possible for the trait implementer to store `thing: &'a Thing` inside itself.

It looks like the lifetime parameter was originally added to `LazyRecord` for `column_names`.
```rust
    fn column_names(&'a self) -> Vec<&'a str>;
``` 
But, removing the lifetime should be perfectly fine here. I don't think it needs to be tied to a trait lifetime.
```rust
    fn column_names(&self) -> Vec<&str>;
    // The lifetime is elided, but the signature is still:
    // fn column_names<'a>(&'a self) -> Vec<&'a str>;
```