### PR TITLE
fix wrong casting with into filesize

### DIFF
--- a/crates/nu-command/src/conversions/into/filesize.rs
+++ b/crates/nu-command/src/conversions/into/filesize.rs
@@ -122,7 +122,7 @@ pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
         Value::Filesize { .. } => input.clone(),
         Value::Int { val, .. } => Value::filesize(*val, value_span),
         Value::Float { val, .. } => Value::filesize(*val as i64, value_span),
-        Value::String { val, .. } => match int_from_string(val, value_span) {
+        Value::String { val, .. } => match i64_from_string(val, value_span) {
             Ok(val) => Value::filesize(val, value_span),
             Err(error) => Value::error(error, value_span),
         },
@@ -139,7 +139,7 @@ pub fn action(input: &Value, _args: &CellPathOnlyArgs, span: Span) -> Value {
     }
 }
 
-fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
+fn i64_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
     // Get the Locale so we know what the thousands separator is
     let locale = get_system_locale();
 
@@ -151,21 +151,32 @@ fn int_from_string(a_string: &str, span: Span) -> Result<i64, ShellError> {
     // Hadle negative file size
     if let Some(stripped_negative_string) = clean_string.strip_prefix('-') {
         match stripped_negative_string.parse::<bytesize::ByteSize>() {
-            Ok(n) => Ok(-(n.as_u64() as i64)),
+            Ok(n) => i64_from_byte_size(n, true, span),
             Err(_) => Err(string_convert_error(span)),
         }
     } else if let Some(stripped_positive_string) = clean_string.strip_prefix('+') {
         match stripped_positive_string.parse::<bytesize::ByteSize>() {
             Ok(n) if stripped_positive_string.starts_with(|c: char| c.is_ascii_digit()) => {
-                Ok(n.as_u64() as i64)
+                i64_from_byte_size(n, false, span)
             }
             _ => Err(string_convert_error(span)),
         }
     } else {
         match clean_string.parse::<bytesize::ByteSize>() {
-            Ok(n) => Ok(n.as_u64() as i64),
+            Ok(n) => i64_from_byte_size(n, false, span),
             Err(_) => Err(string_convert_error(span)),
         }
+    }
+}
+
+fn i64_from_byte_size(
+    byte_size: bytesize::ByteSize,
+    is_negative: bool,
+    span: Span,
+) -> Result<i64, ShellError> {
+    match i64::try_from(byte_size.as_u64()) {
+        Ok(n) => Ok(if is_negative { -n } else { n }),
+        Err(_) => Err(string_convert_error(span)),
     }
 }
 

--- a/crates/nu-command/tests/commands/into_filesize.rs
+++ b/crates/nu-command/tests/commands/into_filesize.rs
@@ -77,6 +77,13 @@ fn into_filesize_wrong_negative_str_filesize() {
 }
 
 #[test]
+fn into_filesize_large_negative_str_filesize() {
+    let actual = nu!("'-10000PiB' | into filesize");
+
+    assert!(actual.err.contains("can't convert string to filesize"));
+}
+
+#[test]
 fn into_filesize_negative_str() {
     let actual = nu!("'-1' | into filesize");
 
@@ -100,6 +107,13 @@ fn into_filesize_positive_str_filesize() {
 #[test]
 fn into_filesize_wrong_positive_str_filesize() {
     let actual = nu!("'++1Kib' | into filesize");
+
+    assert!(actual.err.contains("can't convert string to filesize"));
+}
+
+#[test]
+fn into_filesize_large_positive_str_filesize() {
+    let actual = nu!("'+10000PiB' | into filesize");
 
     assert!(actual.err.contains("can't convert string to filesize"));
 }


### PR DESCRIPTION
# Description
Fix wrong casting which is related to https://github.com/nushell/nushell/pull/12974#discussion_r1618598336

# User-Facing Changes
AS-IS (before fixing)
```
$ "-10000PiB" | into filesize
6.2 EiB                                                         <--- Wrong casted value
$ "10000PiB" | into filesize 
-6.2 EiB                                                        <--- Wrong casted value
```

TO-BE (after fixing)
```
$ "-10000PiB" | into filesize
Error: nu::shell::cant_convert

  × Can't convert to filesize.
   ╭─[entry #6:1:1]
 1 │ "-10000PiB" | into filesize
   · ─────┬─────
   ·      ╰── can't convert string to filesize
   ╰────

$ "10000PiB" | into filesize
Error: nu::shell::cant_convert

  × Can't convert to filesize.
   ╭─[entry #7:1:1]
 1 │ "10000PiB" | into filesize
   · ─────┬────
   ·      ╰── can't convert string to filesize
   ╰────
```
