### PR TITLE
remove --not flag for 'str contains'

### DIFF
--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -40,7 +40,7 @@ impl Command for SubCommand {
                 "For a data structure input, check strings at the given cell paths, and replace with result.",
             )
             .switch("ignore-case", "search is case insensitive", Some('i'))
-            .switch("not", "does not contain", Some('n'))
+            .switch("not", "DEPRECATED OPTION: does not contain", Some('n'))
             .category(Category::Strings)
     }
 
@@ -59,6 +59,19 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
+        if call.has_flag(engine_state, stack, "not")? {
+            nu_protocol::report_error_new(
+                engine_state,
+                &ShellError::GenericError {
+                    error: "Deprecated option".into(),
+                    msg: "`str contains --not {string}` is deprecated and will be removed in 0.95.".into(),
+                    span: Some(call.head),
+                    help: Some("Please use the `not` operator instead.".into()),
+                    inner: vec![],
+                },
+            );
+        }
+
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 1)?;
         let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
         let args = Arguments {
@@ -118,15 +131,6 @@ impl Command for SubCommand {
                     Value::test_bool(true),
                     Value::test_bool(true),
                     Value::test_bool(false),
-                ])),
-            },
-            Example {
-                description: "Check if list does not contain string",
-                example: "[one two three] | str contains --not o",
-                result: Some(Value::test_list(vec![
-                    Value::test_bool(false),
-                    Value::test_bool(false),
-                    Value::test_bool(true),
                 ])),
             },
         ]

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -64,7 +64,8 @@ impl Command for SubCommand {
                 engine_state,
                 &ShellError::GenericError {
                     error: "Deprecated option".into(),
-                    msg: "`str contains --not {string}` is deprecated and will be removed in 0.95.".into(),
+                    msg: "`str contains --not {string}` is deprecated and will be removed in 0.95."
+                        .into(),
                     span: Some(call.head),
                     help: Some("Please use the `not` operator instead.".into()),
                     inner: vec![],

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -10,6 +10,7 @@ struct Arguments {
     substring: String,
     cell_paths: Option<Vec<CellPath>>,
     case_insensitive: bool,
+    not_contain: bool,
 }
 
 impl CmdArgument for Arguments {
@@ -39,6 +40,7 @@ impl Command for SubCommand {
                 "For a data structure input, check strings at the given cell paths, and replace with result.",
             )
             .switch("ignore-case", "search is case insensitive", Some('i'))
+            .switch("not", "does not contain", Some('n'))
             .category(Category::Strings)
     }
 
@@ -63,6 +65,7 @@ impl Command for SubCommand {
             substring: call.req::<String>(engine_state, stack, 0)?,
             cell_paths,
             case_insensitive: call.has_flag(engine_state, stack, "ignore-case")?,
+            not_contain: call.has_flag(engine_state, stack, "not")?,
         };
         operate(action, args, input, call.head, engine_state.ctrlc.clone())
     }
@@ -117,6 +120,15 @@ impl Command for SubCommand {
                     Value::test_bool(false),
                 ])),
             },
+            Example {
+                description: "Check if list does not contain string",
+                example: "[one two three] | str contains --not o",
+                result: Some(Value::test_list(vec![
+                    Value::test_bool(false),
+                    Value::test_bool(false),
+                    Value::test_bool(true),
+                ])),
+            },
         ]
     }
 }
@@ -125,6 +137,7 @@ fn action(
     input: &Value,
     Arguments {
         case_insensitive,
+        not_contain,
         substring,
         ..
     }: &Arguments,
@@ -133,10 +146,22 @@ fn action(
     match input {
         Value::String { val, .. } => Value::bool(
             match case_insensitive {
-                true => val
-                    .to_folded_case()
-                    .contains(substring.to_folded_case().as_str()),
-                false => val.contains(substring),
+                true => {
+                    if *not_contain {
+                        !val.to_folded_case()
+                            .contains(substring.to_folded_case().as_str())
+                    } else {
+                        val.to_folded_case()
+                            .contains(substring.to_folded_case().as_str())
+                    }
+                }
+                false => {
+                    if *not_contain {
+                        !val.contains(substring)
+                    } else {
+                        val.contains(substring)
+                    }
+                }
             },
             head,
         ),


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR resolves an inconsistency between different `str` subcommands, notably `str contains`, `str starts-with` and `str ends-with`. Only the `str contains` command has the `--not` flag and a desicion was made in this #12781 PR to remove the `--not` flag and use the `not` operator instead. 

Before:
`"blob" | str contains --not o`
After:
`not ("blob" | str contains o)` OR `"blob" | str contains o | not $in`

> Note, you can currently do all three, but the first will be broken after this PR is merged.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
- remove `--not(-n)` flag from `str contains` command
  - This is a breaking change!

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- [x] Added tests
- [x] Ran `cargo fmt --all`
- [x] Ran `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used`
- [x] Ran `cargo test --workspace`
- [ ] Ran `cargo run -- -c "use std testing; testing run-tests --path crates/nu-std"`
    - I was unable to get this working.
```
Error: nu::parser::export_not_found

  × Export not found.
   ╭─[source:1:9]
 1 │ use std testing; testing run-tests --path crates/nu-std
   ·         ───┬───
   ·            ╰── could not find imports
   ╰────
```
^ I still can't figure out how to make this work 😂 

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
Requires update of documentation
