### PR TITLE
Allow missing fields in derived `FromValue::from_value` calls

### DIFF
--- a/crates/nu-derive-value/src/from.rs
+++ b/crates/nu-derive-value/src/from.rs
@@ -477,7 +477,6 @@ fn parse_value_via_fields(fields: &Fields, self_ident: impl ToTokens) -> TokenSt
     match fields {
         Fields::Named(fields) => {
             let fields = fields.named.iter().map(|field| {
-                // TODO: handle missing fields for Options as None
                 let ident = field.ident.as_ref().expect("named has idents");
                 let ident_s = ident.to_string();
                 let ty = &field.ty;

--- a/crates/nu-derive-value/src/from.rs
+++ b/crates/nu-derive-value/src/from.rs
@@ -3,6 +3,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use syn::{
     spanned::Spanned, Attribute, Data, DataEnum, DataStruct, DeriveInput, Fields, Generics, Ident,
+    Type,
 };
 
 use crate::attributes::{self, ContainerAttributes};
@@ -116,15 +117,11 @@ fn derive_struct_from_value(
 ///                         src_span: span
 ///                     })?,
 ///             )?,
-///             favorite_toy: <Option<String> as nu_protocol::FromValue>::from_value(
-///                 record
-///                     .remove("favorite_toy")
-///                     .ok_or_else(|| nu_protocol::ShellError::CantFindColumn {
-///                         col_name: std::string::ToString::to_string("favorite_toy"),
-///                         span: std::option::Option::None,
-///                         src_span: span
-///                     })?,
-///             )?,          
+///             favorite_toy: record
+///                 .remove("favorite_toy")
+///                 .map(|v| <#ty as nu_protocol::FromValue>::from_value(v))
+///                 .transpose()?
+///                 .flatten(),         
 ///         })
 ///     }
 /// }
@@ -484,16 +481,26 @@ fn parse_value_via_fields(fields: &Fields, self_ident: impl ToTokens) -> TokenSt
                 let ident = field.ident.as_ref().expect("named has idents");
                 let ident_s = ident.to_string();
                 let ty = &field.ty;
-                quote! {
-                    #ident: <#ty as nu_protocol::FromValue>::from_value(
-                        record
+                match type_is_option(ty) {
+                    true => quote! {
+                        #ident: record
                             .remove(#ident_s)
-                            .ok_or_else(|| nu_protocol::ShellError::CantFindColumn {
-                                col_name: std::string::ToString::to_string(#ident_s),
-                                span: std::option::Option::None,
-                                src_span: span
-                            })?,
-                    )?
+                            .map(|v| <#ty as nu_protocol::FromValue>::from_value(v))
+                            .transpose()?
+                            .flatten()
+                    },
+
+                    false => quote! {
+                        #ident: <#ty as nu_protocol::FromValue>::from_value(
+                            record
+                                .remove(#ident_s)
+                                .ok_or_else(|| nu_protocol::ShellError::CantFindColumn {
+                                    col_name: std::string::ToString::to_string(#ident_s),
+                                    span: std::option::Option::None,
+                                    src_span: span
+                                })?,
+                        )?
+                    },
                 }
             });
             quote! {
@@ -536,4 +543,26 @@ fn parse_value_via_fields(fields: &Fields, self_ident: impl ToTokens) -> TokenSt
             }
         },
     }
+}
+
+const FULLY_QUALIFIED_OPTION: &str = "std::option::Option";
+const PARTIALLY_QUALIFIED_OPTION: &str = "option::Option";
+const PRELUDE_OPTION: &str = "Option";
+
+/// Check if the field type is an `Option`.
+///
+/// This function checks if a given type is an `Option`.
+/// We assume that an `Option` is [`std::option::Option`] because we can't see the whole code and
+/// can't ask the compiler itself.
+/// If the `Option` type isn't `std::option::Option`, the user will get a compile error due to a
+/// type mismatch.
+/// It's very unusual for people to override `Option`, so this should rarely be an issue.
+///
+/// When [rust#63084](https://github.com/rust-lang/rust/issues/63084) is resolved, we can use
+/// [`std::any::type_name`] for a static assertion check to get a more direct error messages.
+fn type_is_option(ty: &Type) -> bool {
+    let s = ty.to_token_stream().to_string();
+    s.starts_with(PRELUDE_OPTION)
+        || s.starts_with(PARTIALLY_QUALIFIED_OPTION)
+        || s.starts_with(FULLY_QUALIFIED_OPTION)
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
In #13031 I added the derive macros for `FromValue` and `IntoValue`. In that implementation, in particular for structs with named fields, it was not possible to omit fields while loading them from a value, when the field is an `Option`. This PR adds extra handling for this behavior, so if a field is an `Option` and that field is missing in the `Value`, then the field becomes `None`. This behavior is also tested in `nu_protocol::value::test_derive::missing_options`.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

When using structs for options or similar, users can now just emit fields in the record and the derive `from_value` method will be able to understand this, if the struct has an `Option` type for that field.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
A showcase for this feature would be great, I tried to use the current derive macro in a plugin of mine for a config but without this addition, they are annoying to use. So, when this is done, I would add an example for such plugin configs that may be loaded via `FromValue`.