### PR TITLE
Group `polars` crate updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,14 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+    groups:
+      # Only update polars as a whole as there are many subcrates that need to
+      # be updated at once. We explicitly depend on some of them, so batch their
+      # updates to not take up dependabot PR slots with dysfunctional PRs
+      polars:
+        patterns:
+          - "polars"
+          - "polars-*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We depend on `polars` and some of its subcrates explicitly. This leads to the unfortunate situtation that we have dependabot opening PRs that are not compiling, independent of whether there are breaking changes we need to account for. By introducing a [dependabot group](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-updates-into-one-pull-request) for `polars` we can at least limit that failure mode.
