### PR TITLE
workflows/release: Make tar archive reproducible

### DIFF
--- a/.github/workflows/release-pkg.nu
+++ b/.github/workflows/release-pkg.nu
@@ -170,7 +170,8 @@ if $os in ['macos-latest'] or $USE_UBUNTU {
 
     print $'(char nl)(ansi g)Archive contents:(ansi reset)'; hr-line; ls $dest | print
 
-    tar -czf $archive $dest
+    # https://reproducible-builds.org/docs/archives/
+    tar --sort=name $"--mtime=@($env.SOURCE_DATE_EPOCH)" --owner=0 --group=0 --numeric-owner '--pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime' -czf $archive $dest
     print $'archive: ---> ($archive)'; ls $archive
     # REF: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
     echo $"archive=($archive)" | save --append $env.GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.3
 
+    - name: Set SOURCE_DATE_EPOCH
+      run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+
     - name: Update Rust Toolchain Target
       run: |
         echo "targets = ['${{matrix.target}}']" >> rust-toolchain.toml


### PR DESCRIPTION
This is just a general good practice, but I hit a weird issue where trying to unpack this tarball in a github action failed because we changed ownership to the runner when run as root.

(I didn't test this locally, sorry)