### PR TITLE
fixes a bug in OSC9;9 execution

### DIFF
--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -1110,7 +1110,7 @@ fn run_shell_integration_osc9_9(engine_state: &EngineState, stack: &mut Stack, u
         let start_time = Instant::now();
 
         // Otherwise, communicate the path as OSC 9;9 from ConEmu (often used for spawning new tabs in the same dir)
-        // This is helpful in Windows Terminal with Duplicat Tab
+        // This is helpful in Windows Terminal with Duplicate Tab
         run_ansi_sequence(&format!(
             "\x1b]9;9;{}\x1b\\",
             percent_encoding::utf8_percent_encode(&path, percent_encoding::CONTROLS)

--- a/crates/nu-cli/src/repl.rs
+++ b/crates/nu-cli/src/repl.rs
@@ -1110,9 +1110,9 @@ fn run_shell_integration_osc9_9(engine_state: &EngineState, stack: &mut Stack, u
         let start_time = Instant::now();
 
         // Otherwise, communicate the path as OSC 9;9 from ConEmu (often used for spawning new tabs in the same dir)
+        // This is helpful in Windows Terminal with Duplicat Tab
         run_ansi_sequence(&format!(
-            "\x1b]9;9;{}{}\x1b\\",
-            if path.starts_with('/') { "" } else { "/" },
+            "\x1b]9;9;{}\x1b\\",
             percent_encoding::utf8_percent_encode(&path, percent_encoding::CONTROLS)
         ));
 


### PR DESCRIPTION
# Description

This fixes a bug in the `OSC 9;9` functionality where the path wasn't being constructed properly and therefore wasn't getting set right for things like "Duplicate Tab" in Windows Terminal. Thanks to @Araxeus for finding it.

Related to https://github.com/nushell/nushell/issues/10166

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
