### PR TITLE
Fixed a nitpick usage-help error - closure v. block

### DIFF
--- a/crates/nu-cmd-extra/src/extra/filters/each_while.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/each_while.rs
@@ -10,7 +10,7 @@ impl Command for EachWhile {
     }
 
     fn usage(&self) -> &str {
-        "Run a block on each row of the input list until a null is found, then create a new list with the results."
+        "Run a closure on each row of the input list until a null is found, then create a new list with the results."
     }
 
     fn search_terms(&self) -> Vec<&str> {


### PR DESCRIPTION
# Description

So minor, but had to be fixed sometime.  `help each while` used the term "block" in the "usage", but the argument type is a closure.

# User-Facing Changes

help-only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`