### PR TITLE
fix do closure with both required, options, and rest args

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -298,9 +298,7 @@ fn bind_args_to(
     if let Some(rest_positional) = &signature.rest_positional {
         let mut rest_items = vec![];
 
-        for result in
-            val_iter.skip(signature.required_positional.len() + signature.optional_positional.len())
-        {
+        for result in val_iter {
             rest_items.push(result);
         }
 

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -539,6 +539,15 @@ fn dynamic_closure_optional_arg() {
 fn dynamic_closure_rest_args() {
     let actual = nu!(r#"let closure = {|...args| $args | str join ""}; do $closure 1 2 3"#);
     assert_eq!(actual.out, "123");
+
+    let actual = nu!(
+        r#"let closure = {|required, ...args| $"($required), ($args | str join "")"}; do $closure 1 2 3"#
+    );
+    assert_eq!(actual.out, "1, 23");
+    let actual = nu!(
+        r#"let closure = {|required, optional?, ...args| $"($required), ($optional), ($args | str join "")"}; do $closure 1 2 3"#
+    );
+    assert_eq!(actual.out, "1, 2, 3");
 }
 
 #[cfg(feature = "which-support")]


### PR DESCRIPTION
# Description
Fixes: #12985

`val_iter` has already handle required positional and optional positional arguments, it not skip them again while handling rest arguments.

# User-Facing Changes
Makes `do {|a, ...b| echo $a ...$b} 1 2 3 4` output the following again:
```nushell
╭───┬───╮
│ 0 │ 1 │
│ 1 │ 2 │
│ 2 │ 3 │
│ 3 │ 4 │
╰───┴───╯
```

# Tests + Formatting
Added some test cases
