### PR TITLE
Fix `explore` panic on empty lists

### DIFF
--- a/crates/nu-explore/src/views/cursor/mod.rs
+++ b/crates/nu-explore/src/views/cursor/mod.rs
@@ -28,11 +28,10 @@ struct Cursor {
 
 impl Cursor {
     /// Constructor to create a new Cursor
-    pub fn new(size: usize) -> Result<Self> {
-        if size == 0 {
-            bail!("Size cannot be zero");
-        }
-        Ok(Cursor { position: 0, size })
+    pub fn new(size: usize) -> Self {
+        // In theory we should not be able to create a cursor with size 0, but in practice
+        // it's easier to allow that for empty lists etc. instead of propagating errors
+        Cursor { position: 0, size }
     }
 
     /// The max position the cursor can be at
@@ -88,7 +87,7 @@ mod tests {
     #[test]
     fn test_cursor_set_position() {
         // from 0 to 9
-        let mut cursor = Cursor::new(10).unwrap();
+        let mut cursor = Cursor::new(10);
         cursor.set_position(5);
         assert_eq!(cursor.position, 5);
 
@@ -99,7 +98,7 @@ mod tests {
     #[test]
     fn test_cursor_move_forward() {
         // from 0 to 9
-        let mut cursor = Cursor::new(10).unwrap();
+        let mut cursor = Cursor::new(10);
         assert_eq!(cursor.position, 0);
         cursor.move_forward(3);
         assert_eq!(cursor.position, 3);
@@ -111,7 +110,7 @@ mod tests {
     #[test]
     fn test_cursor_move_backward() {
         // from 0 to 9
-        let mut cursor = Cursor::new(10).unwrap();
+        let mut cursor = Cursor::new(10);
         cursor.move_backward(3);
         assert_eq!(cursor.position, 0);
 

--- a/crates/nu-explore/src/views/cursor/window_cursor.rs
+++ b/crates/nu-explore/src/views/cursor/window_cursor.rs
@@ -42,8 +42,8 @@ impl WindowCursor {
         }
 
         Ok(Self {
-            view: Cursor::new(view_size)?,
-            window: Cursor::new(window_size)?,
+            view: Cursor::new(view_size),
+            window: Cursor::new(window_size),
         })
     }
 


### PR DESCRIPTION
This fixes up a panic I accidentally introduced when refactoring the cursor code in `explore`: https://github.com/nushell/nushell/pull/12979

Under certain circumstances (running `:nu []`, opening `:try` with the hidden `try.reactive` setting enabled), `explore` would panic when handling an empty list. To fix this for now I've removed the validation I added to the Cursor constructor in that PR.