### PR TITLE
Minimize future false positive typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
         # Using macOS 13 runner because 14 is based on the M1 and has half as much RAM (7 GB,
         # instead of 14 GB) which is too little for us right now.
         #
-        # Failure occuring with clippy for rust 1.77.2
+        # Failure occurring with clippy for rust 1.77.2
         platform: [windows-latest, macos-13, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}

--- a/crates/nu-command/src/date/utils.rs
+++ b/crates/nu-command/src/date/utils.rs
@@ -8,7 +8,7 @@ pub(crate) fn parse_date_from_string(
     match dtparse::parse(input) {
         Ok((native_dt, fixed_offset)) => {
             let offset = match fixed_offset {
-                Some(fo) => fo,
+                Some(offset) => offset,
                 None => *(Local::now().offset()),
             };
             match offset.from_local_datetime(&native_dt) {

--- a/crates/nu-command/tests/commands/table.rs
+++ b/crates/nu-command/tests/commands/table.rs
@@ -2562,12 +2562,12 @@ fn create_theme_output(theme: &str) -> Vec<String> {
 }
 
 fn theme_cmd(theme: &str, footer: bool, then: &str) -> String {
-    let mut with_foorter = String::new();
+    let mut with_footer = String::new();
     if footer {
-        with_foorter = "$env.config.footer_mode = \"always\"".to_string();
+        with_footer = "$env.config.footer_mode = \"always\"".to_string();
     }
 
-    format!("$env.config.table.mode = {theme}; $env.config.table.header_on_separator = true; {with_foorter}; {then}")
+    format!("$env.config.table.mode = {theme}; $env.config.table.header_on_separator = true; {with_footer}; {then}")
 }
 
 #[test]

--- a/crates/nu-json/src/de.rs
+++ b/crates/nu-json/src/de.rs
@@ -260,8 +260,8 @@ where
                     }
                     _ => {
                         if chf == b'-' || chf.is_ascii_digit() {
-                            let mut pn = ParseNumber::new(self.str_buf.iter().copied());
-                            match pn.parse(false) {
+                            let mut parser = ParseNumber::new(self.str_buf.iter().copied());
+                            match parser.parse(false) {
                                 Ok(Number::F64(v)) => {
                                     self.rdr.uneat_char(ch);
                                     return visitor.visit_f64(v);

--- a/crates/nu-std/CONTRIBUTING.md
+++ b/crates/nu-std/CONTRIBUTING.md
@@ -13,7 +13,7 @@ You'll generally find the team members on
 [Discord `#standard-library` channel][discord#standard-library] and can have
 preliminary discussions there to clarify the issues involved.
 
-You can open a [Github issue][new-issue] to have a more focused discussion of
+You can open a [GitHub issue][new-issue] to have a more focused discussion of
 your idea.
 
 Generally, we think the standard library should contain items that are relevant

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -286,7 +286,7 @@ mod stdin_evaluation {
     fn does_not_panic_with_no_newline_in_stream() {
         let actual = nu!(pipeline(
             r#"
-                nu --testbin nonu "wheres the nuline?" | length
+                nu --testbin nonu "where's the nuline?" | length
             "#
         ));
 

--- a/typos.toml
+++ b/typos.toml
@@ -9,7 +9,6 @@ ignore-hidden = false
 [default]
 extend-ignore-re = [
     "Plasticos Rival",
-    "wheres the nuline",
     "│ in_custom_valu │",
     "│ ine │",
     ":es\\|ful\\(",
@@ -18,14 +17,11 @@ extend-ignore-re = [
     "--find ba\\b",
     "0x\\[ba be\\]",
     "\\)BaR'",
-    "@IIF'8bF",
 ]
 
 [type.rust.extend-words]
-fo = "fo"
 nd = "nd"
 numer = "numer"
-pn = "pn"
 
 [default.extend-identifiers]
 ratatui = "ratatui"

--- a/typos.toml
+++ b/typos.toml
@@ -1,17 +1,30 @@
 [files]
-extend-exclude = ["crates/nu-command/tests/commands/table.rs", "*.tsv", "*.json", "*.txt", "tests/fixtures/formats/*"]
+extend-exclude = [
+    "crates/nu-cmd-extra/assets/228_themes.json",
+    "tests/fixtures/formats/",
+]
+ignore-hidden = false
 
-[default.extend-words]
-# Ignore false-positives
-nd = "nd"
-pn = "pn"
+[default]
+extend-ignore-re = [
+    "Plasticos Rival",
+    "wheres the nuline",
+    "│ in_custom_valu │",
+    "│ ine │",
+    ":es\\|ful\\(",
+    "\\\\u\\{e7ba\\}",
+    "([0-9a-f][0-9a-f] ){4}",
+    "--find ba\\b",
+    "0x\\[ba be\\]",
+    "\\)BaR'",
+    "@IIF'8bF",
+]
+
+[type.rust.extend-words]
 fo = "fo"
-ful = "ful"
-ons = "ons"
-ba = "ba"
-Plasticos = "Plasticos"
-IIF = "IIF"
+nd = "nd"
 numer = "numer"
+pn = "pn"
+
+[default.extend-identifiers]
 ratatui = "ratatui"
-doas = "doas"
-wheres = "wheres"

--- a/typos.toml
+++ b/typos.toml
@@ -1,5 +1,6 @@
 [files]
 extend-exclude = [
+    ".git/",
     "crates/nu-cmd-extra/assets/228_themes.json",
     "tests/fixtures/formats/",
 ]


### PR DESCRIPTION
# Description

Make typos config more strict: ignore false positives where they occur.

1. Ignore only files with typos
2. Add regexp-s with context
3. Ignore variable names only in Rust code
4. Ignore only 1 "identifier"
5. Check dot files

🎁 Extra bonus: fix typos!!
