### PR TITLE
Make string related commands parse-time evaluatable

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -1,6 +1,6 @@
 use indexmap::{indexmap, IndexMap};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
+
 use once_cell::sync::Lazy;
 use std::sync::{atomic::AtomicBool, Arc};
 

--- a/crates/nu-command/src/strings/detect_columns.rs
+++ b/crates/nu-command/src/strings/detect_columns.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools;
 use nu_engine::command_prelude::*;
-use nu_protocol::{engine::StateWorkingSet, Range};
+use nu_protocol::Range;
 use std::{io::Cursor, iter::Peekable, str::CharIndices};
 
 type Input<'t> = Peekable<CharIndices<'t>>;

--- a/crates/nu-command/src/strings/encode_decode/decode.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode.rs
@@ -1,5 +1,4 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct Decode;

--- a/crates/nu-command/src/strings/encode_decode/decode.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct Decode;
@@ -46,6 +47,10 @@ documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#
         ]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -53,49 +58,67 @@ documentation link at https://docs.rs/encoding_rs/latest/encoding_rs/#statics"#
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let head = call.head;
         let encoding: Option<Spanned<String>> = call.opt(engine_state, stack, 0)?;
+        run(call, input, encoding)
+    }
 
-        match input {
-            PipelineData::ByteStream(stream, ..) => {
-                let span = stream.span();
-                let bytes = stream.into_bytes()?;
-                match encoding {
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let encoding: Option<Spanned<String>> = call.opt_const(working_set, 0)?;
+        run(call, input, encoding)
+    }
+}
+
+fn run(
+    call: &Call,
+    input: PipelineData,
+    encoding: Option<Spanned<String>>,
+) -> Result<PipelineData, ShellError> {
+    let head = call.head;
+
+    match input {
+        PipelineData::ByteStream(stream, ..) => {
+            let span = stream.span();
+            let bytes = stream.into_bytes()?;
+            match encoding {
+                Some(encoding_name) => super::encoding::decode(head, encoding_name, &bytes),
+                None => super::encoding::detect_encoding_name(head, span, &bytes)
+                    .map(|encoding| encoding.decode(&bytes).0.into_owned())
+                    .map(|s| Value::string(s, head)),
+            }
+            .map(|val| val.into_pipeline_data())
+        }
+        PipelineData::Value(v, ..) => {
+            let input_span = v.span();
+            match v {
+                Value::Binary { val: bytes, .. } => match encoding {
                     Some(encoding_name) => super::encoding::decode(head, encoding_name, &bytes),
-                    None => super::encoding::detect_encoding_name(head, span, &bytes)
+                    None => super::encoding::detect_encoding_name(head, input_span, &bytes)
                         .map(|encoding| encoding.decode(&bytes).0.into_owned())
                         .map(|s| Value::string(s, head)),
                 }
-                .map(|val| val.into_pipeline_data())
+                .map(|val| val.into_pipeline_data()),
+                Value::Error { error, .. } => Err(*error),
+                _ => Err(ShellError::OnlySupportsThisInputType {
+                    exp_input_type: "binary".into(),
+                    wrong_type: v.get_type().to_string(),
+                    dst_span: head,
+                    src_span: v.span(),
+                }),
             }
-            PipelineData::Value(v, ..) => {
-                let input_span = v.span();
-                match v {
-                    Value::Binary { val: bytes, .. } => match encoding {
-                        Some(encoding_name) => super::encoding::decode(head, encoding_name, &bytes),
-                        None => super::encoding::detect_encoding_name(head, input_span, &bytes)
-                            .map(|encoding| encoding.decode(&bytes).0.into_owned())
-                            .map(|s| Value::string(s, head)),
-                    }
-                    .map(|val| val.into_pipeline_data()),
-                    Value::Error { error, .. } => Err(*error),
-                    _ => Err(ShellError::OnlySupportsThisInputType {
-                        exp_input_type: "binary".into(),
-                        wrong_type: v.get_type().to_string(),
-                        dst_span: head,
-                        src_span: v.span(),
-                    }),
-                }
-            }
-            // This should be more precise, but due to difficulties in getting spans
-            // from PipelineData::ListData, this is as it is.
-            _ => Err(ShellError::UnsupportedInput {
-                msg: "non-binary input".into(),
-                input: "value originates from here".into(),
-                msg_span: head,
-                input_span: input.span().unwrap_or(head),
-            }),
         }
+        // This should be more precise, but due to difficulties in getting spans
+        // from PipelineData::ListData, this is as it is.
+        _ => Err(ShellError::UnsupportedInput {
+            msg: "non-binary input".into(),
+            input: "value originates from here".into(),
+            msg_span: head,
+            input_span: input.span().unwrap_or(head),
+        }),
     }
 }
 

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -1,6 +1,5 @@
 use super::base64::{operate, ActionType, Base64CommandArguments, CHARACTER_SET_DESC};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct DecodeBase64;

--- a/crates/nu-command/src/strings/encode_decode/decode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/decode_base64.rs
@@ -1,5 +1,6 @@
-use super::base64::{operate, ActionType, CHARACTER_SET_DESC};
+use super::base64::{operate, ActionType, Base64CommandArguments, CHARACTER_SET_DESC};
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct DecodeBase64;
@@ -66,6 +67,10 @@ impl Command for DecodeBase64 {
         ]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -73,7 +78,34 @@ impl Command for DecodeBase64 {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(ActionType::Decode, engine_state, stack, call, input)
+        let character_set: Option<Spanned<String>> =
+            call.get_flag(engine_state, stack, "character-set")?;
+        let binary = call.has_flag(engine_state, stack, "binary")?;
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+        let args = Base64CommandArguments {
+            action_type: ActionType::Decode,
+            binary,
+            character_set,
+        };
+        operate(engine_state, call, input, cell_paths, args)
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let character_set: Option<Spanned<String>> =
+            call.get_flag_const(working_set, "character-set")?;
+        let binary = call.has_flag_const(working_set, "binary")?;
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
+        let args = Base64CommandArguments {
+            action_type: ActionType::Decode,
+            binary,
+            character_set,
+        };
+        operate(working_set.permanent(), call, input, cell_paths, args)
     }
 }
 

--- a/crates/nu-command/src/strings/encode_decode/encode.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode.rs
@@ -1,5 +1,4 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct Encode;

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -1,6 +1,5 @@
-use super::base64::{operate, ActionType, CHARACTER_SET_DESC, Base64CommandArguments};
+use super::base64::{operate, ActionType, Base64CommandArguments, CHARACTER_SET_DESC};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct EncodeBase64;

--- a/crates/nu-command/src/strings/encode_decode/encode_base64.rs
+++ b/crates/nu-command/src/strings/encode_decode/encode_base64.rs
@@ -1,5 +1,6 @@
-use super::base64::{operate, ActionType, CHARACTER_SET_DESC};
+use super::base64::{operate, ActionType, CHARACTER_SET_DESC, Base64CommandArguments};
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct EncodeBase64;
@@ -70,6 +71,10 @@ impl Command for EncodeBase64 {
         ]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -77,7 +82,34 @@ impl Command for EncodeBase64 {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(ActionType::Encode, engine_state, stack, call, input)
+        let character_set: Option<Spanned<String>> =
+            call.get_flag(engine_state, stack, "character-set")?;
+        let binary = call.has_flag(engine_state, stack, "binary")?;
+        let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+        let args = Base64CommandArguments {
+            action_type: ActionType::Encode,
+            binary,
+            character_set,
+        };
+        operate(engine_state, call, input, cell_paths, args)
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let character_set: Option<Spanned<String>> =
+            call.get_flag_const(working_set, "character-set")?;
+        let binary = call.has_flag_const(working_set, "binary")?;
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
+        let args = Base64CommandArguments {
+            action_type: ActionType::Encode,
+            binary,
+            character_set,
+        };
+        operate(working_set.permanent(), call, input, cell_paths, args)
     }
 }
 

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -2,6 +2,7 @@ use crate::{generate_strftime_list, parse_date_from_string};
 use chrono::{DateTime, Locale, TimeZone};
 use nu_engine::command_prelude::*;
 
+use nu_protocol::engine::StateWorkingSet;
 use nu_utils::locale::{get_system_locale_string, LOCALE_OVERRIDE_ENV_VAR};
 use std::fmt::{Display, Write};
 
@@ -36,36 +37,6 @@ impl Command for FormatDate {
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["fmt", "strftime"]
-    }
-
-    fn run(
-        &self,
-        engine_state: &EngineState,
-        stack: &mut Stack,
-        call: &Call,
-        input: PipelineData,
-    ) -> Result<PipelineData, ShellError> {
-        let head = call.head;
-        if call.has_flag(engine_state, stack, "list")? {
-            return Ok(PipelineData::Value(
-                generate_strftime_list(head, false),
-                None,
-            ));
-        }
-
-        let format = call.opt::<Spanned<String>>(engine_state, stack, 0)?;
-
-        // This doesn't match explicit nulls
-        if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty { dst_span: head });
-        }
-        input.map(
-            move |value| match &format {
-                Some(format) => format_helper(value, format.item.as_str(), format.span, head),
-                None => format_helper_rfc2822(value, head),
-            },
-            engine_state.ctrlc.clone(),
-        )
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -104,6 +75,61 @@ impl Command for FormatDate {
             },
         ]
     }
+
+    fn is_const(&self) -> bool {
+        true
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let list = call.has_flag(engine_state, stack, "list")?;
+        let format = call.opt::<Spanned<String>>(engine_state, stack, 0)?;
+        run(engine_state, call, input, list, format)
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let list = call.has_flag_const(working_set, "list")?;
+        let format = call.opt_const::<Spanned<String>>(working_set, 0)?;
+        run(working_set.permanent(), call, input, list, format)
+    }
+}
+
+fn run(
+    engine_state: &EngineState,
+    call: &Call,
+    input: PipelineData,
+    list: bool,
+    format: Option<Spanned<String>>,
+) -> Result<PipelineData, ShellError> {
+    let head = call.head;
+    if list {
+        return Ok(PipelineData::Value(
+            generate_strftime_list(head, false),
+            None,
+        ));
+    }
+
+    // This doesn't match explicit nulls
+    if matches!(input, PipelineData::Empty) {
+        return Err(ShellError::PipelineEmpty { dst_span: head });
+    }
+    input.map(
+        move |value| match &format {
+            Some(format) => format_helper(value, format.item.as_str(), format.span, head),
+            None => format_helper_rfc2822(value, head),
+        },
+        engine_state.ctrlc.clone(),
+    )
 }
 
 fn format_from<Tz: TimeZone>(date_time: DateTime<Tz>, formatter: &str, span: Span) -> Value

--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -2,7 +2,6 @@ use crate::{generate_strftime_list, parse_date_from_string};
 use chrono::{DateTime, Locale, TimeZone};
 use nu_engine::command_prelude::*;
 
-use nu_protocol::engine::StateWorkingSet;
 use nu_utils::locale::{get_system_locale_string, LOCALE_OVERRIDE_ENV_VAR};
 use std::fmt::{Display, Write};
 

--- a/crates/nu-command/src/strings/format/duration.rs
+++ b/crates/nu-command/src/strings/format/duration.rs
@@ -1,6 +1,5 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 struct Arguments {
     format_value: String,

--- a/crates/nu-command/src/strings/format/duration.rs
+++ b/crates/nu-command/src/strings/format/duration.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 struct Arguments {
     format_value: String,
@@ -53,6 +54,10 @@ impl Command for FormatDuration {
         vec!["convert", "display", "pattern", "human readable"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -78,6 +83,33 @@ impl Command for FormatDuration {
             input,
             call.head,
             engine_state.ctrlc.clone(),
+        )
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let format_value = call
+            .req_const::<Value>(working_set, 0)?
+            .coerce_into_string()?
+            .to_ascii_lowercase();
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 1)?;
+        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+        let float_precision = working_set.permanent().config.float_precision as usize;
+        let arg = Arguments {
+            format_value,
+            float_precision,
+            cell_paths,
+        };
+        operate(
+            format_value_impl,
+            arg,
+            input,
+            call.head,
+            working_set.permanent().ctrlc.clone(),
         )
     }
 

--- a/crates/nu-command/src/strings/parse.rs
+++ b/crates/nu-command/src/strings/parse.rs
@@ -1,6 +1,6 @@
 use fancy_regex::{Captures, Regex};
 use nu_engine::command_prelude::*;
-use nu_protocol::ListStream;
+use nu_protocol::{engine::StateWorkingSet, ListStream};
 use std::{
     collections::VecDeque,
     sync::{atomic::AtomicBool, Arc},
@@ -99,6 +99,10 @@ impl Command for Parse {
         ]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -106,19 +110,31 @@ impl Command for Parse {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input)
+        let pattern: Spanned<String> = call.req(engine_state, stack, 0)?;
+        let regex: bool = call.has_flag(engine_state, stack, "regex")?;
+        operate(engine_state, pattern, regex, call, input)
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let pattern: Spanned<String> = call.req_const(working_set, 0)?;
+        let regex: bool = call.has_flag_const(working_set, "regex")?;
+        operate(working_set.permanent(), pattern, regex, call, input)
     }
 }
 
 fn operate(
     engine_state: &EngineState,
-    stack: &mut Stack,
+    pattern: Spanned<String>,
+    regex: bool,
     call: &Call,
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let head = call.head;
-    let pattern: Spanned<String> = call.req(engine_state, stack, 0)?;
-    let regex: bool = call.has_flag(engine_state, stack, "regex")?;
 
     let pattern_item = pattern.item;
     let pattern_span = pattern.span;

--- a/crates/nu-command/src/strings/split/chars.rs
+++ b/crates/nu-command/src/strings/split/chars.rs
@@ -1,6 +1,6 @@
 use crate::{grapheme_flags, grapheme_flags_const};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
+
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -111,7 +111,7 @@ impl Command for SubCommand {
         let collapse_empty = call.has_flag(engine_state, stack, "collapse-empty")?;
         let has_regex = call.has_flag(engine_state, stack, "regex")?;
 
-        let args = Argument {
+        let args = Arguments {
             separator,
             rest,
             collapse_empty,
@@ -131,7 +131,7 @@ impl Command for SubCommand {
         let collapse_empty = call.has_flag_const(working_set, "collapse-empty")?;
         let has_regex = call.has_flag_const(working_set, "regex")?;
 
-        let args = Argument {
+        let args = Arguments {
             separator,
             rest,
             collapse_empty,
@@ -141,7 +141,7 @@ impl Command for SubCommand {
     }
 }
 
-struct Argument {
+struct Arguments {
     separator: Spanned<String>,
     rest: Vec<Spanned<String>>,
     collapse_empty: bool,
@@ -152,7 +152,7 @@ fn split_column(
     engine_state: &EngineState,
     call: &Call,
     input: PipelineData,
-    args: Argument,
+    args: Arguments,
 ) -> Result<PipelineData, ShellError> {
     let name_span = call.head;
     let regex = if args.has_regex {

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -1,5 +1,6 @@
 use nu_engine::command_prelude::*;
 
+use nu_protocol::engine::StateWorkingSet;
 use regex::Regex;
 
 #[derive(Clone)]
@@ -41,16 +42,6 @@ impl Command for SubCommand {
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["separate", "divide", "regex"]
-    }
-
-    fn run(
-        &self,
-        engine_state: &EngineState,
-        stack: &mut Stack,
-        call: &Call,
-        input: PipelineData,
-    ) -> Result<PipelineData, ShellError> {
-        split_column(engine_state, stack, call, input)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -103,35 +94,83 @@ impl Command for SubCommand {
             },
         ]
     }
+
+    fn is_const(&self) -> bool {
+        true
+    }
+
+    fn run(
+        &self,
+        engine_state: &EngineState,
+        stack: &mut Stack,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let separator: Spanned<String> = call.req(engine_state, stack, 0)?;
+        let rest: Vec<Spanned<String>> = call.rest(engine_state, stack, 1)?;
+        let collapse_empty = call.has_flag(engine_state, stack, "collapse-empty")?;
+        let has_regex = call.has_flag(engine_state, stack, "regex")?;
+
+        let args = Argument {
+            separator,
+            rest,
+            collapse_empty,
+            has_regex,
+        };
+        split_column(engine_state, call, input, args)
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let separator: Spanned<String> = call.req_const(working_set, 0)?;
+        let rest: Vec<Spanned<String>> = call.rest_const(working_set, 1)?;
+        let collapse_empty = call.has_flag_const(working_set, "collapse-empty")?;
+        let has_regex = call.has_flag_const(working_set, "regex")?;
+
+        let args = Argument {
+            separator,
+            rest,
+            collapse_empty,
+            has_regex,
+        };
+        split_column(working_set.permanent(), call, input, args)
+    }
+}
+
+struct Argument {
+    separator: Spanned<String>,
+    rest: Vec<Spanned<String>>,
+    collapse_empty: bool,
+    has_regex: bool,
 }
 
 fn split_column(
     engine_state: &EngineState,
-    stack: &mut Stack,
     call: &Call,
     input: PipelineData,
+    args: Argument,
 ) -> Result<PipelineData, ShellError> {
     let name_span = call.head;
-    let separator: Spanned<String> = call.req(engine_state, stack, 0)?;
-    let rest: Vec<Spanned<String>> = call.rest(engine_state, stack, 1)?;
-    let collapse_empty = call.has_flag(engine_state, stack, "collapse-empty")?;
-
-    let regex = if call.has_flag(engine_state, stack, "regex")? {
-        Regex::new(&separator.item)
+    let regex = if args.has_regex {
+        Regex::new(&args.separator.item)
     } else {
-        let escaped = regex::escape(&separator.item);
+        let escaped = regex::escape(&args.separator.item);
         Regex::new(&escaped)
     }
     .map_err(|e| ShellError::GenericError {
         error: "Error with regular expression".into(),
         msg: e.to_string(),
-        span: Some(separator.span),
+        span: Some(args.separator.span),
         help: None,
         inner: vec![],
     })?;
 
     input.flat_map(
-        move |x| split_column_helper(&x, &regex, &rest, collapse_empty, name_span),
+        move |x| split_column_helper(&x, &regex, &args.rest, args.collapse_empty, name_span),
         engine_state.ctrlc.clone(),
     )
 }

--- a/crates/nu-command/src/strings/split/column.rs
+++ b/crates/nu-command/src/strings/split/column.rs
@@ -1,6 +1,5 @@
 use nu_engine::command_prelude::*;
 
-use nu_protocol::engine::StateWorkingSet;
 use regex::Regex;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/strings/split/list.rs
+++ b/crates/nu-command/src/strings/split/list.rs
@@ -1,6 +1,5 @@
 use nu_engine::command_prelude::*;
 
-use nu_protocol::engine::StateWorkingSet;
 use regex::Regex;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/strings/split/row.rs
+++ b/crates/nu-command/src/strings/split/row.rs
@@ -1,6 +1,5 @@
 use nu_engine::command_prelude::*;
 
-use nu_protocol::engine::StateWorkingSet;
 use regex::Regex;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/strings/split/words.rs
+++ b/crates/nu-command/src/strings/split/words.rs
@@ -2,7 +2,6 @@ use crate::{grapheme_flags, grapheme_flags_const};
 use fancy_regex::Regex;
 use nu_engine::command_prelude::*;
 
-use nu_protocol::engine::StateWorkingSet;
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -36,6 +37,10 @@ impl Command for SubCommand {
         vec!["convert", "style", "caps", "upper"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -43,7 +48,18 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input)
+        let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+        operate(engine_state, call, input, column_paths)
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let column_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
+        operate(working_set.permanent(), call, input, column_paths)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -72,12 +88,11 @@ impl Command for SubCommand {
 
 fn operate(
     engine_state: &EngineState,
-    stack: &mut Stack,
     call: &Call,
     input: PipelineData,
+    column_paths: Vec<CellPath>,
 ) -> Result<PipelineData, ShellError> {
     let head = call.head;
-    let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
     input.map(
         move |v| {
             if column_paths.is_empty() {

--- a/crates/nu-command/src/strings/str_/case/capitalize.rs
+++ b/crates/nu-command/src/strings/str_/case/capitalize.rs
@@ -1,5 +1,4 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -36,6 +37,10 @@ impl Command for SubCommand {
         vec!["lower case", "lowercase"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -43,7 +48,18 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        operate(engine_state, stack, call, input)
+        let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
+        operate(engine_state, call, input, column_paths)
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let column_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
+        operate(working_set.permanent(), call, input, column_paths)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -80,12 +96,11 @@ impl Command for SubCommand {
 
 fn operate(
     engine_state: &EngineState,
-    stack: &mut Stack,
     call: &Call,
     input: PipelineData,
+    column_paths: Vec<CellPath>,
 ) -> Result<PipelineData, ShellError> {
     let head = call.head;
-    let column_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
     input.map(
         move |v| {
             if column_paths.is_empty() {

--- a/crates/nu-command/src/strings/str_/case/downcase.rs
+++ b/crates/nu-command/src/strings/str_/case/downcase.rs
@@ -1,5 +1,4 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;

--- a/crates/nu-command/src/strings/str_/case/upcase.rs
+++ b/crates/nu-command/src/strings/str_/case/upcase.rs
@@ -1,5 +1,4 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -1,7 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
-use nu_protocol::engine::StateWorkingSet;
 use nu_utils::IgnoreCaseExt;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/strings/str_/contains.rs
+++ b/crates/nu-command/src/strings/str_/contains.rs
@@ -1,6 +1,7 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
+use nu_protocol::engine::StateWorkingSet;
 use nu_utils::IgnoreCaseExt;
 
 #[derive(Clone)]
@@ -52,6 +53,10 @@ impl Command for SubCommand {
         vec!["substring", "match", "find", "search"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -82,6 +87,43 @@ impl Command for SubCommand {
             not_contain: call.has_flag(engine_state, stack, "not")?,
         };
         operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        if call.has_flag_const(working_set, "not")? {
+            nu_protocol::report_error_new(
+                working_set.permanent(),
+                &ShellError::GenericError {
+                    error: "Deprecated option".into(),
+                    msg: "`str contains --not {string}` is deprecated and will be removed in 0.95."
+                        .into(),
+                    span: Some(call.head),
+                    help: Some("Please use the `not` operator instead.".into()),
+                    inner: vec![],
+                },
+            );
+        }
+
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 1)?;
+        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+        let args = Arguments {
+            substring: call.req_const::<String>(working_set, 0)?,
+            cell_paths,
+            case_insensitive: call.has_flag_const(working_set, "ignore-case")?,
+            not_contain: call.has_flag_const(working_set, "not")?,
+        };
+        operate(
+            action,
+            args,
+            input,
+            call.head,
+            working_set.permanent().ctrlc.clone(),
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/strings/str_/ends_with.rs
+++ b/crates/nu-command/src/strings/str_/ends_with.rs
@@ -1,7 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
-use nu_protocol::engine::StateWorkingSet;
 use nu_utils::IgnoreCaseExt;
 
 struct Arguments {

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -179,6 +180,10 @@ impl Command for SubCommand {
         ]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -186,32 +191,51 @@ impl Command for SubCommand {
         call: &Call,
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
-        let span = call.head;
-        if matches!(input, PipelineData::Empty) {
-            return Err(ShellError::PipelineEmpty { dst_span: span });
-        }
         let is_path = call.has_flag(engine_state, stack, "path")?;
-        input.map(
-            move |v| {
-                let value_span = v.span();
-                match v.coerce_into_string() {
-                    Ok(s) => {
-                        let contents = if is_path { s.replace('\\', "\\\\") } else { s };
-                        str_expand(&contents, span, value_span)
-                    }
-                    Err(_) => Value::error(
-                        ShellError::PipelineMismatch {
-                            exp_input_type: "string".into(),
-                            dst_span: span,
-                            src_span: value_span,
-                        },
-                        span,
-                    ),
-                }
-            },
-            engine_state.ctrlc.clone(),
-        )
+        run(call, input, is_path, engine_state)
     }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let is_path = call.has_flag_const(working_set, "path")?;
+        run(call, input, is_path, working_set.permanent())
+    }
+}
+
+fn run(
+    call: &Call,
+    input: PipelineData,
+    is_path: bool,
+    engine_state: &EngineState,
+) -> Result<PipelineData, ShellError> {
+    let span = call.head;
+    if matches!(input, PipelineData::Empty) {
+        return Err(ShellError::PipelineEmpty { dst_span: span });
+    }
+    input.map(
+        move |v| {
+            let value_span = v.span();
+            match v.coerce_into_string() {
+                Ok(s) => {
+                    let contents = if is_path { s.replace('\\', "\\\\") } else { s };
+                    str_expand(&contents, span, value_span)
+                }
+                Err(_) => Value::error(
+                    ShellError::PipelineMismatch {
+                        exp_input_type: "string".into(),
+                        dst_span: span,
+                        src_span: value_span,
+                    },
+                    span,
+                ),
+            }
+        },
+        engine_state.ctrlc.clone(),
+    )
 }
 
 fn str_expand(contents: &str, span: Span, value_span: Span) -> Value {

--- a/crates/nu-command/src/strings/str_/expand.rs
+++ b/crates/nu-command/src/strings/str_/expand.rs
@@ -1,5 +1,4 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;

--- a/crates/nu-command/src/strings/str_/index_of.rs
+++ b/crates/nu-command/src/strings/str_/index_of.rs
@@ -1,10 +1,10 @@
-use crate::grapheme_flags;
+use crate::{grapheme_flags, grapheme_flags_const};
 use nu_cmd_base::{
     input_handler::{operate, CmdArgument},
     util,
 };
 use nu_engine::command_prelude::*;
-use nu_protocol::Range;
+use nu_protocol::{engine::StateWorkingSet, Range};
 use unicode_segmentation::UnicodeSegmentation;
 
 struct Arguments {
@@ -72,6 +72,10 @@ impl Command for SubCommand {
         vec!["match", "find", "search"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -90,6 +94,31 @@ impl Command for SubCommand {
             graphemes: grapheme_flags(engine_state, stack, call)?,
         };
         operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let substring: Spanned<String> = call.req_const(working_set, 0)?;
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 1)?;
+        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+        let args = Arguments {
+            substring: substring.item,
+            range: call.get_flag_const(working_set, "range")?,
+            end: call.has_flag_const(working_set, "end")?,
+            cell_paths,
+            graphemes: grapheme_flags_const(working_set, call)?,
+        };
+        operate(
+            action,
+            args,
+            input,
+            call.head,
+            working_set.permanent().ctrlc.clone(),
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 use std::io::Write;
 
 #[derive(Clone)]
@@ -32,6 +33,10 @@ impl Command for StrJoin {
         vec!["collect", "concatenate"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -40,41 +45,17 @@ impl Command for StrJoin {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let separator: Option<String> = call.opt(engine_state, stack, 0)?;
+        run(engine_state, call, input, separator)
+    }
 
-        let config = engine_state.config.clone();
-
-        let span = call.head;
-
-        let metadata = input.metadata();
-        let mut iter = input.into_iter();
-        let mut first = true;
-
-        let output = ByteStream::from_fn(span, None, ByteStreamType::String, move |buffer| {
-            // Write each input to the buffer
-            if let Some(value) = iter.next() {
-                // Write the separator if this is not the first
-                if first {
-                    first = false;
-                } else if let Some(separator) = &separator {
-                    write!(buffer, "{}", separator)?;
-                }
-
-                match value {
-                    Value::Error { error, .. } => {
-                        return Err(*error);
-                    }
-                    // Hmm, not sure what we actually want.
-                    // `to_expanded_string` formats dates as human readable which feels funny.
-                    Value::Date { val, .. } => write!(buffer, "{val:?}")?,
-                    value => write!(buffer, "{}", value.to_expanded_string("\n", &config))?,
-                }
-                Ok(true)
-            } else {
-                Ok(false)
-            }
-        });
-
-        Ok(PipelineData::ByteStream(output, metadata))
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let separator: Option<String> = call.opt_const(working_set, 0)?;
+        run(working_set.permanent(), call, input, separator)
     }
 
     fn examples(&self) -> Vec<Example> {
@@ -91,6 +72,48 @@ impl Command for StrJoin {
             },
         ]
     }
+}
+
+fn run(
+    engine_state: &EngineState,
+    call: &Call,
+    input: PipelineData,
+    separator: Option<String>,
+) -> Result<PipelineData, ShellError> {
+    let config = engine_state.config.clone();
+
+    let span = call.head;
+
+    let metadata = input.metadata();
+    let mut iter = input.into_iter();
+    let mut first = true;
+
+    let output = ByteStream::from_fn(span, None, ByteStreamType::String, move |buffer| {
+        // Write each input to the buffer
+        if let Some(value) = iter.next() {
+            // Write the separator if this is not the first
+            if first {
+                first = false;
+            } else if let Some(separator) = &separator {
+                write!(buffer, "{}", separator)?;
+            }
+
+            match value {
+                Value::Error { error, .. } => {
+                    return Err(*error);
+                }
+                // Hmm, not sure what we actually want.
+                // `to_expanded_string` formats dates as human readable which feels funny.
+                Value::Date { val, .. } => write!(buffer, "{val:?}")?,
+                value => write!(buffer, "{}", value.to_expanded_string("\n", &config))?,
+            }
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    });
+
+    Ok(PipelineData::ByteStream(output, metadata))
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/strings/str_/join.rs
+++ b/crates/nu-command/src/strings/str_/join.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
+
 use std::io::Write;
 
 #[derive(Clone)]

--- a/crates/nu-command/src/strings/str_/length.rs
+++ b/crates/nu-command/src/strings/str_/length.rs
@@ -1,7 +1,7 @@
 use crate::{grapheme_flags, grapheme_flags_const};
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
+
 use unicode_segmentation::UnicodeSegmentation;
 
 struct Arguments {

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -1,6 +1,7 @@
 use fancy_regex::{NoExpand, Regex};
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 struct Arguments {
     all: bool,
@@ -73,6 +74,10 @@ impl Command for SubCommand {
         vec!["search", "shift", "switch", "regex"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -99,6 +104,39 @@ impl Command for SubCommand {
             multiline,
         };
         operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let find: Spanned<String> = call.req_const(working_set, 0)?;
+        let replace: Spanned<String> = call.req_const(working_set, 1)?;
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 2)?;
+        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+        let literal_replace = call.has_flag_const(working_set, "no-expand")?;
+        let no_regex = !call.has_flag_const(working_set, "regex")?
+            && !call.has_flag_const(working_set, "multiline")?;
+        let multiline = call.has_flag_const(working_set, "multiline")?;
+
+        let args = Arguments {
+            all: call.has_flag_const(working_set, "all")?,
+            find,
+            replace,
+            cell_paths,
+            literal_replace,
+            no_regex,
+            multiline,
+        };
+        operate(
+            action,
+            args,
+            input,
+            call.head,
+            working_set.permanent().ctrlc.clone(),
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/strings/str_/replace.rs
+++ b/crates/nu-command/src/strings/str_/replace.rs
@@ -1,7 +1,6 @@
 use fancy_regex::{NoExpand, Regex};
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 struct Arguments {
     all: bool,

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -1,6 +1,5 @@
 use nu_cmd_base::input_handler::{operate, CellPathOnlyArgs};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;

--- a/crates/nu-command/src/strings/str_/reverse.rs
+++ b/crates/nu-command/src/strings/str_/reverse.rs
@@ -1,5 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CellPathOnlyArgs};
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -37,6 +38,10 @@ impl Command for SubCommand {
         vec!["convert", "inverse", "flip"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -47,6 +52,23 @@ impl Command for SubCommand {
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
         let args = CellPathOnlyArgs::from(cell_paths);
         operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
+        let args = CellPathOnlyArgs::from(cell_paths);
+        operate(
+            action,
+            args,
+            input,
+            call.head,
+            working_set.permanent().ctrlc.clone(),
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -1,7 +1,6 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
-use nu_protocol::engine::StateWorkingSet;
 use nu_utils::IgnoreCaseExt;
 
 struct Arguments {

--- a/crates/nu-command/src/strings/str_/starts_with.rs
+++ b/crates/nu-command/src/strings/str_/starts_with.rs
@@ -1,6 +1,7 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
 
+use nu_protocol::engine::StateWorkingSet;
 use nu_utils::IgnoreCaseExt;
 
 struct Arguments {
@@ -51,6 +52,10 @@ impl Command for SubCommand {
         vec!["prefix", "match", "find", "search"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -67,6 +72,29 @@ impl Command for SubCommand {
             case_insensitive: call.has_flag(engine_state, stack, "ignore-case")?,
         };
         operate(action, args, input, call.head, engine_state.ctrlc.clone())
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        let substring: Spanned<String> = call.req_const(working_set, 0)?;
+        let cell_paths: Vec<CellPath> = call.rest_const(working_set, 1)?;
+        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+        let args = Arguments {
+            substring: substring.item,
+            cell_paths,
+            case_insensitive: call.has_flag_const(working_set, "ignore-case")?,
+        };
+        operate(
+            action,
+            args,
+            input,
+            call.head,
+            working_set.permanent().ctrlc.clone(),
+        )
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/strings/str_/stats.rs
+++ b/crates/nu-command/src/strings/str_/stats.rs
@@ -1,5 +1,6 @@
 use fancy_regex::Regex;
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::StateWorkingSet;
 use std::collections::BTreeMap;
 use std::{fmt, str};
 use unicode_segmentation::UnicodeSegmentation;
@@ -29,6 +30,10 @@ impl Command for SubCommand {
         vec!["count", "word", "character", "unicode", "wc"]
     }
 
+    fn is_const(&self) -> bool {
+        true
+    }
+
     fn run(
         &self,
         engine_state: &EngineState,
@@ -37,6 +42,15 @@ impl Command for SubCommand {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         stats(engine_state, call, input)
+    }
+
+    fn run_const(
+        &self,
+        working_set: &StateWorkingSet,
+        call: &Call,
+        input: PipelineData,
+    ) -> Result<PipelineData, ShellError> {
+        stats(working_set.permanent(), call, input)
     }
 
     fn examples(&self) -> Vec<Example> {

--- a/crates/nu-command/src/strings/str_/stats.rs
+++ b/crates/nu-command/src/strings/str_/stats.rs
@@ -1,6 +1,6 @@
 use fancy_regex::Regex;
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
+
 use std::collections::BTreeMap;
 use std::{fmt, str};
 use unicode_segmentation::UnicodeSegmentation;

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -84,44 +84,17 @@ impl Command for SubCommand {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let character = call.get_flag::<Spanned<String>>(engine_state, stack, "char")?;
-        let to_trim = match character.as_ref() {
-            Some(v) => {
-                if v.item.chars().count() > 1 {
-                    return Err(ShellError::GenericError {
-                        error: "Trim only works with single character".into(),
-                        msg: "needs single character".into(),
-                        span: Some(v.span),
-                        help: None,
-                        inner: vec![],
-                    });
-                }
-                v.item.chars().next()
-            }
-            None => None,
-        };
         let cell_paths: Vec<CellPath> = call.rest(engine_state, stack, 0)?;
-        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
-        let mode = match cell_paths {
-            None => ActionMode::Global,
-            Some(_) => ActionMode::Local,
-        };
-
         let left = call.has_flag(engine_state, stack, "left")?;
         let right = call.has_flag(engine_state, stack, "right")?;
-        let trim_side = match (left, right) {
-            (true, true) => TrimSide::Both,
-            (true, false) => TrimSide::Left,
-            (false, true) => TrimSide::Right,
-            (false, false) => TrimSide::Both,
-        };
-
-        let args = Arguments {
-            to_trim,
-            trim_side,
+        run(
+            character,
             cell_paths,
-            mode,
-        };
-        operate(action, args, input, call.head, engine_state.ctrlc.clone())
+            (left, right),
+            call,
+            input,
+            engine_state,
+        )
     }
 
     fn run_const(
@@ -131,49 +104,16 @@ impl Command for SubCommand {
         input: PipelineData,
     ) -> Result<PipelineData, ShellError> {
         let character = call.get_flag_const::<Spanned<String>>(working_set, "char")?;
-        let to_trim = match character.as_ref() {
-            Some(v) => {
-                if v.item.chars().count() > 1 {
-                    return Err(ShellError::GenericError {
-                        error: "Trim only works with single character".into(),
-                        msg: "needs single character".into(),
-                        span: Some(v.span),
-                        help: None,
-                        inner: vec![],
-                    });
-                }
-                v.item.chars().next()
-            }
-            None => None,
-        };
         let cell_paths: Vec<CellPath> = call.rest_const(working_set, 0)?;
-        let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
-        let mode = match cell_paths {
-            None => ActionMode::Global,
-            Some(_) => ActionMode::Local,
-        };
-
         let left = call.has_flag_const(working_set, "left")?;
         let right = call.has_flag_const(working_set, "right")?;
-        let trim_side = match (left, right) {
-            (true, true) => TrimSide::Both,
-            (true, false) => TrimSide::Left,
-            (false, true) => TrimSide::Right,
-            (false, false) => TrimSide::Both,
-        };
-
-        let args = Arguments {
-            to_trim,
-            trim_side,
+        run(
+            character,
             cell_paths,
-            mode,
-        };
-        operate(
-            action,
-            args,
+            (left, right),
+            call,
             input,
-            call.head,
-            working_set.permanent().ctrlc.clone(),
+            working_set.permanent(),
         )
     }
 
@@ -206,6 +146,52 @@ impl Command for SubCommand {
             },
         ]
     }
+}
+
+fn run(
+    character: Option<Spanned<String>>,
+    cell_paths: Vec<CellPath>,
+    (left, right): (bool, bool),
+    call: &Call,
+    input: PipelineData,
+    engine_state: &EngineState,
+) -> Result<PipelineData, ShellError> {
+    let to_trim = match character.as_ref() {
+        Some(v) => {
+            if v.item.chars().count() > 1 {
+                return Err(ShellError::GenericError {
+                    error: "Trim only works with single character".into(),
+                    msg: "needs single character".into(),
+                    span: Some(v.span),
+                    help: None,
+                    inner: vec![],
+                });
+            }
+            v.item.chars().next()
+        }
+        None => None,
+    };
+
+    let cell_paths = (!cell_paths.is_empty()).then_some(cell_paths);
+    let mode = match cell_paths {
+        None => ActionMode::Global,
+        Some(_) => ActionMode::Local,
+    };
+
+    let trim_side = match (left, right) {
+        (true, true) => TrimSide::Both,
+        (true, false) => TrimSide::Left,
+        (false, true) => TrimSide::Right,
+        (false, false) => TrimSide::Both,
+    };
+
+    let args = Arguments {
+        to_trim,
+        trim_side,
+        cell_paths,
+        mode,
+    };
+    operate(action, args, input, call.head, engine_state.ctrlc.clone())
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/nu-command/src/strings/str_/trim/trim_.rs
+++ b/crates/nu-command/src/strings/str_/trim/trim_.rs
@@ -1,6 +1,5 @@
 use nu_cmd_base::input_handler::{operate, CmdArgument};
 use nu_engine::command_prelude::*;
-use nu_protocol::engine::StateWorkingSet;
 
 #[derive(Clone)]
 pub struct SubCommand;

--- a/crates/nu-engine/src/command_prelude.rs
+++ b/crates/nu-engine/src/command_prelude.rs
@@ -1,7 +1,7 @@
 pub use crate::CallExt;
 pub use nu_protocol::{
     ast::{Call, CellPath},
-    engine::{Command, EngineState, Stack},
+    engine::{Command, EngineState, Stack, StateWorkingSet},
     record, ByteStream, ByteStreamType, Category, ErrSpan, Example, IntoInterruptiblePipelineData,
     IntoPipelineData, IntoSpanned, PipelineData, Record, ShellError, Signature, Span, Spanned,
     SyntaxShape, Type, Value,


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

Related meta-issue: #10239.

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

This PR will modify some `str`-related commands so that they can be evaluated at parse time.

See the following list for those implemented by this pr.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Available now:
- `str` subcommands
  - `trim`
  - `contains`
  - `distance`
  - `ends-with`
  - `expand`
  - `index-of`
  - `join`
  - `replace`
  - `reverse`
  - `starts-with`
  - `stats`
  - `substring`
  - `capitalize`
  - `downcase`
  - `upcase`
- `split` subcommands
  - `chars`
  - `column`
  - `list`
  - `row`
  - `words`
- `format` subcommands
  - `date`
  - `duration`
  - `filesize`
- string related commands
  - `parse`
  - `detect columns`
  - `encode` & `decode`

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Unresolved questions:
- [ ] Is there any routine of testing const expressions? I haven't found any yet.
- [ ] Is const expressions required to behave just like there non-const version, like what rust promises?

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

Unresolved questions:
- [ ] Do const commands need special marks in the docs?