### PR TITLE
Fixed small error in the help-examples for the get command

### DIFF
--- a/crates/nu-command/src/filters/get.rs
+++ b/crates/nu-command/src/filters/get.rs
@@ -115,7 +115,7 @@ If multiple cell paths are given, this will produce a list of values."#
             },
             Example {
                 description:
-                    "Extract the name of the 3rd record in a list (same as `ls | $in.name`)",
+                    "Extract the name of the 3rd record in a list (same as `ls | $in.name.2`)",
                 example: "ls | get name.2",
                 result: None,
             },


### PR DESCRIPTION
# Description

Another small error in Help, this time for the `get` command example.

# User-Facing Changes

Help only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

As soon as I say "this change is far too basic to worry about tests", I feel certain I'm going to make a stupid mistake :P 