### PR TITLE
Make the message when running a plugin exe directly clearer

### DIFF
--- a/crates/nu-cmd-plugin/src/commands/plugin/add.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/add.rs
@@ -43,7 +43,8 @@ impl Command for PluginAdd {
 
     fn extra_usage(&self) -> &str {
         r#"
-This does not load the plugin commands into the scope - see `register` for that.
+This does not load the plugin commands into the scope - see `plugin use` for
+that.
 
 Instead, it runs the plugin to get its command signatures, and then edits the
 plugin registry file (by default, `$nu.plugin-path`). The changes will be

--- a/crates/nu-plugin/src/plugin/mod.rs
+++ b/crates/nu-plugin/src/plugin/mod.rs
@@ -260,7 +260,8 @@ pub fn serve_plugin(plugin: &impl Plugin, encoder: impl PluginEncoder + 'static)
         }
     } else {
         eprintln!(
-            "{}: This plugin must be run from within Nushell.",
+            "{}: This plugin must be run from within Nushell. See `plugin add --help` for details \
+            on how to use plugins.",
             env::current_exe()
                 .map(|path| path.display().to_string())
                 .unwrap_or_else(|_| "plugin".into())


### PR DESCRIPTION
# Description

This changes the message that shows up when running a plugin executable directly rather than as a plugin to direct the user to run `plugin add --help`, which should have enough information to figure out what's going on. The message previously just vaguely suggested that the user needs to run the plugin "from within Nushell", which is not really enough - it has to be added with `plugin add` to be used as a plugin.

Also fix docs for `plugin add` to mention `plugin use` rather than `register` (oops)
