### PR TITLE
Eliminate dead code in `nu-explore`

### DIFF
--- a/crates/nu-explore/src/commands/mod.rs
+++ b/crates/nu-explore/src/commands/mod.rs
@@ -51,10 +51,3 @@ pub trait ViewCommand {
         value: Option<Value>,
     ) -> Result<Self::View>;
 }
-
-#[derive(Debug, Default, Clone)]
-pub struct Shortcode {
-    pub code: &'static str,
-    pub context: &'static str,
-    pub description: &'static str,
-}

--- a/crates/nu-explore/src/views/binary/binary_widget.rs
+++ b/crates/nu-explore/src/views/binary/binary_widget.rs
@@ -71,7 +71,7 @@ impl BinarySettings {
 
 #[derive(Debug, Default, Clone)]
 pub struct BinaryStyle {
-    colors: BinaryStyleColors,
+    color_index: OptStyle,
     indent_index: Indent,
     indent_data: Indent,
     indent_ascii: Indent,
@@ -81,7 +81,7 @@ pub struct BinaryStyle {
 
 impl BinaryStyle {
     pub fn new(
-        colors: BinaryStyleColors,
+        color_index: OptStyle,
         indent_index: Indent,
         indent_data: Indent,
         indent_ascii: Indent,
@@ -89,7 +89,7 @@ impl BinaryStyle {
         show_split: bool,
     ) -> Self {
         Self {
-            colors,
+            color_index,
             indent_index,
             indent_data,
             indent_ascii,
@@ -108,17 +108,6 @@ pub struct Indent {
 impl Indent {
     pub fn new(left: u16, right: u16) -> Self {
         Self { left, right }
-    }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct BinaryStyleColors {
-    pub index: OptStyle,
-}
-
-impl BinaryStyleColors {
-    pub fn new(index: OptStyle) -> Self {
-        Self { index }
     }
 }
 
@@ -362,7 +351,7 @@ fn get_segment_char(_w: &BinaryWidget, n: u8) -> (char, OptStyle) {
 }
 
 fn get_index_style(w: &BinaryWidget) -> OptStyle {
-    w.style.colors.index
+    w.style.color_index
 }
 
 fn render_space(buf: &mut Buffer, x: u16, y: u16, height: u16, padding: u16) -> u16 {

--- a/crates/nu-explore/src/views/binary/binary_widget.rs
+++ b/crates/nu-explore/src/views/binary/binary_widget.rs
@@ -154,7 +154,7 @@ fn render_hexdump(area: Rect, buf: &mut Buffer, w: BinaryWidget) {
 
         if show_index {
             x += render_space(buf, x, y, 1, w.style.indent_index.left);
-            x += render_hex_usize(buf, x, y, address, index_width, false, get_index_style(&w));
+            x += render_hex_usize(buf, x, y, address, index_width, get_index_style(&w));
             x += render_space(buf, x, y, 1, w.style.indent_index.right);
         }
 
@@ -194,7 +194,7 @@ fn render_hexdump(area: Rect, buf: &mut Buffer, w: BinaryWidget) {
 
             if show_index {
                 x += render_space(buf, x, y, 1, w.style.indent_index.left);
-                x += render_hex_usize(buf, x, y, address, index_width, false, get_index_style(&w));
+                x += render_hex_usize(buf, x, y, address, index_width, get_index_style(&w));
                 x += render_space(buf, x, y, 1, w.style.indent_index.right);
             }
 
@@ -256,7 +256,7 @@ fn render_segment(buf: &mut Buffer, x: u16, y: u16, line: &[u8], w: &BinaryWidge
         }
 
         let (_, style) = get_segment_char(w, n);
-        size += render_hex_u8(buf, x + size, y, n, false, style);
+        size += render_hex_u8(buf, x + size, y, n, style);
         count -= 1;
     }
 
@@ -305,15 +305,8 @@ fn render_ascii_char(buf: &mut Buffer, x: u16, y: u16, n: char, style: Option<Nu
     1
 }
 
-fn render_hex_u8(
-    buf: &mut Buffer,
-    x: u16,
-    y: u16,
-    n: u8,
-    big: bool,
-    style: Option<NuStyle>,
-) -> u16 {
-    render_hex_usize(buf, x, y, n as usize, 2, big, style)
+fn render_hex_u8(buf: &mut Buffer, x: u16, y: u16, n: u8, style: Option<NuStyle>) -> u16 {
+    render_hex_usize(buf, x, y, n as usize, 2, style)
 }
 
 fn render_hex_usize(
@@ -322,10 +315,9 @@ fn render_hex_usize(
     y: u16,
     n: usize,
     width: u16,
-    big: bool,
     style: Option<NuStyle>,
 ) -> u16 {
-    let text = usize_to_hex(n, width as usize, big);
+    let text = usize_to_hex(n, width as usize);
     let mut p = Paragraph::new(text);
     if let Some(style) = style {
         let style = nu_style_to_tui(style);
@@ -393,7 +385,7 @@ fn get_max_index_size(w: &BinaryWidget) -> usize {
     let line_size = w.opts.count_segments * (w.opts.segment_size * 2);
     let count_lines = w.data.len() / line_size;
     let max_index = w.opts.index_offset + count_lines * line_size;
-    usize_to_hex(max_index, 0, false).len()
+    usize_to_hex(max_index, 0).len()
 }
 
 fn get_widget_width(w: &BinaryWidget) -> usize {
@@ -403,7 +395,7 @@ fn get_widget_width(w: &BinaryWidget) -> usize {
     let count_lines = w.data.len() / line_size;
 
     let max_index = w.opts.index_offset + count_lines * line_size;
-    let index_size = usize_to_hex(max_index, 0, false).len();
+    let index_size = usize_to_hex(max_index, 0).len();
     let index_size = index_size.max(MIN_INDEX_SIZE);
 
     let data_split_size = w.opts.count_segments.saturating_sub(1) * w.style.indent_segment;
@@ -429,17 +421,11 @@ fn get_widget_width(w: &BinaryWidget) -> usize {
     min_width
 }
 
-fn usize_to_hex(n: usize, width: usize, big: bool) -> String {
+fn usize_to_hex(n: usize, width: usize) -> String {
     if width == 0 {
-        match big {
-            true => format!("{:X}", n),
-            false => format!("{:x}", n),
-        }
+        format!("{:x}", n)
     } else {
-        match big {
-            true => format!("{:0>width$X}", n, width = width),
-            false => format!("{:0>width$x}", n, width = width),
-        }
+        format!("{:0>width$x}", n, width = width)
     }
 }
 
@@ -449,9 +435,8 @@ mod tests {
 
     #[test]
     fn test_to_hex() {
-        assert_eq!(usize_to_hex(1, 2, false), "01");
-        assert_eq!(usize_to_hex(16, 2, false), "10");
-        assert_eq!(usize_to_hex(29, 2, false), "1d");
-        assert_eq!(usize_to_hex(29, 2, true), "1D");
+        assert_eq!(usize_to_hex(1, 2), "01");
+        assert_eq!(usize_to_hex(16, 2), "10");
+        assert_eq!(usize_to_hex(29, 2), "1d");
     }
 }

--- a/crates/nu-explore/src/views/binary/binary_widget.rs
+++ b/crates/nu-explore/src/views/binary/binary_widget.rs
@@ -12,8 +12,6 @@ use crate::{
     views::util::{nu_style_to_tui, text_style_to_tui_style},
 };
 
-type OptStyle = Option<NuStyle>;
-
 #[derive(Debug, Clone)]
 pub struct BinaryWidget<'a> {
     data: &'a [u8],
@@ -71,7 +69,7 @@ impl BinarySettings {
 
 #[derive(Debug, Default, Clone)]
 pub struct BinaryStyle {
-    color_index: OptStyle,
+    color_index: Option<NuStyle>,
     indent_index: Indent,
     indent_data: Indent,
     indent_ascii: Indent,
@@ -81,7 +79,7 @@ pub struct BinaryStyle {
 
 impl BinaryStyle {
     pub fn new(
-        color_index: OptStyle,
+        color_index: Option<NuStyle>,
         indent_index: Indent,
         indent_data: Indent,
         indent_ascii: Indent,
@@ -291,7 +289,7 @@ fn render_ascii_line(buf: &mut Buffer, x: u16, y: u16, line: &[u8], w: &BinaryWi
     size
 }
 
-fn render_ascii_char(buf: &mut Buffer, x: u16, y: u16, n: char, style: OptStyle) -> u16 {
+fn render_ascii_char(buf: &mut Buffer, x: u16, y: u16, n: char, style: Option<NuStyle>) -> u16 {
     let text = n.to_string();
 
     let mut p = Paragraph::new(text);
@@ -307,7 +305,14 @@ fn render_ascii_char(buf: &mut Buffer, x: u16, y: u16, n: char, style: OptStyle)
     1
 }
 
-fn render_hex_u8(buf: &mut Buffer, x: u16, y: u16, n: u8, big: bool, style: OptStyle) -> u16 {
+fn render_hex_u8(
+    buf: &mut Buffer,
+    x: u16,
+    y: u16,
+    n: u8,
+    big: bool,
+    style: Option<NuStyle>,
+) -> u16 {
     render_hex_usize(buf, x, y, n as usize, 2, big, style)
 }
 
@@ -318,7 +323,7 @@ fn render_hex_usize(
     n: usize,
     width: u16,
     big: bool,
-    style: OptStyle,
+    style: Option<NuStyle>,
 ) -> u16 {
     let text = usize_to_hex(n, width as usize, big);
     let mut p = Paragraph::new(text);
@@ -334,7 +339,7 @@ fn render_hex_usize(
     width
 }
 
-fn get_ascii_char(_w: &BinaryWidget, n: u8) -> (char, OptStyle) {
+fn get_ascii_char(_w: &BinaryWidget, n: u8) -> (char, Option<NuStyle>) {
     let (style, c) = categorize_byte(&n);
     let c = c.unwrap_or(n as char);
     let style = if style.is_plain() { None } else { Some(style) };
@@ -342,7 +347,7 @@ fn get_ascii_char(_w: &BinaryWidget, n: u8) -> (char, OptStyle) {
     (c, style)
 }
 
-fn get_segment_char(_w: &BinaryWidget, n: u8) -> (char, OptStyle) {
+fn get_segment_char(_w: &BinaryWidget, n: u8) -> (char, Option<NuStyle>) {
     let (style, c) = categorize_byte(&n);
     let c = c.unwrap_or(n as char);
     let style = if style.is_plain() { None } else { Some(style) };
@@ -350,7 +355,7 @@ fn get_segment_char(_w: &BinaryWidget, n: u8) -> (char, OptStyle) {
     (c, style)
 }
 
-fn get_index_style(w: &BinaryWidget) -> OptStyle {
+fn get_index_style(w: &BinaryWidget) -> Option<NuStyle> {
     w.style.color_index
 }
 

--- a/crates/nu-explore/src/views/binary/binary_widget.rs
+++ b/crates/nu-explore/src/views/binary/binary_widget.rs
@@ -12,8 +12,6 @@ use crate::{
     views::util::{nu_style_to_tui, text_style_to_tui_style},
 };
 
-use super::Layout;
-
 type OptStyle = Option<NuStyle>;
 
 #[derive(Debug, Clone)]
@@ -115,59 +113,22 @@ impl Indent {
 
 #[derive(Debug, Default, Clone)]
 pub struct BinaryStyleColors {
-    pub split_left: OptStyle,
-    pub split_right: OptStyle,
     pub index: OptStyle,
-    pub data: SymbolColor,
-    pub ascii: SymbolColor,
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct SymbolColor {
-    pub default: OptStyle,
-    pub zero: OptStyle,
-    pub unknown: OptStyle,
-}
-
-impl SymbolColor {
-    pub fn new(default: OptStyle, zero: OptStyle, unknown: OptStyle) -> Self {
-        Self {
-            default,
-            zero,
-            unknown,
-        }
-    }
 }
 
 impl BinaryStyleColors {
-    pub fn new(
-        index: OptStyle,
-        data: SymbolColor,
-        ascii: SymbolColor,
-        split_left: OptStyle,
-        split_right: OptStyle,
-    ) -> Self {
-        Self {
-            split_left,
-            split_right,
-            index,
-            data,
-            ascii,
-        }
+    pub fn new(index: OptStyle) -> Self {
+        Self { index }
     }
 }
 
 #[derive(Debug, Default)]
-pub struct BinaryWidgetState {
-    pub layout_index: Layout,
-    pub layout_data: Layout,
-    pub layout_ascii: Layout,
-}
+pub struct BinaryWidgetState {}
 
 impl StatefulWidget for BinaryWidget<'_> {
     type State = BinaryWidgetState;
 
-    fn render(self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+    fn render(self, area: Rect, buf: &mut Buffer, _state: &mut Self::State) {
         let min_width = get_widget_width(&self);
 
         if (area.width as usize) < min_width {
@@ -178,12 +139,12 @@ impl StatefulWidget for BinaryWidget<'_> {
             return;
         }
 
-        render_hexdump(area, buf, state, self);
+        render_hexdump(area, buf, self);
     }
 }
 
 // todo: indent color
-fn render_hexdump(area: Rect, buf: &mut Buffer, _state: &mut BinaryWidgetState, w: BinaryWidget) {
+fn render_hexdump(area: Rect, buf: &mut Buffer, w: BinaryWidget) {
     const MIN_INDEX_SIZE: usize = 8;
 
     let show_index = !w.opts.disable_index;

--- a/crates/nu-explore/src/views/binary/binary_widget.rs
+++ b/crates/nu-explore/src/views/binary/binary_widget.rs
@@ -4,7 +4,7 @@ use ratatui::{
     buffer::Buffer,
     layout::Rect,
     text::Span,
-    widgets::{Paragraph, StatefulWidget, Widget},
+    widgets::{Paragraph, Widget},
 };
 
 use crate::{
@@ -122,13 +122,8 @@ impl BinaryStyleColors {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct BinaryWidgetState {}
-
-impl StatefulWidget for BinaryWidget<'_> {
-    type State = BinaryWidgetState;
-
-    fn render(self, area: Rect, buf: &mut Buffer, _state: &mut Self::State) {
+impl Widget for BinaryWidget<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
         let min_width = get_widget_width(&self);
 
         if (area.width as usize) < min_width {

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -21,7 +21,6 @@ use crate::{
 
 use self::binary_widget::{
     BinarySettings, BinaryStyle, BinaryStyleColors, BinaryWidget, BinaryWidgetState, Indent,
-    SymbolColor,
 };
 
 use super::{cursor::XYCursor, Layout, View, ViewConfig};
@@ -206,21 +205,7 @@ fn settings_from_config(config: &ConfigMap) -> Settings {
             0,
         ),
         style: BinaryStyle::new(
-            BinaryStyleColors::new(
-                colors.get("color_index").cloned(),
-                SymbolColor::new(
-                    colors.get("color_segment").cloned(),
-                    colors.get("color_segment_zero").cloned(),
-                    colors.get("color_segment_unknown").cloned(),
-                ),
-                SymbolColor::new(
-                    colors.get("color_ascii").cloned(),
-                    colors.get("color_ascii_zero").cloned(),
-                    colors.get("color_ascii_unknown").cloned(),
-                ),
-                colors.get("color_split_left").cloned(),
-                colors.get("color_split_right").cloned(),
-            ),
+            BinaryStyleColors::new(colors.get("color_index").cloned()),
             Indent::new(
                 config_get_usize(config, "padding_index_left", 2) as u16,
                 config_get_usize(config, "padding_index_right", 2) as u16,

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -26,17 +26,8 @@ use super::{cursor::XYCursor, Layout, View, ViewConfig};
 #[derive(Debug, Clone)]
 pub struct BinaryView {
     data: Vec<u8>,
-    mode: Option<CursorMode>,
     cursor: XYCursor,
     settings: Settings,
-}
-
-#[allow(dead_code)] // todo:
-#[derive(Debug, Clone, Copy)]
-enum CursorMode {
-    Index,
-    Data,
-    Ascii,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -49,7 +40,6 @@ impl BinaryView {
     pub fn new(data: Vec<u8>) -> Self {
         Self {
             data,
-            mode: None,
             cursor: XYCursor::default(),
             settings: Settings::default(),
         }
@@ -73,7 +63,7 @@ impl View for BinaryView {
         let result = handle_event_view_mode(self, &key);
 
         if matches!(&result, Some(Transition::Ok)) {
-            let report = create_report(self.mode, self.cursor);
+            let report = create_report(self.cursor);
             info.status = Some(report);
         }
 
@@ -236,22 +226,17 @@ fn config_get_usize(config: &ConfigMap, key: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
-fn create_report(mode: Option<CursorMode>, cursor: XYCursor) -> Report {
+fn create_report(cursor: XYCursor) -> Report {
     let covered_percent = report_row_position(cursor);
     let cursor = report_cursor_position(cursor);
-    let mode = report_mode_name(mode);
+    let mode = report_mode_name();
     let msg = String::new();
 
     Report::new(msg, Severity::Info, mode, cursor, covered_percent)
 }
 
-fn report_mode_name(cursor: Option<CursorMode>) -> String {
-    match cursor {
-        Some(CursorMode::Index) => String::from("ADDR"),
-        Some(CursorMode::Data) => String::from("DUMP"),
-        Some(CursorMode::Ascii) => String::from("TEXT"),
-        None => String::from("VIEW"),
-    }
+fn report_mode_name() -> String {
+    String::from("VIEW")
 }
 
 fn report_row_position(cursor: XYCursor) -> String {

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     util::create_map,
 };
 
-use self::binary_widget::{BinarySettings, BinaryStyle, BinaryStyleColors, BinaryWidget, Indent};
+use self::binary_widget::{BinarySettings, BinaryStyle, BinaryWidget, Indent};
 
 use super::{cursor::XYCursor, Layout, View, ViewConfig};
 
@@ -192,7 +192,7 @@ fn settings_from_config(config: &ConfigMap) -> Settings {
             0,
         ),
         style: BinaryStyle::new(
-            BinaryStyleColors::new(colors.get("color_index").cloned()),
+            colors.get("color_index").cloned(),
             Indent::new(
                 config_get_usize(config, "padding_index_left", 2) as u16,
                 config_get_usize(config, "padding_index_right", 2) as u16,

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -19,9 +19,7 @@ use crate::{
     util::create_map,
 };
 
-use self::binary_widget::{
-    BinarySettings, BinaryStyle, BinaryStyleColors, BinaryWidget, BinaryWidgetState, Indent,
-};
+use self::binary_widget::{BinarySettings, BinaryStyle, BinaryStyleColors, BinaryWidget, Indent};
 
 use super::{cursor::XYCursor, Layout, View, ViewConfig};
 
@@ -60,9 +58,8 @@ impl BinaryView {
 
 impl View for BinaryView {
     fn draw(&mut self, f: &mut Frame, area: Rect, _cfg: ViewConfig<'_>, _layout: &mut Layout) {
-        let mut state = BinaryWidgetState::default();
         let widget = create_binary_widget(self);
-        f.render_stateful_widget(widget, area, &mut state);
+        f.render_widget(widget, area);
     }
 
     fn handle_input(

--- a/crates/nu-explore/src/views/cursor/xycursor.rs
+++ b/crates/nu-explore/src/views/cursor/xycursor.rs
@@ -32,11 +32,6 @@ impl XYCursor {
         self.x.index()
     }
 
-    #[allow(dead_code)]
-    pub fn column_limit(&self) -> usize {
-        self.x.end()
-    }
-
     pub fn row_limit(&self) -> usize {
         self.y.end()
     }
@@ -55,11 +50,6 @@ impl XYCursor {
 
     pub fn column_window(&self) -> usize {
         self.x.offset()
-    }
-
-    #[allow(dead_code)]
-    pub fn row_window_size(&self) -> usize {
-        self.y.window()
     }
 
     pub fn column_window_size(&self) -> usize {

--- a/crates/nu-explore/src/views/cursor/xycursor.rs
+++ b/crates/nu-explore/src/views/cursor/xycursor.rs
@@ -33,22 +33,12 @@ impl XYCursor {
     }
 
     #[allow(dead_code)]
-    pub fn row_offset(&self) -> usize {
-        self.y.offset()
-    }
-
-    #[allow(dead_code)]
     pub fn column_limit(&self) -> usize {
         self.x.end()
     }
 
     pub fn row_limit(&self) -> usize {
         self.y.end()
-    }
-
-    #[allow(dead_code)]
-    pub fn column_offset(&self) -> usize {
-        self.x.offset()
     }
 
     pub fn row_starts_at(&self) -> usize {
@@ -80,11 +70,6 @@ impl XYCursor {
         self.y.next(1)
     }
 
-    #[allow(dead_code)]
-    pub fn next_row_by(&mut self, i: usize) -> bool {
-        self.y.next(i)
-    }
-
     pub fn next_row_page(&mut self) -> bool {
         self.y.next_window()
     }
@@ -99,11 +84,6 @@ impl XYCursor {
 
     pub fn prev_row(&mut self) -> bool {
         self.y.prev(1)
-    }
-
-    #[allow(dead_code)]
-    pub fn prev_row_by(&mut self, i: usize) -> bool {
-        self.y.prev(i)
     }
 
     pub fn prev_row_page(&mut self) -> bool {


### PR DESCRIPTION
# Description
Nightly clippy found some unused fields leading me down a rabbit hole of dead code hidden behind `pub`

Generally removing any already dead code or premature configurability that is not exposed to the user.

# User-Facing Changes

None in effect.

Removed some options from the `$env.config.explore.hex-dump` record that were only read into a struct but never used and also not validated.
