### PR TITLE
Define keywords

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/break_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/break_.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::CommandType;
 
 #[derive(Clone)]
 pub struct Break;
@@ -16,6 +17,15 @@ impl Command for Break {
         Signature::build("break")
             .input_output_types(vec![(Type::Nothing, Type::Nothing)])
             .category(Category::Core)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/continue_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/continue_.rs
@@ -1,4 +1,5 @@
 use nu_engine::command_prelude::*;
+use nu_protocol::engine::CommandType;
 
 #[derive(Clone)]
 pub struct Continue;
@@ -18,6 +19,14 @@ impl Command for Continue {
             .category(Category::Core)
     }
 
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
+    }
     fn run(
         &self,
         _engine_state: &EngineState,

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::{did_you_mean, engine::CommandType};
+use nu_protocol::did_you_mean;
 
 #[derive(Clone)]
 pub struct HideEnv;
@@ -27,15 +27,6 @@ impl Command for HideEnv {
 
     fn usage(&self) -> &str {
         "Hide environment variables in the current scope."
-    }
-
-    fn extra_usage(&self) -> &str {
-        r#"This command is a parser keyword. For details, check:
-  https://www.nushell.sh/book/thinking_in_nu.html"#
-    }
-
-    fn command_type(&self) -> CommandType {
-        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/hide_env.rs
+++ b/crates/nu-cmd-lang/src/core_commands/hide_env.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::did_you_mean;
+use nu_protocol::{did_you_mean, engine::CommandType};
 
 #[derive(Clone)]
 pub struct HideEnv;
@@ -27,6 +27,15 @@ impl Command for HideEnv {
 
     fn usage(&self) -> &str {
         "Hide environment variables in the current scope."
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/if_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/if_.rs
@@ -2,7 +2,7 @@ use nu_engine::{
     command_prelude::*, get_eval_block, get_eval_expression, get_eval_expression_with_input,
 };
 use nu_protocol::{
-    engine::StateWorkingSet,
+    engine::{CommandType, StateWorkingSet},
     eval_const::{eval_const_subexpression, eval_constant, eval_constant_with_input},
 };
 
@@ -39,6 +39,15 @@ impl Command for If {
                 "Expression or block to run when the condition is false.",
             )
             .category(Category::Core)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn is_const(&self) -> bool {

--- a/crates/nu-cmd-lang/src/core_commands/loop_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/loop_.rs
@@ -1,4 +1,5 @@
 use nu_engine::{command_prelude::*, get_eval_block};
+use nu_protocol::engine::CommandType;
 
 #[derive(Clone)]
 pub struct Loop;
@@ -18,6 +19,15 @@ impl Command for Loop {
             .allow_variants_without_examples(true)
             .required("block", SyntaxShape::Block, "Block to loop.")
             .category(Category::Core)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/match_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/match_.rs
@@ -1,7 +1,7 @@
 use nu_engine::{
     command_prelude::*, get_eval_block, get_eval_expression, get_eval_expression_with_input,
 };
-use nu_protocol::engine::Matcher;
+use nu_protocol::engine::{CommandType, Matcher};
 
 #[derive(Clone)]
 pub struct Match;
@@ -25,6 +25,15 @@ impl Command for Match {
                 "Block to run if check succeeds.",
             )
             .category(Category::Core)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/scope/command.rs
+++ b/crates/nu-cmd-lang/src/core_commands/scope/command.rs
@@ -1,5 +1,4 @@
 use nu_engine::{command_prelude::*, get_full_help};
-use nu_protocol::engine::CommandType;
 
 #[derive(Clone)]
 pub struct Scope;
@@ -18,10 +17,6 @@ impl Command for Scope {
 
     fn usage(&self) -> &str {
         "Commands for getting info about what is in scope."
-    }
-
-    fn command_type(&self) -> CommandType {
-        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/try_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/try_.rs
@@ -1,5 +1,5 @@
 use nu_engine::{command_prelude::*, get_eval_block, EvalBlockFn};
-use nu_protocol::engine::Closure;
+use nu_protocol::engine::{Closure, CommandType};
 
 #[derive(Clone)]
 pub struct Try;
@@ -29,6 +29,15 @@ impl Command for Try {
                 "Closure to run if try block fails.",
             )
             .category(Category::Core)
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-cmd-lang/src/core_commands/while_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/while_.rs
@@ -1,4 +1,5 @@
 use nu_engine::{command_prelude::*, get_eval_block, get_eval_expression};
+use nu_protocol::engine::CommandType;
 
 #[derive(Clone)]
 pub struct While;
@@ -27,6 +28,15 @@ impl Command for While {
 
     fn search_terms(&self) -> Vec<&str> {
         vec!["loop"]
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-command/src/env/export_env.rs
+++ b/crates/nu-command/src/env/export_env.rs
@@ -1,4 +1,5 @@
 use nu_engine::{command_prelude::*, get_eval_block, redirect_env};
+use nu_protocol::engine::CommandType;
 
 #[derive(Clone)]
 pub struct ExportEnv;
@@ -21,6 +22,15 @@ impl Command for ExportEnv {
 
     fn usage(&self) -> &str {
         "Run a block and preserve its environment in a current scope."
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-command/src/env/source_env.rs
+++ b/crates/nu-command/src/env/source_env.rs
@@ -2,6 +2,7 @@ use nu_engine::{
     command_prelude::*, find_in_dirs_env, get_dirs_var_from_call, get_eval_block_with_early_return,
     redirect_env,
 };
+use nu_protocol::engine::CommandType;
 use std::path::PathBuf;
 
 /// Source a file for environment variables.
@@ -26,6 +27,15 @@ impl Command for SourceEnv {
 
     fn usage(&self) -> &str {
         "Source the environment from a source file into the current environment."
+    }
+
+    fn extra_usage(&self) -> &str {
+        r#"This command is a parser keyword. For details, check:
+  https://www.nushell.sh/book/thinking_in_nu.html"#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn run(

--- a/crates/nu-command/src/filters/where_.rs
+++ b/crates/nu-command/src/filters/where_.rs
@@ -1,5 +1,5 @@
 use nu_engine::{command_prelude::*, ClosureEval};
-use nu_protocol::engine::Closure;
+use nu_protocol::engine::{Closure, CommandType};
 
 #[derive(Clone)]
 pub struct Where;
@@ -17,6 +17,10 @@ impl Command for Where {
         r#"This command works similar to 'filter' but allows extra shorthands for working with
 tables, known as "row conditions". On the other hand, reading the condition from a variable is
 not supported."#
+    }
+
+    fn command_type(&self) -> CommandType {
+        CommandType::Keyword
     }
 
     fn signature(&self) -> nu_protocol::Signature {

--- a/crates/nu-parser/src/parse_keywords.rs
+++ b/crates/nu-parser/src/parse_keywords.rs
@@ -42,32 +42,44 @@ use crate::{
 };
 
 /// These parser keywords can be aliased
-pub const ALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[b"overlay hide", b"overlay new", b"overlay use"];
+pub const ALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[
+    b"if",
+    b"match",
+    b"try",
+    b"overlay",
+    b"overlay hide",
+    b"overlay new",
+    b"overlay use",
+];
 
 pub const RESERVED_VARIABLE_NAMES: [&str; 3] = ["in", "nu", "env"];
 
 /// These parser keywords cannot be aliased (either not possible, or support not yet added)
 pub const UNALIASABLE_PARSER_KEYWORDS: &[&[u8]] = &[
-    b"export",
-    b"def",
-    b"export def",
-    b"for",
-    b"extern",
-    b"export extern",
     b"alias",
-    b"export alias",
-    b"export-env",
+    b"const",
+    b"def",
+    b"extern",
     b"module",
     b"use",
+    b"export",
+    b"export alias",
+    b"export const",
+    b"export def",
+    b"export extern",
+    b"export module",
     b"export use",
-    b"hide",
-    // b"overlay",
-    // b"overlay hide",
-    // b"overlay new",
-    // b"overlay use",
+    b"for",
+    b"loop",
+    b"while",
+    b"return",
+    b"break",
+    b"continue",
     b"let",
-    b"const",
     b"mut",
+    b"hide",
+    b"export-env",
+    b"source-env",
     b"source",
     b"where",
     b"register",

--- a/crates/nu-parser/src/parser.rs
+++ b/crates/nu-parser/src/parser.rs
@@ -934,15 +934,12 @@ pub fn parse_internal_call(
     let output = signature.get_output_type();
 
     // storing the var ID for later due to borrowing issues
-    let lib_dirs_var_id = if decl.is_builtin() {
-        match decl.name() {
-            "use" | "overlay use" | "source-env" | "nu-check" => {
-                find_dirs_var(working_set, LIB_DIRS_VAR)
-            }
-            _ => None,
+    let lib_dirs_var_id = match decl.name() {
+        "use" | "overlay use" | "source-env" if decl.is_keyword() => {
+            find_dirs_var(working_set, LIB_DIRS_VAR)
         }
-    } else {
-        None
+        "nu-check" if decl.is_builtin() => find_dirs_var(working_set, LIB_DIRS_VAR),
+        _ => None,
     };
 
     // The index into the positional parameter in the definition


### PR DESCRIPTION
# Description
Some commands in `nu-cmd-lang` are not classified as keywords even though they should be.

# User-Facing Changes
In the output of `which`, `scope commands`, and `help commands`, some commands will now have a `type` of `keyword` instead of `built-in`.
