### PR TITLE
run_external: remove inner quotes once nushell gets `=` sign

### DIFF
--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -223,7 +223,7 @@ fn remove_quotes(s: &str) -> Cow<'_, str> {
     let quoted_by_single_quotes = s.len() >= 2 && s.starts_with('\'') && s.ends_with('\'');
     let quoted_by_backticks = s.len() >= 2 && s.starts_with('`') && s.ends_with('`');
     if quoted_by_double_quotes {
-        Cow::Owned((&s[1..s.len() - 1]).to_string().replace(r#"\""#, "\""))
+        Cow::Owned(s[1..s.len() - 1].to_string().replace(r#"\""#, "\""))
     } else if quoted_by_single_quotes || quoted_by_backticks {
         Cow::Borrowed(&s[1..s.len() - 1])
     } else {

--- a/crates/nu-command/src/system/run_external.rs
+++ b/crates/nu-command/src/system/run_external.rs
@@ -766,8 +766,8 @@ mod test {
         let expected = r#"option=value"#;
         assert_eq!(actual, expected);
 
-        let actual = remove_inner_quotes(r#"option="v\"alue""#);
-        let expected = r#"option=v"alue"#;
+        let actual = remove_inner_quotes(r#"option="v\"value""#);
+        let expected = r#"option=v"value"#;
         assert_eq!(actual, expected);
     }
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -590,4 +590,18 @@ mod external_command_arguments {
 
         assert_eq!(actual.out, "a;&$(hello)");
     }
+
+    #[test]
+    fn remove_quotes_in_shell_arguments() {
+        let actual = nu!("nu --testbin cococo expression='-r -w'");
+        assert_eq!(actual.out, "expression=-r -w");
+        let actual = nu!(r#"nu --testbin cococo expression="-r -w""#);
+        assert_eq!(actual.out, "expression=-r -w");
+        let actual = nu!("nu --testbin cococo expression='-r -w'");
+        assert_eq!(actual.out, "expression=-r -w");
+        let actual = nu!(r#"nu --testbin cococo expression="-r\" -w""#);
+        assert_eq!(actual.out, r#"expression=-r" -w"#);
+        let actual = nu!(r#"nu --testbin cococo expression='-r\" -w'"#);
+        assert_eq!(actual.out, r#"expression=-r\" -w"#);
+    }
 }


### PR DESCRIPTION
# Description
Fixes: #13066

nushell should remove argument values' inner quote once it gets `=`.  Whatever it's a flag or not, and it also replace from `\"` to `"` before passing it to external commands.

# User-Facing Changes
Given the shell script:
```shell
# test.sh
echo $@
```
## Before
```
>  sh test.sh -ldflags="-s -w" github.com
-ldflags="-s -w" github.com
> sh test.sh exp='-s -w' github.com
exp='-s -w' github.com
```
## After
```
>  sh test.sh -ldflags="-s -w" github.com
-ldflags=-s -w github.com
> sh test.sh exp='-s -w' github.com
exp=-s -w github.com
```

# Tests + Formatting
Added some tests
