### PR TITLE
`for` - remove deprecated `--numbered`

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/for_.rs
+++ b/crates/nu-cmd-lang/src/core_commands/for_.rs
@@ -1,6 +1,5 @@
 use nu_engine::{command_prelude::*, get_eval_block, get_eval_expression};
 use nu_protocol::engine::CommandType;
-use nu_protocol::ParseWarning;
 
 #[derive(Clone)]
 pub struct For;
@@ -29,11 +28,6 @@ impl Command for For {
                 "Range of the loop.",
             )
             .required("block", SyntaxShape::Block, "The block to run.")
-            .switch(
-                "numbered",
-                "DEPRECATED: return a numbered item ($it.index and $it.item)",
-                Some('n'),
-            )
             .creates_scope()
             .category(Category::Core)
     }
@@ -78,22 +72,6 @@ impl Command for For {
 
         let value = eval_expression(engine_state, stack, keyword_expr)?;
 
-        let numbered = call.has_flag(engine_state, stack, "numbered")?;
-        if numbered {
-            nu_protocol::report_error_new(
-                engine_state,
-                &ParseWarning::DeprecatedWarning {
-                    old_command: "--numbered/-n".into(),
-                    new_suggestion: "use `enumerate`".into(),
-                    span: call
-                        .get_named_arg("numbered")
-                        .expect("`get_named_arg` found `--numbered` but still failed")
-                        .span,
-                    url: "See `help for` examples".into(),
-                },
-            );
-        }
-
         let ctrlc = engine_state.ctrlc.clone();
         let engine_state = engine_state.clone();
         let block = engine_state.get_block(block_id);
@@ -103,7 +81,7 @@ impl Command for For {
         let span = value.span();
         match value {
             Value::List { vals, .. } => {
-                for (idx, x) in vals.into_iter().enumerate() {
+                for x in vals.into_iter() {
                     if nu_utils::ctrl_c::was_pressed(&ctrlc) {
                         break;
                     }
@@ -112,20 +90,7 @@ impl Command for For {
                     // a different set of environment variables.
                     // Hence, a 'cd' in the first loop won't affect the next loop.
 
-                    stack.add_var(
-                        var_id,
-                        if numbered {
-                            Value::record(
-                                record! {
-                                    "index" => Value::int(idx as i64, head),
-                                    "item" => x,
-                                },
-                                head,
-                            )
-                        } else {
-                            x
-                        },
-                    );
+                    stack.add_var(var_id, x);
 
                     match eval_block(&engine_state, stack, block, PipelineData::empty()) {
                         Err(ShellError::Break { .. }) => {
@@ -151,21 +116,8 @@ impl Command for For {
                 }
             }
             Value::Range { val, .. } => {
-                for (idx, x) in val.into_range_iter(span, ctrlc).enumerate() {
-                    stack.add_var(
-                        var_id,
-                        if numbered {
-                            Value::record(
-                                record! {
-                                    "index" => Value::int(idx as i64, head),
-                                    "item" => x,
-                                },
-                                head,
-                            )
-                        } else {
-                            x
-                        },
-                    );
+                for x in val.into_range_iter(span, ctrlc) {
+                    stack.add_var(var_id, x);
 
                     match eval_block(&engine_state, stack, block, PipelineData::empty()) {
                         Err(ShellError::Break { .. }) => {


### PR DESCRIPTION
# Description

Complete the `--numbered` removal that was started with the deprecation in #13112.

# User-Facing Changes

Breaking change - Use `| enumerate` in place of `--numbered` as shown in the help example

# Tests + Formatting

- :green_circle: `toolkit fmt`
- :green_circle: `toolkit clippy`
- :green_circle: `toolkit test`
- :green_circle: `toolkit test stdlib`

# After Submitting

Searched online doc for `--numbered` to ensure no other usage needed to be updated.