### PR TITLE
update try command's help

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -10,7 +10,7 @@ impl Command for Try {
     }
 
     fn usage(&self) -> &str {
-        "Try to run a block, if it fails optionally run a catch block."
+        "Try to run a block, if it fails optionally run a catch closure."
     }
 
     fn signature(&self) -> nu_protocol::Signature {
@@ -18,7 +18,7 @@ impl Command for Try {
             .input_output_types(vec![(Type::Any, Type::Any)])
             .required("try_block", SyntaxShape::Block, "Block to run.")
             .optional(
-                "catch_block",
+                "catch_closure",
                 SyntaxShape::Keyword(
                     b"catch".to_vec(),
                     Box::new(SyntaxShape::OneOf(vec![
@@ -26,7 +26,7 @@ impl Command for Try {
                         SyntaxShape::Closure(Some(vec![SyntaxShape::Any])),
                     ])),
                 ),
-                "Block to run if try block fails.",
+                "Closure to run if try block fails.",
             )
             .category(Category::Core)
     }
@@ -85,8 +85,13 @@ impl Command for Try {
             },
             Example {
                 description: "Try to run a missing command",
-                example: "try { asdfasdf } catch { 'missing' } ",
+                example: "try { asdfasdf } catch { 'missing' }",
                 result: Some(Value::test_string("missing")),
+            },
+            Example {
+                description: "Try to run a missing command and report the message",
+                example: "try { asdfasdf } catch { |err| $err.msg }",
+                result: Some(Value::test_string("External command failed")),
             },
         ]
     }

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -91,7 +91,7 @@ impl Command for Try {
             Example {
                 description: "Try to run a missing command and report the message",
                 example: "try { asdfasdf } catch { |err| $err.msg }",
-                result: Some(Value::test_string("External command failed")),
+                result: Some(Value::test_string("xternal command")),
             },
         ]
     }

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -91,7 +91,7 @@ impl Command for Try {
             Example {
                 description: "Try to run a missing command and report the message",
                 example: "try { asdfasdf } catch { |err| $err.msg }",
-                result: Some(Value::test_string("xternal command")),
+                result: None,
             },
         ]
     }


### PR DESCRIPTION
# Description

This PR updates the `try` command to show that `catch` is a closure and can be used as such.

### Before
![image](https://github.com/nushell/nushell/assets/343840/dc330b10-cd68-4d70-9ff8-aa1e7cbda5f3)

### After
![image](https://github.com/nushell/nushell/assets/343840/146a7514-6026-4b53-bdf0-603c77c8a259)


# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
