### PR TITLE
Rework for new clippy lints

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -127,7 +127,7 @@ impl Command for Do {
                 let stderr_msg = match stderr {
                     None => "".to_string(),
                     Some(stderr_stream) => {
-                        stderr_ctrlc = stderr_stream.ctrlc.clone();
+                        stderr_ctrlc.clone_from(&stderr_stream.ctrlc);
                         stderr_stream.into_string().map(|s| s.item)?
                     }
                 };
@@ -152,7 +152,7 @@ impl Command for Do {
                 let exit_code: Vec<Value> = match exit_code {
                     None => vec![],
                     Some(exit_code_stream) => {
-                        exit_code_ctrlc = exit_code_stream.ctrlc.clone();
+                        exit_code_ctrlc.clone_from(&exit_code_stream.ctrlc);
                         exit_code_stream.into_iter().collect()
                     }
                 };

--- a/crates/nu-command/src/bytes/at.rs
+++ b/crates/nu-command/src/bytes/at.rs
@@ -150,7 +150,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                         head,
                     ),
                     Ordering::Less => Value::binary(
-                        if end == isize::max_value() {
+                        if end == isize::MAX {
                             val.iter()
                                 .skip(start as usize)
                                 .copied()

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -149,7 +149,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
                     ),
                     Ordering::Less => Value::string(
                         {
-                            if end == isize::max_value() {
+                            if end == isize::MAX {
                                 if args.graphemes {
                                     s.graphemes(true)
                                         .skip(start as usize)
@@ -245,7 +245,7 @@ mod tests {
             expectation("andre", (0, -1)),
             // str substring [ -4 , _ ]
             // str substring   -4 ,
-            expectation("dres", (-4, isize::max_value())),
+            expectation("dres", (-4, isize::MAX)),
             expectation("", (0, -110)),
             expectation("", (6, 0)),
             expectation("", (6, -1)),

--- a/crates/nu-json/src/value.rs
+++ b/crates/nu-json/src/value.rs
@@ -1145,7 +1145,7 @@ mod test {
 
         let v: Value = from_str("{\"a\":-1.1}").unwrap();
         let vo = v.as_object().unwrap();
-        assert!((vo["a"].as_f64().unwrap() + 1.1).abs() < (f64::EPSILON));
+        assert!((vo["a"].as_f64().unwrap() + 1.1).abs() < f64::EPSILON);
 
         let v: Value = from_str("{\"a\":1e6}").unwrap();
         let vo = v.as_object().unwrap();

--- a/crates/nu-json/src/value.rs
+++ b/crates/nu-json/src/value.rs
@@ -1141,18 +1141,18 @@ mod test {
 
         let v: Value = from_str("{\"a\":1.1}").unwrap();
         let vo = v.as_object().unwrap();
-        assert!(vo["a"].as_f64().unwrap() - 1.1 < std::f64::EPSILON);
+        assert!((vo["a"].as_f64().unwrap() - 1.1).abs() < f64::EPSILON);
 
         let v: Value = from_str("{\"a\":-1.1}").unwrap();
         let vo = v.as_object().unwrap();
-        assert!(vo["a"].as_f64().unwrap() + 1.1 > -(std::f64::EPSILON));
+        assert!((vo["a"].as_f64().unwrap() + 1.1).abs() < (f64::EPSILON));
 
         let v: Value = from_str("{\"a\":1e6}").unwrap();
         let vo = v.as_object().unwrap();
-        assert!(vo["a"].as_f64().unwrap() - 1e6 < std::f64::EPSILON);
+        assert!((vo["a"].as_f64().unwrap() - 1e6).abs() < f64::EPSILON);
 
         let v: Value = from_str("{\"a\":-1e6}").unwrap();
         let vo = v.as_object().unwrap();
-        assert!(vo["a"].as_f64().unwrap() + 1e6 > -(std::f64::EPSILON));
+        assert!((vo["a"].as_f64().unwrap() + 1e6).abs() < f64::EPSILON);
     }
 }

--- a/crates/nu-protocol/src/lev_distance.rs
+++ b/crates/nu-protocol/src/lev_distance.rs
@@ -55,7 +55,7 @@ pub fn lev_distance(a: &str, b: &str, limit: usize) -> Option<usize> {
 
 /// Finds the Levenshtein distance between two strings.
 pub fn levenshtein_distance(a: &str, b: &str) -> usize {
-    lev_distance(a, b, usize::max_value()).unwrap_or(usize::max_value())
+    lev_distance(a, b, usize::MAX).unwrap_or(usize::MAX)
 }
 /// Provides a word similarity score between two words that accounts for substrings being more
 /// meaningful than a typical Levenshtein distance. The lower the score, the closer the match.

--- a/crates/nu-protocol/src/plugin/registry_file/mod.rs
+++ b/crates/nu-protocol/src/plugin/registry_file/mod.rs
@@ -66,7 +66,7 @@ impl PluginRegistryFile {
         error_span: Option<Span>,
     ) -> Result<(), ShellError> {
         // Update the Nushell version before writing
-        self.nushell_version = env!("CARGO_PKG_VERSION").to_owned();
+        env!("CARGO_PKG_VERSION").clone_into(&mut self.nushell_version);
 
         // Format is brotli compressed messagepack
         let mut brotli_writer =

--- a/crates/nu-protocol/src/value/mod.rs
+++ b/crates/nu-protocol/src/value/mod.rs
@@ -2893,7 +2893,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::int(
                         (*lhs as f64 / *rhs as f64)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))
@@ -2905,7 +2905,7 @@ impl Value {
                 if *rhs != 0.0 {
                     Ok(Value::int(
                         (*lhs as f64 / *rhs)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))
@@ -2917,7 +2917,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::int(
                         (*lhs / *rhs as f64)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))
@@ -2928,9 +2928,7 @@ impl Value {
             (Value::Float { val: lhs, .. }, Value::Float { val: rhs, .. }) => {
                 if *rhs != 0.0 {
                     Ok(Value::int(
-                        (lhs / rhs)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
-                            .floor() as i64,
+                        (lhs / rhs).clamp(i64::MIN as f64, i64::MAX as f64).floor() as i64,
                         span,
                     ))
                 } else {
@@ -2941,7 +2939,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::int(
                         (*lhs as f64 / *rhs as f64)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))
@@ -2953,7 +2951,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::filesize(
                         ((*lhs as f64) / (*rhs as f64))
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))
@@ -2965,7 +2963,7 @@ impl Value {
                 if *rhs != 0.0 {
                     Ok(Value::filesize(
                         (*lhs as f64 / *rhs)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))
@@ -2977,7 +2975,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::int(
                         (*lhs as f64 / *rhs as f64)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))
@@ -2989,7 +2987,7 @@ impl Value {
                 if *rhs != 0 {
                     Ok(Value::duration(
                         (*lhs as f64 / *rhs as f64)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))
@@ -3001,7 +2999,7 @@ impl Value {
                 if *rhs != 0.0 {
                     Ok(Value::duration(
                         (*lhs as f64 / *rhs)
-                            .clamp(std::i64::MIN as f64, std::i64::MAX as f64)
+                            .clamp(i64::MIN as f64, i64::MAX as f64)
                             .floor() as i64,
                         span,
                     ))

--- a/crates/nu-table/tests/style.rs
+++ b/crates/nu-table/tests/style.rs
@@ -47,10 +47,7 @@ fn test_rounded() {
          ╰───┴───┴───┴───╯"
     );
 
-    assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::rounded()),
-        ""
-    );
+    assert_eq!(create_table_with_size(vec![], true, theme::rounded()), "");
 }
 
 #[test]
@@ -98,10 +95,7 @@ fn test_basic() {
          +---+---+---+---+"
     );
 
-    assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::basic()),
-        ""
-    );
+    assert_eq!(create_table_with_size(vec![], true, theme::basic()), "");
 }
 
 #[test]
@@ -146,7 +140,7 @@ fn test_reinforced() {
     );
 
     assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::reinforced()),
+        create_table_with_size(vec![], true, theme::reinforced()),
         ""
     );
 }
@@ -196,10 +190,7 @@ fn test_compact() {
         )
     );
 
-    assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::compact()),
-        ""
-    );
+    assert_eq!(create_table_with_size(vec![], true, theme::compact()), "");
 }
 
 #[test]
@@ -248,7 +239,7 @@ fn test_compact_double() {
     );
 
     assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::compact_double()),
+        create_table_with_size(vec![], true, theme::compact_double()),
         ""
     );
 }
@@ -296,10 +287,7 @@ fn test_heavy() {
          ┗━━━┻━━━┻━━━┻━━━┛"
     );
 
-    assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::heavy()),
-        ""
-    );
+    assert_eq!(create_table_with_size(vec![], true, theme::heavy()), "");
 }
 
 #[test]
@@ -334,10 +322,7 @@ fn test_light() {
         concat!(" 0   1   2   3 \n", " 0   1   2   3 ")
     );
 
-    assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::light()),
-        ""
-    );
+    assert_eq!(create_table_with_size(vec![], true, theme::light()), "");
 }
 
 #[test]
@@ -367,10 +352,7 @@ fn test_none() {
         concat!(" 0   1   2   3 \n", " 0   1   2   3 ")
     );
 
-    assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::none()),
-        ""
-    );
+    assert_eq!(create_table_with_size(vec![], true, theme::none()), "");
 }
 
 #[test]
@@ -418,10 +400,7 @@ fn test_thin() {
          └───┴───┴───┴───┘"
     );
 
-    assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::thin()),
-        ""
-    );
+    assert_eq!(create_table_with_size(vec![], true, theme::thin()), "");
 }
 
 #[test]
@@ -469,10 +448,7 @@ fn test_with_love() {
         )
     );
 
-    assert_eq!(
-        create_table_with_size(vec![row(4); 0], true, theme::with_love()),
-        ""
-    );
+    assert_eq!(create_table_with_size(vec![], true, theme::with_love()), "");
 }
 
 fn create_table(data: Vec<Vec<CellInfo<String>>>, with_header: bool, theme: theme) -> String {


### PR DESCRIPTION
- **Clippy lint `assigning_clones`**
- **Clippy lint `legacy_numeric_constants`**
- **`clippy::float_equality_without_abs`**
- **`nu-table`: clippy::zero_repeat_side_effects**
