### PR TITLE
Fix usage parsing for commands defined in CRLF (windows) files

### DIFF
--- a/crates/nu-protocol/src/engine/usage.rs
+++ b/crates/nu-protocol/src/engine/usage.rs
@@ -81,7 +81,9 @@ pub(super) fn build_usage(comment_lines: &[&[u8]]) -> (String, String) {
         usage.push_str(&comment_line);
     }
 
-    if let Some((brief_usage, extra_usage)) = usage.split_once("\n\n") {
+    if let Some((brief_usage, extra_usage)) = usage.split_once("\r\n\r\n") {
+        (brief_usage.to_string(), extra_usage.to_string())
+    } else if let Some((brief_usage, extra_usage)) = usage.split_once("\n\n") {
         (brief_usage.to_string(), extra_usage.to_string())
     } else {
         (usage, String::default())

--- a/tests/repl/test_parser.rs
+++ b/tests/repl/test_parser.rs
@@ -262,6 +262,22 @@ fn commands_have_usage() -> TestResult {
 }
 
 #[test]
+fn commands_from_crlf_source_have_short_usage() -> TestResult {
+    run_test_contains(
+        "# This is a test\r\n#\r\n# To see if I have cool usage\r\ndef foo [] {}\r\nscope commands | where name == foo | get usage.0",
+        "This is a test",
+    )
+}
+
+#[test]
+fn commands_from_crlf_source_have_extra_usage() -> TestResult {
+    run_test_contains(
+        "# This is a test\r\n#\r\n# To see if I have cool usage\r\ndef foo [] {}\r\nscope commands | where name == foo | get extra_usage.0",
+        "To see if I have cool usage",
+    )
+}
+
+#[test]
 fn equals_separates_long_flag() -> TestResult {
     run_test(
         r#"'nushell' | fill --alignment right --width=10 --character='-'"#,


### PR DESCRIPTION
Fixes nushell/nushell#13207

# Description
This fixes the parsing of command usage when that command comes from a file with CRLF line endings.

See nushell/nushell#13207 for more details.

# User-Facing Changes
Users on Windows will get correct autocompletion for `std` commands.
