### PR TITLE
Fix PWD cannot point to root paths

### DIFF
--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -943,7 +943,7 @@ impl EngineState {
 
         // Helper function to check if a path is a root path.
         fn is_root(path: &Path) -> bool {
-            path.parent() == None
+            path.parent().is_none()
         }
 
         // Helper function to check if a path has trailing slashes.


### PR DESCRIPTION
PR https://github.com/nushell/nushell/pull/12603 made it so that PWD can never contain a trailing slash. However, a root path (such as `/` or `C:\`) technically counts as "having a trailing slash", so now `cd /` doesn't work.

I feel dumb for missing such an obvious edge case. Let's just merge this quickly before anyone else finds out...

EDIT: It appears I'm too late.