### PR TITLE
Make file redirections apply only to external commands

### DIFF
--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -44,14 +44,14 @@ fn redirect_out() {
     Playground::setup("redirect_out_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "echo 'hello' out> a; open a"
+            "nu -c 'print hello' out> a; open a"
         );
 
         assert!(output.out.contains("hello"));
 
         let output = nu!(
             cwd: dirs.test(),
-            "echo 'hello' out>> a; open a"
+            "nu -c 'print hello' out>> a; open a"
         );
         assert!(output.out.contains("hellohello"));
     })
@@ -64,8 +64,8 @@ fn two_lines_redirection() {
                 cwd: dirs.test(),
                 r#"
 def foobar [] {
-    'hello' out> output1.txt
-    'world' out> output2.txt
+    nu -c 'print hello' out> output1.txt
+    nu -c 'print world' out> output2.txt
 }
 foobar"#);
         let file_out1 = dirs.test().join("output1.txt");
@@ -244,31 +244,31 @@ fn redirect_support_variable() {
     Playground::setup("redirect_out_support_variable", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            "let x = 'tmp_file'; echo 'hello' out> $x; open tmp_file"
+            "let x = 'tmp_file'; nu -c 'print hello' out> $x; open tmp_file"
         );
 
         assert!(output.out.contains("hello"));
 
         nu!(
             cwd: dirs.test(),
-            "let x = 'tmp_file'; echo 'hello there' out+err> $x; open tmp_file"
+            "let x = 'tmp_file'; nu -c 'print hello' out+err> $x; open tmp_file"
         );
         // check for stdout redirection file.
         let expected_out_file = dirs.test().join("tmp_file");
         let actual = file_contents(expected_out_file);
-        assert!(actual.contains("hello there"));
+        assert!(actual.contains("hello"));
 
         // append mode support variable too.
         let output = nu!(
             cwd: dirs.test(),
-            "let x = 'tmp_file'; echo 'hello' out>> $x; open tmp_file"
+            "let x = 'tmp_file'; nu -c 'print hello' out>> $x; open tmp_file"
         );
         let v: Vec<_> = output.out.match_indices("hello").collect();
         assert_eq!(v.len(), 2);
 
         let output = nu!(
             cwd: dirs.test(),
-            "let x = 'tmp_file'; echo 'hello' out+err>> $x; open tmp_file"
+            "let x = 'tmp_file'; nu -c 'print hello' out+err>> $x; open tmp_file"
         );
         // check for stdout redirection file.
         let v: Vec<_> = output.out.match_indices("hello").collect();

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -441,14 +441,6 @@ fn eval_element_with_input_inner<D: DebugContext>(
         }
     }
 
-    let data = if matches!(stack.pipe_stdout(), Some(OutDest::File(_)))
-        && !matches!(stack.pipe_stderr(), Some(OutDest::Pipe))
-    {
-        data.write_to_out_dests(engine_state, stack)?
-    } else {
-        data
-    };
-
     Ok((data, ok))
 }
 

--- a/crates/nu-protocol/src/engine/stack_out_dest.rs
+++ b/crates/nu-protocol/src/engine/stack_out_dest.rs
@@ -121,13 +121,10 @@ impl<'a> StackIoGuard<'a> {
                 let old = mem::replace(&mut out_dest.pipe_stdout, Some(stdout));
                 (old, out_dest.parent_stdout.take())
             }
-            Some(Redirection::File(file)) => {
-                let file = OutDest::from(file);
-                (
-                    mem::replace(&mut out_dest.pipe_stdout, Some(file.clone())),
-                    out_dest.push_stdout(file),
-                )
-            }
+            Some(Redirection::File(file)) => (
+                out_dest.pipe_stdout.take(),
+                out_dest.push_stdout(file.into()),
+            ),
             None => (out_dest.pipe_stdout.take(), out_dest.parent_stdout.take()),
         };
 


### PR DESCRIPTION
# Description
File redirections like `out>` and `err>` refer to the stdout and stderr streams of external commands/processes. However, the `out>`, `out+err>`, `out>>`, and `out+err>>` file redirections also work with values and list streams, saving any values to the file. This is despite the fact that nushell values and list streams do not quite have a defined "stdout" or "stderr". Currently, the pipe redirections (`e>|` and `o+e>|`) only work on external commands, erroring if used on a value or list stream.

```nushell
ls o+e>| get name | save test.txt # errors
```

# User-Facing Changes
Breaking change: `o>`, `o>>`, `o+e>`, and `o+e>>` now only apply to external commands.
