### PR TITLE
feat: add an echo command to nu_plugin_example

### DIFF
--- a/crates/nu_plugin_example/src/commands/echo.rs
+++ b/crates/nu_plugin_example/src/commands/echo.rs
@@ -32,7 +32,7 @@ impl PluginCommand for Echo {
             example: "example seq 1 5 | example echo",
             description: "echos the values from 1 to 5",
             result: Some(Value::test_list(
-                [1..=5].into_iter().map(Value::test_int).collect(),
+                (1..=5).map(Value::test_int).collect::<Vec<_>>(),
             )),
         }]
     }

--- a/crates/nu_plugin_example/src/commands/echo.rs
+++ b/crates/nu_plugin_example/src/commands/echo.rs
@@ -1,0 +1,55 @@
+use nu_plugin::{EngineInterface, EvaluatedCall, PluginCommand};
+use nu_protocol::{Category, Example, LabeledError, PipelineData, Signature, Type, Value};
+
+use crate::ExamplePlugin;
+
+/// `<list> | example echo`
+pub struct Echo;
+
+impl PluginCommand for Echo {
+    type Plugin = ExamplePlugin;
+
+    fn name(&self) -> &str {
+        "example echo"
+    }
+
+    fn usage(&self) -> &str {
+        "Example stream consumer that outputs the received input"
+    }
+
+    fn signature(&self) -> Signature {
+        Signature::build(self.name())
+            .input_output_types(vec![(Type::Any, Type::Any)])
+            .category(Category::Experimental)
+    }
+
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["example"]
+    }
+
+    fn examples(&self) -> Vec<Example> {
+        vec![Example {
+            example: "example seq 1 5 | example echo",
+            description: "echos the values from 1 to 5",
+            result: Some(Value::test_list(
+                [1..=5].into_iter().map(Value::test_int).collect(),
+            )),
+        }]
+    }
+
+    fn run(
+        &self,
+        _plugin: &ExamplePlugin,
+        _engine: &EngineInterface,
+        _call: &EvaluatedCall,
+        input: PipelineData,
+    ) -> Result<PipelineData, LabeledError> {
+        Ok(input)
+    }
+}
+
+#[test]
+fn test_examples() -> Result<(), nu_protocol::ShellError> {
+    use nu_plugin_test_support::PluginTest;
+    PluginTest::new("example", ExamplePlugin.into())?.test_command_examples(&Echo)
+}

--- a/crates/nu_plugin_example/src/commands/mod.rs
+++ b/crates/nu_plugin_example/src/commands/mod.rs
@@ -25,12 +25,14 @@ pub use view_span::ViewSpan;
 
 // Stream demos
 mod collect_external;
+mod echo;
 mod for_each;
 mod generate;
 mod seq;
 mod sum;
 
 pub use collect_external::CollectExternal;
+pub use echo::Echo;
 pub use for_each::ForEach;
 pub use generate::Generate;
 pub use seq::Seq;

--- a/crates/nu_plugin_example/src/lib.rs
+++ b/crates/nu_plugin_example/src/lib.rs
@@ -25,6 +25,7 @@ impl Plugin for ExamplePlugin {
             Box::new(DisableGc),
             // Stream demos
             Box::new(CollectExternal),
+            Box::new(Echo),
             Box::new(ForEach),
             Box::new(Generate),
             Box::new(Seq),


### PR DESCRIPTION
# Description

This PR adds a new `echo` command to the `nu_plugin_example` plugin that simply [streams all of its input to its output](https://github.com/nushell/nushell/pull/12754/files#diff-de9fcf086b8c373039dadcc2bcb664c6014c0b2af8568eab68c0b6666ac5ccceR47).

```
: "hi" | example echo
hi
```

The motivation for adding it is to have a convenient command to exercise interactivity on slow pipelines.

I'll follow up on that front with [another PR](https://github.com/cablehead/nushell/pull/1/files)

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting

https://github.com/nushell/nushell/pull/12754/files#diff-de9fcf086b8c373039dadcc2bcb664c6014c0b2af8568eab68c0b6666ac5ccceR51-R55
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
