### PR TITLE
Expand tables in help examples in std

### DIFF
--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -658,7 +658,7 @@ def build-command-page [command: record] {
             $"  > ($example.example | nu-highlight)"
             (if not ($example.result | is-empty) {
                 $example.result
-                | table
+                | table -e
                 | to text
                 | if ($example.result | describe) == "binary" { str join } else { lines }
                 | each {|line|


### PR DESCRIPTION
# Description

Some command help has example results with nested `table` data which is displayed as the "non-expanded" form. E.g.:

```nu
╭───┬────────────────╮
│ 0 │ [list 2 items] │
│ 1 │ [list 2 items] │
╰───┴────────────────╯
```

For a good example, see `help zip`.

While we could simply remove the offending Example `result`'s from the command itself, `std help` is capable of expanding the table properly.  It already formats the output of each example result using `table`, so simply making it a `table -e` fixes the output.

While I wish we had a way of expanding the tables in the builtin `help`, that seems to be the same type of problem as in formatting the `cal` output (see #11954).

I personally think it's better to add this feature to `std help` than to remove the offending example results, but as long as `std help` is optional, only a small percentage of users are going to see the "expected" results.

# User-Facing Changes

Excerpt from `std help zip` before change:

```nu
Zip two lists
> [1 2] | zip [3 4]
╭───┬────────────────╮
│ 0 │ [list 2 items] │
│ 1 │ [list 2 items] │
╰───┴────────────────╯
```

After:

```nu
Zip two lists
> [1 2] | zip [3 4]
╭───┬───────────╮
│ 0 │ ╭───┬───╮ │
│   │ │ 0 │ 1 │ │
│   │ │ 1 │ 3 │ │
│   │ ╰───┴───╯ │
│ 1 │ ╭───┬───╮ │
│   │ │ 0 │ 2 │ │
│   │ │ 1 │ 4 │ │
│   │ ╰───┴───╯ │
╰───┴───────────╯
```

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`
- 
# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
