### PR TITLE
Fix error message propagation on plugin call failure

### DIFF
--- a/crates/nu-plugin/src/plugin/interface/plugin.rs
+++ b/crates/nu-plugin/src/plugin/interface/plugin.rs
@@ -817,10 +817,15 @@ impl PluginInterface {
                 }
             }
         }
-        // If we fail to get a response
-        Err(ShellError::PluginFailedToDecode {
-            msg: "Failed to receive response to plugin call".into(),
-        })
+        // If we fail to get a response, check for an error in the state first, and return it if
+        // set. This is probably a much more helpful error than 'failed to receive response'
+        if let Some(error) = self.state.error.get() {
+            Err(error.clone())
+        } else {
+            Err(ShellError::PluginFailedToDecode {
+                msg: "Failed to receive response to plugin call".into(),
+            })
+        }
     }
 
     /// Handle an engine call and write the response.


### PR DESCRIPTION
# Description

This should fix the sometimes failing wrong version test for
stress_internals.

The plugin interface state stores an error if some kind of critical
error happened, and this error should be propagated to any future
operations on the interface, but this wasn't being propagated to plugin
calls that were already waiting.

During plugin registration, the wrong version error needs to be received
as a response to the `get_signature()` to show up properly, but this
would only happen if `get_signature()` started after the `Hello` was
already received and processed. That would be a race condition, which
this commit solves.

cc @sholderbach - this should fix the CI issue

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

