### PR TITLE
support plus sign for "into filesize"

### DIFF
--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -159,7 +159,11 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
             }),
         }
     } else {
-        match clean_string.parse::<bytesize::ByteSize>() {
+        match clean_string
+            .strip_prefix('+')
+            .unwrap_or(clean_string)
+            .parse::<bytesize::ByteSize>()
+        {
             Ok(n) => Ok(n.0 as i64),
             Err(_) => Err(ShellError::CantConvert {
                 to_type: "int".into(),

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -152,31 +152,26 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
     if let Some(stripped_negative_string) = clean_string.strip_prefix('-') {
         match stripped_negative_string.parse::<bytesize::ByteSize>() {
             Ok(n) => Ok(-(n.as_u64() as i64)),
-            Err(_) => Err(string_to_into_convert_error(span)),
+            Err(_) => Err(string_convert_error(span)),
         }
     } else if let Some(stripped_positive_string) = clean_string.strip_prefix('+') {
         match stripped_positive_string.parse::<bytesize::ByteSize>() {
-            Ok(n)
-                if stripped_positive_string
-                    .chars()
-                    .next()
-                    .map_or(false, |c| c.is_digit(10)) =>
-            {
+            Ok(n) if stripped_positive_string.starts_with(|c: char| c.is_ascii_digit()) => {
                 Ok(n.0 as i64)
             }
-            _ => Err(string_to_into_convert_error(span)),
+            _ => Err(string_convert_error(span)),
         }
     } else {
         match clean_string.parse::<bytesize::ByteSize>() {
             Ok(n) => Ok(n.0 as i64),
-            Err(_) => Err(string_to_into_convert_error(span)),
+            Err(_) => Err(string_convert_error(span)),
         }
     }
 }
 
-fn string_to_into_convert_error(span: Span) -> ShellError {
+fn string_convert_error(span: Span) -> ShellError {
     ShellError::CantConvert {
-        to_type: "int".into(),
+        to_type: "filesize".into(),
         from_type: "string".into(),
         span,
         help: None,

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -152,12 +152,7 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
     if let Some(stripped_negative_string) = clean_string.strip_prefix('-') {
         match stripped_negative_string.parse::<bytesize::ByteSize>() {
             Ok(n) => Ok(-(n.as_u64() as i64)),
-            Err(_) => Err(ShellError::CantConvert {
-                to_type: "int".into(),
-                from_type: "string".into(),
-                span,
-                help: None,
-            }),
+            Err(_) => Err(string_to_into_convert_error(span)),
         }
     } else if let Some(stripped_positive_string) = clean_string.strip_prefix('+') {
         match stripped_positive_string.parse::<bytesize::ByteSize>() {
@@ -169,23 +164,22 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
             {
                 Ok(n.0 as i64)
             }
-            _ => Err(ShellError::CantConvert {
-                to_type: "int".into(),
-                from_type: "string".into(),
-                span,
-                help: None,
-            }),
+            _ => Err(string_to_into_convert_error(span)),
         }
     } else {
         match clean_string.parse::<bytesize::ByteSize>() {
             Ok(n) => Ok(n.0 as i64),
-            Err(_) => Err(ShellError::CantConvert {
-                to_type: "int".into(),
-                from_type: "string".into(),
-                span,
-                help: None,
-            }),
+            Err(_) => Err(string_to_into_convert_error(span)),
         }
+    }
+}
+
+fn string_to_into_convert_error(span: Span) -> ShellError {
+    ShellError::CantConvert {
+        to_type: "int".into(),
+        from_type: "string".into(),
+        span,
+        help: None,
     }
 }
 

--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -157,13 +157,13 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
     } else if let Some(stripped_positive_string) = clean_string.strip_prefix('+') {
         match stripped_positive_string.parse::<bytesize::ByteSize>() {
             Ok(n) if stripped_positive_string.starts_with(|c: char| c.is_ascii_digit()) => {
-                Ok(n.0 as i64)
+                Ok(n.as_u64() as i64)
             }
             _ => Err(string_convert_error(span)),
         }
     } else {
         match clean_string.parse::<bytesize::ByteSize>() {
-            Ok(n) => Ok(n.0 as i64),
+            Ok(n) => Ok(n.as_u64() as i64),
             Err(_) => Err(string_convert_error(span)),
         }
     }

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -63,15 +63,58 @@ fn into_filesize_negative_filesize() {
 }
 
 #[test]
-fn into_negative_filesize() {
+fn into_filesize_negative_str_filesize() {
+    let actual = nu!("'-3kib' | into filesize");
+
+    assert!(actual.out.contains("-3.0 KiB"));
+}
+
+#[test]
+fn into_filesize_wrong_negative_str_filesize() {
+    let actual = nu!("'--3kib' | into filesize");
+
+    assert!(actual.err.contains("can't convert string to int"));
+
+}
+
+#[test]
+fn into_filesize_negative_str() {
     let actual = nu!("'-1' | into filesize");
 
     assert!(actual.out.contains("-1 B"));
 }
 
 #[test]
-fn into_positive_filesize() {
+fn into_filesize_wrong_negative_str() {
+    let actual = nu!("'--1' | into filesize");
+
+    assert!(actual.err.contains("can't convert string to int"));
+}
+
+#[test]
+fn into_filesize_positive_str_filesize() {
+    let actual = nu!("'+1Kib' | into filesize");
+
+    assert!(actual.out.contains("1.0 KiB"));
+}
+
+#[test]
+fn into_filesize_wrong_positive_str_filesize() {
+    let actual = nu!("'++1Kib' | into filesize");
+
+    assert!(actual.err.contains("can't convert string to int"));
+}
+
+#[test]
+fn into_filesize_positive_str() {
     let actual = nu!("'+1' | into filesize");
 
     assert!(actual.out.contains("1 B"));
+}
+
+#[test]
+fn into_filesize_wrong_positive_str() {
+    let actual = nu!("'++1' | into filesize");
+
+    assert!(actual.err.contains("can't convert string to int"));
 }

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -74,7 +74,6 @@ fn into_filesize_wrong_negative_str_filesize() {
     let actual = nu!("'--3kib' | into filesize");
 
     assert!(actual.err.contains("can't convert string to int"));
-
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -73,7 +73,7 @@ fn into_filesize_negative_str_filesize() {
 fn into_filesize_wrong_negative_str_filesize() {
     let actual = nu!("'--3kib' | into filesize");
 
-    assert!(actual.err.contains("can't convert string to int"));
+    assert!(actual.err.contains("can't convert string to filesize"));
 }
 
 #[test]
@@ -87,7 +87,7 @@ fn into_filesize_negative_str() {
 fn into_filesize_wrong_negative_str() {
     let actual = nu!("'--1' | into filesize");
 
-    assert!(actual.err.contains("can't convert string to int"));
+    assert!(actual.err.contains("can't convert string to filesize"));
 }
 
 #[test]
@@ -101,7 +101,7 @@ fn into_filesize_positive_str_filesize() {
 fn into_filesize_wrong_positive_str_filesize() {
     let actual = nu!("'++1Kib' | into filesize");
 
-    assert!(actual.err.contains("can't convert string to int"));
+    assert!(actual.err.contains("can't convert string to filesize"));
 }
 
 #[test]
@@ -115,5 +115,5 @@ fn into_filesize_positive_str() {
 fn into_filesize_wrong_positive_str() {
     let actual = nu!("'++1' | into filesize");
 
-    assert!(actual.err.contains("can't convert string to int"));
+    assert!(actual.err.contains("can't convert string to filesize"));
 }

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -68,3 +68,10 @@ fn into_negative_filesize() {
 
     assert!(actual.out.contains("-1 B"));
 }
+
+#[test]
+fn into_positive_filesize() {
+    let actual = nu!("'+1' | into filesize");
+
+    assert!(actual.out.contains("1 B"));
+}


### PR DESCRIPTION
# Description
Fixes https://github.com/nushell/nushell/issues/12968. After apply this patch, we can use explict plus sign character included string with `into filesize` cmd.

# User-Facing Changes
AS-IS (before fixing)
```
$ "+8 KiB" | into filesize                                                                                                         
Error: nu::shell::cant_convert

  × Can't convert to int.
   ╭─[entry #31:1:1]
 1 │ "+8 KiB" | into filesize
   · ────┬───
   ·     ╰── can't convert string to int
   ╰────
```

TO-BE (after fixing)
```
$ "+8KiB" | into filesize                                                                                       
8.0 KiB
```

# Tests + Formatting
Added a test 

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
