### PR TITLE
Fix trailing slash issue with autocd

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -915,6 +915,9 @@ fn do_auto_cd(
         path.to_string_lossy().to_string()
     };
 
+    // Strip the trailing slash from the new path. This is required for PWD.
+    let path = nu_path::strip_trailing_slash(&path);
+
     if let PermissionResult::PermissionDenied(reason) = have_permission(path.clone()) {
         report_error_new(
             engine_state,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description

Issues have been fixed for trailing slashes when using `cd ../` (https://github.com/nushell/nushell/pull/12760) or `cd /` (https://github.com/nushell/nushell/pull/12761).
This fixes trailing slash issues with `autocd` e.g. `../` (https://github.com/nushell/nushell/pull/12760#issuecomment-2094961496).

# User-Facing Changes

No more `$env.PWD contains trailing slash` error when using `autocd`.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
