### PR TITLE
Span ID Refactor - Step 1

### DIFF
--- a/crates/nu-cli/src/completions/custom_completions.rs
+++ b/crates/nu-cli/src/completions/custom_completions.rs
@@ -52,18 +52,16 @@ impl Completer for CustomCompletion {
                 decl_id: self.decl_id,
                 head: span,
                 arguments: vec![
-                    Argument::Positional(Expression {
-                        span: Span::unknown(),
-                        ty: Type::String,
-                        expr: Expr::String(self.line.clone()),
-                        custom_completion: None,
-                    }),
-                    Argument::Positional(Expression {
-                        span: Span::unknown(),
-                        ty: Type::Int,
-                        expr: Expr::Int(line_pos as i64),
-                        custom_completion: None,
-                    }),
+                    Argument::Positional(Expression::new_unknown(
+                        Expr::String(self.line.clone()),
+                        Span::unknown(),
+                        Type::String,
+                    )),
+                    Argument::Positional(Expression::new_unknown(
+                        Expr::Int(line_pos as i64),
+                        Span::unknown(),
+                        Type::Int,
+                    )),
                 ],
                 parser_info: HashMap::new(),
             },

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -587,12 +587,7 @@ mod test {
     #[test]
     fn test_eval_argument() {
         fn expression(expr: Expr) -> Expression {
-            Expression {
-                expr,
-                span: Span::unknown(),
-                ty: Type::Any,
-                custom_completion: None,
-            }
+            Expression::new_unknown(expr, Span::unknown(), Type::Any)
         }
 
         fn eval(expr: Expr, spread: bool) -> Result<Vec<String>, ShellError> {

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -2,12 +2,11 @@ use crate::eval_call;
 use nu_protocol::{
     ast::{Argument, Call, Expr, Expression, RecordItem},
     debugger::WithoutDebug,
-    engine::{Command, EngineState, Stack},
-    record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
-    Value, SpanId
+    engine::{Command, EngineState, Stack, UNKNOWN_SPAN_ID},
+    record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SpanId,
+    SyntaxShape, Type, Value,
 };
 use std::{collections::HashMap, fmt::Write};
-use nu_protocol::engine::UNKNOWN_SPAN_ID;
 
 pub fn get_full_help(
     command: &dyn Command,

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{Command, EngineState, Stack},
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
-    Value
+    Value,
 };
 use std::{collections::HashMap, fmt::Write};
 
@@ -378,12 +378,14 @@ fn get_argument_for_color_value(
                 .iter()
                 .map(|(k, v)| {
                     RecordItem::Pair(
-                        Expression::new_existing(engine_state,
+                        Expression::new_existing(
+                            engine_state,
                             Expr::String(k.clone()),
                             span,
                             Type::String,
                         ),
-                        Expression::new_existing(engine_state,
+                        Expression::new_existing(
+                            engine_state,
                             Expr::String(
                                 v.clone().to_expanded_string("", engine_state.get_config()),
                             ),
@@ -397,7 +399,7 @@ fn get_argument_for_color_value(
             Some(Argument::Positional(Expression::new_existing(
                 engine_state,
                 Expr::Record(record_exp),
-                span: Span::unknown(),
+                Span::unknown(),
                 Type::Record(
                     [
                         ("fg".to_string(), Type::String),
@@ -407,8 +409,9 @@ fn get_argument_for_color_value(
                 ),
             )))
         }
-        Value::String { val, .. } => Some(Argument::Positional(Expression::new_existing(engine_state,
-                                                                                        Expr::String(val.clone()),
+        Value::String { val, .. } => Some(Argument::Positional(Expression::new_existing(
+            engine_state,
+            Expr::String(val.clone()),
             Span::unknown(),
             Type::String,
         ))),

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{Command, EngineState, Stack},
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SyntaxShape, Type,
-    Value,
+    Value
 };
 use std::{collections::HashMap, fmt::Write};
 
@@ -378,43 +378,40 @@ fn get_argument_for_color_value(
                 .iter()
                 .map(|(k, v)| {
                     RecordItem::Pair(
-                        Expression {
-                            expr: Expr::String(k.clone()),
+                        Expression::new_existing(engine_state,
+                            Expr::String(k.clone()),
                             span,
-                            ty: Type::String,
-                            custom_completion: None,
-                        },
-                        Expression {
-                            expr: Expr::String(
+                            Type::String,
+                        ),
+                        Expression::new_existing(engine_state,
+                            Expr::String(
                                 v.clone().to_expanded_string("", engine_state.get_config()),
                             ),
                             span,
-                            ty: Type::String,
-                            custom_completion: None,
-                        },
+                            Type::String,
+                        ),
                     )
                 })
                 .collect();
 
-            Some(Argument::Positional(Expression {
+            Some(Argument::Positional(Expression::new_existing(
+                engine_state,
+                Expr::Record(record_exp),
                 span: Span::unknown(),
-                ty: Type::Record(
+                Type::Record(
                     [
                         ("fg".to_string(), Type::String),
                         ("attr".to_string(), Type::String),
                     ]
                     .into(),
                 ),
-                expr: Expr::Record(record_exp),
-                custom_completion: None,
-            }))
+            )))
         }
-        Value::String { val, .. } => Some(Argument::Positional(Expression {
-            span: Span::unknown(),
-            ty: Type::String,
-            expr: Expr::String(val.clone()),
-            custom_completion: None,
-        })),
+        Value::String { val, .. } => Some(Argument::Positional(Expression::new_existing(engine_state,
+                                                                                        Expr::String(val.clone()),
+            Span::unknown(),
+            Type::String,
+        ))),
         _ => None,
     }
 }

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -56,7 +56,9 @@ impl Command for KnownExternal {
         };
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
-        let call_head_id = engine_state.find_span_id(call.head).unwrap_or(UNKNOWN_SPAN_ID);
+        let call_head_id = engine_state
+            .find_span_id(call.head)
+            .unwrap_or(UNKNOWN_SPAN_ID);
 
         let arg_extern_name = Expression::new_existing(
             Expr::String(extern_name[0].to_string()),
@@ -80,7 +82,9 @@ impl Command for KnownExternal {
             match arg {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
-                    let named_span_id = engine_state.find_span_id(named.0.span).unwrap_or(UNKNOWN_SPAN_ID);
+                    let named_span_id = engine_state
+                        .find_span_id(named.0.span)
+                        .unwrap_or(UNKNOWN_SPAN_ID);
                     if let Some(short) = &named.1 {
                         extern_call.add_positional(Expression::new_existing(
                             Expr::String(format!("-{}", short.item)),

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -56,11 +56,12 @@ impl Command for KnownExternal {
         };
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
+        let call_head_id = engine_state.find_span_id(call.head).expect("missing head span");
 
         let arg_extern_name = Expression::new_existing(
-            engine_state,
             Expr::String(extern_name[0].to_string()),
             call.head,
+            call_head_id,
             Type::String,
         );
 
@@ -68,9 +69,9 @@ impl Command for KnownExternal {
 
         for subcommand in extern_name.into_iter().skip(1) {
             extern_call.add_positional(Expression::new_existing(
-                engine_state,
                 Expr::String(subcommand.to_string()),
                 call.head,
+                call_head_id,
                 Type::String,
             ));
         }
@@ -79,18 +80,19 @@ impl Command for KnownExternal {
             match arg {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
+                    let named_span_id = engine_state.find_span_id(named.0.span).expect("missing named span");
                     if let Some(short) = &named.1 {
                         extern_call.add_positional(Expression::new_existing(
-                            engine_state,
                             Expr::String(format!("-{}", short.item)),
                             named.0.span,
+                            named_span_id,
                             Type::String,
                         ));
                     } else {
                         extern_call.add_positional(Expression::new_existing(
-                            engine_state,
                             Expr::String(format!("--{}", named.0.item)),
                             named.0.span,
+                            named_span_id,
                             Type::String,
                         ));
                     }

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -57,22 +57,20 @@ impl Command for KnownExternal {
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
 
-        let arg_extern_name = Expression {
-            expr: Expr::String(extern_name[0].to_string()),
-            span: call.head,
-            ty: Type::String,
-            custom_completion: None,
-        };
+        let arg_extern_name = Expression::new_existing(engine_state,
+            Expr::String(extern_name[0].to_string()),
+            call.head,
+            Type::String,
+        );
 
         extern_call.add_positional(arg_extern_name);
 
         for subcommand in extern_name.into_iter().skip(1) {
-            extern_call.add_positional(Expression {
-                expr: Expr::String(subcommand.to_string()),
-                span: call.head,
-                ty: Type::String,
-                custom_completion: None,
-            });
+            extern_call.add_positional(Expression::new_existing(engine_state,
+                Expr::String(subcommand.to_string()),
+                call.head,
+                Type::String,
+            ));
         }
 
         for arg in &call.arguments {
@@ -80,19 +78,17 @@ impl Command for KnownExternal {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
                     if let Some(short) = &named.1 {
-                        extern_call.add_positional(Expression {
-                            expr: Expr::String(format!("-{}", short.item)),
-                            span: named.0.span,
-                            ty: Type::String,
-                            custom_completion: None,
-                        });
+                        extern_call.add_positional(Expression::new_existing(engine_state,
+                            Expr::String(format!("-{}", short.item)),
+                            named.0.span,
+                            Type::String,
+                        ));
                     } else {
-                        extern_call.add_positional(Expression {
-                            expr: Expr::String(format!("--{}", named.0.item)),
-                            span: named.0.span,
-                            ty: Type::String,
-                            custom_completion: None,
-                        });
+                        extern_call.add_positional(Expression::new_existing(engine_state,
+                            Expr::String(format!("--{}", named.0.item)),
+                            named.0.span,
+                            Type::String,
+                        ));
                     }
                     if let Some(arg) = &named.2 {
                         extern_call.add_positional(arg.clone());

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -57,7 +57,8 @@ impl Command for KnownExternal {
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
 
-        let arg_extern_name = Expression::new_existing(engine_state,
+        let arg_extern_name = Expression::new_existing(
+            engine_state,
             Expr::String(extern_name[0].to_string()),
             call.head,
             Type::String,
@@ -66,7 +67,8 @@ impl Command for KnownExternal {
         extern_call.add_positional(arg_extern_name);
 
         for subcommand in extern_name.into_iter().skip(1) {
-            extern_call.add_positional(Expression::new_existing(engine_state,
+            extern_call.add_positional(Expression::new_existing(
+                engine_state,
                 Expr::String(subcommand.to_string()),
                 call.head,
                 Type::String,
@@ -78,13 +80,15 @@ impl Command for KnownExternal {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
                     if let Some(short) = &named.1 {
-                        extern_call.add_positional(Expression::new_existing(engine_state,
+                        extern_call.add_positional(Expression::new_existing(
+                            engine_state,
                             Expr::String(format!("-{}", short.item)),
                             named.0.span,
                             Type::String,
                         ));
                     } else {
-                        extern_call.add_positional(Expression::new_existing(engine_state,
+                        extern_call.add_positional(Expression::new_existing(
+                            engine_state,
                             Expr::String(format!("--{}", named.0.item)),
                             named.0.span,
                             Type::String,

--- a/crates/nu-parser/src/known_external.rs
+++ b/crates/nu-parser/src/known_external.rs
@@ -1,7 +1,7 @@
 use nu_engine::command_prelude::*;
 use nu_protocol::{
     ast::{Argument, Expr, Expression},
-    engine::CommandType,
+    engine::{CommandType, UNKNOWN_SPAN_ID},
 };
 
 #[derive(Clone)]
@@ -56,7 +56,7 @@ impl Command for KnownExternal {
         };
 
         let extern_name: Vec<_> = extern_name.split(' ').collect();
-        let call_head_id = engine_state.find_span_id(call.head).expect("missing head span");
+        let call_head_id = engine_state.find_span_id(call.head).unwrap_or(UNKNOWN_SPAN_ID);
 
         let arg_extern_name = Expression::new_existing(
             Expr::String(extern_name[0].to_string()),
@@ -80,7 +80,7 @@ impl Command for KnownExternal {
             match arg {
                 Argument::Positional(positional) => extern_call.add_positional(positional.clone()),
                 Argument::Named(named) => {
-                    let named_span_id = engine_state.find_span_id(named.0.span).expect("missing named span");
+                    let named_span_id = engine_state.find_span_id(named.0.span).unwrap_or(UNKNOWN_SPAN_ID);
                     if let Some(short) = &named.1 {
                         extern_call.add_positional(Expression::new_existing(
                             Expr::String(format!("-{}", short.item)),

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{ParseError, Span};
+use nu_protocol::{ParseError, Span, SpanId};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TokenContents {

--- a/crates/nu-parser/src/lex.rs
+++ b/crates/nu-parser/src/lex.rs
@@ -1,4 +1,4 @@
-use nu_protocol::{ParseError, Span, SpanId};
+use nu_protocol::{ParseError, Span};
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum TokenContents {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2210,12 +2210,11 @@ pub fn parse_module(
     });
 
     (
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: Span::concat(spans),
-            ty: Type::Any,
-            custom_completion: None,
-        }]),
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            Span::concat(spans),
+            Type::Any,
+        )]),
         Some(module_id),
     )
 }
@@ -2278,12 +2277,11 @@ pub fn parse_use(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: output,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        output,
+                    )]),
                     vec![],
                 );
             }
@@ -2358,12 +2356,11 @@ pub fn parse_use(
             String::from_utf8_lossy(&import_pattern.head.name).to_string(),
         ));
         return (
-            Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: call_span,
-                ty: Type::Any,
-                custom_completion: None,
-            }]),
+            Pipeline::from_vec(vec![Expression::new(working_set,
+                Expr::Call(call),
+                call_span,
+                Type::Any,
+            )]),
             vec![],
         );
     };
@@ -2421,23 +2418,21 @@ pub fn parse_use(
     working_set.use_variables(constants);
 
     // Create a new Use command call to pass the import pattern as parser info
-    let import_pattern_expr = Expression {
-        expr: Expr::ImportPattern(Box::new(import_pattern)),
-        span: Span::concat(args_spans),
-        ty: Type::Any,
-        custom_completion: None,
-    };
+    let import_pattern_expr = Expression::new(working_set,
+        Expr::ImportPattern(Box::new(import_pattern)),
+        Span::concat(args_spans),
+        Type::Any,
+        );
 
     let mut call = call;
     call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
     (
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: Span::concat(spans),
-            ty: Type::Any,
-            custom_completion: None,
-        }]),
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            Span::concat(spans),
+            Type::Any,
+        )]),
         exportables,
     )
 }
@@ -2473,12 +2468,11 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: output,
-                    custom_completion: None,
-                }]);
+                return Pipeline::from_vec(vec![Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    output,
+                )]);
             }
 
             (call, &spans[1..])
@@ -2605,22 +2599,20 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
         working_set.hide_decls(&decls_to_hide);
 
         // Create a new Use command call to pass the new import pattern
-        let import_pattern_expr = Expression {
-            expr: Expr::ImportPattern(Box::new(import_pattern)),
-            span: Span::concat(args_spans),
-            ty: Type::Any,
-            custom_completion: None,
-        };
+        let import_pattern_expr = Expression::new(working_set,
+            Expr::ImportPattern(Box::new(import_pattern)),
+            Span::concat(args_spans),
+            Type::Any,
+        );
 
         let mut call = call;
         call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: Span::concat(spans),
-            ty: Type::Any,
-            custom_completion: None,
-        }])
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            Span::concat(spans),
+            Type::Any,
+        )])
     } else {
         working_set.error(ParseError::UnknownState(
             "Expected structure: hide <name>".into(),
@@ -2655,12 +2647,11 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )]);
 
     let module_id = working_set.add_module(
         &overlay_name,
@@ -2740,12 +2731,11 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call.clone()),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call.clone()),
+        call_span,
+        Type::Any,
+    )]);
 
     let (final_overlay_name, origin_module, origin_module_id, is_module_updated) =
         if let Some(overlay_frame) = working_set.find_overlay(overlay_name.as_bytes()) {
@@ -2880,24 +2870,22 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
     let mut call = call;
     call.set_parser_info(
         "overlay_expr".to_string(),
-        Expression {
-            expr: Expr::Overlay(if is_module_updated {
+        Expression::new(working_set,
+            Expr::Overlay(if is_module_updated {
                 Some(origin_module_id)
             } else {
                 None
             }),
-            span: overlay_name_span,
-            ty: Type::Any,
-            custom_completion: None,
-        },
+            overlay_name_span,
+            Type::Any,
+    ),
     );
 
-    Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }])
+    Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )])
 }
 
 pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) -> Pipeline {
@@ -2928,12 +2916,11 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )]);
 
     if overlay_name == DEFAULT_OVERLAY_NAME {
         working_set.error(ParseError::CantHideDefaultOverlay(
@@ -2998,12 +2985,11 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 
-                    let rvalue = Expression {
-                        expr: Expr::Block(block_id),
-                        span: rvalue_span,
-                        ty: output_type,
-                        custom_completion: None,
-                    };
+                    let rvalue = Expression::new(working_set,
+                        Expr::Block(block_id),
+                        rvalue_span,
+                        output_type,
+                    );
 
                     let mut idx = 0;
                     let (lvalue, explicit_type) =
@@ -3048,24 +3034,22 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: Span::concat(spans),
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]);
+                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        Span::concat(spans),
+                        Type::Any,
+                        )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: Span::concat(spans),
-            ty: output,
-            custom_completion: None,
-        }]);
+        return Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            Span::concat(spans),
+            output,
+        )]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3194,24 +3178,22 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: Span::concat(spans),
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]);
+                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        Span::concat(spans),
+                        Type::Any,
+                        )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: Span::concat(spans),
-            ty: output,
-            custom_completion: None,
-        }]);
+        return Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            Span::concat(spans),
+            output,
+        )]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3262,12 +3244,11 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 
-                    let rvalue = Expression {
-                        expr: Expr::Block(block_id),
-                        span: rvalue_span,
-                        ty: output_type,
-                        custom_completion: None,
-                    };
+                    let rvalue = Expression::new(working_set,
+                        Expr::Block(block_id),
+                        rvalue_span,
+                        output_type,
+                        );
 
                     let mut idx = 0;
 
@@ -3313,24 +3294,22 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: Span::concat(spans),
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]);
+                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        Span::concat(spans),
+                        Type::Any,
+                        )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: Span::concat(spans),
-            ty: output,
-            custom_completion: None,
-        }]);
+        return Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            Span::concat(spans),
+            output,
+        )]);
     } else {
         working_set.error(ParseError::UnknownState(
             "internal error: let or const statements not found in core language".into(),
@@ -3378,12 +3357,11 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
             };
 
             if is_help {
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: Span::concat(spans),
-                    ty: output,
-                    custom_completion: None,
-                }]);
+                return Pipeline::from_vec(vec![Expression::new(working_set,
+                    Expr::Call(call),
+                    Span::concat(spans),
+                    output,
+                )]);
             }
 
             // Command and one file name
@@ -3394,12 +3372,11 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(val) => val,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, Span::concat(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call),
-                            span: Span::concat(&spans[1..]),
-                            ty: Type::Any,
-                            custom_completion: None,
-                        }]);
+                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                            Expr::Call(call),
+                            Span::concat(&spans[1..]),
+                            Type::Any,
+                        )]);
                     }
                 };
 
@@ -3407,12 +3384,11 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(s) => s,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, Span::concat(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call),
-                            span: Span::concat(&spans[1..]),
-                            ty: Type::Any,
-                            custom_completion: None,
-                        }]);
+                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                            Expr::Call(call),
+                            Span::concat(&spans[1..]),
+                            Type::Any,
+                        )]);
                     }
                 };
 
@@ -3445,31 +3421,28 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                         // after writing `source example.nu`
                         call_with_block.set_parser_info(
                             "block_id".to_string(),
-                            Expression {
-                                expr: Expr::Int(block_id as i64),
-                                span: spans[1],
-                                ty: Type::Any,
-                                custom_completion: None,
-                            },
+                            Expression::new(working_set,
+                                Expr::Int(block_id as i64),
+                                spans[1],
+                                Type::Any,
+                            ),
                         );
 
-                        return Pipeline::from_vec(vec![Expression {
-                            expr: Expr::Call(call_with_block),
-                            span: Span::concat(spans),
-                            ty: Type::Any,
-                            custom_completion: None,
-                        }]);
+                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                            Expr::Call(call_with_block),
+                            Span::concat(spans),
+                            Type::Any,
+                        )]);
                     }
                 } else {
                     working_set.error(ParseError::SourcedFileNotFound(filename, spans[1]));
                 }
             }
-            return Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: Span::concat(spans),
-                ty: Type::Any,
-                custom_completion: None,
-            }]);
+            return Pipeline::from_vec(vec![Expression::new(working_set,
+                Expr::Call(call),
+                Span::concat(spans),
+                Type::Any,
+)]);
         }
     }
     working_set.error(ParseError::UnknownState(
@@ -3515,12 +3488,11 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: output,
-                    custom_completion: None,
-                };
+                return Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    output,
+                );
             }
 
             call
@@ -3534,12 +3506,11 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
         }
     };
 
-    Expression {
-        expr: Expr::Call(call),
-        span: Span::concat(spans),
-        ty: Type::Any,
-        custom_completion: None,
-    }
+    Expression::new(working_set,
+        Expr::Call(call),
+        Span::concat(spans),
+        Type::Any,
+)
 }
 
 pub fn parse_where(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
@@ -3614,12 +3585,11 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: output,
-                    custom_completion: None,
-                }]);
+                return Pipeline::from_vec(vec![Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    output,
+                )]);
             }
 
             (call, call_span)
@@ -3700,12 +3670,11 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             Ok(path) => Some(path),
             Err(err) => {
                 working_set.error(err);
-                return Pipeline::from_vec(vec![Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: Type::Any,
-                    custom_completion: None,
-                }]);
+                return Pipeline::from_vec(vec![Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    Type::Any,
+                    )]);
             }
         },
     };
@@ -3781,12 +3750,11 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
         working_set.error(err);
     }
 
-    Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Nothing,
-        custom_completion: None,
-    }])
+    Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Nothing,
+)])
 }
 
 #[cfg(feature = "plugin")]
@@ -3887,12 +3855,12 @@ pub fn parse_plugin_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> P
 
     let call_span = call.span();
 
-    Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Nothing,
-        custom_completion: None,
-    }])
+    Pipeline::from_vec(vec![Expression::new(
+        working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Nothing,
+    )])
 }
 
 pub fn find_dirs_var(working_set: &StateWorkingSet, var_name: &str) -> Option<VarId> {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -113,7 +113,8 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
         // check help flag first.
         if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
             let call_span = call.span();
-            return Pipeline::from_vec(vec![Expression::new(working_set,
+            return Pipeline::from_vec(vec![Expression::new(
+                working_set,
                 Expr::Call(call),
                 call_span,
                 Type::Any,
@@ -292,11 +293,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Expression::new(working_set,
-                    Expr::Call(call),
-                    call_span,
-                    output,
-                );
+                return Expression::new(working_set, Expr::Call(call), call_span, output);
             }
 
             // Let's get our block and make sure it has the right signature
@@ -353,11 +350,7 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
         );
     }
 
-    Expression::new(working_set,
-        Expr::Call(call),
-        call_span,
-        Type::Nothing,
-    )
+    Expression::new(working_set, Expr::Call(call), call_span, Type::Nothing)
 }
 
 /// If `name` is a keyword, emit an error.
@@ -483,7 +476,8 @@ pub fn parse_def(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         output,
@@ -570,7 +564,8 @@ pub fn parse_def(
                             format!("...rest-like positional argument used in 'def --wrapped' supports only strings. Change the type annotation of ...{} to 'string'.", &rest.name)));
 
                         return (
-                            Pipeline::from_vec(vec![Expression::new(working_set,
+                            Pipeline::from_vec(vec![Expression::new(
+                                working_set,
                                 Expr::Call(call),
                                 call_span,
                                 Type::Any,
@@ -583,7 +578,8 @@ pub fn parse_def(
                 working_set.error(ParseError::MissingPositional("...rest-like positional argument".to_string(), name_expr.span, "def --wrapped must have a ...rest-like positional argument. Add '...rest: string' to the command's signature.".to_string()));
 
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         Type::Any,
@@ -638,7 +634,8 @@ pub fn parse_def(
     working_set.merge_predecl(name.as_bytes());
 
     (
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             call_span,
             Type::Any,
@@ -736,7 +733,8 @@ pub fn parse_extern(
                         "main".to_string(),
                         name_expr_span,
                     ));
-                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                    return Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         Type::Any,
@@ -801,7 +799,8 @@ pub fn parse_extern(
         }
     }
 
-    Pipeline::from_vec(vec![Expression::new(working_set,
+    Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -906,7 +905,8 @@ pub fn parse_alias(
             return garbage_pipeline(spans);
         };
 
-        let alias_pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        let alias_pipeline = Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(alias_call.clone()),
             Span::concat(spans),
             output,
@@ -1164,7 +1164,8 @@ pub fn parse_export_in_block(
         };
 
         if starting_error_count != working_set.parse_errors.len() || is_help {
-            return Pipeline::from_vec(vec![Expression::new(working_set,
+            return Pipeline::from_vec(vec![Expression::new(
+                working_set,
                 Expr::Call(call),
                 call_span,
                 output,
@@ -1569,7 +1570,8 @@ pub fn parse_export_in_module(
     };
 
     (
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             Span::concat(spans),
             Type::Any,
@@ -1616,7 +1618,8 @@ pub fn parse_export_env(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         output,
@@ -1654,7 +1657,8 @@ pub fn parse_export_env(
         return (garbage_pipeline(spans), None);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         Span::concat(spans),
         Type::Any,
@@ -2070,7 +2074,8 @@ pub fn parse_module(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         output,
@@ -2102,7 +2107,8 @@ pub fn parse_module(
                             name.span,
                         ));
                         return (
-                            Pipeline::from_vec(vec![Expression::new(working_set,
+                            Pipeline::from_vec(vec![Expression::new(
+                                working_set,
                                 Expr::Call(call),
                                 call_span,
                                 Type::Any,
@@ -2127,7 +2133,8 @@ pub fn parse_module(
             return (garbage_pipeline(spans), None);
         };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -2189,11 +2196,7 @@ pub fn parse_module(
     module_comments.extend(inner_comments);
     let module_id = working_set.add_module(&module_name, module, module_comments);
 
-    let block_expr = Expression::new(working_set,
-        Expr::Block(block_id),
-        block_span,
-        Type::Block,
-    );
+    let block_expr = Expression::new(working_set, Expr::Block(block_id), block_span, Type::Block);
 
     let module_decl_id = working_set
         .find_decl(b"module")
@@ -2210,7 +2213,8 @@ pub fn parse_module(
     });
 
     (
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             Span::concat(spans),
             Type::Any,
@@ -2277,7 +2281,8 @@ pub fn parse_use(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression::new(working_set,
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         call_span,
                         output,
@@ -2356,7 +2361,8 @@ pub fn parse_use(
             String::from_utf8_lossy(&import_pattern.head.name).to_string(),
         ));
         return (
-            Pipeline::from_vec(vec![Expression::new(working_set,
+            Pipeline::from_vec(vec![Expression::new(
+                working_set,
                 Expr::Call(call),
                 call_span,
                 Type::Any,
@@ -2418,17 +2424,19 @@ pub fn parse_use(
     working_set.use_variables(constants);
 
     // Create a new Use command call to pass the import pattern as parser info
-    let import_pattern_expr = Expression::new(working_set,
+    let import_pattern_expr = Expression::new(
+        working_set,
         Expr::ImportPattern(Box::new(import_pattern)),
         Span::concat(args_spans),
         Type::Any,
-        );
+    );
 
     let mut call = call;
     call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
     (
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             Span::concat(spans),
             Type::Any,
@@ -2468,7 +2476,8 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression::new(working_set,
+                return Pipeline::from_vec(vec![Expression::new(
+                    working_set,
                     Expr::Call(call),
                     call_span,
                     output,
@@ -2599,7 +2608,8 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
         working_set.hide_decls(&decls_to_hide);
 
         // Create a new Use command call to pass the new import pattern
-        let import_pattern_expr = Expression::new(working_set,
+        let import_pattern_expr = Expression::new(
+            working_set,
             Expr::ImportPattern(Box::new(import_pattern)),
             Span::concat(args_spans),
             Type::Any,
@@ -2608,7 +2618,8 @@ pub fn parse_hide(working_set: &mut StateWorkingSet, lite_command: &LiteCommand)
         let mut call = call;
         call.set_parser_info("import_pattern".to_string(), import_pattern_expr);
 
-        Pipeline::from_vec(vec![Expression::new(working_set,
+        Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             Span::concat(spans),
             Type::Any,
@@ -2647,7 +2658,8 @@ pub fn parse_overlay_new(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -2731,7 +2743,8 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call.clone()),
         call_span,
         Type::Any,
@@ -2870,7 +2883,8 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
     let mut call = call;
     call.set_parser_info(
         "overlay_expr".to_string(),
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Overlay(if is_module_updated {
                 Some(origin_module_id)
             } else {
@@ -2878,10 +2892,11 @@ pub fn parse_overlay_use(working_set: &mut StateWorkingSet, call: Box<Call>) -> 
             }),
             overlay_name_span,
             Type::Any,
-    ),
+        ),
     );
 
-    Pipeline::from_vec(vec![Expression::new(working_set,
+    Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -2916,7 +2931,8 @@ pub fn parse_overlay_hide(working_set: &mut StateWorkingSet, call: Box<Call>) ->
         return garbage_pipeline(&[call_span]);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+    let pipeline = Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Any,
@@ -2985,7 +3001,8 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 
-                    let rvalue = Expression::new(working_set,
+                    let rvalue = Expression::new(
+                        working_set,
                         Expr::Block(block_id),
                         rvalue_span,
                         output_type,
@@ -3034,18 +3051,20 @@ pub fn parse_let(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                    return Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         Span::concat(spans),
                         Type::Any,
-                        )]);
+                    )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(working_set,
+        return Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             Span::concat(spans),
             output,
@@ -3178,18 +3197,20 @@ pub fn parse_const(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipelin
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                    return Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         Span::concat(spans),
                         Type::Any,
-                        )]);
+                    )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(working_set,
+        return Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             Span::concat(spans),
             output,
@@ -3244,11 +3265,12 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
 
                     let block_id = working_set.add_block(Arc::new(rvalue_block));
 
-                    let rvalue = Expression::new(working_set,
+                    let rvalue = Expression::new(
+                        working_set,
                         Expr::Block(block_id),
                         rvalue_span,
                         output_type,
-                        );
+                    );
 
                     let mut idx = 0;
 
@@ -3294,18 +3316,20 @@ pub fn parse_mut(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline 
                         parser_info: HashMap::new(),
                     });
 
-                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                    return Pipeline::from_vec(vec![Expression::new(
+                        working_set,
                         Expr::Call(call),
                         Span::concat(spans),
                         Type::Any,
-                        )]);
+                    )]);
                 }
             }
         }
         let ParsedInternalCall { call, output } =
             parse_internal_call(working_set, spans[0], &spans[1..], decl_id);
 
-        return Pipeline::from_vec(vec![Expression::new(working_set,
+        return Pipeline::from_vec(vec![Expression::new(
+            working_set,
             Expr::Call(call),
             Span::concat(spans),
             output,
@@ -3357,7 +3381,8 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
             };
 
             if is_help {
-                return Pipeline::from_vec(vec![Expression::new(working_set,
+                return Pipeline::from_vec(vec![Expression::new(
+                    working_set,
                     Expr::Call(call),
                     Span::concat(spans),
                     output,
@@ -3372,7 +3397,8 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(val) => val,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, Span::concat(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                        return Pipeline::from_vec(vec![Expression::new(
+                            working_set,
                             Expr::Call(call),
                             Span::concat(&spans[1..]),
                             Type::Any,
@@ -3384,7 +3410,8 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     Ok(s) => s,
                     Err(err) => {
                         working_set.error(err.wrap(working_set, Span::concat(&spans[1..])));
-                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                        return Pipeline::from_vec(vec![Expression::new(
+                            working_set,
                             Expr::Call(call),
                             Span::concat(&spans[1..]),
                             Type::Any,
@@ -3421,14 +3448,16 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                         // after writing `source example.nu`
                         call_with_block.set_parser_info(
                             "block_id".to_string(),
-                            Expression::new(working_set,
+                            Expression::new(
+                                working_set,
                                 Expr::Int(block_id as i64),
                                 spans[1],
                                 Type::Any,
                             ),
                         );
 
-                        return Pipeline::from_vec(vec![Expression::new(working_set,
+                        return Pipeline::from_vec(vec![Expression::new(
+                            working_set,
                             Expr::Call(call_with_block),
                             Span::concat(spans),
                             Type::Any,
@@ -3438,11 +3467,12 @@ pub fn parse_source(working_set: &mut StateWorkingSet, lite_command: &LiteComman
                     working_set.error(ParseError::SourcedFileNotFound(filename, spans[1]));
                 }
             }
-            return Pipeline::from_vec(vec![Expression::new(working_set,
+            return Pipeline::from_vec(vec![Expression::new(
+                working_set,
                 Expr::Call(call),
                 Span::concat(spans),
                 Type::Any,
-)]);
+            )]);
         }
     }
     working_set.error(ParseError::UnknownState(
@@ -3488,11 +3518,7 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Expression::new(working_set,
-                    Expr::Call(call),
-                    call_span,
-                    output,
-                );
+                return Expression::new(working_set, Expr::Call(call), call_span, output);
             }
 
             call
@@ -3506,11 +3532,12 @@ pub fn parse_where_expr(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
         }
     };
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::Call(call),
         Span::concat(spans),
         Type::Any,
-)
+    )
 }
 
 pub fn parse_where(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) -> Pipeline {
@@ -3585,7 +3612,8 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Pipeline::from_vec(vec![Expression::new(working_set,
+                return Pipeline::from_vec(vec![Expression::new(
+                    working_set,
                     Expr::Call(call),
                     call_span,
                     output,
@@ -3670,11 +3698,12 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
             Ok(path) => Some(path),
             Err(err) => {
                 working_set.error(err);
-                return Pipeline::from_vec(vec![Expression::new(working_set,
+                return Pipeline::from_vec(vec![Expression::new(
+                    working_set,
                     Expr::Call(call),
                     call_span,
                     Type::Any,
-                    )]);
+                )]);
             }
         },
     };
@@ -3750,11 +3779,12 @@ pub fn parse_register(working_set: &mut StateWorkingSet, lite_command: &LiteComm
         working_set.error(err);
     }
 
-    Pipeline::from_vec(vec![Expression::new(working_set,
+    Pipeline::from_vec(vec![Expression::new(
+        working_set,
         Expr::Call(call),
         call_span,
         Type::Nothing,
-)])
+    )])
 }
 
 #[cfg(feature = "plugin")]

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -113,12 +113,11 @@ pub fn parse_keyword(working_set: &mut StateWorkingSet, lite_command: &LiteComma
         // check help flag first.
         if call.named_iter().any(|(flag, _, _)| flag.item == "help") {
             let call_span = call.span();
-            return Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: call_span,
-                ty: Type::Any,
-                custom_completion: None,
-            }]);
+            return Pipeline::from_vec(vec![Expression::new(working_set,
+                Expr::Call(call),
+                call_span,
+                Type::Any,
+            )]);
         }
 
         match cmd.name() {
@@ -293,12 +292,11 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
             };
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
-                return Expression {
-                    expr: Expr::Call(call),
-                    span: call_span,
-                    ty: output,
-                    custom_completion: None,
-                };
+                return Expression::new(working_set,
+                    Expr::Call(call),
+                    call_span,
+                    output,
+                );
             }
 
             // Let's get our block and make sure it has the right signature
@@ -355,12 +353,11 @@ pub fn parse_for(working_set: &mut StateWorkingSet, lite_command: &LiteCommand) 
         );
     }
 
-    Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Nothing,
-        custom_completion: None,
-    }
+    Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Nothing,
+    )
 }
 
 /// If `name` is a keyword, emit an error.
@@ -486,12 +483,11 @@ pub fn parse_def(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: output,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        output,
+                    )]),
                     None,
                 );
             }
@@ -524,12 +520,12 @@ pub fn parse_def(
                     name_expr_span,
                 ));
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(
+                        working_set,
+                        Expr::Call(call),
+                        call_span,
+                        Type::Any,
+                    )]),
                     None,
                 );
             }
@@ -574,12 +570,11 @@ pub fn parse_def(
                             format!("...rest-like positional argument used in 'def --wrapped' supports only strings. Change the type annotation of ...{} to 'string'.", &rest.name)));
 
                         return (
-                            Pipeline::from_vec(vec![Expression {
-                                expr: Expr::Call(call),
-                                span: call_span,
-                                ty: Type::Any,
-                                custom_completion: None,
-                            }]),
+                            Pipeline::from_vec(vec![Expression::new(working_set,
+                                Expr::Call(call),
+                                call_span,
+                                Type::Any,
+                            )]),
                             result,
                         );
                     }
@@ -588,12 +583,11 @@ pub fn parse_def(
                 working_set.error(ParseError::MissingPositional("...rest-like positional argument".to_string(), name_expr.span, "def --wrapped must have a ...rest-like positional argument. Add '...rest: string' to the command's signature.".to_string()));
 
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        Type::Any,
+                    )]),
                     result,
                 );
             }
@@ -644,12 +638,11 @@ pub fn parse_def(
     working_set.merge_predecl(name.as_bytes());
 
     (
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: call_span,
-            ty: Type::Any,
-            custom_completion: None,
-        }]),
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            call_span,
+            Type::Any,
+        )]),
         result,
     )
 }
@@ -743,12 +736,11 @@ pub fn parse_extern(
                         "main".to_string(),
                         name_expr_span,
                     ));
-                    return Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: Type::Any,
-                        custom_completion: None,
-                    }]);
+                    return Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        Type::Any,
+                    )]);
                 }
             }
 
@@ -809,12 +801,11 @@ pub fn parse_extern(
         }
     }
 
-    Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }])
+    Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )])
 }
 
 fn check_alias_name<'a>(working_set: &mut StateWorkingSet, spans: &'a [Span]) -> Option<&'a Span> {
@@ -915,12 +906,11 @@ pub fn parse_alias(
             return garbage_pipeline(spans);
         };
 
-        let alias_pipeline = Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(alias_call.clone()),
-            span: Span::concat(spans),
-            ty: output,
-            custom_completion: None,
-        }]);
+        let alias_pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(alias_call.clone()),
+            Span::concat(spans),
+            output,
+        )]);
 
         if has_help_flag {
             return alias_pipeline;
@@ -1174,12 +1164,11 @@ pub fn parse_export_in_block(
         };
 
         if starting_error_count != working_set.parse_errors.len() || is_help {
-            return Pipeline::from_vec(vec![Expression {
-                expr: Expr::Call(call),
-                span: call_span,
-                ty: output,
-                custom_completion: None,
-            }]);
+            return Pipeline::from_vec(vec![Expression::new(working_set,
+                Expr::Call(call),
+                call_span,
+                output,
+            )]);
         }
     } else {
         working_set.error(ParseError::UnknownState(
@@ -1580,12 +1569,11 @@ pub fn parse_export_in_module(
     };
 
     (
-        Pipeline::from_vec(vec![Expression {
-            expr: Expr::Call(call),
-            span: Span::concat(spans),
-            ty: Type::Any,
-            custom_completion: None,
-        }]),
+        Pipeline::from_vec(vec![Expression::new(working_set,
+            Expr::Call(call),
+            Span::concat(spans),
+            Type::Any,
+        )]),
         exportables,
     )
 }
@@ -1628,12 +1616,11 @@ pub fn parse_export_env(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: output,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        output,
+                    )]),
                     None,
                 );
             }
@@ -1667,12 +1654,11 @@ pub fn parse_export_env(
         return (garbage_pipeline(spans), None);
     };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: Span::concat(spans),
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        Span::concat(spans),
+        Type::Any,
+    )]);
 
     (pipeline, Some(block_id))
 }
@@ -2084,12 +2070,11 @@ pub fn parse_module(
 
             if starting_error_count != working_set.parse_errors.len() || is_help {
                 return (
-                    Pipeline::from_vec(vec![Expression {
-                        expr: Expr::Call(call),
-                        span: call_span,
-                        ty: output,
-                        custom_completion: None,
-                    }]),
+                    Pipeline::from_vec(vec![Expression::new(working_set,
+                        Expr::Call(call),
+                        call_span,
+                        output,
+                    )]),
                     None,
                 );
             }
@@ -2117,12 +2102,11 @@ pub fn parse_module(
                             name.span,
                         ));
                         return (
-                            Pipeline::from_vec(vec![Expression {
-                                expr: Expr::Call(call),
-                                span: call_span,
-                                ty: Type::Any,
-                                custom_completion: None,
-                            }]),
+                            Pipeline::from_vec(vec![Expression::new(working_set,
+                                Expr::Call(call),
+                                call_span,
+                                Type::Any,
+                            )]),
                             None,
                         );
                     }
@@ -2143,12 +2127,11 @@ pub fn parse_module(
             return (garbage_pipeline(spans), None);
         };
 
-    let pipeline = Pipeline::from_vec(vec![Expression {
-        expr: Expr::Call(call),
-        span: call_span,
-        ty: Type::Any,
-        custom_completion: None,
-    }]);
+    let pipeline = Pipeline::from_vec(vec![Expression::new(working_set,
+        Expr::Call(call),
+        call_span,
+        Type::Any,
+    )]);
 
     if spans.len() == split_id + 1 {
         if let Some(module_id) = parse_module_file_or_dir(
@@ -2206,12 +2189,11 @@ pub fn parse_module(
     module_comments.extend(inner_comments);
     let module_id = working_set.add_module(&module_name, module, module_comments);
 
-    let block_expr = Expression {
-        expr: Expr::Block(block_id),
-        span: block_span,
-        ty: Type::Block,
-        custom_completion: None,
-    };
+    let block_expr = Expression::new(working_set,
+        Expr::Block(block_id),
+        block_span,
+        Type::Block,
+    );
 
     let module_decl_id = working_set
         .find_decl(b"module")

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1868,7 +1868,9 @@ pub fn parse_module_block(
                         command.parts[0],
                     ));
 
-                    block.pipelines.push(garbage_pipeline(working_set, &command.parts))
+                    block
+                        .pipelines
+                        .push(garbage_pipeline(working_set, &command.parts))
                 }
             }
         } else {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -741,37 +741,6 @@ pub struct ParsedInternalCall {
     pub output: Type,
 }
 
-// fn attach_parser_info_builtin(working_set: &mut StateWorkingSet, name: &str, call: &mut Call) {
-//     match name {
-//         "use" | "overlay use" | "source-env" | "nu-check" => {
-//             if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
-//                 call.set_parser_info(
-//                     DIR_VAR_PARSER_INFO.to_owned(),
-//                     Expression::new(working_set,
-//                         Expr::Var(var_id),
-//                         call.head,
-//                         Type::Any,
-//                     ),
-//                 );
-//             }
-//         }
-//         _ => {}
-//     }
-// }
-
-// fn attach_parser_info_builtin(working_set: &StateWorkingSet, name: &str) -> Option<VarId> {
-//     match name {
-//         "use" | "overlay use" | "source-env" | "nu-check" => {
-//             if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
-//                 Some(var_id)
-//             } else {
-//                 None
-//             }
-//         }
-//         _ => None
-//     }
-// }
-
 pub fn parse_internal_call(
     working_set: &mut StateWorkingSet,
     command_span: Span,
@@ -790,9 +759,6 @@ pub fn parse_internal_call(
 
     // storing the var ID for later due to borrowing issues
     let lib_dirs_var_id = if decl.is_builtin() {
-        // attach_parser_info_builtin(working_set, decl.name())
-        // attach_parser_info_builtin(working_set, decl.name(), &mut call);
-
         match decl.name() {
             "use" | "overlay use" | "source-env" | "nu-check" => {
                 if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -761,11 +761,7 @@ pub fn parse_internal_call(
     let lib_dirs_var_id = if decl.is_builtin() {
         match decl.name() {
             "use" | "overlay use" | "source-env" | "nu-check" => {
-                if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
-                    Some(var_id)
-                } else {
-                    None
-                }
+                find_dirs_var(working_set, LIB_DIRS_VAR)
             }
             _ => None,
         }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -788,6 +788,7 @@ pub fn parse_internal_call(
     let signature = decl.signature();
     let output = signature.get_output_type();
 
+    // storing the var ID for later due to borrowing issues
     let lib_dirs_var_id = if decl.is_builtin() {
         // attach_parser_info_builtin(working_set, decl.name())
         // attach_parser_info_builtin(working_set, decl.name(), &mut call);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -752,6 +752,7 @@ pub fn parse_internal_call(
     let mut call = Call::new(command_span);
     call.decl_id = decl_id;
     call.head = command_span;
+    let _ = working_set.add_span(call.head);
 
     let decl = working_set.get_decl(decl_id);
     let signature = decl.signature();
@@ -872,6 +873,8 @@ pub fn parse_internal_call(
                 call.add_unknown(arg);
             } else {
                 for flag in short_flags {
+                    let _ = working_set.add_span(spans[spans_idx]);
+
                     if let Some(arg_shape) = flag.arg {
                         if let Some(arg) = spans.get(spans_idx + 1) {
                             let arg = parse_value(working_set, *arg, &arg_shape);

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5172,13 +5172,11 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                     parse_string_strict(working_set, rhs_span)
                 }
             } else {
-                Expression::string(working_set, String::new(), Type::Nothing, Span::unknown())
-                // Expression {
-                //     expr: Expr::String(String::new()),
-                //     span: Span::unknown(),
-                //     ty: Type::Nothing,
-                //     custom_completion: None,
-                // }
+                Expression::new(working_set,
+                    Expr::String(String::new()),
+                    Span::unknown(),
+                    Type::Nothing,
+                )
             };
 
             if starting_error_count == working_set.parse_errors.len() {
@@ -6288,14 +6286,12 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
         let block_id = working_set.add_block(Arc::new(block));
 
         output.push(Argument::Positional(
-            Expression::closure(working_set, block_id, Type::Any, span)
-        //     Expression {
-        //     expr: Expr::Closure(block_id),
-        //     span,
-        //     ty: Type::Any,
-        //     custom_completion: None,
-        // }
-        ));
+            Expression::new(working_set,
+            Expr::Closure(block_id),
+            span,
+            Type::Any,
+            )
+       ));
 
         output.push(Argument::Named((
             Spanned {
@@ -6309,28 +6305,14 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
         // The containing, synthetic call to `collect`.
         // We don't want to have a real span as it will confuse flattening
         // The args are where we'll get the real info
-        Expression::call(working_set, Call {
+        Expression::new(working_set, Expr::Call(Box::new(Call {
                 head: Span::new(0, 0),
                 arguments: output,
                 decl_id,
                 parser_info: HashMap::new(),
-            },
-            Type::Any,
-            span)
-
-        // Expression {
-        //     expr: Expr::Call(Box::new(Call {
-        //         head: Span::new(0, 0),
-        //         arguments: output,
-        //         decl_id,
-        //         redirect_stdout: true,
-        //         redirect_stderr: false,
-        //         parser_info: HashMap::new(),
-        //     })),
-        //     span,
-        //     ty: Type::Any,
-        //     custom_completion: None,
-        // }
+            })),
+            span,
+        Type::Any,)
     } else {
         Expression::garbage(span)
     }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -722,9 +722,9 @@ pub fn parse_multispan_value(
 
             Expression::new(
                 working_set,
-                Expr::Keyword(Box::new(keyword)),
+                Expr::Keyword(Box::new(keyword.clone())),
                 arg_span,
-                keyword.expr.ty.clone(),
+                keyword.expr.ty,
             )
         }
         _ => {

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -739,23 +739,36 @@ pub struct ParsedInternalCall {
     pub output: Type,
 }
 
-fn attach_parser_info_builtin(working_set: &mut StateWorkingSet, name: &str, call: &mut Call) {
-    match name {
-        "use" | "overlay use" | "source-env" | "nu-check" => {
-            if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
-                call.set_parser_info(
-                    DIR_VAR_PARSER_INFO.to_owned(),
-                    Expression::new(working_set,
-                        Expr::Var(var_id),
-                        call.head,
-                        Type::Any,
-                    ),
-                );
-            }
-        }
-        _ => {}
-    }
-}
+// fn attach_parser_info_builtin(working_set: &mut StateWorkingSet, name: &str, call: &mut Call) {
+//     match name {
+//         "use" | "overlay use" | "source-env" | "nu-check" => {
+//             if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
+//                 call.set_parser_info(
+//                     DIR_VAR_PARSER_INFO.to_owned(),
+//                     Expression::new(working_set,
+//                         Expr::Var(var_id),
+//                         call.head,
+//                         Type::Any,
+//                     ),
+//                 );
+//             }
+//         }
+//         _ => {}
+//     }
+// }
+
+// fn attach_parser_info_builtin(working_set: &StateWorkingSet, name: &str) -> Option<VarId> {
+//     match name {
+//         "use" | "overlay use" | "source-env" | "nu-check" => {
+//             if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
+//                 Some(var_id)
+//             } else {
+//                 None
+//             }
+//         }
+//         _ => None
+//     }
+// }
 
 pub fn parse_internal_call(
     working_set: &mut StateWorkingSet,
@@ -773,9 +786,23 @@ pub fn parse_internal_call(
     let signature = decl.signature();
     let output = signature.get_output_type();
 
-    if decl.is_builtin() {
-        attach_parser_info_builtin(working_set, decl.name(), &mut call);
-    }
+    let lib_dirs_var_id = if decl.is_builtin() {
+        // attach_parser_info_builtin(working_set, decl.name())
+        // attach_parser_info_builtin(working_set, decl.name(), &mut call);
+
+        match decl.name() {
+            "use" | "overlay use" | "source-env" | "nu-check" => {
+                if let Some(var_id) = find_dirs_var(working_set, LIB_DIRS_VAR) {
+                    Some(var_id)
+                } else {
+                    None
+                }
+            }
+            _ => None
+        }
+    } else {
+        None
+    };
 
     // The index into the positional parameter in the definition
     let mut positional_idx = 0;
@@ -805,6 +832,17 @@ pub fn parse_internal_call(
                 output: Type::Any,
             };
         }
+    }
+
+    if let Some(var_id) = lib_dirs_var_id {
+        call.set_parser_info(
+            DIR_VAR_PARSER_INFO.to_owned(),
+            Expression::new(working_set,
+                            Expr::Var(var_id),
+                            call.head,
+                            Type::Any,
+            ),
+        );
     }
 
     if signature.creates_scope {
@@ -2158,18 +2196,20 @@ pub fn parse_full_cell_path(
         };
 
         let tail = parse_cell_path(working_set, tokens, expect_dot);
-
-        Expression::new(working_set,
-                        Expr::FullCellPath(Box::new(FullCellPath { head, tail })),
-                        full_cell_span,
-            // FIXME: Get the type of the data at the tail using follow_cell_path() (or something)
+        // FIXME: Get the type of the data at the tail using follow_cell_path() (or something)
+        let ty =
             if !tail.is_empty() {
                 // Until the aforementioned fix is implemented, this is necessary to allow mutable list upserts
                 // such as $a.1 = 2 to work correctly.
                 Type::Any
             } else {
                 head.ty.clone()
-            },
+            };
+
+        Expression::new(working_set,
+                        Expr::FullCellPath(Box::new(FullCellPath { head, tail })),
+                        full_cell_span,
+            ty
         )
     } else {
         garbage(span)
@@ -2276,8 +2316,11 @@ pub fn parse_duration(working_set: &mut StateWorkingSet, span: Span) -> Expressi
 
     let bytes = working_set.get_span_contents(span);
 
-    match parse_unit_value(working_set, bytes, span, DURATION_UNIT_GROUPS, Type::Duration, |x| x) {
-        Some(Ok(expr)) => expr,
+    match parse_unit_value(bytes, span, DURATION_UNIT_GROUPS, Type::Duration, |x| x) {
+        Some(Ok(expr)) => {
+            let span_id = working_set.add_span(span);
+            expr.with_span_id(span_id)
+        },
         Some(Err(mk_err_for)) => {
             working_set.error(mk_err_for("duration"));
             garbage(span)
@@ -2301,10 +2344,13 @@ pub fn parse_filesize(working_set: &mut StateWorkingSet, span: Span) -> Expressi
         return garbage(span);
     }
 
-    match parse_unit_value(working_set, bytes, span, FILESIZE_UNIT_GROUPS, Type::Filesize, |x| {
+    match parse_unit_value(bytes, span, FILESIZE_UNIT_GROUPS, Type::Filesize, |x| {
         x.to_ascii_uppercase()
     }) {
-        Some(Ok(expr)) => expr,
+        Some(Ok(expr)) => {
+            let span_id = working_set.add_span(span);
+            expr.with_span_id(span_id)
+        },
         Some(Err(mk_err_for)) => {
             working_set.error(mk_err_for("filesize"));
             garbage(span)
@@ -2320,7 +2366,6 @@ type ParseUnitResult<'res> = Result<Expression, Box<dyn Fn(&'res str) -> ParseEr
 type UnitGroup<'unit> = (Unit, &'unit str, Option<(Unit, i64)>);
 
 pub fn parse_unit_value<'res>(
-    working_set: &mut StateWorkingSet,
     bytes: &[u8],
     span: Span,
     unit_groups: &[UnitGroup],
@@ -2370,8 +2415,7 @@ pub fn parse_unit_value<'res>(
 
         trace!("-- found {} {:?}", num, unit);
         let value = ValueWithUnit {
-            expr: Expression::new(
-                working_set,
+            expr: Expression::new_unknown(
                 Expr::Int(num),
                 lhs_span,
                 Type::Number,
@@ -2381,8 +2425,7 @@ pub fn parse_unit_value<'res>(
                 span: unit_span,
             },
         };
-        let expr = Expression::new(
-            working_set,
+        let expr = Expression::new_unknown(
             Expr::ValueWithUnit(Box::new(value)),
             span,
             ty,

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -1600,7 +1600,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
         sharp_cnt
     } else {
         working_set.error(ParseError::Expected("r#", span));
-        return garbage(span);
+        return garbage(working_set, span);
     };
     let expect_postfix_sharp_cnt = prefix_sharp_cnt;
     // check the length of whole raw string.
@@ -1608,7 +1608,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
     // 1(r) + prefix_sharp_cnt + 1(') + 1(') + postfix_sharp characters
     if bytes.len() < prefix_sharp_cnt + expect_postfix_sharp_cnt + 3 {
         working_set.error(ParseError::Unclosed('\''.into(), span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     // check for unbalanced # and single quotes.
@@ -1619,14 +1619,14 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
             "postfix #".to_string(),
             span,
         ));
-        return garbage(span);
+        return garbage(working_set, span);
     }
     // check for unblanaced single quotes.
     if bytes[1 + prefix_sharp_cnt] != b'\''
         || bytes[bytes.len() - expect_postfix_sharp_cnt - 1] != b'\''
     {
         working_set.error(ParseError::Unclosed('\''.into(), span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     let bytes = &bytes[prefix_sharp_cnt + 1 + 1..bytes.len() - 1 - prefix_sharp_cnt];
@@ -1634,7 +1634,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
         Expression::new(working_set, Expr::RawString(token), span, Type::String)
     } else {
         working_set.error(ParseError::Expected("utf8 raw-string", span));
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -22,12 +22,12 @@ use std::{
     sync::Arc,
 };
 
-pub fn garbage(span: Span) -> Expression {
-    Expression::garbage(span)
+pub fn garbage(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+    Expression::garbage(working_set, span)
 }
 
-pub fn garbage_pipeline(spans: &[Span]) -> Pipeline {
-    Pipeline::from_vec(vec![garbage(Span::concat(spans))])
+pub fn garbage_pipeline(working_set: &mut StateWorkingSet, spans: &[Span]) -> Pipeline {
+    Pipeline::from_vec(vec![garbage(working_set, Span::concat(spans))])
 }
 
 fn is_identifier_byte(b: u8) -> bool {
@@ -322,7 +322,7 @@ fn ensure_flag_arg_type(
                 item: arg_name,
                 span: long_name_span,
             },
-            Expression::garbage(arg.span),
+            Expression::garbage(working_set, arg.span),
         )
     } else {
         (
@@ -653,7 +653,7 @@ pub fn parse_multispan_value(
                 ));
             }
 
-            Expression::garbage(span)
+            Expression::garbage(working_set, span)
         }
         SyntaxShape::Expression => {
             trace!("parsing: expression");
@@ -704,7 +704,7 @@ pub fn parse_multispan_value(
                 let keyword = Keyword {
                     keyword: keyword.as_slice().into(),
                     span: spans[*spans_idx - 1],
-                    expr: Expression::garbage(arg_span),
+                    expr: Expression::garbage(working_set, arg_span),
                 };
                 return Expression::new(
                     working_set,
@@ -987,14 +987,14 @@ pub fn parse_internal_call(
                         signature.call_signature(),
                         arg_span,
                     ));
-                    call.add_positional(Expression::garbage(arg_span));
+                    call.add_positional(Expression::garbage(working_set, arg_span));
                 } else if positional_idx < signature.required_positional.len() {
                     working_set.error(ParseError::MissingPositional(
                         signature.required_positional[positional_idx].name.clone(),
                         Span::new(spans[spans_idx].start, spans[spans_idx].start),
                         signature.call_signature(),
                     ));
-                    call.add_positional(Expression::garbage(arg_span));
+                    call.add_positional(Expression::garbage(working_set, arg_span));
                 } else {
                     let rest_shape = match &signature.rest_positional {
                         Some(arg) => arg.shape.clone(),
@@ -1051,7 +1051,7 @@ pub fn parse_internal_call(
                     arg.ty,
                     arg.span,
                 ));
-                Expression::garbage(arg.span)
+                Expression::garbage(working_set, arg.span)
             } else {
                 arg
             };
@@ -1062,7 +1062,7 @@ pub fn parse_internal_call(
 
             call.add_unknown(arg);
         } else {
-            call.add_positional(Expression::garbage(arg_span));
+            call.add_positional(Expression::garbage(working_set, arg_span));
             working_set.error(ParseError::ExtraPositional(
                 signature.call_signature(),
                 arg_span,
@@ -1092,7 +1092,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
             "Encountered command with zero spans".into(),
             Span::concat(spans),
         ));
-        return garbage(head);
+        return garbage(working_set, head);
     }
 
     let mut pos = 0;
@@ -1154,7 +1154,7 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
                     "Incomplete statement".into(),
                     Span::concat(spans),
                 ));
-                return garbage(Span::concat(spans));
+                return garbage(working_set, Span::concat(spans));
             }
         }
 
@@ -1248,7 +1248,7 @@ pub fn parse_binary(working_set: &mut StateWorkingSet, span: Span) -> Expression
         parse_binary_with_base(working_set, span, 2, 8, b"0b[", b"]")
     } else {
         working_set.error(ParseError::Expected("binary", span));
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -1294,7 +1294,7 @@ fn parse_binary_with_base(
                     | TokenContents::OutErrGreaterThan
                     | TokenContents::OutErrGreaterGreaterThan => {
                         working_set.error(ParseError::Expected("binary", span));
-                        return garbage(span);
+                        return garbage(working_set, span);
                     }
                     TokenContents::Comment | TokenContents::Semicolon | TokenContents::Eol => {}
                 }
@@ -1322,14 +1322,14 @@ fn parse_binary_with_base(
                         span,
                         x.to_string(),
                     ));
-                    return garbage(span);
+                    return garbage(working_set, span);
                 }
             }
         }
     }
 
     working_set.error(ParseError::Expected("binary", span));
-    garbage(span)
+    garbage(working_set, span)
 }
 
 fn decode_with_base(s: &str, base: u32, digits_per_byte: usize) -> Result<Vec<u8>, ParseIntError> {
@@ -1368,7 +1368,7 @@ pub fn parse_int(working_set: &mut StateWorkingSet, span: Span) -> Expression {
                 span,
             ));
 
-            garbage(span)
+            garbage(working_set, span)
         }
     }
 
@@ -1376,7 +1376,7 @@ pub fn parse_int(working_set: &mut StateWorkingSet, span: Span) -> Expression {
 
     if token.is_empty() {
         working_set.error(ParseError::Expected("int", span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     if let Some(num) = token.strip_prefix("0b") {
@@ -1389,7 +1389,7 @@ pub fn parse_int(working_set: &mut StateWorkingSet, span: Span) -> Expression {
         Expression::new(working_set, Expr::Int(num), span, Type::Int)
     } else {
         working_set.error(ParseError::Expected("int", span));
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -1402,7 +1402,7 @@ pub fn parse_float(working_set: &mut StateWorkingSet, span: Span) -> Expression 
     } else {
         working_set.error(ParseError::Expected("float", span));
 
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -1428,7 +1428,7 @@ pub fn parse_number(working_set: &mut StateWorkingSet, span: Span) -> Expression
     working_set.parse_errors.truncate(starting_error_count);
 
     working_set.error(ParseError::Expected("number", span));
-    garbage(span)
+    garbage(working_set, span)
 }
 
 pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression {
@@ -1447,12 +1447,12 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression 
         s
     } else {
         working_set.error(ParseError::NonUtf8(span));
-        return garbage(span);
+        return garbage(working_set, span);
     };
 
     if !token.contains("..") {
         working_set.error(ParseError::Expected("at least one range bound set", span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     // First, figure out what exact operators are used and determine their positions
@@ -1466,7 +1466,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression 
                 "one range operator ('..' or '..<') and optionally one next operator ('..')",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
     };
     // Avoid calling sub-parsers on unmatched parens, to prevent quadratic time on things like ((((1..2))))
@@ -1481,7 +1481,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression 
         );
         if let Some(_err) = err {
             working_set.error(ParseError::Expected("Valid expression before ..", span));
-            return garbage(span);
+            return garbage(working_set, span);
         }
     }
 
@@ -1498,7 +1498,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression 
                 "inclusive operator preceding second range bound",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
     } else {
         let op_str = if token.contains("..=") { "..=" } else { ".." };
@@ -1531,7 +1531,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression 
 
     if let (None, None) = (&from, &to) {
         working_set.error(ParseError::Expected("at least one range bound set", span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     let (next, next_op_span) = if let Some(pos) = next_op_pos {
@@ -1678,7 +1678,7 @@ pub fn parse_brace_expr(
             format!("non-block value: {shape}"),
             span,
         ));
-        return Expression::garbage(span);
+        return Expression::garbage(working_set, span);
     }
 
     let bytes = working_set.get_span_contents(Span::new(span.start + 1, span.end - 1));
@@ -1729,7 +1729,7 @@ pub fn parse_brace_expr(
             span,
         ));
 
-        Expression::garbage(span)
+        Expression::garbage(working_set, span)
     }
 }
 
@@ -1941,12 +1941,12 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
         )
     } else if working_set.get_env_var(&name).is_some() {
         working_set.error(ParseError::EnvVarNotVar(name, span));
-        garbage(span)
+        garbage(working_set, span)
     } else {
         let ws = &*working_set;
         let suggestion = DidYouMean::new(&ws.list_variables(), ws.get_span_contents(span));
         working_set.error(ParseError::VariableNotFound(suggestion, span));
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -2120,12 +2120,6 @@ pub fn parse_full_cell_path(
 
             (
                 Expression::new(working_set, Expr::Subexpression(block_id), head_span, ty),
-                // Expression {
-                //     expr: Expr::Subexpression(block_id),
-                //     span: head_span,
-                //     ty,
-                //     custom_completion: None,
-                // },
                 true,
             )
         } else if bytes.starts_with(b"[") {
@@ -2163,7 +2157,7 @@ pub fn parse_full_cell_path(
                 String::from_utf8_lossy(bytes).to_string(),
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         };
 
         let tail = parse_cell_path(working_set, tokens, expect_dot);
@@ -2183,7 +2177,7 @@ pub fn parse_full_cell_path(
             ty,
         )
     } else {
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -2205,7 +2199,7 @@ pub fn parse_directory(working_set: &mut StateWorkingSet, span: Span) -> Express
     } else {
         working_set.error(ParseError::Expected("directory", span));
 
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -2227,7 +2221,7 @@ pub fn parse_filepath(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     } else {
         working_set.error(ParseError::Expected("filepath", span));
 
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -2245,7 +2239,7 @@ pub fn parse_datetime(working_set: &mut StateWorkingSet, span: Span) -> Expressi
         || bytes[4] != b'-'
     {
         working_set.error(ParseError::Expected("datetime", span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     let token = String::from_utf8_lossy(bytes).to_string();
@@ -2268,7 +2262,7 @@ pub fn parse_datetime(working_set: &mut StateWorkingSet, span: Span) -> Expressi
 
     working_set.error(ParseError::Expected("datetime", span));
 
-    garbage(span)
+    garbage(working_set, span)
 }
 
 /// Parse a duration type, eg '10day'
@@ -2284,11 +2278,11 @@ pub fn parse_duration(working_set: &mut StateWorkingSet, span: Span) -> Expressi
         }
         Some(Err(mk_err_for)) => {
             working_set.error(mk_err_for("duration"));
-            garbage(span)
+            garbage(working_set, span)
         }
         None => {
             working_set.error(ParseError::Expected("duration with valid units", span));
-            garbage(span)
+            garbage(working_set, span)
         }
     }
 }
@@ -2302,7 +2296,7 @@ pub fn parse_filesize(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     // the hex digit `b` might be mistaken for the unit `b`, so check that first
     if bytes.starts_with(b"0x") {
         working_set.error(ParseError::Expected("filesize with valid units", span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     match parse_unit_value(bytes, span, FILESIZE_UNIT_GROUPS, Type::Filesize, |x| {
@@ -2314,11 +2308,11 @@ pub fn parse_filesize(working_set: &mut StateWorkingSet, span: Span) -> Expressi
         }
         Some(Err(mk_err_for)) => {
             working_set.error(mk_err_for("filesize"));
-            garbage(span)
+            garbage(working_set, span)
         }
         None => {
             working_set.error(ParseError::Expected("filesize with valid units", span));
-            garbage(span)
+            garbage(working_set, span)
         }
     }
 }
@@ -2483,7 +2477,7 @@ pub fn parse_glob_pattern(working_set: &mut StateWorkingSet, span: Span) -> Expr
     } else {
         working_set.error(ParseError::Expected("glob pattern string", span));
 
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -2689,7 +2683,7 @@ pub fn parse_string(working_set: &mut StateWorkingSet, span: Span) -> Expression
 
     if bytes.is_empty() {
         working_set.error(ParseError::Expected("String", span));
-        return Expression::garbage(span);
+        return Expression::garbage(working_set, span);
     }
 
     // Check for bare word interpolation
@@ -2724,11 +2718,11 @@ pub fn parse_string_strict(working_set: &mut StateWorkingSet, span: Span) -> Exp
         };
         if bytes.starts_with(b"\"") && (bytes.len() == 1 || !bytes.ends_with(b"\"")) {
             working_set.error(ParseError::Unclosed("\"".into(), span));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         if bytes.starts_with(b"\'") && (bytes.len() == 1 || !bytes.ends_with(b"\'")) {
             working_set.error(ParseError::Unclosed("\'".into(), span));
-            return garbage(span);
+            return garbage(working_set, span);
         }
     }
 
@@ -2752,13 +2746,13 @@ pub fn parse_string_strict(working_set: &mut StateWorkingSet, span: Span) -> Exp
         } else if token.contains(' ') {
             working_set.error(ParseError::Expected("string", span));
 
-            garbage(span)
+            garbage(working_set, span)
         } else {
             Expression::new(working_set, Expr::String(token), span, Type::String)
         }
     } else {
         working_set.error(ParseError::Expected("string", span));
-        garbage(span)
+        garbage(working_set, span)
     }
 }
 
@@ -2768,7 +2762,7 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
             "needs at least one component of import pattern".to_string(),
             Span::concat(spans),
         ));
-        return garbage(Span::concat(spans));
+        return garbage(working_set, Span::concat(spans));
     };
 
     let head_expr = parse_value(working_set, *head_span, &SyntaxShape::Any);
@@ -2778,12 +2772,12 @@ pub fn parse_import_pattern(working_set: &mut StateWorkingSet, spans: &[Span]) -
             Ok(s) => (working_set.find_module(s.as_bytes()), s.into_bytes()),
             Err(err) => {
                 working_set.error(err.wrap(working_set, Span::concat(spans)));
-                return garbage(Span::concat(spans));
+                return garbage(working_set, Span::concat(spans));
             }
         },
         Err(err) => {
             working_set.error(err.wrap(working_set, Span::concat(spans)));
-            return garbage(Span::concat(spans));
+            return garbage(working_set, Span::concat(spans));
         }
     };
 
@@ -2907,7 +2901,7 @@ pub fn parse_var_with_opt_type(
         || bytes.contains(&b'`')
     {
         working_set.error(ParseError::VariableNotValid(spans[*spans_idx]));
-        return (garbage(spans[*spans_idx]), None);
+        return (garbage(working_set, spans[*spans_idx]), None);
     }
 
     if bytes.ends_with(b":") {
@@ -2937,7 +2931,7 @@ pub fn parse_var_with_opt_type(
                     "valid variable name",
                     spans[*spans_idx - 1],
                 ));
-                return (garbage(spans[*spans_idx - 1]), None);
+                return (garbage(working_set, spans[*spans_idx - 1]), None);
             }
 
             let id = working_set.add_variable(var_name, spans[*spans_idx - 1], ty.clone(), mutable);
@@ -2959,7 +2953,7 @@ pub fn parse_var_with_opt_type(
                     "valid variable name",
                     spans[*spans_idx],
                 ));
-                return (garbage(spans[*spans_idx]), None);
+                return (garbage(working_set, spans[*spans_idx]), None);
             }
 
             let id = working_set.add_variable(var_name, spans[*spans_idx], Type::Any, mutable);
@@ -2967,12 +2961,6 @@ pub fn parse_var_with_opt_type(
             working_set.error(ParseError::MissingType(spans[*spans_idx]));
             (
                 Expression::new(working_set, Expr::VarDecl(id), spans[*spans_idx], Type::Any),
-                // Expression {
-                //     expr: Expr::VarDecl(id),
-                //     span: spans[*spans_idx],
-                //     ty: Type::Any,
-                //     custom_completion: None,
-                // },
                 None,
             )
         }
@@ -2984,7 +2972,7 @@ pub fn parse_var_with_opt_type(
                 "valid variable name",
                 spans[*spans_idx],
             ));
-            return (garbage(spans[*spans_idx]), None);
+            return (garbage(working_set, spans[*spans_idx]), None);
         }
 
         let id = working_set.add_variable(
@@ -3168,7 +3156,7 @@ pub fn parse_signature(working_set: &mut StateWorkingSet, span: Span) -> Express
         start += 1;
     } else {
         working_set.error(ParseError::Expected("[ or (", Span::new(start, start + 1)));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     if (has_paren && bytes.ends_with(b")")) || (!has_paren && bytes.ends_with(b"]")) {
@@ -3180,12 +3168,6 @@ pub fn parse_signature(working_set: &mut StateWorkingSet, span: Span) -> Express
     let sig = parse_signature_helper(working_set, Span::new(start, end));
 
     Expression::new(working_set, Expr::Signature(sig), span, Type::Signature)
-    // Expression {
-    //     expr: Expr::Signature(sig),
-    //     span,
-    //     ty: Type::Signature,
-    //     custom_completion: None,
-    // }
 }
 
 pub fn parse_signature_helper(working_set: &mut StateWorkingSet, span: Span) -> Box<Signature> {
@@ -3886,17 +3868,6 @@ pub fn parse_list_expression(
         }
     }
 
-    // Expression {
-    //     expr: Expr::List(args),
-    //     span,
-    //     ty: Type::List(Box::new(if let Some(ty) = contained_type {
-    //         ty
-    //     } else {
-    //         Type::Any
-    //     })),
-    //     custom_completion: None,
-    // }
-
     Expression::new(
         working_set,
         Expr::List(args),
@@ -4109,7 +4080,7 @@ pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> 
         start += 1;
     } else {
         working_set.error(ParseError::Expected("block", span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
     if bytes.ends_with(b"}") {
         end -= 1;
@@ -4165,7 +4136,7 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
         start += 1;
     } else {
         working_set.error(ParseError::Expected("closure", span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
     if bytes.ends_with(b"}") {
         end -= 1;
@@ -4281,7 +4252,7 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
 
             if output.get(position).is_none() {
                 working_set.error(mk_err());
-                return garbage(span);
+                return garbage(working_set, span);
             };
 
             let (tokens, found) = if let Some((pos, _)) = output[position..]
@@ -4290,7 +4261,7 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
             {
                 if position + pos == position {
                     working_set.error(mk_err());
-                    return garbage(span);
+                    return garbage(working_set, span);
                 }
 
                 (&output[position..position + pos], true)
@@ -4351,12 +4322,6 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
         span,
         Type::Any,
     )
-    // Expression {
-    //     expr: Expr::MatchBlock(output_matches),
-    //     span,
-    //     ty: Type::Any,
-    //     custom_completion: None,
-    // }
 }
 
 pub fn parse_closure_expression(
@@ -4375,7 +4340,7 @@ pub fn parse_closure_expression(
         start += 1;
     } else {
         working_set.error(ParseError::Expected("closure", span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
     if bytes.ends_with(b"}") {
         end -= 1;
@@ -4481,12 +4446,6 @@ pub fn parse_closure_expression(
     let block_id = working_set.add_block(Arc::new(output));
 
     Expression::new(working_set, Expr::Closure(block_id), span, Type::Closure)
-    // Expression {
-    //     expr: Expr::Closure(block_id),
-    //     span,
-    //     ty: Type::Closure,
-    //     custom_completion: None,
-    // }
 }
 
 pub fn parse_value(
@@ -4500,47 +4459,29 @@ pub fn parse_value(
 
     if bytes.is_empty() {
         working_set.error(ParseError::IncompleteParser(span));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     // Check for reserved keyword values
     match bytes {
         b"true" => {
             if matches!(shape, SyntaxShape::Boolean) || matches!(shape, SyntaxShape::Any) {
-                // return Expression {
-                //     expr: Expr::Bool(true),
-                //     span,
-                //     ty: Type::Bool,
-                //     custom_completion: None,
-                // };
                 return Expression::new(working_set, Expr::Bool(true), span, Type::Bool);
             } else {
                 working_set.error(ParseError::Expected("non-boolean value", span));
-                return Expression::garbage(span);
+                return Expression::garbage(working_set, span);
             }
         }
         b"false" => {
             if matches!(shape, SyntaxShape::Boolean) || matches!(shape, SyntaxShape::Any) {
-                // return Expression {
-                //     expr: Expr::Bool(false),
-                //     span,
-                //     ty: Type::Bool,
-                //     custom_completion: None,
-                // };
                 return Expression::new(working_set, Expr::Bool(false), span, Type::Bool);
             } else {
                 working_set.error(ParseError::Expected("non-boolean value", span));
-                return Expression::garbage(span);
+                return Expression::garbage(working_set, span);
             }
         }
         b"null" => {
             return Expression::new(working_set, Expr::Nothing, span, Type::Nothing);
-            // return Expression {
-            //     expr: Expr::Nothing,
-            //     span,
-            //     ty: Type::Nothing,
-            //     custom_completion: None,
-            // };
         }
         b"-inf" | b"inf" | b"NaN" => {
             return parse_float(working_set, span);
@@ -4562,7 +4503,7 @@ pub fn parse_value(
             | SyntaxShape::GlobPattern => {}
             _ => {
                 working_set.error(ParseError::Expected("non-[] value", span));
-                return Expression::garbage(span);
+                return Expression::garbage(working_set, span);
             }
         },
         b'r' if bytes.len() > 1 && bytes[1] == b'#' => {
@@ -4595,7 +4536,7 @@ pub fn parse_value(
             } else {
                 working_set.error(ParseError::Expected("signature", span));
 
-                Expression::garbage(span)
+                Expression::garbage(working_set, span)
             }
         }
         SyntaxShape::List(elem) => {
@@ -4604,7 +4545,7 @@ pub fn parse_value(
             } else {
                 working_set.error(ParseError::Expected("list", span));
 
-                Expression::garbage(span)
+                Expression::garbage(working_set, span)
             }
         }
         SyntaxShape::Table(_) => {
@@ -4613,7 +4554,7 @@ pub fn parse_value(
             } else {
                 working_set.error(ParseError::Expected("table", span));
 
-                Expression::garbage(span)
+                Expression::garbage(working_set, span)
             }
         }
         SyntaxShape::CellPath => parse_simple_cell_path(working_set, span),
@@ -4621,16 +4562,10 @@ pub fn parse_value(
             // Redundant, though we catch bad boolean parses here
             if bytes == b"true" || bytes == b"false" {
                 Expression::new(working_set, Expr::Bool(true), span, Type::Bool)
-                // Expression {
-                //     expr: Expr::Bool(true),
-                //     span,
-                //     ty: Type::Bool,
-                //     custom_completion: None,
-                // }
             } else {
                 working_set.error(ParseError::Expected("bool", span));
 
-                Expression::garbage(span)
+                Expression::garbage(working_set, span)
             }
         }
 
@@ -4639,7 +4574,7 @@ pub fn parse_value(
         SyntaxShape::Block | SyntaxShape::Closure(..) | SyntaxShape::Record(_) => {
             working_set.error(ParseError::Expected("block, closure or record", span));
 
-            Expression::garbage(span)
+            Expression::garbage(working_set, span)
         }
 
         SyntaxShape::Any => {
@@ -4680,7 +4615,7 @@ pub fn parse_value(
                     }
                 }
                 working_set.error(ParseError::Expected("any shape", span));
-                garbage(span)
+                garbage(working_set, span)
             }
         }
         x => {
@@ -4688,7 +4623,7 @@ pub fn parse_value(
                 x.to_type().to_string(),
                 span,
             ));
-            garbage(span)
+            garbage(working_set, span)
         }
     }
 }
@@ -4742,7 +4677,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
                 "Use '**' for exponentiation or 'bit-xor' for bitwise XOR.",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         equality @ (b"is" | b"===") => {
             working_set.error(ParseError::UnknownOperator(
@@ -4754,7 +4689,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
                 "Did you mean '=='?",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         b"contains" => {
             working_set.error(ParseError::UnknownOperator(
@@ -4762,7 +4697,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
                 "Did you mean '$string =~ $pattern' or '$element in $container'?",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         b"%" => {
             working_set.error(ParseError::UnknownOperator(
@@ -4770,7 +4705,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
                 "Did you mean 'mod'?",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         b"&" => {
             working_set.error(ParseError::UnknownOperator(
@@ -4778,7 +4713,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
                 "Did you mean 'bit-and'?",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         b"<<" => {
             working_set.error(ParseError::UnknownOperator(
@@ -4786,7 +4721,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
                 "Did you mean 'bit-shl'?",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         b">>" => {
             working_set.error(ParseError::UnknownOperator(
@@ -4794,7 +4729,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
                 "Did you mean 'bit-shr'?",
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         bits @ (b"bits-and" | b"bits-xor" | b"bits-or" | b"bits-shl" | b"bits-shr") => {
             working_set.error(ParseError::UnknownOperator(
@@ -4816,20 +4751,13 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
                 },
                 span,
             ));
-            return garbage(span);
+            return garbage(working_set, span);
         }
         _ => {
             working_set.error(ParseError::Expected("operator", span));
-            return garbage(span);
+            return garbage(working_set, span);
         }
     };
-
-    // Expression{
-    //     expr: Expr::Operator(operator),
-    //     span,
-    //     ty: Type::Any,
-    //     custom_completion: None,
-    // }
 
     Expression::new(working_set, Expr::Operator(operator), span, Type::Any)
 }
@@ -4869,7 +4797,7 @@ pub fn parse_math_expression(
                 "expression",
                 Span::new(spans[0].end, spans[0].end),
             ));
-            return garbage(spans[0]);
+            return garbage(working_set, spans[0]);
         }
     } else if first_span == b"not" {
         not_start_spans.push(spans[idx].start);
@@ -4890,7 +4818,7 @@ pub fn parse_math_expression(
                 "expression",
                 Span::new(spans[idx - 1].end, spans[idx - 1].end),
             ));
-            return garbage(spans[idx - 1]);
+            return garbage(working_set, spans[idx - 1]);
         }
     }
 
@@ -4934,8 +4862,8 @@ pub fn parse_math_expression(
             // Handle broken math expr `1 +` etc
             working_set.error(ParseError::IncompleteMathExpression(spans[idx - 1]));
 
-            expr_stack.push(Expression::garbage(spans[idx - 1]));
-            expr_stack.push(Expression::garbage(spans[idx - 1]));
+            expr_stack.push(Expression::garbage(working_set, spans[idx - 1]));
+            expr_stack.push(Expression::garbage(working_set, spans[idx - 1]));
 
             break;
         }
@@ -4967,7 +4895,7 @@ pub fn parse_math_expression(
                     "expression",
                     Span::new(spans[idx - 1].end, spans[idx - 1].end),
                 ));
-                return garbage(spans[idx - 1]);
+                return garbage(working_set, spans[idx - 1]);
             }
         }
         let mut rhs = parse_value(working_set, spans[idx], &SyntaxShape::Any);
@@ -5126,7 +5054,7 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
 
     if pos == spans.len() {
         working_set.error(ParseError::UnknownCommand(spans[0]));
-        return garbage(Span::concat(spans));
+        return garbage(working_set, Span::concat(spans));
     }
 
     let output = if is_math_expression_like(working_set, spans[pos]) {
@@ -5315,7 +5243,7 @@ pub fn parse_builtin_commands(
         b"overlay" => {
             if let Some(redirection) = lite_command.redirection.as_ref() {
                 working_set.error(redirecting_builtin_error("overlay", redirection));
-                return garbage_pipeline(&lite_command.parts);
+                return garbage_pipeline(working_set, &lite_command.parts);
             }
             parse_keyword(working_set, lite_command)
         }
@@ -5335,7 +5263,7 @@ pub fn parse_builtin_commands(
         {
             if let Some(redirection) = lite_command.redirection.as_ref() {
                 working_set.error(redirecting_builtin_error("plugin use", redirection));
-                return garbage_pipeline(&lite_command.parts);
+                return garbage_pipeline(working_set, &lite_command.parts);
             }
             parse_keyword(working_set, lite_command)
         }
@@ -5359,7 +5287,7 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
         start += 1;
     } else {
         working_set.error(ParseError::Expected("{", Span::new(start, start + 1)));
-        return garbage(span);
+        return garbage(working_set, span);
     }
 
     if bytes.ends_with(b"}") {
@@ -5424,8 +5352,8 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
                     Span::new(curr_span.end, curr_span.end),
                 ));
                 output.push(RecordItem::Pair(
-                    garbage(curr_span),
-                    garbage(Span::new(curr_span.end, curr_span.end)),
+                    garbage(working_set, curr_span),
+                    garbage(working_set, Span::new(curr_span.end, curr_span.end)),
                 ));
                 break;
             }
@@ -5439,10 +5367,10 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
                 ));
                 output.push(RecordItem::Pair(
                     field,
-                    garbage(Span::new(
-                        colon_span.start,
-                        tokens[tokens.len() - 1].span.end,
-                    )),
+                    garbage(
+                        working_set,
+                        Span::new(colon_span.start, tokens[tokens.len() - 1].span.end),
+                    ),
                 ));
                 break;
             }
@@ -5452,8 +5380,11 @@ pub fn parse_record(working_set: &mut StateWorkingSet, span: Span) -> Expression
                     Span::new(colon_span.end, colon_span.end),
                 ));
                 output.push(RecordItem::Pair(
-                    garbage(Span::new(curr_span.start, colon_span.end)),
-                    garbage(Span::new(colon_span.end, tokens[tokens.len() - 1].span.end)),
+                    garbage(working_set, Span::new(curr_span.start, colon_span.end)),
+                    garbage(
+                        working_set,
+                        Span::new(colon_span.end, tokens[tokens.len() - 1].span.end),
+                    ),
                 ));
                 break;
             }
@@ -6249,7 +6180,7 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
             Type::Any,
         )
     } else {
-        Expression::garbage(span)
+        Expression::garbage(working_set, span)
     }
 }
 

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -251,7 +251,8 @@ fn parse_external_arg(working_set: &mut StateWorkingSet, span: Span) -> External
             String::from_utf8_lossy(contents).to_string()
         };
 
-        ExternalArgument::Regular(Expression::new(working_set,
+        ExternalArgument::Regular(Expression::new(
+            working_set,
             Expr::String(contents),
             span,
             Type::String,
@@ -282,7 +283,8 @@ pub fn parse_external_call(working_set: &mut StateWorkingSet, spans: &[Span]) ->
             working_set.error(err)
         }
 
-        Box::new(Expression::new(working_set,
+        Box::new(Expression::new(
+            working_set,
             Expr::String(contents),
             head_span,
             Type::String,
@@ -798,7 +800,7 @@ pub fn parse_internal_call(
                     None
                 }
             }
-            _ => None
+            _ => None,
         }
     } else {
         None
@@ -837,11 +839,7 @@ pub fn parse_internal_call(
     if let Some(var_id) = lib_dirs_var_id {
         call.set_parser_info(
             DIR_VAR_PARSER_INFO.to_owned(),
-            Expression::new(working_set,
-                            Expr::Var(var_id),
-                            call.head,
-                            Type::Any,
-            ),
+            Expression::new(working_set, Expr::Var(var_id), call.head, Type::Any),
         );
     }
 
@@ -1211,7 +1209,8 @@ pub fn parse_call(working_set: &mut StateWorkingSet, spans: &[Span], head: Span)
             )
         };
 
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Call(parsed_call.call),
             Span::concat(spans),
             parsed_call.output,
@@ -1316,13 +1315,7 @@ fn parse_binary_with_base(
             let str = String::from_utf8_lossy(&binary_value).to_string();
 
             match decode_with_base(&str, base, min_digits_per_byte) {
-                Ok(v) => {
-                    return Expression::new(working_set,
-                        Expr::Binary(v),
-                        span,
-                        Type::Binary,
-                    )
-                }
+                Ok(v) => return Expression::new(working_set, Expr::Binary(v), span, Type::Binary),
                 Err(x) => {
                     working_set.error(ParseError::IncorrectValue(
                         "not a binary value".into(),
@@ -1367,11 +1360,7 @@ pub fn parse_int(working_set: &mut StateWorkingSet, span: Span) -> Expression {
         radix: u32,
     ) -> Expression {
         if let Ok(num) = i64::from_str_radix(token, radix) {
-            Expression::new(working_set,
-                Expr::Int(num),
-                span,
-                Type::Int,
-            )
+            Expression::new(working_set, Expr::Int(num), span, Type::Int)
         } else {
             working_set.error(ParseError::InvalidLiteral(
                 format!("invalid digits for radix {}", radix),
@@ -1397,11 +1386,7 @@ pub fn parse_int(working_set: &mut StateWorkingSet, span: Span) -> Expression {
     } else if let Some(num) = token.strip_prefix("0x") {
         extract_int(working_set, num, span, 16)
     } else if let Ok(num) = token.parse::<i64>() {
-        Expression::new(working_set,
-            Expr::Int(num),
-            span,
-            Type::Int,
-        )
+        Expression::new(working_set, Expr::Int(num), span, Type::Int)
     } else {
         working_set.error(ParseError::Expected("int", span));
         garbage(span)
@@ -1413,11 +1398,7 @@ pub fn parse_float(working_set: &mut StateWorkingSet, span: Span) -> Expression 
     let token = strip_underscores(token);
 
     if let Ok(x) = token.parse::<f64>() {
-        Expression::new(working_set,
-            Expr::Float(x),
-            span,
-            Type::Float,
-        )
+        Expression::new(working_set, Expr::Float(x), span, Type::Float)
     } else {
         working_set.error(ParseError::Expected("float", span));
 
@@ -1578,12 +1559,7 @@ pub fn parse_range(working_set: &mut StateWorkingSet, span: Span) -> Expression 
         operator,
     };
 
-    Expression::new(
-        working_set,
-        Expr::Range(Box::new(range)),
-        span,
-        Type::Range,
-    )
+    Expression::new(working_set, Expr::Range(Box::new(range)), span, Type::Range)
 }
 
 pub(crate) fn parse_dollar_expr(working_set: &mut StateWorkingSet, span: Span) -> Expression {
@@ -1655,12 +1631,7 @@ pub fn parse_raw_string(working_set: &mut StateWorkingSet, span: Span) -> Expres
 
     let bytes = &bytes[prefix_sharp_cnt + 1 + 1..bytes.len() - 1 - prefix_sharp_cnt];
     if let Ok(token) = String::from_utf8(bytes.into()) {
-        Expression {
-            expr: Expr::RawString(token),
-            span,
-            ty: Type::String,
-            custom_completion: None,
-        }
+        Expression::new(working_set, Expr::RawString(token), span, Type::String)
     } else {
         working_set.error(ParseError::Expected("utf8 raw-string", span));
         garbage(span)
@@ -1833,7 +1804,8 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
                         working_set.error(err);
                     }
 
-                    output.push(Expression::new(working_set,
+                    output.push(Expression::new(
+                        working_set,
                         Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
                         span,
                         Type::String,
@@ -1902,7 +1874,8 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
                     working_set.error(err);
                 }
 
-                output.push(Expression::new(working_set,
+                output.push(Expression::new(
+                    working_set,
                     Expr::String(String::from_utf8_lossy(&str_contents).to_string()),
                     span,
                     Type::String,
@@ -1919,7 +1892,8 @@ pub fn parse_string_interpolation(working_set: &mut StateWorkingSet, span: Span)
         }
     }
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::StringInterpolation(output),
         span,
         Type::String,
@@ -1930,19 +1904,22 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
     let contents = working_set.get_span_contents(span);
 
     if contents == b"$nu" {
-        return Expression::new(working_set,
+        return Expression::new(
+            working_set,
             Expr::Var(nu_protocol::NU_VARIABLE_ID),
             span,
             Type::Any,
         );
     } else if contents == b"$in" {
-        return Expression::new(working_set,
+        return Expression::new(
+            working_set,
             Expr::Var(nu_protocol::IN_VARIABLE_ID),
             span,
             Type::Any,
         );
     } else if contents == b"$env" {
-        return Expression::new(working_set,
+        return Expression::new(
+            working_set,
             Expr::Var(nu_protocol::ENV_VARIABLE_ID),
             span,
             Type::Any,
@@ -1956,7 +1933,8 @@ pub fn parse_variable_expr(working_set: &mut StateWorkingSet, span: Span) -> Exp
     };
 
     if let Some(id) = parse_variable(working_set, span) {
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Var(id),
             span,
             working_set.get_variable(id).ty.clone(),
@@ -2081,7 +2059,8 @@ pub fn parse_simple_cell_path(working_set: &mut StateWorkingSet, span: Span) -> 
 
     let cell_path = parse_cell_path(working_set, tokens, false);
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::CellPath(CellPath { members: cell_path }),
         span,
         Type::CellPath,
@@ -2140,11 +2119,7 @@ pub fn parse_full_cell_path(
             tokens.next();
 
             (
-                Expression::new(working_set,
-                    Expr::Subexpression(block_id),
-                    head_span,
-                    ty,
-                ),
+                Expression::new(working_set, Expr::Subexpression(block_id), head_span, ty),
                 // Expression {
                 //     expr: Expr::Subexpression(block_id),
                 //     span: head_span,
@@ -2179,11 +2154,7 @@ pub fn parse_full_cell_path(
         } else if let Some(var_id) = implicit_head {
             trace!("parsing: implicit head of full cell path");
             (
-                Expression::new(working_set,
-                    Expr::Var(var_id),
-                    head.span,
-                    Type::Any,
-                ),
+                Expression::new(working_set, Expr::Var(var_id), head.span, Type::Any),
                 false,
             )
         } else {
@@ -2197,19 +2168,19 @@ pub fn parse_full_cell_path(
 
         let tail = parse_cell_path(working_set, tokens, expect_dot);
         // FIXME: Get the type of the data at the tail using follow_cell_path() (or something)
-        let ty =
-            if !tail.is_empty() {
-                // Until the aforementioned fix is implemented, this is necessary to allow mutable list upserts
-                // such as $a.1 = 2 to work correctly.
-                Type::Any
-            } else {
-                head.ty.clone()
-            };
+        let ty = if !tail.is_empty() {
+            // Until the aforementioned fix is implemented, this is necessary to allow mutable list upserts
+            // such as $a.1 = 2 to work correctly.
+            Type::Any
+        } else {
+            head.ty.clone()
+        };
 
-        Expression::new(working_set,
-                        Expr::FullCellPath(Box::new(FullCellPath { head, tail })),
-                        full_cell_span,
-            ty
+        Expression::new(
+            working_set,
+            Expr::FullCellPath(Box::new(FullCellPath { head, tail })),
+            full_cell_span,
+            ty,
         )
     } else {
         garbage(span)
@@ -2225,7 +2196,8 @@ pub fn parse_directory(working_set: &mut StateWorkingSet, span: Span) -> Express
     if err.is_none() {
         trace!("-- found {}", token);
 
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Directory(token, quoted),
             span,
             Type::String,
@@ -2246,7 +2218,8 @@ pub fn parse_filepath(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     if err.is_none() {
         trace!("-- found {}", token);
 
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::Filepath(token, quoted),
             span,
             Type::String,
@@ -2278,31 +2251,19 @@ pub fn parse_datetime(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     let token = String::from_utf8_lossy(bytes).to_string();
 
     if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(&token) {
-        return Expression::new(working_set,
-            Expr::DateTime(datetime),
-            span,
-            Type::Date,
-        );
+        return Expression::new(working_set, Expr::DateTime(datetime), span, Type::Date);
     }
 
     // Just the date
     let just_date = token.clone() + "T00:00:00+00:00";
     if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(&just_date) {
-        return Expression::new(working_set,
-            Expr::DateTime(datetime),
-            span,
-            Type::Date,
-        );
+        return Expression::new(working_set, Expr::DateTime(datetime), span, Type::Date);
     }
 
     // Date and time, assume UTC
     let datetime = token + "+00:00";
     if let Ok(datetime) = chrono::DateTime::parse_from_rfc3339(&datetime) {
-        return Expression::new(working_set,
-            Expr::DateTime(datetime),
-            span,
-            Type::Date,
-        );
+        return Expression::new(working_set, Expr::DateTime(datetime), span, Type::Date);
     }
 
     working_set.error(ParseError::Expected("datetime", span));
@@ -2320,7 +2281,7 @@ pub fn parse_duration(working_set: &mut StateWorkingSet, span: Span) -> Expressi
         Some(Ok(expr)) => {
             let span_id = working_set.add_span(span);
             expr.with_span_id(span_id)
-        },
+        }
         Some(Err(mk_err_for)) => {
             working_set.error(mk_err_for("duration"));
             garbage(span)
@@ -2350,7 +2311,7 @@ pub fn parse_filesize(working_set: &mut StateWorkingSet, span: Span) -> Expressi
         Some(Ok(expr)) => {
             let span_id = working_set.add_span(span);
             expr.with_span_id(span_id)
-        },
+        }
         Some(Err(mk_err_for)) => {
             working_set.error(mk_err_for("filesize"));
             garbage(span)
@@ -2415,21 +2376,13 @@ pub fn parse_unit_value<'res>(
 
         trace!("-- found {} {:?}", num, unit);
         let value = ValueWithUnit {
-            expr: Expression::new_unknown(
-                Expr::Int(num),
-                lhs_span,
-                Type::Number,
-            ),
+            expr: Expression::new_unknown(Expr::Int(num), lhs_span, Type::Number),
             unit: Spanned {
                 item: unit,
                 span: unit_span,
             },
         };
-        let expr = Expression::new_unknown(
-            Expr::ValueWithUnit(Box::new(value)),
-            span,
-            ty,
-        );
+        let expr = Expression::new_unknown(Expr::ValueWithUnit(Box::new(value)), span, ty);
 
         Some(Ok(expr))
     } else {
@@ -2521,7 +2474,8 @@ pub fn parse_glob_pattern(working_set: &mut StateWorkingSet, span: Span) -> Expr
     if err.is_none() {
         trace!("-- found {}", token);
 
-        Expression::new(working_set,
+        Expression::new(
+            working_set,
             Expr::GlobPattern(token, quoted),
             span,
             Type::Glob,
@@ -2748,11 +2702,7 @@ pub fn parse_string(working_set: &mut StateWorkingSet, span: Span) -> Expression
         working_set.error(err);
     }
 
-    Expression::new(working_set,
-        Expr::String(s),
-        span,
-        Type::String,
-    )
+    Expression::new(working_set, Expr::String(s), span, Type::String)
 }
 
 fn is_quoted(bytes: &[u8]) -> bool {
@@ -2798,21 +2748,13 @@ pub fn parse_string_strict(working_set: &mut StateWorkingSet, span: Span) -> Exp
         trace!("-- found {}", token);
 
         if quoted {
-            Expression::new(working_set,
-                Expr::String(token),
-                span,
-                Type::String,
-            )
+            Expression::new(working_set, Expr::String(token), span, Type::String)
         } else if token.contains(' ') {
             working_set.error(ParseError::Expected("string", span));
 
             garbage(span)
         } else {
-            Expression::new(working_set,
-                Expr::String(token),
-                span,
-                Type::String,
-            )
+            Expression::new(working_set, Expr::String(token), span, Type::String)
         }
     } else {
         working_set.error(ParseError::Expected("string", span));
@@ -3001,7 +2943,8 @@ pub fn parse_var_with_opt_type(
             let id = working_set.add_variable(var_name, spans[*spans_idx - 1], ty.clone(), mutable);
 
             (
-                Expression::new(working_set,
+                Expression::new(
+                    working_set,
                     Expr::VarDecl(id),
                     Span::concat(&spans[span_beginning..*spans_idx + 1]),
                     ty.clone(),
@@ -3023,11 +2966,7 @@ pub fn parse_var_with_opt_type(
 
             working_set.error(ParseError::MissingType(spans[*spans_idx]));
             (
-                Expression::new(working_set,
-                    Expr::VarDecl(id),
-                    spans[*spans_idx],
-                    Type::Any,
-                ),
+                Expression::new(working_set, Expr::VarDecl(id), spans[*spans_idx], Type::Any),
                 // Expression {
                 //     expr: Expr::VarDecl(id),
                 //     span: spans[*spans_idx],
@@ -3056,12 +2995,7 @@ pub fn parse_var_with_opt_type(
         );
 
         (
-            Expression::new(
-                working_set,
-                Expr::VarDecl(id),
-                spans[*spans_idx],
-                Type::Any,
-            ),
+            Expression::new(working_set, Expr::VarDecl(id), spans[*spans_idx], Type::Any),
             None,
         )
     }
@@ -3216,11 +3150,7 @@ pub fn parse_row_condition(working_set: &mut StateWorkingSet, spans: &[Span]) ->
         }
     };
 
-    Expression::new(working_set,
-                    Expr::RowCondition(block_id),
-        span,
-                    Type::Bool,
-    )
+    Expression::new(working_set, Expr::RowCondition(block_id), span, Type::Bool)
 }
 
 pub fn parse_signature(working_set: &mut StateWorkingSet, span: Span) -> Expression {
@@ -3249,11 +3179,7 @@ pub fn parse_signature(working_set: &mut StateWorkingSet, span: Span) -> Express
 
     let sig = parse_signature_helper(working_set, Span::new(start, end));
 
-    Expression::new(working_set,
-        Expr::Signature(sig),
-        span,
-        Type::Signature,
-    )
+    Expression::new(working_set, Expr::Signature(sig), span, Type::Signature)
     // Expression {
     //     expr: Expr::Signature(sig),
     //     span,
@@ -3971,7 +3897,8 @@ pub fn parse_list_expression(
     //     custom_completion: None,
     // }
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::List(args),
         span,
         Type::List(Box::new(if let Some(ty) = contained_type {
@@ -4125,12 +4052,7 @@ fn parse_table_expression(working_set: &mut StateWorkingSet, span: Span) -> Expr
         rows: rows.into_iter().map(Into::into).collect(),
     };
 
-    Expression::new(
-        working_set,
-        Expr::Table(table),
-        span,
-        ty,
-    )
+    Expression::new(working_set, Expr::Table(table), span, ty)
 }
 
 fn table_type(head: &[Expression], rows: &[Vec<Expression>]) -> (Type, Vec<ParseError>) {
@@ -4230,17 +4152,7 @@ pub fn parse_block_expression(working_set: &mut StateWorkingSet, span: Span) -> 
 
     let block_id = working_set.add_block(Arc::new(output));
 
-    Expression::new(working_set,
-        Expr::Block(block_id),
-        span,
-        Type::Block,
-    )
-    // Expression {
-    //     expr: Expr::Block(block_id),
-    //     span,
-    //     ty: Type::Block,
-    //     custom_completion: None,
-    // }
+    Expression::new(working_set, Expr::Block(block_id), span, Type::Block)
 }
 
 pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Span) -> Expression {
@@ -4433,7 +4345,8 @@ pub fn parse_match_block_expression(working_set: &mut StateWorkingSet, span: Spa
         output_matches.push((pattern, result));
     }
 
-    Expression::new(working_set,
+    Expression::new(
+        working_set,
         Expr::MatchBlock(output_matches),
         span,
         Type::Any,
@@ -4567,11 +4480,7 @@ pub fn parse_closure_expression(
 
     let block_id = working_set.add_block(Arc::new(output));
 
-    Expression::new(working_set,
-        Expr::Closure(block_id),
-        span,
-        Type::Closure,
-    )
+    Expression::new(working_set, Expr::Closure(block_id), span, Type::Closure)
     // Expression {
     //     expr: Expr::Closure(block_id),
     //     span,
@@ -4604,11 +4513,7 @@ pub fn parse_value(
                 //     ty: Type::Bool,
                 //     custom_completion: None,
                 // };
-                return Expression::new(working_set,
-                    Expr::Bool(true),
-                    span,
-                    Type::Bool,
-                );
+                return Expression::new(working_set, Expr::Bool(true), span, Type::Bool);
             } else {
                 working_set.error(ParseError::Expected("non-boolean value", span));
                 return Expression::garbage(span);
@@ -4622,22 +4527,14 @@ pub fn parse_value(
                 //     ty: Type::Bool,
                 //     custom_completion: None,
                 // };
-                return Expression::new(working_set,
-                    Expr::Bool(false),
-                    span,
-                    Type::Bool,
-                );
+                return Expression::new(working_set, Expr::Bool(false), span, Type::Bool);
             } else {
                 working_set.error(ParseError::Expected("non-boolean value", span));
                 return Expression::garbage(span);
             }
         }
         b"null" => {
-            return Expression::new(working_set,
-                Expr::Nothing,
-                span,
-                Type::Nothing,
-            );
+            return Expression::new(working_set, Expr::Nothing, span, Type::Nothing);
             // return Expression {
             //     expr: Expr::Nothing,
             //     span,
@@ -4723,11 +4620,7 @@ pub fn parse_value(
         SyntaxShape::Boolean => {
             // Redundant, though we catch bad boolean parses here
             if bytes == b"true" || bytes == b"false" {
-                Expression::new(working_set,
-                    Expr::Bool(true),
-                    span,
-                    Type::Bool,
-                )
+                Expression::new(working_set, Expr::Bool(true), span, Type::Bool)
                 // Expression {
                 //     expr: Expr::Bool(true),
                 //     span,
@@ -4938,11 +4831,7 @@ pub fn parse_operator(working_set: &mut StateWorkingSet, span: Span) -> Expressi
     //     custom_completion: None,
     // }
 
-    Expression::new(working_set,
-        Expr::Operator(operator),
-        span,
-        Type::Any,
-    )
+    Expression::new(working_set, Expr::Operator(operator), span, Type::Any)
 }
 
 pub fn parse_math_expression(
@@ -5014,7 +4903,8 @@ pub fn parse_math_expression(
         //     ty: Type::Bool,
         //     custom_completion: None,
         // };
-        lhs = Expression::new(working_set,
+        lhs = Expression::new(
+            working_set,
             Expr::UnaryNot(Box::new(lhs)),
             Span::new(*not_start_span, spans[idx].end),
             Type::Bool,
@@ -5089,7 +4979,8 @@ pub fn parse_math_expression(
             //     ty: Type::Bool,
             //     custom_completion: None,
             // };
-            rhs = Expression::new(working_set,
+            rhs = Expression::new(
+                working_set,
                 Expr::UnaryNot(Box::new(rhs)),
                 Span::new(*not_start_span, spans[idx].end),
                 Type::Bool,
@@ -5129,13 +5020,12 @@ pub fn parse_math_expression(
             }
 
             let op_span = Span::append(lhs.span, rhs.span);
-            expr_stack.push(
-                Expression::new(working_set,
-                    Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
-                    op_span,
-                    result_ty,
-                )
-            );
+            expr_stack.push(Expression::new(
+                working_set,
+                Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
+                op_span,
+                result_ty,
+            ));
         }
         expr_stack.push(op);
         expr_stack.push(rhs);
@@ -5166,13 +5056,12 @@ pub fn parse_math_expression(
         }
 
         let binary_op_span = Span::append(lhs.span, rhs.span);
-        expr_stack.push(
-            Expression::new(working_set,
-                Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
-                binary_op_span,
-                result_ty,
-            )
-        );
+        expr_stack.push(Expression::new(
+            working_set,
+            Expr::BinaryOp(Box::new(lhs), Box::new(op), Box::new(rhs)),
+            binary_op_span,
+            result_ty,
+        ));
     }
 
     expr_stack
@@ -5215,7 +5104,8 @@ pub fn parse_expression(working_set: &mut StateWorkingSet, spans: &[Span]) -> Ex
                     parse_string_strict(working_set, rhs_span)
                 }
             } else {
-                Expression::new(working_set,
+                Expression::new(
+                    working_set,
                     Expr::String(String::new()),
                     Span::unknown(),
                     Type::Nothing,
@@ -6328,13 +6218,12 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
 
         let block_id = working_set.add_block(Arc::new(block));
 
-        output.push(Argument::Positional(
-            Expression::new(working_set,
+        output.push(Argument::Positional(Expression::new(
+            working_set,
             Expr::Closure(block_id),
             span,
             Type::Any,
-            )
-       ));
+        )));
 
         output.push(Argument::Named((
             Spanned {
@@ -6348,14 +6237,17 @@ fn wrap_expr_with_collect(working_set: &mut StateWorkingSet, expr: &Expression) 
         // The containing, synthetic call to `collect`.
         // We don't want to have a real span as it will confuse flattening
         // The args are where we'll get the real info
-        Expression::new(working_set, Expr::Call(Box::new(Call {
+        Expression::new(
+            working_set,
+            Expr::Call(Box::new(Call {
                 head: Span::new(0, 0),
                 arguments: output,
                 decl_id,
                 parser_info: HashMap::new(),
             })),
             span,
-        Type::Any,)
+            Type::Any,
+        )
     } else {
         Expression::garbage(span)
     }

--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -68,7 +68,7 @@ pub fn type_compatible(lhs: &Type, rhs: &Type) -> bool {
 }
 
 pub fn math_result_type(
-    _working_set: &StateWorkingSet,
+    working_set: &mut StateWorkingSet,
     lhs: &mut Expression,
     op: &mut Expression,
     rhs: &mut Expression,
@@ -104,7 +104,7 @@ pub fn math_result_type(
                     | Type::Filesize,
                     _,
                 ) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -118,7 +118,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -130,7 +130,7 @@ pub fn math_result_type(
                     )
                 }
             },
-            Operator::Math(Math::Append) => check_append(lhs, rhs, op),
+            Operator::Math(Math::Append) => check_append(working_set, lhs, rhs, op),
             Operator::Math(Math::Minus) => match (&lhs.ty, &rhs.ty) {
                 (Type::Int, Type::Int) => (Type::Int, None),
                 (Type::Float, Type::Int) => (Type::Float, None),
@@ -152,7 +152,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Date | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -166,7 +166,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -209,7 +209,7 @@ pub fn math_result_type(
                 | (Type::Duration, _)
                 | (Type::Filesize, _)
                 | (Type::List(_), _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -223,7 +223,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -252,7 +252,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -266,7 +266,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -302,7 +302,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Filesize | Type::Duration, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -316,7 +316,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -348,7 +348,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int | Type::Float | Type::Filesize | Type::Duration, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -362,7 +362,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -390,7 +390,7 @@ pub fn math_result_type(
                     // definitions. As soon as that syntax is added this should be removed
                     (a, b) if a == b => (Type::Bool, None),
                     (Type::Bool, _) => {
-                        *op = Expression::garbage(op.span);
+                        *op = Expression::garbage(working_set, op.span);
                         (
                             Type::Any,
                             Some(ParseError::UnsupportedOperationRHS(
@@ -404,7 +404,7 @@ pub fn math_result_type(
                         )
                     }
                     _ => {
-                        *op = Expression::garbage(op.span);
+                        *op = Expression::garbage(working_set, op.span);
                         (
                             Type::Any,
                             Some(ParseError::UnsupportedOperationLHS(
@@ -441,7 +441,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -455,7 +455,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -491,7 +491,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -505,7 +505,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -541,7 +541,7 @@ pub fn math_result_type(
                 (Type::Nothing, _) => (Type::Nothing, None),
                 (_, Type::Nothing) => (Type::Nothing, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -555,7 +555,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -591,7 +591,7 @@ pub fn math_result_type(
                 (Type::Nothing, _) => (Type::Nothing, None),
                 (_, Type::Nothing) => (Type::Nothing, None),
                 (Type::Int | Type::Float | Type::Duration | Type::Filesize, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -605,7 +605,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -638,7 +638,7 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -652,7 +652,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -673,7 +673,7 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -687,7 +687,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -708,7 +708,7 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -722,7 +722,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -743,7 +743,7 @@ pub fn math_result_type(
                 (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
 
                 (Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -757,7 +757,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -781,7 +781,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -795,7 +795,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -819,7 +819,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Bool, None),
                 (_, Type::Any) => (Type::Bool, None),
                 (Type::Int | Type::Float | Type::String, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -833,7 +833,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -855,7 +855,7 @@ pub fn math_result_type(
                 (Type::Any, _) => (Type::Any, None),
                 (_, Type::Any) => (Type::Any, None),
                 (Type::Int, _) => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationRHS(
@@ -869,7 +869,7 @@ pub fn math_result_type(
                     )
                 }
                 _ => {
-                    *op = Expression::garbage(op.span);
+                    *op = Expression::garbage(working_set, op.span);
                     (
                         Type::Any,
                         Some(ParseError::UnsupportedOperationLHS(
@@ -881,7 +881,9 @@ pub fn math_result_type(
                     )
                 }
             },
-            Operator::Assignment(Assignment::AppendAssign) => check_append(lhs, rhs, op),
+            Operator::Assignment(Assignment::AppendAssign) => {
+                check_append(working_set, lhs, rhs, op)
+            }
             Operator::Assignment(_) => match (&lhs.ty, &rhs.ty) {
                 (x, y) if x == y => (Type::Nothing, None),
                 (Type::Any, _) => (Type::Nothing, None),
@@ -894,7 +896,7 @@ pub fn math_result_type(
             },
         },
         _ => {
-            *op = Expression::garbage(op.span);
+            *op = Expression::garbage(working_set, op.span);
 
             (
                 Type::Any,
@@ -1026,6 +1028,7 @@ pub fn check_block_input_output(working_set: &StateWorkingSet, block: &Block) ->
 }
 
 fn check_append(
+    working_set: &mut StateWorkingSet,
     lhs: &Expression,
     rhs: &Expression,
     op: &mut Expression,
@@ -1050,7 +1053,7 @@ fn check_append(
         (Type::Binary, Type::Binary) => (Type::Binary, None),
         (Type::Any, _) | (_, Type::Any) => (Type::Any, None),
         (Type::Table(_) | Type::String | Type::Binary, _) => {
-            *op = Expression::garbage(op.span);
+            *op = Expression::garbage(working_set, op.span);
             (
                 Type::Any,
                 Some(ParseError::UnsupportedOperationRHS(
@@ -1064,7 +1067,7 @@ fn check_append(
             )
         }
         _ => {
-            *op = Expression::garbage(op.span);
+            *op = Expression::garbage(working_set, op.span);
             (
                 Type::Any,
                 Some(ParseError::UnsupportedOperationLHS(

--- a/crates/nu-protocol/src/ast/call.rs
+++ b/crates/nu-protocol/src/ast/call.rs
@@ -338,9 +338,13 @@ impl Call {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::engine::EngineState;
 
     #[test]
     fn argument_span_named() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
         let named = Spanned {
             item: "named".to_string(),
             span: Span::new(2, 3),
@@ -349,7 +353,7 @@ mod test {
             item: "short".to_string(),
             span: Span::new(5, 7),
         };
-        let expr = Expression::garbage(Span::new(11, 13));
+        let expr = Expression::garbage(&mut working_set, Span::new(11, 13));
 
         let arg = Argument::Named((named.clone(), None, None));
 
@@ -370,8 +374,11 @@ mod test {
 
     #[test]
     fn argument_span_positional() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
         let span = Span::new(2, 3);
-        let expr = Expression::garbage(span);
+        let expr = Expression::garbage(&mut working_set, span);
         let arg = Argument::Positional(expr);
 
         assert_eq!(span, arg.span());
@@ -379,8 +386,11 @@ mod test {
 
     #[test]
     fn argument_span_unknown() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
         let span = Span::new(2, 3);
-        let expr = Expression::garbage(span);
+        let expr = Expression::garbage(&mut working_set, span);
         let arg = Argument::Unknown(expr);
 
         assert_eq!(span, arg.span());
@@ -388,9 +398,12 @@ mod test {
 
     #[test]
     fn call_arguments_span() {
+        let engine_state = EngineState::new();
+        let mut working_set = StateWorkingSet::new(&engine_state);
+
         let mut call = Call::new(Span::new(0, 1));
-        call.add_positional(Expression::garbage(Span::new(2, 3)));
-        call.add_positional(Expression::garbage(Span::new(5, 7)));
+        call.add_positional(Expression::garbage(&mut working_set, Span::new(2, 3)));
+        call.add_positional(Expression::garbage(&mut working_set, Span::new(5, 7)));
 
         assert_eq!(Span::new(2, 7), call.arguments_span());
     }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -16,11 +16,12 @@ pub struct Expression {
 }
 
 impl Expression {
-    pub fn garbage(span: Span) -> Expression {
+    pub fn garbage(working_set: &mut StateWorkingSet, span: Span) -> Expression {
+        let span_id = working_set.add_span(span);
         Expression {
             expr: Expr::Garbage,
             span,
-            span_id: todo!("add span id to garbage"),
+            span_id,
             ty: Type::Any,
             custom_completion: None,
         }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -495,5 +495,25 @@ impl Expression {
             custom_completion: None
         }
     }
+
+    pub fn new_unknown(expr: Expr, span: Span, ty: Type) -> Expression {
+        Expression {
+            expr,
+            span,
+            span_id: SpanId(0),
+            ty,
+            custom_completion: None
+        }
+    }
+
+    pub fn with_span_id(self, span_id: SpanId) -> Expression {
+        Expression {
+            expr: self.expr,
+            span: self.span,
+            span_id,
+            ty: self.ty,
+            custom_completion: self.custom_completion
+        }
+    }
 }
 

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, MatchPattern, RecordItem},
-    engine::{EngineState, StateWorkingSet},
+    engine::StateWorkingSet,
     BlockId, DeclId, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
@@ -487,12 +487,11 @@ impl Expression {
     }
 
     pub fn new_existing(
-        engine_state: &EngineState,
         expr: Expr,
         span: Span,
+        span_id: SpanId,
         ty: Type,
     ) -> Expression {
-        let span_id = engine_state.get_span_id(span);
         Expression {
             expr,
             span,

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, MatchPattern, RecordItem},
-    engine::StateWorkingSet,
+    engine::{EngineState, StateWorkingSet},
     BlockId, DeclId, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
@@ -514,5 +514,9 @@ impl Expression {
             ty: self.ty,
             custom_completion: self.custom_completion,
         }
+    }
+
+    pub fn span(&self, engine_state: &EngineState) -> Span {
+        engine_state.get_span(self.span_id)
     }
 }

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -486,12 +486,7 @@ impl Expression {
         }
     }
 
-    pub fn new_existing(
-        expr: Expr,
-        span: Span,
-        span_id: SpanId,
-        ty: Type,
-    ) -> Expression {
+    pub fn new_existing(expr: Expr, span: Span, span_id: SpanId, ty: Type) -> Expression {
         Expression {
             expr,
             span,

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, MatchPattern, RecordItem},
     engine::StateWorkingSet,
-    BlockId, DeclId, Signature, Span, Type, VarId, IN_VARIABLE_ID,
+    BlockId, DeclId, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -10,6 +10,7 @@ use std::sync::Arc;
 pub struct Expression {
     pub expr: Expr,
     pub span: Span,
+    pub span_id: SpanId,
     pub ty: Type,
     pub custom_completion: Option<DeclId>,
 }
@@ -19,6 +20,7 @@ impl Expression {
         Expression {
             expr: Expr::Garbage,
             span,
+            span_id: todo!("add span id to garbage"),
             ty: Type::Any,
             custom_completion: None,
         }
@@ -471,4 +473,27 @@ impl Expression {
             Expr::VarDecl(_) => {}
         }
     }
+
+    pub fn new(working_set: &mut StateWorkingSet, expr: Expr, span: Span, ty: Type) -> Expression {
+        let span_id = working_set.add_span(span);
+        Expression {
+            expr,
+            span,
+            span_id,
+            ty,
+            custom_completion: None
+        }
+    }
+
+    pub fn new_existing(engine_state: &EngineState, expr: Expr, span: Span, ty: Type) -> Expression {
+        let span_id = engine_state.get_span_id(span);
+        Expression {
+            expr,
+            span,
+            span_id,
+            ty,
+            custom_completion: None
+        }
+    }
 }
+

--- a/crates/nu-protocol/src/ast/expression.rs
+++ b/crates/nu-protocol/src/ast/expression.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::{Argument, Block, Expr, ExternalArgument, ImportPattern, MatchPattern, RecordItem},
-    engine::StateWorkingSet,
+    engine::{EngineState, StateWorkingSet},
     BlockId, DeclId, Signature, Span, SpanId, Type, VarId, IN_VARIABLE_ID,
 };
 use serde::{Deserialize, Serialize};
@@ -481,18 +481,23 @@ impl Expression {
             span,
             span_id,
             ty,
-            custom_completion: None
+            custom_completion: None,
         }
     }
 
-    pub fn new_existing(engine_state: &EngineState, expr: Expr, span: Span, ty: Type) -> Expression {
+    pub fn new_existing(
+        engine_state: &EngineState,
+        expr: Expr,
+        span: Span,
+        ty: Type,
+    ) -> Expression {
         let span_id = engine_state.get_span_id(span);
         Expression {
             expr,
             span,
             span_id,
             ty,
-            custom_completion: None
+            custom_completion: None,
         }
     }
 
@@ -502,7 +507,7 @@ impl Expression {
             span,
             span_id: SpanId(0),
             ty,
-            custom_completion: None
+            custom_completion: None,
         }
     }
 
@@ -512,8 +517,7 @@ impl Expression {
             span: self.span,
             span_id,
             ty: self.ty,
-            custom_completion: self.custom_completion
+            custom_completion: self.custom_completion,
         }
     }
 }
-

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -7,8 +7,8 @@ use crate::{
         Variable, Visibility, DEFAULT_OVERLAY_NAME,
     },
     eval_const::create_nu_constant,
-    BlockId, Category, Config, DeclId, FileId, HistoryConfig, Module, ModuleId, OverlayId,
-    ShellError, Signature, Span, Type, Value, VarId, VirtualPathId,
+    BlockId, Category, Config, DeclId, Example, FileId, HistoryConfig, Module, ModuleId, OverlayId,
+    ShellError, Signature, Span, SpanId, Type, Value, VarId, VirtualPathId,
 };
 use fancy_regex::Regex;
 use lru::LruCache;
@@ -1018,6 +1018,15 @@ impl EngineState {
                 NonZeroUsize::new(REGEX_CACHE_SIZE).expect("tried to create cache of size zero"),
             )));
         }
+    }
+
+    pub fn add_span(&mut self, span: Span) -> SpanId {
+        todo!("impl adding spans");
+        todo!("push first span unknown!")
+    }
+
+    pub fn get_span_id(&self, span: Span) -> SpanId {
+        todo!("impl span search")
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -571,6 +571,9 @@ impl EngineState {
         self.modules.len()
     }
 
+    pub fn num_spans(&self) -> usize {
+        self.spans.len()
+    }
     pub fn print_vars(&self) {
         for var in self.vars.iter().enumerate() {
             println!("var{}: {:?}", var.0, var.1);
@@ -1029,12 +1032,12 @@ impl EngineState {
     /// Add new span and return its ID
     pub fn add_span(&mut self, span: Span) -> SpanId {
         self.spans.push(span);
-        SpanId(self.spans.len() - 1)
+        SpanId(self.num_spans() - 1)
     }
 
     /// Get existing span
     pub fn get_span(&self, span_id: SpanId) -> Span {
-        self.spans[span_id.0]
+        *self.spans.get(&span_id.0).expect("internal error: missing span")
     }
 
     /// Find ID of a span (should be avoided if possible)

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -7,7 +7,7 @@ use crate::{
         Variable, Visibility, DEFAULT_OVERLAY_NAME,
     },
     eval_const::create_nu_constant,
-    BlockId, Category, Config, DeclId, Example, FileId, HistoryConfig, Module, ModuleId, OverlayId,
+    BlockId, Category, Config, DeclId, FileId, HistoryConfig, Module, ModuleId, OverlayId,
     ShellError, Signature, Span, SpanId, Type, Value, VarId, VirtualPathId,
 };
 use fancy_regex::Regex;

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1037,7 +1037,10 @@ impl EngineState {
 
     /// Get existing span
     pub fn get_span(&self, span_id: SpanId) -> Span {
-        *self.spans.get(span_id.0).expect("internal error: missing span")
+        *self
+            .spans
+            .get(span_id.0)
+            .expect("internal error: missing span")
     }
 
     /// Find ID of a span (should be avoided if possible)

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -116,6 +116,9 @@ pub const IN_VARIABLE_ID: usize = 1;
 pub const ENV_VARIABLE_ID: usize = 2;
 // NOTE: If you add more to this list, make sure to update the > checks based on the last in the list
 
+// The first span is unknown span
+pub const UNKNOWN_SPAN_ID: SpanId = SpanId(0);
+
 impl EngineState {
     pub fn new() -> Self {
         Self {
@@ -1030,13 +1033,11 @@ impl EngineState {
     }
 
     /// Find ID of a span
-    pub fn get_span_id(&self, span: Span) -> SpanId {
-        SpanId(
+    pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
             self.spans
                 .iter()
                 .position(|sp| sp == &span)
-                .expect("span not found"),
-        )
+                .map(SpanId)
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1037,7 +1037,7 @@ impl EngineState {
 
     /// Get existing span
     pub fn get_span(&self, span_id: SpanId) -> Span {
-        *self.spans.get(&span_id.0).expect("internal error: missing span")
+        *self.spans.get(span_id.0).expect("internal error: missing span")
     }
 
     /// Find ID of a span (should be avoided if possible)

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1032,7 +1032,12 @@ impl EngineState {
         SpanId(self.spans.len() - 1)
     }
 
-    /// Find ID of a span
+    /// Get existing span
+    pub fn get_span(&self, span_id: SpanId) -> Span {
+        self.spans[span_id.0]
+    }
+
+    /// Find ID of a span (should be avoided if possible)
     pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
         self.spans.iter().position(|sp| sp == &span).map(SpanId)
     }

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -1034,10 +1034,7 @@ impl EngineState {
 
     /// Find ID of a span
     pub fn find_span_id(&self, span: Span) -> Option<SpanId> {
-            self.spans
-                .iter()
-                .position(|sp| sp == &span)
-                .map(SpanId)
+        self.spans.iter().position(|sp| sp == &span).map(SpanId)
     }
 }
 

--- a/crates/nu-protocol/src/engine/engine_state.rs
+++ b/crates/nu-protocol/src/engine/engine_state.rs
@@ -81,6 +81,7 @@ pub struct EngineState {
     // especially long, so it helps
     pub(super) blocks: Arc<Vec<Arc<Block>>>,
     pub(super) modules: Arc<Vec<Arc<Module>>>,
+    pub spans: Vec<Span>,
     usage: Usage,
     pub scope: ScopeFrame,
     pub ctrlc: Option<Arc<AtomicBool>>,
@@ -132,6 +133,7 @@ impl EngineState {
             modules: Arc::new(vec![Arc::new(Module::new(
                 DEFAULT_OVERLAY_NAME.as_bytes().to_vec(),
             ))]),
+            spans: vec![Span::unknown()],
             usage: Usage::new(),
             // make sure we have some default overlay:
             scope: ScopeFrame::with_empty_overlay(
@@ -184,6 +186,7 @@ impl EngineState {
         self.files.extend(delta.files);
         self.virtual_paths.extend(delta.virtual_paths);
         self.vars.extend(delta.vars);
+        self.spans.extend(delta.spans);
         self.usage.merge_with(delta.usage);
 
         // Avoid potentially cloning the Arcs if we aren't adding anything
@@ -1020,13 +1023,20 @@ impl EngineState {
         }
     }
 
+    /// Add new span and return its ID
     pub fn add_span(&mut self, span: Span) -> SpanId {
-        todo!("impl adding spans");
-        todo!("push first span unknown!")
+        self.spans.push(span);
+        SpanId(self.spans.len() - 1)
     }
 
+    /// Find ID of a span
     pub fn get_span_id(&self, span: Span) -> SpanId {
-        todo!("impl span search")
+        SpanId(
+            self.spans
+                .iter()
+                .position(|sp| sp == &span)
+                .expect("span not found"),
+        )
     }
 }
 

--- a/crates/nu-protocol/src/engine/state_delta.rs
+++ b/crates/nu-protocol/src/engine/state_delta.rs
@@ -4,7 +4,7 @@ use crate::{
         usage::Usage, CachedFile, Command, EngineState, OverlayFrame, ScopeFrame, Variable,
         VirtualPath,
     },
-    Module, Span
+    Module, Span,
 };
 use std::sync::Arc;
 

--- a/crates/nu-protocol/src/engine/state_delta.rs
+++ b/crates/nu-protocol/src/engine/state_delta.rs
@@ -4,7 +4,7 @@ use crate::{
         usage::Usage, CachedFile, Command, EngineState, OverlayFrame, ScopeFrame, Variable,
         VirtualPath,
     },
-    Module,
+    Module, Span
 };
 use std::sync::Arc;
 
@@ -21,6 +21,7 @@ pub struct StateDelta {
     pub(super) decls: Vec<Box<dyn Command>>, // indexed by DeclId
     pub blocks: Vec<Arc<Block>>,             // indexed by BlockId
     pub(super) modules: Vec<Arc<Module>>,    // indexed by ModuleId
+    pub spans: Vec<Span>,                    // indexed by SpanId
     pub(super) usage: Usage,
     pub scope: Vec<ScopeFrame>,
     #[cfg(feature = "plugin")]
@@ -45,6 +46,7 @@ impl StateDelta {
             decls: vec![],
             blocks: vec![],
             modules: vec![],
+            spans: vec![],
             scope: vec![scope_frame],
             usage: Usage::new(),
             #[cfg(feature = "plugin")]

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1015,11 +1015,9 @@ impl<'a> StateWorkingSet<'a> {
     }
 
     pub fn add_span(&mut self, span: Span) -> SpanId {
-        todo!("impl adding spans")
-    }
-
-    pub fn get_span_id(&self, span: Span) -> SpanId {
-        todo!("impl span search")
+        let num_permanent_spans = self.permanent_state.spans.len();
+        self.delta.spans.push(span);
+        SpanId(num_permanent_spans + self.delta.spans.len() - 1)
     }
 }
 

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1019,6 +1019,18 @@ impl<'a> StateWorkingSet<'a> {
         self.delta.spans.push(span);
         SpanId(num_permanent_spans + self.delta.spans.len() - 1)
     }
+
+    pub fn get_span(&self, span_id: SpanId) -> Span {
+        let num_permanent_spans = self.permanent_state.num_spans();
+        if span_id.0 < num_permanent_spans {
+            self.permanent_state.get_span(span_id)
+        } else {
+            *self.delta
+                .spans
+                .get(&span_id.0 - &num_permanent_spans)
+                .expect("internal error: missing span")
+        }
+    }
 }
 
 impl<'a> miette::SourceCode for &StateWorkingSet<'a> {

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -5,7 +5,7 @@ use crate::{
         StateDelta, Variable, VirtualPath, Visibility,
     },
     BlockId, Category, Config, DeclId, FileId, Module, ModuleId, ParseError, ParseWarning, Span,
-    Type, Value, VarId, VirtualPathId,
+    SpanId, Type, Value, VarId, VirtualPathId,
 };
 use core::panic;
 use std::{
@@ -1012,6 +1012,10 @@ impl<'a> StateWorkingSet<'a> {
                 .get(virtual_path_id - num_permanent_virtual_paths)
                 .expect("internal error: missing virtual path")
         }
+    }
+
+    pub fn add_span(&mut self, span: Span) -> SpanId {
+        todo!("impl adding spans")
     }
 }
 

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1025,9 +1025,10 @@ impl<'a> StateWorkingSet<'a> {
         if span_id.0 < num_permanent_spans {
             self.permanent_state.get_span(span_id)
         } else {
-            *self.delta
+            *self
+                .delta
                 .spans
-                .get(&span_id.0 - &num_permanent_spans)
+                .get(span_id.0 - num_permanent_spans)
                 .expect("internal error: missing span")
         }
     }

--- a/crates/nu-protocol/src/engine/state_working_set.rs
+++ b/crates/nu-protocol/src/engine/state_working_set.rs
@@ -1017,6 +1017,10 @@ impl<'a> StateWorkingSet<'a> {
     pub fn add_span(&mut self, span: Span) -> SpanId {
         todo!("impl adding spans")
     }
+
+    pub fn get_span_id(&self, span: Span) -> SpanId {
+        todo!("impl span search")
+    }
 }
 
 impl<'a> miette::SourceCode for &StateWorkingSet<'a> {

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 pub type VarId = usize;
 pub type DeclId = usize;
 pub type BlockId = usize;
@@ -5,3 +7,5 @@ pub type ModuleId = usize;
 pub type OverlayId = usize;
 pub type FileId = usize;
 pub type VirtualPathId = usize;
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct SpanId(pub usize);  // more robust ID style used in the new parser

--- a/crates/nu-protocol/src/id.rs
+++ b/crates/nu-protocol/src/id.rs
@@ -8,4 +8,4 @@ pub type OverlayId = usize;
 pub type FileId = usize;
 pub type VirtualPathId = usize;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct SpanId(pub usize);  // more robust ID style used in the new parser
+pub struct SpanId(pub usize); // more robust ID style used in the new parser

--- a/crates/nuon/src/from.rs
+++ b/crates/nuon/src/from.rs
@@ -56,12 +56,12 @@ pub fn from_nuon(input: &str, span: Option<Span>) -> Result<Value, ShellError> {
     }
 
     let expr = if block.pipelines.is_empty() {
-        Expression {
-            expr: Expr::Nothing,
-            span: span.unwrap_or(Span::unknown()),
-            custom_completion: None,
-            ty: Type::Nothing,
-        }
+        Expression::new(
+            &mut working_set,
+            Expr::Nothing,
+            span.unwrap_or(Span::unknown()),
+            Type::Nothing,
+        )
     } else {
         let mut pipeline = Arc::make_mut(&mut block).pipelines.remove(0);
 
@@ -81,12 +81,12 @@ pub fn from_nuon(input: &str, span: Option<Span>) -> Result<Value, ShellError> {
         }
 
         if pipeline.elements.is_empty() {
-            Expression {
-                expr: Expr::Nothing,
-                span: span.unwrap_or(Span::unknown()),
-                custom_completion: None,
-                ty: Type::Nothing,
-            }
+            Expression::new(
+                &mut working_set,
+                Expr::Nothing,
+                span.unwrap_or(Span::unknown()),
+                Type::Nothing,
+            )
         } else {
             pipeline.elements.remove(0).expr
         }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

First part of SpanID refactoring series. This PR adds a `SpanId` type and a corresponding `span_id` field to `Expression`. Parser creating expressions will now add them to an array in `StateWorkingSet`, generates a corresponding ID and saves the ID to the Expression. The IDs are not used anywhere yet.

For the rough overall plan, see https://github.com/nushell/nushell/issues/12963.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Hopefully none. This is only a refactor of Nushell's internals that shouldn't have visible side effects.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
