### PR TITLE
fix: coredump without any messages

### DIFF
--- a/crates/nu-protocol/src/errors/shell_error.rs
+++ b/crates/nu-protocol/src/errors/shell_error.rs
@@ -876,6 +876,21 @@ pub enum ShellError {
         span: Span,
     },
 
+    #[cfg(unix)]
+    /// An I/O operation failed.
+    ///
+    /// ## Resolution
+    ///
+    /// This is a generic error. Refer to the specific error message for further details.
+    #[error("program coredump error")]
+    #[diagnostic(code(nu::shell::coredump_error))]
+    CoredumpErrorSpanned {
+        msg: String,
+        signal: i32,
+        #[label("{msg}")]
+        span: Span,
+    },
+
     /// Tried to `cd` to a path that isn't a directory.
     ///
     /// ## Resolution

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -23,7 +23,21 @@ impl ExitStatusFuture {
             ExitStatusFuture::Finished(Err(err)) => Err(err.as_ref().clone()),
             ExitStatusFuture::Running(receiver) => {
                 let code = match receiver.recv() {
-                    Ok(Ok(status)) => Ok(status),
+                    Ok(Ok(status)) => {
+                        #[cfg(unix)]
+                        if let ExitStatus::Signaled {
+                            signal,
+                            core_dumped: true,
+                        } = status
+                        {
+                            return Err(ShellError::CoredumpErrorSpanned {
+                                msg: format!("program coredumped, receive signal: {signal}"),
+                                signal,
+                                span,
+                            });
+                        }
+                        Ok(status)
+                    }
                     Ok(Err(err)) => Err(ShellError::IOErrorSpanned {
                         msg: format!("failed to get exit code: {err:?}"),
                         span,

--- a/crates/nu-protocol/src/process/child.rs
+++ b/crates/nu-protocol/src/process/child.rs
@@ -31,7 +31,7 @@ impl ExitStatusFuture {
                         } = status
                         {
                             return Err(ShellError::CoredumpErrorSpanned {
-                                msg: format!("program coredumped, receive signal: {signal}"),
+                                msg: format!("coredump detected. received signal: {signal}"),
                                 signal,
                                 span,
                             });


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.

- this PR should close https://github.com/nushell/nushell/issues/12874
- fixes https://github.com/nushell/nushell/issues/12874
I want to fix the issue which is induced by the fix for https://github.com/nushell/nushell/issues/12369. after this pr. This pr induced a new error for unix system, in order to show coredump messages

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

- this PR should close https://github.com/nushell/nushell/issues/12874
- fixes https://github.com/nushell/nushell/issues/12874
I want to fix the issue which is induced by the fix for https://github.com/nushell/nushell/issues/12369. after this pr. This pr induced a new error for unix system, in order to show coredump messages

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

after fix for 12874, coredump message is messing, so I want to fix it

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->

![image](https://github.com/nushell/nushell/assets/60290287/6d8ab756-3031-4212-a5f5-5f71be3857f9)


