### PR TITLE
Fix pipe redirection into `complete`

### DIFF
--- a/crates/nu-command/tests/commands/complete.rs
+++ b/crates/nu-command/tests/commands/complete.rs
@@ -92,3 +92,16 @@ fn capture_error_with_both_stdout_stderr_messages_not_hang_nushell() {
         },
     )
 }
+
+#[test]
+fn combined_pipe_redirection() {
+    let actual = nu!("$env.FOO = hello; $env.BAR = world; nu --testbin echo_env_mixed out-err FOO BAR o+e>| complete | get stdout");
+    assert_eq!(actual.out, "helloworld");
+}
+
+#[test]
+fn err_pipe_redirection() {
+    let actual =
+        nu!("$env.FOO = hello; nu --testbin echo_env_stderr FOO e>| complete | get stdout");
+    assert_eq!(actual.out, "hello");
+}


### PR DESCRIPTION
# Description
Fixes #12796 where a combined out and err pipe redirection (`o+e>|`) into `complete` still provides separate `stdout` and `stderr` columns in the record. Now, the combined output will be in the `stdout` column. This PR also fixes a similar error with the `e>|` pipe redirection.

# Tests + Formatting
Added two tests.