### PR TITLE
Fix Windows Terminal profile installation

### DIFF
--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -392,10 +392,11 @@
 
         <Property Id='ARPHELPLINK' Value='https://www.nushell.sh/book/'/>
 
+        <!-- for Value, see https://learn.microsoft.com/en-ca/windows/win32/msi/formatted -->
         <SetProperty
             Id="ReplacePathsInWindowsTerminalProfile"
             Sequence="execute"
-            Value="&quot;[#exe0]&quot; -c &quot;open `[#WindowsTerminalProfileFile]` | update profiles.commandline `[#exe0]` | update profiles.icon `[#icon0]` | collect &#123; save -f `[#WindowsTerminalProfileFile]` &#125;&quot;"
+            Value="&quot;[#exe0]&quot; -c &quot;let doc = (open `[#WindowsTerminalProfileFile]` | update profiles.commandline `[#exe0]` | update profiles.icon `[#icon0]`); $doc | save -f `[#WindowsTerminalProfileFile]`&quot;"
             After='CostFinalize'/>
         <CustomAction
             Id="ReplacePathsInWindowsTerminalProfile"

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -395,7 +395,7 @@
         <SetProperty
             Id="ReplacePathsInWindowsTerminalProfile"
             Sequence="execute"
-            Value="&quot;[#exe0]&quot; -c &quot;open `[#WindowsTerminalProfileFile]` | update profiles.commandline `[#exe0]` | update profiles.icon `[#icon0]` | collect { save -f `[#WindowsTerminalProfileFile]` }&quot;"
+            Value="&quot;[#exe0]&quot; -c &quot;open `[#WindowsTerminalProfileFile]` | update profiles.commandline `[#exe0]` | update profiles.icon `[#icon0]` | collect &#123; save -f `[#WindowsTerminalProfileFile]` &#125;&quot;"
             After='CostFinalize'/>
         <CustomAction
             Id="ReplacePathsInWindowsTerminalProfile"

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -395,7 +395,7 @@
         <SetProperty
             Id="ReplacePathsInWindowsTerminalProfile"
             Sequence="execute"
-            Value="&quot;[#exe0]&quot; -c &quot;open `[#WindowsTerminalProfileFile]` | update profiles.commandline `[#exe0]` | update profiles.icon `[#icon0]` | save -f `[#WindowsTerminalProfileFile]`&quot;"
+            Value="&quot;[#exe0]&quot; -c &quot;open `[#WindowsTerminalProfileFile]` | update profiles.commandline `[#exe0]` | update profiles.icon `[#icon0]` | collect { save -f `[#WindowsTerminalProfileFile]` }&quot;"
             After='CostFinalize'/>
         <CustomAction
             Id="ReplacePathsInWindowsTerminalProfile"


### PR DESCRIPTION
# Description

The command used to edit the Windows Terminal profiling was failing due to the `open file | save -f file` metadata safeguard introduced in this version. With this, the installer is now fixed again.
