### PR TITLE
Add `toolkit release-pkg windows` for Windows release pkg builds

### DIFF
--- a/toolkit.nu
+++ b/toolkit.nu
@@ -491,4 +491,46 @@ export def cov [] {
     print $"Coverage generation took ($end - $start)."
 }
 
+# Build all Windows archives and MSIs for release manually
+#
+# This builds std and full distributions for both aarch64 and x86_64.
+#
+# You need to have the cross-compilers for MSVC installed (see Visual Studio).
+# If compiling on x86_64, you need ARM64 compilers and libs too, and vice versa.
+export def 'release-pkg windows' [
+    --artifacts-dir="artifacts" # Where to copy the final msi and zip files to
+] {
+    $env.RUSTFLAGS = ""
+    $env.CARGO_TARGET_DIR = ""
+    hide-env RUSTFLAGS
+    hide-env CARGO_TARGET_DIR
+    $env.OS = "windows-latest"
+    $env.GITHUB_WORKSPACE = ("." | path expand)
+    $env.GITHUB_OUTPUT = ("./output/out.txt" | path expand)
+    let version = (open Cargo.toml | get package.version)
+    mkdir $artifacts_dir
+    for target in ["aarch64" "x86_64"] {
+        $env.TARGET = $target ++ "-pc-windows-msvc"
+        for release_type in ["" full] {
+            $env.RELEASE_TYPE = $release_type
+            $env.TARGET_RUSTFLAGS = if $release_type == "full" {
+                "--features=dataframe"
+            } else {
+                ""
+            }
+            let out_filename = if $release_type == "full" {
+                $target ++ "-windows-msvc-full"
+            } else {
+                $target ++ "-pc-windows-msvc"
+            }
+            rm -rf output
+            _EXTRA_=bin nu .github/workflows/release-pkg.nu
+            cp $"output/nu-($version)-($out_filename).zip" $artifacts_dir
+            rm -rf output
+            _EXTRA_=msi nu .github/workflows/release-pkg.nu
+            cp $"target/wix/nu-($version)-($out_filename).msi" $artifacts_dir
+        }
+    }
+}
+
 export def main [] { help toolkit }


### PR DESCRIPTION
# Description

We have often had issues with winget during release, and have to fix the Windows installers and then create new packages.

This runs `release-pkg.nu` for all eight Windows packages we release: std and full, aarch64 and x86_64, and zip and msi variants.

It requires the cross compiling toolchain for MSVC to be installed, since Rust generally needs that to build things on Windows. Use the Visual Studio Installer to do so.

If there's ever a need, this can be extended for other platforms too.
