### PR TITLE
Make the subcommands (`from {csv, tsv, ssv}`) 0-based for consistency

### DIFF
--- a/crates/nu-command/src/formats/from/delimited.rs
+++ b/crates/nu-command/src/formats/from/delimited.rs
@@ -39,7 +39,7 @@ fn from_delimited_stream(
         .from_reader(input_reader);
 
     let headers = if noheaders {
-        (1..=reader
+        (0..reader
             .headers()
             .map_err(|err| from_csv_error(err, span))?
             .len())

--- a/crates/nu-command/src/formats/from/ssv.rs
+++ b/crates/nu-command/src/formats/from/ssv.rs
@@ -52,12 +52,12 @@ impl Command for FromSsv {
                 Value::test_list(
                     vec![
                         Value::test_record(record! {
-                            "column1" => Value::test_string("FOO"),
-                            "column2" => Value::test_string("BAR"),
+                            "column0" => Value::test_string("FOO"),
+                            "column1" => Value::test_string("BAR"),
                         }),
                         Value::test_record(record! {
-                            "column1" => Value::test_string("1"),
-                            "column2" => Value::test_string("2"),
+                            "column0" => Value::test_string("1"),
+                            "column1" => Value::test_string("2"),
                         }),
                     ],
                 )
@@ -170,7 +170,7 @@ fn parse_aligned_columns<'a>(
         let headers: Vec<(String, usize)> = indices
             .iter()
             .enumerate()
-            .map(|(i, position)| (format!("column{}", i + 1), *position))
+            .map(|(i, position)| (format!("column{}", i), *position))
             .collect();
 
         construct(ls.iter().map(|s| s.to_owned()), headers)
@@ -215,7 +215,7 @@ fn parse_separated_columns<'a>(
     let parse_without_headers = |ls: Vec<&str>| {
         let num_columns = ls.iter().map(|r| r.len()).max().unwrap_or(0);
 
-        let headers = (1..=num_columns)
+        let headers = (0..=num_columns)
             .map(|i| format!("column{i}"))
             .collect::<Vec<String>>();
         collect(headers, ls.into_iter(), separator)
@@ -370,9 +370,9 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                vec![owned("column1", "a"), owned("column2", "b")],
-                vec![owned("column1", "1"), owned("column2", "2")],
-                vec![owned("column1", "3"), owned("column2", "4")]
+                vec![owned("column0", "a"), owned("column1", "b")],
+                vec![owned("column0", "1"), owned("column1", "2")],
+                vec![owned("column0", "3"), owned("column1", "4")]
             ]
         );
     }
@@ -484,25 +484,25 @@ mod tests {
             result,
             vec![
                 vec![
-                    owned("column1", "a multi-word value"),
-                    owned("column2", "b"),
-                    owned("column3", ""),
-                    owned("column4", "d"),
-                    owned("column5", "")
-                ],
-                vec![
-                    owned("column1", "1"),
+                    owned("column0", "a multi-word value"),
+                    owned("column1", "b"),
                     owned("column2", ""),
-                    owned("column3", "3-3"),
-                    owned("column4", "4"),
-                    owned("column5", "")
+                    owned("column3", "d"),
+                    owned("column4", "")
                 ],
                 vec![
+                    owned("column0", "1"),
+                    owned("column1", ""),
+                    owned("column2", "3-3"),
+                    owned("column3", "4"),
+                    owned("column4", "")
+                ],
+                vec![
+                    owned("column0", ""),
                     owned("column1", ""),
                     owned("column2", ""),
                     owned("column3", ""),
-                    owned("column4", ""),
-                    owned("column5", "last")
+                    owned("column4", "last")
                 ],
             ]
         );

--- a/crates/nu-command/tests/format_conversions/csv.rs
+++ b/crates/nu-command/tests/format_conversions/csv.rs
@@ -284,7 +284,7 @@ fn from_csv_text_skipping_headers_to_table() {
             r#"
                 open los_tres_amigos.txt
                 | from csv --noheaders
-                | get column3
+                | get column2
                 | length
             "#
         ));

--- a/crates/nu-command/tests/format_conversions/ssv.rs
+++ b/crates/nu-command/tests/format_conversions/ssv.rs
@@ -74,7 +74,7 @@ fn from_ssv_text_treating_first_line_as_data_with_flag() {
                 open oc_get_svc.txt
                 | from ssv --noheaders -a
                 | first
-                | get column1
+                | get column0
             "#
         ));
 
@@ -84,7 +84,7 @@ fn from_ssv_text_treating_first_line_as_data_with_flag() {
                 open oc_get_svc.txt
                 | from ssv --noheaders
                 | first
-                | get column1
+                | get column0
 
             "#
         ));

--- a/crates/nu-command/tests/format_conversions/tsv.rs
+++ b/crates/nu-command/tests/format_conversions/tsv.rs
@@ -207,7 +207,7 @@ fn from_tsv_text_skipping_headers_to_table() {
             r#"
                 open los_tres_amigos.txt
                 | from tsv --noheaders
-                | get column3
+                | get column2
                 | length
             "#
         ));


### PR DESCRIPTION
# Description

fixed #11678

The sub-commands of from command (`from {csv, tsv, ssv}`) name columns starting from index 0.
This behaviour is inconsistent with other commands such as `detect columns`.
This PR makes the subcommands index 0-based.

# User-Facing Changes

The subcommands (`from {csv, tsv, ssv}`) return a table with the columns starting at index 0 if no header data is passed.

```
~/Development/nushell> "foo bar baz" | from ssv -n -m 1 
╭───┬─────────┬─────────┬─────────╮
│ # │ column0 │ column1 │ column2 │
├───┼─────────┼─────────┼─────────┤
│ 0 │ foo     │ bar     │ baz     │
╰───┴─────────┴─────────┴─────────╯
~/Development/nushell> "foo,bar,baz" | from csv -n 
╭───┬─────────┬─────────┬─────────╮
│ # │ column0 │ column1 │ column2 │
├───┼─────────┼─────────┼─────────┤
│ 0 │ foo     │ bar     │ baz     │
╰───┴─────────┴─────────┴─────────╯
~/Development/nushell> "foo\tbar\tbaz" | from tsv -n
╭───┬─────────┬─────────┬─────────╮
│ # │ column0 │ column1 │ column2 │
├───┼─────────┼─────────┼─────────┤
│ 0 │ foo     │ bar     │ baz     │
╰───┴─────────┴─────────┴─────────╯
```


# Tests + Formatting

When I ran tests, `commands::touch::change_file_mtime_to_reference` failed with the following error.
The error also occurs in the master branch, so it's probably unrelated to these changes.
(maybe a problem with my dev environment)

```
$ toolkit check pr

~~~~~~~~

failures:

---- commands::touch::change_file_mtime_to_reference stdout ----
=== stderr

thread 'commands::touch::change_file_mtime_to_reference' panicked at crates/nu-command/tests/commands/touch.rs:298:9:
assertion `left == right` failed
  left: SystemTime { tv_sec: 1719149697, tv_nsec: 57576929 }
 right: SystemTime { tv_sec: 1719149697, tv_nsec: 78219489 }


failures:
    commands::touch::change_file_mtime_to_reference

test result: FAILED. 1533 passed; 1 failed; 32 ignored; 0 measured; 0 filtered out; finished in 10.87s

error: test failed, to rerun pass `-p nu-command --test main`
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :red_circle: `toolkit test`
- :black_circle: `toolkit test stdlib`
```

# After Submitting

nothing