### PR TITLE
Fix raw strings as external argument

### DIFF
--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -228,6 +228,8 @@ fn parse_external_arg(working_set: &mut StateWorkingSet, span: Span) -> External
         ExternalArgument::Regular(parse_dollar_expr(working_set, span))
     } else if contents.starts_with(b"[") {
         ExternalArgument::Regular(parse_list_expression(working_set, span, &SyntaxShape::Any))
+    } else if contents.starts_with(b"r#") {
+        ExternalArgument::Regular(parse_raw_string(working_set, span))
     } else if contents.len() > 3
         && contents.starts_with(b"...")
         && (contents[3] == b'$' || contents[3] == b'[' || contents[3] == b'(')

--- a/src/tests/test_strings.rs
+++ b/src/tests/test_strings.rs
@@ -154,11 +154,6 @@ fn raw_string_inside_closure() -> TestResult {
 }
 
 #[test]
-fn raw_string_as_external_argument() -> TestResult {
-    run_test("nu --testbin cococo r#'asdf'#", "asdf")
-}
-
-#[test]
 fn incomplete_raw_string() -> TestResult {
     fail_test("r#abc", "expected '")
 }

--- a/src/tests/test_strings.rs
+++ b/src/tests/test_strings.rs
@@ -154,6 +154,11 @@ fn raw_string_inside_closure() -> TestResult {
 }
 
 #[test]
+fn raw_string_as_external_argument() -> TestResult {
+    run_test("nu --testbin cococo r#'asdf'#", "asdf")
+}
+
+#[test]
 fn incomplete_raw_string() -> TestResult {
     fail_test("r#abc", "expected '")
 }

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -314,6 +314,7 @@ mod external_words {
     use super::nu;
     use nu_test_support::fs::Stub::FileWithContent;
     use nu_test_support::{pipeline, playground::Playground};
+
     #[test]
     fn relaxed_external_words() {
         let actual = nu!("
@@ -321,6 +322,12 @@ mod external_words {
         ");
 
         assert_eq!(actual.out, "joturner@foo.bar.baz");
+    }
+
+    #[test]
+    fn raw_string_as_external_argument() {
+        let actual = nu!("nu --testbin cococo r#'asdf'#");
+        assert_eq!(actual.out, "asdf");
     }
 
     //FIXME: jt: limitation in testing - can't use single ticks currently


### PR DESCRIPTION
# Description
As discovered by @YizhePKU in a [comment](https://github.com/nushell/nushell/pull/9956#issuecomment-2103123797) in #9956, raw strings are not parsed properly when they are used as an argument to an external command. This PR fixes that.

# Tests + Formatting
Added a test.