### PR TITLE
Specify the required minimum `chrono` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ byteorder = "1.5"
 bytesize = "1.3"
 calamine = "0.24.0"
 chardetng = "0.1.17"
-chrono = { default-features = false, version = "0.4" }
+chrono = { default-features = false, version = "0.4.34" }
 chrono-humanize = "0.2.3"
 chrono-tz = "0.8"
 crossbeam-channel = "0.5.8"


### PR DESCRIPTION
See #12765 and h/t to @FMOtalleb in https://discord.com/channels/601130461678272522/855947301380947968/1236286905843454032

`Duration/TimeDelta::try_milliseconds` was added in `0.4.34`
https://github.com/chronotope/chrono/releases/tag/v0.4.34
