### PR TITLE
Do not propagate glob creation error for external args

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -295,19 +295,15 @@ fn expand_tilde(arg: &str) -> String {
     nu_path::expand_tilde(arg).to_string_lossy().to_string()
 }
 
-/// Performs glob expansion on `arg`. If the expansion found no matches, returns
-/// the original string as the expansion result.
+/// Performs glob expansion on `arg`. If the expansion found no matches or the pattern
+/// is not a valid glob, then this returns the original string as the expansion result.
 ///
 /// Note: This matches the default behavior of Bash, but is known to be
 /// error-prone. We might want to change this behavior in the future.
 fn expand_glob(arg: &str, cwd: &Path, span: Span) -> Result<Vec<String>, ShellError> {
-    let paths =
-        nu_glob::glob_with_parent(arg, nu_glob::MatchOptions::default(), cwd).map_err(|err| {
-            ShellError::InvalidGlobPattern {
-                msg: err.msg.to_string(),
-                span,
-            }
-        })?;
+    let Ok(paths) = nu_glob::glob_with_parent(arg, nu_glob::MatchOptions::default(), cwd) else {
+        return Ok(vec![arg.into()]);
+    };
 
     let mut result = vec![];
     for path in paths {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -643,7 +643,9 @@ mod test {
         let expected = &["'*.txt'"];
         assert_eq!(actual, expected);
 
-        expand_glob("[*.txt", cwd, Span::unknown()).unwrap_err();
+        let actual = expand_glob("[*.txt", cwd, Span::unknown()).unwrap();
+        let expected = &["[*.txt"];
+        assert_eq!(actual, expected);
     }
 
     #[test]


### PR DESCRIPTION
# Description
Instead of returning an error, this PR changes `expand_glob` in `run_external.rs` to return the original string arg if glob creation failed. This makes it so that, e.g.,
```nushell
^echo `[`
^echo `***`
```
no longer fail with a shell error. (This follows from #12921.)
