### PR TITLE
Fix the use of right hand expressions in operations

### DIFF
--- a/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
+++ b/crates/nu_plugin_polars/src/dataframe/values/nu_expression/custom_value.rs
@@ -63,32 +63,16 @@ fn compute_with_value(
     op: Span,
     right: &Value,
 ) -> Result<Value, ShellError> {
-    match right {
-        Value::Custom { .. } => {
-            let rhs = NuExpression::try_from_value(plugin, right)?;
-            with_operator(
-                (plugin, engine),
-                operator,
-                left,
-                &rhs,
-                lhs_span,
-                right.span(),
-                op,
-            )
-        }
-        _ => {
-            let rhs = NuExpression::try_from_value(plugin, right)?;
-            with_operator(
-                (plugin, engine),
-                operator,
-                left,
-                &rhs,
-                lhs_span,
-                right.span(),
-                op,
-            )
-        }
-    }
+    let rhs = NuExpression::try_from_value(plugin, right)?;
+    with_operator(
+        (plugin, engine),
+        operator,
+        left,
+        &rhs,
+        lhs_span,
+        right.span(),
+        op,
+    )
 }
 
 fn with_operator(


### PR DESCRIPTION
As reported by @maxim-uvarov and pyz in the dataframes discord channel:

```nushell
[[a b]; [1 1] [1 2] [2 1] [2 2] [3 1] [3 2]] | polars into-df | polars with-column ((polars col a) / (polars col b)) --name c


  × Type mismatch.
   ╭─[entry #45:1:102]
 1 │ [[a b]; [1 1] [1 2] [2 1] [2 2] [3 1] [3 2]] | polars into-df | polars with-column ((polars col a) / (polars col b)) --name c
   ·                                                                                                      ───────┬──────
   ·                                                                                                             ╰── Right hand side not a dataframe expression
   ╰────
```

This pull request corrects the type casting on the right hand side and allows more than just polars literal expressions.