### PR TITLE
Enable reloading changes to a submodule

### DIFF
--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -304,15 +304,13 @@ mod test {
     #[test]
     fn test_gather_env_vars() {
         let mut engine_state = EngineState::new();
-        let symbols = r##" !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##.to_string();
+        let symbols = r##" !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##;
 
-        let foo_key = "FOO".to_string();
-        let symbols_key = "SYMBOLS".to_string();
         gather_env_vars(
             [
-                (foo_key.clone(), "foo".into()),
-                (symbols_key.clone(), symbols.into()),
-                (symbols.clone()(), "symbols".into()),
+                ("FOO".into(), "foo".into()),
+                ("SYMBOLS".into(), symbols.into()),
+                (symbols.into(), "symbols".into()),
             ]
             .into_iter(),
             &mut engine_state,
@@ -321,12 +319,16 @@ mod test {
 
         let env = engine_state.render_env_vars();
 
-        assert!(matches!(env.get(&foo_key), Some(&Value::String { val, .. }) if val == "foo"));
         assert!(
-            matches!(env.get(&symbols_key), Some(&Value::String { val, .. }) if val == symbols)
+            matches!(env.get(&"FOO".to_string()), Some(&Value::String { val, .. }) if val == "foo")
         );
-        assert!(matches!(env.get(&symbols), Some(&Value::String { val, .. }) if val == "symbols"));
-        assert!(env.get(&"PWD").is_some());
+        assert!(
+            matches!(env.get(&"SYMBOLS".to_string()), Some(&Value::String { val, .. }) if val == symbols)
+        );
+        assert!(
+            matches!(env.get(&symbols.to_string()), Some(&Value::String { val, .. }) if val == "symbols")
+        );
+        assert!(env.get(&"PWD".to_string()).is_some());
         assert_eq!(env.len(), 4);
     }
 }

--- a/crates/nu-cli/src/util.rs
+++ b/crates/nu-cli/src/util.rs
@@ -304,13 +304,15 @@ mod test {
     #[test]
     fn test_gather_env_vars() {
         let mut engine_state = EngineState::new();
-        let symbols = r##" !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##;
+        let symbols = r##" !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"##.to_string();
 
+        let foo_key = "FOO".to_string();
+        let symbols_key = "SYMBOLS".to_string();
         gather_env_vars(
             [
-                ("FOO".into(), "foo".into()),
-                ("SYMBOLS".into(), symbols.into()),
-                (symbols.into(), "symbols".into()),
+                (foo_key.clone(), "foo".into()),
+                (symbols_key.clone(), symbols.into()),
+                (symbols.clone()(), "symbols".into()),
             ]
             .into_iter(),
             &mut engine_state,
@@ -319,16 +321,12 @@ mod test {
 
         let env = engine_state.render_env_vars();
 
+        assert!(matches!(env.get(&foo_key), Some(&Value::String { val, .. }) if val == "foo"));
         assert!(
-            matches!(env.get(&"FOO".to_string()), Some(&Value::String { val, .. }) if val == "foo")
+            matches!(env.get(&symbols_key), Some(&Value::String { val, .. }) if val == symbols)
         );
-        assert!(
-            matches!(env.get(&"SYMBOLS".to_string()), Some(&Value::String { val, .. }) if val == symbols)
-        );
-        assert!(
-            matches!(env.get(&symbols.to_string()), Some(&Value::String { val, .. }) if val == "symbols")
-        );
-        assert!(env.get(&"PWD".to_string()).is_some());
+        assert!(matches!(env.get(&symbols), Some(&Value::String { val, .. }) if val == "symbols"));
+        assert!(env.get(&"PWD").is_some());
         assert_eq!(env.len(), 4);
     }
 }

--- a/crates/nu-parser/src/lib.rs
+++ b/crates/nu-parser/src/lib.rs
@@ -8,7 +8,6 @@ mod parse_keywords;
 mod parse_patterns;
 mod parse_shape_specs;
 mod parser;
-mod parser_path;
 mod type_check;
 
 pub use deparse::{escape_for_script_arg, escape_quote_string};
@@ -18,8 +17,8 @@ pub use flatten::{
 pub use known_external::KnownExternal;
 pub use lex::{lex, lex_signature, Token, TokenContents};
 pub use lite_parser::{lite_parse, LiteBlock, LiteCommand};
+pub use nu_protocol::parser_path::*;
 pub use parse_keywords::*;
-pub use parser_path::*;
 
 pub use parser::{
     is_math_expression_like, parse, parse_block, parse_expression, parse_external_call,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -12,9 +12,9 @@ use nu_protocol::{
         Argument, Block, Call, Expr, Expression, ImportPattern, ImportPatternHead,
         ImportPatternMember, Pipeline, PipelineElement,
     },
-    parser_path::ParserPath,
     engine::{StateWorkingSet, DEFAULT_OVERLAY_NAME},
     eval_const::eval_constant,
+    parser_path::ParserPath,
     Alias, BlockId, DeclId, Module, ModuleId, ParseError, PositionalArg, ResolvedImportPattern,
     Span, Spanned, SyntaxShape, Type, Value, VarId,
 };

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -2,7 +2,6 @@ use crate::{
     exportable::Exportable,
     parse_block,
     parser::{parse_redirection, redirecting_builtin_error},
-    parser_path::ParserPath,
     type_check::{check_block_input_output, type_compatible},
 };
 use itertools::Itertools;
@@ -13,6 +12,7 @@ use nu_protocol::{
         Argument, Block, Call, Expr, Expression, ImportPattern, ImportPatternHead,
         ImportPatternMember, Pipeline, PipelineElement,
     },
+    parser_path::ParserPath,
     engine::{StateWorkingSet, DEFAULT_OVERLAY_NAME},
     eval_const::eval_constant,
     Alias, BlockId, DeclId, Module, ModuleId, ParseError, PositionalArg, ResolvedImportPattern,

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -1211,7 +1211,7 @@ pub fn parse_export_in_module(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
     module_name: &[u8],
-    module: &mut Module,
+    parent_module: &mut Module,
 ) -> (Pipeline, Vec<Exportable>) {
     let spans = &lite_command.parts[..];
 
@@ -1417,7 +1417,8 @@ pub fn parse_export_in_module(
                     pipe: lite_command.pipe,
                     redirection: lite_command.redirection.clone(),
                 };
-                let (pipeline, exportables) = parse_use(working_set, &lite_command, Some(module));
+                let (pipeline, exportables) =
+                    parse_use(working_set, &lite_command, Some(parent_module));
 
                 let export_use_decl_id = if let Some(id) = working_set.find_decl(b"export use") {
                     id
@@ -2265,7 +2266,7 @@ pub fn parse_module(
 pub fn parse_use(
     working_set: &mut StateWorkingSet,
     lite_command: &LiteCommand,
-    user_module: Option<&mut Module>,
+    parent_module: Option<&mut Module>,
 ) -> (Pipeline, Vec<Exportable>) {
     let spans = &lite_command.parts;
 
@@ -2458,7 +2459,7 @@ pub fn parse_use(
 
     import_pattern.constants = constants.iter().map(|(_, id)| *id).collect();
 
-    if let Some(m) = user_module {
+    if let Some(m) = parent_module {
         m.track_imported_modules(
             definitions
                 .modules

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -5219,7 +5219,7 @@ pub fn parse_builtin_commands(
         }
         b"alias" => parse_alias(working_set, lite_command, None),
         b"module" => parse_module(working_set, lite_command, None).0,
-        b"use" => parse_use(working_set, lite_command).0,
+        b"use" => parse_use(working_set, lite_command, None).0,
         b"overlay" => {
             if let Some(redirection) = lite_command.redirection.as_ref() {
                 working_set.error(redirecting_builtin_error("overlay", redirection));

--- a/crates/nu-protocol/src/lib.rs
+++ b/crates/nu-protocol/src/lib.rs
@@ -11,6 +11,7 @@ mod example;
 mod id;
 mod lev_distance;
 mod module;
+pub mod parser_path;
 mod pipeline;
 #[cfg(feature = "plugin")]
 mod plugin;

--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -36,7 +36,7 @@ pub struct Module {
     pub env_block: Option<BlockId>, // `export-env { ... }` block
     pub main: Option<DeclId>,       // `export def main`
     pub span: Option<Span>,
-    pub use_modules: Vec<ModuleId>,
+    pub imported_modules: Vec<ModuleId>, // use other_module.nu
     pub file: Option<PathBuf>,
 }
 
@@ -50,7 +50,7 @@ impl Module {
             env_block: None,
             main: None,
             span: None,
-            use_modules: vec![],
+            imported_modules: vec![],
             file: None,
         }
     }
@@ -64,7 +64,7 @@ impl Module {
             env_block: None,
             main: None,
             span: Some(span),
-            use_modules: vec![],
+            imported_modules: vec![],
             file: None,
         }
     }
@@ -89,9 +89,9 @@ impl Module {
         self.env_block = Some(block_id);
     }
 
-    pub fn add_usage_modules(&mut self, module_id: &[ModuleId]) {
+    pub fn track_imported_modules(&mut self, module_id: &[ModuleId]) {
         for m in module_id {
-            self.use_modules.push(*m)
+            self.imported_modules.push(*m)
         }
     }
 

--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -2,6 +2,7 @@ use crate::{
     ast::ImportPatternMember, engine::StateWorkingSet, BlockId, DeclId, ModuleId, ParseError, Span,
     Value, VarId,
 };
+use std::path::PathBuf;
 
 use indexmap::IndexMap;
 
@@ -35,6 +36,8 @@ pub struct Module {
     pub env_block: Option<BlockId>, // `export-env { ... }` block
     pub main: Option<DeclId>,       // `export def main`
     pub span: Option<Span>,
+    pub use_modules: Vec<ModuleId>,
+    pub file: Option<PathBuf>,
 }
 
 impl Module {
@@ -47,6 +50,8 @@ impl Module {
             env_block: None,
             main: None,
             span: None,
+            use_modules: vec![],
+            file: None,
         }
     }
 
@@ -59,6 +64,8 @@ impl Module {
             env_block: None,
             main: None,
             span: Some(span),
+            use_modules: vec![],
+            file: None,
         }
     }
 
@@ -80,6 +87,12 @@ impl Module {
 
     pub fn add_env_block(&mut self, block_id: BlockId) {
         self.env_block = Some(block_id);
+    }
+
+    pub fn add_usage_modules(&mut self, module_id: &[ModuleId]) {
+        for m in module_id {
+            self.use_modules.push(*m)
+        }
     }
 
     pub fn has_decl(&self, name: &[u8]) -> bool {

--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -1,9 +1,9 @@
 use crate::{
-    ast::ImportPatternMember, engine::StateWorkingSet, BlockId, DeclId, ModuleId, ParseError, Span,
-    Value, VarId,
+    ast::ImportPatternMember, engine::StateWorkingSet, BlockId, DeclId, FileId, ModuleId,
+    ParseError, Span, Value, VarId,
 };
-use std::path::PathBuf;
 
+use crate::parser_path::ParserPath;
 use indexmap::IndexMap;
 
 pub struct ResolvedImportPattern {
@@ -37,7 +37,7 @@ pub struct Module {
     pub main: Option<DeclId>,       // `export def main`
     pub span: Option<Span>,
     pub imported_modules: Vec<ModuleId>, // use other_module.nu
-    pub file: Option<PathBuf>,
+    pub file: Option<(ParserPath, FileId)>,
 }
 
 impl Module {

--- a/crates/nu-protocol/src/module.rs
+++ b/crates/nu-protocol/src/module.rs
@@ -1,9 +1,9 @@
 use crate::{
-    ast::ImportPatternMember, engine::StateWorkingSet, BlockId, DeclId, FileId, ModuleId,
-    ParseError, Span, Value, VarId,
+    ast::ImportPatternMember, engine::StateWorkingSet, BlockId, DeclId, ModuleId, ParseError, Span,
+    Value, VarId,
 };
+use std::path::PathBuf;
 
-use crate::parser_path::ParserPath;
 use indexmap::IndexMap;
 
 pub struct ResolvedImportPattern {
@@ -37,7 +37,7 @@ pub struct Module {
     pub main: Option<DeclId>,       // `export def main`
     pub span: Option<Span>,
     pub imported_modules: Vec<ModuleId>, // use other_module.nu
-    pub file: Option<(ParserPath, FileId)>,
+    pub file: Option<PathBuf>,
 }
 
 impl Module {
@@ -103,6 +103,9 @@ impl Module {
         self.decls.contains_key(name)
     }
 
+    /// Resolve `members` from given module, which is indicated by `self_id` to import.
+    ///
+    /// When resolving, all modules are recorded in `imported_modules`.
     pub fn resolve_import_pattern(
         &self,
         working_set: &StateWorkingSet,
@@ -110,7 +113,9 @@ impl Module {
         members: &[ImportPatternMember],
         name_override: Option<&[u8]>, // name under the module was stored (doesn't have to be the same as self.name)
         backup_span: Span,
+        imported_modules: &mut Vec<ModuleId>,
     ) -> (ResolvedImportPattern, Vec<ParseError>) {
+        imported_modules.push(self_id);
         let final_name = name_override.unwrap_or(&self.name).to_vec();
 
         let (head, rest) = if let Some((head, rest)) = members.split_first() {
@@ -125,8 +130,14 @@ impl Module {
                 let submodule = working_set.get_module(*id);
                 let span = submodule.span.or(self.span).unwrap_or(backup_span);
 
-                let (sub_results, sub_errors) =
-                    submodule.resolve_import_pattern(working_set, *id, &[], None, span);
+                let (sub_results, sub_errors) = submodule.resolve_import_pattern(
+                    working_set,
+                    *id,
+                    &[],
+                    None,
+                    span,
+                    imported_modules,
+                );
                 errors.extend(sub_errors);
 
                 for (sub_name, sub_decl_id) in sub_results.decls {
@@ -225,6 +236,7 @@ impl Module {
                         rest,
                         None,
                         self.span.unwrap_or(backup_span),
+                        imported_modules,
                     )
                 } else {
                     (
@@ -247,6 +259,7 @@ impl Module {
                         &[],
                         None,
                         self.span.unwrap_or(backup_span),
+                        imported_modules,
                     );
                     decls.extend(sub_results.decls);
 
@@ -300,6 +313,7 @@ impl Module {
                             rest,
                             None,
                             self.span.unwrap_or(backup_span),
+                            imported_modules,
                         );
 
                         decls.extend(sub_results.decls);

--- a/crates/nu-protocol/src/parser_path.rs
+++ b/crates/nu-protocol/src/parser_path.rs
@@ -1,4 +1,4 @@
-use nu_protocol::engine::{StateWorkingSet, VirtualPath};
+use crate::engine::{StateWorkingSet, VirtualPath};
 use std::{
     ffi::OsStr,
     path::{Path, PathBuf},

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -903,5 +903,19 @@ fn use_nested_submodules() {
         ];
         let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
         assert_eq!(actual.out, "true");
+
+        sandbox.with_files(&[
+            FileWithContent("animals.nu", r#"export use nested_animals.nu cat"#),
+            FileWithContent("nested_animals.nu", "export def cat [] { 'meow' }"),
+        ]);
+        let inp = [
+            "module voice { export module animals.nu }",
+            "use voice",
+            r#""export def cat [] {'woem'}" | save -f nested_animals.nu"#,
+            "use voice.nu",
+            "(voice animals cat) == 'woem'",
+        ];
+        let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
+        assert_eq!(actual.out, "true");
     })
 }

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -775,9 +775,17 @@ fn reload_submodules() {
             "use voice.nu",
             "(voice animals cat) == 'woem'",
         ];
-
         let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
+        assert_eq!(actual.out, "true");
 
+        // should also verify something unchanged if `use voice`.
+        let inp = [
+            "use voice.nu",
+            r#""export def cat [] {'meow'}" | save -f animals.nu"#,
+            "use voice",
+            "(voice animals cat) == 'woem'",
+        ];
+        let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
         assert_eq!(actual.out, "true");
     });
 }
@@ -796,9 +804,17 @@ fn use_submodules() {
             "use voice.nu",
             "(voice animals cat) == 'woem'",
         ];
-
         let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
+        assert_eq!(actual.out, "true");
 
+        // should also verify something unchanged if `use voice`.
+        let inp = [
+            "use voice.nu",
+            r#""export def cat [] {'meow'}" | save -f animals.nu"#,
+            "use voice",
+            "(voice animals cat) == 'woem'",
+        ];
+        let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
         assert_eq!(actual.out, "true");
     });
 }

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -784,7 +784,7 @@ fn reload_submodules() {
 
 #[test]
 fn use_submodules() {
-    Playground::setup("reload_submodule_changed_file", |dirs, sandbox| {
+    Playground::setup("use_submodules", |dirs, sandbox| {
         sandbox.with_files(&[
             FileWithContent("voice.nu", r#"export use animals.nu"#),
             FileWithContent("animals.nu", "export def cat [] { 'meow'}"),

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -797,7 +797,7 @@ fn reload_submodules() {
             "use voice.nu animals cat",
             r#""export def cat [] {'woem'}" | save -f animals.nu"#,
             "use voice.nu animals cat",
-            "(voice animals cat) == 'woem'",
+            "(cat) == 'woem'",
         ];
         let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
         assert_eq!(actual.out, "true");

--- a/tests/modules/mod.rs
+++ b/tests/modules/mod.rs
@@ -787,6 +787,20 @@ fn reload_submodules() {
         ];
         let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
         assert_eq!(actual.out, "true");
+
+        // should also works if we use members directly.
+        sandbox.with_files(&[
+            FileWithContent("voice.nu", r#"export module animals.nu"#),
+            FileWithContent("animals.nu", "export def cat [] { 'meow'}"),
+        ]);
+        let inp = [
+            "use voice.nu animals cat",
+            r#""export def cat [] {'woem'}" | save -f animals.nu"#,
+            "use voice.nu animals cat",
+            "(voice animals cat) == 'woem'",
+        ];
+        let actual = nu!(cwd: dirs.test(), nu_repl_code(&inp));
+        assert_eq!(actual.out, "true");
     });
 }
 


### PR DESCRIPTION
# Description

Fixes: https://github.com/nushell/nushell/issues/12099

Currently if user run `use voice.nu`, and file is unchanged, then run `use voice.nu` again. nushell will use the module directly, even if submodule inside `voice.nu` is changed.

After discussed with @kubouch, I think it's ok to re-parse the module file when:
1. It exports sub modules which are defined by a file
2. It uses other modules which are defined by a file

## About the change:
To achieve the behavior, we need to add 2 attributes to `Module`:
1.  `imported_modules`: it tracks the other modules is imported by the givem `module`, e.g: `use foo.nu`
2. `file`: the path of a module, if a module is defined by a file, it will be `Some(path)`, or else it will be `None`.

After the change:

    use voice.nu always read the file and parse it.
    use voice will still use the module which is saved in EngineState.

# User-Facing Changes

use `xxx.nu` will read the file and parse it if it exports submodules or uses submodules

# Tests + Formatting

Done