### PR TITLE
`cd`/`def --env` examples

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -61,7 +61,7 @@ impl Command for Def {
                 result: Some(Value::test_string("BAZ")),
             },
             Example {
-                description: "cd (change directory) affects the environment, so '--env' is required",
+                description: "cd affects the environment, so '--env' is required",
                 example: r#"cd /; def --env gohome [] { cd ~ }; gohome; $env.pwd == ('~' | path expand)"#,
                 result: Some(Value::test_string("true")),
             },

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -61,8 +61,8 @@ impl Command for Def {
                 result: Some(Value::test_string("BAZ")),
             },
             Example {
-                description: "cd affects the environment, so '--env' is required",
-                example: r#"cd /; def --env gohome [] { cd ~ }; gohome; $env.pwd == ('~' | path expand)"#,
+                description: "cd affects the environment, so '--env' is required to change directory from within a command",
+                example: r#"def --env gohome [] { cd ~ }; gohome; $env.PWD == ('~' | path expand)"#,
                 result: Some(Value::test_string("true")),
             },
             Example {

--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -61,6 +61,11 @@ impl Command for Def {
                 result: Some(Value::test_string("BAZ")),
             },
             Example {
+                description: "cd (change directory) affects the environment, so '--env' is required",
+                example: r#"cd /; def --env gohome [] { cd ~ }; gohome; $env.pwd == ('~' | path expand)"#,
+                result: Some(Value::test_string("true")),
+            },
+            Example {
                 description: "Define a custom wrapper for an external command",
                 example: r#"def --wrapped my-echo [...rest] { echo $rest }; my-echo spam"#,
                 result: Some(Value::test_list(vec![Value::test_string("spam")])),

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -135,6 +135,11 @@ impl Command for Cd {
                 example: r#"cd -"#,
                 result: None,
             },
+            Example {
+                description: "Changing directories inside a custom command requires 'def --env'",
+                example: r#"def --env gohome [] { cd ~ }"#,
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/filesystem/cd.rs
+++ b/crates/nu-command/src/filesystem/cd.rs
@@ -136,7 +136,7 @@ impl Command for Cd {
                 result: None,
             },
             Example {
-                description: "Changing directories inside a custom command requires 'def --env'",
+                description: "Changing directory with a custom command requires 'def --env'",
                 example: r#"def --env gohome [] { cd ~ }"#,
                 result: None,
             },


### PR DESCRIPTION
# Description

Per a Discord question (https://discord.com/channels/601130461678272522/1244293194603167845/1247794228696711198), this adds examples to the `help` for both:

* `cd`
* `def`

to demonstrate that `def --env` is required when changing directories in a custom command.

Since the existing examples for `def` were a bit more complex (and had output) but the `cd` ones were more simplified, I did use slightly different examples in each.  Either or both could be tweaked if desired.

# User-Facing Changes

Command `help` examples

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A