### PR TITLE
Fix list spread syntax highlighting

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -3895,7 +3895,7 @@ pub fn parse_list_expression(
                         Type::List(elem_ty) => *elem_ty.clone(),
                         _ => Type::Any,
                     };
-                    let span = Span::new(curr_span.start, spread_arg.span.end);
+                    let span = Span::new(curr_span.start, curr_span.start + 3);
                     (ListItem::Spread(span, spread_arg), elem_ty)
                 } else {
                     let arg = parse_multispan_value(


### PR DESCRIPTION
# Description
I broke syntax highlighting for list spreads in #12529. This should fix #12792 :sweat_smile:. I just copied the code for highlighting record spreads.