### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,7 +2846,6 @@ dependencies = [
  "nu-test-support",
  "nu-utils",
  "once_cell",
- "pathdiff",
  "percent-encoding",
  "reedline",
  "rstest",

--- a/crates/nu-cli/Cargo.toml
+++ b/crates/nu-cli/Cargo.toml
@@ -39,7 +39,6 @@ miette = { workspace = true, features = ["fancy-no-backtrace"] }
 lscolors = { workspace = true, default-features = false, features = ["nu-ansi-term"] }
 once_cell = { workspace = true }
 percent-encoding = { workspace = true }
-pathdiff = { workspace = true }
 sysinfo = { workspace = true }
 unicode-segmentation = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/crates/nu-protocol/Cargo.toml
+++ b/crates/nu-protocol/Cargo.toml
@@ -28,7 +28,6 @@ miette = { workspace = true, features = ["fancy-no-backtrace"] }
 num-format = { workspace = true }
 rmp-serde = { workspace = true, optional = true }
 serde = { workspace = true, default-features = false }
-serde_json = { workspace = true, optional = true }
 thiserror = "1.0"
 typetag = "0.2"
 os_pipe = { workspace = true, features = ["io_safety"] }
@@ -40,7 +39,6 @@ nix = { workspace = true, default-features = false, features = ["signal"] }
 plugin = [
   "brotli",
   "rmp-serde",
-  "serde_json",
 ]
 
 [dev-dependencies]


### PR DESCRIPTION
- **Remove unused `pathdiff` dep in `nu-cli`**
- **Remove unused `serde_json` dep on `nu-protocol`**
  - Unnecessary after moving the plugin file to msgpack (still a dev-dependency)
