### PR TITLE
Added search terms to `if`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/if_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/if_.rs
@@ -122,6 +122,10 @@ impl Command for If {
         }
     }
 
+    fn search_terms(&self) -> Vec<&str> {
+        vec!["else", "conditional"]
+    }
+
     fn examples(&self) -> Vec<Example> {
         vec![
             Example {


### PR DESCRIPTION
# Description

In this PR, I continue my tradition of trivial but hopefully helpful `help` tweaks.  As mentioned in #13143, I noticed that `help -f else` oddly didn't return the `if` statement itself.  Perhaps not so oddly, since who the heck is going to go looking for *"else"* in the help?  Well, I did ... 

Added *"else"* and *"conditional"* to the search terms for `if`.

I'll work on the meat of #13143 next - That's more substantiative.

# User-Facing Changes

Help only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
- 
# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
