### PR TITLE
Fix an `into bits` example

### DIFF
--- a/crates/nu-cmd-extra/src/extra/bits/into.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/into.rs
@@ -64,7 +64,7 @@ impl Command for BitsInto {
         vec![
             Example {
                 description: "convert a binary value into a string, padded to 8 places with 0s",
-                example: "01b | into bits",
+                example: "0x[1] | into bits",
                 result: Some(Value::string("00000001",
                     Span::test_data(),
                 )),


### PR DESCRIPTION
# Description
One example for `into bits` says it uses binary value when it actually uses a filesize. This lead to issue #11412, but I never got around to fixing the example until this PR.