### PR TITLE
Expand tilde and ndots in command names

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -46,36 +46,15 @@ impl Command for External {
     ) -> Result<PipelineData, ShellError> {
         let cwd = engine_state.cwd(Some(stack))?;
 
-        // Evaluate the command name in the same way the arguments are evaluated. Since this isn't
-        // a spread, it should return a one-element vec.
-        let name_expr = call
-            .positional_nth(0)
-            .ok_or_else(|| ShellError::MissingParameter {
-                param_name: "command".into(),
-                span: call.head,
-            })?;
-        let name = eval_argument(engine_state, stack, name_expr, false)?
-            .pop()
-            .expect("eval_argument returned zero-element vec")
-            .into_spanned(name_expr.span);
-
         // Find the absolute path to the executable. On Windows, set the
         // executable to "cmd.exe" if it's is a CMD internal command. If the
         // command is not found, display a helpful error message.
+        let name: Spanned<String> = call.req(engine_state, stack, 0)?;
         let executable = if cfg!(windows) && is_cmd_internal_command(&name.item) {
             PathBuf::from("cmd.exe")
         } else {
-            // Expand tilde on the name if it's a bare string (#13000)
-            let expanded_name = if is_bare_string(name_expr) {
-                expand_tilde(&name.item)
-            } else {
-                name.item.clone()
-            };
-
-            // Determine the PATH to be used and then use `which` to find it - though this has no
-            // effect if it's an absolute path already
             let paths = nu_engine::env::path_str(engine_state, stack, call.head)?;
-            let Some(executable) = which(&expanded_name, &paths, &cwd) else {
+            let Some(executable) = which(&name.item, &paths, &cwd) else {
                 return Err(command_not_found(
                     &name.item,
                     call.head,

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -345,3 +345,13 @@ fn command_name_can_contain_tilde() {
     let actual = nu!(format!("{} --testbin cococo", name.display()));
     assert_eq!(actual.out, "cococo");
 }
+
+#[test]
+fn command_name_can_use_string_interpolation() {
+    let executable_dir = nu_test_support::fs::binaries();
+    let actual = nu!(format!(
+        "let bin = 'nu'; ^$'{}/($bin)' --testbin cococo",
+        executable_dir.display()
+    ));
+    assert_eq!(actual.out, "cococo");
+}

--- a/crates/nu-command/tests/commands/run_external.rs
+++ b/crates/nu-command/tests/commands/run_external.rs
@@ -2,6 +2,7 @@
 use nu_test_support::fs::Stub::EmptyFile;
 use nu_test_support::playground::Playground;
 use nu_test_support::{nu, pipeline};
+use std::path::Path;
 
 #[test]
 fn better_empty_redirection() {
@@ -332,4 +333,15 @@ fn redirect_combine() {
         // Lines are collapsed in the nu! macro
         assert_eq!(actual.out, "FooBar");
     });
+}
+
+#[test]
+fn command_name_can_contain_tilde() {
+    let home = nu_path::home_dir().unwrap();
+    let executable = nu_test_support::fs::executable_path();
+    let diff = pathdiff::diff_paths(executable, home).unwrap();
+    let name = Path::new("~").join(diff);
+
+    let actual = nu!(format!("{} --testbin cococo", name.display()));
+    assert_eq!(actual.out, "cococo");
 }

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -278,14 +278,13 @@ pub fn parse_external_call(working_set: &mut StateWorkingSet, spans: &[Span]) ->
         let arg = parse_expression(working_set, &[head_span]);
         Box::new(arg)
     } else {
-        // Eval stage will unquote the string, so we don't bother with that here
-        let (contents, err) = unescape_string(&head_contents, head_span);
+        let (contents, err) = unescape_unquote_string(&head_contents, head_span);
         if let Some(err) = err {
             working_set.error(err)
         }
 
         Box::new(Expression {
-            expr: Expr::String(String::from_utf8_lossy(&contents).into_owned()),
+            expr: Expr::String(contents),
             span: head_span,
             ty: Type::String,
             custom_completion: None,


### PR DESCRIPTION
This PR reverts https://github.com/nushell/nushell/pull/13001 and fixes https://github.com/nushell/nushell/issues/13000 in a different way.

Differences from #13001:

* Supports string interpolations as command name (e.g. `^$"~/.cargo/bin/($bin)"`)
* Doesn't require additional parser hack
* Expands ndots (`...`) in addition to tilde

It adds a regression test for #13000. It also adds a test that ensures string interpolation works in command position.