### PR TITLE
Add `sys` subcommands

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -119,6 +119,12 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             Exec,
             NuCheck,
             Sys,
+            SysCpu,
+            SysDisks,
+            SysHost,
+            SysMem,
+            SysNet,
+            SysTemp,
             UName,
 
         };

--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -125,11 +125,6 @@ If multiple cell paths are given, this will produce a list of values."#
                 result: None,
             },
             Example {
-                description: "Extract the cpu list from the sys information record",
-                example: "sys | get cpu",
-                result: None,
-            },
-            Example {
                 description: "Getting Path/PATH in a case insensitive way",
                 example: "$env | get paTH",
                 result: None,

--- a/crates/nu-command/src/help/help_.rs
+++ b/crates/nu-command/src/help/help_.rs
@@ -66,8 +66,8 @@ Each stage in the pipeline works together to load, parse, and display informatio
 List the files in the current directory, sorted by size:
     ls | sort-by size
 
-Get information about the current system:
-    sys | get host
+Get the current system host name:
+    sys host | get hostname
 
 Get the processes on your system actively using CPU:
     ps | where cpu > 0

--- a/crates/nu-command/src/system/mod.rs
+++ b/crates/nu-command/src/system/mod.rs
@@ -30,6 +30,6 @@ pub use ps::Ps;
 #[cfg(windows)]
 pub use registry_query::RegistryQuery;
 pub use run_external::{External, ExternalCommand};
-pub use sys::Sys;
+pub use sys::*;
 pub use uname::UName;
 pub use which_::Which;

--- a/crates/nu-command/src/system/sys/cpu.rs
+++ b/crates/nu-command/src/system/sys/cpu.rs
@@ -30,6 +30,10 @@ impl Command for SysCpu {
     }
 
     fn examples(&self) -> Vec<Example> {
-        todo!()
+        vec![Example {
+            description: "Show info about the system CPUs",
+            example: "sys cpu",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/system/sys/cpu.rs
+++ b/crates/nu-command/src/system/sys/cpu.rs
@@ -1,0 +1,35 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct SysCpu;
+
+impl Command for SysCpu {
+    fn name(&self) -> &str {
+        "sys cpu"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("sys cpu")
+            .filter()
+            .category(Category::System)
+            .input_output_types(vec![(Type::Nothing, Type::table())])
+    }
+
+    fn usage(&self) -> &str {
+        "View information about the system CPUs."
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(super::cpu(call.head).into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        todo!()
+    }
+}

--- a/crates/nu-command/src/system/sys/disks.rs
+++ b/crates/nu-command/src/system/sys/disks.rs
@@ -1,0 +1,35 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct SysDisks;
+
+impl Command for SysDisks {
+    fn name(&self) -> &str {
+        "sys disks"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("sys disks")
+            .filter()
+            .category(Category::System)
+            .input_output_types(vec![(Type::Nothing, Type::table())])
+    }
+
+    fn usage(&self) -> &str {
+        "View information about the system disks."
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(super::disks(call.head).into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        todo!()
+    }
+}

--- a/crates/nu-command/src/system/sys/disks.rs
+++ b/crates/nu-command/src/system/sys/disks.rs
@@ -30,6 +30,10 @@ impl Command for SysDisks {
     }
 
     fn examples(&self) -> Vec<Example> {
-        todo!()
+        vec![Example {
+            description: "Show info about the system disks",
+            example: "sys disks",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/system/sys/host.rs
+++ b/crates/nu-command/src/system/sys/host.rs
@@ -1,0 +1,35 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct SysHost;
+
+impl Command for SysHost {
+    fn name(&self) -> &str {
+        "sys host"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("sys host")
+            .filter()
+            .category(Category::System)
+            .input_output_types(vec![(Type::Nothing, Type::record())])
+    }
+
+    fn usage(&self) -> &str {
+        "View information about the system host."
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(super::host(call.head).into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        todo!()
+    }
+}

--- a/crates/nu-command/src/system/sys/host.rs
+++ b/crates/nu-command/src/system/sys/host.rs
@@ -30,6 +30,10 @@ impl Command for SysHost {
     }
 
     fn examples(&self) -> Vec<Example> {
-        todo!()
+        vec![Example {
+            description: "Show info about the system host",
+            example: "sys host",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/system/sys/mem.rs
+++ b/crates/nu-command/src/system/sys/mem.rs
@@ -1,0 +1,35 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct SysMem;
+
+impl Command for SysMem {
+    fn name(&self) -> &str {
+        "sys mem"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("sys mem")
+            .filter()
+            .category(Category::System)
+            .input_output_types(vec![(Type::Nothing, Type::record())])
+    }
+
+    fn usage(&self) -> &str {
+        "View information about the system memory."
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(super::mem(call.head).into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        todo!()
+    }
+}

--- a/crates/nu-command/src/system/sys/mem.rs
+++ b/crates/nu-command/src/system/sys/mem.rs
@@ -30,6 +30,10 @@ impl Command for SysMem {
     }
 
     fn examples(&self) -> Vec<Example> {
-        todo!()
+        vec![Example {
+            description: "Show info about the system memory",
+            example: "sys mem",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/system/sys/mod.rs
+++ b/crates/nu-command/src/system/sys/mod.rs
@@ -109,23 +109,14 @@ pub fn mem(span: Span) -> Value {
     let mut sys = System::new();
     sys.refresh_memory();
 
-    let total_mem = sys.total_memory();
-    let free_mem = sys.free_memory();
-    let used_mem = sys.used_memory();
-    let avail_mem = sys.available_memory();
-
-    let total_swap = sys.total_swap();
-    let free_swap = sys.free_swap();
-    let used_swap = sys.used_swap();
-
     let record = record! {
-        "total" => Value::filesize(total_mem as i64, span),
-        "free" => Value::filesize(free_mem as i64, span),
-        "used" => Value::filesize(used_mem as i64, span),
-        "available" => Value::filesize(avail_mem as i64, span),
-        "swap total" => Value::filesize(total_swap as i64, span),
-        "swap free" => Value::filesize(free_swap as i64, span),
-        "swap used" => Value::filesize(used_swap as i64, span),
+        "total" => Value::filesize(sys.total_memory() as i64, span),
+        "free" => Value::filesize(sys.free_memory() as i64, span),
+        "used" => Value::filesize(sys.used_memory() as i64, span),
+        "available" => Value::filesize(sys.available_memory() as i64, span),
+        "swap total" => Value::filesize(sys.total_swap() as i64, span),
+        "swap free" => Value::filesize(sys.free_swap() as i64, span),
+        "swap used" => Value::filesize(sys.used_swap() as i64, span),
     };
 
     Value::record(record, span)

--- a/crates/nu-command/src/system/sys/mod.rs
+++ b/crates/nu-command/src/system/sys/mod.rs
@@ -176,11 +176,9 @@ pub fn host(span: Span) -> Value {
 
             Value::record(record, span)
         })
-        .collect::<Vec<_>>();
+        .collect();
 
-    if !users.is_empty() {
-        record.push("sessions", Value::list(users, span));
-    }
+    record.push("sessions", Value::list(users, span));
 
     Value::record(record, span)
 }

--- a/crates/nu-command/src/system/sys/mod.rs
+++ b/crates/nu-command/src/system/sys/mod.rs
@@ -186,22 +186,22 @@ pub fn host(span: Span) -> Value {
 }
 
 pub fn temp(span: Span) -> Value {
-    let components = Components::new_with_refreshed_list();
+    let components = Components::new_with_refreshed_list()
+        .iter()
+        .map(|component| {
+            let mut record = record! {
+                "unit" => Value::string(component.label(), span),
+                "temp" => Value::float(component.temperature().into(), span),
+                "high" => Value::float(component.max().into(), span),
+            };
 
-    let mut output = vec![];
+            if let Some(critical) = component.critical() {
+                record.push("critical", Value::float(critical.into(), span));
+            }
 
-    for component in components.list() {
-        let mut record = record! {
-            "unit" => Value::string(component.label(), span),
-            "temp" => Value::float(component.temperature() as f64, span),
-            "high" => Value::float(component.max() as f64, span),
-        };
+            Value::record(record, span)
+        })
+        .collect();
 
-        if let Some(critical) = component.critical() {
-            record.push("critical", Value::float(critical as f64, span));
-        }
-        output.push(Value::record(record, span));
-    }
-
-    Value::list(output, span)
+    Value::list(components, span)
 }

--- a/crates/nu-command/src/system/sys/mod.rs
+++ b/crates/nu-command/src/system/sys/mod.rs
@@ -1,78 +1,25 @@
+mod cpu;
+mod disks;
+mod host;
+mod mem;
+mod net;
+mod sys_;
+mod temp;
+
+pub use cpu::SysCpu;
+pub use disks::SysDisks;
+pub use host::SysHost;
+pub use mem::SysMem;
+pub use net::SysNet;
+pub use sys_::Sys;
+pub use temp::SysTemp;
+
 use chrono::{DateTime, Local};
-use nu_engine::command_prelude::*;
+use nu_protocol::{record, Record, Span, Value};
 use std::time::{Duration, UNIX_EPOCH};
 use sysinfo::{
     Components, CpuRefreshKind, Disks, Networks, System, Users, MINIMUM_CPU_UPDATE_INTERVAL,
 };
-
-#[derive(Clone)]
-pub struct Sys;
-
-impl Command for Sys {
-    fn name(&self) -> &str {
-        "sys"
-    }
-
-    fn signature(&self) -> Signature {
-        Signature::build("sys")
-            .filter()
-            .category(Category::System)
-            .input_output_types(vec![(Type::Nothing, Type::record())])
-    }
-
-    fn usage(&self) -> &str {
-        "View information about the system."
-    }
-
-    fn run(
-        &self,
-        _engine_state: &EngineState,
-        _stack: &mut Stack,
-        call: &Call,
-        _input: PipelineData,
-    ) -> Result<PipelineData, ShellError> {
-        Ok(all_columns(call.head).into_pipeline_data())
-    }
-
-    fn examples(&self) -> Vec<Example> {
-        vec![
-            Example {
-                description: "Show info about the system",
-                example: "sys",
-                result: None,
-            },
-            Example {
-                description: "Show the os system name with get",
-                example: "(sys).host | get name",
-                result: None,
-            },
-            Example {
-                description: "Show the os system name",
-                example: "(sys).host.name",
-                result: None,
-            },
-        ]
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct SysResult {
-    pub span: Span,
-}
-
-fn all_columns(span: Span) -> Value {
-    Value::record(
-        record! {
-            "host" => host(span),
-            "cpu" => cpu(span),
-            "disks" => disks(span),
-            "mem" => mem(span),
-            "temp" => temp(span),
-            "net" => net(span),
-        },
-        span,
-    )
-}
 
 pub fn trim_cstyle_null(s: String) -> String {
     s.trim_matches(char::from(0)).to_string()

--- a/crates/nu-command/src/system/sys/net.rs
+++ b/crates/nu-command/src/system/sys/net.rs
@@ -30,6 +30,10 @@ impl Command for SysNet {
     }
 
     fn examples(&self) -> Vec<Example> {
-        todo!()
+        vec![Example {
+            description: "Show info about the system network",
+            example: "sys net",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/system/sys/net.rs
+++ b/crates/nu-command/src/system/sys/net.rs
@@ -1,0 +1,35 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct SysNet;
+
+impl Command for SysNet {
+    fn name(&self) -> &str {
+        "sys net"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("sys net")
+            .filter()
+            .category(Category::System)
+            .input_output_types(vec![(Type::Nothing, Type::table())])
+    }
+
+    fn usage(&self) -> &str {
+        "View information about the system network interfaces."
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(super::net(call.head).into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        todo!()
+    }
+}

--- a/crates/nu-command/src/system/sys/sys_.rs
+++ b/crates/nu-command/src/system/sys/sys_.rs
@@ -25,11 +25,23 @@ impl Command for Sys {
 
     fn run(
         &self,
-        _engine_state: &EngineState,
+        engine_state: &EngineState,
         _stack: &mut Stack,
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        nu_protocol::report_error_new(
+            engine_state,
+            &ShellError::GenericError {
+                error: "Deprecated command".into(),
+                msg: "the `sys` command is deprecated, please use the new subcommands (`sys host`, `sys mem`, etc.)."
+                    .into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            },
+        );
+
         let head = call.head;
         let record = record! {
             "host" => super::host(head),

--- a/crates/nu-command/src/system/sys/sys_.rs
+++ b/crates/nu-command/src/system/sys/sys_.rs
@@ -20,7 +20,7 @@ impl Command for Sys {
     }
 
     fn extra_usage(&self) -> &str {
-        "Note that this command may take a noticable amount of time to run. To reduce the time taken, you can use the various `sys` sub commands to get the subset of information you are interested in."
+        "Note that this command may take a noticeable amount of time to run. To reduce the time taken, you can use the various `sys` sub commands to get the subset of information you are interested in."
     }
 
     fn run(

--- a/crates/nu-command/src/system/sys/sys_.rs
+++ b/crates/nu-command/src/system/sys/sys_.rs
@@ -19,6 +19,10 @@ impl Command for Sys {
         "View information about the system."
     }
 
+    fn extra_usage(&self) -> &str {
+        "Note that this command may take a noticable amount of time to run. To reduce the time taken, you can use the various `sys` sub commands to get the subset of information you are interested in."
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,
@@ -39,22 +43,10 @@ impl Command for Sys {
     }
 
     fn examples(&self) -> Vec<Example> {
-        vec![
-            Example {
-                description: "Show info about the system",
-                example: "sys",
-                result: None,
-            },
-            Example {
-                description: "Show the os system name with get",
-                example: "(sys).host | get name",
-                result: None,
-            },
-            Example {
-                description: "Show the os system name",
-                example: "(sys).host.name",
-                result: None,
-            },
-        ]
+        vec![Example {
+            description: "Show info about the system",
+            example: "sys",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/system/sys/sys_.rs
+++ b/crates/nu-command/src/system/sys/sys_.rs
@@ -1,0 +1,60 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct Sys;
+
+impl Command for Sys {
+    fn name(&self) -> &str {
+        "sys"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("sys")
+            .filter()
+            .category(Category::System)
+            .input_output_types(vec![(Type::Nothing, Type::record())])
+    }
+
+    fn usage(&self) -> &str {
+        "View information about the system."
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let head = call.head;
+        let record = record! {
+            "host" => super::host(head),
+            "cpu" => super::cpu(head),
+            "disks" => super::disks(head),
+            "mem" => super::mem(head),
+            "temp" => super::temp(head),
+            "net" => super::net(head),
+        };
+        Ok(Value::record(record, head).into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![
+            Example {
+                description: "Show info about the system",
+                example: "sys",
+                result: None,
+            },
+            Example {
+                description: "Show the os system name with get",
+                example: "(sys).host | get name",
+                result: None,
+            },
+            Example {
+                description: "Show the os system name",
+                example: "(sys).host.name",
+                result: None,
+            },
+        ]
+    }
+}

--- a/crates/nu-command/src/system/sys/temp.rs
+++ b/crates/nu-command/src/system/sys/temp.rs
@@ -1,0 +1,35 @@
+use nu_engine::command_prelude::*;
+
+#[derive(Clone)]
+pub struct SysTemp;
+
+impl Command for SysTemp {
+    fn name(&self) -> &str {
+        "sys temp"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build("sys temp")
+            .filter()
+            .category(Category::System)
+            .input_output_types(vec![(Type::Nothing, Type::table())])
+    }
+
+    fn usage(&self) -> &str {
+        "View the temperatures of system components."
+    }
+
+    fn run(
+        &self,
+        _engine_state: &EngineState,
+        _stack: &mut Stack,
+        call: &Call,
+        _input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        Ok(super::temp(call.head).into_pipeline_data())
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        todo!()
+    }
+}

--- a/crates/nu-command/src/system/sys/temp.rs
+++ b/crates/nu-command/src/system/sys/temp.rs
@@ -30,6 +30,10 @@ impl Command for SysTemp {
     }
 
     fn examples(&self) -> Vec<Example> {
-        todo!()
+        vec![Example {
+            description: "Show the system temperatures",
+            example: "sys temp",
+            result: None,
+        }]
     }
 }

--- a/crates/nu-command/src/system/sys/temp.rs
+++ b/crates/nu-command/src/system/sys/temp.rs
@@ -19,6 +19,10 @@ impl Command for SysTemp {
         "View the temperatures of system components."
     }
 
+    fn extra_usage(&self) -> &str {
+        "Some system components do not support temperature readings, so this command may return an empty list if no components support temperature."
+    }
+
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-command/tests/commands/select.rs
+++ b/crates/nu-command/tests/commands/select.rs
@@ -172,7 +172,7 @@ fn select_ignores_errors_successfully2() {
 
 #[test]
 fn select_ignores_errors_successfully3() {
-    let actual = nu!("sys | select invalid_key? | to nuon");
+    let actual = nu!("{foo: bar} | select invalid_key? | to nuon");
 
     assert_eq!(actual.out, "{invalid_key: null}".to_string());
     assert!(actual.err.is_empty());

--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -110,8 +110,8 @@ impl Command for Explore {
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {
-                description: "Explore the system information record",
-                example: r#"sys | explore"#,
+                description: "Explore the system host information record",
+                example: r#"sys host | explore"#,
                 result: None,
             },
             Example {

--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -739,7 +739,7 @@ Each stage in the pipeline works together to load, parse, and display informatio
     List the files in the current directory, sorted by size
     > ('ls | sort-by size' | nu-highlight)
 
-    Get Get the current system host name
+    Get the current system host name
     > ('sys host | get hostname' | nu-highlight)
 
     Get the processes on your system actively using CPU

--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -739,8 +739,8 @@ Each stage in the pipeline works together to load, parse, and display informatio
     List the files in the current directory, sorted by size
     > ('ls | sort-by size' | nu-highlight)
 
-    Get information about the current system
-    > ('sys | get host' | nu-highlight)
+    Get Get the current system host name
+    > ('sys host | get hostname' | nu-highlight)
 
     Get the processes on your system actively using CPU
     > ('ps | where cpu > 0' | nu-highlight)

--- a/crates/nu-std/testing.nu
+++ b/crates/nu-std/testing.nu
@@ -1,7 +1,7 @@
 use std log
 
 def "nu-complete threads" [] {
-    seq 1 (sys|get cpu|length)
+    seq 1 (sys cpu | length)
 }
 
 # Here we store the map of annotations internal names and the annotation actually used during test creation


### PR DESCRIPTION
# Description
Adds subcommands to `sys` corresponding to each column of the record returned by `sys`. This is to alleviate the fact that `sys` now returns a regular record, meaning that it must compute every column which might take a noticeable amount of time. The subcommands, on the other hand, only need to compute and return a subset of the data which should be much faster. In fact, it should be as fast as before, since this is how the lazy record worked (it would compute only each column as necessary).

I choose to add subcommands instead of having an optional cell-path parameter on `sys`, since the cell-path parameter would:
- increase the code complexity (can access any value at any row or nested column)
- prevents discovery with tab-completion
- hinders type checking and allows users to pass potentially invalid columns

# User-Facing Changes
Deprecates `sys` in favor of the new `sys` subcommands.
