### PR TITLE
Create `CITATION.cff`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+title: 'nushell: a new type of shell'
+message: >-
+  If you use this software in wish to cite it, 
+  you can use the metadata from this file.
+type: software
+authors:
+  - family-names: The Nushell Project Developers
+identifiers:
+  - type: url
+    value: 'https://github.com/nushell/nushell'
+    description: Repository
+repository-code: 'https://github.com/nushell/nushell'
+url: 'https://www.nushell.sh/'
+abstract: >-
+  The goal of the Nushell project is to take the Unix
+  philosophy of shells, where pipes connect simple commands
+  together, and bring it to the modern style of development.
+  Thus, rather than being either a shell, or a programming
+  language, Nushell connects both by bringing a rich
+  programming language and a full-featured shell together
+  into one package.
+keywords:
+  - nushell
+  - shell
+license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ message: >-
   you can use the metadata from this file.
 type: software
 authors:
-  - family-names: The Nushell Project Developers
+  - name: "The Nushell Project Team"
 identifiers:
   - type: url
     value: 'https://github.com/nushell/nushell'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: 'nushell: a new type of shell'
+title: 'Nushell'
 message: >-
   If you use this software and wish to cite it, 
   you can use the metadata from this file.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: 'nushell: a new type of shell'
 message: >-
-  If you use this software in wish to cite it, 
+  If you use this software and wish to cite it, 
   you can use the metadata from this file.
 type: software
 authors:


### PR DESCRIPTION
# Description
This PR creates a `CITATION.cff` file. 

# User-Facing Changes
Users will now be able to properly cite `nushell` when used e.g. in scientific work. The  `CITATION.cff` file also enables users to get the citation withe the Github integration, see [documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files). More information about the `.cff` standard [here](https://citation-file-format.github.io/).

# After Submitting
Do you want it documented in the docs somewhere? If so, where exactly? Happy to make a PR there.

One feature that could well be implemented later on is automatic updates to the CITATION file with a Github Action (this is outside of my comfort zone, so I'll leave that for a separate PR should anyone want to implement it). Ideally, the `CITATION.cff` file points to the latest release , and could do so with the following fields:
```
commit: 
version: 
date-released: 
```

