### PR TITLE
Make `which-support` feature non-optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,6 @@ default = ["default-no-clipboard", "system-clipboard"]
 # See https://github.com/nushell/nushell/pull/11535
 default-no-clipboard = [
   "plugin",
-  "which-support",
   "trash-support",
   "sqlite",
   "mimalloc",
@@ -264,7 +263,6 @@ system-clipboard = [
 ]
 
 # Stable (Default)
-which-support = ["nu-command/which-support", "nu-cmd-lang/which-support"]
 trash-support = ["nu-command/trash-support", "nu-cmd-lang/trash-support"]
 
 # SQLite commands for nushell

--- a/crates/nu-cmd-extra/Cargo.toml
+++ b/crates/nu-cmd-extra/Cargo.toml
@@ -32,10 +32,6 @@ serde_urlencoded = { workspace = true }
 v_htmlescape = { workspace = true }
 itertools = { workspace = true }
 
-[features]
-extra = ["default"]
-default = []
-
 [dev-dependencies]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.94.3" }
 nu-command = { path = "../nu-command", version = "0.94.3" }

--- a/crates/nu-cmd-lang/Cargo.toml
+++ b/crates/nu-cmd-lang/Cargo.toml
@@ -25,7 +25,6 @@ shadow-rs = { version = "0.28", default-features = false }
 
 [features]
 mimalloc = []
-which-support = []
 trash-support = []
 sqlite = []
 static-link-openssl = []

--- a/crates/nu-cmd-lang/src/core_commands/version.rs
+++ b/crates/nu-cmd-lang/src/core_commands/version.rs
@@ -160,11 +160,6 @@ fn features_enabled() -> Vec<String> {
 
     // NOTE: There should be another way to know features on.
 
-    #[cfg(feature = "which-support")]
-    {
-        names.push("which".to_string());
-    }
-
     #[cfg(feature = "trash-support")]
     {
         names.push("trash".to_string());

--- a/crates/nu-command/Cargo.toml
+++ b/crates/nu-command/Cargo.toml
@@ -134,7 +134,6 @@ workspace = true
 plugin = ["nu-parser/plugin"]
 sqlite = ["rusqlite"]
 trash-support = ["trash"]
-which-support = []
 
 [dev-dependencies]
 nu-cmd-lang = { path = "../nu-cmd-lang", version = "0.94.3" }

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -127,7 +127,7 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             SysTemp,
             SysUsers,
             UName,
-
+            Which,
         };
 
         // Help
@@ -171,8 +171,6 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
             target_os = "windows"
         ))]
         bind_command! { Ps };
-
-        bind_command! { Which };
 
         // Strings
         bind_command! {

--- a/crates/nu-command/src/default_context.rs
+++ b/crates/nu-command/src/default_context.rs
@@ -172,7 +172,6 @@ pub fn add_shell_command_context(mut engine_state: EngineState) -> EngineState {
         ))]
         bind_command! { Ps };
 
-        #[cfg(feature = "which-support")]
         bind_command! { Which };
 
         // Strings

--- a/crates/nu-command/src/system/which_.rs
+++ b/crates/nu-command/src/system/which_.rs
@@ -92,7 +92,6 @@ fn get_entries_in_nu(
     all_entries
 }
 
-#[cfg(feature = "which-support")]
 fn get_first_entry_in_path(
     item: &str,
     span: Span,
@@ -104,17 +103,6 @@ fn get_first_entry_in_path(
         .ok()
 }
 
-#[cfg(not(feature = "which-support"))]
-fn get_first_entry_in_path(
-    _item: &str,
-    _span: Span,
-    _cwd: impl AsRef<Path>,
-    _paths: impl AsRef<OsStr>,
-) -> Option<Value> {
-    None
-}
-
-#[cfg(feature = "which-support")]
 fn get_all_entries_in_path(
     item: &str,
     span: Span,
@@ -127,16 +115,6 @@ fn get_all_entries_in_path(
                 .collect()
         })
         .unwrap_or_default()
-}
-
-#[cfg(not(feature = "which-support"))]
-fn get_all_entries_in_path(
-    _item: &str,
-    _span: Span,
-    _cwd: impl AsRef<Path>,
-    _paths: impl AsRef<OsStr>,
-) -> Vec<Value> {
-    vec![]
 }
 
 #[derive(Debug)]

--- a/crates/nu-command/tests/commands/mod.rs
+++ b/crates/nu-command/tests/commands/mod.rs
@@ -125,7 +125,6 @@ mod upsert;
 mod url;
 mod use_;
 mod where_;
-#[cfg(feature = "which-support")]
 mod which;
 mod while_;
 mod with_env;

--- a/tests/shell/environment/nu_env.rs
+++ b/tests/shell/environment/nu_env.rs
@@ -36,7 +36,6 @@ fn picks_up_env_keys_when_entering_trusted_directory() {
     })
 }
 
-#[cfg(feature = "which-support")]
 #[test]
 #[serial]
 fn picks_up_and_lets_go_env_keys_when_entering_trusted_directory_with_implied_cd() {
@@ -433,7 +432,6 @@ fn given_a_hierarchy_of_trusted_directories_going_back_restores_overwritten_vari
     })
 }
 
-#[cfg(feature = "which-support")]
 #[test]
 #[serial]
 fn local_config_env_var_present_and_removed_correctly() {
@@ -487,7 +485,6 @@ fn local_config_env_var_present_and_removed_correctly() {
     });
 }
 
-#[cfg(feature = "which-support")]
 #[test]
 #[serial]
 fn local_config_env_var_gets_overwritten() {
@@ -553,7 +550,6 @@ fn local_config_env_var_gets_overwritten() {
     });
 }
 
-#[cfg(feature = "which-support")]
 #[test]
 #[serial]
 fn autoenv_test_entry_scripts() {
@@ -601,7 +597,6 @@ fn autoenv_test_entry_scripts() {
     });
 }
 
-#[cfg(feature = "which-support")]
 #[test]
 #[serial]
 fn autoenv_test_exit_scripts() {

--- a/tests/shell/mod.rs
+++ b/tests/shell/mod.rs
@@ -3,9 +3,7 @@ use nu_test_support::playground::Playground;
 use nu_test_support::{nu, nu_repl_code, pipeline};
 use pretty_assertions::assert_eq;
 
-#[cfg(feature = "which-support")]
 mod environment;
-
 mod pipeline;
 mod repl;
 

--- a/tests/shell/pipeline/commands/external.rs
+++ b/tests/shell/pipeline/commands/external.rs
@@ -3,7 +3,6 @@ use nu_test_support::nu;
 use nu_test_support::playground::Playground;
 use pretty_assertions::assert_eq;
 
-#[cfg(feature = "which-support")]
 #[test]
 fn shows_error_for_command_not_found() {
     let actual = nu!("ferris_is_not_here.exe");
@@ -11,7 +10,6 @@ fn shows_error_for_command_not_found() {
     assert!(!actual.err.is_empty());
 }
 
-#[cfg(feature = "which-support")]
 #[test]
 fn shows_error_for_command_not_found_in_pipeline() {
     let actual = nu!("ferris_is_not_here.exe | echo done");
@@ -20,7 +18,6 @@ fn shows_error_for_command_not_found_in_pipeline() {
 }
 
 #[ignore] // jt: we can't test this using the -c workaround currently
-#[cfg(feature = "which-support")]
 #[test]
 fn automatically_change_directory() {
     use nu_test_support::playground::Playground;

--- a/tests/shell/pipeline/commands/internal.rs
+++ b/tests/shell/pipeline/commands/internal.rs
@@ -550,7 +550,6 @@ fn dynamic_closure_rest_args() {
     assert_eq!(actual.out, "1, 2, 3");
 }
 
-#[cfg(feature = "which-support")]
 #[test]
 fn argument_subexpression_reports_errors() {
     let actual = nu!("echo (ferris_is_not_here.exe)");


### PR DESCRIPTION
# Description
Removes the `which-support` cargo feature and makes all of its feature-gated code enabled by default in all builds. I'm not sure why this one command is gated behind a feature. It seems to be a relic of older code where we had features for what seems like every command.