### PR TITLE
Return an empty list when no `std help --find` results are found

### DIFF
--- a/crates/nu-std/std/help.nu
+++ b/crates/nu-std/std/help.nu
@@ -771,6 +771,11 @@ You can also learn more at (ansi default_italic)(ansi light_cyan_underline)https
 
     let modules = (try { modules $target_item --find $find })
     if not ($modules | is-empty) { return $modules }
+    
+    if ($find | is-not-empty) {
+        print -e $"No help results found mentioning: ($find)"
+        return []
+    }
 
     let span = (metadata $item | get span)
     error make {


### PR DESCRIPTION
# Description

Fixes #13143 by returning an empty list when there are no results found by `std help --find/-f`

# User-Facing Changes

In addition, prints a message to stderr.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
