### PR TITLE
Add `char nul`

### DIFF
--- a/crates/nu-command/src/strings/char_.rs
+++ b/crates/nu-command/src/strings/char_.rs
@@ -19,6 +19,9 @@ static CHAR_MAP: Lazy<IndexMap<&'static str, String>> = Lazy::new(|| {
         // These are some regular characters that either can't be used or
         // it's just easier to use them like this.
 
+        "nul" => '\x00'.to_string(),                                // nul character, 0x00
+        "null_byte" => '\x00'.to_string(),                          // nul character, 0x00
+        "zero_byte" => '\x00'.to_string(),                          // nul character, 0x00
         // This are the "normal" characters section
         "newline" => '\n'.to_string(),
         "enter" => '\n'.to_string(),


### PR DESCRIPTION
# Description

Adds `char nul`, `char null_byte` and `char zero_byte` named characters. All of them generate 0x00 byte.

# User-Facing Changes
Three new named characters are added:
 * `char nul` - generates 0x00 byte
 * `char null_byte` - generates 0x00 byte
 * `char zero_byte` - generates 0x00 byte
