### PR TITLE
Fix `char` panic

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -245,8 +245,8 @@ impl Command for Char {
         }
         // handle the rest
         else {
-            let string_args: Vec<String> = call.rest_const(working_set, 0)?;
-            handle_the_rest(string_args, call, call_span)
+            let string_args = call.rest_const(working_set, 0)?;
+            handle_the_rest(string_args, call_span)
         }
     }
 
@@ -280,8 +280,8 @@ impl Command for Char {
         }
         // handle the rest
         else {
-            let string_args: Vec<String> = call.rest(engine_state, stack, 0)?;
-            handle_the_rest(string_args, call, call_span)
+            let string_args = call.rest(engine_state, stack, 0)?;
+            handle_the_rest(string_args, call_span)
         }
     }
 }
@@ -347,26 +347,24 @@ fn handle_unicode_flag(
 }
 
 fn handle_the_rest(
-    string_args: Vec<String>,
-    call: &Call,
+    string_args: Vec<Spanned<String>>,
     call_span: Span,
 ) -> Result<PipelineData, ShellError> {
-    if string_args.is_empty() {
+    let Some(s) = string_args.first() else {
         return Err(ShellError::MissingParameter {
             param_name: "missing name of the character".into(),
             span: call_span,
         });
-    }
-    let special_character = str_to_character(&string_args[0]);
+    };
+
+    let special_character = str_to_character(&s.item);
+
     if let Some(output) = special_character {
         Ok(Value::string(output, call_span).into_pipeline_data())
     } else {
         Err(ShellError::TypeMismatch {
             err_message: "error finding named character".into(),
-            span: call
-                .positional_nth(0)
-                .expect("Unexpected missing argument")
-                .span,
+            span: s.span,
         })
     }
 }

--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -235,8 +235,8 @@ impl Command for Char {
 
         // handle -i flag
         if integer {
-            let int_args: Vec<i64> = call.rest_const(working_set, 0)?;
-            handle_integer_flag(int_args, call, call_span)
+            let int_args = call.rest_const(working_set, 0)?;
+            handle_integer_flag(int_args, call_span)
         }
         // handle -u flag
         else if unicode {
@@ -270,8 +270,8 @@ impl Command for Char {
 
         // handle -i flag
         if integer {
-            let int_args: Vec<i64> = call.rest(engine_state, stack, 0)?;
-            handle_integer_flag(int_args, call, call_span)
+            let int_args = call.rest(engine_state, stack, 0)?;
+            handle_integer_flag(int_args, call_span)
         }
         // handle -u flag
         else if unicode {
@@ -309,8 +309,7 @@ fn generate_character_list(ctrlc: Option<Arc<AtomicBool>>, call_span: Span) -> P
 }
 
 fn handle_integer_flag(
-    int_args: Vec<i64>,
-    call: &Call,
+    int_args: Vec<Spanned<i64>>,
     call_span: Span,
 ) -> Result<PipelineData, ShellError> {
     if int_args.is_empty() {
@@ -320,12 +319,8 @@ fn handle_integer_flag(
         });
     }
     let mut multi_byte = String::new();
-    for (i, &arg) in int_args.iter().enumerate() {
-        let span = call
-            .positional_nth(i)
-            .expect("Unexpected missing argument")
-            .span;
-        multi_byte.push(integer_to_unicode_char(arg, span)?)
+    for arg in int_args {
+        multi_byte.push(integer_to_unicode_char(arg.item, arg.span)?)
     }
     Ok(Value::string(multi_byte, call_span).into_pipeline_data())
 }


### PR DESCRIPTION
# Description
The `char` command can panic due to a failed `expect`: `char --integer ...[77 78 79]`

This PR fixes the panic for the `--integer` flag and also the `--unicode` flag.

# After Submitting
Check other commands and places where similar bugs can occur due to usages of `Call::positional_nth` and related methods.