### PR TITLE
Fix multiple issues with `def --wrapped` help example

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/def.rs
+++ b/crates/nu-cmd-lang/src/core_commands/def.rs
@@ -67,8 +67,8 @@ impl Command for Def {
             },
             Example {
                 description: "Define a custom wrapper for an external command",
-                example: r#"def --wrapped my-echo [...rest] { echo $rest }; my-echo spam"#,
-                result: Some(Value::test_list(vec![Value::test_string("spam")])),
+                example: r#"def --wrapped my-echo [...rest] { ^echo ...$rest }; my-echo -e 'spam\tspam'"#,
+                result: Some(Value::test_string("spam\tspam")),
             },
         ]
     }


### PR DESCRIPTION
# Description

I've noticed this several times but kept forgetting to fix it:

The example given for `help def` for the `--wrapped` flag is:

```nu
Define a custom wrapper for an external command
> def --wrapped my-echo [...rest] { echo $rest }; my-echo spam
  ╭───┬──────╮
  │ 0 │ spam │
  ╰───┴──────╯
```

That's ... odd, since (a) it specifically says *"for an external"* command, and yet uses (and shows the output from) the builtin `echo`.  Also, (b) I believe `--wrapped` is *only* applicable to external commands.  Finally, (c) the `my-echo spam` doesn't even demonstrate a wrapped argument.

Unless I'm truly missing something, the example just makes no sense.

This updates the example to really demonstrate `def --wrapped` with the *external* version of `^echo`.  It uses the `-e` command to interpret the escape-tab character in the string.

```nu
> def --wrapped my-echo [...rest] { ^echo ...$rest }; my-echo -e 'spam\tspam'
spam  spam
```

# User-Facing Changes

Help example only.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
