### PR TITLE
nu-explore: Add vertical lines && fix index/transpose issue

### DIFF
--- a/crates/nu-explore/src/explore.rs
+++ b/crates/nu-explore/src/explore.rs
@@ -34,6 +34,7 @@ impl Command for Explore {
                 None,
             )
             .switch("index", "Show row indexes when viewing a list", Some('i'))
+            .switch("show-lines", "Show lines between columns/rows", None)
             .switch(
                 "tail",
                 "Start with the viewport scrolled to the bottom",
@@ -62,6 +63,7 @@ impl Command for Explore {
         let show_index: bool = call.has_flag(engine_state, stack, "index")?;
         let tail: bool = call.has_flag(engine_state, stack, "tail")?;
         let peek_value: bool = call.has_flag(engine_state, stack, "peek")?;
+        let sep_lines: bool = call.has_flag(engine_state, stack, "show-lines")?;
 
         let ctrlc = engine_state.ctrlc.clone();
         let nu_config = engine_state.get_config();
@@ -70,6 +72,7 @@ impl Command for Explore {
         let mut explore_config = ExploreConfig::from_nu_config(nu_config);
         explore_config.table.show_header = show_head;
         explore_config.table.show_index = show_index;
+        explore_config.table.show_separator_lines = sep_lines;
         explore_config.table.separator_style = lookup_color(&style_computer, "separator");
 
         let lscolors = create_lscolors(engine_state, stack);
@@ -245,6 +248,7 @@ pub struct TableConfig {
     pub separator_style: Style,
     pub show_index: bool,
     pub show_header: bool,
+    pub show_separator_lines: bool,
     pub column_padding_left: usize,
     pub column_padding_right: usize,
 }


### PR DESCRIPTION
Somehow I believe that split lines were implemented originally; (I haven't got to find it though; from a quick look)
I mean a long time ago before a lot a changes were made.

Probably adding horizontal lines would make also some sense.

ref #13116
close #13140

Take care

________________

If `explore` is used, frequently, or planned to be so.
I guess it would be a good one to create a test suite for it; to not break things occasionally :sweat_smile: 

I did approached it one time back then using `expectrl` (literally `expect`), but there was some issues.
Maybe smth. did change.
Or some `clean` mode could be introduced for it, to being able to be used by outer programs; to control `nu`.

Just thoughts here.