### PR TITLE
make it clearer what is being loaded with --log-level info

### DIFF
--- a/src/config_files.rs
+++ b/src/config_files.rs
@@ -1,4 +1,4 @@
-use log::{info, trace};
+use log::warn;
 #[cfg(feature = "plugin")]
 use nu_cli::read_plugin_file;
 use nu_cli::{eval_config_contents, eval_source};
@@ -27,7 +27,10 @@ pub(crate) fn read_config_file(
     config_file: Option<Spanned<String>>,
     is_env_config: bool,
 ) {
-    trace!("read_config_file {:?}", &config_file);
+    warn!(
+        "read_config_file() config_file_specified: {:?}, is_env_config: {is_env_config}",
+        &config_file
+    );
     // Load config startup file
     if let Some(file) = config_file {
         let working_set = StateWorkingSet::new(engine_state);
@@ -122,21 +125,27 @@ pub(crate) fn read_config_file(
 }
 
 pub(crate) fn read_loginshell_file(engine_state: &mut EngineState, stack: &mut Stack) {
+    warn!(
+        "read_loginshell_file() {}:{}:{}",
+        file!(),
+        line!(),
+        column!()
+    );
+
     // read and execute loginshell file if exists
     if let Some(mut config_path) = nu_path::config_dir() {
         config_path.push(NUSHELL_FOLDER);
         config_path.push(LOGINSHELL_FILE);
 
+        warn!("loginshell_file: {}", config_path.display());
+
         if config_path.exists() {
             eval_config_contents(config_path, engine_state, stack);
         }
     }
-
-    info!("read_loginshell_file {}:{}:{}", file!(), line!(), column!());
 }
 
 pub(crate) fn read_default_env_file(engine_state: &mut EngineState, stack: &mut Stack) {
-    trace!("read_default_env_file");
     let config_file = get_default_env();
     eval_source(
         engine_state,
@@ -147,7 +156,13 @@ pub(crate) fn read_default_env_file(engine_state: &mut EngineState, stack: &mut 
         false,
     );
 
-    info!("read_config_file {}:{}:{}", file!(), line!(), column!());
+    warn!(
+        "read_default_env_file() env_file_contents: {config_file} {}:{}:{}",
+        file!(),
+        line!(),
+        column!()
+    );
+
     // Merge the environment in case env vars changed in the config
     match engine_state.cwd(Some(stack)) {
         Ok(cwd) => {
@@ -167,10 +182,9 @@ fn eval_default_config(
     config_file: &str,
     is_env_config: bool,
 ) {
-    trace!(
-        "eval_default_config: config_file: {:?}, is_env_config: {}",
-        &config_file,
-        is_env_config
+    warn!(
+        "eval_default_config() config_file_specified: {:?}, is_env_config: {}",
+        &config_file, is_env_config
     );
     println!("Continuing without config file");
     // Just use the contents of "default_config.nu" or "default_env.nu"
@@ -208,11 +222,9 @@ pub(crate) fn setup_config(
     env_file: Option<Spanned<String>>,
     is_login_shell: bool,
 ) {
-    trace!(
-        "setup_config: config: {:?}, env: {:?}, login: {}",
-        &config_file,
-        &env_file,
-        is_login_shell
+    warn!(
+        "setup_config() config_file_specified: {:?}, env_file_specified: {:?}, login: {}",
+        &config_file, &env_file, is_login_shell
     );
     let result = catch_unwind(AssertUnwindSafe(|| {
         #[cfg(feature = "plugin")]
@@ -240,12 +252,9 @@ pub(crate) fn set_config_path(
     key: &str,
     config_file: Option<&Spanned<String>>,
 ) {
-    trace!(
-        "set_config_path: cwd: {:?}, default_config: {}, key: {}, config_file: {:?}",
-        &cwd,
-        &default_config_name,
-        &key,
-        &config_file
+    warn!(
+        "set_config_path() cwd: {:?}, default_config: {}, key: {}, config_file_specified: {:?}",
+        &cwd, &default_config_name, &key, &config_file
     );
     let config_path = match config_file {
         Some(s) => canonicalize_with(&s.item, cwd).ok(),


### PR DESCRIPTION
# Description

A common question we get is what config files are loaded when and with what parameters. It's for this reason that I wrote [this gist](https://gist.github.com/fdncred/b87b784f04984dc31a150baed9ad2447). Another way to figure this out is to use `nu --log-level info`. This will show some performance timings but will also show what is being loaded when. For the most part the `[INFO]` lines show the performance timings and the `[WARN]` lines show the files.

This PR tries to make things a little bit clearer when using the `--log-level info` parameter.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
