### PR TITLE
Fixed help for `banner`

### DIFF
--- a/crates/nu-std/std/mod.nu
+++ b/crates/nu-std/std/mod.nu
@@ -161,10 +161,7 @@ export def bench [
     }
 }
 
-# print a banner for nushell, with information about the project
-#
-# Example:
-# an example can be found in [this asciinema recording](https://asciinema.org/a/566513)
+# Print a banner for nushell with information about the project
 export def banner [] {
 let dt = (datetime-diff (date now) 2019-05-10T09:59:12-07:00)
 $"(ansi green)     __  ,(ansi reset)


### PR DESCRIPTION
# Description

`help banner` had several issues:

* It used a Markdown link to an Asciinema recording, but Markdown links aren't rendered as Markdown links by the help system (and can't be, since (most?) terminals don't support that)
* Minor grammatical issues
* The Asciinema recording is out of date anyway.  It still uses `use stdn.nu banner` which isn't valid syntax any longer.

Since everyone at this point knows exactly what `banner` does 😉, I chose to simply remove the link to the recording.  Also tweaked the text (initial caps and removed comma).

# User-Facing Changes

Help only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`