### PR TITLE
Add plugin error propagation on write/flush

### DIFF
--- a/crates/nu_plugin_stress_internals/src/main.rs
+++ b/crates/nu_plugin_stress_internals/src/main.rs
@@ -82,6 +82,12 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         std::process::exit(1)
     }
 
+    // Read `Hello` message
+    let mut de = serde_json::Deserializer::from_reader(&mut input);
+    let hello: Value = Value::deserialize(&mut de)?;
+
+    assert!(hello.get("Hello").is_some());
+
     // Send `Hello` message
     write(
         &mut output,
@@ -102,12 +108,6 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             }
         }),
     )?;
-
-    // Read `Hello` message
-    let mut de = serde_json::Deserializer::from_reader(&mut input);
-    let hello: Value = Value::deserialize(&mut de)?;
-
-    assert!(hello.get("Hello").is_some());
 
     if opts.exit_early {
         // Exit without handling anything other than Hello


### PR DESCRIPTION
# Description
Yet another attempt to fix the `stress_internals::test_wrong_version()` test...

This time I think it's probably because we are getting a broken pipe write error when we try to send `Hello` or perhaps something after it, because the pipe has already been closed by the reader when it saw the invalid version. In that case, an error should be available in state. It probably makes more sense to send that back to the user rather than an unhelpful I/O error.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

