### PR TITLE
Move `format date` to `Category::Strings`

### DIFF
--- a/crates/nu-command/src/strings/format/date.rs
+++ b/crates/nu-command/src/strings/format/date.rs
@@ -27,7 +27,7 @@ impl Command for FormatDate {
                 SyntaxShape::String,
                 "The desired format date.",
             )
-            .category(Category::Date)
+            .category(Category::Strings)
     }
 
     fn usage(&self) -> &str {


### PR DESCRIPTION
The rest of the `format` commands live there.

Closes https://github.com/nushell/nushell.github.io/issues/1435
