### PR TITLE
Small improvements to `debug profile`

### DIFF
--- a/crates/nu-command/src/debug/profile.rs
+++ b/crates/nu-command/src/debug/profile.rs
@@ -28,6 +28,7 @@ impl Command for DebugProfile {
                 Some('v'),
             )
             .switch("expr", "Collect expression types", Some('x'))
+            .switch("lines", "Collect line numbers", Some('l'))
             .named(
                 "max-depth",
                 SyntaxShape::Int,
@@ -90,6 +91,7 @@ confusing the id/parent_id hierarchy. The --expr flag is helpful for investigati
         let collect_expanded_source = call.has_flag(engine_state, stack, "expanded-source")?;
         let collect_values = call.has_flag(engine_state, stack, "values")?;
         let collect_exprs = call.has_flag(engine_state, stack, "expr")?;
+        let collect_lines = call.has_flag(engine_state, stack, "lines")?;
         let max_depth = call
             .get_flag(engine_state, stack, "max-depth")?
             .unwrap_or(2);
@@ -101,6 +103,7 @@ confusing the id/parent_id hierarchy. The --expr flag is helpful for investigati
             collect_expanded_source,
             collect_values,
             collect_exprs,
+            collect_lines,
             call.span(),
         );
 

--- a/crates/nu-command/src/debug/profile.rs
+++ b/crates/nu-command/src/debug/profile.rs
@@ -121,14 +121,11 @@ confusing the id/parent_id hierarchy. The --expr flag is helpful for investigati
 
         let result = ClosureEvalOnce::new(engine_state, stack, closure).run_with_input(input);
 
-        // TODO: See eval_source()
-        match result {
-            Ok(pipeline_data) => {
-                let _ = pipeline_data.into_value(call.span());
-                // pipeline_data.print(engine_state, caller_stack, true, false)
-            }
-            Err(_e) => (), // TODO: Report error
-        }
+        // Return potential errors
+        let pipeline_data = result?;
+
+        // Collect the output
+        let _ = pipeline_data.into_value(call.span());
 
         Ok(engine_state
             .deactivate_debugger()

--- a/crates/nu-protocol/src/debugger/profiler.rs
+++ b/crates/nu-protocol/src/debugger/profiler.rs
@@ -305,7 +305,7 @@ fn collect_data(
             row.push("line_num", Value::int(line_num as i64, profiler_span));
         } else {
             row.push("file", Value::nothing(profiler_span));
-            row.push("line_num", Value::nothing(profiler_span));
+            row.push("line", Value::nothing(profiler_span));
         }
     }
 

--- a/crates/nu-protocol/src/debugger/profiler.rs
+++ b/crates/nu-protocol/src/debugger/profiler.rs
@@ -270,7 +270,7 @@ fn expr_to_string(engine_state: &EngineState, expr: &Expr) -> String {
 // Find a file name and a line number (indexed from 1) of a span
 fn find_file_of_span(engine_state: &EngineState, span: Span) -> Option<(&str, usize)> {
     for file in engine_state.files() {
-        if file.covered_span.start < span.start && file.covered_span.end > span.start {
+        if file.covered_span.contains_span(span) {
             // count the number of lines between file start and the searched span start
             let chunk =
                 engine_state.get_span_contents(Span::new(file.covered_span.start, span.start));

--- a/crates/nu-protocol/src/debugger/profiler.rs
+++ b/crates/nu-protocol/src/debugger/profiler.rs
@@ -275,7 +275,15 @@ fn find_file_of_span(engine_state: &EngineState, span: Span) -> Option<(&str, us
             let chunk =
                 engine_state.get_span_contents(Span::new(file.covered_span.start, span.start));
             let nlines = chunk.lines().count();
-            let line_num = if nlines <= 1 { 1 } else { nlines + 1 };
+            // account for leading part of current line being counted as a separate line
+            let line_num = if chunk.last() == Some(&b'\n') {
+                nlines + 1
+            } else {
+                nlines
+            };
+
+            // first line has no previous line, clamp up to `1`
+            let line_num = usize::max(line_num, 1);
 
             return Some((&file.name, line_num));
         }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

1. With the `-l` flag, `debug profile` now collects files and line numbers of profiled pipeline elements
![profiler_lines](https://github.com/nushell/nushell/assets/25571562/b400a956-d958-4aff-aa4c-7e65da3f78fa)

2. Error from the profiled closure will be reported instead of silently ignored.
![profiler_lines_error](https://github.com/nushell/nushell/assets/25571562/54f7ad7a-06a3-4d56-92c2-c3466917bee8)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

New `--lines(-l)` flag to `debug profile`. The command will also fail if the profiled closure fails, so technically it is a breaking change.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
