### PR TITLE
Deprecate `--numbered` from `for`

### DIFF
--- a/crates/nu-protocol/src/errors/parse_warning.rs
+++ b/crates/nu-protocol/src/errors/parse_warning.rs
@@ -10,7 +10,7 @@ pub enum ParseWarning {
     DeprecatedWarning {
         old_command: String,
         new_suggestion: String,
-        #[label("`{old_command}` is deprecated and will be removed in 0.94. Please {new_suggestion} instead")]
+        #[label("`{old_command}` is deprecated and will be removed in a future release. Please {new_suggestion} instead")]
         span: Span,
         url: String,
     },


### PR DESCRIPTION
# Description

#7777 removed the `--numbered` flag from `each`, `par-each`, `reduce`, and `each while`.  It was suggested at the time that it should be removed from `for` as well, but for several reasons it wasn't.

This PR deprecates `--numbered` in anticipation of removing it in 0.96.

Note:  Please review carefully, as this is my first "real" Rust/Nushell code. I was hoping that some prior commit would be useful as a template, but since this was an argument on a parser keyword, I didn't find too much useful.  So I had to actually find the relevant helpers in the code and `nu_protocol` doc and learn how to use them - oh darn ;-)  But please make sure I did it correctly.

# User-Facing Changes

* Use of `--numbered` will result in a deprecation warning.
* Changed help example to demonstrate the new syntax.
* Help shows deprecation notice on the flag

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

