### PR TITLE
restore `query web --as-table` to working order

### DIFF
--- a/crates/nu_plugin_query/src/query_web.rs
+++ b/crates/nu_plugin_query/src/query_web.rs
@@ -126,10 +126,6 @@ pub fn parse_selector_params(call: &EvaluatedCall, input: &Value) -> Result<Valu
                 .with_label(err.to_string(), query.span)
                 .with_help("cannot parse this query as a valid CSS selector"));
         }
-    } else {
-        return Err(
-            LabeledError::new("Missing query argument").with_label("add --query here", call.head)
-        );
     }
 
     let selector = Selector {


### PR DESCRIPTION
# Description

This PR fixes a problem introduced with PR https://github.com/nushell/nushell/pull/12236. That PR accidentally stopped `--as-table` from working.

Closes https://github.com/nushell/nushell/issues/12689

It works again.
![image](https://github.com/nushell/nushell/assets/343840/b517507f-6b92-4e39-a389-5c69907d77c0)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
