### PR TITLE
Add completer for std help

### DIFF
--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -93,6 +93,18 @@ def "nu-complete list-commands" [] {
     scope commands | select name usage | rename value description
 }
 
+def "nu-complete main-help" [] {
+    [
+        { value: "commands", description: "Show help on Nushell commands." }
+        { value: "aliases", description: "Show help on Nushell aliases." }
+        { value: "modules", description: "Show help on Nushell modules." }
+        { value: "externs", description: "Show help on Nushell externs." }
+        { value: "operators", description: "Show help on Nushell operators." }
+        { value: "escapes", description: "Show help on Nushell string escapes." }
+    ]
+    | append (nu-complete list-commands)
+}
+
 def "nu-complete list-externs" [] {
     scope commands | where is_extern | select name usage | rename value description
 }
@@ -720,7 +732,7 @@ def pretty-cmd [] {
 #   search for string in command names, usage and search terms
 #   > help --find char
 export def main [
-    ...item: string  # the name of the help item to get help on
+    ...item: string@"nu-complete main-help"  # the name of the help item to get help on
     --find (-f): string  # string to find in help items names and usage
 ] {
     if ($item | is-empty) and ($find | is-empty) {


### PR DESCRIPTION
# Description

While each of the `help <subcommands>` in `std` had completers, there wasn't one for the main `help` command.

This adds all internals and custom commands (as with `help commands`) as possible completions.

# User-Facing Changes

`help ` + <kbd>Tab</kbd> will now suggest completions for both the `help <subcommands>` as well as all internal and custom commands.

# Tests + Formatting

Note: Cannot add tests for completion functions since they are module-internal and not visible to test cases, that I can see.

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`