### PR TITLE
Remove list support in `with-env`

### DIFF
--- a/crates/nu-command/src/env/with_env.rs
+++ b/crates/nu-command/src/env/with_env.rs
@@ -1,6 +1,5 @@
 use nu_engine::{command_prelude::*, eval_block};
 use nu_protocol::{debugger::WithoutDebug, engine::Closure};
-use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct WithEnv;
@@ -58,78 +57,14 @@ fn with_env(
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
-    let variable: Value = call.req(engine_state, stack, 0)?;
-
+    let env: Record = call.req(engine_state, stack, 0)?;
     let capture_block: Closure = call.req(engine_state, stack, 1)?;
     let block = engine_state.get_block(capture_block.block_id);
     let mut stack = stack.captures_to_stack_preserve_out_dest(capture_block.captures);
 
-    let mut env: HashMap<String, Value> = HashMap::new();
-
-    match &variable {
-        Value::List { vals: table, .. } => {
-            nu_protocol::report_error_new(
-                engine_state,
-                &ShellError::GenericError {
-                    error: "Deprecated argument type".into(),
-                    msg: "providing the variables to `with-env` as a list or single row table has been deprecated".into(),
-                    span: Some(variable.span()),
-                    help: Some("use the record form instead".into()),
-                    inner: vec![],
-                },
-            );
-            if table.len() == 1 {
-                // single row([[X W]; [Y Z]])
-                match &table[0] {
-                    Value::Record { val, .. } => {
-                        for (k, v) in &**val {
-                            env.insert(k.to_string(), v.clone());
-                        }
-                    }
-                    x => {
-                        return Err(ShellError::CantConvert {
-                            to_type: "record".into(),
-                            from_type: x.get_type().to_string(),
-                            span: x.span(),
-                            help: None,
-                        });
-                    }
-                }
-            } else {
-                // primitive values([X Y W Z])
-                for row in table.chunks(2) {
-                    if row.len() == 2 {
-                        env.insert(row[0].coerce_string()?, row[1].clone());
-                    }
-                    if row.len() == 1 {
-                        return Err(ShellError::IncorrectValue {
-                            msg: format!("Missing value for $env.{}", row[0].coerce_string()?),
-                            val_span: row[0].span(),
-                            call_span: call.head,
-                        });
-                    }
-                }
-            }
-        }
-        // when get object by `open x.json` or `from json`
-        Value::Record { val, .. } => {
-            for (k, v) in &**val {
-                env.insert(k.clone(), v.clone());
-            }
-        }
-        x => {
-            return Err(ShellError::CantConvert {
-                to_type: "record".into(),
-                from_type: x.get_type().to_string(),
-                span: x.span(),
-                help: None,
-            });
-        }
-    };
-
     // TODO: factor list of prohibited env vars into common place
     for prohibited in ["PWD", "FILE_PWD", "CURRENT_FILE"] {
-        if env.contains_key(prohibited) {
+        if env.contains(prohibited) {
             return Err(ShellError::AutomaticEnvVarSetManually {
                 envvar_name: prohibited.into(),
                 span: call.head,


### PR DESCRIPTION
# Description
Following from #12523, this PR removes support for lists of environments variables in the `with-env` command. Rather, only records will be supported now.

# After Submitting
Update examples using the list form in the docs and book.