### PR TITLE
Add `--stream` option to `str join` and `bytes collect`

### DIFF
--- a/crates/nu-command/src/example_test.rs
+++ b/crates/nu-command/src/example_test.rs
@@ -20,10 +20,10 @@ pub fn test_examples_with_commands(cmd: impl Command + 'static, commands: &[&dyn
 #[cfg(test)]
 mod test_examples {
     use super::super::{
-        Ansi, Date, Enumerate, Filter, First, Flatten, From, Get, Into, IntoDatetime, IntoString,
-        Lines, Math, MathRound, MathSum, ParEach, Path, PathParse, Random, Seq, Sort, SortBy,
-        Split, SplitColumn, SplitRow, Str, StrJoin, StrLength, StrReplace, Update, Url, Values,
-        Wrap,
+        Ansi, Date, Enumerate, Filter, First, Flatten, From, Get, Into, IntoBinary, IntoDatetime,
+        IntoString, Lines, Math, MathRound, MathSum, ParEach, Path, PathParse, Random, Seq, Sort,
+        SortBy, Split, SplitColumn, SplitRow, Str, StrJoin, StrLength, StrReplace, Update, Url,
+        Values, Wrap,
     };
     use crate::{Default, Each, To};
     use nu_cmd_lang::example_support::{
@@ -91,6 +91,7 @@ mod test_examples {
             working_set.add_decl(Box::new(Get));
             working_set.add_decl(Box::new(If));
             working_set.add_decl(Box::new(Into));
+            working_set.add_decl(Box::new(IntoBinary));
             working_set.add_decl(Box::new(IntoString));
             working_set.add_decl(Box::new(IntoDatetime));
             working_set.add_decl(Box::new(Let));

--- a/crates/nu-lsp/src/lib.rs
+++ b/crates/nu-lsp/src/lib.rs
@@ -1033,7 +1033,7 @@ mod tests {
             serde_json::json!({
                 "contents": {
                     "kind": "markdown",
-                    "value": "Concatenate multiple strings into a single string, with an optional separator between each.\n### Usage \n```nu\n  str join {flags} <separator?>\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n\n### Parameters\n\n  `separator: string` - Optional separator to use when creating string.\n\n\n### Input/output types\n\n```nu\n list<any> | string\n string | string\n\n```\n### Example(s)\n  Create a string from input\n```nu\n  ['nu', 'shell'] | str join\n```\n  Create a string from input with a separator\n```nu\n  ['nu', 'shell'] | str join '-'\n```\n"
+                    "value": "Concatenate multiple strings into a single string, with an optional separator between each.\n### Usage \n```nu\n  str join {flags} <separator?>\n```\n\n### Flags\n\n  `-h`, `--help` - Display the help message for this command\n\n  `-s`, `--stream` - Output the result as a raw stream, instead of collecting to a string.\n\n\n### Parameters\n\n  `separator: string` - Optional separator to use when creating string.\n\n\n### Input/output types\n\n```nu\n list<any> | string\n string | string\n\n```\n### Example(s)\n  Create a string from input\n```nu\n  ['nu', 'shell'] | str join\n```\n  Create a string from input with a separator\n```nu\n  ['nu', 'shell'] | str join '-'\n```\n  Join a stream of numbers with commas\n```nu\n  seq 1 5 | str join --stream \", \"\n```\n  Join an infinite stream of numbers with commas\n```nu\n  1.. | each {} | str join --stream \", \"\n```\n",
                 }
             })
         );


### PR DESCRIPTION
# Description
This adds two useful ways to create raw streams, depending on whether you want to join strings or bytes. If you have a need to create streaming output that is just raw data, you can use one of these two commands to do it.

This competes with #12674, which adds a single command to do the same for either or a mix of the two. I personally prefer this one, because it feels more discoverable, and I've found myself wanting a `str join` that was streaming in the past.

The only potential UX quirk here is that `bytes collect --stream` could potentially create valid UTF-8 data, which would then be interpreted as a string if passed to a command that collects it. That's a little bit weird, and something `to raw` avoids by just not making any guarantee about the output.

On the plus side, I do think this improves the code for these two commands a little bit at the same time, and it's relatively straightforward to use one base iterator to produce both paths.

# User-Facing Changes
- add `--stream` to `str join`
- add `--stream` to `bytes collect`

# Tests + Formatting
Examples added for both.

# After Submitting
- [ ] release notes