### PR TITLE
msgpackz: increase default compression level

### DIFF
--- a/crates/nu-command/src/formats/to/msgpackz.rs
+++ b/crates/nu-command/src/formats/to/msgpackz.rs
@@ -5,7 +5,7 @@ use nu_engine::command_prelude::*;
 use super::msgpack::write_value;
 
 const BUFFER_SIZE: usize = 65536;
-const DEFAULT_QUALITY: u32 = 1;
+const DEFAULT_QUALITY: u32 = 3; // 1 can be very bad
 const DEFAULT_WINDOW_SIZE: u32 = 20;
 
 #[derive(Clone)]
@@ -22,7 +22,7 @@ impl Command for ToMsgpackz {
             .named(
                 "quality",
                 SyntaxShape::Int,
-                "Quality of brotli compression (default 1)",
+                "Quality of brotli compression (default 3)",
                 Some('q'),
             )
             .named(

--- a/crates/nu-protocol/src/plugin/registry_file/mod.rs
+++ b/crates/nu-protocol/src/plugin/registry_file/mod.rs
@@ -11,7 +11,7 @@ use crate::{PluginIdentity, PluginSignature, ShellError, Span};
 const BUFFER_SIZE: usize = 65536;
 
 // Chose settings at the low end, because we're just trying to get the maximum speed
-const COMPRESSION_QUALITY: u32 = 1;
+const COMPRESSION_QUALITY: u32 = 3; // 1 can be very bad
 const WIN_SIZE: u32 = 20; // recommended 20-22
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
# Description
Increase default compression level for brotli on msgpackz to 3. This has the best compression time generally. Level 0 and 1 give weird results and sometimes cause extremely inflated outputs rather than being compressed. So far this hasn't really been a problem for the plugin registry file, but has been for other data.

The `$example` is the web-app example from https://json.org/example.html

Benchmarked with:

```nushell
seq 0 11 | each { |level|
  let compressed = ($example | to msgpackz --quality $level)
  let time = (timeit { $example | to msgpackz --quality $level })
  {
    level: $level
    time: $time
    length: ($compressed | bytes length)
    ratio: (($uncompressed_length | into float) / ($compressed | bytes length))
  }
}
```

```
╭────┬───────┬─────────────────┬────────┬───────╮
│  # │ level │      time       │ length │ ratio │
├────┼───────┼─────────────────┼────────┼───────┤
│  0 │     0 │ 4ms 611µs 875ns │   3333 │  0.72 │
│  1 │     1 │ 1ms 334µs 500ns │   3333 │  0.72 │
│  2 │     2 │     190µs 333ns │   1185 │  2.02 │
│  3 │     3 │      184µs 42ns │   1128 │  2.12 │
│  4 │     4 │      245µs 83ns │   1098 │  2.18 │
│  5 │     5 │     265µs 584ns │   1040 │  2.30 │
│  6 │     6 │     270µs 792ns │   1040 │  2.30 │
│  7 │     7 │     444µs 708ns │   1040 │  2.30 │
│  8 │     8 │       1ms 801µs │   1040 │  2.30 │
│  9 │     9 │     843µs 875ns │   1037 │  2.31 │
│ 10 │    10 │ 4ms 128µs 375ns │    984 │  2.43 │
│ 11 │    11 │ 6ms 352µs 834ns │    986 │  2.43 │
╰────┴───────┴─────────────────┴────────┴───────╯
```

cc @maxim-uvarov
