### PR TITLE
Allow stor insert and stor update to accept pipeline input

### DIFF
--- a/crates/nu-command/src/stor/update.rs
+++ b/crates/nu-command/src/stor/update.rs
@@ -11,14 +11,17 @@ impl Command for StorUpdate {
 
     fn signature(&self) -> Signature {
         Signature::build("stor update")
-            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .input_output_types(vec![
+                (Type::Nothing, Type::table()),
+                (Type::record(), Type::table()),
+            ])
             .required_named(
                 "table-name",
                 SyntaxShape::String,
                 "name of the table you want to insert into",
                 Some('t'),
             )
-            .required_named(
+            .named(
                 "update-record",
                 SyntaxShape::Record(vec![]),
                 "a record of column names and column values to update in the specified table",
@@ -54,6 +57,11 @@ impl Command for StorUpdate {
             example: "stor update --table-name nudb --update-record {str1: nushell datetime1: 2020-04-17} --where-clause \"bool1 = 1\"",
             result: None,
         },
+        Example {
+            description: "Update the in-memory sqlite database through pipeline input",
+            example: "{str1: nushell datetime1: 2020-04-17} | stor update --table-name nudb",
+            result: None,
+        },
         ]
     }
 
@@ -62,89 +70,145 @@ impl Command for StorUpdate {
         engine_state: &EngineState,
         stack: &mut Stack,
         call: &Call,
-        _input: PipelineData,
+        input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let span = call.head;
         let table_name: Option<String> = call.get_flag(engine_state, stack, "table-name")?;
-        let columns: Option<Record> = call.get_flag(engine_state, stack, "update-record")?;
+        let update_record: Option<Record> = call.get_flag(engine_state, stack, "update-record")?;
         let where_clause_opt: Option<Spanned<String>> =
             call.get_flag(engine_state, stack, "where-clause")?;
 
         // Open the in-mem database
         let db = Box::new(SQLiteDatabase::new(std::path::Path::new(MEMORY_DB), None));
 
-        if table_name.is_none() {
-            return Err(ShellError::MissingParameter {
-                param_name: "requires at table name".into(),
-                span,
-            });
-        }
-        let new_table_name = table_name.unwrap_or("table".into());
-        if let Ok(conn) = db.open_connection() {
-            match columns {
-                Some(record) => {
-                    let mut update_stmt = format!("UPDATE {} ", new_table_name);
+        // Check if the record is being passed as input or using the update record parameter
+        let columns = handle(span, update_record, input)?;
 
-                    update_stmt.push_str("SET ");
-                    let vals = record.iter();
-                    vals.for_each(|(key, val)| match val {
-                        Value::Int { val, .. } => {
-                            update_stmt.push_str(&format!("{} = {}, ", key, val));
-                        }
-                        Value::Float { val, .. } => {
-                            update_stmt.push_str(&format!("{} = {}, ", key, val));
-                        }
-                        Value::String { val, .. } => {
-                            update_stmt.push_str(&format!("{} = '{}', ", key, val));
-                        }
-                        Value::Date { val, .. } => {
-                            update_stmt.push_str(&format!("{} = '{}', ", key, val));
-                        }
-                        Value::Bool { val, .. } => {
-                            update_stmt.push_str(&format!("{} = {}, ", key, val));
-                        }
-                        _ => {
-                            // return Err(ShellError::UnsupportedInput {
-                            //     msg: format!("{} is not a valid datepart, expected one of year, month, day, hour, minute, second, millisecond, microsecond, nanosecond", part.item),
-                            //     input: "value originates from here".to_string(),
-                            //     msg_span: span,
-                            //     input_span: val.span(),
-                            // });
-                        }
-                    });
-                    if update_stmt.ends_with(", ") {
-                        update_stmt.pop();
-                        update_stmt.pop();
-                    }
+        process(table_name, span, &db, columns, where_clause_opt)?;
 
-                    // Yup, this is a bit janky, but I'm not sure a better way to do this without having
-                    // --and and --or flags as well as supporting ==, !=, <>, is null, is not null, etc.
-                    // and other sql syntax. So, for now, just type a sql where clause as a string.
-                    if let Some(where_clause) = where_clause_opt {
-                        update_stmt.push_str(&format!(" WHERE {}", where_clause.item));
-                    }
-                    // dbg!(&update_stmt);
-
-                    conn.execute(&update_stmt, [])
-                        .map_err(|err| ShellError::GenericError {
-                            error: "Failed to open SQLite connection in memory from update".into(),
-                            msg: err.to_string(),
-                            span: Some(Span::test_data()),
-                            help: None,
-                            inner: vec![],
-                        })?;
-                }
-                None => {
-                    return Err(ShellError::MissingParameter {
-                        param_name: "requires at least one column".into(),
-                        span: call.head,
-                    });
-                }
-            };
-        }
-        // dbg!(db.clone());
         Ok(Value::custom(db, span).into_pipeline_data())
     }
+}
+
+fn handle(
+    span: Span,
+    update_record: Option<Record>,
+    input: PipelineData,
+) -> Result<Record, ShellError> {
+    match input {
+        PipelineData::Empty => update_record.ok_or_else(|| ShellError::MissingParameter {
+            param_name: "requires a record".into(),
+            span,
+        }),
+        PipelineData::Value(value, ..) => {
+            // Since input is being used, check if the data record parameter is used too
+            if update_record.is_some() {
+                return Err(ShellError::GenericError {
+                    error: "Pipeline and Flag both being used".into(),
+                    msg: "Use either pipeline input or '--update-record' parameter".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                });
+            }
+            match value {
+                Value::Record { val, .. } => Ok(val.into_owned()),
+                val => Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "record".into(),
+                    wrong_type: val.get_type().to_string(),
+                    dst_span: Span::unknown(),
+                    src_span: val.span(),
+                }),
+            }
+        }
+        _ => {
+            if update_record.is_some() {
+                return Err(ShellError::GenericError {
+                    error: "Pipeline and Flag both being used".into(),
+                    msg: "Use either pipeline input or '--update-record' parameter".into(),
+                    span: Some(span),
+                    help: None,
+                    inner: vec![],
+                });
+            }
+            Err(ShellError::OnlySupportsThisInputType {
+                exp_input_type: "record".into(),
+                wrong_type: "".into(),
+                dst_span: span,
+                src_span: span,
+            })
+        }
+    }
+}
+
+fn process(
+    table_name: Option<String>,
+    span: Span,
+    db: &SQLiteDatabase,
+    record: Record,
+    where_clause_opt: Option<Spanned<String>>,
+) -> Result<(), ShellError> {
+    if table_name.is_none() {
+        return Err(ShellError::MissingParameter {
+            param_name: "requires at table name".into(),
+            span,
+        });
+    }
+    let new_table_name = table_name.unwrap_or("table".into());
+    if let Ok(conn) = db.open_connection() {
+        let mut update_stmt = format!("UPDATE {} ", new_table_name);
+
+        update_stmt.push_str("SET ");
+        let vals = record.iter();
+        vals.for_each(|(key, val)| match val {
+            Value::Int { val, .. } => {
+                update_stmt.push_str(&format!("{} = {}, ", key, val));
+            }
+            Value::Float { val, .. } => {
+                update_stmt.push_str(&format!("{} = {}, ", key, val));
+            }
+            Value::String { val, .. } => {
+                update_stmt.push_str(&format!("{} = '{}', ", key, val));
+            }
+            Value::Date { val, .. } => {
+                update_stmt.push_str(&format!("{} = '{}', ", key, val));
+            }
+            Value::Bool { val, .. } => {
+                update_stmt.push_str(&format!("{} = {}, ", key, val));
+            }
+            _ => {
+                // return Err(ShellError::UnsupportedInput {
+                //     msg: format!("{} is not a valid datepart, expected one of year, month, day, hour, minute, second, millisecond, microsecond, nanosecond", part.item),
+                //     input: "value originates from here".to_string(),
+                //     msg_span: span,
+                //     input_span: val.span(),
+                // });
+            }
+        });
+        if update_stmt.ends_with(", ") {
+            update_stmt.pop();
+            update_stmt.pop();
+        }
+
+        // Yup, this is a bit janky, but I'm not sure a better way to do this without having
+        // --and and --or flags as well as supporting ==, !=, <>, is null, is not null, etc.
+        // and other sql syntax. So, for now, just type a sql where clause as a string.
+        if let Some(where_clause) = where_clause_opt {
+            update_stmt.push_str(&format!(" WHERE {}", where_clause.item));
+        }
+        // dbg!(&update_stmt);
+
+        conn.execute(&update_stmt, [])
+            .map_err(|err| ShellError::GenericError {
+                error: "Failed to open SQLite connection in memory from update".into(),
+                msg: err.to_string(),
+                span: Some(Span::test_data()),
+                help: None,
+                inner: vec![],
+            })?;
+    }
+    // dbg!(db.clone());
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- this PR should close #11433 

# Description
This PR implements pipeline input support for the stor insert and stor update commands, 
enabling users to directly pass data to these commands without relying solely on flag parameters. 

Previously, it was only possible to specify the record data using flag parameters,
which could be less intuitive and become cumbersome:

```bash
stor insert --table-name nudb --data-record {bool1: true, int1: 5, float1: 1.1, str1: fdncred, datetime1: 2023-04-17}
stor update --table-name nudb --update-record {str1: nushell datetime1: 2020-04-17}
```

Now it is also possible to pass a record through pipeline input:

```bash
{bool1: true, int1: 5, float1: 1.1, str1: fdncred, datetime1: 2023-04-17} | stor insert --table-name nudb
{str1: nushell datetime1: 2020-04-17} | stor update --table-name nudb"
```

Changes made on code:

- Modified stor insert and stor update to accept a record from the pipeline.
- Added logic to handle data from the pipeline record.
- Implemented an error case to prevent simultaneous data input from both pipeline and flag.

# User-facing changes

Returns an error when both ways of inserting data are used.

The examples for both commands were updated and in each command, when the -d or -u fags are being used at the same time as input is being passed through the pipeline, it returns an error:

![image](https://github.com/nushell/nushell/assets/120738170/c5b15c1b-716a-4df4-95e8-3bca8f7ae224)

Also returns an error when both of them are missing:

![image](https://github.com/nushell/nushell/assets/120738170/47f538ab-79f1-4fcc-9c62-d7a7d60f86a1)


# Tests + Formating
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
