### PR TITLE
`path type` error and not found changes

### DIFF
--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -39,7 +39,7 @@ impl Command for SubCommand {
 
     fn extra_usage(&self) -> &str {
         r#"This checks the file system to confirm the path's object type.
-If nothing is found, null will be returned."#
+If the path does not exist, null will be returned."#
     }
 
     fn is_const(&self) -> bool {
@@ -107,7 +107,7 @@ If nothing is found, null will be returned."#
 
 fn path_type(path: &Path, span: Span, args: &Arguments) -> Value {
     let path = nu_path::expand_path_with(path, &args.pwd, true);
-    match std::fs::symlink_metadata(path) {
+    match path.metadata() {
         Ok(metadata) => Value::string(get_file_type(&metadata), span),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Value::nothing(span),
         Err(err) => Value::error(err.into_spanned(span).into(), span),

--- a/crates/nu-command/src/path/type.rs
+++ b/crates/nu-command/src/path/type.rs
@@ -107,7 +107,7 @@ If the path does not exist, null will be returned."#
 
 fn path_type(path: &Path, span: Span, args: &Arguments) -> Value {
     let path = nu_path::expand_path_with(path, &args.pwd, true);
-    match path.metadata() {
+    match path.symlink_metadata() {
         Ok(metadata) => Value::string(get_file_type(&metadata), span),
         Err(err) if err.kind() == io::ErrorKind::NotFound => Value::nothing(span),
         Err(err) => Value::error(err.into_spanned(span).into(), span),


### PR DESCRIPTION
# Description
Instead of an empty string, this PR changes `path type` to return null if the path does not exist. If some other IO error is encountered, then that error is bubbled up instead of treating it as a "not found" case.

# User-Facing Changes
- `path type` will now return null instead of an empty string, which is technically a breaking change. In most cases though, I think this shouldn't affect the behavior of scripts too much.
- `path type` can now error instead of returning an empty string if some other IO error besides a "not found" error occurs.

Since this PR introduces breaking changes, it should be merged after the 0.94.1 patch.