### PR TITLE
Remove usages of `Call::positional_nth`

### DIFF
--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -90,10 +90,7 @@ fn with_env(
                         return Err(ShellError::CantConvert {
                             to_type: "record".into(),
                             from_type: x.get_type().to_string(),
-                            span: call
-                                .positional_nth(1)
-                                .expect("already checked through .req")
-                                .span,
+                            span: x.span(),
                             help: None,
                         });
                     }
@@ -124,10 +121,7 @@ fn with_env(
             return Err(ShellError::CantConvert {
                 to_type: "record".into(),
                 from_type: x.get_type().to_string(),
-                span: call
-                    .positional_nth(1)
-                    .expect("already checked through .req")
-                    .span,
+                span: x.span(),
                 help: None,
             });
         }

--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -117,7 +117,7 @@ impl Command for Touch {
         #[allow(deprecated)]
         let cwd = current_dir(engine_state, stack)?;
 
-        for (index, glob) in files.into_iter().enumerate() {
+        for glob in files {
             let path = expand_path_with(glob.item.as_ref(), &cwd, glob.item.is_expand());
 
             // If --no-create is passed and the file/dir does not exist there's nothing to do
@@ -135,10 +135,7 @@ impl Command for Touch {
                 {
                     return Err(ShellError::CreateNotPossible {
                         msg: format!("Failed to create file: {err}"),
-                        span: call
-                            .positional_nth(index)
-                            .expect("already checked positional")
-                            .span,
+                        span: glob.span,
                     });
                 };
             }
@@ -148,10 +145,7 @@ impl Command for Touch {
                 {
                     return Err(ShellError::ChangeModifiedTimeNotPossible {
                         msg: format!("Failed to change the modified time: {err}"),
-                        span: call
-                            .positional_nth(index)
-                            .expect("already checked positional")
-                            .span,
+                        span: glob.span,
                     });
                 };
             }
@@ -161,10 +155,7 @@ impl Command for Touch {
                 {
                     return Err(ShellError::ChangeAccessTimeNotPossible {
                         msg: format!("Failed to change the access time: {err}"),
-                        span: call
-                            .positional_nth(index)
-                            .expect("already checked positional")
-                            .span,
+                        span: glob.span,
                     });
                 };
             }

--- a/crates/nu-command/src/platform/ansi/ansi_.rs
+++ b/crates/nu-command/src/platform/ansi/ansi_.rs
@@ -784,10 +784,7 @@ fn heavy_lifting(code: Value, escape: bool, osc: bool, call: &Call) -> Result<St
                 None => {
                     return Err(ShellError::TypeMismatch {
                         err_message: String::from("Unknown ansi code"),
-                        span: call
-                            .positional_nth(0)
-                            .expect("Unexpected missing argument")
-                            .span,
+                        span: code.span(),
                     })
                 }
             }

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -154,28 +154,8 @@ impl Call {
             })
     }
 
-    pub fn positional_iter_mut(&mut self) -> impl Iterator<Item = &mut Expression> {
-        self.arguments
-            .iter_mut()
-            .take_while(|arg| match arg {
-                Argument::Spread(_) => false, // Don't include positional arguments given to rest parameter
-                _ => true,
-            })
-            .filter_map(|arg| match arg {
-                Argument::Named(_) => None,
-                Argument::Positional(positional) => Some(positional),
-                Argument::Unknown(unknown) => Some(unknown),
-                Argument::Spread(_) => None,
-            })
-    }
-
     pub fn positional_nth(&self, i: usize) -> Option<&Expression> {
         self.positional_iter().nth(i)
-    }
-
-    // TODO this method is never used. Delete?
-    pub fn positional_nth_mut(&mut self, i: usize) -> Option<&mut Expression> {
-        self.positional_iter_mut().nth(i)
     }
 
     pub fn positional_len(&self) -> usize {


### PR DESCRIPTION
# Description
Following from #12867, this PR replaces usages of `Call::positional_nth` with existing spans. This removes several `expect`s from the code.
