### PR TITLE
Upgrade Nu to v0.93.0 for nightly and release workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -39,7 +39,7 @@ jobs:
         uses: hustcer/setup-nu@v3.10
         if: github.repository == 'nushell/nightly'
         with:
-          version: 0.91.0
+          version: 0.93.0
 
       # Synchronize the main branch of nightly repo with the main branch of Nushell official repo
       - name: Prepare for Nightly Release
@@ -141,7 +141,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3.10
       with:
-        version: 0.91.0
+        version: 0.93.0
 
     - name: Release Nu Binary
       id: nu
@@ -253,7 +253,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3.10
       with:
-        version: 0.91.0
+        version: 0.93.0
 
     - name: Release Nu Binary
       id: nu
@@ -317,7 +317,7 @@ jobs:
       - name: Setup Nushell
         uses: hustcer/setup-nu@v3.10
         with:
-          version: 0.91.0
+          version: 0.93.0
 
       # Keep the last a few releases
       - name: Delete Older Releases

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3.10
       with:
-        version: 0.91.0
+        version: 0.93.0
 
     - name: Release Nu Binary
       id: nu
@@ -179,7 +179,7 @@ jobs:
     - name: Setup Nushell
       uses: hustcer/setup-nu@v3.10
       with:
-        version: 0.91.0
+        version: 0.93.0
 
     - name: Release Nu Binary
       id: nu


### PR DESCRIPTION
Upgrade Nu to v0.93.0 for nightly and release workflow
Nightly test: https://github.com/nushell/nightly/actions/runs/8909902492