### PR TITLE
Add example and search term for 'repeat' to the `fill` command

### DIFF
--- a/crates/nu-command/src/conversions/fill.rs
+++ b/crates/nu-command/src/conversions/fill.rs
@@ -73,7 +73,7 @@ impl Command for Fill {
     }
 
     fn search_terms(&self) -> Vec<&str> {
-        vec!["display", "render", "format", "pad", "align"]
+        vec!["display", "render", "format", "pad", "align", "repeat"]
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -91,9 +91,9 @@ impl Command for Fill {
                 result: Some(Value::string("────────nushell", Span::test_data())),
             },
             Example {
-                description: "Fill a string on both sides to a width of 15 with the character '─'",
-                example: "'nushell' | fill --alignment m --character '─' --width 15",
-                result: Some(Value::string("────nushell────", Span::test_data())),
+                description: "Fill an empty string with 10 '─' characters",
+                example: "'' | fill --character '─' --width 10",
+                result: Some(Value::string("──────────", Span::test_data())),
             },
             Example {
                 description:


### PR DESCRIPTION
# Description

It's commonly forgotten or overlooked that a lot of `std repeat` functionality can be handled with the built-in `fill`.  Added 'repeat` as a search term for `fill` to improve discoverability.

Also replaced one of the existing examples with one `fill`ing an empty string, a la `repeat`.  There were 6 examples already, and 3 of them pretty much were variations on the same theme, so I repurposed one of those rather than adding a 7th.

# User-Facing Changes

Changes to `help` only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

I assume the "Commands" doc is auto-generated from the `help`, but I'll double-check that assumption.
