### PR TITLE
Exclude polars from ensure_plugins_built(), for performance reasons

### DIFF
--- a/crates/nu-test-support/src/commands.rs
+++ b/crates/nu-test-support/src/commands.rs
@@ -21,7 +21,18 @@ pub fn ensure_plugins_built() {
     }
 
     let cargo_path = env!("CARGO");
-    let mut arguments = vec!["build", "--package", "nu_plugin_*", "--quiet"];
+    let mut arguments = vec![
+        "build",
+        "--workspace",
+        "--bins",
+        // Don't build nu, so that we only build the plugins
+        "--exclude",
+        "nu",
+        // Exclude nu_plugin_polars, because it's not needed at this stage, and is a large build
+        "--exclude",
+        "nu_plugin_polars",
+        "--quiet",
+    ];
 
     let profile = std::env::var("NUSHELL_CARGO_PROFILE");
     if let Ok(profile) = &profile {


### PR DESCRIPTION
# Description

We have been building `nu_plugin_polars` unnecessarily during `cargo test`, which is very slow. All of its tests are run within its own crate, which happens during the plugins CI phase.

This should speed up the CI a bit.
