### PR TITLE
Fix display formatting for command type in `help commands`

### DIFF
--- a/crates/nu-command/src/help/help_commands.rs
+++ b/crates/nu-command/src/help/help_commands.rs
@@ -122,7 +122,7 @@ fn build_help_commands(engine_state: &EngineState, span: Span) -> Vec<Value> {
         let usage = sig.usage;
         let search_terms = sig.search_terms;
 
-        let command_type = format!("{:?}", decl.command_type()).to_ascii_lowercase();
+        let command_type = decl.command_type().to_string();
 
         // Build table of parameters
         let param_table = {


### PR DESCRIPTION
# Description
Related to #12832, this PR changes the way `help commands` displays the command type to be consistent with `scope commands` and `which`.

# User-Facing Changes
Technically a breaking change since the `help commands` output can now be different.