### PR TITLE
Fix missing local socket feature

### DIFF
--- a/crates/nu-plugin-core/Cargo.toml
+++ b/crates/nu-plugin-core/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 
 [dependencies]
 nu-protocol = { path = "../nu-protocol", version = "0.92.3" }
-nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.92.3" }
+nu-plugin-protocol = { path = "../nu-plugin-protocol", version = "0.92.3", default-features = false }
 
 rmp-serde = { workspace = true }
 serde = { workspace = true }
@@ -22,7 +22,7 @@ interprocess = { workspace = true, optional = true }
 
 [features]
 default = ["local-socket"]
-local-socket = ["interprocess"]
+local-socket = ["interprocess", "nu-plugin-protocol/local-socket"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { workspace = true }

--- a/crates/nu-plugin-protocol/Cargo.toml
+++ b/crates/nu-plugin-protocol/Cargo.toml
@@ -18,3 +18,7 @@ bincode = "1.3"
 serde = { workspace = true, features = ["derive"] }
 semver = "1.0"
 typetag = "0.2"
+
+[features]
+default = ["local-socket"]
+local-socket = []


### PR DESCRIPTION
# Description

So sorry to do this during the pre-release freeze, but my plugin crate split PR broke local socket mode, because `nu-plugin-protocol` didn't have the compile feature to advertise the `LocalSocket` protocol feature.

This is a very simple, configuration-only bugfix that I think really needs to be merged before the release, or else local socket mode won't work at all.

# Tests + Formatting

There's an oversight in my testing that caused this to not be caught: the engine really did have the feature, but it just wasn't advertising it, so for `stress_internals` it was still able to use it successfully. Post-release I'll try to make sure this is properly handled somehow.
