### PR TITLE
fix nu-system build on arm64 FreeBSD

### DIFF
--- a/crates/nu-system/src/freebsd.rs
+++ b/crates/nu-system/src/freebsd.rs
@@ -1,6 +1,7 @@
 use itertools::{EitherOrBoth, Itertools};
 use libc::{
-    kinfo_proc, sysctl, CTL_HW, CTL_KERN, KERN_PROC, KERN_PROC_ALL, KERN_PROC_ARGS, TDF_IDLETD,
+    c_char, kinfo_proc, sysctl, CTL_HW, CTL_KERN, KERN_PROC, KERN_PROC_ALL, KERN_PROC_ARGS,
+    TDF_IDLETD,
 };
 use std::{
     ffi::CStr,
@@ -16,7 +17,7 @@ pub struct ProcessInfo {
     pub ppid: i32,
     pub name: String,
     pub argv: Vec<u8>,
-    pub stat: i8,
+    pub stat: c_char,
     pub percent_cpu: f64,
     pub mem_resident: u64, // in bytes
     pub mem_virtual: u64,  // in bytes


### PR DESCRIPTION
# Description

Fixes #13194

`ki_stat` is supposed to be a `c_char`, but was defined was `i8`. Unfortunately, `c_char` is `u8` on Aarch64 (on all platforms), so this doesn't compile. I fixed it to use `c_char` instead.

Double checked whether NetBSD is affected, but the `libc` code defines it as `i8` for some reason (erroneously, really) but that doesn't matter too much. Anyway should be ok there.

Sorry, I can't quite test this right now but will be able to soon. I've seen this issue before so I'm pretty sure this is all it is. In the meantime @yurivict if you're able to check if this builds for you, that would be lovely. Thanks!
