### PR TITLE
Fix custom converters with `save`

### DIFF
--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -416,11 +416,11 @@ fn save_with_custom_converter() {
         nu!(cwd: dirs.test(), pipeline(
             r#"
                 def "to ndjson" []: any -> string { each { to json --raw } | to text } ;
-                [a b] | save test.ndjson
+                {a: 1, b: 2} | save test.ndjson
             "#
         ));
 
         let actual = file_contents(file);
-        assert_eq!(actual, "\"a\"\n\"b\"\n");
+        assert_eq!(actual, r#"{"a":1,"b":2}"#);
     })
 }

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -407,3 +407,20 @@ fn save_same_file_without_extension_pipeline() {
             .contains("pipeline input and output are the same file"));
     })
 }
+
+#[test]
+fn save_with_custom_converter() {
+    Playground::setup("save_with_custom_converter", |dirs, _| {
+        let file = dirs.test().join("test.ndjson");
+
+        nu!(cwd: dirs.test(), pipeline(
+            r#"
+                def "to ndjson" []: any -> string { each { to json --raw } | to text } ;
+                [a b] | save test.ndjson
+            "#
+        ));
+
+        let actual = file_contents(file);
+        assert_eq!(actual, "\"a\"\n\"b\"\n");
+    })
+}


### PR DESCRIPTION
# Description
Fixes #10429 where `save` fails if a custom command is used as the file format converter.

# Tests + Formatting
Added a test.
