### PR TITLE
Add options for filtering the log output from `nu`

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -33,7 +33,7 @@ pub(crate) fn gather_commandline_args() -> (Vec<String>, String, Vec<String>) {
             | "--env-config" | "-I" | "ide-ast" => args.next().map(|a| escape_quote_string(&a)),
             #[cfg(feature = "plugin")]
             "--plugin-config" => args.next().map(|a| escape_quote_string(&a)),
-            "--log-level" | "--log-target" | "--testbin" | "--threads" | "-t"
+            "--log-level" | "--log-target" | "--log-include" | "--testbin" | "--threads" | "-t"
             | "--include-path" | "--lsp" | "--ide-goto-def" | "--ide-hover" | "--ide-complete"
             | "--ide-check" => args.next(),
             #[cfg(feature = "plugin")]
@@ -97,6 +97,7 @@ pub(crate) fn parse_commandline_args(
             let env_file = call.get_flag_expr("env-config");
             let log_level = call.get_flag_expr("log-level");
             let log_target = call.get_flag_expr("log-target");
+            let log_include = call.get_flag_expr("log-include");
             let execute = call.get_flag_expr("execute");
             let table_mode: Option<Value> =
                 call.get_flag(engine_state, &mut stack, "table-mode")?;
@@ -155,38 +156,45 @@ pub(crate) fn parse_commandline_args(
                 }
             }
 
+            fn extract_list(
+                expression: Option<&Expression>,
+                type_name: &str,
+                mut extract_item: impl FnMut(&Expression) -> Option<String>,
+            ) -> Result<Option<Vec<Spanned<String>>>, ShellError> {
+                expression
+                    .map(|expr| match &expr.expr {
+                        Expr::List(list) => list
+                            .iter()
+                            .map(|item| {
+                                extract_item(item.expr())
+                                    .map(|s| s.into_spanned(item.expr().span))
+                                    .ok_or_else(|| ShellError::TypeMismatch {
+                                        err_message: type_name.into(),
+                                        span: item.expr().span,
+                                    })
+                            })
+                            .collect::<Result<Vec<Spanned<String>>, _>>(),
+                        _ => Err(ShellError::TypeMismatch {
+                            err_message: format!("list<{type_name}>"),
+                            span: expr.span,
+                        }),
+                    })
+                    .transpose()
+            }
+
             let commands = extract_contents(commands)?;
             let testbin = extract_contents(testbin)?;
             #[cfg(feature = "plugin")]
             let plugin_file = extract_path(plugin_file)?;
+            #[cfg(feature = "plugin")]
+            let plugins = extract_list(plugins, "path", |expr| expr.as_filepath().map(|t| t.0))?;
             let config_file = extract_path(config_file)?;
             let env_file = extract_path(env_file)?;
             let log_level = extract_contents(log_level)?;
             let log_target = extract_contents(log_target)?;
+            let log_include = extract_list(log_include, "string", |expr| expr.as_string())?;
             let execute = extract_contents(execute)?;
             let include_path = extract_contents(include_path)?;
-
-            #[cfg(feature = "plugin")]
-            let plugins = plugins
-                .map(|expr| match &expr.expr {
-                    Expr::List(list) => list
-                        .iter()
-                        .map(|item| {
-                            item.expr()
-                                .as_filepath()
-                                .map(|(s, _)| s.into_spanned(item.expr().span))
-                                .ok_or_else(|| ShellError::TypeMismatch {
-                                    err_message: "path".into(),
-                                    span: item.expr().span,
-                                })
-                        })
-                        .collect::<Result<Vec<Spanned<String>>, _>>(),
-                    _ => Err(ShellError::TypeMismatch {
-                        err_message: "list<path>".into(),
-                        span: expr.span,
-                    }),
-                })
-                .transpose()?;
 
             let help = call.has_flag(engine_state, &mut stack, "help")?;
 
@@ -224,6 +232,7 @@ pub(crate) fn parse_commandline_args(
                 env_file,
                 log_level,
                 log_target,
+                log_include,
                 execute,
                 include_path,
                 ide_goto_def,
@@ -262,6 +271,7 @@ pub(crate) struct NushellCliArgs {
     pub(crate) env_file: Option<Spanned<String>>,
     pub(crate) log_level: Option<Spanned<String>>,
     pub(crate) log_target: Option<Spanned<String>>,
+    pub(crate) log_include: Option<Vec<Spanned<String>>>,
     pub(crate) execute: Option<Spanned<String>>,
     pub(crate) table_mode: Option<Value>,
     pub(crate) no_newline: Option<Spanned<String>>,
@@ -401,6 +411,12 @@ impl Command for Nu {
                 "log-target",
                 SyntaxShape::String,
                 "set the target for the log to output. stdout, stderr(default), mixed or file",
+                None,
+            )
+            .named(
+                "log-include",
+                SyntaxShape::List(Box::new(SyntaxShape::String)),
+                "set the Rust module prefixes to include in the log output. default: [nu]",
                 None,
             )
             .switch(

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -66,10 +66,15 @@ fn set_write_logger(level: LevelFilter, config: Config, path: &Path) -> Result<(
     }
 }
 
+pub struct Filters {
+    pub include: Option<Vec<String>>,
+    pub exclude: Option<Vec<String>>,
+}
+
 pub fn configure(
     level: &str,
     target: &str,
-    filters: Option<&[String]>,
+    filters: Filters,
     builder: &mut ConfigBuilder,
 ) -> (LevelFilter, LogTarget) {
     let level = match Level::from_str(level) {
@@ -78,12 +83,19 @@ pub fn configure(
     };
 
     // Add allowed module filter
-    if let Some(filters) = filters {
-        for filter in filters {
-            builder.add_filter_allow(filter.clone());
+    if let Some(include) = filters.include {
+        for filter in include {
+            builder.add_filter_allow(filter);
         }
     } else {
         builder.add_filter_allow_str("nu");
+    }
+
+    // Add ignored module filter
+    if let Some(exclude) = filters.exclude {
+        for filter in exclude {
+            builder.add_filter_ignore(filter);
+        }
     }
 
     // Set level padding

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -69,6 +69,7 @@ fn set_write_logger(level: LevelFilter, config: Config, path: &Path) -> Result<(
 pub fn configure(
     level: &str,
     target: &str,
+    filters: Option<&[String]>,
     builder: &mut ConfigBuilder,
 ) -> (LevelFilter, LogTarget) {
     let level = match Level::from_str(level) {
@@ -77,7 +78,13 @@ pub fn configure(
     };
 
     // Add allowed module filter
-    builder.add_filter_allow_str("nu");
+    if let Some(filters) = filters {
+        for filter in filters {
+            builder.add_filter_allow(filter.clone());
+        }
+    } else {
+        builder.add_filter_allow_str("nu");
+    }
 
     // Set level padding
     builder.set_level_padding(LevelPadding::Right);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use nu_lsp::LanguageServer;
 use nu_path::canonicalize_with;
 use nu_protocol::{
     engine::{EngineState, StateWorkingSet},
-    report_error, report_error_new, ByteStream, PipelineData, ShellError, Span, Spanned, Value,
+    report_error_new, ByteStream, PipelineData, ShellError, Span, Spanned, Value,
 };
 use nu_std::load_standard_library;
 use nu_utils::utils::perf;
@@ -157,8 +157,7 @@ fn main() -> Result<()> {
     let (args_to_nushell, script_name, args_to_script) = gather_commandline_args();
     let parsed_nu_cli_args = parse_commandline_args(&args_to_nushell.join(" "), &mut engine_state)
         .unwrap_or_else(|err| {
-            let working_set = StateWorkingSet::new(&engine_state);
-            report_error(&working_set, &err);
+            report_error_new(&engine_state, &err);
             std::process::exit(1)
         });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ use nu_cmd_base::util::get_init_cwd;
 use nu_lsp::LanguageServer;
 use nu_path::canonicalize_with;
 use nu_protocol::{
-    engine::{EngineState, StateWorkingSet},
-    report_error_new, ByteStream, PipelineData, ShellError, Span, Spanned, Value,
+    engine::EngineState, report_error_new, ByteStream, PipelineData, ShellError, Span, Spanned,
+    Value,
 };
 use nu_std::load_standard_library;
 use nu_utils::utils::perf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,7 +389,7 @@ fn main() -> Result<()> {
     #[cfg(feature = "plugin")]
     if let Some(plugins) = &parsed_nu_cli_args.plugins {
         use nu_plugin_engine::{GetPlugin, PluginDeclaration};
-        use nu_protocol::{ErrSpan, PluginIdentity};
+        use nu_protocol::{engine::StateWorkingSet, ErrSpan, PluginIdentity};
 
         // Load any plugins specified with --plugins
         start_time = std::time::Instant::now();


### PR DESCRIPTION
# Description

Add `--log-include` and `--log-exclude` options to filter the log output from `nu` to specific module prefixes. For example,

```nushell
nu --log-level trace --log-exclude '[nu_parser]'
```

This avoids having to scan through parser spam when trying to debug something else at `TRACE` level, and should make it feel much more reasonable to add logging, particularly at `TRACE` level, to various places in the codebase. It can also be used to debug non-Nushell crates that support the Rust logging infrastructure, as many do.

You can also include a specific module instead of excluding the parser log output:

```nushell
nu --log-level trace --log-include '[nu_plugin]'
```

Pinging #13041 for reference, but hesitant to outright say that this closes that. I think it address that concern though. I've also struggled with debugging plugin stuff with all of the other output, so this will really help me there.

# User-Facing Changes

- New `nu` option: `--log-include`
- New `nu` option: `--log-exclude`
