### PR TITLE
Do example

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -234,9 +234,19 @@ impl Command for Do {
                 result: Some(Value::test_int(177)),
             },
             Example {
-                description: "Run the closure, with input",
-                example: r#"77 | do {|x| 100 + $in }"#,
-                result: None, // TODO: returns 177
+                description: "Run the closure, with pipeline input",
+                example: r#"77 | do {100 + $in }"#,
+                result: Some(Value::test_int(177)),
+            },
+            Example {
+                description: "Run the closure, with a default parameter value",
+                example: r#"77 | do {|x=100| $x + $in }"#,
+                result: Some(Value::test_int(177)),
+            },
+            Example {
+                description: "Run the closure, with two positional parameters",
+                example: r#"do {|x,y| $x + $y } 77 100"#,
+                result: Some(Value::test_int(177)),
             },
             Example {
                 description: "Run the closure and keep changes to the environment",

--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -229,22 +229,22 @@ impl Command for Do {
                 result: None,
             },
             Example {
-                description: "Run the closure, with a positional parameter",
-                example: r#"do {|x| 100 + $x } 77"#,
+                description: "Run the closure with a positional, type-checked parameter",
+                example: r#"do {|x:int| 100 + $x } 77"#,
                 result: Some(Value::test_int(177)),
             },
             Example {
-                description: "Run the closure, with pipeline input",
-                example: r#"77 | do {100 + $in }"#,
+                description: "Run the closure with pipeline input",
+                example: r#"77 | do { 100 + $in }"#,
                 result: Some(Value::test_int(177)),
             },
             Example {
-                description: "Run the closure, with a default parameter value",
+                description: "Run the closure with a default parameter value",
                 example: r#"77 | do {|x=100| $x + $in }"#,
                 result: Some(Value::test_int(177)),
             },
             Example {
-                description: "Run the closure, with two positional parameters",
+                description: "Run the closure with two positional parameters",
                 example: r#"do {|x,y| $x + $y } 77 100"#,
                 result: Some(Value::test_int(177)),
             },


### PR DESCRIPTION
# Description

#12056 added support for default and type-checked arguments in `do` closures.

This PR adds examples for those features.  It also:

* Fixes the TODO (a closure parameter that wasn't being used) that was preventing a result from being added
* Removes extraneous commas from the descriptions
* Adds an example demonstrating multiple positional closure arguments

# User-Facing Changes

Help examples only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
