### PR TITLE
Take owned `Read` and `Write`

### DIFF
--- a/crates/nu-command/src/filesystem/save.rs
+++ b/crates/nu-command/src/filesystem/save.rs
@@ -508,7 +508,7 @@ fn get_files(
 }
 
 fn stream_to_file(
-    mut source: impl Read,
+    source: impl Read,
     known_size: Option<u64>,
     ctrlc: Option<Arc<AtomicBool>>,
     mut file: File,
@@ -555,7 +555,7 @@ fn stream_to_file(
             Ok(())
         }
     } else {
-        copy_with_interrupt(&mut source, &mut file, span, ctrlc.as_deref())?;
+        copy_with_interrupt(source, file, span, ctrlc.as_deref())?;
         Ok(())
     }
 }

--- a/crates/nu-command/src/filters/tee.rs
+++ b/crates/nu-command/src/filters/tee.rs
@@ -403,8 +403,8 @@ struct StreamInfo {
     metadata: Option<PipelineMetadata>,
 }
 
-fn copy(mut src: impl Read, mut dest: impl Write, info: &StreamInfo) -> Result<(), ShellError> {
-    copy_with_interrupt(&mut src, &mut dest, info.span, info.ctrlc.as_deref())?;
+fn copy(src: impl Read, dest: impl Write, info: &StreamInfo) -> Result<(), ShellError> {
+    copy_with_interrupt(src, dest, info.span, info.ctrlc.as_deref())?;
     Ok(())
 }
 
@@ -416,8 +416,8 @@ fn copy_pipe(pipe: ChildPipe, dest: impl Write, info: &StreamInfo) -> Result<(),
 }
 
 fn copy_on_thread(
-    mut src: impl Read + Send + 'static,
-    mut dest: impl Write + Send + 'static,
+    src: impl Read + Send + 'static,
+    dest: impl Write + Send + 'static,
     info: &StreamInfo,
 ) -> Result<JoinHandle<Result<(), ShellError>>, ShellError> {
     let span = info.span;
@@ -425,7 +425,7 @@ fn copy_on_thread(
     thread::Builder::new()
         .name("stderr copier".into())
         .spawn(move || {
-            copy_with_interrupt(&mut src, &mut dest, span, ctrlc.as_deref())?;
+            copy_with_interrupt(src, dest, span, ctrlc.as_deref())?;
             Ok(())
         })
         .map_err(|e| e.into_spanned(span).into())


### PR DESCRIPTION
# Description
As @YizhePKU pointed out, the [Rust API guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#generic-readerwriter-functions-take-r-read-and-w-write-by-value-c-rw-value) recommend that generic functions take readers and writers by value and not by reference. This PR changes `copy_with_interupt` and few other places to take owned `Read` and `Write` instead of mutable references. 