### PR TITLE
Add shape_glob_interpolation to default_config.nu

### DIFF
--- a/crates/nu-utils/src/sample_config/default_config.nu
+++ b/crates/nu-utils/src/sample_config/default_config.nu
@@ -48,6 +48,7 @@ let dark_theme = {
     shape_float: purple_bold
     # shapes are used to change the cli syntax highlighting
     shape_garbage: { fg: white bg: red attr: b}
+    shape_glob_interpolation: cyan_bold
     shape_globpattern: cyan_bold
     shape_int: purple_bold
     shape_internalcall: cyan_bold


### PR DESCRIPTION
# Description

Just missed this during #13089. Adds `shape_glob_interpolation` to the config.

This actually isn't really going to be seen at all yet, so I debated whether it's really needed at all. It's only used to highlight the quotes themselves, and we don't have any quoted glob interpolations at the moment.

