### PR TITLE
Table help rendering

### DIFF
--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -170,7 +170,10 @@ impl Command for Table {
                     }),
                     Value::test_record(record! {
                         "a" =>  Value::test_int(3),
-                        "b" =>  Value::test_int(4),
+                        "b" =>  Value::test_list(vec![
+                            Value::test_int(4),
+                            Value::test_int(4),
+                        ])
                     }),
                 ])),
             },

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -187,7 +187,10 @@ impl Command for Table {
                     }),
                     Value::test_record(record! {
                         "a" =>  Value::test_int(3),
-                        "b" =>  Value::test_int(4),
+                        "b" =>  Value::test_list(vec![
+                            Value::test_int(4),
+                            Value::test_int(4),
+                        ])
                     }),
                 ])),
             },

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -3,8 +3,8 @@ use nu_protocol::{
     ast::{Argument, Call, Expr, Expression, RecordItem},
     debugger::WithoutDebug,
     engine::{Command, EngineState, Stack, UNKNOWN_SPAN_ID},
-    record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SpanId,
-    SyntaxShape, Type, Value, Spanned
+    record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SpanId, Spanned,
+    SyntaxShape, Type, Value,
 };
 use std::{collections::HashMap, fmt::Write};
 
@@ -300,7 +300,7 @@ fn get_documentation(
             table_expand_call.add_named((
                 Spanned {
                     item: "expand".to_string(),
-                    span: Span::unknown()
+                    span: Span::unknown(),
                 },
                 None,
                 None,

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -297,7 +297,7 @@ fn get_documentation(
 
         if let Some(result) = &example.result {
             let mut table_call = Call::new(Span::unknown());
-            if *&example.example.ends_with("--collapse") {
+            if example.example.ends_with("--collapse") {
                 // collapse the result
                 table_call.add_named((
                     Spanned {

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -4,7 +4,7 @@ use nu_protocol::{
     debugger::WithoutDebug,
     engine::{Command, EngineState, Stack, UNKNOWN_SPAN_ID},
     record, Category, Example, IntoPipelineData, PipelineData, Signature, Span, SpanId,
-    SyntaxShape, Type, Value,
+    SyntaxShape, Type, Value, Spanned
 };
 use std::{collections::HashMap, fmt::Write};
 
@@ -296,6 +296,15 @@ fn get_documentation(
         }
 
         if let Some(result) = &example.result {
+            let mut table_expand_call = Call::new(Span::unknown());
+            table_expand_call.add_named((
+                Spanned {
+                    item: "expand".to_string(),
+                    span: Span::unknown()
+                },
+                None,
+                None,
+            ));
             let table = engine_state
                 .find_decl("table".as_bytes(), &[])
                 .and_then(|decl_id| {
@@ -304,7 +313,7 @@ fn get_documentation(
                         .run(
                             engine_state,
                             stack,
-                            &Call::new(Span::new(0, 0)),
+                            &table_expand_call,
                             PipelineData::Value(result.clone(), None),
                         )
                         .ok()

--- a/crates/nu-engine/src/documentation.rs
+++ b/crates/nu-engine/src/documentation.rs
@@ -296,15 +296,28 @@ fn get_documentation(
         }
 
         if let Some(result) = &example.result {
-            let mut table_expand_call = Call::new(Span::unknown());
-            table_expand_call.add_named((
-                Spanned {
-                    item: "expand".to_string(),
-                    span: Span::unknown(),
-                },
-                None,
-                None,
-            ));
+            let mut table_call = Call::new(Span::unknown());
+            if *&example.example.ends_with("--collapse") {
+                // collapse the result
+                table_call.add_named((
+                    Spanned {
+                        item: "collapse".to_string(),
+                        span: Span::unknown(),
+                    },
+                    None,
+                    None,
+                ))
+            } else {
+                // expand the result
+                table_call.add_named((
+                    Spanned {
+                        item: "expand".to_string(),
+                        span: Span::unknown(),
+                    },
+                    None,
+                    None,
+                ))
+            }
             let table = engine_state
                 .find_decl("table".as_bytes(), &[])
                 .and_then(|decl_id| {
@@ -313,7 +326,7 @@ fn get_documentation(
                         .run(
                             engine_state,
                             stack,
-                            &table_expand_call,
+                            &table_call,
                             PipelineData::Value(result.clone(), None),
                         )
                         .ok()


### PR DESCRIPTION
# Description

Mostly fixes #13149 with much of the credit to @fdncred.

This PR runs `table --expand` against `help` example results.  This is essentially the same fix that #13146 was for `std help`.

It also changes the shape of the result for the `table --expand` example, as it was hardcoded wrong.

~Still needed is a fix for the `table --collapse` example.~  Note that this is also still a bug in `std help` that I didn't noticed before.

# User-Facing Changes

Certain tables are now rendered correctly in the help examples for:

* `table`
* `zip`
* `flatten`
* And almost certainly others

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
