### PR TITLE
Fixed `generate` command signature

### DIFF
--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -12,13 +12,7 @@ impl Command for Generate {
 
     fn signature(&self) -> Signature {
         Signature::build("generate")
-            .input_output_types(vec![
-                (Type::Nothing, Type::List(Box::new(Type::Any))),
-                (
-                    Type::List(Box::new(Type::Any)),
-                    Type::List(Box::new(Type::Any)),
-                ),
-            ])
+            .input_output_types(vec![(Type::Nothing, Type::List(Box::new(Type::Any)))])
             .required("initial", SyntaxShape::Any, "Initial value.")
             .required(
                 "closure",
@@ -63,23 +57,10 @@ used as the next argument to the closure, otherwise generation stops.
                 )),
             },
             Example {
-                example: "generate [0, 1] {|fib| {out: $fib.0, next: [$fib.1, ($fib.0 + $fib.1)]} } | first 10",
-                description: "Generate a stream of fibonacci numbers",
-                result: Some(Value::list(
-                    vec![
-                        Value::test_int(0),
-                        Value::test_int(1),
-                        Value::test_int(1),
-                        Value::test_int(2),
-                        Value::test_int(3),
-                        Value::test_int(5),
-                        Value::test_int(8),
-                        Value::test_int(13),
-                        Value::test_int(21),
-                        Value::test_int(34),
-                    ],
-                    Span::test_data(),
-                )),
+                example:
+                    "generate [0, 1] {|fib| {out: $fib.0, next: [$fib.1, ($fib.0 + $fib.1)]} }",
+                description: "Generate a continuous stream of Fibonacci numbers",
+                result: None,
             },
         ]
     }


### PR DESCRIPTION
# Description

Removes `list<any>` as an input type for the `generate` command.  This command does not accept pipeline input (and cannot, logically).  This can be seen by the use of `_input` in the command's `run()`.

Also, due to #13199, in order to pass `toolkit check pr`, one of the examples was changed to remove the `result`.  This is probably a better demonstration of the ability of the command to infinitely generate a list anyway, and an infinite list can't be represented in a `result`.

# User-Facing Changes

Should only be a change to the help.  The input type was never valid and couldn't have been used.

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`