### PR TITLE
add a system level folder for future autoloading

### DIFF
--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -763,7 +763,7 @@ fn variables_completions() {
     // Test completions for $nu
     let suggestions = completer.complete("$nu.", 4);
 
-    assert_eq!(17, suggestions.len());
+    assert_eq!(18, suggestions.len());
 
     let expected: Vec<String> = vec![
         "cache-dir".into(),
@@ -783,6 +783,7 @@ fn variables_completions() {
         "plugin-path".into(),
         "startup-time".into(),
         "temp-path".into(),
+        "vendor-autoload-dir".into(),
     ];
 
     // Match results

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -181,6 +181,44 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
         },
     );
 
+    // Create a system level directory for nushell scripts, modules, completions, etc
+    // that can be changed by setting the NU_VENDOR_AUTOLOAD_DIR env var on any platform
+    // OR if NU_VENDOR_AUTOLOAD_DIR is not set for non-windows systems, the PREFIX env var
+    // can be used as PREFIX/nushell/vendor/autoload
+    record.push(
+        "vendor-autoload-dir",
+        // pseudo code
+        // if env var NU_VENDOR_AUTOLOAD_DIR is set, in any platform, use it
+        // if not, if windows, use ALLUSERPROFILE\nushell\vendor\autoload
+        // if not, if non-windows, if env var PREFIX is set, use PREFIX/share/nushell/vendor/autoload
+        // if not, use the default /usr/share/nushell/vendor/autoload
+
+        // check to see if NU_VENDOR_AUTOLOAD_DIR env var is set, if not, use the default
+        option_env!("NU_VENDOR_AUTOLOAD_DIR")
+            .map(String::from)
+            .or_else(|| {
+                if cfg!(windows) {
+                    let all_user_profile = match engine_state.get_env_var("ALLUSERPROFILE") {
+                        Some(v) => format!(
+                            "{}\\nushell\\vendor\\autoload",
+                            v.coerce_string().unwrap_or("C:\\ProgramData".into())
+                        ),
+                        None => "C:\\ProgramData\\nushell\\vendor\\autoload".into(),
+                    };
+                    Some(all_user_profile)
+                } else {
+                    // In non-Windows environments, if NU_VENDOR_AUTOLOAD_DIR is not set
+                    // check to see if PREFIX env var is set, and use it as PREFIX/nushell/vendor/autoload
+                    // otherwise default to /usr/share/nushell/vendor/autoload
+                    option_env!("PREFIX").map(String::from).map_or_else(
+                        || Some("/usr/share/nushell/vendor/autoload".into()),
+                        |prefix| Some(format!("{}/nushell/vendor/autoload", prefix)),
+                    )
+                }
+            })
+            .map_or_else(|| Value::nothing(span), |s| Value::string(s, span)),
+    );
+
     record.push("temp-path", {
         let canon_temp_path = canonicalize_path(engine_state, &std::env::temp_dir());
         Value::string(canon_temp_path.to_string_lossy(), span)

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -183,8 +183,8 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
 
     // Create a system level directory for nushell scripts, modules, completions, etc
     // that can be changed by setting the NU_VENDOR_AUTOLOAD_DIR env var on any platform
-    // OR if NU_VENDOR_AUTOLOAD_DIR is not set for non-windows systems, the PREFIX env var
-    // can be used as PREFIX/nushell/vendor/autoload
+    // before nushell is compiled OR if NU_VENDOR_AUTOLOAD_DIR is not set for non-windows
+    // systems, the PREFIX env var can be set before compile and used as PREFIX/nushell/vendor/autoload
     record.push(
         "vendor-autoload-dir",
         // pseudo code

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -211,8 +211,8 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
                     // check to see if PREFIX env var is set, and use it as PREFIX/nushell/vendor/autoload
                     // otherwise default to /usr/share/nushell/vendor/autoload
                     option_env!("PREFIX").map(String::from).map_or_else(
-                        || Some("/usr/share/nushell/vendor/autoload".into()),
-                        |prefix| Some(format!("{}/nushell/vendor/autoload", prefix)),
+                        || Some("/usr/local/nushell/vendor/autoload".into()),
+                        |prefix| Some(format!("{}/share/nushell/vendor/autoload", prefix)),
                     )
                 }
             })

--- a/crates/nu-protocol/src/eval_const.rs
+++ b/crates/nu-protocol/src/eval_const.rs
@@ -211,7 +211,7 @@ pub(crate) fn create_nu_constant(engine_state: &EngineState, span: Span) -> Valu
                     // check to see if PREFIX env var is set, and use it as PREFIX/nushell/vendor/autoload
                     // otherwise default to /usr/share/nushell/vendor/autoload
                     option_env!("PREFIX").map(String::from).map_or_else(
-                        || Some("/usr/local/nushell/vendor/autoload".into()),
+                        || Some("/usr/local/share/nushell/vendor/autoload".into()),
                         |prefix| Some(format!("{}/share/nushell/vendor/autoload", prefix)),
                     )
                 }


### PR DESCRIPTION
# Description

This PR adds a directory to the `$nu` constant that shows where the system level autoload directory is located at. This folder is modifiable at compile time with environment variables.
```rust
    // Create a system level directory for nushell scripts, modules, completions, etc
    // that can be changed by setting the NU_VENDOR_AUTOLOAD_DIR env var on any platform
    // before nushell is compiled OR if NU_VENDOR_AUTOLOAD_DIR is not set for non-windows 
    // systems, the PREFIX env var can be set before compile and used as PREFIX/nushell/vendor/autoload

    // pseudo code
    // if env var NU_VENDOR_AUTOLOAD_DIR is set, in any platform, use it
    // if not, if windows, use ALLUSERPROFILE\nushell\vendor\autoload
    // if not, if non-windows, if env var PREFIX is set, use PREFIX/share/nushell/vendor/autoload
    // if not, use the default /usr/share/nushell/vendor/autoload
```

### Windows default
```nushell
❯ $nu.vendor-autoload-dir
C:\ProgramData\nushell\vendor\autoload
```
### Non-Windows default
```nushell
❯ $nu.vendor-autoload-dir
/usr/local/share/nushell/vendor/autoload
```
### Non-Windows with PREFIX set
```nushell
❯ PREFIX=/usr/bob cargo r
❯ $nu.vendor-autoload-dir
/usr/bob/share/nushell/vendor/autoload
```
### Non-Windows with NU_VENDOR_AUTOLOAD_DIR set
```nushell
❯ NU_VENDOR_AUTOLOAD_DIR=/some/other/path/nushell/stuff cargo r
❯ $nu.vendor-autoload-dir
/some/other/path/nushell/stuff
```

> [!IMPORTANT] 
To be clear, this PR does not do the auto-loading, it just sets up the folder to support that functionality that can be added in a later PR. The PR also does not create the folder defined. It's just setting the $nu constant.
 
# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
