### PR TITLE
Add `FilesizeFormat` enum 

### DIFF
--- a/crates/nu-protocol/src/config/filesize.rs
+++ b/crates/nu-protocol/src/config/filesize.rs
@@ -1,0 +1,46 @@
+use super::ReconstructVal;
+use crate::{Span, Value};
+use byte_unit::Unit;
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::{self, Display},
+    str::FromStr,
+};
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+pub enum FilesizeFormat {
+    #[default]
+    Auto,
+    Unit(Unit),
+}
+
+impl Display for FilesizeFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FilesizeFormat::Auto => write!(f, "auto"),
+            FilesizeFormat::Unit(unit) => write!(f, "{unit}"),
+        }
+    }
+}
+
+impl FromStr for FilesizeFormat {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            Err("")
+        } else if s.eq_ignore_ascii_case("auto") {
+            Ok(FilesizeFormat::Auto)
+        } else {
+            Unit::parse_str(s, false, true).map(FilesizeFormat::Unit).map_err(|_| {
+                "expected either 'auto', 'B', 'KB', 'KiB', 'MB', 'MiB', 'GB', 'GiB', 'TB', 'TiB', 'PB', 'PiB', 'EB', 'EiB', 'b', 'Kb', 'Kib', 'Mb', 'Mib', 'Gb', 'Gib', 'Tb', 'Tib', 'Pb', 'Pib', 'Eb', or 'Eib'"
+            })
+        }
+    }
+}
+
+impl ReconstructVal for FilesizeFormat {
+    fn reconstruct_value(&self, span: Span) -> Value {
+        Value::string(self.to_string(), span)
+    }
+}

--- a/crates/nu-protocol/src/config/filesize.rs
+++ b/crates/nu-protocol/src/config/filesize.rs
@@ -28,7 +28,7 @@ impl FromStr for FilesizeFormat {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.is_empty() {
-            Err("")
+            Err("expected either 'auto', 'B', 'KB', 'KiB', 'MB', 'MiB', 'GB', 'GiB', 'TB', 'TiB', 'PB', 'PiB', 'EB', 'EiB', 'b', 'Kb', 'Kib', 'Mb', 'Mib', 'Gb', 'Gib', 'Tb', 'Tib', 'Pb', 'Pib', 'Eb', or 'Eib'")
         } else if s.eq_ignore_ascii_case("auto") {
             Ok(FilesizeFormat::Auto)
         } else {

--- a/crates/nu-protocol/src/value/filesize.rs
+++ b/crates/nu-protocol/src/value/filesize.rs
@@ -1,5 +1,5 @@
-use crate::Config;
-use byte_unit::UnitType;
+use crate::{Config, FilesizeFormat};
+use byte_unit::{Unit, UnitType};
 use nu_utils::get_system_locale;
 use num_format::ToFormattedString;
 
@@ -8,7 +8,7 @@ pub fn format_filesize_from_conf(num_bytes: i64, config: &Config) -> String {
     // and filesize_metric is false, return KiB
     format_filesize(
         num_bytes,
-        config.filesize_format.as_str(),
+        config.filesize_format,
         Some(config.filesize_metric),
     )
 }
@@ -17,14 +17,14 @@ pub fn format_filesize_from_conf(num_bytes: i64, config: &Config) -> String {
 // other places (such as `format filesize`) don't.
 pub fn format_filesize(
     num_bytes: i64,
-    format_value: &str,
+    format: FilesizeFormat,
     filesize_metric: Option<bool>,
 ) -> String {
     // Allow the user to specify how they want their numbers formatted
 
     // When format_value is "auto" or an invalid value, the returned ByteUnit doesn't matter
     // and is always B.
-    let filesize_unit = get_filesize_format(format_value, filesize_metric);
+    let filesize_unit = get_filesize_format(format, filesize_metric);
     let byte = byte_unit::Byte::from_u64(num_bytes.unsigned_abs());
     let adj_byte = if let Some(unit) = filesize_unit {
         byte.get_adjusted_unit(unit)
@@ -67,35 +67,50 @@ pub fn format_filesize(
 
 /// Get the filesize unit, or None if format is "auto"
 fn get_filesize_format(
-    format_value: &str,
+    format: FilesizeFormat,
     filesize_metric: Option<bool>,
 ) -> Option<byte_unit::Unit> {
-    // filesize_metric always overrides the unit of filesize_format.
-    let metric = filesize_metric.unwrap_or(!format_value.ends_with("ib"));
+    let unit = match format {
+        FilesizeFormat::Auto => return None,
+        FilesizeFormat::Unit(unit) => unit,
+    };
 
-    if metric {
-        match format_value {
-            "b" => Some(byte_unit::Unit::B),
-            "kb" | "kib" => Some(byte_unit::Unit::KB),
-            "mb" | "mib" => Some(byte_unit::Unit::MB),
-            "gb" | "gib" => Some(byte_unit::Unit::GB),
-            "tb" | "tib" => Some(byte_unit::Unit::TB),
-            "pb" | "pib" => Some(byte_unit::Unit::TB),
-            "eb" | "eib" => Some(byte_unit::Unit::EB),
-            _ => None,
+    // filesize_metric always overrides the unit of filesize_format.
+    let unit = if filesize_metric.unwrap_or(!unit.is_binary_multiples()) {
+        match unit {
+            unit @ (Unit::Bit | Unit::B) => unit,
+            Unit::Kbit | Unit::Kibit => Unit::Kbit,
+            Unit::KB | Unit::KiB => Unit::KB,
+            Unit::Mbit | Unit::Mibit => Unit::Mbit,
+            Unit::MB | Unit::MiB => Unit::MB,
+            Unit::Gbit | Unit::Gibit => Unit::Gbit,
+            Unit::GB | Unit::GiB => Unit::GB,
+            Unit::Tbit | Unit::Tibit => Unit::Tbit,
+            Unit::TB | Unit::TiB => Unit::TB,
+            Unit::Pbit | Unit::Pibit => Unit::Pbit,
+            Unit::PB | Unit::PiB => Unit::PB,
+            Unit::Ebit | Unit::Eibit => Unit::Ebit,
+            Unit::EB | Unit::EiB => Unit::EB,
         }
     } else {
-        match format_value {
-            "b" => Some(byte_unit::Unit::B),
-            "kb" | "kib" => Some(byte_unit::Unit::KiB),
-            "mb" | "mib" => Some(byte_unit::Unit::MiB),
-            "gb" | "gib" => Some(byte_unit::Unit::GiB),
-            "tb" | "tib" => Some(byte_unit::Unit::TiB),
-            "pb" | "pib" => Some(byte_unit::Unit::TiB),
-            "eb" | "eib" => Some(byte_unit::Unit::EiB),
-            _ => None,
+        match unit {
+            unit @ (Unit::Bit | Unit::B) => unit,
+            Unit::Kbit | Unit::Kibit => Unit::Kibit,
+            Unit::KB | Unit::KiB => Unit::KiB,
+            Unit::Mbit | Unit::Mibit => Unit::Mibit,
+            Unit::MB | Unit::MiB => Unit::MiB,
+            Unit::Gbit | Unit::Gibit => Unit::Gibit,
+            Unit::GB | Unit::GiB => Unit::GiB,
+            Unit::Tbit | Unit::Tibit => Unit::Tibit,
+            Unit::TB | Unit::TiB => Unit::TiB,
+            Unit::Pbit | Unit::Pibit => Unit::Pibit,
+            Unit::PB | Unit::PiB => Unit::PiB,
+            Unit::Ebit | Unit::Eibit => Unit::Eibit,
+            Unit::EB | Unit::EiB => Unit::EiB,
         }
-    }
+    };
+
+    Some(unit)
 }
 
 #[cfg(test)]
@@ -104,18 +119,18 @@ mod tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case(1000, Some(true), "auto", "1.0 KB")]
-    #[case(1000, Some(false), "auto", "1,000 B")]
-    #[case(1000, Some(false), "kb", "1.0 KiB")]
-    #[case(3000, Some(false), "auto", "2.9 KiB")]
-    #[case(3_000_000, None, "auto", "2.9 MiB")]
-    #[case(3_000_000, None, "kib", "2929.7 KiB")]
+    #[case(1000, Some(true), FilesizeFormat::Auto, "1.0 KB")]
+    #[case(1000, Some(false), FilesizeFormat::Auto, "1,000 B")]
+    #[case(1000, Some(false), FilesizeFormat::Unit(Unit::KB), "1.0 KiB")]
+    #[case(3000, Some(false), FilesizeFormat::Auto, "2.9 KiB")]
+    #[case(3_000_000, None, FilesizeFormat::Auto, "2.9 MiB")]
+    #[case(3_000_000, None, FilesizeFormat::Unit(Unit::KiB), "2929.7 KiB")]
     fn test_filesize(
         #[case] val: i64,
         #[case] filesize_metric: Option<bool>,
-        #[case] filesize_format: String,
+        #[case] filesize_format: FilesizeFormat,
         #[case] exp: &str,
     ) {
-        assert_eq!(exp, format_filesize(val, &filesize_format, filesize_metric));
+        assert_eq!(exp, format_filesize(val, filesize_format, filesize_metric));
     }
 }

--- a/crates/nu-protocol/tests/test_config.rs
+++ b/crates/nu-protocol/tests/test_config.rs
@@ -13,8 +13,8 @@ fn filesize_metric_true() {
 #[test]
 fn filesize_metric_false() {
     let code = &[
-        r#"$env.config = { filesize: { metric: false, format:"mib" } }"#,
-        r#"20mib | into string"#,
+        r#"$env.config = { filesize: { metric: false, format:"miB" } }"#,
+        r#"20miB | into string"#,
     ];
     let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, "20.0 MiB");
@@ -23,8 +23,8 @@ fn filesize_metric_false() {
 #[test]
 fn filesize_metric_overrides_format() {
     let code = &[
-        r#"$env.config = { filesize: { metric: false, format:"mb" } }"#,
-        r#"20mib | into string"#,
+        r#"$env.config = { filesize: { metric: false, format:"mB" } }"#,
+        r#"20miB | into string"#,
     ];
     let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, "20.0 MiB");
@@ -44,7 +44,7 @@ fn filesize_format_auto_metric_true() {
 fn filesize_format_auto_metric_false() {
     let code = &[
         r#"$env.config = { filesize: { metric: false, format:"auto" } }"#,
-        r#"[2mb 2gb 2tb] | into string | to nuon"#,
+        r#"[2mB 2gB 2tB] | into string | to nuon"#,
     ];
     let actual = nu!(nu_repl_code(code));
     assert_eq!(actual.out, r#"["1.9 MiB", "1.9 GiB", "1.8 TiB"]"#);


### PR DESCRIPTION
# Description
This PR adds a `FilesizeFormat` to enforce that a proper/supported unit is used when formatting filesizes. This also partially address #6807, since filesizes are now case-sensitive only for the `B` in certain cases.

# User-Facing Changes
Breaking change: filesizes must now have an upper case `B` for the `format filesize` command and for the `filesize.format` config setting.

# After Submitting
Make similar changes to the parser to be case-sensitive for filesizes.