### PR TITLE
prevent auto-cd '../' from rendering nushell unusable

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -900,7 +900,7 @@ fn do_auto_cd(
     engine_state: &mut EngineState,
     span: Span,
 ) {
-    let path = {
+    let mut path = {
         if !path.exists() {
             report_error_new(
                 engine_state,
@@ -921,6 +921,10 @@ fn do_auto_cd(
             },
         );
         return;
+    }
+
+    if path.ends_with('/') {
+        path.pop();
     }
 
     stack.add_env_var("OLDPWD".into(), Value::string(cwd.clone(), Span::unknown()));


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

I was playing around with nushell when I stumbled upon this rendering the shell unusable:
```
~/CodingProjects/nushell> ../                                                                                       10/05/2024 12:49:17
Error:   × $env.PWD contains trailing slashes


Error:   × $env.PWD contains trailing slashes


Error:   × $env.PWD contains trailing slashes


Error:   × $env.PWD contains trailing slashes


Error:   × $env.PWD contains trailing slashes

~/CodingProjects> exit                                                                                              10/05/2024 12:50:15
Error:   × $env.PWD contains trailing slashes


Error:   × $env.PWD contains trailing slashes


Error:   × $env.PWD contains trailing slashes


Error:   × $env.PWD contains trailing slashes


Error:   × $env.PWD contains trailing slashes

```

This PR resolves that issue.