### PR TITLE
Enable columns with spaces for into_sqlite by adding quotes to column names

### DIFF
--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -269,7 +269,8 @@ fn insert_in_transaction(
         let insert_statement = format!(
             "INSERT INTO [{}] ({}) VALUES ({})",
             table_name,
-            Itertools::intersperse(val.columns().map(|c| format!("`{}`", c)), ", ".to_string()).collect::<String>(),
+            Itertools::intersperse(val.columns().map(|c| format!("`{}`", c)), ", ".to_string())
+                .collect::<String>(),
             Itertools::intersperse(itertools::repeat_n("?", val.len()), ", ").collect::<String>(),
         );
 
@@ -390,9 +391,11 @@ fn get_columns_with_sqlite_types(
     let mut columns: Vec<(String, &'static str)> = vec![];
 
     for (c, v) in record {
-        if !columns.iter()
-            .map(|name| ( format!("`{}`", name.0), name.1) )
-            .any(|(name, _)| name == *c) {
+        if !columns
+            .iter()
+            .map(|name| (format!("`{}`", name.0), name.1))
+            .any(|(name, _)| name == *c)
+        {
             columns.push((format!("`{}`", c), nu_value_to_sqlite_type(v)?));
         }
     }

--- a/crates/nu-command/src/database/commands/into_sqlite.rs
+++ b/crates/nu-command/src/database/commands/into_sqlite.rs
@@ -269,7 +269,7 @@ fn insert_in_transaction(
         let insert_statement = format!(
             "INSERT INTO [{}] ({}) VALUES ({})",
             table_name,
-            Itertools::intersperse(val.columns().map(String::as_str), ", ").collect::<String>(),
+            Itertools::intersperse(val.columns().map(|c| format!("`{}`", c)), ", ".to_string()).collect::<String>(),
             Itertools::intersperse(itertools::repeat_n("?", val.len()), ", ").collect::<String>(),
         );
 
@@ -390,8 +390,10 @@ fn get_columns_with_sqlite_types(
     let mut columns: Vec<(String, &'static str)> = vec![];
 
     for (c, v) in record {
-        if !columns.iter().any(|(name, _)| name == c) {
-            columns.push((c.clone(), nu_value_to_sqlite_type(v)?));
+        if !columns.iter()
+            .map(|name| ( format!("`{}`", name.0), name.1) )
+            .any(|(name, _)| name == *c) {
+            columns.push((format!("`{}`", c), nu_value_to_sqlite_type(v)?));
         }
     }
 


### PR DESCRIPTION
# Description
Spaces were causing an issue with into_sqlite when they appeared in column names.

This is because the column names were not properly wrapped with backticks that allow sqlite to properly interpret the column.

The issue has been addressed by adding backticks to the column names of into sqlite. The output of the column names when using open is unchanged, and the column names appear without backticks as expected.

fixes #12700 

# User-Facing Changes
N/A

# Tests + Formatting
Formatting has been respected.

Repro steps from the issue have been done, and ran multiple times. New values get added to the correct columns as expected.

