### PR TITLE
Add Stack::stdout_file and Stack::stderr_file to capture stdout/-err of external commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3259,6 +3259,7 @@ dependencies = [
  "nu-test-support",
  "nu-utils",
  "num-format",
+ "os_pipe",
  "pretty_assertions",
  "rmp-serde",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ num-traits = "0.2"
 omnipath = "0.1"
 once_cell = "1.18"
 open = "5.1"
-os_pipe = "1.1"
+os_pipe = { version = "1.1", features = ["io_safety"] }
 pathdiff = "0.2"
 percent-encoding = "2"
 pretty_assertions = "1.4"

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -47,6 +47,7 @@ nu-test-support = { path = "../nu-test-support", version = "0.93.1" }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }
 tempfile = { workspace = true }
+os_pipe = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use std::{
     collections::{HashMap, HashSet},
+    fs::File,
     sync::Arc,
 };
 
@@ -590,6 +591,57 @@ impl Stack {
     pub fn reset_pipes(mut self) -> Self {
         self.out_dest.pipe_stdout = None;
         self.out_dest.pipe_stderr = None;
+        self
+    }
+
+    /// Replaces the default stdout of the stack with a given file.
+    ///
+    /// This method configures the default stdout to redirect to a specified file.
+    /// It is primarily useful for applications using `nu` as a language, where the stdout of
+    /// external commands that are not explicitly piped can be redirected to a file.
+    ///
+    /// # Using Pipes
+    ///
+    /// For use in third-party applications pipes might be very useful as they allow using the
+    /// stdout of external commands for different uses.
+    /// For example the [`os_pipe`](https://docs.rs/os_pipe) crate provides a elegant way to to
+    /// access the stdout.
+    ///
+    /// ```
+    /// # use std::{fs::File, io, thread, error};
+    /// # use nu_protocol::engine::Stack;
+    /// #
+    /// let (mut reader, writer) = os_pipe::pipe().unwrap();
+    /// // Use a thread to avoid blocking the execution of the called command.
+    /// let reader = thread::spawn(move || {
+    ///     let mut buf: Vec<u8> = Vec::new();
+    ///     let _ = io::copy(&mut reader, &mut buf); // Maybe handle errors more gracefully.
+    ///     buf
+    /// });
+    ///
+    /// #[cfg(windows)]
+    /// let file = std::os::windows::io::OwnedHandle::from(writer).into();
+    /// #[cfg(unix)]
+    /// let file = std::os::unix::io::OwnedFd::from(writer).into();
+    ///
+    /// let stack = Stack::new().stdout_file(file);
+    ///
+    /// // Execute some nu code.
+    ///
+    /// drop(stack); // drop the stack so that the writer will be dropped too
+    /// let buf = reader.join().unwrap();
+    /// // Do with your buffer whatever you want.
+    /// ```
+    pub fn stdout_file(mut self, file: File) -> Self {
+        self.out_dest.stdout = OutDest::File(Arc::new(file));
+        self
+    }
+
+    /// Replaces the default stderr of the stack with a given file.
+    ///
+    /// For more info, see [`stdout_file`](Self::stdout_file).
+    pub fn stderr_file(mut self, file: File) -> Self {
+        self.out_dest.stderr = OutDest::File(Arc::new(file));
         self
     }
 

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -608,15 +608,15 @@ impl Stack {
     /// access the stdout.
     ///
     /// ```
-    /// # use std::{fs::File, io, thread, error};
+    /// # use std::{fs::File, io::{self, Read}, thread, error};
     /// # use nu_protocol::engine::Stack;
     /// #
     /// let (mut reader, writer) = os_pipe::pipe().unwrap();
     /// // Use a thread to avoid blocking the execution of the called command.
     /// let reader = thread::spawn(move || {
     ///     let mut buf: Vec<u8> = Vec::new();
-    ///     let _ = io::copy(&mut reader, &mut buf); // Maybe handle errors more gracefully.
-    ///     buf
+    ///     reader.read_to_end(&mut buf)?;
+    ///     Ok::<_, io::Error>(buf)
     /// });
     ///
     /// #[cfg(windows)]
@@ -629,7 +629,7 @@ impl Stack {
     /// // Execute some nu code.
     ///
     /// drop(stack); // drop the stack so that the writer will be dropped too
-    /// let buf = reader.join().unwrap();
+    /// let buf = reader.join().unwrap().unwrap();
     /// // Do with your buffer whatever you want.
     /// ```
     pub fn stdout_file(mut self, file: File) -> Self {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
In this PR I added two new methods to `Stack`, `stdout_file` and `stderr_file`. These two modify the inner `StackOutDest` and set a `File` into the `stdout` and `stderr` respectively. Different to the `push_redirection` methods,  these do not require to hold a guard up all the time but require ownership of the stack.

This is primarly useful for applications that use `nu` as a language but not the `nushell`.

This PR replaces my first attempt #12851 to add a way to capture stdout/-err of external commands. Capturing the stdout without having to write into a file is possible with crates like [`os_pipe`](https://docs.rs/os_pipe), an example for this is given in the doc comment of the `stdout_file` command and can be executed as a doctest (although it doesn't validate that you actually got any data). 

This implementation takes `File` as input to make it easier to implement on different operating systems without having to worry about `OwnedHandle` or `OwnedFd`. Also this doesn't expose any use `os_pipe` to not leak its types into this API, making it depend on it.

As in my previous attempt, @IanManske guided me here.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
This change has no effect on `nushell` and therefore no user-facing changes.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
This only exposes a new way of using already existing code and has therefore no further testing. The doctest succeeds on my machine at least (x86 Windows, 64 Bit).

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
All the required documentation is already part of this PR.