### PR TITLE
fixed syntax shape requirements for --quantiles option for polars summary

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/eager/summary.rs
+++ b/crates/nu_plugin_polars/src/dataframe/eager/summary.rs
@@ -38,7 +38,7 @@ impl PluginCommand for Summary {
             )
             .named(
                 "quantiles",
-                SyntaxShape::Table(vec![]),
+                SyntaxShape::List(Box::new(SyntaxShape::Float)),
                 "provide optional quantiles",
                 Some('q'),
             )


### PR DESCRIPTION
Fix for #12730

All of the code expected a list of floats, but the syntax shape expected a table. Resolved by changing the syntax shape to list of floats.

cc: @maxim-uvarov 