### PR TITLE
Improves commands that support range input

### DIFF
--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -20,7 +20,7 @@ pub fn get_guaranteed_cwd(engine_state: &EngineState, stack: &Stack) -> PathBuf 
 
 type MakeRangeError = fn(&str, Span) -> ShellError;
 
-/// Returns a inclusively pair of boundary in given `range`.
+/// Returns a inclusive pair of boundary in given `range`.
 pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
     match range {
         Range::IntRange(range) => {

--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -20,6 +20,7 @@ pub fn get_guaranteed_cwd(engine_state: &EngineState, stack: &Stack) -> PathBuf 
 
 type MakeRangeError = fn(&str, Span) -> ShellError;
 
+/// Returns a inclusively pair of boundary in given `range`.
 pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
     match range {
         Range::IntRange(range) => {

--- a/crates/nu-cmd-base/src/util.rs
+++ b/crates/nu-cmd-base/src/util.rs
@@ -25,8 +25,8 @@ pub fn process_range(range: &Range) -> Result<(isize, isize), MakeRangeError> {
         Range::IntRange(range) => {
             let start = range.start().try_into().unwrap_or(0);
             let end = match range.end() {
-                Bound::Included(v) => (v + 1) as isize,
-                Bound::Excluded(v) => v as isize,
+                Bound::Included(v) => v as isize,
+                Bound::Excluded(v) => (v - 1) as isize,
                 Bound::Unbounded => isize::MAX,
             };
             Ok((start, end))

--- a/crates/nu-command/src/strings/str_/substring.rs
+++ b/crates/nu-command/src/strings/str_/substring.rs
@@ -5,7 +5,6 @@ use nu_cmd_base::{
 };
 use nu_engine::command_prelude::*;
 use nu_protocol::{engine::StateWorkingSet, Range};
-use std::cmp::Ordering;
 use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Clone)]
@@ -178,7 +177,7 @@ fn action(input: &Value, args: &Arguments, head: Span) -> Value {
             };
 
             if start > end {
-                return Value::string("", head);
+                Value::string("", head)
             } else {
                 Value::string(
                     {

--- a/crates/nu-command/tests/commands/detect_columns.rs
+++ b/crates/nu-command/tests/commands/detect_columns.rs
@@ -31,12 +31,12 @@ fn detect_columns_with_legacy_and_flag_c() {
         (
             "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
             "[[c1,c3,c4,c5]; ['a b',c,d,e]]",
-            "0..0",
+            "0..1",
         ),
         (
             "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
             "[[c1,c2,c3,c4]; [a,b,c,'d e']]",
-            "(-2)..(-2)",
+            "(-2)..(-1)",
         ),
         (
             "$\"c1 c2 c3 c4 c5(char nl)a b c d e\"",
@@ -72,10 +72,10 @@ drwxr-xr-x  2 root root 4.0K Mar 20 08:28 =(char nl)
 drwxr-xr-x  4 root root 4.0K Mar 20 08:18 ~(char nl)
 -rw-r--r--  1 root root 3.0K Mar 20 07:23 ~asdf(char nl)\"";
     let expected = "[
-['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column8'];
-['drwxr-xr-x', '2', 'root', 'root', '4.0K', 'Mar 20 08:28', '='],
-['drwxr-xr-x', '4', 'root', 'root', '4.0K', 'Mar 20 08:18', '~'],
-['-rw-r--r--',  '1', 'root', 'root', '3.0K', 'Mar 20 07:23', '~asdf']
+['column0', 'column1', 'column2', 'column3', 'column4', 'column5', 'column7', 'column8'];
+['drwxr-xr-x', '2', 'root', 'root', '4.0K', 'Mar 20', '08:28', '='],
+['drwxr-xr-x', '4', 'root', 'root', '4.0K', 'Mar 20', '08:18', '~'],
+['-rw-r--r--',  '1', 'root', 'root', '3.0K', 'Mar 20', '07:23', '~asdf']
 ]";
     let range = "5..6";
     let cmd = format!(

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -255,7 +255,7 @@ fn substrings_the_input() {
 }
 
 #[test]
-fn substring_errors_if_start_index_is_greater_than_end_index() {
+fn substring_empty_if_start_index_is_greater_than_end_index() {
     Playground::setup("str_test_9", |dirs, sandbox| {
         sandbox.with_files(&[FileWithContent(
             "sample.toml",

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -270,6 +270,7 @@ fn substring_empty_if_start_index_is_greater_than_end_index() {
             r#"
                  open sample.toml
                  | str substring 6..4 fortune.teller.phone
+                 | get fortune.teller.phone
              "#
         ));
         assert_eq!(actual.out, "")

--- a/crates/nu-command/tests/commands/str_/mod.rs
+++ b/crates/nu-command/tests/commands/str_/mod.rs
@@ -272,10 +272,7 @@ fn substring_errors_if_start_index_is_greater_than_end_index() {
                  | str substring 6..4 fortune.teller.phone
              "#
         ));
-
-        assert!(actual
-            .err
-            .contains("End must be greater than or equal to Start"))
+        assert_eq!(actual.out, "")
     })
 }
 
@@ -372,6 +369,21 @@ fn substrings_the_input_and_treats_end_index_as_length_if_blank_end_index_given(
         ));
 
         assert_eq!(actual.out, "arepas");
+    })
+}
+
+#[test]
+fn substring_by_negative_index() {
+    Playground::setup("str_test_13", |dirs, _| {
+        let actual = nu!(
+            cwd: dirs.test(), "'apples' | str substring 0..-1",
+        );
+        assert_eq!(actual.out, "apples");
+
+        let actual = nu!(
+            cwd: dirs.test(), "'apples' | str substring 0..<-1",
+        );
+        assert_eq!(actual.out, "apple");
     })
 }
 


### PR DESCRIPTION
# Description
Fixes: #13105
Fixes: #13077

This pr makes `str substring`, `bytes at` work better with negative index.

And it also fixes the false range semantic on `detect columns -c` in some cases.

# User-Facing Changes
For `str substring`, `bytes at`, it will no-longer return an error if start index is larger than end index.  It makes sense to return an empty string of empty bytes directly.

### Before
```nushell
# str substring
❯ ("aaa" | str substring 2..-3) == ""
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[entry #23:1:10]
 1 │ ("aaa" | str substring 2..-3) == ""
   ·          ──────┬──────
   ·                ╰── End must be greater than or equal to Start
 2 │ true
   ╰────

# bytes at
❯ ("aaa" | encode utf-8 | bytes at 2..-3) == ("" | encode utf-8)
Error: nu::shell::type_mismatch

  × Type mismatch.
   ╭─[entry #27:1:25]
 1 │ ("aaa" | encode utf-8 | bytes at 2..-3) == ("" | encode utf-8)
   ·                         ────┬───
   ·                             ╰── End must be greater than or equal to Start
   ╰────
```
### After
```nushell
# str substring
❯ ("aaa" | str substring 2..-3) == ""
true

# bytes at
❯  ("aaa" | encode utf-8 | bytes at 2..-3) == ("" | encode utf-8)
true
```
# Tests + Formatting
Added some tests, adjust existing tests