### PR TITLE
allow define it as a variable inside closure

### DIFF
--- a/crates/nu-command/tests/commands/do_.rs
+++ b/crates/nu-command/tests/commands/do_.rs
@@ -66,3 +66,10 @@ fn ignore_error_works_with_list_stream() {
     let actual = nu!(r#"do -i { ["a", null, "b"] | ansi strip }"#);
     assert!(actual.err.is_empty());
 }
+
+#[test]
+fn run_closure_with_it_using() {
+    let actual = nu!(r#"let x = {let it = 3; $it}; do $x"#);
+    assert!(actual.err.is_empty());
+    assert_eq!(actual.out, "3");
+}

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4518,20 +4518,6 @@ pub fn parse_closure_expression(
 
     if let Some(signature) = signature {
         output.signature = signature.0;
-    } else if let Some(last) = working_set.delta.scope.last() {
-        // FIXME: this only supports the top $it. Is this sufficient?
-
-        if let Some(var_id) = last.get_var(b"$it") {
-            let mut signature = Signature::new("");
-            signature.required_positional.push(PositionalArg {
-                var_id: Some(*var_id),
-                name: "$it".into(),
-                desc: String::new(),
-                shape: SyntaxShape::Any,
-                default_value: None,
-            });
-            output.signature = Box::new(signature);
-        }
     }
 
     output.span = Some(span);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -4177,20 +4177,6 @@ pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> 
 
     if let Some(signature) = signature {
         output.signature = signature.0;
-    } else if let Some(last) = working_set.delta.scope.last() {
-        // FIXME: this only supports the top $it. Is this sufficient?
-
-        if let Some(var_id) = last.get_var(b"$it") {
-            let mut signature = Signature::new("");
-            signature.required_positional.push(PositionalArg {
-                var_id: Some(*var_id),
-                name: "$it".into(),
-                desc: String::new(),
-                shape: SyntaxShape::Any,
-                default_value: None,
-            });
-            output.signature = Box::new(signature);
-        }
     }
 
     output.span = Some(span);


### PR DESCRIPTION
# Description
Fixes: #12690 

The issue is happened after https://github.com/nushell/nushell/pull/12056 is merged.  It will raise error if user doesn't supply required parameter when run closure with do.
And parser adds a `$it` parameter when parsing closure or block expression.

I believe the previous behavior is because we allow such syntax on previous version(0.44):
```nushell
let x = { print $it }
```
But it's no longer allowed after 0.60.  So I think they can be removed.

# User-Facing Changes
```nushell
let tmp = {
  let it = 42
  print $it
}

do -c $tmp
```
should be possible again.

# Tests + Formatting
Added 1 test