### PR TITLE
Create separate `nu-testbin` binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,6 +302,11 @@ name = "nu"
 path = "src/main.rs"
 bench = false
 
+# Test binary
+[[bin]]
+name = "nu-testbin"
+path = "testbin/src/main.rs"
+
 # To use a development version of a dependency please use a global override here
 # changing versions in each sub-crate of the workspace is tedious
 [patch.crates-io]

--- a/crates/nu-cmd-extra/tests/commands/bytes/starts_with.rs
+++ b/crates/nu-cmd-extra/tests/commands/bytes/starts_with.rs
@@ -22,7 +22,7 @@ fn basic_string_fails() {
 #[test]
 fn short_stream_binary() {
     let actual = nu!(r#"
-            nu --testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101]
+            nu-testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101]
         "#);
 
     assert_eq!(actual.out, "true");
@@ -31,7 +31,7 @@ fn short_stream_binary() {
 #[test]
 fn short_stream_mismatch() {
     let actual = nu!(r#"
-            nu --testbin repeater (0x[010203]) 5 | bytes starts-with 0x[010204]
+            nu-testbin repeater (0x[010203]) 5 | bytes starts-with 0x[010204]
         "#);
 
     assert_eq!(actual.out, "false");
@@ -40,7 +40,7 @@ fn short_stream_mismatch() {
 #[test]
 fn short_stream_binary_overflow() {
     let actual = nu!(r#"
-            nu --testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101010101]
+            nu-testbin repeater (0x[01]) 5 | bytes starts-with 0x[010101010101]
         "#);
 
     assert_eq!(actual.out, "false");
@@ -49,7 +49,7 @@ fn short_stream_binary_overflow() {
 #[test]
 fn long_stream_binary() {
     let actual = nu!(r#"
-            nu --testbin repeater (0x[01]) 32768 | bytes starts-with 0x[010101]
+            nu-testbin repeater (0x[01]) 32768 | bytes starts-with 0x[010101]
         "#);
 
     assert_eq!(actual.out, "true");
@@ -59,7 +59,7 @@ fn long_stream_binary() {
 fn long_stream_binary_overflow() {
     // .. ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            nu --testbin repeater (0x[01]) 32768 | bytes starts-with (0..32768 | each {|| 0x[01] } | bytes collect)
+            nu-testbin repeater (0x[01]) 32768 | bytes starts-with (0..32768 | each {|| 0x[01] } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "false");
@@ -69,7 +69,7 @@ fn long_stream_binary_overflow() {
 fn long_stream_binary_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            nu --testbin repeater (0x[01020304]) 8192 | bytes starts-with (0..<8192 | each {|| 0x[01020304] } | bytes collect)
+            nu-testbin repeater (0x[01020304]) 8192 | bytes starts-with (0..<8192 | each {|| 0x[01020304] } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "true");
@@ -79,7 +79,7 @@ fn long_stream_binary_exact() {
 fn long_stream_string_exact() {
     // ranges are inclusive..inclusive, so we don't need to +1 to check for an overflow
     let actual = nu!(r#"
-            nu --testbin repeater hell 8192 | bytes starts-with (0..<8192 | each {|| "hell" | into binary } | bytes collect)
+            nu-testbin repeater hell 8192 | bytes starts-with (0..<8192 | each {|| "hell" | into binary } | bytes collect)
         "#);
 
     assert_eq!(actual.out, "true");
@@ -92,7 +92,7 @@ fn long_stream_mixed_exact() {
             let binseg = (0..<2048 | each {|| 0x[003d9fbf] } | bytes collect)
             let strseg = (0..<2048 | each {|| "hell" | into binary } | bytes collect)
 
-            nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg)
+            nu-testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg)
         "#);
 
     assert_eq!(
@@ -109,7 +109,7 @@ fn long_stream_mixed_overflow() {
             let binseg = (0..<2048 | each {|| 0x[003d9fbf] } | bytes collect)
             let strseg = (0..<2048 | each {|| "hell" | into binary } | bytes collect)
 
-            nu --testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg 0x[01])
+            nu-testbin repeat_bytes 003d9fbf 2048 68656c6c 2048 | bytes starts-with (bytes build $binseg $strseg 0x[01])
         "#);
 
     assert_eq!(

--- a/crates/nu-command/tests/commands/complete.rs
+++ b/crates/nu-command/tests/commands/complete.rs
@@ -3,10 +3,10 @@ use nu_test_support::nu;
 #[test]
 fn basic_stdout() {
     let without_complete = nu!(r#"
-        nu --testbin cococo test
+        nu-testbin cococo test
     "#);
     let with_complete = nu!(r#"
-        (nu --testbin cococo test | complete).stdout
+        (nu-testbin cococo test | complete).stdout
     "#);
 
     assert_eq!(with_complete.out, without_complete.out);
@@ -15,7 +15,7 @@ fn basic_stdout() {
 #[test]
 fn basic_exit_code() {
     let with_complete = nu!(r#"
-        (nu --testbin cococo test | complete).exit_code
+        (nu-testbin cococo test | complete).exit_code
     "#);
 
     assert_eq!(with_complete.out, "0");
@@ -95,13 +95,12 @@ fn capture_error_with_both_stdout_stderr_messages_not_hang_nushell() {
 
 #[test]
 fn combined_pipe_redirection() {
-    let actual = nu!("$env.FOO = hello; $env.BAR = world; nu --testbin echo_env_mixed out-err FOO BAR o+e>| complete | get stdout");
+    let actual = nu!("$env.FOO = hello; $env.BAR = world; nu-testbin echo_env_mixed out-err FOO BAR o+e>| complete | get stdout");
     assert_eq!(actual.out, "helloworld");
 }
 
 #[test]
 fn err_pipe_redirection() {
-    let actual =
-        nu!("$env.FOO = hello; nu --testbin echo_env_stderr FOO e>| complete | get stdout");
+    let actual = nu!("$env.FOO = hello; nu-testbin echo_env_stderr FOO e>| complete | get stdout");
     assert_eq!(actual.out, "hello");
 }

--- a/crates/nu-command/tests/commands/debug/timeit.rs
+++ b/crates/nu-command/tests/commands/debug/timeit.rs
@@ -2,13 +2,13 @@ use nu_test_support::nu;
 
 #[test]
 fn timeit_show_stdout() {
-    let actual = nu!("let t = timeit nu --testbin cococo abcdefg");
+    let actual = nu!("let t = timeit nu-testbin cococo abcdefg");
     assert_eq!(actual.out, "abcdefg");
 }
 
 #[test]
 fn timeit_show_stderr() {
-    let actual = nu!(" with-env {FOO: bar, FOO2: baz} { let t = timeit { nu --testbin echo_env_mixed out-err FOO FOO2 } }");
+    let actual = nu!(" with-env {FOO: bar, FOO2: baz} { let t = timeit { nu-testbin echo_env_mixed out-err FOO FOO2 } }");
     assert!(actual.out.contains("bar"));
     assert!(actual.err.contains("baz"));
 }

--- a/crates/nu-command/tests/commands/def.rs
+++ b/crates/nu-command/tests/commands/def.rs
@@ -184,7 +184,7 @@ fn def_wrapped_with_block() {
 #[test]
 fn def_wrapped_from_module() {
     let actual = nu!(r#"module spam {
-            export def --wrapped my-echo [...rest] { nu --testbin cococo ...$rest }
+            export def --wrapped my-echo [...rest] { nu-testbin cococo ...$rest }
         }
 
         use spam

--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -11,21 +11,21 @@ fn capture_errors_works() {
 
 #[test]
 fn capture_errors_works_for_external() {
-    let actual = nu!("do -c {nu --testbin fail}");
+    let actual = nu!("do -c {nu-testbin fail}");
     assert!(actual.err.contains("External command failed"));
     assert_eq!(actual.out, "");
 }
 
 #[test]
 fn capture_errors_works_for_external_with_pipeline() {
-    let actual = nu!("do -c {nu --testbin fail} | echo `text`");
+    let actual = nu!("do -c {nu-testbin fail} | echo `text`");
     assert!(actual.err.contains("External command failed"));
     assert_eq!(actual.out, "");
 }
 
 #[test]
 fn capture_errors_works_for_external_with_semicolon() {
-    let actual = nu!(r#"do -c {nu --testbin fail}; echo `text`"#);
+    let actual = nu!(r#"do -c {nu-testbin fail}; echo `text`"#);
     assert!(actual.err.contains("External command failed"));
     assert_eq!(actual.out, "");
 }
@@ -55,7 +55,7 @@ fn ignore_program_errors_works_for_external_with_semicolon() {
 
 #[test]
 fn ignore_error_should_work_for_external_command() {
-    let actual = nu!(r#"do -i { nu --testbin fail asdf }; echo post"#);
+    let actual = nu!(r#"do -i { nu-testbin fail asdf }; echo post"#);
 
     assert_eq!(actual.err, "");
     assert_eq!(actual.out, "post");

--- a/crates/nu-command/tests/commands/each.rs
+++ b/crates/nu-command/tests/commands/each.rs
@@ -38,7 +38,7 @@ fn each_no_args_in_block() {
 #[test]
 fn each_implicit_it_in_block() {
     let actual = nu!(
-        "echo [[foo bar]; [a b] [c d] [e f]] | each { |it| nu --testbin cococo $it.foo } | str join"
+        "echo [[foo bar]; [a b] [c d] [e f]] | each { |it| nu-testbin cococo $it.foo } | str join"
     );
 
     assert_eq!(actual.out, "ace");

--- a/crates/nu-command/tests/commands/exec.rs
+++ b/crates/nu-command/tests/commands/exec.rs
@@ -7,7 +7,7 @@ fn basic_exec() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu -n -c 'exec nu --testbin cococo a b c'
+                nu -n -c 'exec nu-testbin cococo a b c'
             "#
         ));
 
@@ -21,7 +21,7 @@ fn exec_complex_args() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu -n -c 'exec nu --testbin cococo b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --'
+                nu -n -c 'exec nu-testbin cococo b --bar=2 -sab --arwr - -DTEEE=aasd-290 -90 --'
             "#
         ));
 
@@ -30,16 +30,17 @@ fn exec_complex_args() {
 }
 
 #[test]
-fn exec_fail_batched_short_args() {
+fn exec_fail() {
     Playground::setup("test_exec_3", |dirs, _| {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu -n -c 'exec nu --testbin cococo -ab 10'
+                nu -n -c 'exec nu-testbin cocono'
             "#
         ));
 
         assert_eq!(actual.out, "");
+        assert_eq!(actual.err, "unknown command: cocono\n");
     })
 }
 
@@ -49,7 +50,7 @@ fn exec_misc_values() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu -n -c 'let x = "abc"; exec nu --testbin cococo $x ...[ a b c ]'
+                nu -n -c 'let x = "abc"; exec nu-testbin cococo $x ...[ a b c ]'
             "#
         ));
 

--- a/crates/nu-command/tests/commands/for_.rs
+++ b/crates/nu-command/tests/commands/for_.rs
@@ -16,7 +16,7 @@ fn for_break_on_external_failed() {
     let actual = nu!("
         for i in 1..2 {
             print 1;
-            nu --testbin fail
+            nu-testbin fail
         }");
     // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`
@@ -27,7 +27,7 @@ fn for_break_on_external_failed() {
 fn failed_for_should_break_running() {
     let actual = nu!("
         for i in 1..2 {
-            nu --testbin fail
+            nu-testbin fail
         }
         print 3");
     assert!(!actual.out.contains('3'));
@@ -35,7 +35,7 @@ fn failed_for_should_break_running() {
     let actual = nu!("
         let x = [1 2]
         for i in $x {
-            nu --testbin fail
+            nu-testbin fail
         }
         print 3");
     assert!(!actual.out.contains('3'));

--- a/crates/nu-command/tests/commands/let_.rs
+++ b/crates/nu-command/tests/commands/let_.rs
@@ -55,7 +55,7 @@ fn let_pipeline_redirects_internals() {
 
 #[test]
 fn let_pipeline_redirects_externals() {
-    let actual = nu!(r#"let x = nu --testbin cococo 'bar'; $x | str length"#);
+    let actual = nu!(r#"let x = nu-testbin cococo 'bar'; $x | str length"#);
 
     assert_eq!(actual.out, "3");
 }
@@ -63,7 +63,7 @@ fn let_pipeline_redirects_externals() {
 #[test]
 fn let_err_pipeline_redirects_externals() {
     let actual = nu!(
-        r#"let x = with-env { FOO: "foo" } {nu --testbin echo_env_stderr FOO e>| str length}; $x"#
+        r#"let x = with-env { FOO: "foo" } {nu-testbin echo_env_stderr FOO e>| str length}; $x"#
     );
     assert_eq!(actual.out, "3");
 }
@@ -71,7 +71,7 @@ fn let_err_pipeline_redirects_externals() {
 #[test]
 fn let_outerr_pipeline_redirects_externals() {
     let actual = nu!(
-        r#"let x = with-env { FOO: "foo" } {nu --testbin echo_env_stderr FOO o+e>| str length}; $x"#
+        r#"let x = with-env { FOO: "foo" } {nu-testbin echo_env_stderr FOO o+e>| str length}; $x"#
     );
     assert_eq!(actual.out, "3");
 }
@@ -81,7 +81,7 @@ fn let_outerr_pipeline_redirects_externals() {
 fn let_with_external_failed() {
     // FIXME: this test hasn't run successfully for a long time. We should
     // bring it back to life at some point.
-    let actual = nu!(r#"let x = nu --testbin outcome_err "aa"; echo fail"#);
+    let actual = nu!(r#"let x = nu-testbin outcome_err "aa"; echo fail"#);
 
     assert!(!actual.out.contains("fail"));
 }

--- a/crates/nu-command/tests/commands/loop_.rs
+++ b/crates/nu-command/tests/commands/loop_.rs
@@ -28,7 +28,7 @@ fn loop_break_on_external_failed() {
                 $total += 1;
             }
             print 1;
-            nu --testbin fail;
+            nu-testbin fail;
         }");
     // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`.
@@ -45,7 +45,7 @@ fn failed_loop_should_break_running() {
             } else {
                 $total += 1;
             }
-            nu --testbin fail;
+            nu-testbin fail;
         }
         print 3");
     assert!(!actual.out.contains('3'));

--- a/crates/nu-command/tests/commands/redirection.rs
+++ b/crates/nu-command/tests/commands/redirection.rs
@@ -7,14 +7,14 @@ fn redirect_err() {
     Playground::setup("redirect_err_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            r#"$env.BAZ = "asdfasdfasdf.txt"; nu --testbin echo_env_stderr BAZ err> a.txt; open a.txt"#
+            r#"$env.BAZ = "asdfasdfasdf.txt"; nu-testbin echo_env_stderr BAZ err> a.txt; open a.txt"#
         );
         assert!(output.out.contains("asdfasdfasdf.txt"));
 
         // check append mode
         let output = nu!(
             cwd: dirs.test(),
-            r#"$env.BAZ = "asdfasdfasdf.txt"; nu --testbin echo_env_stderr BAZ err>> a.txt; open a.txt"#
+            r#"$env.BAZ = "asdfasdfasdf.txt"; nu-testbin echo_env_stderr BAZ err>> a.txt; open a.txt"#
         );
         let v: Vec<_> = output.out.match_indices("asdfasdfasdf.txt").collect();
         assert_eq!(v.len(), 2);
@@ -26,13 +26,13 @@ fn redirect_outerr() {
     Playground::setup("redirect_outerr_test", |dirs, _sandbox| {
         let output = nu!(
             cwd: dirs.test(),
-            r#"$env.BAZ = "asdfasdfasdf.txt"; nu --testbin echo_env_stderr BAZ out+err> a.txt; open a.txt"#
+            r#"$env.BAZ = "asdfasdfasdf.txt"; nu-testbin echo_env_stderr BAZ out+err> a.txt; open a.txt"#
         );
         assert!(output.out.contains("asdfasdfasdf.txt"));
 
         let output = nu!(
             cwd: dirs.test(),
-            r#"$env.BAZ = "asdfasdfasdf.txt"; nu --testbin echo_env_stderr BAZ o+e>> a.txt; open a.txt"#
+            r#"$env.BAZ = "asdfasdfasdf.txt"; nu-testbin echo_env_stderr BAZ o+e>> a.txt; open a.txt"#
         );
         let v: Vec<_> = output.out.match_indices("asdfasdfasdf.txt").collect();
         assert_eq!(v.len(), 2);
@@ -85,7 +85,7 @@ fn separate_redirection() {
             let expect_body = "message";
             nu!(
                 cwd: dirs.test(),
-                r#"$env.BAZ = "message"; nu --testbin echo_env_mixed out-err BAZ BAZ o> out.txt e> err.txt"#,
+                r#"$env.BAZ = "message"; nu-testbin echo_env_mixed out-err BAZ BAZ o> out.txt e> err.txt"#,
             );
 
             // check for stdout redirection file.
@@ -100,7 +100,7 @@ fn separate_redirection() {
 
             nu!(
                 cwd: dirs.test(),
-                r#"$env.BAZ = "message"; nu --testbin echo_env_mixed out-err BAZ BAZ o>> out.txt e>> err.txt"#,
+                r#"$env.BAZ = "message"; nu-testbin echo_env_mixed out-err BAZ BAZ o>> out.txt e>> err.txt"#,
             );
             // check for stdout redirection file.
             let expected_out_file = dirs.test().join("out.txt");
@@ -133,7 +133,7 @@ fn same_target_redirection_with_too_much_stderr_not_hang_nushell() {
             cwd: dirs.test(), pipeline(
                 "
                 $env.LARGE = (open --raw a_large_file.txt);
-                nu --testbin echo_env_stderr LARGE out+err> another_large_file.txt
+                nu-testbin echo_env_stderr LARGE out+err> another_large_file.txt
                 "
             ),
         );
@@ -149,7 +149,7 @@ fn same_target_redirection_with_too_much_stderr_not_hang_nushell() {
             cwd: dirs.test(), pipeline(
                 "
                 $env.LARGE = (open --raw a_large_file.txt);
-                nu --testbin echo_env_stderr LARGE out+err>> another_large_file.txt
+                nu-testbin echo_env_stderr LARGE out+err>> another_large_file.txt
                 "
             ),
         );
@@ -164,7 +164,7 @@ fn redirection_keep_exit_codes() {
     Playground::setup("redirection preserves exit code", |dirs, _| {
         let out = nu!(
             cwd: dirs.test(),
-            "nu --testbin fail e> a.txt | complete | get exit_code"
+            "nu-testbin fail e> a.txt | complete | get exit_code"
         );
         // needs to use contains "1", because it complete will output `Some(RawStream)`.
         assert!(out.out.contains('1'));
@@ -176,7 +176,7 @@ fn redirection_stderr_with_failed_program() {
     Playground::setup("redirection stderr with failed program", |dirs, _| {
         let out = nu!(
             cwd: dirs.test(),
-            r#"$env.FOO = "bar"; nu --testbin echo_env_stderr_fail FOO e> file.txt; echo 3"#
+            r#"$env.FOO = "bar"; nu-testbin echo_env_stderr_fail FOO e> file.txt; echo 3"#
         );
         // firstly echo 3 shouldn't run, because previous command runs to failed.
         // second `file.txt` should contain "bar".
@@ -193,7 +193,7 @@ fn redirection_with_non_zero_exit_code_should_stop_from_running() {
         for redirection in ["o>", "o>>", "e>", "e>>", "o+e>", "o+e>>"] {
             let output = nu!(
                 cwd: dirs.test(),
-                &format!("nu --testbin fail {redirection} log.txt; echo 3")
+                &format!("nu-testbin fail {redirection} log.txt; echo 3")
             );
             assert!(!output.out.contains('3'));
         }
@@ -203,7 +203,7 @@ fn redirection_with_non_zero_exit_code_should_stop_from_running() {
         for (out, err) in [("o>", "e>"), ("o>>", "e>"), ("o>", "e>>"), ("o>>", "e>>")] {
             let output = nu!(
                 cwd: dirs.test(),
-                &format!("nu --testbin fail {out} log.txt {err} err_log.txt; echo 3")
+                &format!("nu-testbin fail {out} log.txt {err} err_log.txt; echo 3")
             );
             assert!(!output.out.contains('3'));
         }
@@ -224,14 +224,14 @@ fn redirection_with_pipeline_works() {
 
             let actual = nu!(
                 cwd: dirs.test(),
-                r#"$env.BAZ = "message"; nu --testbin echo_env BAZ out> out.txt | describe; open out.txt"#,
+                r#"$env.BAZ = "message"; nu-testbin echo_env BAZ out> out.txt | describe; open out.txt"#,
             );
             assert!(actual.out.contains(expect_body));
 
             // check append mode works
             let actual = nu!(
                 cwd: dirs.test(),
-                r#"$env.BAZ = "message"; nu --testbin echo_env BAZ out>> out.txt | describe; open out.txt"#,
+                r#"$env.BAZ = "message"; nu-testbin echo_env BAZ out>> out.txt | describe; open out.txt"#,
             );
             let v: Vec<_> = actual.out.match_indices("message").collect();
             assert_eq!(v.len(), 2);
@@ -287,7 +287,7 @@ fn separate_redirection_support_variable() {
                 r#"
             let o_f = "out2.txt"
             let e_f = "err2.txt"
-            $env.BAZ = "message"; nu --testbin echo_env_mixed out-err BAZ BAZ o> $o_f e> $e_f"#,
+            $env.BAZ = "message"; nu-testbin echo_env_mixed out-err BAZ BAZ o> $o_f e> $e_f"#,
             );
             // check for stdout redirection file.
             let expected_out_file = dirs.test().join("out2.txt");
@@ -304,7 +304,7 @@ fn separate_redirection_support_variable() {
                 r#"
             let o_f = "out2.txt"
             let e_f = "err2.txt"
-            $env.BAZ = "message"; nu --testbin echo_env_mixed out-err BAZ BAZ out>> $o_f err>> $e_f"#,
+            $env.BAZ = "message"; nu-testbin echo_env_mixed out-err BAZ BAZ out>> $o_f err>> $e_f"#,
             );
             // check for stdout redirection file.
             let expected_out_file = dirs.test().join("out2.txt");
@@ -355,7 +355,7 @@ fn redirection_with_out_pipe() {
         // check for stdout
         let actual = nu!(
             cwd: dirs.test(),
-            r#"$env.BAZ = "message"; nu --testbin echo_env_mixed out-err BAZ BAZ err> tmp_file | str length"#,
+            r#"$env.BAZ = "message"; nu-testbin echo_env_mixed out-err BAZ BAZ err> tmp_file | str length"#,
         );
 
         assert_eq!(actual.out, "7");
@@ -373,7 +373,7 @@ fn redirection_with_err_pipe() {
         // check for stdout
         let actual = nu!(
             cwd: dirs.test(),
-            r#"$env.BAZ = "message"; nu --testbin echo_env_mixed out-err BAZ BAZ out> tmp_file e>| str length"#,
+            r#"$env.BAZ = "message"; nu-testbin echo_env_mixed out-err BAZ BAZ out> tmp_file e>| str length"#,
         );
 
         assert_eq!(actual.out, "7");

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -8,7 +8,7 @@ fn better_empty_redirection() {
     let actual = nu!(
         cwd: "tests/fixtures/formats", pipeline(
         "
-            ls | each { |it| nu --testbin cococo $it.name } | ignore
+            ls | each { |it| nu-testbin cococo $it.name } | ignore
         "
     ));
 
@@ -145,7 +145,7 @@ fn external_args_with_quoted() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu --testbin cococo "foo=bar 'hi'"
+                nu-testbin cococo "foo=bar 'hi'"
             "#
         ));
 
@@ -175,7 +175,7 @@ fn external_arg_with_variable_name() {
             cwd: dirs.test(), pipeline(
             r#"
                 let dump_command = "PGPASSWORD='db_secret' pg_dump -Fc -h 'db.host' -p '$db.port' -U postgres -d 'db_name' > '/tmp/dump_name'";
-                nu --testbin nonu $dump_command
+                nu-testbin nonu $dump_command
             "#
         ));
 
@@ -192,7 +192,7 @@ fn external_command_escape_args() {
         let actual = nu!(
             cwd: dirs.test(), pipeline(
             r#"
-                nu --testbin cococo "\"abcd"
+                nu-testbin cococo "\"abcd"
             "#
         ));
 
@@ -205,7 +205,7 @@ fn external_command_not_expand_tilde_with_quotes() {
     Playground::setup(
         "external command not expand tilde with quotes",
         |dirs, _| {
-            let actual = nu!(cwd: dirs.test(), pipeline(r#"nu --testbin nonu "~""#));
+            let actual = nu!(cwd: dirs.test(), pipeline(r#"nu-testbin nonu "~""#));
             assert_eq!(actual.out, r#"~"#);
         },
     )
@@ -216,7 +216,7 @@ fn external_command_expand_tilde_with_back_quotes() {
     Playground::setup(
         "external command not expand tilde with quotes",
         |dirs, _| {
-            let actual = nu!(cwd: dirs.test(), pipeline(r#"nu --testbin nonu `~`"#));
+            let actual = nu!(cwd: dirs.test(), pipeline(r#"nu-testbin nonu `~`"#));
             assert!(!actual.out.contains('~'));
         },
     )
@@ -226,7 +226,7 @@ fn external_command_expand_tilde_with_back_quotes() {
 fn external_command_receives_raw_binary_data() {
     Playground::setup("external command receives raw binary data", |dirs, _| {
         let actual =
-            nu!(cwd: dirs.test(), pipeline("0x[deadbeef] | nu --testbin input_bytes_length"));
+            nu!(cwd: dirs.test(), pipeline("0x[deadbeef] | nu-testbin input_bytes_length"));
         assert_eq!(actual.out, r#"4"#);
     })
 }
@@ -311,7 +311,7 @@ fn quotes_trimmed_when_shelling_out() {
     // regression test for a bug where we weren't trimming quotes around string args before shelling out to cmd.exe
     let actual = nu!(pipeline(
         r#"
-            nu --testbin cococo "foo"
+            nu-testbin cococo "foo"
         "#
     ));
 

--- a/crates/nu-command/tests/commands/save.rs
+++ b/crates/nu-command/tests/commands/save.rs
@@ -93,7 +93,7 @@ fn save_stderr_and_stdout_to_afame_file() {
             r#"
             $env.FOO = "bar";
             $env.BAZ = "ZZZ";
-            do -c {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_5/new-file.txt --stderr save_test_5/new-file.txt
+            do -c {nu -n -c 'nu-testbin echo_env FOO; nu-testbin echo_env_stderr BAZ'} | save -r save_test_5/new-file.txt --stderr save_test_5/new-file.txt
             "#,
         );
         assert!(actual
@@ -115,7 +115,7 @@ fn save_stderr_and_stdout_to_diff_file() {
             r#"
             $env.FOO = "bar";
             $env.BAZ = "ZZZ";
-            do -c {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_6/log.txt --stderr save_test_6/err.txt
+            do -c {nu -n -c 'nu-testbin echo_env FOO; nu-testbin echo_env_stderr BAZ'} | save -r save_test_6/log.txt --stderr save_test_6/err.txt
             "#,
         );
 
@@ -208,7 +208,7 @@ fn save_append_works_on_stderr() {
             r#"
             $env.FOO = " New";
             $env.BAZ = " New Err";
-            do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -a -r save_test_11/log.txt --stderr save_test_11/err.txt"#,
+            do -i {nu -n -c 'nu-testbin echo_env FOO; nu-testbin echo_env_stderr BAZ'} | save -a -r save_test_11/log.txt --stderr save_test_11/err.txt"#,
         );
 
         let actual = file_contents(expected_file);
@@ -229,7 +229,7 @@ fn save_not_overrides_err_by_default() {
             r#"
             $env.FOO = " New";
             $env.BAZ = " New Err";
-            do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -r save_test_12/log.txt --stderr save_test_12/err.txt"#,
+            do -i {nu -n -c 'nu-testbin echo_env FOO; nu-testbin echo_env_stderr BAZ'} | save -r save_test_12/log.txt --stderr save_test_12/err.txt"#,
         );
 
         assert!(actual.err.contains("Destination file already exists"));
@@ -252,7 +252,7 @@ fn save_override_works_stderr() {
             r#"
             $env.FOO = "New";
             $env.BAZ = "New Err";
-            do -i {nu -n -c 'nu --testbin echo_env FOO; nu --testbin echo_env_stderr BAZ'} | save -f -r save_test_13/log.txt --stderr save_test_13/err.txt"#,
+            do -i {nu -n -c 'nu-testbin echo_env FOO; nu-testbin echo_env_stderr BAZ'} | save -f -r save_test_13/log.txt --stderr save_test_13/err.txt"#,
         );
 
         let actual = file_contents(expected_file);

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -387,7 +387,7 @@ fn str_reverse() {
 #[test]
 fn test_redirection_trim() {
     let actual = nu!(r#"
-        let x = (nu --testbin cococo niceone); $x | str trim | str length
+        let x = (nu-testbin cococo niceone); $x | str trim | str length
         "#);
 
     assert_eq!(actual.out, "7");

--- a/crates/nu-command/tests/commands/tee.rs
+++ b/crates/nu-command/tests/commands/tee.rs
@@ -22,7 +22,7 @@ fn tee_save_stdout_to_file() {
             cwd: dirs.test(),
             r#"
                 $env.FOO = "teststring"
-                nu --testbin echo_env FOO | tee { save copy.txt }
+                nu-testbin echo_env FOO | tee { save copy.txt }
             "#
         );
         assert_eq!("teststring", output.out);
@@ -37,7 +37,7 @@ fn tee_save_stderr_to_file() {
             cwd: dirs.test(),
             "\
                 $env.FOO = \"teststring\"; \
-                do { nu --testbin echo_env_stderr FOO } | \
+                do { nu-testbin echo_env_stderr FOO } | \
                     tee --stderr { save copy.txt } | \
                     complete | \
                     get stderr

--- a/crates/nu-command/tests/commands/try_.rs
+++ b/crates/nu-command/tests/commands/try_.rs
@@ -30,7 +30,7 @@ fn catch_can_access_error_as_dollar_in() {
 
 #[test]
 fn external_failed_should_be_caught() {
-    let output = nu!("try { nu --testbin fail; echo 'success' } catch { echo 'fail' }");
+    let output = nu!("try { nu-testbin fail; echo 'success' } catch { echo 'fail' }");
 
     assert!(output.out.contains("fail"));
 }

--- a/crates/nu-command/tests/commands/while_.rs
+++ b/crates/nu-command/tests/commands/while_.rs
@@ -20,7 +20,7 @@ fn while_doesnt_auto_print_in_each_iteration() {
 #[test]
 fn while_break_on_external_failed() {
     let actual =
-        nu!("mut total = 0; while $total < 2 { $total = $total + 1; print 1; nu --testbin fail }");
+        nu!("mut total = 0; while $total < 2 { $total = $total + 1; print 1; nu-testbin fail }");
     // Note: nu! macro auto replace "\n" and "\r\n" with ""
     // so our output will be `1`
     assert_eq!(actual.out, "1");
@@ -29,6 +29,6 @@ fn while_break_on_external_failed() {
 #[test]
 fn failed_while_should_break_running() {
     let actual =
-        nu!("mut total = 0; while $total < 2 { $total = $total + 1; nu --testbin fail }; print 3");
+        nu!("mut total = 0; while $total < 2 { $total = $total + 1; nu-testbin fail }; print 3");
     assert!(!actual.out.contains('3'));
 }

--- a/crates/nu-command/tests/commands/with_env.rs
+++ b/crates/nu-command/tests/commands/with_env.rs
@@ -16,7 +16,7 @@ fn with_env_shorthand() {
 
 #[test]
 fn shorthand_doesnt_reorder_arguments() {
-    let actual = nu!("FOO=BARRRR nu --testbin cococo first second");
+    let actual = nu!("FOO=BARRRR nu-testbin cococo first second");
 
     assert_eq!(actual.out, "first second");
 }
@@ -39,8 +39,7 @@ fn with_env_and_shorthand_same_result() {
 
 #[test]
 fn test_redirection2() {
-    let actual =
-        nu!("let x = (FOO=BAR nu --testbin cococo niceenvvar); $x | str trim | str length");
+    let actual = nu!("let x = (FOO=BAR nu-testbin cococo niceenvvar); $x | str trim | str length");
 
     assert_eq!(actual.out, "10");
 }

--- a/crates/nu-test-support/src/lib.rs
+++ b/crates/nu-test-support/src/lib.rs
@@ -45,7 +45,7 @@ pub fn pipeline(commands: &str) -> String {
 }
 
 pub fn nu_repl_code(source_lines: &[&str]) -> String {
-    let mut out = String::from("nu --testbin=nu_repl ...[ ");
+    let mut out = String::from("nu-testbin nu_repl ...[ ");
 
     for line in source_lines.iter() {
         // convert each "line" to really be a single line to prevent nu! macro joining the newlines

--- a/crates/nu-test-support/src/playground/director.rs
+++ b/crates/nu-test-support/src/playground/director.rs
@@ -14,21 +14,6 @@ pub struct Director {
 }
 
 impl Director {
-    pub fn cococo(&self, arg: &str) -> Self {
-        let mut process = NuProcess {
-            environment_vars: self.environment_vars.clone(),
-            ..Default::default()
-        };
-
-        process.args(&["--testbin", "cococo", arg]);
-        Director {
-            config: self.config.clone(),
-            executable: Some(process),
-            environment_vars: self.environment_vars.clone(),
-            ..Default::default()
-        }
-    }
-
     pub fn and_then(&mut self, commands: &str) -> &mut Self {
         let commands = commands.to_string();
 

--- a/crates/nu-test-support/src/playground/play.rs
+++ b/crates/nu-test-support/src/playground/play.rs
@@ -156,10 +156,6 @@ impl<'a> Playground<'a> {
         }
     }
 
-    pub fn cococo(&mut self, arg: &str) -> Director {
-        self.build().cococo(arg)
-    }
-
     pub fn pipeline(&mut self, commands: &str) -> Director {
         self.build().pipeline(commands)
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -33,9 +33,8 @@ pub(crate) fn gather_commandline_args() -> (Vec<String>, String, Vec<String>) {
             | "--env-config" | "-I" | "ide-ast" => args.next().map(|a| escape_quote_string(&a)),
             #[cfg(feature = "plugin")]
             "--plugin-config" => args.next().map(|a| escape_quote_string(&a)),
-            "--log-level" | "--log-target" | "--testbin" | "--threads" | "-t"
-            | "--include-path" | "--lsp" | "--ide-goto-def" | "--ide-hover" | "--ide-complete"
-            | "--ide-check" => args.next(),
+            "--log-level" | "--log-target" | "--threads" | "-t" | "--include-path" | "--lsp"
+            | "--ide-goto-def" | "--ide-hover" | "--ide-complete" | "--ide-check" => args.next(),
             #[cfg(feature = "plugin")]
             "--plugins" => args.next(),
             _ => None,
@@ -85,7 +84,6 @@ pub(crate) fn parse_commandline_args(
             let login_shell = call.get_named_arg("login");
             let interactive_shell = call.get_named_arg("interactive");
             let commands = call.get_flag_expr("commands");
-            let testbin = call.get_flag_expr("testbin");
             #[cfg(feature = "plugin")]
             let plugin_file = call.get_flag_expr("plugin-config");
             #[cfg(feature = "plugin")]
@@ -156,7 +154,6 @@ pub(crate) fn parse_commandline_args(
             }
 
             let commands = extract_contents(commands)?;
-            let testbin = extract_contents(testbin)?;
             #[cfg(feature = "plugin")]
             let plugin_file = extract_path(plugin_file)?;
             let config_file = extract_path(config_file)?;
@@ -218,7 +215,6 @@ pub(crate) fn parse_commandline_args(
                 login_shell,
                 interactive_shell,
                 commands,
-                testbin,
                 #[cfg(feature = "plugin")]
                 plugin_file,
                 #[cfg(feature = "plugin")]
@@ -262,7 +258,6 @@ pub(crate) struct NushellCliArgs {
     pub(crate) login_shell: Option<Spanned<String>>,
     pub(crate) interactive_shell: Option<Spanned<String>>,
     pub(crate) commands: Option<Spanned<String>>,
-    pub(crate) testbin: Option<Spanned<String>>,
     #[cfg(feature = "plugin")]
     pub(crate) plugin_file: Option<Spanned<String>>,
     #[cfg(feature = "plugin")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ mod run;
 mod signals;
 #[cfg(unix)]
 mod terminal;
-mod test_bins;
 #[cfg(test)]
 mod tests;
 
@@ -165,9 +164,7 @@ fn main() -> Result<()> {
 
     // keep this condition in sync with the branches at the end
     engine_state.is_interactive = parsed_nu_cli_args.interactive_shell.is_some()
-        || (parsed_nu_cli_args.testbin.is_none()
-            && parsed_nu_cli_args.commands.is_none()
-            && script_name.is_empty());
+        || (parsed_nu_cli_args.commands.is_none() && script_name.is_empty());
 
     engine_state.is_login = parsed_nu_cli_args.login_shell.is_some();
 
@@ -310,39 +307,6 @@ fn main() -> Result<()> {
 
         return Ok(());
     }
-
-    start_time = std::time::Instant::now();
-    if let Some(testbin) = &parsed_nu_cli_args.testbin {
-        // Call out to the correct testbin
-        match testbin.item.as_str() {
-            "echo_env" => test_bins::echo_env(true),
-            "echo_env_stderr" => test_bins::echo_env(false),
-            "echo_env_stderr_fail" => test_bins::echo_env_and_fail(false),
-            "echo_env_mixed" => test_bins::echo_env_mixed(),
-            "cococo" => test_bins::cococo(),
-            "meow" => test_bins::meow(),
-            "meowb" => test_bins::meowb(),
-            "relay" => test_bins::relay(),
-            "iecho" => test_bins::iecho(),
-            "fail" => test_bins::fail(),
-            "nonu" => test_bins::nonu(),
-            "chop" => test_bins::chop(),
-            "repeater" => test_bins::repeater(),
-            "repeat_bytes" => test_bins::repeat_bytes(),
-            "nu_repl" => test_bins::nu_repl(),
-            "input_bytes_length" => test_bins::input_bytes_length(),
-            _ => std::process::exit(1),
-        }
-        std::process::exit(0)
-    }
-    perf(
-        "run test_bins",
-        start_time,
-        file!(),
-        line!(),
-        column!(),
-        use_color,
-    );
 
     start_time = std::time::Instant::now();
     let input = if let Some(redirect_stdin) = &parsed_nu_cli_args.redirect_stdin {

--- a/src/tests/test_spread.rs
+++ b/src/tests/test_spread.rs
@@ -101,12 +101,12 @@ fn spread_type_record() -> TestResult {
 #[test]
 fn spread_external_args() {
     assert_eq!(
-        nu!(r#"nu --testbin cococo ...[1 "foo"] 2 ...[3 "bar"]"#).out,
+        nu!(r#"nu-testbin cococo ...[1 "foo"] 2 ...[3 "bar"]"#).out,
         "1 foo 2 3 bar",
     );
     // exec doesn't have rest parameters but allows unknown arguments
     assert_eq!(
-        nu!(r#"exec nu --testbin cococo "foo" ...[5 6]"#).out,
+        nu!(r#"exec nu-testbin cococo "foo" ...[5 6]"#).out,
         "foo 5 6"
     );
 }
@@ -163,7 +163,7 @@ fn bad_spread_internal_args() -> TestResult {
 #[test]
 fn spread_non_list_args() {
     fail_test(r#"echo ...(1)"#, "cannot spread value").unwrap();
-    assert!(nu!(r#"nu --testbin cococo ...(1)"#)
+    assert!(nu!(r#"nu-testbin cococo ...(1)"#)
         .err
         .contains("cannot spread value"));
 }
@@ -184,7 +184,7 @@ fn explain_spread_args() -> TestResult {
 #[test]
 fn disallow_implicit_spread_for_externals() -> TestResult {
     fail_test(
-        r#"nu --testbin cococo [1 2]"#,
+        r#"nu-testbin cococo [1 2]"#,
         "Lists are not automatically spread",
     )
 }

--- a/testbin/Cargo.toml
+++ b/testbin/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["The Nushell Project Developers"]
+description = "A binary used by tests"
+edition = "2021"
+license = "MIT"
+name = "nu-testbin"
+version = "0.1.0"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -121,7 +121,7 @@ fn load_env_pwd_env_var_fails() {
 #[test]
 fn passes_with_env_env_var_to_external_process() {
     let actual = nu!("
-        with-env { FOO: foo } {nu --testbin echo_env FOO}
+        with-env { FOO: foo } {nu-testbin echo_env FOO}
         ");
     assert_eq!(actual.out, "foo");
 }
@@ -163,7 +163,7 @@ fn passes_env_from_local_cfg_to_external_process() {
 
         let actual = Trusted::in_path(&dirs, || {
             nu!(cwd: dirs.test(), "
-                nu --testbin echo_env FOO
+                nu-testbin echo_env FOO
             ")
         });
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -63,7 +63,7 @@ fn automatically_change_directory_with_trailing_slash_and_same_name_as_command()
 
 #[test]
 fn correctly_escape_external_arguments() {
-    let actual = nu!("^nu --testbin cococo '$0'");
+    let actual = nu!("^nu-testbin cococo '$0'");
 
     assert_eq!(actual.out, "$0");
 }
@@ -78,8 +78,8 @@ fn escape_also_escapes_equals() {
 #[test]
 fn execute_binary_in_string() {
     let actual = nu!(r#"
-        let cmd = "nu"
-        ^$"($cmd)" --testbin cococo "$0"
+        let cmd = "nu-testbin"
+        ^$"($cmd)" cococo "$0"
     "#);
 
     assert_eq!(actual.out, "$0");
@@ -87,20 +87,20 @@ fn execute_binary_in_string() {
 
 #[test]
 fn single_quote_dollar_external() {
-    let actual = nu!("let author = 'JT'; nu --testbin cococo $'foo=($author)'");
+    let actual = nu!("let author = 'JT'; nu-testbin cococo $'foo=($author)'");
 
     assert_eq!(actual.out, "foo=JT");
 }
 
 #[test]
 fn redirects_custom_command_external() {
-    let actual = nu!("def foo [] { nu --testbin cococo foo bar }; foo | str length");
+    let actual = nu!("def foo [] { nu-testbin cococo foo bar }; foo | str length");
     assert_eq!(actual.out, "7");
 }
 
 #[test]
 fn passes_binary_data_between_externals() {
-    let actual = nu!(cwd: "tests/fixtures/formats", "nu --testbin meowb sample.db | nu --testbin relay | hash sha256");
+    let actual = nu!(cwd: "tests/fixtures/formats", "nu-testbin meowb sample.db | nu-testbin relay | hash sha256");
 
     assert_eq!(
         actual.out,
@@ -133,12 +133,12 @@ fn command_not_found_error_shows_not_found_1() {
 #[test]
 fn command_substitution_wont_output_extra_newline() {
     let actual = nu!(r#"
-        with-env { FOO: "bar" } { echo $"prefix (nu --testbin echo_env FOO) suffix" }
+        with-env { FOO: "bar" } { echo $"prefix (nu-testbin echo_env FOO) suffix" }
         "#);
     assert_eq!(actual.out, "prefix bar suffix");
 
     let actual = nu!(r#"
-        with-env { FOO: "bar" } { (nu --testbin echo_env FOO) }
+        with-env { FOO: "bar" } { (nu-testbin echo_env FOO) }
         "#);
     assert_eq!(actual.out, "bar");
 }
@@ -146,14 +146,14 @@ fn command_substitution_wont_output_extra_newline() {
 #[test]
 fn basic_err_pipe_works() {
     let actual =
-        nu!(r#"with-env { FOO: "bar" } { nu --testbin echo_env_stderr FOO e>| str length }"#);
+        nu!(r#"with-env { FOO: "bar" } { nu-testbin echo_env_stderr FOO e>| str length }"#);
     assert_eq!(actual.out, "3");
 }
 
 #[test]
 fn basic_outerr_pipe_works() {
     let actual = nu!(
-        r#"with-env { FOO: "bar" } { nu --testbin echo_env_mixed out-err FOO FOO o+e>| str length }"#
+        r#"with-env { FOO: "bar" } { nu-testbin echo_env_mixed out-err FOO FOO o+e>| str length }"#
     );
     assert_eq!(actual.out, "7");
 }
@@ -161,7 +161,7 @@ fn basic_outerr_pipe_works() {
 #[test]
 fn err_pipe_with_failed_external_works() {
     let actual =
-        nu!(r#"with-env { FOO: "bar" } { nu --testbin echo_env_stderr_fail FOO e>| str length }"#);
+        nu!(r#"with-env { FOO: "bar" } { nu-testbin echo_env_stderr_fail FOO e>| str length }"#);
     assert_eq!(actual.out, "3");
 }
 
@@ -173,7 +173,7 @@ fn dont_run_glob_if_pass_variable_to_external() {
             EmptyFile("andres_likes_arepas.txt"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), r#"let f = "*.txt"; nu --testbin nonu $f"#);
+        let actual = nu!(cwd: dirs.test(), r#"let f = "*.txt"; nu-testbin nonu $f"#);
 
         assert_eq!(actual.out, "*.txt");
     })
@@ -187,7 +187,7 @@ fn run_glob_if_pass_variable_to_external() {
             EmptyFile("andres_likes_arepas.txt"),
         ]);
 
-        let actual = nu!(cwd: dirs.test(), r#"let f = "*.txt"; nu --testbin nonu ...(glob $f)"#);
+        let actual = nu!(cwd: dirs.test(), r#"let f = "*.txt"; nu-testbin nonu ...(glob $f)"#);
 
         assert!(actual.out.contains("jt_likes_cake.txt"));
         assert!(actual.out.contains("andres_likes_arepas.txt"));
@@ -213,7 +213,7 @@ mod it_evaluation {
                 ls
                 | sort-by name
                 | get name
-                | each { |it| nu --testbin cococo $it }
+                | each { |it| nu-testbin cococo $it }
                 | get 1
                 "
             ));
@@ -238,7 +238,7 @@ mod it_evaluation {
             "
                 open nu_candies.txt
                 | lines
-                | each { |it| nu --testbin chop $it}
+                | each { |it| nu-testbin chop $it}
                 | get 1
                 "
             ));
@@ -250,7 +250,7 @@ mod it_evaluation {
     #[test]
     fn can_properly_buffer_lines_externally() {
         let actual = nu!("
-                nu --testbin repeater c 8197 | lines | length
+                nu-testbin repeater c 8197 | lines | length
             ");
 
         assert_eq!(actual.out, "1");
@@ -269,7 +269,7 @@ mod it_evaluation {
                 cwd: dirs.test(), pipeline(
                 "
                     open sample.toml
-                    | nu --testbin cococo $in.nu_party_venue
+                    | nu-testbin cococo $in.nu_party_venue
                 "
             ));
 
@@ -286,7 +286,7 @@ mod stdin_evaluation {
     fn does_not_panic_with_no_newline_in_stream() {
         let actual = nu!(pipeline(
             r#"
-                nu --testbin nonu "where's the nuline?" | length
+                nu-testbin nonu "where's the nuline?" | length
             "#
         ));
 
@@ -297,9 +297,9 @@ mod stdin_evaluation {
     fn does_not_block_indefinitely() {
         let stdout = nu!(pipeline(
             "
-                ( nu --testbin iecho yes
-                | nu --testbin chop
-                | nu --testbin chop
+                ( nu-testbin iecho yes
+                | nu-testbin chop
+                | nu-testbin chop
                 | lines
                 | first )
             "
@@ -318,7 +318,7 @@ mod external_words {
     #[test]
     fn relaxed_external_words() {
         let actual = nu!("
-        nu --testbin cococo joturner@foo.bar.baz
+        nu-testbin cococo joturner@foo.bar.baz
         ");
 
         assert_eq!(actual.out, "joturner@foo.bar.baz");
@@ -326,7 +326,7 @@ mod external_words {
 
     #[test]
     fn raw_string_as_external_argument() {
-        let actual = nu!("nu --testbin cococo r#'asdf'#");
+        let actual = nu!("nu-testbin cococo r#'asdf'#");
         assert_eq!(actual.out, "asdf");
     }
 
@@ -335,7 +335,7 @@ mod external_words {
     #[test]
     fn no_escaping_for_single_quoted_strings() {
         let actual = nu!(r#"
-        nu --testbin cococo 'test "things"'
+        nu-testbin cococo 'test "things"'
         "#);
 
         assert_eq!(actual.out, "test \"things\"");
@@ -366,7 +366,7 @@ mod external_words {
             let actual = nu!(
                 cwd: dirs.test(), pipeline(
                 &format!("
-                    nu --testbin meow {nu_path_argument} | from toml | get nu_party_venue
+                    nu-testbin meow {nu_path_argument} | from toml | get nu_party_venue
                 ")
             ));
 
@@ -461,7 +461,7 @@ mod tilde_expansion {
     #[test]
     fn as_home_directory_when_passed_as_argument_and_begins_with_tilde() {
         let actual = nu!("
-            nu --testbin cococo  ~
+            nu-testbin cococo  ~
         ");
 
         assert!(!actual.out.contains('~'));
@@ -470,7 +470,7 @@ mod tilde_expansion {
     #[test]
     fn does_not_expand_when_passed_as_argument_and_does_not_start_with_tilde() {
         let actual = nu!(r#"
-                nu --testbin cococo  "1~1"
+                nu-testbin cococo  "1~1"
                 "#);
 
         assert_eq!(actual.out, "1~1");
@@ -495,7 +495,7 @@ mod external_command_arguments {
                 let actual = nu!(
                 cwd: dirs.test(), pipeline(
                 "
-                    nu --testbin cococo ...(ls | get name)
+                    nu-testbin cococo ...(ls | get name)
                 "
                 ));
 
@@ -521,7 +521,7 @@ mod external_command_arguments {
                 let actual = nu!(
                 cwd: dirs.test(), pipeline(
                 "
-                    nu --testbin cococo (ls | sort-by name | get name).1
+                    nu-testbin cococo (ls | sort-by name | get name).1
                 "
                 ));
 
@@ -543,7 +543,7 @@ mod external_command_arguments {
                 let actual = nu!(
                 cwd: dirs.test(), pipeline(
                 r#"
-                    nu --testbin cococo $"(pwd)/cd"
+                    nu-testbin cococo $"(pwd)/cd"
                 "#
                 ));
 
@@ -554,14 +554,14 @@ mod external_command_arguments {
 
     #[test]
     fn semicolons_are_sanitized_before_passing_to_subshell() {
-        let actual = nu!("nu --testbin cococo \"a;b\"");
+        let actual = nu!("nu-testbin cococo \"a;b\"");
 
         assert_eq!(actual.out, "a;b");
     }
 
     #[test]
     fn ampersands_are_sanitized_before_passing_to_subshell() {
-        let actual = nu!("nu --testbin cococo \"a&b\"");
+        let actual = nu!("nu-testbin cococo \"a&b\"");
 
         assert_eq!(actual.out, "a&b");
     }
@@ -569,7 +569,7 @@ mod external_command_arguments {
     #[cfg(not(windows))]
     #[test]
     fn subcommands_are_sanitized_before_passing_to_subshell() {
-        let actual = nu!("nu --testbin cococo \"$(ls)\"");
+        let actual = nu!("nu-testbin cococo \"$(ls)\"");
 
         assert_eq!(actual.out, "$(ls)");
     }
@@ -577,7 +577,7 @@ mod external_command_arguments {
     #[cfg(not(windows))]
     #[test]
     fn shell_arguments_are_sanitized_even_if_coming_from_other_commands() {
-        let actual = nu!("nu --testbin cococo (echo \"a;&$(hello)\")");
+        let actual = nu!("nu-testbin cococo (echo \"a;&$(hello)\")");
 
         assert_eq!(actual.out, "a;&$(hello)");
     }

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -17,7 +17,7 @@ fn takes_rows_of_nu_value_strings_and_pipes_it_to_stdin_of_external() {
         "
             {sample}
             | get origin
-            | each {{ |it| nu --testbin cococo $it | nu --testbin chop }}
+            | each {{ |it| nu-testbin cococo $it | nu-testbin chop }}
             | get 2
             "
     )));
@@ -56,7 +56,7 @@ fn treats_dot_dot_as_path_not_range() {
 #[test]
 fn subexpression_properly_redirects() {
     let actual = nu!(r#"
-            echo (nu --testbin cococo "hello") | str join
+            echo (nu-testbin cococo "hello") | str join
         "#);
 
     assert_eq!(actual.out, "hello");
@@ -99,7 +99,7 @@ fn subexpression_handles_dot() {
         "
             echo (open nu_times.csv)
             | get name
-            | each { |it| nu --testbin chop $it }
+            | each { |it| nu-testbin chop $it }
             | get 3
             "
         ));
@@ -551,7 +551,7 @@ fn argument_subexpression_reports_errors() {
 
 #[test]
 fn can_process_one_row_from_internal_and_pipes_it_to_stdin_of_external() {
-    let actual = nu!(r#""nushelll" | nu --testbin chop"#);
+    let actual = nu!(r#""nushelll" | nu-testbin chop"#);
 
     assert_eq!(actual.out, "nushell");
 }


### PR DESCRIPTION
# Description

This PR removes the `--testbin` flag on the main nushell binary and moves this functionality to the new `nu-testbin` binary. This binary was added to the workspace and marked as `publish = false` in its `Cargo.toml`. After this, we will no longer ship testing code to our users, and the removal of the `--testbin` flag will make the CLI slightly less cluttered.

# User-Facing Changes
"Breaking" change: removes the `--testbin` flag from the main nushell binary.
