### PR TITLE
fix range semantic in detect_columns, str substring, str index-of

### DIFF
--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -25,8 +25,8 @@ pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
         Range::IntRange(range) => {
             let start = range.start().try_into().unwrap_or(0);
             let end = match range.end() {
-                Bound::Included(v) => v as isize,
-                Bound::Excluded(v) => (v - 1) as isize,
+                Bound::Included(v) => (v + 1) as isize,
+                Bound::Excluded(v) => v as isize,
                 Bound::Unbounded => isize::MAX,
             };
             Ok((start, end))

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -405,7 +405,7 @@ mod tests {
         let range = Range::new(
             Value::int(0, Span::test_data()),
             Value::int(1, Span::test_data()),
-            Value::int(3, Span::test_data()),
+            Value::int(2, Span::test_data()),
             RangeInclusion::Inclusive,
             Span::test_data(),
         )

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -70,7 +70,7 @@ impl Command for SubCommand {
     }
 
     fn usage(&self) -> &str {
-        "Get part of a string. Note that the start is included but the end is excluded, and that the first character of a string is index 0."
+        "Get part of a string. Note that the first character of a string is index 0."
     }
 
     fn search_terms(&self) -> Vec<&str> {
@@ -108,12 +108,12 @@ impl Command for SubCommand {
             Example {
                 description:
                     "Get a substring \"nushell\" from the text \"good nushell\" using a range",
-                example: " 'good nushell' | str substring 5..12",
+                example: " 'good nushell' | str substring 5..11",
                 result: Some(Value::test_string("nushell")),
             },
             Example {
                 description: "Count indexes and split using grapheme clusters",
-                example: " '🇯🇵ほげ ふが ぴよ' | str substring --grapheme-clusters 4..6",
+                example: " '🇯🇵ほげ ふが ぴよ' | str substring --grapheme-clusters 4..5",
                 result: Some(Value::test_string("ふが")),
             },
         ]

--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -31,12 +31,12 @@ fn detect_columns_with_legacy_and_flag_c() {
         (
             "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
             "[[c1,c3,c4,c5]; ['a b',c,d,e]]",
-            "0..1",
+            "0..0",
         ),
         (
             "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
             "[[c1,c2,c3,c4]; [a,b,c,'d e']]",
-            "(-2)..(-1)",
+            "(-2)..(-2)",
         ),
         (
             "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
@@ -77,7 +77,7 @@ drwxr-xr-x  4 root root 4.0K Mar 20 08:18 ~(char nl)
 ['drwxr-xr-x', '4', 'root', 'root', '4.0K', 'Mar 20 08:18', '~'],
 ['-rw-r--r--',  '1', 'root', 'root', '3.0K', 'Mar 20 07:23', '~asdf']
 ]";
-    let range = "5..7";
+    let range = "5..6";
     let cmd = format!(
         "({} | detect columns -c {} -s 1 --no-headers) == {}",
         pipeline(body),

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -269,7 +269,7 @@ fn substring_errors_if_start_index_is_greater_than_end_index() {
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring 6..5 fortune.teller.phone
+                 | str substring 6..4 fortune.teller.phone
              "#
         ));
 
@@ -342,7 +342,7 @@ fn substrings_the_input_and_treats_start_index_as_zero_if_blank_start_index_give
             cwd: dirs.test(), pipeline(
             r#"
                  open sample.toml
-                 | str substring ..2 package.name
+                 | str substring ..1 package.name
                  | get package.name
              "#
         ));

--- a/tests/repl/test_strings.rs
+++ b/tests/repl/test_strings.rs
@@ -3,7 +3,7 @@ use crate::repl::tests::{fail_test, run_test, TestResult};
 #[test]
 fn cjk_in_substrings() -> TestResult {
     run_test(
-        r#"let s = '[Rust 程序设计语言](title-page.md)'; let start = ($s | str index-of '('); let end = ($s | str index-of ')'); $s | str substring ($start + 1)..($end)"#,
+        r#"let s = '[Rust 程序设计语言](title-page.md)'; let start = ($s | str index-of '('); let end = ($s | str index-of ')'); $s | str substring ($start + 1)..<($end)"#,
         "title-page.md",
     )
 }


### PR DESCRIPTION
# Description
Fixes: https://github.com/nushell/nushell/issues/7761

It's still unsure if we want to change the `range semantic` itself, but it's good to keep range semantic consistent between nushell commands.

# User-Facing Changes
### Before
```nushell
❯ "abc" | str substring 1..=2
b
```
### After
```nushell
❯ "abc" | str substring 1..=2
bc
```

# Tests + Formatting
Adjust tests to fit new behavior
