### PR TITLE
Disallow byte stream input to `parse`

### DIFF
--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -61,6 +61,16 @@ impl Command for Parse {
                 )),
             },
             Example {
+                description: "Parse each line of output of an external commmand",
+                example: "^cat .profile | lines | parse -r 'export (?<env>.*)=(?<val>.*)'",
+                result: None,
+            },
+            Example {
+                description: "Parse the output of an external commmand (multi-line)",
+                example: "^cat file.txt | collect | parse -r '(?ms)foo: (?<foo>\\w+).*bar: (?<bar>\\w+)'",
+                result: None,
+            },
+            Example {
                 description: "Parse a string using fancy-regex capture group pattern",
                 example: "\"foo! bar.\" | parse --regex '(\\w+)(?=\\.)|(\\w+)(?=!)'",
                 result: Some(Value::test_list(

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -208,22 +208,12 @@ fn operate(
                 }
             })
             .into()),
-        PipelineData::ByteStream(stream, ..) => {
-            if let Some(lines) = stream.lines() {
-                let iter = ParseIter {
-                    captures: VecDeque::new(),
-                    regex,
-                    columns,
-                    iter: lines,
-                    span: head,
-                    ctrlc,
-                };
-
-                Ok(ListStream::new(iter, head, None).into())
-            } else {
-                Ok(PipelineData::Empty)
-            }
-        }
+        PipelineData::ByteStream(stream, ..) => Err(ShellError::UnsupportedInput {
+            msg: "`parse` does not support byte stream input. Use `lines` or `collect` right before this command.".into(),
+            input: "byte stream originates from here".into(),
+            msg_span: head,
+            input_span: stream.span(),
+        }),
     }
 }
 

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -61,12 +61,12 @@ impl Command for Parse {
                 )),
             },
             Example {
-                description: "Parse each line of output of an external commmand",
+                description: "Parse each line of output of an external command",
                 example: "^cat .profile | lines | parse -r 'export (?<env>.*)=(?<val>.*)'",
                 result: None,
             },
             Example {
-                description: "Parse the output of an external commmand (multi-line)",
+                description: "Parse the output of an external command (multi-line)",
                 example: "^cat file.txt | collect | parse -r '(?ms)foo: (?<foo>\\w+).*bar: (?<bar>\\w+)'",
                 result: None,
             },

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -123,6 +123,7 @@ mod regex {
                 cwd: dirs.test(), pipeline(
                 r#"
                     open nushell_git_log_oneline.txt
+                    | lines
                     | parse --regex "(?P<Hash>\\w+) (?P<Message>.+) \\(#(?P<PR>\\d+)\\)"
                     | get 1
                     | get PR
@@ -142,6 +143,7 @@ mod regex {
                 cwd: dirs.test(), pipeline(
                 r#"
                     open nushell_git_log_oneline.txt
+                    | lines
                     | parse --regex "(\\w+) (.+) \\(#(\\d+)\\)"
                     | get 1
                     | get capture0
@@ -161,6 +163,7 @@ mod regex {
                 cwd: dirs.test(), pipeline(
                 r#"
                     open nushell_git_log_oneline.txt
+                    | lines
                     | parse --regex "(?P<Hash>\\w+) (.+) \\(#(?P<PR>\\d+)\\)"
                     | get 1
                     | get capture1
@@ -180,6 +183,7 @@ mod regex {
                 cwd: dirs.test(), pipeline(
                 r#"
                     open nushell_git_log_oneline.txt
+                    | lines
                     | parse --regex "(?P<Hash>\\w+ unfinished capture group"
                 "#
             ));

--- a/crates/nu-command/tests/commands/parse.rs
+++ b/crates/nu-command/tests/commands/parse.rs
@@ -183,7 +183,6 @@ mod regex {
                 cwd: dirs.test(), pipeline(
                 r#"
                     open nushell_git_log_oneline.txt
-                    | lines
                     | parse --regex "(?P<Hash>\\w+ unfinished capture group"
                 "#
             ));
@@ -214,20 +213,5 @@ mod regex {
         ));
 
         assert_eq!(actual.out, "2");
-    }
-
-    #[test]
-    fn parse_handles_external_stream_chunking() {
-        Playground::setup("parse_test_streaming_1", |dirs, sandbox| {
-            let data: String = "abcdefghijklmnopqrstuvwxyz".repeat(1000);
-            sandbox.with_files(&[Stub::FileWithContent("data.txt", &data)]);
-
-            let actual = nu!(
-                cwd: dirs.test(),
-                r#"open data.txt | parse --regex "(abcdefghijklmnopqrstuvwxyz)" | length"#
-            );
-
-            assert_eq!(actual.out, "1000");
-        })
     }
 }


### PR DESCRIPTION
# Description
The regex crates currently do not support streaming. Before 0.94.0, we would collect the byte stream and then run the regex on the collect input. Currently, we split it on lines and run the regex on each line. Neither of these solutions are ideal, so rather than adding hidden behavior, we should ask the user for their intention. This PR disallows byte stream input to `parse` and instead returns an error asking the user to prepend the `parse` command with either `lines` or `collect`.

# User-Facing Changes
Breaking change: `parse` no longer accepts byte stream input.
