### PR TITLE
`explore`: consolidate padding config, handle ByteStream, tweak naming+comments

### DIFF
--- a/crates/nu-explore/src/commands/table.rs
+++ b/crates/nu-explore/src/commands/table.rs
@@ -25,8 +25,6 @@ struct TableSettings {
     selected_column_s: Option<Style>,
     padding_column_left: Option<usize>,
     padding_column_right: Option<usize>,
-    padding_index_left: Option<usize>,
-    padding_index_right: Option<usize>,
     turn_on_cursor_mode: bool,
 }
 
@@ -100,16 +98,6 @@ impl ViewCommand for TableCmd {
         if let Some(p) = self.settings.padding_column_right {
             let c = view.get_padding_column();
             view.set_padding_column((c.0, p))
-        }
-
-        if let Some(p) = self.settings.padding_index_left {
-            let c = view.get_padding_index();
-            view.set_padding_index((p, c.1))
-        }
-
-        if let Some(p) = self.settings.padding_index_right {
-            let c = view.get_padding_index();
-            view.set_padding_index((c.0, p))
         }
 
         if self.settings.turn_on_cursor_mode {

--- a/crates/nu-explore/src/views/binary/binary_widget.rs
+++ b/crates/nu-explore/src/views/binary/binary_widget.rs
@@ -12,7 +12,7 @@ use crate::{
     views::util::{nu_style_to_tui, text_style_to_tui_style},
 };
 
-// Padding between segments in the hex view
+/// Padding between segments in the hex view
 const SEGMENT_PADDING: u16 = 1;
 
 #[derive(Debug, Clone)]

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     util::create_map,
 };
 
-use self::binary_widget::{BinarySettings, BinaryStyle, BinaryWidget, Indent};
+use self::binary_widget::{BinarySettings, BinaryStyle, BinaryWidget};
 
 use super::{cursor::XYCursor, Layout, View, ViewConfig};
 
@@ -193,19 +193,8 @@ fn settings_from_config(config: &ConfigMap) -> Settings {
         ),
         style: BinaryStyle::new(
             colors.get("color_index").cloned(),
-            Indent::new(
-                config_get_usize(config, "padding_index_left", 2) as u16,
-                config_get_usize(config, "padding_index_right", 2) as u16,
-            ),
-            Indent::new(
-                config_get_usize(config, "padding_data_left", 2) as u16,
-                config_get_usize(config, "padding_data_right", 2) as u16,
-            ),
-            Indent::new(
-                config_get_usize(config, "padding_ascii_left", 2) as u16,
-                config_get_usize(config, "padding_ascii_right", 2) as u16,
-            ),
-            config_get_usize(config, "padding_segment", 1),
+            config_get_usize(config, "column_padding_left", 1) as u16,
+            config_get_usize(config, "column_padding_right", 1) as u16,
             config_get_bool(config, "split", false),
         ),
     }

--- a/crates/nu-explore/src/views/record/mod.rs
+++ b/crates/nu-explore/src/views/record/mod.rs
@@ -71,26 +71,14 @@ impl<'a> RecordView<'a> {
     }
 
     pub fn set_padding_column(&mut self, (left, right): (usize, usize)) {
-        self.theme.table.padding_column_left = left;
-        self.theme.table.padding_column_right = right;
-    }
-
-    pub fn set_padding_index(&mut self, (left, right): (usize, usize)) {
-        self.theme.table.padding_index_left = left;
-        self.theme.table.padding_index_right = right;
+        self.theme.table.column_padding_left = left;
+        self.theme.table.column_padding_right = right;
     }
 
     pub fn get_padding_column(&self) -> (usize, usize) {
         (
-            self.theme.table.padding_column_left,
-            self.theme.table.padding_column_right,
-        )
-    }
-
-    pub fn get_padding_index(&self) -> (usize, usize) {
-        (
-            self.theme.table.padding_index_left,
-            self.theme.table.padding_index_right,
+            self.theme.table.column_padding_left,
+            self.theme.table.column_padding_right,
         )
     }
 
@@ -853,10 +841,8 @@ fn theme_from_config(config: &ConfigMap) -> TableTheme {
     theme.table.show_header = config_get_bool(config, "show_head", true);
     theme.table.show_index = config_get_bool(config, "show_index", false);
 
-    theme.table.padding_index_left = config_get_usize(config, "padding_index_left", 2);
-    theme.table.padding_index_right = config_get_usize(config, "padding_index_right", 1);
-    theme.table.padding_column_left = config_get_usize(config, "padding_column_left", 2);
-    theme.table.padding_column_right = config_get_usize(config, "padding_column_right", 2);
+    theme.table.column_padding_left = config_get_usize(config, "column_padding_left", 1);
+    theme.table.column_padding_right = config_get_usize(config, "column_padding_right", 1);
 
     theme
 }

--- a/crates/nu-explore/src/views/record/tablew.rs
+++ b/crates/nu-explore/src/views/record/tablew.rs
@@ -617,8 +617,8 @@ fn create_column(data: &[Vec<NuText>], col: usize) -> Vec<NuText> {
     column
 }
 
-// Starting at cell [x, y]: paint `width` characters of `c` (left to right), move 1 row down, repeat
-// Repeat this `height` times
+/// Starting at cell [x, y]: paint `width` characters of `c` (left to right), move 1 row down, repeat
+/// Repeat this `height` times
 fn repeat_vertical(
     buf: &mut ratatui::buffer::Buffer,
     x: u16,

--- a/crates/nu-explore/src/views/record/tablew.rs
+++ b/crates/nu-explore/src/views/record/tablew.rs
@@ -157,7 +157,7 @@ impl<'a> TableW<'a> {
                 padding_index_r,
             );
 
-            width += render_vertical(
+            width += render_vertical_line_with_split(
                 buf,
                 width,
                 data_y,
@@ -248,7 +248,7 @@ impl<'a> TableW<'a> {
         }
 
         if width < area.width {
-            width += render_vertical(
+            width += render_vertical_line_with_split(
                 buf,
                 width,
                 data_y,
@@ -296,7 +296,7 @@ impl<'a> TableW<'a> {
                 padding_index_r,
             );
 
-            left_w += render_vertical(
+            left_w += render_vertical_line_with_split(
                 buf,
                 area.x + left_w,
                 area.y,
@@ -328,7 +328,7 @@ impl<'a> TableW<'a> {
 
             if !show_index {
                 let x = area.x + left_w;
-                left_w += render_vertical(buf, x, area.y, area.height, false, false, splitline_s);
+                left_w += render_vertical_line_with_split(buf, x, area.y, area.height, false, false, splitline_s);
             }
 
             let x = area.x + left_w;
@@ -345,7 +345,7 @@ impl<'a> TableW<'a> {
                     .push(text, layout_x, area.y + i as u16, columns_width as u16, 1);
             }
 
-            left_w += render_vertical(
+            left_w += render_vertical_line_with_split(
                 buf,
                 area.x + left_w,
                 area.y,
@@ -561,7 +561,7 @@ fn render_index(
     width
 }
 
-fn render_vertical(
+fn render_vertical_line_with_split(
     buf: &mut Buffer,
     x: u16,
     y: u16,
@@ -570,7 +570,7 @@ fn render_vertical(
     bottom_slit: bool,
     style: NuStyle,
 ) -> u16 {
-    render_vertical_split(buf, x, y, height, style);
+    render_vertical_line(buf, x, y, height, style);
 
     if top_slit && y > 0 {
         render_top_connector(buf, x, y - 1, style);
@@ -583,7 +583,7 @@ fn render_vertical(
     1
 }
 
-fn render_vertical_split(buf: &mut Buffer, x: u16, y: u16, height: u16, style: NuStyle) {
+fn render_vertical_line(buf: &mut Buffer, x: u16, y: u16, height: u16, style: NuStyle) {
     let style = TextStyle {
         alignment: Alignment::Left,
         color_style: Some(style),
@@ -615,10 +615,12 @@ fn create_column(data: &[Vec<NuText>], col: usize) -> Vec<NuText> {
     column
 }
 
+// Starting at cell [x, y]: paint `width` characters of `c` (left to right), move 1 row down, repeat
+// Repeat this `height` times
 fn repeat_vertical(
     buf: &mut ratatui::buffer::Buffer,
-    x_offset: u16,
-    y_offset: u16,
+    x: u16,
+    y: u16,
     width: u16,
     height: u16,
     c: char,
@@ -631,7 +633,7 @@ fn repeat_vertical(
     let span = Span::styled(text, style);
 
     for row in 0..height {
-        buf.set_span(x_offset, y_offset + row, &span, width);
+        buf.set_span(x, y + row, &span, width);
     }
 }
 


### PR DESCRIPTION
Some minor changes to `explore`, continuing on my mission to simplify the command in preparation for a larger UX overhaul:

1. Consolidate padding configuration. I don't think we need separate config points for the (optional) index column and regular data columns in the normal pager, they can share padding configuration. Likewise, in the binary viewer all 3 columns (index, data, ASCII) had their left+right padding configured independently.
2. Update `explore` so we use the binary viewer for the new `ByteStream` type. `cat foo.txt | into binary | explore` was not using the binary viewer after the `ByteStream` changes.
3. Tweak the naming of a few helper functions, add a comment

I've put the changes in separate commits to make them easier to review.