### PR TITLE
add support for cell-paths to NUON

### DIFF
--- a/crates/nuon/src/from.rs
+++ b/crates/nuon/src/from.rs
@@ -148,12 +148,7 @@ fn convert_to_value(
             msg: "calls not supported in nuon".into(),
             span: expr.span,
         }),
-        Expr::CellPath(..) => Err(ShellError::OutsideSpannedLabeledError {
-            src: original_text.to_string(),
-            error: "Error when loading".into(),
-            msg: "subexpressions and cellpaths not supported in nuon".into(),
-            span: expr.span,
-        }),
+        Expr::CellPath(val) => Ok(Value::cell_path(val, span)),
         Expr::DateTime(dt) => Ok(Value::date(dt, span)),
         Expr::ExternalCall(..) => Err(ShellError::OutsideSpannedLabeledError {
             src: original_text.to_string(),

--- a/crates/nuon/src/lib.rs
+++ b/crates/nuon/src/lib.rs
@@ -14,7 +14,11 @@ pub use to::ToStyle;
 #[cfg(test)]
 mod tests {
     use chrono::DateTime;
-    use nu_protocol::{ast::RangeInclusion, engine::Closure, record, IntRange, Range, Span, Value};
+    use nu_protocol::{
+        ast::{CellPath, PathMember, RangeInclusion},
+        engine::Closure,
+        record, IntRange, Range, Span, Value,
+    };
 
     use crate::{from_nuon, to_nuon, ToStyle};
 
@@ -322,6 +326,20 @@ mod tests {
                     "b" => Value::test_string("lu"),
                 )),
             ])),
+        );
+    }
+
+    #[test]
+    fn cell_path() {
+        nuon_end_to_end(
+            r#"$.foo.bar.0"#,
+            Some(Value::test_cell_path(CellPath {
+                members: vec![
+                    PathMember::string("foo".to_string(), false, Span::new(2, 5)),
+                    PathMember::string("bar".to_string(), false, Span::new(6, 9)),
+                    PathMember::int(0, false, Span::new(10, 11)),
+                ],
+            })),
         );
     }
 

--- a/crates/nuon/src/to.rs
+++ b/crates/nuon/src/to.rs
@@ -97,12 +97,7 @@ fn value_to_string(
                 Ok("false".to_string())
             }
         }
-        Value::CellPath { .. } => Err(ShellError::UnsupportedInput {
-            msg: "cell-paths are currently not nuon-compatible".to_string(),
-            input: "value originates from here".into(),
-            msg_span: span,
-            input_span: v.span(),
-        }),
+        Value::CellPath { val, .. } => Ok(format!("$.{}", val)),
         Value::Custom { .. } => Err(ShellError::UnsupportedInput {
             msg: "custom values are currently not nuon-compatible".to_string(),
             input: "value originates from here".into(),


### PR DESCRIPTION
# Description
_cell paths_ can be easily serialized back and forth to NUON with the leading `$.` syntax.

# User-Facing Changes
```nushell
$.foo.bar.0 | to nuon
```
and
```nushell
"$.foo.bar.0" | from nuon
```
are now possible

# Tests + Formatting
a new `cell_path` test has been added to `nuon`

# After Submitting