### PR TITLE
Search terms for compact command

### DIFF
--- a/crates/nu-command/src/filters/compact.rs
+++ b/crates/nu-command/src/filters/compact.rs
@@ -31,6 +31,10 @@ impl Command for Compact {
         "Creates a table with non-empty rows."
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["empty", "remove"]
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,


### PR DESCRIPTION
# Description

There was a question in Discord today about how to remove empty rows from a table.  The user found the `compact` command on their own, but I realized that there were no search terms on the command.  I've added 'empty' and 'remove', although I subsequently figured out that 'empty' is found in the "usage" anyway.  That said, I don't think it hurts to have good search terms behind it regardless.

# User-Facing Changes

Just the help

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

