### PR TITLE
Allow int values to be converted into floats.

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
@@ -269,38 +269,36 @@ fn typed_column_to_series(name: &str, column: TypedColumn) -> Result<Series, She
                 let series_values: Result<Vec<_>, _> = column
                     .values
                     .iter()
-                    .map(|v| {
-                        match v {
-                            Value::Float { val, .. } => Ok(*val as f32),
-                            Value::Int { val, .. } => Ok(*val as f32),
-                            x => Err(ShellError::GenericError {
-                                error: "Error converting to f32".into(),
-                                msg: "".into(),
-                                span: None,
-                                help: Some(format!("Unexpected type: {x:?}")),
-                                inner: vec![],
-                            }),
-                                                    
-                        }
+                    .map(|v| match v {
+                        Value::Float { val, .. } => Ok(*val as f32),
+                        Value::Int { val, .. } => Ok(*val as f32),
+                        x => Err(ShellError::GenericError {
+                            error: "Error converting to f32".into(),
+                            msg: "".into(),
+                            span: None,
+                            help: Some(format!("Unexpected type: {x:?}")),
+                            inner: vec![],
+                        }),
                     })
                     .collect();
                 Ok(Series::new(name, series_values?))
             }
             DataType::Float64 => {
-                let series_values: Result<Vec<_>, _> =
-                    column.values.iter().map(|v| {
-                        match v {
-                            Value::Float { val, .. } => Ok(*val),
-                            Value::Int { val, .. } => Ok(*val as f64),
-                            x => Err(ShellError::GenericError {
-                                error: "Error converting to f64".into(),
-                                msg: "".into(),
-                                span: None,
-                                help: Some(format!("Unexpected type: {x:?}")),
-                                inner: vec![],
-                            }),
-                        }
-                    }).collect();
+                let series_values: Result<Vec<_>, _> = column
+                    .values
+                    .iter()
+                    .map(|v| match v {
+                        Value::Float { val, .. } => Ok(*val),
+                        Value::Int { val, .. } => Ok(*val as f64),
+                        x => Err(ShellError::GenericError {
+                            error: "Error converting to f64".into(),
+                            msg: "".into(),
+                            span: None,
+                            help: Some(format!("Unexpected type: {x:?}")),
+                            inner: vec![],
+                        }),
+                    })
+                    .collect();
                 Ok(Series::new(name, series_values?))
             }
             DataType::UInt8 => {

--- a/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_dataframe/conversion.rs
@@ -269,13 +269,38 @@ fn typed_column_to_series(name: &str, column: TypedColumn) -> Result<Series, She
                 let series_values: Result<Vec<_>, _> = column
                     .values
                     .iter()
-                    .map(|v| v.as_f64().map(|v| v as f32))
+                    .map(|v| {
+                        match v {
+                            Value::Float { val, .. } => Ok(*val as f32),
+                            Value::Int { val, .. } => Ok(*val as f32),
+                            x => Err(ShellError::GenericError {
+                                error: "Error converting to f32".into(),
+                                msg: "".into(),
+                                span: None,
+                                help: Some(format!("Unexpected type: {x:?}")),
+                                inner: vec![],
+                            }),
+                                                    
+                        }
+                    })
                     .collect();
                 Ok(Series::new(name, series_values?))
             }
             DataType::Float64 => {
                 let series_values: Result<Vec<_>, _> =
-                    column.values.iter().map(|v| v.as_f64()).collect();
+                    column.values.iter().map(|v| {
+                        match v {
+                            Value::Float { val, .. } => Ok(*val),
+                            Value::Int { val, .. } => Ok(*val as f64),
+                            x => Err(ShellError::GenericError {
+                                error: "Error converting to f64".into(),
+                                msg: "".into(),
+                                span: None,
+                                help: Some(format!("Unexpected type: {x:?}")),
+                                inner: vec![],
+                            }),
+                        }
+                    }).collect();
                 Ok(Series::new(name, series_values?))
             }
             DataType::UInt8 => {


### PR DESCRIPTION
Addresses the bug found by @maxim-uvarov when trying to coerce an int Value to a polars float:

<img width="863" alt="image" src="https://github.com/nushell/nushell/assets/56345/4d858812-a7b3-4296-98f4-dce0c544b4c6">

Conversion now works correctly:

<img width="891" alt="Screenshot 2024-05-31 at 14 28 51" src="https://github.com/nushell/nushell/assets/56345/78d9f711-7ad5-4503-abc6-7aba64a2e675">
