### PR TITLE
Add --not flag to 'str starts-with' and 'str ends-with'

### DIFF
--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -102,22 +102,26 @@ fn action(
         not_ends_with,
         ..
     }: &Arguments,
-    head: Span) -> Value {
+    head: Span,
+) -> Value {
     match input {
         Value::String { val, .. } => Value::bool(
-            if *case_insensitive {
-                if *not_ends_with {
-                    !val.to_folded_case()
-                        .ends_with(substring.to_folded_case().as_str())
-                } else {
-                    val.to_folded_case()
-                        .ends_with(substring.to_folded_case().as_str())
+            match case_insensitive {
+                true => {
+                    if *not_ends_with {
+                        !val.to_folded_case()
+                            .ends_with(substring.to_folded_case().as_str())
+                    } else {
+                        val.to_folded_case()
+                            .ends_with(substring.to_folded_case().as_str())
+                    }
                 }
-            } else {
-                if *not_ends_with {
-                    !val.ends_with(substring)
-                } else {
-                    val.ends_with(substring)
+                false => {
+                    if *not_ends_with {
+                        !val.ends_with(substring)
+                    } else {
+                        val.ends_with(substring)
+                    }
                 }
             },
             head,

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -110,19 +110,22 @@ fn action(
 ) -> Value {
     match input {
         Value::String { val, .. } => Value::bool(
-            if *case_insensitive {
-                if *not_starts_with {
-                    !val.to_folded_case()
-                        .starts_with(substring.to_folded_case().as_str())
-                } else {
-                    val.to_folded_case()
-                        .starts_with(substring.to_folded_case().as_str())
+            match case_insensitive {
+                true => {
+                    if *not_starts_with {
+                        !val.to_folded_case()
+                            .starts_with(substring.to_folded_case().as_str())
+                    } else {
+                        val.to_folded_case()
+                            .starts_with(substring.to_folded_case().as_str())
+                    }
                 }
-            } else {
-                if *not_starts_with {
-                    !val.starts_with(substring)
-                } else {
-                    val.starts_with(substring)
+                false => {
+                    if *not_starts_with {
+                        !val.starts_with(substring)
+                    } else {
+                        val.starts_with(substring)
+                    }
                 }
             },
             head,

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -423,7 +423,7 @@ fn str_ends_with() {
 #[test]
 fn str_not_ends_with_returns_false() {
     let actual = nu!(r#"
-        echo "nushell" | str ends-with --not "nu"
+        echo "nushell" | str ends-with --not "ell"
         "#);
 
     assert_eq!(actual.out, "false");

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -385,6 +385,60 @@ fn str_reverse() {
 }
 
 #[test]
+fn str_starts_with() {
+    let actual = nu!(r#"
+        echo "nushell" | str starts-with "nush"
+        "#);
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn str_not_starts_with_returns_false() {
+    let actual = nu!(r#"
+        echo "nushell" | str starts-with --not "nush"
+        "#);
+
+    assert_eq!(actual.out, "false");
+}
+
+#[test]
+fn str_not_starts_with_returns_true() {
+    let actual = nu!(r#"
+        echo "nushell" | str starts-with --not "shell"
+        "#);
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn str_ends_with() {
+    let actual = nu!(r#"
+        echo "nushell" | str ends-with "ell"
+        "#);
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
+fn str_not_ends_with_returns_false() {
+    let actual = nu!(r#"
+        echo "nushell" | str ends-with --not "nu"
+        "#);
+
+    assert_eq!(actual.out, "false");
+}
+
+#[test]
+fn str_not_ends_with_returns_true() {
+    let actual = nu!(r#"
+        echo "nushell" | str ends-with --not "nush"
+        "#);
+
+    assert_eq!(actual.out, "true");
+}
+
+#[test]
 fn test_redirection_trim() {
     let actual = nu!(r#"
         let x = (nu --testbin cococo niceone); $x | str trim | str length


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

- This PR resolves nushell/nushell#12299 also made by me

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR adds a `--not` flag to two built-in commands: `str starts-with` and `str ends-with`.
This is similar to how to `str contains` command already and this unifies the three similar commands' behaviors.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
- add `--not(-n)` flag to `str starts-with` command
- add `--not(-n)` flag to `str ends-with` command

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- [x] Added tests
- [x] Ran `cargo fmt --all`
- [x] Ran `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used`
- [x] Ran `cargo test --workspace`
- [ ] Ran `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"`
    - I was unable to get this working.
```
Error: nu::parser::export_not_found

  × Export not found.
   ╭─[source:1:9]
 1 │ use std testing; testing run-tests --path crates/nu-std
   ·         ───┬───
   ·            ╰── could not find imports
   ╰────
```
^ Any help on this matter is appreciated

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
Requires update of documentation
