### PR TITLE
Fix `do` signature

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/do_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/do_.rs
@@ -23,11 +23,7 @@ impl Command for Do {
 
     fn signature(&self) -> Signature {
         Signature::build("do")
-            .required(
-                "closure",
-                SyntaxShape::OneOf(vec![SyntaxShape::Closure(None), SyntaxShape::Any]),
-                "The closure to run.",
-            )
+            .required("closure", SyntaxShape::Closure(None), "The closure to run.")
             .input_output_types(vec![(Type::Any, Type::Any)])
             .switch(
                 "ignore-errors",

--- a/crates/nu-std/tests/test_asserts.nu
+++ b/crates/nu-std/tests/test_asserts.nu
@@ -38,8 +38,8 @@ def assert_error [] {
     assert error $failing_code
 
     let good_code = {|| }
-    let assert_error_raised = (try { do assert $good_code; false } catch { true })
-    assert $assert_error_raised "The assert error should raise an error if there is no error in the executed code."
+    let assert_error_raised = (try { assert error $good_code; false } catch { true })
+    assert $assert_error_raised "The assert error should be false if there is no error in the executed code."
 }
 
 #[test]


### PR DESCRIPTION
Recommend holding until after #13125 is fully digested and *possibly* until 0.96.

# Description

Fixes one of the issues described in #13125 

The `do` signature included a `SyntaxShape:Any` as one of the possible first-positional types.  This is incorrect.  `do` only takes a closure as a positional.  This had the result of:

1. Moving what should have been a parser error to evaluation-time

   ## Before

   ```nu
   > do 1
   Error: nu::shell::cant_convert

     × Can't convert to Closure.
      ╭─[entry #26:1:4]
    1 │ do 1
      ·    ┬
      ·    ╰── can't convert int to Closure
      ╰────
   ```

   ## After

   ```nu
   > do 1
   Error: nu::parser::parse_mismatch

     × Parse mismatch during operation.
      ╭─[entry #5:1:4]
    1 │ do 1
      ·    ┬
      ·    ╰── expected block, closure or record
      ╰────
   ```  

2. Masking a bad test in `std assert`

This is a bit convoluted, but `std assert` tests included testing `assert error` to make sure it:

* Asserts on bad code
* Doesn't assert on good code

The good-code test was broken, and was essentially bad-code (really bad-code) that wasn't getting caught due to the bad signature.

Fixing this resulted in *parse time* failures on every call to `test_asserts` (not something that particular test was designed to handle.

This PR also fixes the test case to properly evaluate `std assert error` against a good code path.

# User-Facing Changes

* Error-type returned (possible breaking change?)

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A