### PR TITLE
Suppress column index for default `cal` output

### DIFF
--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -81,9 +81,15 @@ impl Command for Cal {
                 result: None,
             },
             Example {
-                description: "This month's calendar with the week starting on monday",
+                description: "This month's calendar with the week starting on Monday",
                 example: "cal --week-start mo",
                 result: None,
+            },
+            Example {
+                description: "How many Friday the 13ths occurred in 2015",
+                example: "cal --as-table --full-year 2015 | where {$it.fr == 13} | length",
+                result: None,
+                //result: Some(Value::test_int(3)),
             },
         ]
     }

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -86,7 +86,7 @@ impl Command for Cal {
                 result: None,
             },
             Example {
-                description: "How many Friday the 13ths occurred in 2015",
+                description: "How many 'Friday the Thirteenths' occurred in 2015?",
                 example: "cal --as-table --full-year 2015 | where fr == 13 | length",
                 result: None,
             },

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -87,7 +87,7 @@ impl Command for Cal {
             },
             Example {
                 description: "How many Friday the 13ths occurred in 2015",
-                example: "cal --as-table --full-year 2015 | where {$it.fr == 13} | length",
+                example: "cal --as-table --full-year 2015 | where fr == 13 | length",
                 result: None,
             },
         ]

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -89,7 +89,6 @@ impl Command for Cal {
                 description: "How many Friday the 13ths occurred in 2015",
                 example: "cal --as-table --full-year 2015 | where {$it.fr == 13} | length",
                 result: None,
-                //result: Some(Value::test_int(3)),
             },
         ]
     }

--- a/crates/nu-command/src/generators/cal.rs
+++ b/crates/nu-command/src/generators/cal.rs
@@ -1,6 +1,7 @@
 use chrono::{Datelike, Local, NaiveDate};
 use nu_color_config::StyleComputer;
 use nu_engine::command_prelude::*;
+use nu_protocol::ast::{Expr, Expression};
 
 use std::collections::VecDeque;
 
@@ -14,6 +15,7 @@ struct Arguments {
     month_names: bool,
     full_year: Option<Spanned<i64>>,
     week_start: Option<Spanned<String>>,
+    as_table: bool,
 }
 
 impl Command for Cal {
@@ -26,6 +28,7 @@ impl Command for Cal {
             .switch("year", "Display the year column", Some('y'))
             .switch("quarter", "Display the quarter column", Some('q'))
             .switch("month", "Display the month column", Some('m'))
+            .switch("as-table", "output as a table", Some('t'))
             .named(
                 "full-year",
                 SyntaxShape::Int,
@@ -43,7 +46,10 @@ impl Command for Cal {
                 "Display the month names instead of integers",
                 None,
             )
-            .input_output_types(vec![(Type::Nothing, Type::table())])
+            .input_output_types(vec![
+                (Type::Nothing, Type::table()),
+                (Type::Nothing, Type::String),
+            ])
             .allow_variants_without_examples(true) // TODO: supply exhaustive examples
             .category(Category::Generators)
     }
@@ -101,6 +107,7 @@ pub fn cal(
         quarter: call.has_flag(engine_state, stack, "quarter")?,
         full_year: call.get_flag(engine_state, stack, "full-year")?,
         week_start: call.get_flag(engine_state, stack, "week-start")?,
+        as_table: call.has_flag(engine_state, stack, "as-table")?,
     };
 
     let style_computer = &StyleComputer::from_config(engine_state, stack);
@@ -131,7 +138,27 @@ pub fn cal(
         style_computer,
     )?;
 
-    Ok(Value::list(calendar_vec_deque.into_iter().collect(), tag).into_pipeline_data())
+    let mut table_no_index = Call::new(Span::unknown());
+    table_no_index.add_named((
+        Spanned {
+            item: "index".to_string(),
+            span: Span::unknown(),
+        },
+        None,
+        Some(Expression::new_unknown(
+            Expr::Bool(false),
+            Span::unknown(),
+            Type::Bool,
+        )),
+    ));
+
+    let cal_table_output =
+        Value::list(calendar_vec_deque.into_iter().collect(), tag).into_pipeline_data();
+    if !arguments.as_table {
+        crate::Table.run(engine_state, stack, &table_no_index, cal_table_output)
+    } else {
+        Ok(cal_table_output)
+    }
 }
 
 fn get_invalid_year_shell_error(head: Span) -> ShellError {

--- a/crates/nu-command/tests/commands/cal.rs
+++ b/crates/nu-command/tests/commands/cal.rs
@@ -1,8 +1,9 @@
 use nu_test_support::{nu, pipeline};
 
+// Tests against table/structured data
 #[test]
 fn cal_full_year() {
-    let actual = nu!("cal -y --full-year 2010 | first | to json -r");
+    let actual = nu!("cal -t -y --full-year 2010 | first | to json -r");
 
     let first_week_2010_json =
         r#"{"year":2010,"su":null,"mo":null,"tu":null,"we":null,"th":null,"fr":1,"sa":2}"#;
@@ -14,7 +15,7 @@ fn cal_full_year() {
 fn cal_february_2020_leap_year() {
     let actual = nu!(pipeline(
         r#"
-        cal -ym --full-year 2020 --month-names | where month == "february" | to json -r
+        cal --as-table -ym --full-year 2020 --month-names | where month == "february" | to json -r
         "#
     ));
 
@@ -27,7 +28,7 @@ fn cal_february_2020_leap_year() {
 fn cal_fr_the_thirteenths_in_2015() {
     let actual = nu!(pipeline(
         r#"
-        cal --full-year 2015 | default 0 fr | where fr == 13 | length
+        cal --as-table --full-year 2015 | default 0 fr | where fr == 13 | length
         "#
     ));
 
@@ -38,7 +39,7 @@ fn cal_fr_the_thirteenths_in_2015() {
 fn cal_rows_in_2020() {
     let actual = nu!(pipeline(
         r#"
-        cal --full-year 2020 | length
+        cal --as-table --full-year 2020 | length
         "#
     ));
 
@@ -49,7 +50,7 @@ fn cal_rows_in_2020() {
 fn cal_week_day_start_mo() {
     let actual = nu!(pipeline(
         r#"
-        cal --full-year 2020 -m --month-names --week-start mo | where month == january | to json -r
+        cal --as-table --full-year 2020 -m --month-names --week-start mo | where month == january | to json -r
         "#
     ));
 
@@ -62,9 +63,43 @@ fn cal_week_day_start_mo() {
 fn cal_sees_pipeline_year() {
     let actual = nu!(pipeline(
         r#"
-        cal --full-year 1020 | get mo | first 4 | to json -r
+        cal --as-table --full-year 1020 | get mo | first 4 | to json -r
         "#
     ));
 
     assert_eq!(actual.out, "[null,3,10,17]");
+}
+
+// Tests against default string output
+#[test]
+fn cal_is_string() {
+    let actual = nu!(pipeline(
+        r#"
+        cal | describe
+        "#
+    ));
+
+    assert_eq!(actual.out, "string (stream)");
+}
+
+#[test]
+fn cal_year_num_lines() {
+    let actual = nu!(pipeline(
+        r#"
+        cal --full-year 2024 | lines | length
+        "#
+    ));
+
+    assert_eq!(actual.out, "68");
+}
+
+#[test]
+fn cal_week_start_string() {
+    let actual = nu!(pipeline(
+        r#"
+        cal --week-start fr | lines | get 1 | split row '│' | get 2 | ansi strip | str trim
+        "#
+    ));
+
+    assert_eq!(actual.out, "sa");
 }

--- a/crates/nu-command/tests/commands/length.rs
+++ b/crates/nu-command/tests/commands/length.rs
@@ -2,7 +2,7 @@ use nu_test_support::nu;
 
 #[test]
 fn length_columns_in_cal_table() {
-    let actual = nu!("cal | columns | length");
+    let actual = nu!("cal --as-table | columns | length");
 
     assert_eq!(actual.out, "7");
 }


### PR DESCRIPTION
# Description

* As discussed in the comments in #11954, this suppresses the index column on `cal` output.  It does that by running `table -i false` on the results by default.
* Added new `--as-table/-t` flag to revert to the old behavior and output the calendar as structured data
* Updated existing tests to use `--as-table`
* Added new tests against the string output
* Updated `length` test which also used `cal`
* Added new example for `--as-table`, with result

# User-Facing Changes

## Breaking change

The *default* `cal` output has changed from a `list` to a `string`.  To obtain structured data from `cal`, use the new `--as-table/-t` flag.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`


# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
