### PR TITLE
Add `sys users` command

### DIFF
--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -125,6 +125,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             SysMem,
             SysNet,
             SysTemp,
+            SysUsers,
             UName,
 
         };

--- a/crates/nu-command/src/system/sys/sys_.rs
+++ b/crates/nu-command/src/system/sys/sys_.rs
@@ -43,8 +43,11 @@ impl Command for Sys {
         );
 
         let head = call.head;
+
+        let mut host = super::host(head);
+        host.push("sessions", super::users(head));
         let record = record! {
-            "host" => super::host(head),
+            "host" => Value::record(host, head),
             "cpu" => super::cpu(head),
             "disks" => super::disks(head),
             "mem" => super::mem(head),

--- a/crates/nu-command/src/system/sys/users.rs
+++ b/crates/nu-command/src/system/sys/users.rs
@@ -1,22 +1,21 @@
 use nu_engine::command_prelude::*;
 
 #[derive(Clone)]
-pub struct SysHost;
+pub struct SysUsers;
 
-impl Command for SysHost {
+impl Command for SysUsers {
     fn name(&self) -> &str {
-        "sys host"
+        "sys users"
     }
 
     fn signature(&self) -> Signature {
-        Signature::build("sys host")
-            .filter()
+        Signature::build("sys users")
             .category(Category::System)
             .input_output_types(vec![(Type::Nothing, Type::record())])
     }
 
     fn usage(&self) -> &str {
-        "View information about the system host."
+        "View information about the users on the system."
     }
 
     fn run(
@@ -26,14 +25,13 @@ impl Command for SysHost {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let host = super::host(call.head);
-        Ok(Value::record(host, call.head).into_pipeline_data())
+        Ok(super::users(call.head).into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<Example> {
         vec![Example {
-            description: "Show info about the system host",
-            example: "sys host",
+            description: "Show info about the system users",
+            example: "sys users",
             result: None,
         }]
     }


### PR DESCRIPTION
# Description
Add a new `sys users` command which returns a table of the users of the system. This is the same table that is currently present as `(sys).host.sessions`. The same table has been removed from the recently added `sys host` command.

# User-Facing Changes
Adds a new command. (The old `sys` command is left as is.)