### PR TITLE
Fix the colors when completing using a relative path

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -1,7 +1,7 @@
 use crate::completions::{matches, CompletionOptions};
 use nu_ansi_term::Style;
 use nu_engine::env_to_string;
-use nu_path::home_dir;
+use nu_path::{expand_to_real_path, home_dir};
 use nu_protocol::{
     engine::{EngineState, Stack, StateWorkingSet},
     Span,
@@ -185,9 +185,14 @@ pub fn complete_item(
     .map(|p| {
         let path = original_cwd.apply(p);
         let style = ls_colors.as_ref().map(|lsc| {
-            lsc.style_for_path_with_metadata(&path, std::fs::symlink_metadata(&path).ok().as_ref())
-                .map(lscolors::Style::to_nu_ansi_term_style)
-                .unwrap_or_default()
+            lsc.style_for_path_with_metadata(
+                &path,
+                std::fs::symlink_metadata(expand_to_real_path(&path))
+                    .ok()
+                    .as_ref(),
+            )
+            .map(lscolors::Style::to_nu_ansi_term_style)
+            .unwrap_or_default()
         });
         (span, escape_path(path, want_directory), style)
     })


### PR DESCRIPTION
# Description
Fixes a bug where the autocompletion menu has the wrong colors due to 'std::fs::symlink_metadata' not being able to handle relative paths. Attached below are screenshots before and after applying the commit, in which the colors are wrong when autocompleting on a path prefixed by a tilde, whereas the same directory is highlighted correctly when prefixed by a dot.

BEFORE:
![1715982514020](https://github.com/nushell/nushell/assets/89810988/62051f03-0846-430d-b493-e6f3cd6d0e04)
![1715982873231](https://github.com/nushell/nushell/assets/89810988/28c647ab-3b2a-47ef-9967-5d09927e299d)
AFTER:
![1715982490585](https://github.com/nushell/nushell/assets/89810988/7a370138-50af-42fd-9724-a34cc605bede)
![1715982894748](https://github.com/nushell/nushell/assets/89810988/e884f69f-f757-426e-98c4-bc9f7f6fc561)