### PR TITLE
Lazy record deprecation

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/lazy_make.rs
@@ -54,6 +54,18 @@ impl Command for LazyMake {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        nu_protocol::report_error_new(
+            engine_state,
+            &ShellError::GenericError {
+                error: "Deprecated command".into(),
+                msg: "warning: lazy records and the `lazy make` command will be removed in 0.94.0"
+                    .into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            },
+        );
+
         let span = call.head;
         let columns: Vec<Spanned<String>> = call
             .get_flag(engine_state, stack, "columns")?


### PR DESCRIPTION
# Description
In this week's nushell meeting, we decided to go ahead with #12622 and remove lazy records in 0.94.0. For 0.93.0, we will only deprecate `lazy make`, and so this PR makes `lazy make` print a deprecation warning.

# User-Facing Changes
None, besides the deprecation warning.

# After Submitting
Remove lazy records.