### PR TITLE
Fixes #13093 - Erroneous example in 'touch' help

### DIFF
--- a/crates/nu-command/src/filesystem/touch.rs
+++ b/crates/nu-command/src/filesystem/touch.rs
@@ -35,12 +35,12 @@ impl Command for Touch {
             )
             .switch(
                 "modified",
-                "change the modification time of the file or directory. If no timestamp, date or reference file/directory is given, the current time is used",
+                "change the modification time of the file or directory. If no reference file/directory is given, the current time is used",
                 Some('m'),
             )
             .switch(
                 "access",
-                "change the access time of the file or directory. If no timestamp, date or reference file/directory is given, the current time is used",
+                "change the access time of the file or directory. If no reference file/directory is given, the current time is used",
                 Some('a'),
             )
             .switch(
@@ -187,11 +187,6 @@ impl Command for Touch {
             Example {
                 description: r#"Changes the last modified time of file d and e to "fixture.json"'s last modified time"#,
                 example: r#"touch -m -r fixture.json d e"#,
-                result: None,
-            },
-            Example {
-                description: r#"Changes the last accessed time of "fixture.json" to a date"#,
-                example: r#"touch -a -d "August 24, 2019; 12:30:30" fixture.json"#,
                 result: None,
             },
         ]


### PR DESCRIPTION
# Description

Fixes #13093 by:

* Removing the mentioned help example
* Updating the `--accessed` and `--modified` flag descriptions to remove mention of "timestamp/date"

# User-Facing Changes

Help changes

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`