### PR TITLE
Avoid taking unnecessary ownership of intermediates

### DIFF
--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -87,7 +87,7 @@ impl Highlighter for NuHighlighter {
                 .to_string();
 
             let mut add_colored_token = |shape: &FlatShape, text: String| {
-                output.push((get_shape_color(shape.to_string(), &self.config), text));
+                output.push((get_shape_color(&shape.to_string(), &self.config), text));
             };
 
             match shape.1 {
@@ -127,7 +127,7 @@ impl Highlighter for NuHighlighter {
                         let start = part.start - span.start;
                         let end = part.end - span.start;
                         let text = next_token[start..end].to_string();
-                        let mut style = get_shape_color(shape.to_string(), &self.config);
+                        let mut style = get_shape_color(&shape.to_string(), &self.config);
                         if highlight {
                             style = get_matching_brackets_style(style, &self.config);
                         }

--- a/crates/nu-cli/src/syntax_highlight.rs
+++ b/crates/nu-cli/src/syntax_highlight.rs
@@ -87,7 +87,7 @@ impl Highlighter for NuHighlighter {
                 .to_string();
 
             let mut add_colored_token = |shape: &FlatShape, text: String| {
-                output.push((get_shape_color(&shape.to_string(), &self.config), text));
+                output.push((get_shape_color(shape.as_str(), &self.config), text));
             };
 
             match shape.1 {
@@ -127,7 +127,7 @@ impl Highlighter for NuHighlighter {
                         let start = part.start - span.start;
                         let end = part.end - span.start;
                         let text = next_token[start..end].to_string();
-                        let mut style = get_shape_color(&shape.to_string(), &self.config);
+                        let mut style = get_shape_color(shape.as_str(), &self.config);
                         if highlight {
                             style = get_matching_brackets_style(style, &self.config);
                         }

--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -13,7 +13,7 @@ pub fn lookup_ansi_color_style(s: &str) -> Style {
             .and_then(|c| c.map(|c| c.normal()))
             .unwrap_or_default()
     } else if s.starts_with('{') {
-        color_string_to_nustyle(s.to_string())
+        color_string_to_nustyle(s)
     } else {
         lookup_style(s)
     }
@@ -74,7 +74,7 @@ fn get_style_from_value(record: &Record) -> Option<NuStyle> {
     }
 }
 
-fn color_string_to_nustyle(color_string: String) -> Style {
+fn color_string_to_nustyle(color_string: &str) -> Style {
     // eprintln!("color_string: {}", &color_string);
     if color_string.is_empty() {
         return Style::default();
@@ -97,13 +97,13 @@ mod tests {
     #[test]
     fn test_color_string_to_nustyle_empty_string() {
         let color_string = String::new();
-        let style = color_string_to_nustyle(color_string);
+        let style = color_string_to_nustyle(&color_string);
         assert_eq!(style, Style::default());
     }
 
     #[test]
     fn test_color_string_to_nustyle_valid_string() {
-        let color_string = r#"{"fg": "black", "bg": "white", "attr": "b"}"#.to_string();
+        let color_string = r#"{"fg": "black", "bg": "white", "attr": "b"}"#;
         let style = color_string_to_nustyle(color_string);
         assert_eq!(style.foreground, Some(Color::Black));
         assert_eq!(style.background, Some(Color::White));
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn test_color_string_to_nustyle_invalid_string() {
-        let color_string = "invalid string".to_string();
+        let color_string = "invalid string";
         let style = color_string_to_nustyle(color_string);
         assert_eq!(style, Style::default());
     }

--- a/crates/nu-color-config/src/color_config.rs
+++ b/crates/nu-color-config/src/color_config.rs
@@ -80,7 +80,7 @@ fn color_string_to_nustyle(color_string: &str) -> Style {
         return Style::default();
     }
 
-    let nu_style = match nu_json::from_str::<NuStyle>(&color_string) {
+    let nu_style = match nu_json::from_str::<NuStyle>(color_string) {
         Ok(s) => s,
         Err(_) => return Style::default(),
     };

--- a/crates/nu-color-config/src/shape_color.rs
+++ b/crates/nu-color-config/src/shape_color.rs
@@ -3,8 +3,8 @@ use nu_ansi_term::{Color, Style};
 use nu_protocol::{Config, Value};
 
 // The default colors for shapes, used when there is no config for them.
-pub fn default_shape_color(shape: String) -> Style {
-    match shape.as_ref() {
+pub fn default_shape_color(shape: &str) -> Style {
+    match shape {
         "shape_and" => Style::new().fg(Color::Purple).bold(),
         "shape_binary" => Style::new().fg(Color::Purple).bold(),
         "shape_block" => Style::new().fg(Color::Blue).bold(),
@@ -45,8 +45,8 @@ pub fn default_shape_color(shape: String) -> Style {
     }
 }
 
-pub fn get_shape_color(shape: String, conf: &Config) -> Style {
-    match conf.color_config.get(shape.as_str()) {
+pub fn get_shape_color(shape: &str, conf: &Config) -> Style {
+    match conf.color_config.get(shape) {
         Some(int_color) => {
             // Shapes do not use color_config closures, currently.
             match int_color {

--- a/crates/nu-command/src/conversions/into/datetime.rs
+++ b/crates/nu-command/src/conversions/into/datetime.rs
@@ -39,7 +39,7 @@ impl Zone {
             Self::Error // Out of range
         }
     }
-    fn from_string(s: String) -> Self {
+    fn from_string(s: &str) -> Self {
         match s.to_ascii_lowercase().as_str() {
             "utc" | "u" => Self::Utc,
             "local" | "l" => Self::Local,
@@ -126,7 +126,7 @@ impl Command for SubCommand {
                         span: zone_offset.span,
                     }),
                     None => timezone.as_ref().map(|zone| Spanned {
-                        item: Zone::from_string(zone.item.clone()),
+                        item: Zone::from_string(&zone.item),
                         span: zone.span,
                     }),
                 };

--- a/crates/nu-command/src/env/config/config_env.rs
+++ b/crates/nu-command/src/env/config/config_env.rs
@@ -57,7 +57,7 @@ impl Command for ConfigEnv {
 
         let env_vars_str = env_to_strings(engine_state, stack)?;
         let nu_config = match engine_state.get_config_path("env-path") {
-            Some(path) => path.clone(),
+            Some(path) => path,
             None => {
                 return Err(ShellError::GenericError {
                     error: "Could not find $nu.env-path".into(),

--- a/crates/nu-command/src/env/config/config_nu.rs
+++ b/crates/nu-command/src/env/config/config_nu.rs
@@ -61,7 +61,7 @@ impl Command for ConfigNu {
 
         let env_vars_str = env_to_strings(engine_state, stack)?;
         let nu_config = match engine_state.get_config_path("config-path") {
-            Some(path) => path.clone(),
+            Some(path) => path,
             None => {
                 return Err(ShellError::GenericError {
                     error: "Could not find $nu.config-path".into(),

--- a/crates/nu-command/src/env/config/utils.rs
+++ b/crates/nu-command/src/env/config/utils.rs
@@ -1,10 +1,10 @@
 use crate::ExternalCommand;
 use nu_protocol::{OutDest, Span, Spanned};
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, path::Path};
 
 pub(crate) fn gen_command(
     span: Span,
-    config_path: PathBuf,
+    config_path: &Path,
     item: String,
     config_args: Vec<String>,
     env_vars_str: HashMap<String, String>,

--- a/crates/nu-command/src/formats/from/xml.rs
+++ b/crates/nu-command/src/formats/from/xml.rs
@@ -197,15 +197,15 @@ fn from_document_to_value(d: &roxmltree::Document, info: &ParsingInfo) -> Value 
     element_to_value(&d.root_element(), info)
 }
 
-fn from_xml_string_to_value(s: String, info: &ParsingInfo) -> Result<Value, roxmltree::Error> {
-    let parsed = roxmltree::Document::parse(&s)?;
+fn from_xml_string_to_value(s: &str, info: &ParsingInfo) -> Result<Value, roxmltree::Error> {
+    let parsed = roxmltree::Document::parse(s)?;
     Ok(from_document_to_value(&parsed, info))
 }
 
 fn from_xml(input: PipelineData, info: &ParsingInfo) -> Result<PipelineData, ShellError> {
     let (concat_string, span, metadata) = input.collect_string_strict(info.span)?;
 
-    match from_xml_string_to_value(concat_string, info) {
+    match from_xml_string_to_value(&concat_string, info) {
         Ok(x) => Ok(x.into_pipeline_data_with_metadata(metadata)),
         Err(err) => Err(process_xml_parse_error(err, span)),
     }
@@ -370,7 +370,7 @@ mod tests {
             keep_comments: false,
             keep_processing_instructions: false,
         };
-        from_xml_string_to_value(xml.to_string(), &info)
+        from_xml_string_to_value(xml, &info)
     }
 
     #[test]

--- a/crates/nu-command/tests/commands/alias.rs
+++ b/crates/nu-command/tests/commands/alias.rs
@@ -92,7 +92,7 @@ fn alias_wont_recurse() {
 #[test]
 fn alias_wont_recurse2() {
     Playground::setup("alias_wont_recurse2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 def eggs [] { spam 'eggs' }

--- a/crates/nu-command/tests/commands/cd.rs
+++ b/crates/nu-command/tests/commands/cd.rs
@@ -151,7 +151,7 @@ fn filesystem_change_to_a_directory_containing_spaces() {
 #[test]
 fn filesystem_not_a_directory() {
     Playground::setup("cd_test_10", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("ferris_did_it.txt")]);
+        sandbox.with_files(&[EmptyFile("ferris_did_it.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(),

--- a/crates/nu-command/tests/commands/complete.rs
+++ b/crates/nu-command/tests/commands/complete.rs
@@ -38,7 +38,7 @@ fn capture_error_with_too_much_stderr_not_hang_nushell() {
         for _ in 0..bytes {
             large_file_body.push('a');
         }
-        sandbox.with_files(vec![FileWithContent("a_large_file.txt", &large_file_body)]);
+        sandbox.with_files(&[FileWithContent("a_large_file.txt", &large_file_body)]);
 
         let actual =
             nu!(cwd: dirs.test(), "sh -c 'cat a_large_file.txt 1>&2' | complete | get stderr");
@@ -58,7 +58,7 @@ fn capture_error_with_too_much_stdout_not_hang_nushell() {
         for _ in 0..bytes {
             large_file_body.push('a');
         }
-        sandbox.with_files(vec![FileWithContent("a_large_file.txt", &large_file_body)]);
+        sandbox.with_files(&[FileWithContent("a_large_file.txt", &large_file_body)]);
 
         let actual = nu!(cwd: dirs.test(), "sh -c 'cat a_large_file.txt' | complete | get stdout");
 
@@ -81,7 +81,7 @@ fn capture_error_with_both_stdout_stderr_messages_not_hang_nushell() {
         "#;
             let expect_body = "=".repeat(40960);
 
-            sandbox.with_files(vec![FileWithContent("test.sh", script_body)]);
+            sandbox.with_files(&[FileWithContent("test.sh", script_body)]);
 
             // check for stdout
             let actual = nu!(cwd: dirs.test(), "sh test.sh | complete | get stdout | str trim");

--- a/crates/nu-command/tests/commands/database/into_sqlite.rs
+++ b/crates/nu-command/tests/commands/database/into_sqlite.rs
@@ -304,7 +304,7 @@ fn into_sqlite_big_insert() {
 
         let nuon_path = dirs.test().join(NUON_FILE_NAME);
 
-        playground.with_files(vec![Stub::EmptyFile(&nuon_path.to_string_lossy())]);
+        playground.with_files(&[Stub::EmptyFile(&nuon_path.to_string_lossy())]);
 
         let mut expected_rows = Vec::new();
         let mut nuon_file = std::fs::OpenOptions::new()

--- a/crates/nu-command/tests/commands/du.rs
+++ b/crates/nu-command/tests/commands/du.rs
@@ -51,7 +51,7 @@ fn test_du_flag_max_depth() {
 #[case("a][c")]
 fn du_files_with_glob_metachars(#[case] src_name: &str) {
     Playground::setup("du_test_16", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile(src_name)]);
+        sandbox.with_files(&[EmptyFile(src_name)]);
 
         let src = dirs.test().join(src_name);
 

--- a/crates/nu-command/tests/commands/every.rs
+++ b/crates/nu-command/tests/commands/every.rs
@@ -5,7 +5,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn gets_all_rows_by_every_zero() {
     Playground::setup("every_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
             EmptyFile("los.txt"),
@@ -32,7 +32,7 @@ fn gets_all_rows_by_every_zero() {
 #[test]
 fn gets_no_rows_by_every_skip_zero() {
     Playground::setup("every_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
             EmptyFile("los.txt"),
@@ -56,7 +56,7 @@ fn gets_no_rows_by_every_skip_zero() {
 #[test]
 fn gets_all_rows_by_every_one() {
     Playground::setup("every_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
             EmptyFile("los.txt"),
@@ -83,7 +83,7 @@ fn gets_all_rows_by_every_one() {
 #[test]
 fn gets_no_rows_by_every_skip_one() {
     Playground::setup("every_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
             EmptyFile("los.txt"),
@@ -107,7 +107,7 @@ fn gets_no_rows_by_every_skip_one() {
 #[test]
 fn gets_first_row_by_every_too_much() {
     Playground::setup("every_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
             EmptyFile("los.txt"),
@@ -132,7 +132,7 @@ fn gets_first_row_by_every_too_much() {
 #[test]
 fn gets_all_rows_except_first_by_every_skip_too_much() {
     Playground::setup("every_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
             EmptyFile("los.txt"),
@@ -156,7 +156,7 @@ fn gets_all_rows_except_first_by_every_skip_too_much() {
 #[test]
 fn gets_every_third_row() {
     Playground::setup("every_test_7", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
             EmptyFile("los.txt"),
@@ -181,7 +181,7 @@ fn gets_every_third_row() {
 #[test]
 fn skips_every_third_row() {
     Playground::setup("every_test_8", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("amigos.txt"),
             EmptyFile("arepas.clu"),
             EmptyFile("los.txt"),

--- a/crates/nu-command/tests/commands/first.rs
+++ b/crates/nu-command/tests/commands/first.rs
@@ -5,7 +5,7 @@ use nu_test_support::playground::Playground;
 #[test]
 fn gets_first_rows_by_amount() {
     Playground::setup("first_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
             EmptyFile("amigos.txt"),
@@ -21,7 +21,7 @@ fn gets_first_rows_by_amount() {
 #[test]
 fn gets_all_rows_if_amount_higher_than_all_rows() {
     Playground::setup("first_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
             EmptyFile("amigos.txt"),
@@ -38,7 +38,7 @@ fn gets_all_rows_if_amount_higher_than_all_rows() {
 #[test]
 fn gets_first_row_when_no_amount_given() {
     Playground::setup("first_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("caballeros.txt"), EmptyFile("arepas.clu")]);
+        sandbox.with_files(&[EmptyFile("caballeros.txt"), EmptyFile("arepas.clu")]);
 
         // FIXME: We should probably change first to return a one row table instead of a record here
         let actual = nu!(cwd: dirs.test(), "ls | first | values | length");

--- a/crates/nu-command/tests/commands/format.rs
+++ b/crates/nu-command/tests/commands/format.rs
@@ -65,7 +65,7 @@ fn error_unmatched_brace() {
 #[test]
 fn format_filesize_works() {
     Playground::setup("format_filesize_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
@@ -90,7 +90,7 @@ fn format_filesize_works_with_nonempty_files() {
     Playground::setup(
         "format_filesize_works_with_nonempty_files",
         |dirs, sandbox| {
-            sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
                 "sample.toml",
                 r#"
                     [dependency]

--- a/crates/nu-command/tests/commands/get.rs
+++ b/crates/nu-command/tests/commands/get.rs
@@ -17,7 +17,7 @@ fn simple_get_list() {
 #[test]
 fn fetches_a_row() {
     Playground::setup("get_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                 nu_party_venue = "zion"
@@ -33,7 +33,7 @@ fn fetches_a_row() {
 #[test]
 fn fetches_by_index() {
     Playground::setup("get_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                 [package]
@@ -53,7 +53,7 @@ fn fetches_by_index() {
 #[test]
 fn fetches_by_column_path() {
     Playground::setup("get_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                 [package]
@@ -70,7 +70,7 @@ fn fetches_by_column_path() {
 #[test]
 fn column_paths_are_either_double_quoted_or_regular_unquoted_words_separated_by_dot() {
     Playground::setup("get_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                 [package]
@@ -88,7 +88,7 @@ fn column_paths_are_either_double_quoted_or_regular_unquoted_words_separated_by_
 #[test]
 fn fetches_more_than_one_column_path() {
     Playground::setup("get_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                 [[fortune_tellers]]
@@ -121,7 +121,7 @@ fn fetches_more_than_one_column_path() {
 #[test]
 fn errors_fetching_by_column_not_present() {
     Playground::setup("get_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                 [tacos]
@@ -141,7 +141,7 @@ fn errors_fetching_by_column_not_present() {
 #[test]
 fn errors_fetching_by_column_using_a_number() {
     Playground::setup("get_test_7", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                 [spanish_lesson]
@@ -158,7 +158,7 @@ fn errors_fetching_by_column_using_a_number() {
 #[test]
 fn errors_fetching_by_index_out_of_bounds() {
     Playground::setup("get_test_8", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                 [spanish_lesson]

--- a/crates/nu-command/tests/commands/glob.rs
+++ b/crates/nu-command/tests/commands/glob.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 #[test]
 fn empty_glob_pattern_triggers_error() {
     Playground::setup("glob_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
@@ -25,7 +25,7 @@ fn empty_glob_pattern_triggers_error() {
 #[test]
 fn nonempty_glob_lists_matching_paths() {
     Playground::setup("glob_sanity_star", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
@@ -43,13 +43,13 @@ fn nonempty_glob_lists_matching_paths() {
 #[test]
 fn glob_subdirs() {
     Playground::setup("glob_subdirs", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
         ]);
         sandbox.mkdir("children");
-        sandbox.within("children").with_files(vec![
+        sandbox.within("children").with_files(&[
             EmptyFile("timothy.txt"),
             EmptyFile("tiffany.txt"),
             EmptyFile("trish.txt"),
@@ -70,13 +70,13 @@ fn glob_subdirs() {
 #[test]
 fn glob_subdirs_ignore_dirs() {
     Playground::setup("glob_subdirs_ignore_directories", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
         ]);
         sandbox.mkdir("children");
-        sandbox.within("children").with_files(vec![
+        sandbox.within("children").with_files(&[
             EmptyFile("timothy.txt"),
             EmptyFile("tiffany.txt"),
             EmptyFile("trish.txt"),
@@ -97,13 +97,13 @@ fn glob_subdirs_ignore_dirs() {
 #[test]
 fn glob_ignore_files() {
     Playground::setup("glob_ignore_files", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
         ]);
         sandbox.mkdir("children");
-        sandbox.within("children").with_files(vec![
+        sandbox.within("children").with_files(&[
             EmptyFile("timothy.txt"),
             EmptyFile("tiffany.txt"),
             EmptyFile("trish.txt"),

--- a/crates/nu-command/tests/commands/help.rs
+++ b/crates/nu-command/tests/commands/help.rs
@@ -38,7 +38,7 @@ fn help_aliases() {
 #[test]
 fn help_alias_usage_1() {
     Playground::setup("help_alias_usage_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # line1
@@ -70,7 +70,7 @@ fn help_alias_usage_2() {
 #[test]
 fn help_alias_usage_3() {
     Playground::setup("help_alias_usage_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # line1
@@ -92,7 +92,7 @@ fn help_alias_usage_3() {
 #[test]
 fn help_alias_name() {
     Playground::setup("help_alias_name", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # line1
@@ -113,7 +113,7 @@ fn help_alias_name() {
 #[test]
 fn help_alias_name_f() {
     Playground::setup("help_alias_name_f", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # line1
@@ -132,7 +132,7 @@ fn help_alias_name_f() {
 #[test]
 fn help_export_alias_name_single_word() {
     Playground::setup("help_export_alias_name_single_word", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # line1
@@ -153,7 +153,7 @@ fn help_export_alias_name_single_word() {
 #[test]
 fn help_export_alias_name_multi_word() {
     Playground::setup("help_export_alias_name_multi_word", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # line1
@@ -174,7 +174,7 @@ fn help_export_alias_name_multi_word() {
 #[test]
 fn help_module_usage_1() {
     Playground::setup("help_module_usage", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # line1
@@ -199,7 +199,7 @@ fn help_module_usage_1() {
 #[test]
 fn help_module_name() {
     Playground::setup("help_module_name", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # line1
@@ -222,7 +222,7 @@ fn help_module_name() {
 #[test]
 fn help_module_sorted_decls() {
     Playground::setup("help_module_sorted_decls", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 module SPAM {
@@ -242,7 +242,7 @@ fn help_module_sorted_decls() {
 #[test]
 fn help_module_sorted_aliases() {
     Playground::setup("help_module_sorted_aliases", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 module SPAM {
@@ -262,7 +262,7 @@ fn help_module_sorted_aliases() {
 #[test]
 fn help_usage_extra_usage_command() {
     Playground::setup("help_usage_extra_usage_command", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # module_line1
@@ -299,7 +299,7 @@ fn help_usage_extra_usage_command() {
 #[test]
 fn help_usage_extra_usage_alias() {
     Playground::setup("help_usage_extra_usage_alias", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "spam.nu",
             r#"
                 # module_line1

--- a/crates/nu-command/tests/commands/last.rs
+++ b/crates/nu-command/tests/commands/last.rs
@@ -15,7 +15,7 @@ fn gets_the_last_row() {
 #[test]
 fn gets_last_rows_by_amount() {
     Playground::setup("last_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
             EmptyFile("amigos.txt"),
@@ -31,7 +31,7 @@ fn gets_last_rows_by_amount() {
 #[test]
 fn gets_last_row_when_no_amount_given() {
     Playground::setup("last_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("caballeros.txt"), EmptyFile("arepas.clu")]);
+        sandbox.with_files(&[EmptyFile("caballeros.txt"), EmptyFile("arepas.clu")]);
 
         // FIXME: We should probably change last to return a one row table instead of a record here
         let actual = nu!(cwd: dirs.test(), "ls | last | values | length");

--- a/crates/nu-command/tests/commands/ls.rs
+++ b/crates/nu-command/tests/commands/ls.rs
@@ -5,7 +5,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn lists_regular_files() {
     Playground::setup("ls_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
@@ -26,7 +26,7 @@ fn lists_regular_files() {
 #[test]
 fn lists_regular_files_using_asterisk_wildcard() {
     Playground::setup("ls_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
             EmptyFile("amigos.txt"),
@@ -56,11 +56,11 @@ fn lists_regular_files_in_special_folder() {
             .mkdir("abcd")
             .mkdir("abcd/*")
             .mkdir("abcd/?")
-            .with_files(vec![EmptyFile("[abcd]/test.txt")])
-            .with_files(vec![EmptyFile("abcd]/test.txt")])
-            .with_files(vec![EmptyFile("abcd/*/test.txt")])
-            .with_files(vec![EmptyFile("abcd/?/test.txt")])
-            .with_files(vec![EmptyFile("abcd/?/test2.txt")]);
+            .with_files(&[EmptyFile("[abcd]/test.txt")])
+            .with_files(&[EmptyFile("abcd]/test.txt")])
+            .with_files(&[EmptyFile("abcd/*/test.txt")])
+            .with_files(&[EmptyFile("abcd/?/test.txt")])
+            .with_files(&[EmptyFile("abcd/?/test2.txt")]);
 
         let actual = nu!(
             cwd: dirs.test().join("abcd]"), format!(r#"ls | length"#));
@@ -119,7 +119,7 @@ fn lists_regular_files_in_special_folder() {
 #[case("'[bbcd].txt'", 1)]
 fn lists_regular_files_using_question_mark(#[case] command: &str, #[case] expected: usize) {
     Playground::setup("ls_test_3", |dirs, sandbox| {
-        sandbox.mkdir("abcd").mkdir("bbcd").with_files(vec![
+        sandbox.mkdir("abcd").mkdir("bbcd").with_files(&[
             EmptyFile("abcd/xy.txt"),
             EmptyFile("bbcd/yy.txt"),
             EmptyFile("[abcd].txt"),
@@ -141,7 +141,7 @@ fn lists_regular_files_using_question_mark(#[case] command: &str, #[case] expect
 #[test]
 fn lists_regular_files_using_question_mark_wildcard() {
     Playground::setup("ls_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.10.txt"),
             EmptyFile("jt.10.txt"),
             EmptyFile("andres.10.txt"),
@@ -164,11 +164,11 @@ fn lists_regular_files_using_question_mark_wildcard() {
 fn lists_all_files_in_directories_from_stream() {
     Playground::setup("ls_test_4", |dirs, sandbox| {
         sandbox
-            .with_files(vec![EmptyFile("root1.txt"), EmptyFile("root2.txt")])
+            .with_files(&[EmptyFile("root1.txt"), EmptyFile("root2.txt")])
             .within("dir_a")
-            .with_files(vec![EmptyFile("yehuda.10.txt"), EmptyFile("jt10.txt")])
+            .with_files(&[EmptyFile("yehuda.10.txt"), EmptyFile("jt10.txt")])
             .within("dir_b")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("andres.10.txt"),
                 EmptyFile("chicken_not_to_be_picked_up.100.txt"),
             ]);
@@ -206,7 +206,7 @@ fn does_not_fail_if_glob_matches_empty_directory() {
 #[test]
 fn fails_when_glob_doesnt_match() {
     Playground::setup("ls_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("root1.txt"), EmptyFile("root2.txt")]);
+        sandbox.with_files(&[EmptyFile("root1.txt"), EmptyFile("root2.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(),
@@ -220,7 +220,7 @@ fn fails_when_glob_doesnt_match() {
 #[test]
 fn list_files_from_two_parents_up_using_multiple_dots() {
     Playground::setup("ls_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yahuda.yaml"),
             EmptyFile("jtjson"),
             EmptyFile("andres.xml"),
@@ -243,7 +243,7 @@ fn list_files_from_two_parents_up_using_multiple_dots() {
 #[test]
 fn lists_hidden_file_when_explicitly_specified() {
     Playground::setup("ls_test_7", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
             EmptyFile("amigos.txt"),
@@ -267,19 +267,19 @@ fn lists_hidden_file_when_explicitly_specified() {
 fn lists_all_hidden_files_when_glob_contains_dot() {
     Playground::setup("ls_test_8", |dirs, sandbox| {
         sandbox
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("root1.txt"),
                 EmptyFile("root2.txt"),
                 EmptyFile(".dotfile1"),
             ])
             .within("dir_a")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("yehuda.10.txt"),
                 EmptyFile("jt10.txt"),
                 EmptyFile(".dotfile2"),
             ])
             .within("dir_b")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("andres.10.txt"),
                 EmptyFile("chicken_not_to_be_picked_up.100.txt"),
                 EmptyFile(".dotfile3"),
@@ -304,19 +304,19 @@ fn lists_all_hidden_files_when_glob_contains_dot() {
 fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
     Playground::setup("ls_test_8", |dirs, sandbox| {
         sandbox
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("root1.txt"),
                 EmptyFile("root2.txt"),
                 EmptyFile(".dotfile1"),
             ])
             .within("dir_a")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("yehuda.10.txt"),
                 EmptyFile("jt10.txt"),
                 EmptyFile(".dotfile2"),
             ])
             .within(".dir_b")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("andres.10.txt"),
                 EmptyFile("chicken_not_to_be_picked_up.100.txt"),
                 EmptyFile(".dotfile3"),
@@ -340,7 +340,7 @@ fn lists_all_hidden_files_when_glob_does_not_contain_dot() {
 #[cfg(unix)]
 fn glob_with_hidden_directory() {
     Playground::setup("ls_test_8", |dirs, sandbox| {
-        sandbox.within(".dir_b").with_files(vec![
+        sandbox.within(".dir_b").with_files(&[
             EmptyFile("andres.10.txt"),
             EmptyFile("chicken_not_to_be_picked_up.100.txt"),
             EmptyFile(".dotfile3"),
@@ -376,7 +376,7 @@ fn fails_with_ls_to_dir_without_permission() {
     Playground::setup("ls_test_1", |dirs, sandbox| {
         sandbox
             .within("dir_a")
-            .with_files(vec![EmptyFile("yehuda.11.txt"), EmptyFile("jt10.txt")]);
+            .with_files(&[EmptyFile("yehuda.11.txt"), EmptyFile("jt10.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -404,7 +404,7 @@ fn fails_with_ls_to_dir_without_permission() {
 #[test]
 fn lists_files_including_starting_with_dot() {
     Playground::setup("ls_test_9", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
@@ -427,7 +427,7 @@ fn lists_files_including_starting_with_dot() {
 #[test]
 fn list_all_columns() {
     Playground::setup("ls_test_all_columns", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("Leonardo.yaml"),
             EmptyFile("Raphael.json"),
             EmptyFile("Donatello.xml"),
@@ -486,7 +486,7 @@ fn lists_with_directory_flag() {
     Playground::setup("ls_test_flag_directory_1", |dirs, sandbox| {
         sandbox
             .within("dir_files")
-            .with_files(vec![EmptyFile("nushell.json")])
+            .with_files(&[EmptyFile("nushell.json")])
             .within("dir_empty");
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -514,7 +514,7 @@ fn lists_with_directory_flag_without_argument() {
     Playground::setup("ls_test_flag_directory_2", |dirs, sandbox| {
         sandbox
             .within("dir_files")
-            .with_files(vec![EmptyFile("nushell.json")])
+            .with_files(&[EmptyFile("nushell.json")])
             .within("dir_empty");
         // Test if there are some files in the current directory
         let actual = nu!(
@@ -631,7 +631,7 @@ fn list_directory_contains_invalid_utf8() {
 #[test]
 fn list_ignores_ansi() {
     Playground::setup("ls_test_ansi", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
             EmptyFile("amigos.txt"),
@@ -662,7 +662,7 @@ fn list_unknown_flag() {
 fn list_flag_false() {
     // Check that ls flags respect explicit values
     Playground::setup("ls_test_false_flag", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile(".hidden"),
             EmptyFile("normal"),
             EmptyFile("another_normal"),
@@ -705,7 +705,7 @@ fn list_flag_false() {
 #[test]
 fn list_empty_string() {
     Playground::setup("ls_empty_string", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("yehuda.txt")]);
+        sandbox.with_files(&[EmptyFile("yehuda.txt")]);
 
         let actual = nu!(cwd: dirs.test(), "ls ''");
         assert!(actual.err.contains("does not exist"));
@@ -717,7 +717,7 @@ fn list_with_tilde() {
     Playground::setup("ls_tilde", |dirs, sandbox| {
         sandbox
             .within("~tilde")
-            .with_files(vec![EmptyFile("f1.txt"), EmptyFile("f2.txt")]);
+            .with_files(&[EmptyFile("f1.txt"), EmptyFile("f2.txt")]);
 
         let actual = nu!(cwd: dirs.test(), "ls '~tilde'");
         assert!(actual.out.contains("f1.txt"));
@@ -737,7 +737,7 @@ fn list_with_tilde() {
 #[test]
 fn list_with_multiple_path() {
     Playground::setup("ls_multiple_path", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("f1.txt"),
             EmptyFile("f2.txt"),
             EmptyFile("f3.txt"),

--- a/crates/nu-command/tests/commands/move_/umv.rs
+++ b/crates/nu-command/tests/commands/move_/umv.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 fn moves_a_file() {
     Playground::setup("umv_test_1", |dirs, sandbox| {
         sandbox
-            .with_files(vec![EmptyFile("andres.txt")])
+            .with_files(&[EmptyFile("andres.txt")])
             .mkdir("expected");
 
         let original = dirs.test().join("andres.txt");
@@ -27,7 +27,7 @@ fn moves_a_file() {
 #[test]
 fn overwrites_if_moving_to_existing_file_and_force_provided() {
     Playground::setup("umv_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("andres.txt"), EmptyFile("jttxt")]);
+        sandbox.with_files(&[EmptyFile("andres.txt"), EmptyFile("jttxt")]);
 
         let original = dirs.test().join("andres.txt");
         let expected = dirs.test().join("jttxt");
@@ -63,9 +63,7 @@ fn moves_a_directory() {
 #[test]
 fn moves_the_file_inside_directory_if_path_to_move_is_existing_directory() {
     Playground::setup("umv_test_4", |dirs, sandbox| {
-        sandbox
-            .with_files(vec![EmptyFile("jttxt")])
-            .mkdir("expected");
+        sandbox.with_files(&[EmptyFile("jttxt")]).mkdir("expected");
 
         let original_dir = dirs.test().join("jttxt");
         let expected = dirs.test().join("expected/jttxt");
@@ -85,7 +83,7 @@ fn moves_the_directory_inside_directory_if_path_to_move_is_existing_directory() 
     Playground::setup("umv_test_5", |dirs, sandbox| {
         sandbox
             .within("contributors")
-            .with_files(vec![EmptyFile("jttxt")])
+            .with_files(&[EmptyFile("jttxt")])
             .mkdir("expected");
 
         let original_dir = dirs.test().join("contributors");
@@ -107,7 +105,7 @@ fn moves_using_path_with_wildcard() {
     Playground::setup("umv_test_7", |dirs, sandbox| {
         sandbox
             .within("originals")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("andres.ini"),
                 EmptyFile("caco3_plastics.csv"),
                 EmptyFile("cargo_sample.toml"),
@@ -138,7 +136,7 @@ fn moves_using_a_glob() {
     Playground::setup("umv_test_8", |dirs, sandbox| {
         sandbox
             .within("meals")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("arepa.txt"),
                 EmptyFile("empanada.txt"),
                 EmptyFile("taquiza.txt"),
@@ -166,11 +164,11 @@ fn moves_a_directory_with_files() {
         sandbox
             .mkdir("vehicles/car")
             .mkdir("vehicles/bicycle")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("vehicles/car/car1.txt"),
                 EmptyFile("vehicles/car/car2.txt"),
             ])
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("vehicles/bicycle/bicycle1.txt"),
                 EmptyFile("vehicles/bicycle/bicycle2.txt"),
             ]);
@@ -213,7 +211,7 @@ fn errors_if_source_doesnt_exist() {
 #[ignore = "GNU/uutils overwrites rather than error out"]
 fn error_if_moving_to_existing_file_without_force() {
     Playground::setup("umv_test_10_0", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("andres.txt"), EmptyFile("jttxt")]);
+        sandbox.with_files(&[EmptyFile("andres.txt"), EmptyFile("jttxt")]);
 
         let actual = nu!(
             cwd: dirs.test(),
@@ -226,7 +224,7 @@ fn error_if_moving_to_existing_file_without_force() {
 #[test]
 fn errors_if_destination_doesnt_exist() {
     Playground::setup("umv_test_10_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("empty.txt")]);
+        sandbox.with_files(&[EmptyFile("empty.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(),
@@ -241,7 +239,7 @@ fn errors_if_destination_doesnt_exist() {
 #[ignore = "GNU/uutils doesnt expand, rather cannot stat 'file?.txt'"]
 fn errors_if_multiple_sources_but_destination_not_a_directory() {
     Playground::setup("umv_test_10_2", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("file1.txt"),
             EmptyFile("file2.txt"),
             EmptyFile("file3.txt"),
@@ -261,9 +259,7 @@ fn errors_if_multiple_sources_but_destination_not_a_directory() {
 #[test]
 fn errors_if_renaming_directory_to_an_existing_file() {
     Playground::setup("umv_test_10_3", |dirs, sandbox| {
-        sandbox
-            .mkdir("mydir")
-            .with_files(vec![EmptyFile("empty.txt")]);
+        sandbox.mkdir("mydir").with_files(&[EmptyFile("empty.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(),
@@ -293,7 +289,7 @@ fn does_not_error_on_relative_parent_path() {
     Playground::setup("umv_test_11", |dirs, sandbox| {
         sandbox
             .mkdir("first")
-            .with_files(vec![EmptyFile("first/william_hartnell.txt")]);
+            .with_files(&[EmptyFile("first/william_hartnell.txt")]);
 
         let original = dirs.test().join("first/william_hartnell.txt");
         let expected = dirs.test().join("william_hartnell.txt");
@@ -311,7 +307,7 @@ fn does_not_error_on_relative_parent_path() {
 #[test]
 fn move_files_using_glob_two_parents_up_using_multiple_dots() {
     Playground::setup("umv_test_12", |dirs, sandbox| {
-        sandbox.within("foo").within("bar").with_files(vec![
+        sandbox.within("foo").within("bar").with_files(&[
             EmptyFile("jtjson"),
             EmptyFile("andres.xml"),
             EmptyFile("yehuda.yaml"),
@@ -345,7 +341,7 @@ fn move_files_using_glob_two_parents_up_using_multiple_dots() {
 #[test]
 fn move_file_from_two_parents_up_using_multiple_dots_to_current_dir() {
     Playground::setup("cp_test_10", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("hello_there")]);
+        sandbox.with_files(&[EmptyFile("hello_there")]);
         sandbox.within("foo").mkdir("bar");
 
         nu!(
@@ -380,7 +376,7 @@ fn does_not_error_when_some_file_is_moving_into_itself() {
 #[test]
 fn mv_ignores_ansi() {
     Playground::setup("umv_test_ansi", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
+        sandbox.with_files(&[EmptyFile("test.txt")]);
         let actual = nu!(
              cwd: sandbox.cwd(),
             r#"
@@ -420,7 +416,7 @@ fn mv_change_case_of_directory() {
     Playground::setup("mv_change_case_of_directory", |dirs, sandbox| {
         sandbox
             .mkdir("somedir")
-            .with_files(vec![EmptyFile("somedir/somefile.txt")]);
+            .with_files(&[EmptyFile("somedir/somefile.txt")]);
 
         let original_dir = String::from("somedir");
         let new_dir = String::from("SomeDir");
@@ -459,7 +455,7 @@ fn mv_change_case_of_directory() {
 // but fail on both macOS and Windows.
 fn mv_change_case_of_file() {
     Playground::setup("mv_change_case_of_file", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("somefile.txt")]);
+        sandbox.with_files(&[EmptyFile("somefile.txt")]);
 
         let original_file_name = String::from("somefile.txt");
         let new_file_name = String::from("SomeFile.txt");
@@ -489,7 +485,7 @@ fn mv_change_case_of_file() {
 #[ignore = "Update not supported..remove later"]
 fn mv_with_update_flag() {
     Playground::setup("umv_with_update_flag", |_dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("valid.txt"),
             FileWithContent("newer_valid.txt", "body"),
         ]);
@@ -502,12 +498,12 @@ fn mv_with_update_flag() {
 
         // create a file after assert to make sure that newest_valid.txt is newest
         std::thread::sleep(std::time::Duration::from_secs(1));
-        sandbox.with_files(vec![FileWithContent("newest_valid.txt", "newest_body")]);
+        sandbox.with_files(&[FileWithContent("newest_valid.txt", "newest_body")]);
         let actual = nu!(cwd: sandbox.cwd(), "mv -uf newest_valid.txt valid.txt; open valid.txt");
         assert_eq!(actual.out, "newest_body");
 
         // when destination doesn't exist
-        sandbox.with_files(vec![FileWithContent("newest_valid.txt", "newest_body")]);
+        sandbox.with_files(&[FileWithContent("newest_valid.txt", "newest_body")]);
         let actual = nu!(cwd: sandbox.cwd(), "mv -uf newest_valid.txt des_missing.txt; open des_missing.txt");
         assert_eq!(actual.out, "newest_body");
     });
@@ -518,8 +514,8 @@ fn test_mv_no_clobber() {
     Playground::setup("umv_test_13", |dirs, sandbox| {
         let file_a = "test_mv_no_clobber_file_a";
         let file_b = "test_mv_no_clobber_file_b";
-        sandbox.with_files(vec![EmptyFile(file_a)]);
-        sandbox.with_files(vec![EmptyFile(file_b)]);
+        sandbox.with_files(&[EmptyFile(file_a)]);
+        sandbox.with_files(&[EmptyFile(file_b)]);
 
         let actual = nu!(
             cwd: dirs.test(),
@@ -566,7 +562,7 @@ fn mv_with_no_target() {
 #[case("a][c")]
 fn mv_files_with_glob_metachars(#[case] src_name: &str) {
     Playground::setup("umv_test_16", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             src_name,
             "What is the sound of one hand clapping?",
         )]);
@@ -592,7 +588,7 @@ fn mv_files_with_glob_metachars(#[case] src_name: &str) {
 #[case("a][c")]
 fn mv_files_with_glob_metachars_when_input_are_variables(#[case] src_name: &str) {
     Playground::setup("umv_test_18", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             src_name,
             "What is the sound of one hand clapping?",
         )]);
@@ -626,7 +622,7 @@ fn mv_with_cd() {
     Playground::setup("umv_test_17", |_dirs, sandbox| {
         sandbox
             .mkdir("tmp_dir")
-            .with_files(vec![FileWithContent("tmp_dir/file.txt", "body")]);
+            .with_files(&[FileWithContent("tmp_dir/file.txt", "body")]);
 
         let actual = nu!(
             cwd: sandbox.cwd(),
@@ -642,7 +638,7 @@ fn test_cp_inside_glob_metachars_dir() {
         let sub_dir = "test[]";
         sandbox
             .within(sub_dir)
-            .with_files(vec![FileWithContent("test_file.txt", "hello")]);
+            .with_files(&[FileWithContent("test_file.txt", "hello")]);
 
         let actual = nu!(
             cwd: dirs.test().join(sub_dir),
@@ -661,7 +657,7 @@ fn test_cp_inside_glob_metachars_dir() {
 #[test]
 fn mv_with_tilde() {
     Playground::setup("mv_tilde", |dirs, sandbox| {
-        sandbox.within("~tilde").with_files(vec![
+        sandbox.within("~tilde").with_files(&[
             EmptyFile("f1.txt"),
             EmptyFile("f2.txt"),
             EmptyFile("f3.txt"),

--- a/crates/nu-command/tests/commands/nu_check.rs
+++ b/crates/nu-command/tests/commands/nu_check.rs
@@ -5,7 +5,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn parse_script_success() {
     Playground::setup("nu_check_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "script.nu",
             r#"
                 greet "world"
@@ -30,7 +30,7 @@ fn parse_script_success() {
 #[test]
 fn parse_script_with_wrong_type() {
     Playground::setup("nu_check_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "script.nu",
             r#"
                 greet "world"
@@ -54,7 +54,7 @@ fn parse_script_with_wrong_type() {
 #[test]
 fn parse_script_failure() {
     Playground::setup("nu_check_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "script.nu",
             r#"
                 greet "world"
@@ -79,7 +79,7 @@ fn parse_script_failure() {
 #[test]
 fn parse_module_success() {
     Playground::setup("nu_check_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "foo.nu",
             r#"
                 # foo.nu
@@ -108,7 +108,7 @@ fn parse_module_success() {
 #[test]
 fn parse_module_with_wrong_type() {
     Playground::setup("nu_check_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "foo.nu",
             r#"
                 # foo.nu
@@ -136,7 +136,7 @@ fn parse_module_with_wrong_type() {
 #[test]
 fn parse_module_failure() {
     Playground::setup("nu_check_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "foo.nu",
             r#"
                 # foo.nu
@@ -179,7 +179,7 @@ fn file_not_exist() {
 #[test]
 fn parse_module_success_2() {
     Playground::setup("nu_check_test_10", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "foo.nu",
             r#"
                 # foo.nu
@@ -202,7 +202,7 @@ fn parse_module_success_2() {
 #[test]
 fn parse_script_success_with_raw_stream() {
     Playground::setup("nu_check_test_11", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "script.nu",
             r#"
                 greet "world"
@@ -227,7 +227,7 @@ fn parse_script_success_with_raw_stream() {
 #[test]
 fn parse_module_success_with_raw_stream() {
     Playground::setup("nu_check_test_12", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "foo.nu",
             r#"
                 # foo.nu
@@ -285,7 +285,7 @@ fn parse_string_as_script() {
 #[test]
 fn parse_module_success_with_internal_stream() {
     Playground::setup("nu_check_test_15", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "foo.nu",
             r#"
                 # foo.nu
@@ -314,7 +314,7 @@ fn parse_module_success_with_internal_stream() {
 #[test]
 fn parse_script_success_with_complex_internal_stream() {
     Playground::setup("nu_check_test_16", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "grep.nu",
             r#"
                 #grep for nu
@@ -363,7 +363,7 @@ fn parse_script_success_with_complex_internal_stream() {
 #[test]
 fn parse_script_failure_with_complex_internal_stream() {
     Playground::setup("nu_check_test_17", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "grep.nu",
             r#"
                 #grep for nu
@@ -412,7 +412,7 @@ fn parse_script_failure_with_complex_internal_stream() {
 #[test]
 fn parse_script_success_with_complex_external_stream() {
     Playground::setup("nu_check_test_18", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "grep.nu",
             r#"
                 #grep for nu
@@ -461,7 +461,7 @@ fn parse_script_success_with_complex_external_stream() {
 #[test]
 fn parse_module_success_with_complex_external_stream() {
     Playground::setup("nu_check_test_19", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "grep.nu",
             r#"
                 #grep for nu
@@ -510,7 +510,7 @@ fn parse_module_success_with_complex_external_stream() {
 #[test]
 fn parse_with_flag_success_for_complex_external_stream() {
     Playground::setup("nu_check_test_20", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "grep.nu",
             r#"
                 #grep for nu
@@ -559,7 +559,7 @@ fn parse_with_flag_success_for_complex_external_stream() {
 #[test]
 fn parse_with_flag_failure_for_complex_external_stream() {
     Playground::setup("nu_check_test_21", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "grep.nu",
             r#"
                 #grep for nu
@@ -608,7 +608,7 @@ fn parse_with_flag_failure_for_complex_external_stream() {
 #[test]
 fn parse_with_flag_failure_for_complex_list_stream() {
     Playground::setup("nu_check_test_22", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "grep.nu",
             r#"
                 #grep for nu
@@ -659,7 +659,7 @@ fn parse_script_with_nested_scripts_success() {
     Playground::setup("nu_check_test_24", |dirs, sandbox| {
         sandbox
             .mkdir("lol")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol.nu",
                 r#"
                     source-env ../foo.nu
@@ -667,13 +667,13 @@ fn parse_script_with_nested_scripts_success() {
                     overlay use ../lol/lol_shell.nu
                 "#,
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol_shell.nu",
                 r#"
                     export def ls [] { "lol" }
                 "#,
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "foo.nu",
                 r#"
                     $env.FOO = 'foo'
@@ -696,13 +696,13 @@ fn nu_check_respects_file_pwd() {
     Playground::setup("nu_check_test_25", |dirs, sandbox| {
         sandbox
             .mkdir("lol")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol.nu",
                 r#"
                     $env.RETURN = (nu-check ../foo.nu)
                 "#,
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "foo.nu",
                 r#"
                     echo 'foo'
@@ -725,14 +725,14 @@ fn nu_check_module_dir() {
     Playground::setup("nu_check_test_26", |dirs, sandbox| {
         sandbox
             .mkdir("lol")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/mod.nu",
                 r#"
                     export module foo.nu
                     export def main [] { 'lol' }
                 "#,
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/foo.nu",
                 r#"
                     export def main [] { 'lol foo' }

--- a/crates/nu-command/tests/commands/open.rs
+++ b/crates/nu-command/tests/commands/open.rs
@@ -8,7 +8,7 @@ use rstest::rstest;
 #[test]
 fn parses_file_with_uppercase_extension() {
     Playground::setup("open_test_uppercase_extension", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "nu.zion.JSON",
             r#"{
                 "glossary": {
@@ -38,7 +38,7 @@ fn parses_file_with_uppercase_extension() {
 #[test]
 fn parses_file_with_multiple_extensions() {
     Playground::setup("open_test_multiple_extensions", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             FileWithContent("file.tar.gz", "this is a tar.gz file"),
             FileWithContent("file.tar.xz", "this is a tar.xz file"),
         ]);
@@ -77,7 +77,7 @@ fn parses_file_with_multiple_extensions() {
 #[test]
 fn parses_dotfile() {
     Playground::setup("open_test_dotfile", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             ".gitignore",
             r#"
               /target/
@@ -101,7 +101,7 @@ fn parses_dotfile() {
 #[test]
 fn parses_csv() {
     Playground::setup("open_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "nu.zion.csv",
             r#"
                     author,lang,source
@@ -318,7 +318,7 @@ fn test_open_block_command() {
 #[test]
 fn open_ignore_ansi() {
     Playground::setup("open_test_ansi", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("nu.zion.txt")]);
+        sandbox.with_files(&[EmptyFile("nu.zion.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -345,7 +345,7 @@ fn open_no_parameter() {
 #[case("a][c")]
 fn open_files_with_glob_metachars(#[case] src_name: &str) {
     Playground::setup("open_test_with_glob_metachars", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(src_name, "hello")]);
+        sandbox.with_files(&[FileWithContent(src_name, "hello")]);
 
         let src = dirs.test().join(src_name);
 
@@ -384,7 +384,7 @@ fn open_files_inside_glob_metachars_dir() {
         let sub_dir = "test[]";
         sandbox
             .within(sub_dir)
-            .with_files(vec![FileWithContent("test_file.txt", "hello")]);
+            .with_files(&[FileWithContent("test_file.txt", "hello")]);
 
         let actual = nu!(
             cwd: dirs.test().join(sub_dir),

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -8,7 +8,7 @@ mod simple {
     #[test]
     fn extracts_fields_from_the_given_the_pattern() {
         Playground::setup("parse_test_1", |dirs, sandbox| {
-            sandbox.with_files(vec![Stub::FileWithContentToBeTrimmed(
+            sandbox.with_files(&[Stub::FileWithContentToBeTrimmed(
                 "key_value_separated_arepa_ingredients.txt",
                 r#"
                     VAR1=Cheese
@@ -117,7 +117,7 @@ mod regex {
     #[test]
     fn extracts_fields_with_all_named_groups() {
         Playground::setup("parse_test_regex_1", |dirs, sandbox| {
-            sandbox.with_files(nushell_git_log_oneline());
+            sandbox.with_files(&nushell_git_log_oneline());
 
             let actual = nu!(
                 cwd: dirs.test(), pipeline(
@@ -136,7 +136,7 @@ mod regex {
     #[test]
     fn extracts_fields_with_all_unnamed_groups() {
         Playground::setup("parse_test_regex_2", |dirs, sandbox| {
-            sandbox.with_files(nushell_git_log_oneline());
+            sandbox.with_files(&nushell_git_log_oneline());
 
             let actual = nu!(
                 cwd: dirs.test(), pipeline(
@@ -155,7 +155,7 @@ mod regex {
     #[test]
     fn extracts_fields_with_named_and_unnamed_groups() {
         Playground::setup("parse_test_regex_3", |dirs, sandbox| {
-            sandbox.with_files(nushell_git_log_oneline());
+            sandbox.with_files(&nushell_git_log_oneline());
 
             let actual = nu!(
                 cwd: dirs.test(), pipeline(
@@ -174,7 +174,7 @@ mod regex {
     #[test]
     fn errors_with_invalid_regex() {
         Playground::setup("parse_test_regex_1", |dirs, sandbox| {
-            sandbox.with_files(nushell_git_log_oneline());
+            sandbox.with_files(&nushell_git_log_oneline());
 
             let actual = nu!(
                 cwd: dirs.test(), pipeline(
@@ -216,7 +216,7 @@ mod regex {
     fn parse_handles_external_stream_chunking() {
         Playground::setup("parse_test_streaming_1", |dirs, sandbox| {
             let data: String = "abcdefghijklmnopqrstuvwxyz".repeat(1000);
-            sandbox.with_files(vec![Stub::FileWithContent("data.txt", &data)]);
+            sandbox.with_files(&[Stub::FileWithContent("data.txt", &data)]);
 
             let actual = nu!(
                 cwd: dirs.test(),

--- a/crates/nu-command/tests/commands/path/exists.rs
+++ b/crates/nu-command/tests/commands/path/exists.rs
@@ -5,7 +5,7 @@ use nu_test_support::playground::Playground;
 #[test]
 fn checks_if_existing_file_exists() {
     Playground::setup("path_exists_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(),

--- a/crates/nu-command/tests/commands/path/expand.rs
+++ b/crates/nu-command/tests/commands/path/expand.rs
@@ -7,9 +7,7 @@ use std::path::PathBuf;
 #[test]
 fn expands_path_with_dot() {
     Playground::setup("path_expand_1", |dirs, sandbox| {
-        sandbox
-            .within("menu")
-            .with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.within("menu").with_files(&[EmptyFile("spam.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -28,9 +26,7 @@ fn expands_path_with_dot() {
 #[test]
 fn expands_path_without_follow_symlink() {
     Playground::setup("path_expand_3", |dirs, sandbox| {
-        sandbox
-            .within("menu")
-            .with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.within("menu").with_files(&[EmptyFile("spam.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -49,9 +45,7 @@ fn expands_path_without_follow_symlink() {
 #[test]
 fn expands_path_with_double_dot() {
     Playground::setup("path_expand_2", |dirs, sandbox| {
-        sandbox
-            .within("menu")
-            .with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.within("menu").with_files(&[EmptyFile("spam.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -69,9 +63,7 @@ fn expands_path_with_double_dot() {
 #[test]
 fn const_path_expand() {
     Playground::setup("const_path_expand", |dirs, sandbox| {
-        sandbox
-            .within("menu")
-            .with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.within("menu").with_files(&[EmptyFile("spam.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -121,9 +113,7 @@ mod windows {
     #[test]
     fn expands_path_without_follow_symlink() {
         Playground::setup("path_expand_3", |dirs, sandbox| {
-            sandbox
-                .within("menu")
-                .with_files(vec![EmptyFile("spam.txt")]);
+            sandbox.within("menu").with_files(&[EmptyFile("spam.txt")]);
 
             let cwd = dirs.test();
             std::os::windows::fs::symlink_file(

--- a/crates/nu-command/tests/commands/path/type_.rs
+++ b/crates/nu-command/tests/commands/path/type_.rs
@@ -18,9 +18,7 @@ fn returns_type_of_missing_file() {
 #[test]
 fn returns_type_of_existing_file() {
     Playground::setup("path_expand_1", |dirs, sandbox| {
-        sandbox
-            .within("menu")
-            .with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.within("menu").with_files(&[EmptyFile("spam.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -37,9 +35,7 @@ fn returns_type_of_existing_file() {
 #[test]
 fn returns_type_of_existing_directory() {
     Playground::setup("path_expand_1", |dirs, sandbox| {
-        sandbox
-            .within("menu")
-            .with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.within("menu").with_files(&[EmptyFile("spam.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -65,9 +61,7 @@ fn returns_type_of_existing_directory() {
 #[test]
 fn returns_type_of_existing_file_const() {
     Playground::setup("path_type_const", |dirs, sandbox| {
-        sandbox
-            .within("menu")
-            .with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.within("menu").with_files(&[EmptyFile("spam.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(

--- a/crates/nu-command/tests/commands/prepend.rs
+++ b/crates/nu-command/tests/commands/prepend.rs
@@ -5,7 +5,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn adds_a_row_to_the_beginning() {
     Playground::setup("prepend_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 Andrés N. Robalino

--- a/crates/nu-command/tests/commands/range.rs
+++ b/crates/nu-command/tests/commands/range.rs
@@ -5,7 +5,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn selects_a_row() {
     Playground::setup("range_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("notes.txt"), EmptyFile("tests.txt")]);
+        sandbox.with_files(&[EmptyFile("notes.txt"), EmptyFile("tests.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -24,7 +24,7 @@ fn selects_a_row() {
 #[test]
 fn selects_some_rows() {
     Playground::setup("range_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("notes.txt"),
             EmptyFile("tests.txt"),
             EmptyFile("persons.txt"),
@@ -47,7 +47,7 @@ fn selects_some_rows() {
 #[test]
 fn negative_indices() {
     Playground::setup("range_test_negative_indices", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("notes.txt"),
             EmptyFile("tests.txt"),
             EmptyFile("persons.txt"),

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -127,7 +127,7 @@ fn same_target_redirection_with_too_much_stderr_not_hang_nushell() {
         for _ in 0..bytes {
             large_file_body.push('a');
         }
-        sandbox.with_files(vec![FileWithContent("a_large_file.txt", &large_file_body)]);
+        sandbox.with_files(&[FileWithContent("a_large_file.txt", &large_file_body)]);
 
         nu!(
             cwd: dirs.test(), pipeline(
@@ -220,7 +220,7 @@ fn redirection_with_pipeline_works() {
             let script_body = r"echo message";
             let expect_body = "message";
 
-            sandbox.with_files(vec![FileWithContent("test.sh", script_body)]);
+            sandbox.with_files(&[FileWithContent("test.sh", script_body)]);
 
             let actual = nu!(
                 cwd: dirs.test(),

--- a/crates/nu-command/tests/commands/rm.rs
+++ b/crates/nu-command/tests/commands/rm.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 #[test]
 fn removes_a_file() {
     Playground::setup("rm_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("i_will_be_deleted.txt")]);
+        sandbox.with_files(&[EmptyFile("i_will_be_deleted.txt")]);
 
         nu!(
             cwd: dirs.root(),
@@ -26,17 +26,17 @@ fn removes_files_with_wildcard() {
     Playground::setup("rm_test_2", |dirs, sandbox| {
         sandbox
             .within("src")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("cli.rs"),
                 EmptyFile("lib.rs"),
                 EmptyFile("prelude.rs"),
             ])
             .within("src/parser")
-            .with_files(vec![EmptyFile("parse.rs"), EmptyFile("parser.rs")])
+            .with_files(&[EmptyFile("parse.rs"), EmptyFile("parser.rs")])
             .within("src/parser/parse")
-            .with_files(vec![EmptyFile("token_tree.rs")])
+            .with_files(&[EmptyFile("token_tree.rs")])
             .within("src/parser/hir")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("baseline_parse.rs"),
                 EmptyFile("baseline_parse_tokens.rs"),
             ]);
@@ -67,17 +67,17 @@ fn removes_deeply_nested_directories_with_wildcard_and_recursive_flag() {
     Playground::setup("rm_test_3", |dirs, sandbox| {
         sandbox
             .within("src")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("cli.rs"),
                 EmptyFile("lib.rs"),
                 EmptyFile("prelude.rs"),
             ])
             .within("src/parser")
-            .with_files(vec![EmptyFile("parse.rs"), EmptyFile("parser.rs")])
+            .with_files(&[EmptyFile("parse.rs"), EmptyFile("parser.rs")])
             .within("src/parser/parse")
-            .with_files(vec![EmptyFile("token_tree.rs")])
+            .with_files(&[EmptyFile("token_tree.rs")])
             .within("src/parser/hir")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("baseline_parse.rs"),
                 EmptyFile("baseline_parse_tokens.rs"),
             ]);
@@ -109,7 +109,7 @@ fn removes_directory_contents_without_recursive_flag_if_empty() {
 #[test]
 fn removes_directory_contents_with_recursive_flag() {
     Playground::setup("rm_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
@@ -127,7 +127,7 @@ fn removes_directory_contents_with_recursive_flag() {
 #[test]
 fn errors_if_attempting_to_delete_a_directory_with_content_without_recursive_flag() {
     Playground::setup("rm_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("some_empty_file.txt")]);
+        sandbox.with_files(&[EmptyFile("some_empty_file.txt")]);
         let actual = nu!(
             cwd: dirs.root(),
             "rm rm_test_6"
@@ -179,11 +179,11 @@ fn removes_multiple_directories() {
     Playground::setup("rm_test_9", |dirs, sandbox| {
         sandbox
             .within("src")
-            .with_files(vec![EmptyFile("a.rs"), EmptyFile("b.rs")])
+            .with_files(&[EmptyFile("a.rs"), EmptyFile("b.rs")])
             .within("src/cli")
-            .with_files(vec![EmptyFile("c.rs"), EmptyFile("d.rs")])
+            .with_files(&[EmptyFile("c.rs"), EmptyFile("d.rs")])
             .within("test")
-            .with_files(vec![EmptyFile("a_test.rs"), EmptyFile("b_test.rs")]);
+            .with_files(&[EmptyFile("a_test.rs"), EmptyFile("b_test.rs")]);
 
         nu!(
             cwd: dirs.test(),
@@ -200,7 +200,7 @@ fn removes_multiple_directories() {
 #[test]
 fn removes_multiple_files() {
     Playground::setup("rm_test_10", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jttxt"),
             EmptyFile("andres.txt"),
@@ -221,7 +221,7 @@ fn removes_multiple_files() {
 #[test]
 fn removes_multiple_files_with_asterisks() {
     Playground::setup("rm_test_11", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jt.txt"),
             EmptyFile("andres.toml"),
@@ -242,7 +242,7 @@ fn removes_multiple_files_with_asterisks() {
 #[test]
 fn allows_doubly_specified_file() {
     Playground::setup("rm_test_12", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("yehuda.txt"), EmptyFile("jt.toml")]);
+        sandbox.with_files(&[EmptyFile("yehuda.txt"), EmptyFile("jt.toml")]);
 
         let actual = nu!(
             cwd: dirs.test(),
@@ -260,7 +260,7 @@ fn allows_doubly_specified_file() {
 #[test]
 fn remove_files_from_two_parents_up_using_multiple_dots_and_glob() {
     Playground::setup("rm_test_13", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("yehuda.txt"),
             EmptyFile("jt.txt"),
             EmptyFile("kevin.txt"),
@@ -295,7 +295,7 @@ fn no_errors_if_attempting_to_delete_non_existent_file_with_f_flag() {
 #[test]
 fn rm_wildcard_keeps_dotfiles() {
     Playground::setup("rm_test_15", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("foo"), EmptyFile(".bar")]);
+        sandbox.with_files(&[EmptyFile("foo"), EmptyFile(".bar")]);
 
         nu!(
             cwd: dirs.test(),
@@ -310,7 +310,7 @@ fn rm_wildcard_keeps_dotfiles() {
 #[test]
 fn rm_wildcard_leading_dot_deletes_dotfiles() {
     Playground::setup("rm_test_16", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("foo"), EmptyFile(".bar")]);
+        sandbox.with_files(&[EmptyFile("foo"), EmptyFile(".bar")]);
 
         nu!(
             cwd: dirs.test(),
@@ -325,7 +325,7 @@ fn rm_wildcard_leading_dot_deletes_dotfiles() {
 #[test]
 fn removes_files_with_case_sensitive_glob_matches_by_default() {
     Playground::setup("glob_test", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("A0"), EmptyFile("a1")]);
+        sandbox.with_files(&[EmptyFile("A0"), EmptyFile("a1")]);
 
         nu!(
             cwd: dirs.root(),
@@ -343,7 +343,7 @@ fn removes_files_with_case_sensitive_glob_matches_by_default() {
 #[test]
 fn remove_ignores_ansi() {
     Playground::setup("rm_test_ansi", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
+        sandbox.with_files(&[EmptyFile("test.txt")]);
 
         let actual = nu!(
             cwd: sandbox.cwd(),
@@ -358,7 +358,7 @@ fn removes_symlink() {
     let symlink_target = "symlink_target";
     let symlink = "symlink";
     Playground::setup("rm_test_symlink", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile(symlink_target)]);
+        sandbox.with_files(&[EmptyFile(symlink_target)]);
 
         #[cfg(not(windows))]
         std::os::unix::fs::symlink(dirs.test().join(symlink_target), dirs.test().join(symlink))
@@ -392,7 +392,7 @@ fn removes_symlink_pointing_to_directory() {
 #[test]
 fn removes_file_after_cd() {
     Playground::setup("rm_after_cd", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("delete.txt")]);
+        sandbox.with_files(&[EmptyFile("delete.txt")]);
 
         nu!(
             cwd: dirs.root(),
@@ -431,11 +431,11 @@ fn rm_prints_filenames_on_error() {
     Playground::setup("rm_prints_filenames_on_error", |dirs, sandbox| {
         let file_names = vec!["test1.txt", "test2.txt"];
 
-        let with_files = file_names
+        let with_files: Vec<_> = file_names
             .iter()
             .map(|file_name| EmptyFile(file_name))
             .collect();
-        sandbox.with_files(with_files);
+        sandbox.with_files(&with_files);
 
         let test_dir = dirs.test();
 
@@ -467,7 +467,7 @@ fn rm_files_inside_glob_metachars_dir() {
         let sub_dir = "test[]";
         sandbox
             .within(sub_dir)
-            .with_files(vec![EmptyFile("test_file.txt")]);
+            .with_files(&[EmptyFile("test_file.txt")]);
 
         let actual = nu!(
             cwd: dirs.test().join(sub_dir),
@@ -489,7 +489,7 @@ fn rm_files_inside_glob_metachars_dir() {
 #[case("a][c")]
 fn rm_files_with_glob_metachars(#[case] src_name: &str) {
     Playground::setup("rm_files_with_glob_metachars", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile(src_name)]);
+        sandbox.with_files(&[EmptyFile(src_name)]);
 
         let src = dirs.test().join(src_name);
 
@@ -503,7 +503,7 @@ fn rm_files_with_glob_metachars(#[case] src_name: &str) {
         assert!(!src.exists());
 
         // test with variables
-        sandbox.with_files(vec![EmptyFile(src_name)]);
+        sandbox.with_files(&[EmptyFile(src_name)]);
         let actual = nu!(
             cwd: dirs.test(),
             "let f = '{}'; rm $f",
@@ -527,7 +527,7 @@ fn rm_files_with_glob_metachars_nw(#[case] src_name: &str) {
 #[test]
 fn force_rm_suppress_error() {
     Playground::setup("force_rm_suppress_error", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test_file.txt")]);
+        sandbox.with_files(&[EmptyFile("test_file.txt")]);
 
         // the second rm should suppress error.
         let actual = nu!(
@@ -542,7 +542,7 @@ fn force_rm_suppress_error() {
 #[test]
 fn rm_with_tilde() {
     Playground::setup("rm_tilde", |dirs, sandbox| {
-        sandbox.within("~tilde").with_files(vec![
+        sandbox.within("~tilde").with_files(&[
             EmptyFile("f1.txt"),
             EmptyFile("f2.txt"),
             EmptyFile("f3.txt"),

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -21,7 +21,7 @@ fn better_empty_redirection() {
 #[test]
 fn explicit_glob() {
     Playground::setup("external with explicit glob", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("D&D_volume_1.txt"),
             EmptyFile("D&D_volume_2.txt"),
             EmptyFile("foo.sh"),
@@ -42,7 +42,7 @@ fn explicit_glob() {
 #[test]
 fn bare_word_expand_path_glob() {
     Playground::setup("bare word should do the expansion", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("D&D_volume_1.txt"),
             EmptyFile("D&D_volume_2.txt"),
             EmptyFile("foo.sh"),
@@ -64,7 +64,7 @@ fn bare_word_expand_path_glob() {
 #[test]
 fn backtick_expand_path_glob() {
     Playground::setup("backtick should do the expansion", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("D&D_volume_1.txt"),
             EmptyFile("D&D_volume_2.txt"),
             EmptyFile("foo.sh"),
@@ -86,7 +86,7 @@ fn backtick_expand_path_glob() {
 #[test]
 fn single_quote_does_not_expand_path_glob() {
     Playground::setup("single quote do not run the expansion", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("D&D_volume_1.txt"),
             EmptyFile("D&D_volume_2.txt"),
             EmptyFile("foo.sh"),
@@ -107,7 +107,7 @@ fn single_quote_does_not_expand_path_glob() {
 #[test]
 fn double_quote_does_not_expand_path_glob() {
     Playground::setup("double quote do not run the expansion", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("D&D_volume_1.txt"),
             EmptyFile("D&D_volume_2.txt"),
             EmptyFile("foo.sh"),
@@ -251,7 +251,7 @@ fn failed_command_with_semicolon_will_not_execute_following_cmds_windows() {
 fn can_run_batch_files() {
     use nu_test_support::fs::Stub::FileWithContent;
     Playground::setup("run a Windows batch file", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "foo.cmd",
             r#"
                 @echo off
@@ -271,7 +271,7 @@ fn can_run_batch_files_without_cmd_extension() {
     Playground::setup(
         "run a Windows batch file without specifying the extension",
         |dirs, sandbox| {
-            sandbox.with_files(vec![FileWithContent(
+            sandbox.with_files(&[FileWithContent(
                 "foo.cmd",
                 r#"
                 @echo off
@@ -292,7 +292,7 @@ fn can_run_batch_files_without_bat_extension() {
     Playground::setup(
         "run a Windows batch file without specifying the extension",
         |dirs, sandbox| {
-            sandbox.with_files(vec![FileWithContent(
+            sandbox.with_files(&[FileWithContent(
                 "foo.bat",
                 r#"
                 @echo off

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 #[test]
 fn writes_out_csv() {
     Playground::setup("save_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
 
         let expected_file = dirs.test().join("cargo_sample.csv");
 
@@ -24,7 +24,7 @@ fn writes_out_csv() {
 #[test]
 fn writes_out_list() {
     Playground::setup("save_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
 
         let expected_file = dirs.test().join("list_sample.txt");
 
@@ -42,7 +42,7 @@ fn writes_out_list() {
 #[test]
 fn save_append_will_create_file_if_not_exists() {
     Playground::setup("save_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
 
         let expected_file = dirs.test().join("new-file.txt");
 
@@ -60,7 +60,7 @@ fn save_append_will_create_file_if_not_exists() {
 #[test]
 fn save_append_will_not_overwrite_content() {
     Playground::setup("save_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
 
         let expected_file = dirs.test().join("new-file.txt");
 
@@ -86,7 +86,7 @@ fn save_append_will_not_overwrite_content() {
 #[test]
 fn save_stderr_and_stdout_to_afame_file() {
     Playground::setup("save_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
 
         let actual = nu!(
             cwd: dirs.root(),
@@ -105,7 +105,7 @@ fn save_stderr_and_stdout_to_afame_file() {
 #[test]
 fn save_stderr_and_stdout_to_diff_file() {
     Playground::setup("save_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
 
         let expected_file = dirs.test().join("log.txt");
         let expected_stderr_file = dirs.test().join("err.txt");
@@ -132,7 +132,7 @@ fn save_stderr_and_stdout_to_diff_file() {
 #[test]
 fn save_string_and_stream_as_raw() {
     Playground::setup("save_test_7", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
         let expected_file = dirs.test().join("temp.html");
         nu!(
             cwd: dirs.root(),
@@ -151,7 +151,7 @@ fn save_string_and_stream_as_raw() {
 #[test]
 fn save_not_override_file_by_default() {
     Playground::setup("save_test_8", |dirs, sandbox| {
-        sandbox.with_files(vec![Stub::EmptyFile("log.txt")]);
+        sandbox.with_files(&[Stub::EmptyFile("log.txt")]);
 
         let actual = nu!(
             cwd: dirs.root(),
@@ -164,7 +164,7 @@ fn save_not_override_file_by_default() {
 #[test]
 fn save_override_works() {
     Playground::setup("save_test_9", |dirs, sandbox| {
-        sandbox.with_files(vec![Stub::EmptyFile("log.txt")]);
+        sandbox.with_files(&[Stub::EmptyFile("log.txt")]);
 
         let expected_file = dirs.test().join("log.txt");
         nu!(
@@ -179,7 +179,7 @@ fn save_override_works() {
 #[test]
 fn save_failure_not_overrides() {
     Playground::setup("save_test_10", |dirs, sandbox| {
-        sandbox.with_files(vec![Stub::FileWithContent("result.toml", "Old content")]);
+        sandbox.with_files(&[Stub::FileWithContent("result.toml", "Old content")]);
 
         let expected_file = dirs.test().join("result.toml");
         nu!(
@@ -195,7 +195,7 @@ fn save_failure_not_overrides() {
 #[test]
 fn save_append_works_on_stderr() {
     Playground::setup("save_test_11", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             Stub::FileWithContent("log.txt", "Old"),
             Stub::FileWithContent("err.txt", "Old Err"),
         ]);
@@ -222,7 +222,7 @@ fn save_append_works_on_stderr() {
 #[test]
 fn save_not_overrides_err_by_default() {
     Playground::setup("save_test_12", |dirs, sandbox| {
-        sandbox.with_files(vec![Stub::FileWithContent("err.txt", "Old Err")]);
+        sandbox.with_files(&[Stub::FileWithContent("err.txt", "Old Err")]);
 
         let actual = nu!(
             cwd: dirs.root(),
@@ -239,7 +239,7 @@ fn save_not_overrides_err_by_default() {
 #[test]
 fn save_override_works_stderr() {
     Playground::setup("save_test_13", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             Stub::FileWithContent("log.txt", "Old"),
             Stub::FileWithContent("err.txt", "Old Err"),
         ]);
@@ -266,7 +266,7 @@ fn save_override_works_stderr() {
 #[test]
 fn save_list_stream() {
     Playground::setup("save_test_13", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
 
         let expected_file = dirs.test().join("list_sample.txt");
 
@@ -283,7 +283,7 @@ fn save_list_stream() {
 #[test]
 fn writes_out_range() {
     Playground::setup("save_test_14", |dirs, sandbox| {
-        sandbox.with_files(vec![]);
+        sandbox.with_files(&[]);
 
         let expected_file = dirs.test().join("list_sample.json");
 
@@ -302,7 +302,7 @@ fn writes_out_range() {
 #[test]
 fn save_file_correct_relative_path() {
     Playground::setup("save_test_15", |dirs, sandbox| {
-        sandbox.with_files(vec![Stub::FileWithContent(
+        sandbox.with_files(&[Stub::FileWithContent(
             "test.nu",
             r#"
                 export def main [] {

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -119,7 +119,7 @@ fn ignores_duplicate_columns_selected() {
 #[test]
 fn selects_a_row() {
     Playground::setup("select_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("notes.txt"), EmptyFile("arepas.txt")]);
+        sandbox.with_files(&[EmptyFile("notes.txt"), EmptyFile("arepas.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -138,7 +138,7 @@ fn selects_a_row() {
 #[test]
 fn selects_many_rows() {
     Playground::setup("select_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("notes.txt"), EmptyFile("arepas.txt")]);
+        sandbox.with_files(&[EmptyFile("notes.txt"), EmptyFile("arepas.txt")]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(

--- a/crates/nu-command/tests/commands/source_env.rs
+++ b/crates/nu-command/tests/commands/source_env.rs
@@ -12,7 +12,7 @@ fn sources_also_files_under_custom_lib_dirs_path() {
         let library_path = AbsolutePath::new(dirs.test().join("lib"));
 
         nu.with_config(&file);
-        nu.with_files(vec![FileWithContent(
+        nu.with_files(&[FileWithContent(
             "config.toml",
             &format!(
                 r#"
@@ -22,13 +22,13 @@ fn sources_also_files_under_custom_lib_dirs_path() {
             ),
         )]);
 
-        nu.within("lib").with_files(vec![FileWithContent(
+        nu.within("lib").with_files(&[FileWithContent(
             "my_library.nu",
             r#"
                 source-env my_library/main.nu
             "#,
         )]);
-        nu.within("lib/my_library").with_files(vec![FileWithContent(
+        nu.within("lib/my_library").with_files(&[FileWithContent(
             "main.nu",
             r#"
                 $env.hello = "hello nu"
@@ -55,7 +55,7 @@ fn try_source_foo_with_double_quotes_in(testdir: &str, playdir: &str) {
         foo_file.push_str("/foo.nu");
 
         sandbox.mkdir(&testdir);
-        sandbox.with_files(vec![FileWithContent(&foo_file, "echo foo")]);
+        sandbox.with_files(&[FileWithContent(&foo_file, "echo foo")]);
 
         let cmd = String::from("source-env ") + r#"""# + foo_file.as_str() + r#"""#;
 
@@ -72,7 +72,7 @@ fn try_source_foo_with_single_quotes_in(testdir: &str, playdir: &str) {
         foo_file.push_str("/foo.nu");
 
         sandbox.mkdir(&testdir);
-        sandbox.with_files(vec![FileWithContent(&foo_file, "echo foo")]);
+        sandbox.with_files(&[FileWithContent(&foo_file, "echo foo")]);
 
         let cmd = String::from("source-env ") + r#"'"# + foo_file.as_str() + r#"'"#;
 
@@ -89,7 +89,7 @@ fn try_source_foo_without_quotes_in(testdir: &str, playdir: &str) {
         foo_file.push_str("/foo.nu");
 
         sandbox.mkdir(&testdir);
-        sandbox.with_files(vec![FileWithContent(&foo_file, "echo foo")]);
+        sandbox.with_files(&[FileWithContent(&foo_file, "echo foo")]);
 
         let cmd = String::from("source-env ") + foo_file.as_str();
 
@@ -148,7 +148,7 @@ fn can_source_dynamic_path() {
     Playground::setup("can_source_dynamic_path", |dirs, sandbox| {
         let foo_file = "foo.nu";
 
-        sandbox.with_files(vec![FileWithContent(foo_file, "echo foo")]);
+        sandbox.with_files(&[FileWithContent(foo_file, "echo foo")]);
 
         let cmd = format!("let file = `{foo_file}`; source-env $file");
         let actual = nu!(cwd: dirs.test(), &cmd);
@@ -160,7 +160,7 @@ fn can_source_dynamic_path() {
 #[test]
 fn source_env_eval_export_env() {
     Playground::setup("source_env_eval_export_env", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 export-env { $env.FOO = 'foo' }
@@ -178,7 +178,7 @@ fn source_env_eval_export_env() {
 #[test]
 fn source_env_eval_export_env_hide() {
     Playground::setup("source_env_eval_export_env", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 export-env { hide-env FOO }
@@ -202,7 +202,7 @@ fn source_env_do_cd() {
     Playground::setup("source_env_do_cd", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 r#"
                     cd test1/test2
@@ -225,7 +225,7 @@ fn source_env_do_cd_file_relative() {
     Playground::setup("source_env_do_cd_file_relative", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 r#"
                     cd ($env.FILE_PWD | path join '..')
@@ -248,7 +248,7 @@ fn source_env_dont_cd_overlay() {
     Playground::setup("source_env_dont_cd_overlay", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 r#"
                     overlay new spam
@@ -271,7 +271,7 @@ fn source_env_dont_cd_overlay() {
 #[test]
 fn source_env_is_scoped() {
     Playground::setup("source_env_is_scoped", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 def no-name-similar-to-this [] { 'no-name-similar-to-this' }
@@ -296,7 +296,7 @@ fn source_env_is_scoped() {
 #[test]
 fn source_env_const_file() {
     Playground::setup("source_env_const_file", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 $env.FOO = 'foo'

--- a/crates/nu-command/tests/commands/split_by.rs
+++ b/crates/nu-command/tests/commands/split_by.rs
@@ -36,7 +36,7 @@ fn errors_if_no_input() {
 #[test]
 fn errors_if_non_record_input() {
     Playground::setup("split_by_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("los.txt"),
             EmptyFile("tres.txt"),
             EmptyFile("amigos.txt"),

--- a/crates/nu-command/tests/commands/split_column.rs
+++ b/crates/nu-command/tests/commands/split_column.rs
@@ -5,7 +5,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn to_column() {
     Playground::setup("split_column_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             FileWithContentToBeTrimmed(
                 "sample.txt",
                 r#"

--- a/crates/nu-command/tests/commands/split_row.rs
+++ b/crates/nu-command/tests/commands/split_row.rs
@@ -5,7 +5,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn to_row() {
     Playground::setup("split_row_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             FileWithContentToBeTrimmed(
                 "sample.txt",
                 r#"

--- a/crates/nu-command/tests/commands/str_/into_string.rs
+++ b/crates/nu-command/tests/commands/str_/into_string.rs
@@ -50,7 +50,7 @@ fn from_string() {
 #[test]
 fn from_filename() {
     Playground::setup("from_filename", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "sample.toml",
             r#"
                 [dependency]
@@ -70,7 +70,7 @@ fn from_filename() {
 #[test]
 fn from_filesize() {
     Playground::setup("from_filesize", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "sample.toml",
             r#"
                 [dependency]

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -8,7 +8,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn trims() {
     Playground::setup("str_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [dependency]
@@ -39,7 +39,7 @@ fn error_trim_multiple_chars() {
 #[test]
 fn capitalizes() {
     Playground::setup("str_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [dependency]
@@ -59,7 +59,7 @@ fn capitalizes() {
 #[test]
 fn downcases() {
     Playground::setup("str_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [dependency]
@@ -86,7 +86,7 @@ fn non_ascii_downcase() {
 #[test]
 fn upcases() {
     Playground::setup("str_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [package]
@@ -114,7 +114,7 @@ fn non_ascii_upcase() {
 #[ignore = "Playgrounds are not supported in nu-cmd-extra"]
 fn camelcases() {
     Playground::setup("str_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [dependency]
@@ -165,7 +165,7 @@ fn converts_to_float() {
 #[test]
 fn find_and_replaces() {
     Playground::setup("str_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                      [fortune.teller]
@@ -189,7 +189,7 @@ fn find_and_replaces() {
 #[test]
 fn find_and_replaces_without_passing_field() {
     Playground::setup("str_test_7", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                      [fortune.teller]
@@ -233,7 +233,7 @@ fn regex_error_in_pattern() {
 #[test]
 fn substrings_the_input() {
     Playground::setup("str_test_8", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                      [fortune.teller]
@@ -257,7 +257,7 @@ fn substrings_the_input() {
 #[test]
 fn substring_errors_if_start_index_is_greater_than_end_index() {
     Playground::setup("str_test_9", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                      [fortune.teller]
@@ -282,7 +282,7 @@ fn substring_errors_if_start_index_is_greater_than_end_index() {
 #[test]
 fn substrings_the_input_and_returns_the_string_if_end_index_exceeds_length() {
     Playground::setup("str_test_10", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                      [package]
@@ -306,7 +306,7 @@ fn substrings_the_input_and_returns_the_string_if_end_index_exceeds_length() {
 #[test]
 fn substrings_the_input_and_returns_blank_if_start_index_exceeds_length() {
     Playground::setup("str_test_11", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                      [package]
@@ -330,7 +330,7 @@ fn substrings_the_input_and_returns_blank_if_start_index_exceeds_length() {
 #[test]
 fn substrings_the_input_and_treats_start_index_as_zero_if_blank_start_index_given() {
     Playground::setup("str_test_12", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                      [package]
@@ -354,7 +354,7 @@ fn substrings_the_input_and_treats_start_index_as_zero_if_blank_start_index_give
 #[test]
 fn substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given() {
     Playground::setup("str_test_13", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                      [package]

--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -505,7 +505,7 @@ fn external_with_too_much_stdout_should_not_hang_nu() {
         for _ in 0..bytes {
             large_file_body.push('a');
         }
-        sandbox.with_files(vec![FileWithContent("a_large_file.txt", &large_file_body)]);
+        sandbox.with_files(&[FileWithContent("a_large_file.txt", &large_file_body)]);
 
         let actual = nu!(
             cwd: dirs.test(), pipeline(
@@ -536,7 +536,7 @@ fn table_index_0() {
 #[test]
 fn test_expand_big_0() {
     Playground::setup("test_expand_big_0", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
             [package]
@@ -1820,7 +1820,7 @@ fn table_expande_with_no_header_internally_1() {
 #[test]
 fn test_collapse_big_0() {
     Playground::setup("test_expand_big_0", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
             [package]

--- a/crates/nu-command/tests/commands/touch.rs
+++ b/crates/nu-command/tests/commands/touch.rs
@@ -39,7 +39,7 @@ fn creates_two_files() {
 #[test]
 fn change_modified_time_of_file_to_today() {
     Playground::setup("change_time_test_9", |dirs, sandbox| {
-        sandbox.with_files(vec![Stub::EmptyFile("file.txt")]);
+        sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
         let path = dirs.test().join("file.txt");
 
         // Set file.txt's times to the past before the test to make sure `touch` actually changes the mtime to today
@@ -69,7 +69,7 @@ fn change_modified_time_of_file_to_today() {
 #[test]
 fn change_access_time_of_file_to_today() {
     Playground::setup("change_time_test_18", |dirs, sandbox| {
-        sandbox.with_files(vec![Stub::EmptyFile("file.txt")]);
+        sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
         let path = dirs.test().join("file.txt");
 
         // Set file.txt's times to the past before the test to make sure `touch` actually changes the atime to today
@@ -99,7 +99,7 @@ fn change_access_time_of_file_to_today() {
 #[test]
 fn change_modified_and_access_time_of_file_to_today() {
     Playground::setup("change_time_test_27", |dirs, sandbox| {
-        sandbox.with_files(vec![Stub::EmptyFile("file.txt")]);
+        sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
         let path = dirs.test().join("file.txt");
 
         filetime::set_file_times(&path, TIME_ONE, TIME_ONE).unwrap();
@@ -143,7 +143,7 @@ fn change_file_times_if_exists_with_no_create() {
     Playground::setup(
         "change_file_times_if_exists_with_no_create",
         |dirs, sandbox| {
-            sandbox.with_files(vec![Stub::EmptyFile("file.txt")]);
+            sandbox.with_files(&[Stub::EmptyFile("file.txt")]);
             let path = dirs.test().join("file.txt");
 
             filetime::set_file_times(&path, TIME_ONE, TIME_ONE).unwrap();
@@ -208,7 +208,7 @@ fn creates_file_four_dots_quotation_marks() {
 #[test]
 fn change_file_times_to_reference_file() {
     Playground::setup("change_dir_times_to_reference_dir", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             Stub::EmptyFile("reference_file"),
             Stub::EmptyFile("target_file"),
         ]);
@@ -253,7 +253,7 @@ fn change_file_times_to_reference_file() {
 #[test]
 fn change_file_mtime_to_reference() {
     Playground::setup("change_file_mtime_to_reference", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             Stub::EmptyFile("reference_file"),
             Stub::EmptyFile("target_file"),
         ]);

--- a/crates/nu-command/tests/commands/ucp.rs
+++ b/crates/nu-command/tests/commands/ucp.rs
@@ -113,7 +113,7 @@ fn copies_the_directory_inside_directory_if_path_to_copy_is_directory_and_with_r
     Playground::setup("ucp_test_4", |dirs, sandbox| {
         sandbox
             .within("originals")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("yehuda.txt"),
                 EmptyFile("jttxt"),
                 EmptyFile("andres.txt"),
@@ -151,19 +151,19 @@ fn deep_copies_with_recursive_flag_impl(progress: bool) {
     Playground::setup("ucp_test_5", |dirs, sandbox| {
         sandbox
             .within("originals")
-            .with_files(vec![EmptyFile("manifest.txt")])
+            .with_files(&[EmptyFile("manifest.txt")])
             .within("originals/contributors")
-            .with_files(vec![
+            .with_files(&[
                 EmptyFile("yehuda.txt"),
                 EmptyFile("jttxt"),
                 EmptyFile("andres.txt"),
             ])
             .within("originals/contributors/JT")
-            .with_files(vec![EmptyFile("errors.txt"), EmptyFile("multishells.txt")])
+            .with_files(&[EmptyFile("errors.txt"), EmptyFile("multishells.txt")])
             .within("originals/contributors/andres")
-            .with_files(vec![EmptyFile("coverage.txt"), EmptyFile("commands.txt")])
+            .with_files(&[EmptyFile("coverage.txt"), EmptyFile("commands.txt")])
             .within("originals/contributors/yehuda")
-            .with_files(vec![EmptyFile("defer-evaluation.txt")])
+            .with_files(&[EmptyFile("defer-evaluation.txt")])
             .mkdir("expected");
 
         let expected_dir = dirs.test().join("expected").join("originals");
@@ -324,7 +324,7 @@ fn copy_files_using_glob_two_parents_up_using_multiple_dots() {
 
 fn copy_files_using_glob_two_parents_up_using_multiple_dots_imp(progress: bool) {
     Playground::setup("ucp_test_9", |dirs, sandbox| {
-        sandbox.within("foo").within("bar").with_files(vec![
+        sandbox.within("foo").within("bar").with_files(&[
             EmptyFile("jtjson"),
             EmptyFile("andres.xml"),
             EmptyFile("yehuda.yaml"),
@@ -363,7 +363,7 @@ fn copy_file_and_dir_from_two_parents_up_using_multiple_dots_to_current_dir_recu
     progress: bool,
 ) {
     Playground::setup("ucp_test_10", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("hello_there")]);
+        sandbox.with_files(&[EmptyFile("hello_there")]);
         sandbox.mkdir("hello_again");
         sandbox.within("foo").mkdir("bar");
 
@@ -390,7 +390,7 @@ fn copy_to_non_existing_dir() {
 
 fn copy_to_non_existing_dir_impl(progress: bool) {
     Playground::setup("ucp_test_11", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("empty_file")]);
+        sandbox.with_files(&[EmptyFile("empty_file")]);
         let progress_flag = if progress { "-p" } else { "" };
 
         let actual = nu!(
@@ -413,7 +413,7 @@ fn copy_dir_contains_symlink_ignored_impl(progress: bool) {
     Playground::setup("ucp_test_12", |_dirs, sandbox| {
         sandbox
             .within("tmp_dir")
-            .with_files(vec![EmptyFile("hello_there"), EmptyFile("good_bye")])
+            .with_files(&[EmptyFile("hello_there"), EmptyFile("good_bye")])
             .within("tmp_dir")
             .symlink("good_bye", "dangle_symlink");
 
@@ -446,7 +446,7 @@ fn copy_dir_contains_symlink_impl(progress: bool) {
     Playground::setup("ucp_test_13", |_dirs, sandbox| {
         sandbox
             .within("tmp_dir")
-            .with_files(vec![EmptyFile("hello_there"), EmptyFile("good_bye")])
+            .with_files(&[EmptyFile("hello_there"), EmptyFile("good_bye")])
             .within("tmp_dir")
             .symlink("good_bye", "dangle_symlink");
 
@@ -477,7 +477,7 @@ fn copy_dir_symlink_file_body_not_changed_impl(progress: bool) {
     Playground::setup("ucp_test_14", |_dirs, sandbox| {
         sandbox
             .within("tmp_dir")
-            .with_files(vec![EmptyFile("hello_there"), EmptyFile("good_bye")])
+            .with_files(&[EmptyFile("hello_there"), EmptyFile("good_bye")])
             .within("tmp_dir")
             .symlink("good_bye", "dangle_symlink");
 
@@ -507,7 +507,7 @@ fn copy_identical_file() {
 
 fn copy_identical_file_impl(progress: bool) {
     Playground::setup("ucp_test_15", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("same.txt")]);
+        sandbox.with_files(&[EmptyFile("same.txt")]);
 
         let progress_flag = if progress { "-p" } else { "" };
 
@@ -538,7 +538,7 @@ fn copy_ignores_ansi() {
 
 fn copy_ignores_ansi_impl(progress: bool) {
     Playground::setup("ucp_test_16", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("test.txt")]);
+        sandbox.with_files(&[EmptyFile("test.txt")]);
 
         let progress_flag = if progress { "-p" } else { "" };
 
@@ -563,7 +563,7 @@ fn copy_file_not_exists_dst() {
 #[cfg(unix)]
 fn copy_file_not_exists_dst_impl(progress: bool) {
     Playground::setup("ucp_test_17", |_dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("valid.txt")]);
+        sandbox.with_files(&[EmptyFile("valid.txt")]);
 
         let progress_flag = if progress { "-p" } else { "" };
 
@@ -589,7 +589,7 @@ fn copy_file_with_read_permission() {
 
 fn copy_file_with_read_permission_impl(progress: bool) {
     Playground::setup("ucp_test_18", |_dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("valid.txt"),
             FileWithPermission("invalid_prem.txt", false),
         ]);
@@ -775,7 +775,7 @@ fn test_cp_arg_force() {
     Playground::setup("ucp_test_24", |dirs, sandbox| {
         let src = dirs.fixtures.join("cp").join(TEST_HELLO_WORLD_SOURCE);
         let src_hash = get_file_hash(src.display());
-        sandbox.with_files(vec![FileWithPermission("invalid_prem.txt", false)]);
+        sandbox.with_files(&[FileWithPermission("invalid_prem.txt", false)]);
 
         nu!(
         cwd: dirs.root(),
@@ -827,7 +827,7 @@ fn test_cp_nested_directory_to_itself_disallowed() {
 #[test]
 fn test_cp_same_file_force() {
     Playground::setup("ucp_test_27", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("f")]);
+        sandbox.with_files(&[EmptyFile("f")]);
         let actual = nu!(
         cwd: dirs.test(),
         "cp --force {} {}",
@@ -862,7 +862,7 @@ fn test_cp_arg_no_clobber() {
 #[test]
 fn test_cp_arg_no_clobber_twice() {
     Playground::setup("ucp_test_29", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("source.txt"),
             FileWithContent("source_with_body.txt", "some-body"),
         ]);
@@ -961,7 +961,7 @@ fn test_cp_only_source_no_dest() {
 #[test]
 fn test_cp_with_vars() {
     Playground::setup("ucp_test_33", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("input")]);
+        sandbox.with_files(&[EmptyFile("input")]);
         nu!(
         cwd: dirs.test(),
         "let src = 'input'; let dst = 'target'; cp $src $dst",
@@ -974,7 +974,7 @@ fn test_cp_with_vars() {
 fn test_cp_destination_after_cd() {
     Playground::setup("ucp_test_34", |dirs, sandbox| {
         sandbox.mkdir("test");
-        sandbox.with_files(vec![EmptyFile("test/file.txt")]);
+        sandbox.with_files(&[EmptyFile("test/file.txt")]);
         nu!(
         cwd: dirs.test(),
             // Defining variable avoid path expansion of cp argument.
@@ -992,7 +992,7 @@ fn test_cp_destination_after_cd() {
 #[case("a][c")]
 fn copies_files_with_glob_metachars(#[case] src_name: &str) {
     Playground::setup("ucp_test_34", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             src_name,
             "What is the sound of one hand clapping?",
         )]);
@@ -1026,7 +1026,7 @@ fn copies_files_with_glob_metachars(#[case] src_name: &str) {
 #[case("a][c")]
 fn copies_files_with_glob_metachars_when_input_are_variables(#[case] src_name: &str) {
     Playground::setup("ucp_test_35", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             src_name,
             "What is the sound of one hand clapping?",
         )]);
@@ -1069,7 +1069,7 @@ fn test_cp_preserve_timestamps() {
     // Preserve timestamp and mode
 
     Playground::setup("ucp_test_35", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("file.txt")]);
+        sandbox.with_files(&[EmptyFile("file.txt")]);
         let actual = nu!(
         cwd: dirs.test(),
         "
@@ -1093,7 +1093,7 @@ fn test_cp_preserve_only_timestamps() {
     // Preserve timestamps and discard all other attributes including mode
 
     Playground::setup("ucp_test_35", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("file.txt")]);
+        sandbox.with_files(&[EmptyFile("file.txt")]);
         let actual = nu!(
         cwd: dirs.test(),
         "
@@ -1118,7 +1118,7 @@ fn test_cp_preserve_nothing() {
     // Preserve no attributes
 
     Playground::setup("ucp_test_35", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("file.txt")]);
+        sandbox.with_files(&[EmptyFile("file.txt")]);
         let actual = nu!(
         cwd: dirs.test(),
         "
@@ -1142,7 +1142,7 @@ fn test_cp_inside_glob_metachars_dir() {
         let sub_dir = "test[]";
         sandbox
             .within(sub_dir)
-            .with_files(vec![FileWithContent("test_file.txt", "hello")]);
+            .with_files(&[FileWithContent("test_file.txt", "hello")]);
 
         let actual = nu!(
             cwd: dirs.test().join(sub_dir),
@@ -1163,7 +1163,7 @@ fn test_cp_inside_glob_metachars_dir() {
 fn test_cp_to_customized_home_directory() {
     Playground::setup("cp_to_home", |dirs, sandbox| {
         std::env::set_var("HOME", dirs.test());
-        sandbox.with_files(vec![EmptyFile("test_file.txt")]);
+        sandbox.with_files(&[EmptyFile("test_file.txt")]);
         let actual = nu!(cwd: dirs.test(), "mkdir test; cp test_file.txt ~/test/");
 
         assert!(actual.err.is_empty());
@@ -1177,7 +1177,7 @@ fn test_cp_to_customized_home_directory() {
 #[test]
 fn cp_with_tilde() {
     Playground::setup("cp_tilde", |dirs, sandbox| {
-        sandbox.within("~tilde").with_files(vec![
+        sandbox.within("~tilde").with_files(&[
             EmptyFile("f1.txt"),
             EmptyFile("f2.txt"),
             EmptyFile("f3.txt"),
@@ -1218,7 +1218,7 @@ fn copy_file_with_update_flag() {
 
 fn copy_file_with_update_flag_impl(progress: bool) {
     Playground::setup("cp_test_36", |_dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("valid.txt"),
             FileWithContent("newer_valid.txt", "body"),
         ]);
@@ -1234,7 +1234,7 @@ fn copy_file_with_update_flag_impl(progress: bool) {
 
         // create a file after assert to make sure that newest_valid.txt is newest
         std::thread::sleep(std::time::Duration::from_secs(1));
-        sandbox.with_files(vec![FileWithContent("newest_valid.txt", "newest_body")]);
+        sandbox.with_files(&[FileWithContent("newest_valid.txt", "newest_body")]);
         let actual = nu!(cwd: sandbox.cwd(), "cp {} -u newest_valid.txt valid.txt; open valid.txt", progress_flag);
         assert_eq!(actual.out, "newest_body");
 
@@ -1249,7 +1249,7 @@ fn cp_with_cd() {
     Playground::setup("cp_test_37", |_dirs, sandbox| {
         sandbox
             .mkdir("tmp_dir")
-            .with_files(vec![FileWithContent("tmp_dir/file.txt", "body")]);
+            .with_files(&[FileWithContent("tmp_dir/file.txt", "body")]);
 
         let actual = nu!(
             cwd: sandbox.cwd(),

--- a/crates/nu-command/tests/commands/use_.rs
+++ b/crates/nu-command/tests/commands/use_.rs
@@ -9,7 +9,7 @@ fn use_module_file_within_block() {
     Playground::setup("use_test_1", |dirs, nu| {
         let file = AbsolutePath::new(dirs.test().join("spam.nu"));
 
-        nu.with_files(vec![FileWithContent(
+        nu.with_files(&[FileWithContent(
             &file.to_string(),
             r#"
                 export def foo [] {
@@ -39,7 +39,7 @@ fn use_keeps_doc_comments() {
     Playground::setup("use_doc_comments", |dirs, nu| {
         let file = AbsolutePath::new(dirs.test().join("spam.nu"));
 
-        nu.with_files(vec![FileWithContent(
+        nu.with_files(&[FileWithContent(
             &file.to_string(),
             r#"
                 # this is my foo command
@@ -68,7 +68,7 @@ fn use_keeps_doc_comments() {
 #[test]
 fn use_eval_export_env() {
     Playground::setup("use_eval_export_env", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 export-env { $env.FOO = 'foo' }
@@ -86,7 +86,7 @@ fn use_eval_export_env() {
 #[test]
 fn use_eval_export_env_hide() {
     Playground::setup("use_eval_export_env", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 export-env { hide-env FOO }
@@ -106,7 +106,7 @@ fn use_do_cd() {
     Playground::setup("use_do_cd", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 r#"
                     export-env { cd test1/test2 }
@@ -126,7 +126,7 @@ fn use_do_cd_file_relative() {
     Playground::setup("use_do_cd_file_relative", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 r#"
                     export-env { cd ($env.FILE_PWD | path join '..') }
@@ -146,7 +146,7 @@ fn use_dont_cd_overlay() {
     Playground::setup("use_dont_cd_overlay", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 r#"
                     export-env {
@@ -168,7 +168,7 @@ fn use_dont_cd_overlay() {
 #[test]
 fn use_export_env_combined() {
     Playground::setup("use_is_scoped", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 def foo [] { 'foo' }

--- a/crates/nu-command/tests/commands/zip.rs
+++ b/crates/nu-command/tests/commands/zip.rs
@@ -17,7 +17,7 @@ export def expect [
 #[test]
 fn zips_two_tables() {
     Playground::setup("zip_test_1", |dirs, nu| {
-        nu.with_files(vec![FileWithContent(
+        nu.with_files(&[FileWithContent(
             "zip_test.nu",
             &format!("{ZIP_POWERED_TEST_ASSERTION_SCRIPT}\n"),
         )]);

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -15,7 +15,7 @@ fn table_to_csv_text_and_from_csv_text_back_into_table() {
 #[test]
 fn table_to_csv_text() {
     Playground::setup("filter_to_csv_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "csv_text_sample.txt",
             r#"
                 importer,shipper,tariff_item,name,origin
@@ -47,7 +47,7 @@ fn table_to_csv_text() {
 #[test]
 fn table_to_csv_text_skipping_headers_after_conversion() {
     Playground::setup("filter_to_csv_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "csv_text_sample.txt",
             r#"
                 importer,shipper,tariff_item,name,origin
@@ -77,7 +77,7 @@ fn table_to_csv_text_skipping_headers_after_conversion() {
 #[test]
 fn infers_types() {
     Playground::setup("filter_from_csv_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_cuatro_mosqueteros.csv",
             r#"
                 first_name,last_name,rusty_luck,d
@@ -104,7 +104,7 @@ fn infers_types() {
 #[test]
 fn from_csv_text_to_table() {
     Playground::setup("filter_from_csv_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name,last_name,rusty_luck
@@ -131,7 +131,7 @@ fn from_csv_text_to_table() {
 #[test]
 fn from_csv_text_with_separator_to_table() {
     Playground::setup("filter_from_csv_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name;last_name;rusty_luck
@@ -158,7 +158,7 @@ fn from_csv_text_with_separator_to_table() {
 #[test]
 fn from_csv_text_with_tab_separator_to_table() {
     Playground::setup("filter_from_csv_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name	last_name	rusty_luck
@@ -185,7 +185,7 @@ fn from_csv_text_with_tab_separator_to_table() {
 #[test]
 fn from_csv_text_with_comments_to_table() {
     Playground::setup("filter_from_csv_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 # This is a comment
@@ -215,7 +215,7 @@ fn from_csv_text_with_comments_to_table() {
 #[test]
 fn from_csv_text_with_custom_quotes_to_table() {
     Playground::setup("filter_from_csv_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name,last_name,rusty_luck
@@ -242,7 +242,7 @@ fn from_csv_text_with_custom_quotes_to_table() {
 #[test]
 fn from_csv_text_with_custom_escapes_to_table() {
     Playground::setup("filter_from_csv_test_7", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name,last_name,rusty_luck
@@ -269,7 +269,7 @@ fn from_csv_text_with_custom_escapes_to_table() {
 #[test]
 fn from_csv_text_skipping_headers_to_table() {
     Playground::setup("filter_from_csv_test_8", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_amigos.txt",
             r#"
                 Andrés,Robalino,1
@@ -295,7 +295,7 @@ fn from_csv_text_skipping_headers_to_table() {
 #[test]
 fn from_csv_text_with_missing_columns_to_table() {
     Playground::setup("filter_from_csv_test_9", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name,last_name,rusty_luck
@@ -323,7 +323,7 @@ fn from_csv_text_with_missing_columns_to_table() {
 #[test]
 fn from_csv_text_with_multiple_char_separator() {
     Playground::setup("filter_from_csv_test_10", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name,last_name,rusty_luck
@@ -350,7 +350,7 @@ fn from_csv_text_with_multiple_char_separator() {
 #[test]
 fn from_csv_text_with_wrong_type_separator() {
     Playground::setup("filter_from_csv_test_11", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name,last_name,rusty_luck
@@ -410,7 +410,7 @@ fn string_to_csv_error() {
 #[test]
 fn parses_csv_with_unicode_sep() {
     Playground::setup("filter_from_csv_unicode_sep_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name;last_name;rusty_luck
@@ -437,7 +437,7 @@ fn parses_csv_with_unicode_sep() {
 #[test]
 fn parses_csv_with_unicode_x1f_sep() {
     Playground::setup("filter_from_csv_unicode_sep_x1f_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_namelast_namerusty_luck

--- a/crates/nu-command/tests/format_conversions/json.rs
+++ b/crates/nu-command/tests/format_conversions/json.rs
@@ -20,7 +20,7 @@ fn table_to_json_text_and_from_json_text_back_into_table() {
 #[test]
 fn from_json_text_to_table() {
     Playground::setup("filter_from_json_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "katz.txt",
             r#"
                 {
@@ -46,7 +46,7 @@ fn from_json_text_to_table() {
 #[test]
 fn from_json_text_to_table_strict() {
     Playground::setup("filter_from_json_test_1_strict", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "katz.txt",
             r#"
                 {
@@ -72,7 +72,7 @@ fn from_json_text_to_table_strict() {
 #[test]
 fn from_json_text_recognizing_objects_independently_to_table() {
     Playground::setup("filter_from_json_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "katz.txt",
             r#"
                 {"name":   "Yehuda", "rusty_luck": 1}
@@ -99,7 +99,7 @@ fn from_json_text_recognizing_objects_independently_to_table() {
 #[test]
 fn from_json_text_recognizing_objects_independently_to_table_strict() {
     Playground::setup("filter_from_json_test_2_strict", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "katz.txt",
             r#"
                 {"name":   "Yehuda", "rusty_luck": 1}
@@ -126,7 +126,7 @@ fn from_json_text_recognizing_objects_independently_to_table_strict() {
 #[test]
 fn table_to_json_text() {
     Playground::setup("filter_to_json_test", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "sample.txt",
             r#"
                 JonAndrehudaTZ,3
@@ -155,7 +155,7 @@ fn table_to_json_text() {
 #[test]
 fn table_to_json_text_strict() {
     Playground::setup("filter_to_json_test_strict", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "sample.txt",
             r#"
                 JonAndrehudaTZ,3

--- a/crates/nu-command/tests/format_conversions/ssv.rs
+++ b/crates/nu-command/tests/format_conversions/ssv.rs
@@ -5,7 +5,7 @@ use nu_test_support::{nu, pipeline};
 #[test]
 fn from_ssv_text_to_table() {
     Playground::setup("filter_from_ssv_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "oc_get_svc.txt",
             r#"
                 NAME              LABELS                                    SELECTOR                  IP              PORT(S)
@@ -32,7 +32,7 @@ fn from_ssv_text_to_table() {
 #[test]
 fn from_ssv_text_to_table_with_separator_specified() {
     Playground::setup("filter_from_ssv_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "oc_get_svc.txt",
             r#"
                 NAME              LABELS                                    SELECTOR                  IP              PORT(S)
@@ -59,7 +59,7 @@ fn from_ssv_text_to_table_with_separator_specified() {
 #[test]
 fn from_ssv_text_treating_first_line_as_data_with_flag() {
     Playground::setup("filter_from_ssv_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "oc_get_svc.txt",
             r#"
                 docker-registry   docker-registry=default                   docker-registry=default   172.30.78.158   5000/TCP

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -25,7 +25,7 @@ fn table_to_tsv_text_and_from_tsv_text_back_into_table_using_csv_separator() {
 #[test]
 fn table_to_tsv_text() {
     Playground::setup("filter_to_tsv_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "tsv_text_sample.txt",
             r#"
                 importer	shipper	tariff_item	name	origin
@@ -54,7 +54,7 @@ fn table_to_tsv_text() {
 #[test]
 fn table_to_tsv_text_skipping_headers_after_conversion() {
     Playground::setup("filter_to_tsv_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "tsv_text_sample.txt",
             r#"
                 importer    shipper tariff_item name    origin
@@ -81,7 +81,7 @@ fn table_to_tsv_text_skipping_headers_after_conversion() {
 #[test]
 fn from_tsv_text_to_table() {
     Playground::setup("filter_from_tsv_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_amigos.txt",
             r#"
                 first Name	Last Name	rusty_luck
@@ -108,7 +108,7 @@ fn from_tsv_text_to_table() {
 #[test]
 fn from_tsv_text_with_comments_to_table() {
     Playground::setup("filter_from_tsv_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 # This is a comment
@@ -138,7 +138,7 @@ fn from_tsv_text_with_comments_to_table() {
 #[test]
 fn from_tsv_text_with_custom_quotes_to_table() {
     Playground::setup("filter_from_tsv_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name	last_name	rusty_luck
@@ -165,7 +165,7 @@ fn from_tsv_text_with_custom_quotes_to_table() {
 #[test]
 fn from_tsv_text_with_custom_escapes_to_table() {
     Playground::setup("filter_from_tsv_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name	last_name	rusty_luck
@@ -192,7 +192,7 @@ fn from_tsv_text_with_custom_escapes_to_table() {
 #[test]
 fn from_tsv_text_skipping_headers_to_table() {
     Playground::setup("filter_from_tsv_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_amigos.txt",
             r#"
                 Andrés	Robalino	1
@@ -218,7 +218,7 @@ fn from_tsv_text_skipping_headers_to_table() {
 #[test]
 fn from_tsv_text_with_missing_columns_to_table() {
     Playground::setup("filter_from_tsv_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name	last_name	rusty_luck
@@ -246,7 +246,7 @@ fn from_tsv_text_with_missing_columns_to_table() {
 #[test]
 fn from_tsv_text_with_multiple_char_comment() {
     Playground::setup("filter_from_tsv_test_7", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name	last_name	rusty_luck
@@ -271,7 +271,7 @@ fn from_tsv_text_with_multiple_char_comment() {
 #[test]
 fn from_tsv_text_with_wrong_type_comment() {
     Playground::setup("filter_from_csv_test_8", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "los_tres_caballeros.txt",
             r#"
                 first_name	last_name	rusty_luck

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -49,46 +49,52 @@ pub enum FlatShape {
     VarDecl(VarId),
 }
 
+impl FlatShape {
+    pub fn as_str(&self) -> &str {
+        match self {
+            FlatShape::And => "shape_and",
+            FlatShape::Binary => "shape_binary",
+            FlatShape::Block => "shape_block",
+            FlatShape::Bool => "shape_bool",
+            FlatShape::Closure => "shape_closure",
+            FlatShape::Custom(_) => "shape_custom",
+            FlatShape::DateTime => "shape_datetime",
+            FlatShape::Directory => "shape_directory",
+            FlatShape::External => "shape_external",
+            FlatShape::ExternalArg => "shape_externalarg",
+            FlatShape::ExternalResolved => "shape_external_resolved",
+            FlatShape::Filepath => "shape_filepath",
+            FlatShape::Flag => "shape_flag",
+            FlatShape::Float => "shape_float",
+            FlatShape::Garbage => "shape_garbage",
+            FlatShape::GlobPattern => "shape_globpattern",
+            FlatShape::Int => "shape_int",
+            FlatShape::InternalCall(_) => "shape_internalcall",
+            FlatShape::Keyword => "shape_keyword",
+            FlatShape::List => "shape_list",
+            FlatShape::Literal => "shape_literal",
+            FlatShape::MatchPattern => "shape_match_pattern",
+            FlatShape::Nothing => "shape_nothing",
+            FlatShape::Operator => "shape_operator",
+            FlatShape::Or => "shape_or",
+            FlatShape::Pipe => "shape_pipe",
+            FlatShape::Range => "shape_range",
+            FlatShape::RawString => "shape_raw_string",
+            FlatShape::Record => "shape_record",
+            FlatShape::Redirection => "shape_redirection",
+            FlatShape::Signature => "shape_signature",
+            FlatShape::String => "shape_string",
+            FlatShape::StringInterpolation => "shape_string_interpolation",
+            FlatShape::Table => "shape_table",
+            FlatShape::Variable(_) => "shape_variable",
+            FlatShape::VarDecl(_) => "shape_vardecl",
+        }
+    }
+}
+
 impl Display for FlatShape {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        match self {
-            FlatShape::And => write!(f, "shape_and"),
-            FlatShape::Binary => write!(f, "shape_binary"),
-            FlatShape::Block => write!(f, "shape_block"),
-            FlatShape::Bool => write!(f, "shape_bool"),
-            FlatShape::Closure => write!(f, "shape_closure"),
-            FlatShape::Custom(_) => write!(f, "shape_custom"),
-            FlatShape::DateTime => write!(f, "shape_datetime"),
-            FlatShape::Directory => write!(f, "shape_directory"),
-            FlatShape::External => write!(f, "shape_external"),
-            FlatShape::ExternalArg => write!(f, "shape_externalarg"),
-            FlatShape::ExternalResolved => write!(f, "shape_external_resolved"),
-            FlatShape::Filepath => write!(f, "shape_filepath"),
-            FlatShape::Flag => write!(f, "shape_flag"),
-            FlatShape::Float => write!(f, "shape_float"),
-            FlatShape::Garbage => write!(f, "shape_garbage"),
-            FlatShape::GlobPattern => write!(f, "shape_globpattern"),
-            FlatShape::Int => write!(f, "shape_int"),
-            FlatShape::InternalCall(_) => write!(f, "shape_internalcall"),
-            FlatShape::Keyword => write!(f, "shape_keyword"),
-            FlatShape::List => write!(f, "shape_list"),
-            FlatShape::Literal => write!(f, "shape_literal"),
-            FlatShape::MatchPattern => write!(f, "shape_match_pattern"),
-            FlatShape::Nothing => write!(f, "shape_nothing"),
-            FlatShape::Operator => write!(f, "shape_operator"),
-            FlatShape::Or => write!(f, "shape_or"),
-            FlatShape::Pipe => write!(f, "shape_pipe"),
-            FlatShape::Range => write!(f, "shape_range"),
-            FlatShape::RawString => write!(f, "shape_raw_string"),
-            FlatShape::Record => write!(f, "shape_record"),
-            FlatShape::Redirection => write!(f, "shape_redirection"),
-            FlatShape::Signature => write!(f, "shape_signature"),
-            FlatShape::String => write!(f, "shape_string"),
-            FlatShape::StringInterpolation => write!(f, "shape_string_interpolation"),
-            FlatShape::Table => write!(f, "shape_table"),
-            FlatShape::Variable(_) => write!(f, "shape_variable"),
-            FlatShape::VarDecl(_) => write!(f, "shape_vardecl"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/nu-table/src/types/general.rs
+++ b/crates/nu-table/src/types/general.rs
@@ -99,7 +99,7 @@ fn table(input: &[Value], opts: &TableOpts<'_>) -> TableResult {
         .filter(|header| header != INDEX_COLUMN_NAME)
         .collect();
 
-    let table = to_table_with_header(input, headers, with_index, row_offset, opts)?;
+    let table = to_table_with_header(input, &headers, with_index, row_offset, opts)?;
     let table = table.map(|table| TableOutput::new(table, true, with_index));
 
     Ok(table)
@@ -107,7 +107,7 @@ fn table(input: &[Value], opts: &TableOpts<'_>) -> TableResult {
 
 fn to_table_with_header(
     input: &[Value],
-    headers: Vec<String>,
+    headers: &[String],
     with_index: bool,
     row_offset: usize,
     opts: &TableOpts<'_>,

--- a/crates/nu-test-support/src/macros.rs
+++ b/crates/nu-test-support/src/macros.rs
@@ -284,7 +284,7 @@ pub fn nu_run_test(opts: NuOpts, commands: impl AsRef<str>, with_std: bool) -> O
         command.arg("--no-std-lib");
     }
     command
-        .arg(format!("-c {}", escape_quote_string(commands)))
+        .arg(format!("-c {}", escape_quote_string(&commands)))
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
@@ -353,7 +353,7 @@ where
             let plugin_path = nu_path::canonicalize_with(&plugin, &test_bins)
                 .unwrap_or_else(|_| panic!("failed to canonicalize plugin {} path", &plugin));
             let plugin_path = plugin_path.to_string_lossy();
-            escape_quote_string(plugin_path.into_owned())
+            escape_quote_string(&plugin_path)
         })
         .collect();
     let plugins_arg = format!("[{}]", plugin_paths_quoted.join(","));
@@ -397,7 +397,7 @@ where
     Outcome::new(out, err.into_owned(), output.status)
 }
 
-fn escape_quote_string(input: String) -> String {
+fn escape_quote_string(input: &str) -> String {
     let mut output = String::with_capacity(input.len() + 2);
     output.push('"');
 

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -199,7 +199,7 @@ impl<'a> Playground<'a> {
         self
     }
 
-    pub fn with_files(&mut self, files: Vec<Stub>) -> &mut Self {
+    pub fn with_files(&mut self, files: &[Stub]) -> &mut Self {
         let endl = fs::line_ending();
 
         files

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -7,7 +7,7 @@ use pretty_assertions::assert_eq;
 fn module_private_import_decl() {
     Playground::setup("module_private_import_decl", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     use spam.nu foo-helper
@@ -15,7 +15,7 @@ fn module_private_import_decl() {
                     export def foo [] { foo-helper }
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 r#"
                     def get-foo [] { "foo" }
@@ -35,7 +35,7 @@ fn module_private_import_decl() {
 fn module_private_import_alias() {
     Playground::setup("module_private_import_alias", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     use spam.nu foo-helper
@@ -43,7 +43,7 @@ fn module_private_import_alias() {
                     export def foo [] { foo-helper }
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 r#"
                     export alias foo-helper = echo "foo"
@@ -62,13 +62,13 @@ fn module_private_import_alias() {
 fn module_private_import_decl_not_public() {
     Playground::setup("module_private_import_decl_not_public", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     use spam.nu foo-helper
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 r#"
                     def get-foo [] { "foo" }
@@ -88,13 +88,13 @@ fn module_private_import_decl_not_public() {
 fn module_public_import_decl() {
     Playground::setup("module_public_import_decl", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     export use spam.nu foo
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 r#"
                     def foo-helper [] { "foo" }
@@ -114,13 +114,13 @@ fn module_public_import_decl() {
 fn module_public_import_alias() {
     Playground::setup("module_public_import_alias", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     export use spam.nu foo
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 r#"
                     export alias foo = echo "foo"
@@ -139,25 +139,25 @@ fn module_public_import_alias() {
 fn module_nested_imports() {
     Playground::setup("module_nested_imports", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     export use spam.nu [ foo bar ]
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 "
                     export use spam2.nu [ foo bar ]
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam2.nu",
                 "
                     export use spam3.nu [ foo bar ]
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam3.nu",
                 r#"
                     export def foo [] { "foo" }
@@ -183,25 +183,25 @@ fn module_nested_imports_in_dirs() {
             .mkdir("spam")
             .mkdir("spam/spam2")
             .mkdir("spam/spam3")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     export use spam/spam.nu [ foo bar ]
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam/spam.nu",
                 "
                     export use spam2/spam2.nu [ foo bar ]
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam/spam2/spam2.nu",
                 "
                     export use ../spam3/spam3.nu [ foo bar ]
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam/spam3/spam3.nu",
                 r#"
                     export def foo [] { "foo" }
@@ -224,13 +224,13 @@ fn module_nested_imports_in_dirs() {
 fn module_public_import_decl_prefixed() {
     Playground::setup("module_public_import_decl", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     export use spam.nu
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 r#"
                     def foo-helper [] { "foo" }
@@ -253,26 +253,26 @@ fn module_nested_imports_in_dirs_prefixed() {
             .mkdir("spam")
             .mkdir("spam/spam2")
             .mkdir("spam/spam3")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 r#"
                     export use spam/spam.nu [ "spam2 foo" "spam2 spam3 bar" ]
                 "#,
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam/spam.nu",
                 "
                     export use spam2/spam2.nu
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam/spam2/spam2.nu",
                 "
                     export use ../spam3/spam3.nu
                     export use ../spam3/spam3.nu foo
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam/spam3/spam3.nu",
                 r#"
                     export def foo [] { "foo" }
@@ -295,7 +295,7 @@ fn module_nested_imports_in_dirs_prefixed() {
 fn module_import_env_1() {
     Playground::setup("module_import_env_1", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     export-env { source-env spam.nu }
@@ -303,7 +303,7 @@ fn module_import_env_1() {
                     export def foo [] { $env.FOO_HELPER }
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 r#"
                     export-env { $env.FOO_HELPER = "foo" }
@@ -322,13 +322,13 @@ fn module_import_env_1() {
 fn module_import_env_2() {
     Playground::setup("module_import_env_2", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     export-env { source-env spam.nu }
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 r#"
                     export-env { $env.FOO = "foo" }
@@ -346,7 +346,7 @@ fn module_import_env_2() {
 #[test]
 fn module_cyclical_imports_0() {
     Playground::setup("module_cyclical_imports_0", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             "
                     use eggs.nu
@@ -364,7 +364,7 @@ fn module_cyclical_imports_0() {
 #[test]
 fn module_cyclical_imports_1() {
     Playground::setup("module_cyclical_imports_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             "
                     use spam.nu
@@ -383,13 +383,13 @@ fn module_cyclical_imports_1() {
 fn module_cyclical_imports_2() {
     Playground::setup("module_cyclical_imports_2", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 "
                     use eggs.nu
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "eggs.nu",
                 "
                     use spam.nu
@@ -408,19 +408,19 @@ fn module_cyclical_imports_2() {
 fn module_cyclical_imports_3() {
     Playground::setup("module_cyclical_imports_3", |dirs, sandbox| {
         sandbox
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "spam.nu",
                 "
                     use eggs.nu
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "eggs.nu",
                 "
                     use bacon.nu
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "bacon.nu",
                 "
                     use spam.nu
@@ -438,7 +438,7 @@ fn module_cyclical_imports_3() {
 #[test]
 fn module_import_const_file() {
     Playground::setup("module_import_const_file", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 export def foo [] { "foo" }
@@ -456,7 +456,7 @@ fn module_import_const_file() {
 #[test]
 fn module_import_const_module_name() {
     Playground::setup("module_import_const_file", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam.nu",
             r#"
                 export def foo [] { "foo" }

--- a/tests/overlays/mod.rs
+++ b/tests/overlays/mod.rs
@@ -873,7 +873,7 @@ fn overlay_use_do_cd() {
     Playground::setup("overlay_use_do_cd", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 "
                     export-env { cd test1/test2 }
@@ -896,7 +896,7 @@ fn overlay_use_do_cd_file_relative() {
     Playground::setup("overlay_use_do_cd_file_relative", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 "
                     export-env { cd ($env.FILE_PWD | path join '..') }
@@ -919,7 +919,7 @@ fn overlay_use_dont_cd_overlay() {
     Playground::setup("overlay_use_dont_cd_overlay", |dirs, sandbox| {
         sandbox
             .mkdir("test1/test2")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "test1/test2/spam.nu",
                 "
                     export-env {

--- a/tests/parsing/mod.rs
+++ b/tests/parsing/mod.rs
@@ -93,7 +93,7 @@ fn parse_file_relative_to_parsed_file_simple() {
         sandbox
             .mkdir("lol")
             .mkdir("lol/lol")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol/lol.nu",
                 "
                     use ../lol_shell.nu
@@ -101,7 +101,7 @@ fn parse_file_relative_to_parsed_file_simple() {
                     $env.LOL = (lol_shell ls)
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol_shell.nu",
                 r#"
                     export def ls [] { "lol" }
@@ -123,7 +123,7 @@ fn parse_file_relative_to_parsed_file_simple() {
 #[test]
 fn predecl_signature_single_inp_out_type() {
     Playground::setup("predecl_signature_single_inp_out_type", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "spam1.nu",
             "
                 def main [] { foo }
@@ -143,7 +143,7 @@ fn predecl_signature_multiple_inp_out_types() {
     Playground::setup(
         "predecl_signature_multiple_inp_out_types",
         |dirs, sandbox| {
-            sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
                 "spam2.nu",
                 "
                 def main [] { foo }
@@ -166,7 +166,7 @@ fn parse_file_relative_to_parsed_file() {
         sandbox
             .mkdir("lol")
             .mkdir("lol/lol")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol/lol.nu",
                 "
                     source-env ../../foo.nu
@@ -176,13 +176,13 @@ fn parse_file_relative_to_parsed_file() {
                     $env.LOL = $'($env.FOO) (lol_shell ls) (ls)'
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol_shell.nu",
                 r#"
                     export def ls [] { "lol" }
                 "#,
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "foo.nu",
                 "
                     $env.FOO = 'foo'
@@ -206,19 +206,19 @@ fn parse_file_relative_to_parsed_file_dont_use_cwd_1() {
     Playground::setup("relative_files", |dirs, sandbox| {
         sandbox
             .mkdir("lol")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol.nu",
                 "
                     source-env foo.nu
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/foo.nu",
                 "
                     $env.FOO = 'good'
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "foo.nu",
                 "
                     $env.FOO = 'bad'
@@ -242,13 +242,13 @@ fn parse_file_relative_to_parsed_file_dont_use_cwd_2() {
     Playground::setup("relative_files", |dirs, sandbox| {
         sandbox
             .mkdir("lol")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "lol/lol.nu",
                 "
                     source-env foo.nu
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "foo.nu",
                 "
                     $env.FOO = 'bad'

--- a/tests/path/canonicalize.rs
+++ b/tests/path/canonicalize.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 #[test]
 fn canonicalize_path() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let mut spam = dirs.test().to_owned();
         spam.push("spam.txt");
@@ -23,7 +23,7 @@ fn canonicalize_path() {
 #[test]
 fn canonicalize_unicode_path() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("🚒.txt")]);
+        sandbox.with_files(&[EmptyFile("🚒.txt")]);
 
         let mut spam = dirs.test().to_owned();
         spam.push("🚒.txt");
@@ -45,7 +45,7 @@ fn canonicalize_non_utf8_path() {
 #[test]
 fn canonicalize_path_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with("spam.txt", dirs.test()).expect("Failed to canonicalize");
         let mut expected = dirs.test().to_owned();
@@ -59,7 +59,7 @@ fn canonicalize_path_relative_to() {
 fn canonicalize_unicode_path_relative_to_unicode_path_with_spaces() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("e-$ èрт🚒♞中片-j");
-        sandbox.with_files(vec![EmptyFile("e-$ èрт🚒♞中片-j/🚒.txt")]);
+        sandbox.with_files(&[EmptyFile("e-$ èрт🚒♞中片-j/🚒.txt")]);
 
         let mut relative_to = dirs.test().to_owned();
         relative_to.push("e-$ èрт🚒♞中片-j");
@@ -81,7 +81,7 @@ fn canonicalize_non_utf8_path_relative_to_non_utf8_path_with_spaces() {
 #[test]
 fn canonicalize_absolute_path_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let mut absolute_path = dirs.test().to_owned();
         absolute_path.push("spam.txt");
@@ -116,7 +116,7 @@ fn canonicalize_many_dots() {
 #[test]
 fn canonicalize_path_with_dot_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with("./spam.txt", dirs.test()).expect("Failed to canonicalize");
         let mut expected = dirs.test().to_owned();
@@ -129,7 +129,7 @@ fn canonicalize_path_with_dot_relative_to() {
 #[test]
 fn canonicalize_path_with_many_dots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with("././/.//////./././//.////spam.txt", dirs.test())
             .expect("Failed to canonicalize");
@@ -155,7 +155,7 @@ fn canonicalize_double_dot() {
 fn canonicalize_path_with_double_dot_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo");
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual =
             canonicalize_with("foo/../spam.txt", dirs.test()).expect("Failed to canonicalize");
@@ -170,7 +170,7 @@ fn canonicalize_path_with_double_dot_relative_to() {
 fn canonicalize_path_with_many_double_dots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo/bar/baz");
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with("foo/bar/baz/../../../spam.txt", dirs.test())
             .expect("Failed to canonicalize");
@@ -205,7 +205,7 @@ fn canonicalize_ndots2() {
 fn canonicalize_path_with_3_ndots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo/bar");
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual =
             canonicalize_with("foo/bar/.../spam.txt", dirs.test()).expect("Failed to canonicalize");
@@ -220,7 +220,7 @@ fn canonicalize_path_with_3_ndots_relative_to() {
 fn canonicalize_path_with_many_3_ndots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo/bar/baz/eggs/sausage/bacon");
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with(
             "foo/bar/baz/eggs/sausage/bacon/.../.../.../spam.txt",
@@ -238,7 +238,7 @@ fn canonicalize_path_with_many_3_ndots_relative_to() {
 fn canonicalize_path_with_4_ndots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo/bar/baz");
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with("foo/bar/baz/..../spam.txt", dirs.test())
             .expect("Failed to canonicalize");
@@ -253,7 +253,7 @@ fn canonicalize_path_with_4_ndots_relative_to() {
 fn canonicalize_path_with_many_4_ndots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo/bar/baz/eggs/sausage/bacon");
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let actual = canonicalize_with(
             "foo/bar/baz/eggs/sausage/bacon/..../..../spam.txt",
@@ -271,7 +271,7 @@ fn canonicalize_path_with_many_4_ndots_relative_to() {
 fn canonicalize_path_with_way_too_many_dots_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo/bar/baz/eggs/sausage/bacon/vikings");
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
 
         let mut relative_to = dirs.test().to_owned();
         relative_to.push("foo/bar/baz/eggs/sausage/bacon/vikings");
@@ -289,7 +289,7 @@ fn canonicalize_path_with_way_too_many_dots_relative_to() {
 fn canonicalize_unicode_path_with_way_too_many_dots_relative_to_unicode_path_with_spaces() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo/áčěéí  +šř=é/baz/eggs/e-$ èрт🚒♞中片-j/bacon/öäöä öäöä");
-        sandbox.with_files(vec![EmptyFile("🚒.txt")]);
+        sandbox.with_files(&[EmptyFile("🚒.txt")]);
 
         let mut relative_to = dirs.test().to_owned();
         relative_to.push("foo/áčěéí  +šř=é/baz/eggs/e-$ èрт🚒♞中片-j/bacon/öäöä öäöä");
@@ -329,7 +329,7 @@ fn canonicalize_tilde_relative_to() {
 #[test]
 fn canonicalize_symlink() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
         sandbox.symlink("spam.txt", "link_to_spam.txt");
 
         let mut symlink_path = dirs.test().to_owned();
@@ -348,7 +348,7 @@ fn canonicalize_symlink() {
 #[test]
 fn canonicalize_symlink_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
         sandbox.symlink("spam.txt", "link_to_spam.txt");
 
         let actual =
@@ -379,7 +379,7 @@ fn canonicalize_symlink_loop_relative_to_should_fail() {
 #[test]
 fn canonicalize_nested_symlink_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![EmptyFile("spam.txt")]);
+        sandbox.with_files(&[EmptyFile("spam.txt")]);
         sandbox.symlink("spam.txt", "link_to_spam.txt");
         sandbox.symlink("link_to_spam.txt", "link_to_link_to_spam.txt");
 
@@ -397,7 +397,7 @@ fn canonicalize_nested_symlink_relative_to() {
 fn canonicalize_nested_symlink_within_symlink_dir_relative_to() {
     Playground::setup("nu_path_test_1", |dirs, sandbox| {
         sandbox.mkdir("foo/bar/baz");
-        sandbox.with_files(vec![EmptyFile("foo/bar/baz/spam.txt")]);
+        sandbox.with_files(&[EmptyFile("foo/bar/baz/spam.txt")]);
         sandbox.symlink("foo/bar/baz/spam.txt", "foo/bar/link_to_spam.txt");
         sandbox.symlink("foo/bar/link_to_spam.txt", "foo/link_to_link_to_spam.txt");
         sandbox.symlink("foo", "link_to_foo");

--- a/tests/plugins/core_inc.rs
+++ b/tests/plugins/core_inc.rs
@@ -26,7 +26,7 @@ fn chooses_highest_increment_if_given_more_than_one() {
 #[test]
 fn by_one_with_field_passed() {
     Playground::setup("plugin_inc_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [package]
@@ -47,7 +47,7 @@ fn by_one_with_field_passed() {
 #[test]
 fn by_one_with_no_field_passed() {
     Playground::setup("plugin_inc_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [package]
@@ -68,7 +68,7 @@ fn by_one_with_no_field_passed() {
 #[test]
 fn semversion_major_inc() {
     Playground::setup("plugin_inc_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [package]
@@ -89,7 +89,7 @@ fn semversion_major_inc() {
 #[test]
 fn semversion_minor_inc() {
     Playground::setup("plugin_inc_test_4", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [package]
@@ -110,7 +110,7 @@ fn semversion_minor_inc() {
 #[test]
 fn semversion_patch_inc() {
     Playground::setup("plugin_inc_test_5", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [package]
@@ -131,7 +131,7 @@ fn semversion_patch_inc() {
 #[test]
 fn semversion_without_passing_field() {
     Playground::setup("plugin_inc_test_6", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "sample.toml",
             r#"
                     [package]

--- a/tests/plugins/formats/ics.rs
+++ b/tests/plugins/formats/ics.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 #[test]
 fn infers_types() {
     Playground::setup("filter_from_ics_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "calendar.ics",
             r#"
                 BEGIN:VCALENDAR
@@ -58,7 +58,7 @@ fn infers_types() {
 #[test]
 fn from_ics_text_to_table() {
     Playground::setup("filter_from_ics_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "calendar.txt",
             r#"
                 BEGIN:VCALENDAR
@@ -102,7 +102,7 @@ fn from_ics_text_to_table() {
 #[test]
 fn from_ics_text_with_linebreak_to_table() {
     Playground::setup("filter_from_ics_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "calendar.txt",
             r#"BEGIN:VCALENDAR
 BEGIN:VEVENT

--- a/tests/plugins/formats/ini.rs
+++ b/tests/plugins/formats/ini.rs
@@ -33,7 +33,7 @@ fn parses_utf16_ini() {
 #[test]
 fn read_ini_with_missing_session() {
     Playground::setup("from ini with missiong session", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "some_missing.ini",
             r#"
             min-width=450

--- a/tests/plugins/formats/vcf.rs
+++ b/tests/plugins/formats/vcf.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 #[test]
 fn infers_types() {
     Playground::setup("filter_from_vcf_test_1", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "contacts.vcf",
             r"
                 BEGIN:VCARD
@@ -46,7 +46,7 @@ fn infers_types() {
 #[test]
 fn from_vcf_text_to_table() {
     Playground::setup("filter_from_vcf_test_2", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "contacts.txt",
             r"
                 BEGIN:VCARD
@@ -86,7 +86,7 @@ fn from_vcf_text_to_table() {
 #[test]
 fn from_vcf_text_with_linebreak_to_table() {
     Playground::setup("filter_from_vcf_test_3", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "contacts.txt",
             r"BEGIN:VCARD
 VERSION:3.0

--- a/tests/plugins/registry_file.rs
+++ b/tests/plugins/registry_file.rs
@@ -136,7 +136,7 @@ fn plugin_add_to_custom_path() {
 fn plugin_rm_then_restart_nu() {
     let example_plugin_path = example_plugin_path();
     Playground::setup("plugin rm from custom path", |dirs, playground| {
-        playground.with_files(vec![
+        playground.with_files(&[
             Stub::FileWithContent("config.nu", ""),
             Stub::FileWithContent("env.nu", ""),
         ]);
@@ -318,7 +318,7 @@ fn plugin_rm_using_filename() {
 fn warning_on_invalid_plugin_item() {
     let example_plugin_path = example_plugin_path();
     Playground::setup("warning on invalid plugin item", |dirs, playground| {
-        playground.with_files(vec![
+        playground.with_files(&[
             Stub::FileWithContent("config.nu", ""),
             Stub::FileWithContent("env.nu", ""),
         ]);
@@ -380,7 +380,7 @@ fn warning_on_invalid_plugin_item() {
 #[test]
 fn plugin_use_error_not_found() {
     Playground::setup("plugin use error not found", |dirs, playground| {
-        playground.with_files(vec![
+        playground.with_files(&[
             Stub::FileWithContent("config.nu", ""),
             Stub::FileWithContent("env.nu", ""),
         ]);

--- a/tests/scope/mod.rs
+++ b/tests/scope/mod.rs
@@ -109,7 +109,7 @@ fn correct_scope_modules_fields() {
     "#;
 
     Playground::setup("correct_scope_modules_fields", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent("spam.nu", module_setup)]);
+        sandbox.with_files(&[FileWithContent("spam.nu", module_setup)]);
 
         let inp = &[
             "use spam.nu",
@@ -191,7 +191,7 @@ fn correct_scope_aliases_fields() {
     "#;
 
     Playground::setup("correct_scope_aliases_fields", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent("spam.nu", module_setup)]);
+        sandbox.with_files(&[FileWithContent("spam.nu", module_setup)]);
 
         let inp = &[
             "use spam.nu",
@@ -248,7 +248,7 @@ fn correct_scope_externs_fields() {
     "#;
 
     Playground::setup("correct_scope_aliases_fields", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent("spam.nu", module_setup)]);
+        sandbox.with_files(&[FileWithContent("spam.nu", module_setup)]);
 
         let inp = &[
             "use spam.nu",

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -129,7 +129,7 @@ fn passes_with_env_env_var_to_external_process() {
 #[test]
 fn has_file_pwd() {
     Playground::setup("has_file_pwd", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent("spam.nu", "$env.FILE_PWD")]);
+        sandbox.with_files(&[FileWithContent("spam.nu", "$env.FILE_PWD")]);
 
         let actual = nu!(cwd: dirs.test(), "nu spam.nu");
 
@@ -140,7 +140,7 @@ fn has_file_pwd() {
 #[test]
 fn has_file_loc() {
     Playground::setup("has_file_pwd", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent("spam.nu", "$env.CURRENT_FILE")]);
+        sandbox.with_files(&[FileWithContent("spam.nu", "$env.CURRENT_FILE")]);
 
         let actual = nu!(cwd: dirs.test(), "nu spam.nu");
 
@@ -154,7 +154,7 @@ fn has_file_loc() {
 #[serial]
 fn passes_env_from_local_cfg_to_external_process() {
     Playground::setup("autoenv_dir", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             ".nu-env",
             r#"[env]
             FOO = "foo"

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -65,7 +65,7 @@ fn nu_lib_dirs_repl() {
     Playground::setup("nu_lib_dirs_repl", |dirs, sandbox| {
         sandbox
             .mkdir("scripts")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "scripts/foo.nu",
                 r#"
                     $env.FOO = "foo"
@@ -90,13 +90,13 @@ fn nu_lib_dirs_script() {
     Playground::setup("nu_lib_dirs_script", |dirs, sandbox| {
         sandbox
             .mkdir("scripts")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "scripts/foo.nu",
                 r#"
                     $env.FOO = "foo"
                 "#,
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     source-env foo.nu
@@ -121,7 +121,7 @@ fn nu_lib_dirs_relative_repl() {
     Playground::setup("nu_lib_dirs_relative_repl", |dirs, sandbox| {
         sandbox
             .mkdir("scripts")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "scripts/foo.nu",
                 r#"
                     $env.FOO = "foo"
@@ -147,13 +147,13 @@ fn const_nu_lib_dirs_relative() {
     Playground::setup("const_nu_lib_dirs_relative", |dirs, sandbox| {
         sandbox
             .mkdir("scripts")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "scripts/foo.nu",
                 r#"
                     $env.FOO = "foo"
                 "#,
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "main.nu",
                 "
                     const NU_LIB_DIRS = [ 'scripts' ]
@@ -174,13 +174,13 @@ fn nu_lib_dirs_relative_script() {
     Playground::setup("nu_lib_dirs_relative_script", |dirs, sandbox| {
         sandbox
             .mkdir("scripts")
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "scripts/main.nu",
                 "
                     source-env ../foo.nu
                 ",
             )])
-            .with_files(vec![FileWithContentToBeTrimmed(
+            .with_files(&[FileWithContentToBeTrimmed(
                 "foo.nu",
                 r#"
                     $env.FOO = "foo"
@@ -288,7 +288,7 @@ fn run_with_no_newline() {
 fn main_script_can_have_subcommands1() {
     Playground::setup("main_subcommands", |dirs, sandbox| {
         sandbox.mkdir("main_subcommands");
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "script.nu",
             r#"def "main foo" [x: int] {
                     print ($x + 100)
@@ -309,7 +309,7 @@ fn main_script_can_have_subcommands1() {
 fn main_script_can_have_subcommands2() {
     Playground::setup("main_subcommands", |dirs, sandbox| {
         sandbox.mkdir("main_subcommands");
-        sandbox.with_files(vec![FileWithContent(
+        sandbox.with_files(&[FileWithContent(
             "script.nu",
             r#"def "main foo" [x: int] {
                     print ($x + 100)
@@ -330,7 +330,7 @@ fn main_script_can_have_subcommands2() {
 fn source_empty_file() {
     Playground::setup("source_empty_file", |dirs, sandbox| {
         sandbox.mkdir("source_empty_file");
-        sandbox.with_files(vec![FileWithContent("empty.nu", "")]);
+        sandbox.with_files(&[FileWithContent("empty.nu", "")]);
 
         let actual = nu!(cwd: dirs.test(), pipeline("nu empty.nu"));
         assert!(actual.out.is_empty());

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -168,7 +168,7 @@ fn err_pipe_with_failed_external_works() {
 #[test]
 fn dont_run_glob_if_pass_variable_to_external() {
     Playground::setup("dont_run_glob", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("jt_likes_cake.txt"),
             EmptyFile("andres_likes_arepas.txt"),
         ]);
@@ -182,7 +182,7 @@ fn dont_run_glob_if_pass_variable_to_external() {
 #[test]
 fn run_glob_if_pass_variable_to_external() {
     Playground::setup("run_glob_on_external", |dirs, sandbox| {
-        sandbox.with_files(vec![
+        sandbox.with_files(&[
             EmptyFile("jt_likes_cake.txt"),
             EmptyFile("andres_likes_arepas.txt"),
         ]);
@@ -202,7 +202,7 @@ mod it_evaluation {
     #[test]
     fn takes_rows_of_nu_value_strings() {
         Playground::setup("it_argument_test_1", |dirs, sandbox| {
-            sandbox.with_files(vec![
+            sandbox.with_files(&[
                 EmptyFile("jt_likes_cake.txt"),
                 EmptyFile("andres_likes_arepas.txt"),
             ]);
@@ -225,7 +225,7 @@ mod it_evaluation {
     #[test]
     fn takes_rows_of_nu_value_lines() {
         Playground::setup("it_argument_test_2", |dirs, sandbox| {
-            sandbox.with_files(vec![FileWithContentToBeTrimmed(
+            sandbox.with_files(&[FileWithContentToBeTrimmed(
                 "nu_candies.txt",
                 "
                     AndrásWithKitKatzz
@@ -258,7 +258,7 @@ mod it_evaluation {
     #[test]
     fn supports_fetching_given_a_column_path_to_it() {
         Playground::setup("it_argument_test_3", |dirs, sandbox| {
-            sandbox.with_files(vec![FileWithContent(
+            sandbox.with_files(&[FileWithContent(
                 "sample.toml",
                 r#"
                     nu_party_venue = "zion"
@@ -349,7 +349,7 @@ mod external_words {
     #[case("$ sign.toml", r#""$ sign.toml""#)]
     fn external_arg_with_special_characters(#[case] path: &str, #[case] nu_path_argument: &str) {
         Playground::setup("external_arg_with_quotes", |dirs, sandbox| {
-            sandbox.with_files(vec![FileWithContent(
+            sandbox.with_files(&[FileWithContent(
                 path,
                 r#"
                     nu_party_venue = "zion"
@@ -479,7 +479,7 @@ mod external_command_arguments {
         Playground::setup(
             "expands_table_of_primitives_to_positional_arguments",
             |dirs, sandbox| {
-                sandbox.with_files(vec![
+                sandbox.with_files(&[
                     EmptyFile("jt_likes_cake.txt"),
                     EmptyFile("andres_likes_arepas.txt"),
                     EmptyFile("ferris_not_here.txt"),
@@ -505,7 +505,7 @@ mod external_command_arguments {
         Playground::setup(
             "expands_table_of_primitives_to_positional_arguments",
             |dirs, sandbox| {
-                sandbox.with_files(vec![
+                sandbox.with_files(&[
                     EmptyFile("jt_likes_cake.txt"),
                     EmptyFile("andres_likes_arepas.txt"),
                     EmptyFile("ferris_not_here.txt"),
@@ -531,7 +531,7 @@ mod external_command_arguments {
             |dirs, sandbox| {
                 sandbox.mkdir("cd");
 
-                sandbox.with_files(vec![EmptyFile("cd/jt_likes_cake.txt")]);
+                sandbox.with_files(&[EmptyFile("cd/jt_likes_cake.txt")]);
 
                 let actual = nu!(
                 cwd: dirs.test(), pipeline(

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -29,7 +29,7 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
 #[test]
 fn treats_dot_dot_as_path_not_range() {
     Playground::setup("dot_dot_dir", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "nu_times.csv",
             "
                 name,rusty_luck,origin
@@ -83,7 +83,7 @@ fn for_loop() {
 #[test]
 fn subexpression_handles_dot() {
     Playground::setup("subexpression_handles_dot", |dirs, sandbox| {
-        sandbox.with_files(vec![FileWithContentToBeTrimmed(
+        sandbox.with_files(&[FileWithContentToBeTrimmed(
             "nu_times.csv",
             "
                 name,rusty_luck,origin


### PR DESCRIPTION
# Description

Judiciously try to avoid allocations/clone by changing the signature of functions

- **Don't pass str by value unnecessarily if only read**
- **Don't require a vec in `Sandbox::with_files`**
- **Remove unnecessary string clone**
- **Fixup unnecessary borrow**
- **Use `&str` in shape color instead**
- **Vec -> Slice**
- **Elide string clone**
- **Elide `Path` clone**
- **Take &str to elide clone in tests**

# User-Facing Changes
None

# Tests + Formatting
This touches many tests purely in changing from owned to borrowed/static data
