### PR TITLE
Update and add ls examples

### DIFF
--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -175,18 +175,30 @@ impl Command for Ls {
             },
             Example {
                 description: "List files and directories whose name do not contain 'bar'",
-                example: "ls -s | where name !~ bar",
+                example: "ls | where name !~ bar",
                 result: None,
             },
             Example {
-                description: "List all dirs in your home directory",
+                description: "List the full path of all dirs in your home directory",
                 example: "ls -a ~ | where type == dir",
                 result: None,
             },
             Example {
                 description:
-                    "List all dirs in your home directory which have not been modified in 7 days",
+                    "List only the names (not paths) of all dirs in your home directory which have not been modified in 7 days",
                 example: "ls -as ~ | where type == dir and modified < ((date now) - 7day)",
+                result: None,
+            },
+            Example {
+                description:
+                    "Recursively list all files and subdirectories under the current directory using a glob pattern",
+                example: "ls -a **/*",
+                result: None,
+            },
+            Example {
+                description:
+                    "Recursively list *.rs and *.toml files using the glob command",
+                example: "ls ...(glob **/*.{rs,toml})",
                 result: None,
             },
             Example {


### PR DESCRIPTION
# Description

Based on #13219, added several examples to `ls` doc to demonstrate recursive directory listings.  List of changes in this PR:

* Add example for `ls **/*` to demonstrate recursive listing using glob pattern
* Add example for `ls ...(glob )`... to demonstrate recursive listing using glob command
* Remove `-s` from an example where it had no use (since it was based on the current directory and was not recursive)
* Update the description of `ls -a ~ `... to clarify that it lists the full path of directories
* Update the description of `ls -as ~ `... (the difference being the `-s`) to clarify that it lists only the filenames, not paths.


# User-Facing Changes

Help only

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

N/A