### PR TITLE
Handle polars panics during collect

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_lazyframe/mod.rs
@@ -53,16 +53,21 @@ impl NuLazyFrame {
     }
 
     pub fn collect(self, span: Span) -> Result<NuDataFrame, ShellError> {
-        self.to_polars()
-            .collect()
-            .map_err(|e| ShellError::GenericError {
-                error: "Error collecting lazy frame".into(),
-                msg: e.to_string(),
-                span: Some(span),
-                help: None,
-                inner: vec![],
-            })
-            .map(NuDataFrame::new)
+        crate::handle_panic(
+            || {
+                self.to_polars()
+                    .collect()
+                    .map_err(|e| ShellError::GenericError {
+                        error: "Error collecting lazy frame".into(),
+                        msg: e.to_string(),
+                        span: Some(span),
+                        help: None,
+                        inner: vec![],
+                    })
+                    .map(NuDataFrame::new)
+            },
+            span,
+        )
     }
 
     pub fn apply_with_expr<F>(self, expr: NuExpression, f: F) -> Self

--- a/crates/nu_plugin_polars/src/lib.rs
+++ b/crates/nu_plugin_polars/src/lib.rs
@@ -239,7 +239,7 @@ where
     match catch_unwind(AssertUnwindSafe(f)) {
         Ok(inner_result) => inner_result,
         Err(_) => Err(ShellError::GenericError {
-            error: format!("Panic occurred"),
+            error: "Panic occurred".into(),
             msg: "".into(),
             span: Some(span),
             help: None,

--- a/crates/nu_plugin_polars/src/lib.rs
+++ b/crates/nu_plugin_polars/src/lib.rs
@@ -234,9 +234,9 @@ pub mod test {
 
 pub(crate) fn handle_panic<F, R>(f: F, span: Span) -> Result<R, ShellError>
 where
-    F: FnOnce() -> Result<R, ShellError>,
+    F: FnOnce() -> Result<R, ShellError> + UnwindSafe,
 {
-    match catch_unwind(AssertUnwindSafe(f)) {
+    match catch_unwind(f) {
         Ok(inner_result) => inner_result,
         Err(_) => Err(ShellError::GenericError {
             error: "Panic occurred".into(),

--- a/crates/nu_plugin_polars/src/lib.rs
+++ b/crates/nu_plugin_polars/src/lib.rs
@@ -234,9 +234,9 @@ pub mod test {
 
 pub(crate) fn handle_panic<F, R>(f: F, span: Span) -> Result<R, ShellError>
 where
-    F: FnOnce() -> Result<R, ShellError> + UnwindSafe,
+    F: FnOnce() -> Result<R, ShellError>,
 {
-    match catch_unwind(f) {
+    match catch_unwind(AssertUnwindSafe(f)) {
         Ok(inner_result) => inner_result,
         Err(_) => Err(ShellError::GenericError {
             error: "Panic occurred".into(),


### PR DESCRIPTION
When polars panics it will kill the instance of the plugin, causing all internal cached state to be lost. This most often happens when a collect operation is performed. This pull request wraps all collect panics in a panic handler. 

related: #12732