### PR TITLE
Refactor message printing in `rm`

### DIFF
--- a/crates/nu-command/src/filesystem/rm.rs
+++ b/crates/nu-command/src/filesystem/rm.rs
@@ -3,7 +3,7 @@ use super::util::{get_rest_for_glob_pattern, try_interaction};
 use nu_engine::{command_prelude::*, env::current_dir};
 use nu_glob::MatchOptions;
 use nu_path::expand_path_with;
-use nu_protocol::{engine::StateWorkingSet, format_error, NuGlob};
+use nu_protocol::{report_error_new, NuGlob};
 #[cfg(unix)]
 use std::os::unix::prelude::FileTypeExt;
 use std::{
@@ -459,14 +459,8 @@ fn rm(
 
         match result {
             Ok(None) => {}
-            Ok(Some(msg)) => {
-                eprintln!("{msg}");
-            }
-            Err(err) => {
-                let working_set = StateWorkingSet::new(engine_state);
-                let msg = format_error(&working_set, &err);
-                eprintln!("{msg}");
-            }
+            Ok(Some(msg)) => eprintln!("{msg}"),
+            Err(err) => report_error_new(engine_state, &err),
         }
     }
 

--- a/crates/nu-protocol/src/pipeline_data/mod.rs
+++ b/crates/nu-protocol/src/pipeline_data/mod.rs
@@ -877,32 +877,6 @@ impl PipelineData {
         Ok(0)
     }
 
-    /// Consume and print self data immediately.
-    ///
-    /// Unlike [`.print()`] does not call `table` to format data and just prints it
-    /// one element on a line
-    /// * `no_newline` controls if we need to attach newline character to output.
-    /// * `to_stderr` controls if data is output to stderr, when the value is false, the data is output to stdout.
-    pub fn print_not_formatted(
-        self,
-        engine_state: &EngineState,
-        no_newline: bool,
-        to_stderr: bool,
-    ) -> Result<i64, ShellError> {
-        if let PipelineData::ExternalStream {
-            stdout: stream,
-            stderr: stderr_stream,
-            exit_code,
-            ..
-        } = self
-        {
-            print_if_stream(stream, stderr_stream, to_stderr, exit_code)
-        } else {
-            let config = engine_state.get_config();
-            self.write_all_and_flush(engine_state, config, no_newline, to_stderr)
-        }
-    }
-
     fn write_all_and_flush(
         self,
         engine_state: &EngineState,


### PR DESCRIPTION
# Description
Changes the iterator in `rm` to be an iterator over `Result<Option<String>, ShellError>` (an optional message or error) instead of an iterator over `Value`. Then, the iterator is consumed and each message is printed. This allows the `PipelineData::print_not_formatted` method to be removed.