### PR TITLE
Add `fs` feature to `nix` dependency

### DIFF
--- a/crates/nu-utils/Cargo.toml
+++ b/crates/nu-utils/Cargo.toml
@@ -29,4 +29,4 @@ unicase = "2.7.0"
 crossterm_winapi = "0.9"
 
 [target.'cfg(unix)'.dependencies]
-nix = { workspace = true, default-features = false, features = ["user"] }
+nix = { workspace = true, default-features = false, features = ["user", "fs"] }


### PR DESCRIPTION
# Description
Caught a compilation error using `cargo hack` -- `nu-utils` will not compile without the `fs` feature enabled for `nix`.