### PR TITLE
Migrate to a new PWD API (part 2)

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -21,8 +21,8 @@ fn load_bench_commands() -> EngineState {
 }
 
 fn canonicalize_path(engine_state: &EngineState, path: &Path) -> PathBuf {
-    #[allow(deprecated)]
-    let cwd = engine_state.current_work_dir();
+    // We're running a benchmark. Using `unwrap()` is fine.
+    let cwd = engine_state.cwd_as_string(None).unwrap();
 
     if path.exists() {
         match nu_path::canonicalize_with(path, cwd) {

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -21,7 +21,6 @@ fn load_bench_commands() -> EngineState {
 }
 
 fn canonicalize_path(engine_state: &EngineState, path: &Path) -> PathBuf {
-    // We're running a benchmark. Using `unwrap()` is fine.
     let cwd = engine_state.cwd_as_string(None).unwrap();
 
     if path.exists() {

--- a/crates/nu-cli/src/config_files.rs
+++ b/crates/nu-cli/src/config_files.rs
@@ -177,36 +177,36 @@ pub fn add_plugin_file(
     use std::path::Path;
 
     let working_set = StateWorkingSet::new(engine_state);
-    #[allow(deprecated)]
-    let cwd = working_set.get_cwd();
 
-    if let Some(plugin_file) = plugin_file {
-        let path = Path::new(&plugin_file.item);
-        let path_dir = path.parent().unwrap_or(path);
-        // Just try to canonicalize the directory of the plugin file first.
-        if let Ok(path_dir) = canonicalize_with(path_dir, &cwd) {
-            // Try to canonicalize the actual filename, but it's ok if that fails. The file doesn't
-            // have to exist.
-            let path = path_dir.join(path.file_name().unwrap_or(path.as_os_str()));
-            let path = canonicalize_with(&path, &cwd).unwrap_or(path);
-            engine_state.plugin_path = Some(path)
-        } else {
-            // It's an error if the directory for the plugin file doesn't exist.
-            report_error(
-                &working_set,
-                &ParseError::FileNotFound(
-                    path_dir.to_string_lossy().into_owned(),
-                    plugin_file.span,
-                ),
-            );
+    if let Ok(cwd) = engine_state.cwd_as_string(None) {
+        if let Some(plugin_file) = plugin_file {
+            let path = Path::new(&plugin_file.item);
+            let path_dir = path.parent().unwrap_or(path);
+            // Just try to canonicalize the directory of the plugin file first.
+            if let Ok(path_dir) = canonicalize_with(path_dir, &cwd) {
+                // Try to canonicalize the actual filename, but it's ok if that fails. The file doesn't
+                // have to exist.
+                let path = path_dir.join(path.file_name().unwrap_or(path.as_os_str()));
+                let path = canonicalize_with(&path, &cwd).unwrap_or(path);
+                engine_state.plugin_path = Some(path)
+            } else {
+                // It's an error if the directory for the plugin file doesn't exist.
+                report_error(
+                    &working_set,
+                    &ParseError::FileNotFound(
+                        path_dir.to_string_lossy().into_owned(),
+                        plugin_file.span,
+                    ),
+                );
+            }
+        } else if let Some(mut plugin_path) = nu_path::config_dir() {
+            // Path to store plugins signatures
+            plugin_path.push(storage_path);
+            let mut plugin_path = canonicalize_with(&plugin_path, &cwd).unwrap_or(plugin_path);
+            plugin_path.push(PLUGIN_FILE);
+            let plugin_path = canonicalize_with(&plugin_path, &cwd).unwrap_or(plugin_path);
+            engine_state.plugin_path = Some(plugin_path);
         }
-    } else if let Some(mut plugin_path) = nu_path::config_dir() {
-        // Path to store plugins signatures
-        plugin_path.push(storage_path);
-        let mut plugin_path = canonicalize_with(&plugin_path, &cwd).unwrap_or(plugin_path);
-        plugin_path.push(PLUGIN_FILE);
-        let plugin_path = canonicalize_with(&plugin_path, &cwd).unwrap_or(plugin_path);
-        engine_state.plugin_path = Some(plugin_path);
     }
 }
 
@@ -236,8 +236,7 @@ pub fn eval_config_contents(
             engine_state.file = prev_file;
 
             // Merge the environment in case env vars changed in the config
-            #[allow(deprecated)]
-            match nu_engine::env::current_dir(engine_state, stack) {
+            match engine_state.cwd(Some(stack)) {
                 Ok(cwd) => {
                     if let Err(e) = engine_state.merge_env(stack, cwd) {
                         let working_set = StateWorkingSet::new(engine_state);
@@ -274,8 +273,9 @@ pub fn migrate_old_plugin_file(engine_state: &EngineState, storage_path: &str) -
 
     let start_time = std::time::Instant::now();
 
-    #[allow(deprecated)]
-    let cwd = engine_state.current_work_dir();
+    let Ok(cwd) = engine_state.cwd_as_string(None) else {
+        return false;
+    };
 
     let Some(config_dir) = nu_path::config_dir().and_then(|mut dir| {
         dir.push(storage_path);

--- a/crates/nu-cli/src/eval_file.rs
+++ b/crates/nu-cli/src/eval_file.rs
@@ -1,8 +1,7 @@
 use crate::util::eval_source;
 use log::{info, trace};
 use miette::{IntoDiagnostic, Result};
-#[allow(deprecated)]
-use nu_engine::{convert_env_values, current_dir, eval_block};
+use nu_engine::{convert_env_values, eval_block};
 use nu_parser::parse;
 use nu_path::canonicalize_with;
 use nu_protocol::{
@@ -30,8 +29,7 @@ pub fn evaluate_file(
         std::process::exit(1);
     }
 
-    #[allow(deprecated)]
-    let cwd = current_dir(engine_state, stack)?;
+    let cwd = engine_state.cwd_as_string(Some(stack))?;
 
     let file_path = canonicalize_with(&path, cwd).unwrap_or_else(|e| {
         let working_set = StateWorkingSet::new(engine_state);

--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -13,8 +13,7 @@ pub fn get_init_cwd() -> PathBuf {
 }
 
 pub fn get_guaranteed_cwd(engine_state: &EngineState, stack: &Stack) -> PathBuf {
-    #[allow(deprecated)]
-    nu_engine::env::current_dir(engine_state, stack).unwrap_or_else(|e| {
+    engine_state.cwd(Some(stack)).unwrap_or_else(|e| {
         let working_set = StateWorkingSet::new(engine_state);
         report_error(&working_set, &e);
         crate::util::get_init_cwd()

--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -1,5 +1,4 @@
-#[allow(deprecated)]
-use nu_engine::{command_prelude::*, current_dir};
+use nu_engine::command_prelude::*;
 use nu_plugin_engine::{GetPlugin, PersistentPlugin};
 use nu_protocol::{PluginGcConfig, PluginIdentity, PluginRegistryItem, RegisteredPlugin};
 use std::sync::Arc;
@@ -82,8 +81,7 @@ apparent the next time `nu` is next launched with that plugin registry file.
         let filename: Spanned<String> = call.req(engine_state, stack, 0)?;
         let shell: Option<Spanned<String>> = call.get_flag(engine_state, stack, "shell")?;
 
-        #[allow(deprecated)]
-        let cwd = current_dir(engine_state, stack)?;
+        let cwd = engine_state.cwd(Some(stack))?;
 
         // Check the current directory, or fall back to NU_PLUGIN_DIRS
         let filename_expanded = nu_path::locate_in_dirs(&filename.item, &cwd, || {

--- a/crates/nu-command/src/filesystem/glob.rs
+++ b/crates/nu-command/src/filesystem/glob.rs
@@ -1,5 +1,4 @@
-#[allow(deprecated)]
-use nu_engine::{command_prelude::*, env::current_dir};
+use nu_engine::command_prelude::*;
 use std::sync::{atomic::AtomicBool, Arc};
 use wax::{Glob as WaxGlob, WalkBehavior, WalkEntry};
 
@@ -179,8 +178,7 @@ impl Command for Glob {
             }
         };
 
-        #[allow(deprecated)]
-        let path = current_dir(engine_state, stack)?;
+        let path = engine_state.cwd_as_string(Some(stack))?;
         let path = match nu_path::canonicalize_with(prefix, path) {
             Ok(path) => path,
             Err(e) if e.to_string().contains("os error 2") =>

--- a/crates/nu-command/src/filesystem/watch.rs
+++ b/crates/nu-command/src/filesystem/watch.rs
@@ -5,8 +5,7 @@ use notify_debouncer_full::{
         EventKind, RecursiveMode, Watcher,
     },
 };
-#[allow(deprecated)]
-use nu_engine::{command_prelude::*, current_dir, ClosureEval};
+use nu_engine::{command_prelude::*, ClosureEval};
 use nu_protocol::{
     engine::{Closure, StateWorkingSet},
     format_error,
@@ -74,8 +73,7 @@ impl Command for Watch {
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let head = call.head;
-        #[allow(deprecated)]
-        let cwd = current_dir(engine_state, stack)?;
+        let cwd = engine_state.cwd_as_string(Some(stack))?;
         let path_arg: Spanned<String> = call.req(engine_state, stack, 0)?;
 
         let path_no_whitespace = &path_arg

--- a/crates/nu-engine/src/env.rs
+++ b/crates/nu-engine/src/env.rs
@@ -286,8 +286,7 @@ pub fn find_in_dirs_env(
             Err(e) => return Err(e),
         }
     } else {
-        #[allow(deprecated)]
-        current_dir_str(engine_state, stack)?
+        engine_state.cwd_as_string(Some(stack))?
     };
 
     let check_dir = |lib_dirs: Option<Value>| -> Option<PathBuf> {

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -977,6 +977,20 @@ impl EngineState {
         }
     }
 
+    /// Like `EngineState::cwd()`, but returns a String instead of a PathBuf for convenience.
+    pub fn cwd_as_string(&self, stack: Option<&Stack>) -> Result<String, ShellError> {
+        let cwd = self.cwd(stack)?;
+        cwd.into_os_string()
+            .into_string()
+            .map_err(|err| ShellError::NonUtf8Custom {
+                msg: format!(
+                    "The current working directory is not a valid utf-8 string: {:?}",
+                    err
+                ),
+                span: Span::unknown(),
+            })
+    }
+
     // TODO: see if we can completely get rid of this
     pub fn get_file_contents(&self) -> &[CachedFile] {
         &self.files

--- a/crates/nu-std/src/lib.rs
+++ b/crates/nu-std/src/lib.rs
@@ -1,6 +1,5 @@
 use log::trace;
-#[allow(deprecated)]
-use nu_engine::{env::current_dir, eval_block};
+use nu_engine::eval_block;
 use nu_parser::parse;
 use nu_protocol::{
     debugger::WithoutDebug,
@@ -99,8 +98,7 @@ use std pwd
 
     eval_block::<WithoutDebug>(engine_state, &mut stack, &block, pipeline_data)?;
 
-    #[allow(deprecated)]
-    let cwd = current_dir(engine_state, &stack)?;
+    let cwd = engine_state.cwd(Some(&stack))?;
     engine_state.merge_env(&mut stack, cwd)?;
 
     Ok(())

--- a/src/test_bins.rs
+++ b/src/test_bins.rs
@@ -249,8 +249,9 @@ pub fn nu_repl() {
 
     for (i, line) in source_lines.iter().enumerate() {
         let mut stack = Stack::with_parent(top_stack.clone());
-        #[allow(deprecated)]
-        let cwd = nu_engine::env::current_dir(&engine_state, &stack)
+
+        let cwd = engine_state
+            .cwd(Some(&stack))
             .unwrap_or_else(|err| outcome_err(&engine_state, &err));
 
         // Before doing anything, merge the environment from the previous REPL iteration into the


### PR DESCRIPTION
Refer to #12603 for part 1.

We need to be careful when migrating to the new API, because the new API has slightly different semantics (PWD can contain symlinks). This PR handles the "obviously safe" part of the migrations. Namely, it handles two specific use cases:

* Passing PWD into `canonicalize_with()`
* Passing PWD into `EngineState::merge_env()`

The first case is safe because symlinks are canonicalized away. The second case is safe because `EngineState::merge_env()` only uses PWD to call `std::env::set_current_dir()`, which shouldn't affact Nushell. The commit message contains detailed stats on the updated files.

Because these migrations touch a lot of files, I want to keep these PRs small to avoid merge conflicts.