### PR TITLE
Make `query xml` return nodes in document order

### DIFF
--- a/crates/nu_plugin_query/src/query_xml.rs
+++ b/crates/nu_plugin_query/src/query_xml.rs
@@ -88,7 +88,8 @@ pub fn execute_xpath_query(
 
             match r {
                 sxd_xpath::Value::Nodeset(ns) => {
-                    for n in ns.into_iter() {
+                    let nodes = ns.document_order();
+                    for n in nodes {
                         record.push(key.clone(), Value::string(n.string_value(), call.head));
                     }
                 }

--- a/crates/nu_plugin_query/src/query_xml.rs
+++ b/crates/nu_plugin_query/src/query_xml.rs
@@ -88,8 +88,7 @@ pub fn execute_xpath_query(
 
             match r {
                 sxd_xpath::Value::Nodeset(ns) => {
-                    let nodes = ns.document_order();
-                    for n in nodes {
+                    for n in ns.document_order() {
                         record.push(key.clone(), Value::string(n.string_value(), call.head));
                     }
                 }


### PR DESCRIPTION
# Description

`query xml` used to return results from an XPath query in a random, non-deterministic order. With this change, results get returned in the order they appear in the document.

# User-Facing Changes
`query xml` will now return results in a non-random order.

# Tests + Formatting
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
