### PR TITLE
Make `get_full_help` take `&dyn Command`

### DIFF
--- a/crates/nu-cli/src/commands/keybindings.rs
+++ b/crates/nu-cli/src/commands/keybindings.rs
@@ -36,16 +36,6 @@ For more information on input and keybindings, check:
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Keybindings.signature(),
-                &Keybindings.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-cli/src/menus/help_completions.rs
+++ b/crates/nu-cli/src/menus/help_completions.rs
@@ -12,50 +12,49 @@ impl NuHelpCompleter {
     }
 
     fn completion_helper(&self, line: &str, pos: usize) -> Vec<Suggestion> {
-        let full_commands = self.0.get_signatures_with_examples(false);
         let folded_line = line.to_folded_case();
 
-        //Vec<(Signature, Vec<Example>, bool, bool)> {
-        let mut commands = full_commands
-            .iter()
-            .filter(|(sig, _, _)| {
-                sig.name.to_folded_case().contains(&folded_line)
-                    || sig.usage.to_folded_case().contains(&folded_line)
-                    || sig
-                        .search_terms
-                        .iter()
+        let mut commands = self
+            .0
+            .get_decls_sorted(false)
+            .into_iter()
+            .filter_map(|(_, decl_id)| {
+                let decl = self.0.get_decl(decl_id);
+                (decl.name().to_folded_case().contains(&folded_line)
+                    || decl.usage().to_folded_case().contains(&folded_line)
+                    || decl
+                        .search_terms()
+                        .into_iter()
                         .any(|term| term.to_folded_case().contains(&folded_line))
-                    || sig.extra_usage.to_folded_case().contains(&folded_line)
+                    || decl.extra_usage().to_folded_case().contains(&folded_line))
+                .then_some(decl)
             })
             .collect::<Vec<_>>();
 
-        commands.sort_by(|(a, _, _), (b, _, _)| {
-            let a_distance = levenshtein_distance(line, &a.name);
-            let b_distance = levenshtein_distance(line, &b.name);
-            a_distance.cmp(&b_distance)
-        });
+        commands.sort_by_cached_key(|decl| levenshtein_distance(line, decl.name()));
 
         commands
             .into_iter()
-            .map(|(sig, examples, _)| {
+            .map(|decl| {
                 let mut long_desc = String::new();
 
-                let usage = &sig.usage;
+                let usage = decl.usage();
                 if !usage.is_empty() {
                     long_desc.push_str(usage);
                     long_desc.push_str("\r\n\r\n");
                 }
 
-                let extra_usage = &sig.extra_usage;
+                let extra_usage = decl.extra_usage();
                 if !extra_usage.is_empty() {
                     long_desc.push_str(extra_usage);
                     long_desc.push_str("\r\n\r\n");
                 }
 
+                let sig = decl.signature();
                 let _ = write!(long_desc, "Usage:\r\n  > {}\r\n", sig.call_signature());
 
                 if !sig.named.is_empty() {
-                    long_desc.push_str(&get_flags_section(Some(&*self.0.clone()), sig, |v| {
+                    long_desc.push_str(&get_flags_section(Some(&*self.0.clone()), &sig, |v| {
                         v.to_parsable_string(", ", &self.0.config)
                     }))
                 }
@@ -93,13 +92,14 @@ impl NuHelpCompleter {
                     }
                 }
 
-                let extra: Vec<String> = examples
+                let extra: Vec<String> = decl
+                    .examples()
                     .iter()
                     .map(|example| example.example.replace('\n', "\r\n"))
                     .collect();
 
                 Suggestion {
-                    value: sig.name.clone(),
+                    value: decl.name().into(),
                     description: Some(long_desc),
                     style: None,
                     extra: Some(extra),

--- a/crates/nu-cmd-dataframe/src/dataframe/stub.rs
+++ b/crates/nu-cmd-dataframe/src/dataframe/stub.rs
@@ -29,16 +29,6 @@ impl Command for Dfr {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Dfr.signature(),
-                &Dfr.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-cmd-extra/src/extra/bits/bits_.rs
+++ b/crates/nu-cmd-extra/src/extra/bits/bits_.rs
@@ -29,16 +29,6 @@ impl Command for Bits {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Bits.signature(),
-                &Bits.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-cmd-extra/src/extra/filters/roll/roll_.rs
+++ b/crates/nu-cmd-extra/src/extra/filters/roll/roll_.rs
@@ -33,16 +33,6 @@ impl Command for Roll {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Roll.signature(),
-                &Roll.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-cmd-extra/src/extra/strings/str_/case/str_.rs
+++ b/crates/nu-cmd-extra/src/extra/strings/str_/case/str_.rs
@@ -29,16 +29,6 @@ impl Command for Str {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Str.signature(),
-                &Str.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/export.rs
+++ b/crates/nu-cmd-lang/src/core_commands/export.rs
@@ -35,17 +35,7 @@ impl Command for ExportCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &ExportCommand.signature(),
-                &ExportCommand.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-cmd-lang/src/core_commands/overlay/command.rs
+++ b/crates/nu-cmd-lang/src/core_commands/overlay/command.rs
@@ -37,16 +37,6 @@ impl Command for Overlay {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Overlay.signature(),
-                &[],
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-cmd-lang/src/core_commands/scope/command.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/command.rs
@@ -31,16 +31,6 @@ impl Command for Scope {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Scope.signature(),
-                &[],
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-cmd-plugin/src/commands/plugin/mod.rs
+++ b/crates/nu-cmd-plugin/src/commands/plugin/mod.rs
@@ -37,17 +37,7 @@ impl Command for PluginCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &PluginCommand.signature(),
-                &PluginCommand.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/bytes/bytes_.rs
+++ b/crates/nu-command/src/bytes/bytes_.rs
@@ -29,16 +29,6 @@ impl Command for Bytes {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Bytes.signature(),
-                &Bytes.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/conversions/into/command.rs
+++ b/crates/nu-command/src/conversions/into/command.rs
@@ -29,16 +29,6 @@ impl Command for Into {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Into.signature(),
-                &[],
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/date/date_.rs
+++ b/crates/nu-command/src/date/date_.rs
@@ -42,26 +42,6 @@ impl Command for Date {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        date(engine_state, stack, call)
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
-}
-
-fn date(
-    engine_state: &EngineState,
-    stack: &mut Stack,
-    call: &Call,
-) -> Result<PipelineData, ShellError> {
-    let head = call.head;
-
-    Ok(Value::string(
-        get_full_help(
-            &Date.signature(),
-            &Date.examples(),
-            engine_state,
-            stack,
-            false,
-        ),
-        head,
-    )
-    .into_pipeline_data())
 }

--- a/crates/nu-command/src/debug/view.rs
+++ b/crates/nu-command/src/debug/view.rs
@@ -29,16 +29,6 @@ impl Command for View {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &View.signature(),
-                &View.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/env/config/config_.rs
+++ b/crates/nu-command/src/env/config/config_.rs
@@ -29,17 +29,7 @@ impl Command for ConfigMeta {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &ConfigMeta.signature(),
-                &ConfigMeta.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 
     fn search_terms(&self) -> Vec<&str> {

--- a/crates/nu-command/src/formats/from/command.rs
+++ b/crates/nu-command/src/formats/from/command.rs
@@ -29,16 +29,6 @@ impl Command for From {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &From.signature(),
-                &From.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/formats/to/command.rs
+++ b/crates/nu-command/src/formats/to/command.rs
@@ -29,16 +29,6 @@ impl Command for To {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &To.signature(),
-                &To.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/hash/hash_.rs
+++ b/crates/nu-command/src/hash/hash_.rs
@@ -29,16 +29,6 @@ impl Command for Hash {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Self.signature(),
-                &Self.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/help/help_externs.rs
+++ b/crates/nu-command/src/help/help_externs.rs
@@ -1,7 +1,6 @@
 use crate::help::highlight_search_in_table;
 use nu_color_config::StyleComputer;
 use nu_engine::{command_prelude::*, get_full_help, scope::ScopeData};
-use nu_protocol::engine::CommandType;
 
 #[derive(Clone)]
 pub struct HelpExterns;
@@ -109,18 +108,13 @@ pub fn help_externs(
         }
 
         let output = engine_state
-            .get_signatures_with_examples(false)
-            .iter()
-            .filter(|(signature, _, _)| signature.name == name)
-            .map(|(signature, examples, cmd_type)| {
-                get_full_help(
-                    signature,
-                    examples,
-                    engine_state,
-                    stack,
-                    cmd_type == &CommandType::Keyword,
-                )
+            .get_decls_sorted(false)
+            .into_iter()
+            .filter_map(|(_, decl_id)| {
+                let decl = engine_state.get_decl(decl_id);
+                (decl.name() == name).then_some(decl)
             })
+            .map(|cmd| get_full_help(cmd, engine_state, stack))
             .collect::<Vec<String>>();
 
         if !output.is_empty() {

--- a/crates/nu-command/src/help/help_modules.rs
+++ b/crates/nu-command/src/help/help_modules.rs
@@ -149,6 +149,7 @@ pub fn help_modules(
         if !module.decls.is_empty() || module.main.is_some() {
             let commands: Vec<(Vec<u8>, DeclId)> = engine_state
                 .get_decls_sorted(false)
+                .into_iter()
                 .filter(|(_, id)| !engine_state.get_decl(*id).is_alias())
                 .collect();
 
@@ -186,6 +187,7 @@ pub fn help_modules(
         if !module.decls.is_empty() {
             let aliases: Vec<(Vec<u8>, DeclId)> = engine_state
                 .get_decls_sorted(false)
+                .into_iter()
                 .filter(|(_, id)| engine_state.get_decl(*id).is_alias())
                 .collect();
 

--- a/crates/nu-command/src/math/math_.rs
+++ b/crates/nu-command/src/math/math_.rs
@@ -29,16 +29,6 @@ impl Command for MathCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &MathCommand.signature(),
-                &MathCommand.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/network/http/http_.rs
+++ b/crates/nu-command/src/network/http/http_.rs
@@ -35,16 +35,6 @@ impl Command for Http {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Http.signature(),
-                &Http.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/network/url/url_.rs
+++ b/crates/nu-command/src/network/url/url_.rs
@@ -33,16 +33,6 @@ impl Command for Url {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Url.signature(),
-                &Url.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/path/path_.rs
+++ b/crates/nu-command/src/path/path_.rs
@@ -42,16 +42,6 @@ the path literal."#
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &PathCommand.signature(),
-                &PathCommand.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/random/random_.rs
+++ b/crates/nu-command/src/random/random_.rs
@@ -33,16 +33,6 @@ impl Command for RandomCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &RandomCommand.signature(),
-                &RandomCommand.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/stor/stor_.rs
+++ b/crates/nu-command/src/stor/stor_.rs
@@ -29,16 +29,6 @@ impl Command for Stor {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Stor.signature(),
-                &Stor.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/strings/format/format_.rs
+++ b/crates/nu-command/src/strings/format/format_.rs
@@ -29,16 +29,6 @@ impl Command for Format {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Format.signature(),
-                &Format.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/strings/split/command.rs
+++ b/crates/nu-command/src/strings/split/command.rs
@@ -29,16 +29,6 @@ impl Command for SplitCommand {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &SplitCommand.signature(),
-                &SplitCommand.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-command/src/strings/str_/case/str_.rs
+++ b/crates/nu-command/src/strings/str_/case/str_.rs
@@ -29,16 +29,6 @@ impl Command for Str {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(
-                &Str.signature(),
-                &Str.examples(),
-                engine_state,
-                stack,
-                self.is_keyword(),
-            ),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 }

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -2,18 +2,16 @@ use crate::eval_call;
 use nu_protocol::{
     ast::{Argument, Call, Expr, Expression, RecordItem},
     debugger::WithoutDebug,
-    engine::{EngineState, Stack},
+    engine::{Command, EngineState, Stack},
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
     Value,
 };
 use std::{collections::HashMap, fmt::Write};
 
 pub fn get_full_help(
-    sig: &Signature,
-    examples: &[Example],
+    command: &dyn Command,
     engine_state: &EngineState,
     stack: &mut Stack,
-    is_parser_keyword: bool,
 ) -> String {
     let config = engine_state.get_config();
     let doc_config = DocumentationConfig {
@@ -23,14 +21,15 @@ pub fn get_full_help(
     };
 
     let stack = &mut stack.start_capture();
+    let signature = command.signature().update_from_command(command);
 
     get_documentation(
-        sig,
-        examples,
+        &signature,
+        &command.examples(),
         engine_state,
         stack,
         &doc_config,
-        is_parser_keyword,
+        command.is_keyword(),
     )
 }
 
@@ -61,7 +60,6 @@ fn nu_highlight_string(code_string: &str, engine_state: &EngineState, stack: &mu
     code_string.to_string()
 }
 
-#[allow(clippy::cognitive_complexity)]
 fn get_documentation(
     sig: &Signature,
     examples: &[Example],

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -27,12 +27,8 @@ pub fn eval_call<D: DebugContext>(
     let decl = engine_state.get_decl(call.decl_id);
 
     if !decl.is_known_external() && call.named_iter().any(|(flag, _, _)| flag.item == "help") {
-        let mut signature = engine_state.get_signature(decl);
-        signature.usage = decl.usage().to_string();
-        signature.extra_usage = decl.extra_usage().to_string();
-
-        let full_help = get_full_help(decl, engine_state, caller_stack);
-        Ok(Value::string(full_help, call.head).into_pipeline_data())
+        let help = get_full_help(decl, engine_state, caller_stack);
+        Ok(Value::string(help, call.head).into_pipeline_data())
     } else if let Some(block_id) = decl.block_id() {
         let block = engine_state.get_block(block_id);
 

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -31,13 +31,7 @@ pub fn eval_call<D: DebugContext>(
         signature.usage = decl.usage().to_string();
         signature.extra_usage = decl.extra_usage().to_string();
 
-        let full_help = get_full_help(
-            &signature,
-            &decl.examples(),
-            engine_state,
-            caller_stack,
-            decl.is_keyword(),
-        );
+        let full_help = get_full_help(decl, engine_state, caller_stack);
         Ok(Value::string(full_help, call.head).into_pipeline_data())
     } else if let Some(block_id) = decl.block_id() {
         let block = engine_state.get_block(block_id);

--- a/crates/nu-plugin-engine/src/context.rs
+++ b/crates/nu-plugin-engine/src/context.rs
@@ -139,14 +139,10 @@ impl<'a> PluginExecutionContext for PluginExecutionCommandContext<'a> {
     fn get_help(&self) -> Result<Spanned<String>, ShellError> {
         let decl = self.engine_state.get_decl(self.call.decl_id);
 
-        Ok(get_full_help(
-            &decl.signature(),
-            &decl.examples(),
-            &self.engine_state,
-            &mut self.stack.clone(),
-            false,
+        Ok(
+            get_full_help(decl, &self.engine_state, &mut self.stack.clone())
+                .into_spanned(self.call.head),
         )
-        .into_spanned(self.call.head))
     }
 
     fn get_span_contents(&self, span: Span) -> Result<Spanned<Vec<u8>>, ShellError> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,7 +2,7 @@ use nu_engine::{command_prelude::*, get_full_help};
 use nu_parser::{escape_for_script_arg, escape_quote_string, parse};
 use nu_protocol::{
     ast::{Expr, Expression},
-    engine::StateWorkingSet,
+    engine::{CommandType, StateWorkingSet},
     report_error,
 };
 use nu_utils::stdout_write_all_and_flush;
@@ -191,13 +191,7 @@ pub(crate) fn parse_commandline_args(
             let help = call.has_flag(engine_state, &mut stack, "help")?;
 
             if help {
-                let full_help = get_full_help(
-                    &Nu.signature(),
-                    &Nu.examples(),
-                    engine_state,
-                    &mut stack,
-                    true,
-                );
+                let full_help = get_full_help(&Nu, engine_state, &mut stack);
 
                 let _ = std::panic::catch_unwind(move || stdout_write_all_and_flush(full_help));
 
@@ -245,13 +239,7 @@ pub(crate) fn parse_commandline_args(
     }
 
     // Just give the help and exit if the above fails
-    let full_help = get_full_help(
-        &Nu.signature(),
-        &Nu.examples(),
-        engine_state,
-        &mut stack,
-        true,
-    );
+    let full_help = get_full_help(&Nu, engine_state, &mut stack);
     print!("{full_help}");
     std::process::exit(1);
 }
@@ -452,11 +440,7 @@ impl Command for Nu {
         call: &Call,
         _input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        Ok(Value::string(
-            get_full_help(&Nu.signature(), &Nu.examples(), engine_state, stack, true),
-            call.head,
-        )
-        .into_pipeline_data())
+        Ok(Value::string(get_full_help(self, engine_state, stack), call.head).into_pipeline_data())
     }
 
     fn examples(&self) -> Vec<nu_protocol::Example> {
@@ -472,5 +456,9 @@ impl Command for Nu {
                 result: None,
             },
         ]
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -2,7 +2,7 @@ use nu_engine::{command_prelude::*, get_full_help};
 use nu_parser::{escape_for_script_arg, escape_quote_string, parse};
 use nu_protocol::{
     ast::{Expr, Expression},
-    engine::{CommandType, StateWorkingSet},
+    engine::StateWorkingSet,
     report_error,
 };
 use nu_utils::stdout_write_all_and_flush;
@@ -456,9 +456,5 @@ impl Command for Nu {
                 result: None,
             },
         ]
-    }
-
-    fn command_type(&self) -> CommandType {
-        CommandType::Keyword
     }
 }

--- a/tests/repl/test_engine.rs
+++ b/tests/repl/test_engine.rs
@@ -54,8 +54,7 @@ fn in_and_if_else() -> TestResult {
 
 #[test]
 fn help_works_with_missing_requirements() -> TestResult {
-    let expected_length = "70";
-    run_test(r#"each --help | lines | length"#, expected_length)
+    run_test(r#"each --help | lines | length"#, "72")
 }
 
 #[test]
@@ -65,12 +64,12 @@ fn scope_variable() -> TestResult {
         "int",
     )
 }
+
 #[rstest]
 #[case("a", "<> nothing")]
 #[case("b", "<1.23> float")]
 #[case("flag1", "<> nothing")]
 #[case("flag2", "<4.56> float")]
-
 fn scope_command_defaults(#[case] var: &str, #[case] exp_result: &str) -> TestResult {
     run_test(
         &format!(


### PR DESCRIPTION
# Description
Changes `get_full_help` to take a `&dyn Command` instead of multiple arguments (`&Signature`, `&Examples` `is_parser_keyword`). All of these arguments can be gathered from a `Command`, so there is no need to pass the pieces to `get_full_help`.

This PR also fixes an issue where the search terms are not shown if `--help` is used on a command.