### PR TITLE
Bump `reedline` to `0.32.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4878,8 +4878,9 @@ dependencies = [
 
 [[package]]
 name = "reedline"
-version = "0.31.0"
-source = "git+https://github.com/nushell/reedline?branch=main#4cf8c75d68ccb51451dc483b07dbf3d30ab1da10"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf59e4c97b5049ba96b052cdb652368305a2eddcbce9bf1c16f9d003139eeea"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ quickcheck_macros = "1.0"
 rand = "0.8"
 ratatui = "0.26"
 rayon = "1.10"
-reedline = "0.31.0"
+reedline = "0.32.0"
 regex = "1.9.5"
 rmp = "0.8"
 rmp-serde = "1.2"
@@ -304,7 +304,7 @@ bench = false
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]
-reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
+# reedline = { git = "https://github.com/nushell/reedline", branch = "main" }
 # nu-ansi-term = {git = "https://github.com/nushell/nu-ansi-term.git", branch = "main"}
 
 # Run all benchmarks with `cargo bench`


### PR DESCRIPTION
# Description

Follow `reedline` release to `0.32.0`, disable crates.io git patch
