### PR TITLE
Force reload module on `parse_module_file`

### DIFF
--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1913,11 +1913,6 @@ fn parse_module_file(
     let file_id = working_set.add_file(path.path().to_string_lossy().to_string(), &contents);
     let new_span = working_set.get_span_for_file(file_id);
 
-    // Check if we've parsed the module before.
-    if let Some(module_id) = working_set.find_module_by_span(new_span) {
-        return Some(module_id);
-    }
-
     // Add the file to the stack of files being processed.
     if let Err(e) = working_set.files.push(path.path_buf(), path_span) {
         working_set.error(e);

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -760,3 +760,25 @@ fn nested_list_export_works() {
     let actual = nu!(&inp.join("; "));
     assert_eq!(actual.out, "bacon");
 }
+
+#[test]
+fn load_module_file_no_cache() {
+    Playground::setup("reload_submodule_changed_file", |dirs, sandbox| {
+        sandbox.with_files(&[
+            FileWithContentToBeTrimmed("voice.nu", r#"export module animals.nu"#),
+            FileWithContentToBeTrimmed("animals.nu", "export def cat [] { 'meow'}"),
+        ]);
+
+        let inp = &[
+            "use voice.nu",
+            "(voice animals cat) == 'meow'",
+            r#""export def cat [] {'meowww'}" | save -f animals.nu"#,
+            "use voice.nu",
+            "(voice animals cat) == 'meowww'",
+        ];
+
+        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+
+        assert_eq!(actual.out, "true\ntrue");
+    });
+}

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -769,17 +769,16 @@ fn load_module_file_no_cache() {
             FileWithContent("animals.nu", "export def cat [] { 'meow'}"),
         ]);
 
-        let inp = &[
+        let inp = [
             "use voice.nu",
-            "print -e (voice animals cat)",
+            "print (voice animals cat) == 'meow'",
             "(voice animals cat) == 'meow'",
             r#""export def cat [] {'meowww'}" | save animals.nu"#,
             "use voice.nu",
-            "print -e (voice animals cat)",
             "(voice animals cat) == 'meowww'",
         ];
 
-        let actual = nu!(cwd: dirs.test(), &inp.join("; "));
+        let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
 
         assert_eq!(actual.out, "true\ntrue");
     });

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -1,4 +1,4 @@
-use nu_test_support::fs::Stub::FileWithContentToBeTrimmed;
+use nu_test_support::fs::Stub::{FileWithContent, FileWithContentToBeTrimmed};
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, nu_repl_code};
 use pretty_assertions::assert_eq;
@@ -765,15 +765,17 @@ fn nested_list_export_works() {
 fn load_module_file_no_cache() {
     Playground::setup("reload_submodule_changed_file", |dirs, sandbox| {
         sandbox.with_files(&[
-            FileWithContentToBeTrimmed("voice.nu", r#"export module animals.nu"#),
-            FileWithContentToBeTrimmed("animals.nu", "export def cat [] { 'meow'}"),
+            FileWithContent("voice.nu", r#"export module animals.nu"#),
+            FileWithContent("animals.nu", "export def cat [] { 'meow'}"),
         ]);
 
         let inp = &[
             "use voice.nu",
+            "print -e (voice animals cat)",
             "(voice animals cat) == 'meow'",
-            r#""export def cat [] {'meowww'}" | save -f animals.nu"#,
+            r#""export def cat [] {'meowww'}" | save animals.nu"#,
             "use voice.nu",
+            "print -e (voice animals cat)",
             "(voice animals cat) == 'meowww'",
         ];
 

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -771,15 +771,13 @@ fn load_module_file_no_cache() {
 
         let inp = [
             "use voice.nu",
-            "print (voice animals cat) == 'meow'",
-            "(voice animals cat) == 'meow'",
-            r#""export def cat [] {'meowww'}" | save animals.nu"#,
+            r#""export def cat [] {'meowww'}" | save -f animals.nu"#,
             "use voice.nu",
             "(voice animals cat) == 'meowww'",
         ];
 
         let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
 
-        assert_eq!(actual.out, "true\ntrue");
+        assert_eq!(actual.out, "true");
     });
 }


### PR DESCRIPTION
# Description
Fixes: #12099

Currently if user run `use voice.nu`, and file is unchanged, then run `use foo.nu` again.  nushell will use the module directly, even if submodule inside `voice.nu` is changed.

I think it's ok to parse the module file when user runs `use foo.nu`.

After the change:
1. `use voice.nu` always read the file and parse it.
2. `use voice` will use the module which is saved in EngineState.

# User-Facing Changes
`use xxx.nu` will always read the file and parse it.

# Tests + Formatting
Done