### PR TITLE
Clear environment for child `Command`s

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -530,6 +530,9 @@ impl ExternalCommand {
     }
 
     /// Spawn a command without shelling out to an external shell
+    ///
+    /// Note that this function will not set the cwd or environment variables.
+    /// It only creates the command and adds arguments.
     pub fn spawn_simple_command(&self, cwd: &str) -> Result<std::process::Command, ShellError> {
         let (head, _, _) = trim_enclosing_quotes(&self.name.item);
         let head = nu_path::expand_to_real_path(head)

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -537,6 +537,7 @@ impl ExternalCommand {
             .to_string();
 
         let mut process = std::process::Command::new(head);
+        process.env_clear();
 
         for (arg, arg_keep_raw) in self.args.iter().zip(self.arg_keep_raw.iter()) {
             trim_expand_and_apply_arg(&mut process, arg, arg_keep_raw, cwd);

--- a/tests/shell/environment/env.rs
+++ b/tests/shell/environment/env.rs
@@ -127,6 +127,15 @@ fn passes_with_env_env_var_to_external_process() {
 }
 
 #[test]
+fn hides_environment_from_child() {
+    let actual = nu!(r#"
+        $env.TEST = 1; ^$nu.current-exe -c "hide-env TEST; ^$nu.current-exe -c '$env.TEST'"
+    "#);
+    assert!(actual.out.is_empty());
+    assert!(actual.err.contains("cannot find column"));
+}
+
+#[test]
 fn has_file_pwd() {
     Playground::setup("has_file_pwd", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent("spam.nu", "$env.FILE_PWD")]);


### PR DESCRIPTION
# Description
There is a bug when `hide-env` is used on environment variables that were present at shell startup. Namely, child processes still inherit the hidden environment variable. This PR fixes #12900, fixes #11495, and fixes #7937.

# Tests + Formatting
Added a test.