### PR TITLE
`explore` cleanup: remove+move binary viewer config

### DIFF
--- a/crates/nu-explore/src/views/binary/binary_widget.rs
+++ b/crates/nu-explore/src/views/binary/binary_widget.rs
@@ -20,11 +20,17 @@ pub struct BinaryWidget<'a> {
     data: &'a [u8],
     opts: BinarySettings,
     style: BinaryStyle,
+    row_offset: usize,
 }
 
 impl<'a> BinaryWidget<'a> {
     pub fn new(data: &'a [u8], opts: BinarySettings, style: BinaryStyle) -> Self {
-        Self { data, opts, style }
+        Self {
+            data,
+            opts,
+            style,
+            row_offset: 0,
+        }
     }
 
     pub fn count_lines(&self) -> usize {
@@ -35,8 +41,8 @@ impl<'a> BinaryWidget<'a> {
         self.opts.count_segments * self.opts.segment_size
     }
 
-    pub fn set_index_offset(&mut self, offset: usize) {
-        self.opts.index_offset = offset;
+    pub fn set_row_offset(&mut self, offset: usize) {
+        self.row_offset = offset;
     }
 }
 
@@ -44,15 +50,13 @@ impl<'a> BinaryWidget<'a> {
 pub struct BinarySettings {
     segment_size: usize,
     count_segments: usize,
-    index_offset: usize,
 }
 
 impl BinarySettings {
-    pub fn new(segment_size: usize, count_segments: usize, index_offset: usize) -> Self {
+    pub fn new(segment_size: usize, count_segments: usize) -> Self {
         Self {
             segment_size,
             count_segments,
-            index_offset,
         }
     }
 }
@@ -101,7 +105,7 @@ fn render_hexdump(area: Rect, buf: &mut Buffer, w: BinaryWidget) {
     for line in 0..area.height {
         let data_line_length = w.opts.count_segments * w.opts.segment_size;
         let start_index = line as usize * data_line_length;
-        let address = w.opts.index_offset + start_index;
+        let address = w.row_offset + start_index;
 
         if start_index > w.data.len() {
             last_line = Some(line);
@@ -140,7 +144,7 @@ fn render_hexdump(area: Rect, buf: &mut Buffer, w: BinaryWidget) {
         for line in last_line..area.height {
             let data_line_length = w.opts.count_segments * w.opts.segment_size;
             let start_index = line as usize * data_line_length;
-            let address = w.opts.index_offset + start_index;
+            let address = w.row_offset + start_index;
 
             let mut x = 0;
             let y = line;
@@ -333,7 +337,7 @@ fn repeat_vertical(
 fn get_max_index_size(w: &BinaryWidget) -> usize {
     let line_size = w.opts.count_segments * (w.opts.segment_size * 2);
     let count_lines = w.data.len() / line_size;
-    let max_index = w.opts.index_offset + count_lines * line_size;
+    let max_index = w.row_offset + count_lines * line_size;
     usize_to_hex(max_index, 0).len()
 }
 
@@ -343,7 +347,7 @@ fn get_widget_width(w: &BinaryWidget) -> usize {
     let line_size = w.opts.count_segments * (w.opts.segment_size * 2);
     let count_lines = w.data.len() / line_size;
 
-    let max_index = w.opts.index_offset + count_lines * line_size;
+    let max_index = w.row_offset + count_lines * line_size;
     let index_size = usize_to_hex(max_index, 0).len();
     let index_size = index_size.max(MIN_INDEX_SIZE);
 

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -107,7 +107,7 @@ fn create_binary_widget(v: &BinaryView) -> BinaryWidget<'_> {
     let data = &v.data[index..];
 
     let mut w = BinaryWidget::new(data, v.settings.opts, v.settings.style.clone());
-    w.set_index_offset(index);
+    w.set_row_offset(index);
 
     w
 }
@@ -186,7 +186,6 @@ fn settings_from_config(config: &ConfigMap) -> Settings {
         opts: BinarySettings::new(
             config_get_usize(config, "segment_size", 2),
             config_get_usize(config, "count_segments", 8),
-            0,
         ),
         style: BinaryStyle::new(
             colors.get("color_index").cloned(),

--- a/crates/nu-explore/src/views/binary/mod.rs
+++ b/crates/nu-explore/src/views/binary/mod.rs
@@ -184,9 +184,6 @@ fn settings_from_config(config: &ConfigMap) -> Settings {
 
     Settings {
         opts: BinarySettings::new(
-            !config_get_bool(config, "show_index", true),
-            !config_get_bool(config, "show_ascii", true),
-            !config_get_bool(config, "show_data", true),
             config_get_usize(config, "segment_size", 2),
             config_get_usize(config, "count_segments", 8),
             0,
@@ -195,16 +192,8 @@ fn settings_from_config(config: &ConfigMap) -> Settings {
             colors.get("color_index").cloned(),
             config_get_usize(config, "column_padding_left", 1) as u16,
             config_get_usize(config, "column_padding_right", 1) as u16,
-            config_get_bool(config, "split", false),
         ),
     }
-}
-
-fn config_get_bool(config: &ConfigMap, key: &str, default: bool) -> bool {
-    config
-        .get(key)
-        .and_then(|v| v.as_bool().ok())
-        .unwrap_or(default)
 }
 
 fn config_get_usize(config: &ConfigMap, key: &str, default: usize) -> usize {


### PR DESCRIPTION
Small change, removing 4 more configuration options from `explore`'s binary viewer:

1. `show_index`
2. `show_data`
3. `show_ascii`
4. `show_split`

These controlled whether the 3 columns in the binary viewer (index, hex data, ASCII) and the pipe separator (`|`) in between them are shown. I don't think we need this level of configurability until the `explore` command is more mature, and maybe even not then; we can just show them all.

I think it's very unlikely that anyone is using these configuration points.

Also, the row offset (e.g. how many rows we have scrolled down) was being stored in config/settings when it's arguably not config; more like internal state of the binary viewer. I moved it to a more appropriate location and renamed it.