### PR TITLE
Bump `base64` to 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
@@ -2919,7 +2919,7 @@ name = "nu-command"
 version = "0.93.1"
 dependencies = [
  "alphanumeric-sort",
- "base64 0.22.0",
+ "base64 0.22.1",
  "bracoxide",
  "brotli 5.0.0",
  "byteorder",

--- a/crates/nu-command/src/strings/encode_decode/base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/base64.rs
@@ -281,7 +281,7 @@ mod tests {
 
     #[test]
     fn base64_decode_binhex() {
-        let word = Value::test_string("A5\"KC9jRB@IIF'8bF!");
+        let word = Value::test_string(r#"B5"LD@jSCAJJG'9cG!"#);
         let expected = Value::binary(b"a binhex test".as_slice(), Span::test_data());
 
         let actual = action(
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn base64_decode_binhex_with_new_line_input() {
-        let word = Value::test_string("A5\"KC9jRB\n@IIF'8bF!");
+        let word = Value::test_string("B5\"LD@jSC\nAJJG'9cG!");
         let expected = Value::binary(b"a binhex test".as_slice(), Span::test_data());
 
         let actual = action(

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -65,7 +65,7 @@ impl Command for EncodeBase64 {
             Example {
                 description: "Encode a string with the binhex character set",
                 example: "'Some Data' | encode base64 --character-set binhex",
-                result: Some(Value::test_string(r#"7epXB5"%A@4J"#)),
+                result: Some(Value::test_string(r#"8fpYC5"%BA4K"#)),
             },
         ]
     }

--- a/crates/nu-command/tests/commands/hash_/mod.rs
+++ b/crates/nu-command/tests/commands/hash_/mod.rs
@@ -15,7 +15,7 @@ fn base64_encode_characterset_binhex() {
         echo 'username:password' | encode base64 --character-set binhex
         "#);
 
-    assert_eq!(actual.out, "F@0NEPjJD97kE\'&bEhFZEP3");
+    assert_eq!(actual.out, "GA0PFQjKE@8kF'&cFhG[FQ3");
 }
 
 #[test]
@@ -31,9 +31,9 @@ fn error_when_invalid_character_set_given() {
 
 #[test]
 fn base64_decode_characterset_binhex() {
-    let actual = nu!(r#"
-        echo "F@0NEPjJD97kE'&bEhFZEP3" | decode base64 --character-set binhex --binary | decode utf-8
-        "#);
+    let actual = nu!(
+        r#""GA0PFQjKE@8kF'&cFhG[FQ3" | decode base64 --character-set binhex --binary | decode utf-8"#
+    );
 
     assert_eq!(actual.out, "username:password");
 }


### PR DESCRIPTION
# Description
Bumps `base64` to 0.22.1 which fixes the alphabet used for binhex encoding and decoding. This required updating some test expected output. 

Related to PR #12469 where `base64` was also bumped and ran into the failing tests.

# User-Facing Changes
Bug fix, but still changes binhex encoding and decoding output.

# Tests + Formatting
Updated test expected output.

