### PR TITLE
Use `IntoValue` and `FromValue` derive macros in `nu_plugin_example` for example usage

### DIFF
--- a/crates/nu_plugin_example/src/commands/two.rs
+++ b/crates/nu_plugin_example/src/commands/two.rs
@@ -1,5 +1,5 @@
 use nu_plugin::{EngineInterface, EvaluatedCall, SimplePluginCommand};
-use nu_protocol::{record, Category, LabeledError, Signature, SyntaxShape, Value};
+use nu_protocol::{Category, IntoValue, LabeledError, Signature, SyntaxShape, Value};
 
 use crate::ExamplePlugin;
 
@@ -38,14 +38,22 @@ impl SimplePluginCommand for Two {
     ) -> Result<Value, LabeledError> {
         plugin.print_values(2, call, input)?;
 
+        // Use the IntoValue derive macro and trait to easily design output data.
+        #[derive(IntoValue)]
+        struct Output {
+            one: i64,
+            two: i64,
+            three: i64,
+        }
+
         let vals = (0..10i64)
             .map(|i| {
-                let record = record! {
-                    "one" => Value::int(i, call.head),
-                    "two" => Value::int(2 * i, call.head),
-                    "three" => Value::int(3 * i, call.head),
-                };
-                Value::record(record, call.head)
+                Output {
+                    one: i,
+                    two: 2 * i,
+                    three: 3 * i,
+                }
+                .into_value(call.head)
             })
             .collect();
 

--- a/tests/plugins/config.rs
+++ b/tests/plugins/config.rs
@@ -1,28 +1,6 @@
 use nu_test_support::nu_with_plugins;
 
 #[test]
-fn closure() {
-    let actual = nu_with_plugins!(
-        cwd: "tests",
-        plugin: ("nu_plugin_example"),
-        r#"
-            $env.env_value = "value from env"
-
-            $env.config = {
-                plugins: {
-                    example: {||
-                        $env.env_value
-                    }
-                }
-            }
-            example config
-        "#
-    );
-
-    assert!(actual.out.contains("value from env"));
-}
-
-#[test]
 fn none() {
     let actual = nu_with_plugins!(
         cwd: "tests",
@@ -34,7 +12,7 @@ fn none() {
 }
 
 #[test]
-fn record() {
+fn some() {
     let actual = nu_with_plugins!(
         cwd: "tests",
         plugin: ("nu_plugin_example"),
@@ -42,8 +20,11 @@ fn record() {
             $env.config = {
                 plugins: {
                     example: {
-                        key1: "value"
-                        key2: "other"
+                        path: "some/path",
+                        nested: {
+                            bool: true,
+                            string: "Hello Example!"
+                        }
                     }
                 }
             }
@@ -51,6 +32,6 @@ fn record() {
         "#
     );
 
-    assert!(actual.out.contains("value"));
-    assert!(actual.out.contains("other"));
+    assert!(actual.out.contains("some/path"));
+    assert!(actual.out.contains("Hello Example!"));
 }


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
The derive macros provided by #13031 are very useful for plugin authors. In this PR I made use of these macros for two commands.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
This Example usage could be highlighted in the changelog for plugin authors as this is probably very useful for them.
