### PR TITLE
Upgrade hustcer/setup-nu to v3.10 to fix macOS arm64 build errors

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -36,7 +36,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Setup Nushell
-        uses: hustcer/setup-nu@v3.9
+        uses: hustcer/setup-nu@v3.10
         if: github.repository == 'nushell/nightly'
         with:
           version: 0.91.0
@@ -139,7 +139,7 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.9
+      uses: hustcer/setup-nu@v3.10
       with:
         version: 0.91.0
 
@@ -251,7 +251,7 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.9
+      uses: hustcer/setup-nu@v3.10
       with:
         version: 0.91.0
 
@@ -315,7 +315,7 @@ jobs:
           ref: main
 
       - name: Setup Nushell
-        uses: hustcer/setup-nu@v3.9
+        uses: hustcer/setup-nu@v3.10
         with:
           version: 0.91.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.9
+      uses: hustcer/setup-nu@v3.10
       with:
         version: 0.91.0
 
@@ -177,7 +177,7 @@ jobs:
         rustflags: ''
 
     - name: Setup Nushell
-      uses: hustcer/setup-nu@v3.9
+      uses: hustcer/setup-nu@v3.10
       with:
         version: 0.91.0
 


### PR DESCRIPTION
Upgrade hustcer/setup-nu to [v3.10](https://github.com/hustcer/setup-nu/releases/tag/v3.10) to fix macOS arm64 build errors
Release Testing: https://github.com/nushell/nightly/actions/runs/8856404620