### PR TITLE
Fix `run_external::expand_glob()` to return paths that are PWD-relative but reflect the original intent

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -155,6 +155,9 @@ impl Command for External {
             }
         };
 
+        // Log the command we're about to run in case it's useful for debugging purposes.
+        log::trace!("run-external spawning: {command:?}");
+
         // Spawn the child process. On Unix, also put the child process to
         // foreground if we're in an interactive session.
         #[cfg(windows)]


### PR DESCRIPTION
# Description

Fix #13021

This changes the `expand_glob()` function to use `nu_engine::glob_from()` so that absolute paths are actually preserved, rather than being made relative to the provided parent. This preserves the intent of whoever wrote the original path/glob, and also makes it so that tilde always produces absolute paths.

I also made `expand_glob()` handle Ctrl-C so that it can be interrupted.

cc @YizhePKU

# Tests + Formatting
No additional tests here... but that might be a good idea.
