### PR TITLE
Use pipeline data for http post|put|patch|delete commands.

### DIFF
--- a/crates/nu-cmd-extra/src/extra/formats/to/html.rs
+++ b/crates/nu-cmd-extra/src/extra/formats/to/html.rs
@@ -368,6 +368,7 @@ fn theme_demo(span: Span) -> PipelineData {
         .collect();
     Value::list(result, span).into_pipeline_data_with_metadata(PipelineMetadata {
         data_source: DataSource::HtmlThemes,
+        content_type: None,
     })
 }
 

--- a/crates/nu-cmd-lang/src/core_commands/collect.rs
+++ b/crates/nu-cmd-lang/src/core_commands/collect.rs
@@ -50,6 +50,7 @@ is particularly large, this can cause high memory usage."#
             // check where some input came from.
             Some(PipelineMetadata {
                 data_source: DataSource::FilePath(_),
+                content_type: None,
             }) => None,
             other => other,
         };

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -80,19 +80,23 @@ impl Command for Metadata {
                     match x {
                         PipelineMetadata {
                             data_source: DataSource::Ls,
+                            ..
                         } => record.push("source", Value::string("ls", head)),
                         PipelineMetadata {
                             data_source: DataSource::HtmlThemes,
+                            ..
                         } => record.push("source", Value::string("into html --list", head)),
                         PipelineMetadata {
                             data_source: DataSource::FilePath(path),
+                            ..
                         } => record.push(
                             "source",
                             Value::string(path.to_string_lossy().to_string(), head),
                         ),
-                        PipelineMetadata {
-                            data_source: DataSource::ContentType(content_type),
-                        } => record.push("content_type", Value::string(content_type, head)),
+                        _ => {}
+                    }
+                    if let Some(ref content_type) = x.content_type {
+                        record.push("content_type", Value::string(content_type, head));
                     }
                 }
 
@@ -136,19 +140,23 @@ fn build_metadata_record(arg: &Value, metadata: Option<&PipelineMetadata>, head:
         match x {
             PipelineMetadata {
                 data_source: DataSource::Ls,
+                ..
             } => record.push("source", Value::string("ls", head)),
             PipelineMetadata {
                 data_source: DataSource::HtmlThemes,
+                ..
             } => record.push("source", Value::string("into html --list", head)),
             PipelineMetadata {
                 data_source: DataSource::FilePath(path),
+                ..
             } => record.push(
                 "source",
                 Value::string(path.to_string_lossy().to_string(), head),
             ),
-            PipelineMetadata {
-                data_source: DataSource::ContentType(content_type),
-            } => record.push("content_type", Value::string(content_type, head)),
+            _ => {}
+        }
+        if let Some(ref content_type) = x.content_type {
+            record.push("content_type", Value::string(content_type, head));
         }
     }
 

--- a/crates/nu-command/src/debug/metadata.rs
+++ b/crates/nu-command/src/debug/metadata.rs
@@ -90,6 +90,9 @@ impl Command for Metadata {
                             "source",
                             Value::string(path.to_string_lossy().to_string(), head),
                         ),
+                        PipelineMetadata {
+                            data_source: DataSource::ContentType(content_type),
+                        } => record.push("content_type", Value::string(content_type, head)),
                     }
                 }
 
@@ -143,6 +146,9 @@ fn build_metadata_record(arg: &Value, metadata: Option<&PipelineMetadata>, head:
                 "source",
                 Value::string(path.to_string_lossy().to_string(), head),
             ),
+            PipelineMetadata {
+                data_source: DataSource::ContentType(content_type),
+            } => record.push("content_type", Value::string(content_type, head)),
         }
     }
 

--- a/crates/nu-command/src/debug/metadata_set.rs
+++ b/crates/nu-command/src/debug/metadata_set.rs
@@ -46,6 +46,7 @@ impl Command for MetadataSet {
             (Some(path), false) => {
                 let metadata = PipelineMetadata {
                     data_source: DataSource::FilePath(path.into()),
+                    content_type: None,
                 };
                 Ok(input.into_pipeline_data_with_metadata(
                     head,
@@ -56,6 +57,7 @@ impl Command for MetadataSet {
             (None, true) => {
                 let metadata = PipelineMetadata {
                     data_source: DataSource::Ls,
+                    content_type: None,
                 };
                 Ok(input.into_pipeline_data_with_metadata(
                     head,

--- a/crates/nu-command/src/filesystem/ls.rs
+++ b/crates/nu-command/src/filesystem/ls.rs
@@ -122,6 +122,7 @@ impl Command for Ls {
                     ctrl_c,
                     PipelineMetadata {
                         data_source: DataSource::Ls,
+                        content_type: None,
                     },
                 )),
             Some(pattern) => {
@@ -145,6 +146,7 @@ impl Command for Ls {
                         ctrl_c,
                         PipelineMetadata {
                             data_source: DataSource::Ls,
+                            content_type: None,
                         },
                     ))
             }

--- a/crates/nu-command/src/filesystem/open.rs
+++ b/crates/nu-command/src/filesystem/open.rs
@@ -147,6 +147,7 @@ impl Command for Open {
                         ByteStream::file(file, call_span, ctrlc.clone()),
                         Some(PipelineMetadata {
                             data_source: DataSource::FilePath(path.to_path_buf()),
+                            content_type: None,
                         }),
                     );
 

--- a/crates/nu-command/src/formats/from/json.rs
+++ b/crates/nu-command/src/formats/from/json.rs
@@ -266,7 +266,9 @@ fn convert_string_to_value_strict(string_input: &str, span: Span) -> Result<Valu
 fn update_metadata(metadata: Option<PipelineMetadata>) -> Option<PipelineMetadata> {
     metadata
         .map(|md| md.with_content_type(Some("application/json".into())))
-        .or_else(|| Some(PipelineMetadata::default().with_content_type(Some("application/json".into()))))
+        .or_else(|| {
+            Some(PipelineMetadata::default().with_content_type(Some("application/json".into())))
+        })
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -64,7 +64,7 @@ impl Command for ToJson {
                 let res = Value::string(serde_json_string, span);
                 let metadata = PipelineMetadata {
                     data_source: nu_protocol::DataSource::None,
-                    content_type: None,
+                    content_type: Some("application/json".to_string()),
                 };
                 Ok(PipelineData::Value(res, Some(metadata)))
             }

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -63,7 +63,8 @@ impl Command for ToJson {
             Ok(serde_json_string) => {
                 let res = Value::string(serde_json_string, span);
                 let metadata = PipelineMetadata {
-                    data_source: nu_protocol::DataSource::ContentType("application/json".to_string())
+                    data_source: nu_protocol::DataSource::None,
+                    content_type: None,
                 };
                 Ok(PipelineData::Value(res, Some(metadata)))
             }

--- a/crates/nu-command/src/formats/to/json.rs
+++ b/crates/nu-command/src/formats/to/json.rs
@@ -1,5 +1,5 @@
 use nu_engine::command_prelude::*;
-use nu_protocol::ast::PathMember;
+use nu_protocol::{ast::PathMember, PipelineMetadata};
 
 #[derive(Clone)]
 pub struct ToJson;
@@ -61,7 +61,11 @@ impl Command for ToJson {
 
         match json_result {
             Ok(serde_json_string) => {
-                Ok(Value::string(serde_json_string, span).into_pipeline_data())
+                let res = Value::string(serde_json_string, span);
+                let metadata = PipelineMetadata {
+                    data_source: nu_protocol::DataSource::ContentType("application/json".to_string())
+                };
+                Ok(PipelineData::Value(res, Some(metadata)))
             }
             _ => Ok(Value::error(
                 ShellError::CantConvert {

--- a/crates/nu-command/src/formats/to/text.rs
+++ b/crates/nu-command/src/formats/to/text.rs
@@ -1,6 +1,8 @@
 use chrono_humanize::HumanTime;
 use nu_engine::command_prelude::*;
-use nu_protocol::{format_duration, format_filesize_from_conf, ByteStream, Config};
+use nu_protocol::{
+    format_duration, format_filesize_from_conf, ByteStream, Config, PipelineMetadata,
+};
 
 const LINE_ENDING: &str = if cfg!(target_os = "windows") {
     "\r\n"
@@ -37,10 +39,14 @@ impl Command for ToText {
         let input = input.try_expand_range()?;
 
         match input {
-            PipelineData::Empty => Ok(Value::string(String::new(), span).into_pipeline_data()),
+            PipelineData::Empty => Ok(Value::string(String::new(), span)
+                .into_pipeline_data_with_metadata(update_metadata(None))),
             PipelineData::Value(value, ..) => {
                 let str = local_into_string(value, LINE_ENDING, engine_state.get_config());
-                Ok(Value::string(str, span).into_pipeline_data())
+                Ok(
+                    Value::string(str, span)
+                        .into_pipeline_data_with_metadata(update_metadata(None)),
+                )
             }
             PipelineData::ListStream(stream, meta) => {
                 let span = stream.span();
@@ -57,10 +63,12 @@ impl Command for ToText {
                         engine_state.ctrlc.clone(),
                         ByteStreamType::String,
                     ),
-                    meta,
+                    update_metadata(meta),
                 ))
             }
-            PipelineData::ByteStream(stream, meta) => Ok(PipelineData::ByteStream(stream, meta)),
+            PipelineData::ByteStream(stream, meta) => {
+                Ok(PipelineData::ByteStream(stream, update_metadata(meta)))
+            }
         }
     }
 
@@ -122,6 +130,14 @@ fn local_into_string(value: Value, separator: &str, config: &Config) -> String {
             .map(|val| local_into_string(val, separator, config))
             .unwrap_or_else(|_| format!("<{}>", val.type_name())),
     }
+}
+
+fn update_metadata(metadata: Option<PipelineMetadata>) -> Option<PipelineMetadata> {
+    metadata
+        .map(|md| md.with_content_type(Some("text/plain".to_string())))
+        .or_else(|| {
+            Some(PipelineMetadata::default().with_content_type(Some("text/plain".to_string())))
+        })
 }
 
 #[cfg(test)]

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -213,7 +213,7 @@ pub fn send_request2(
 
     match http_body {
         HttpBody::None => {
-            return send_cancellable_request(&request_url, Box::new(|| request.call()), ctrl_c);
+            send_cancellable_request(&request_url, Box::new(|| request.call()), ctrl_c)
         }
         HttpBody::ByteStream(byte_stream) => {
             let bytes = byte_stream.into_bytes()?;

--- a/crates/nu-command/src/network/http/client.rs
+++ b/crates/nu-command/src/network/http/client.rs
@@ -187,23 +187,8 @@ pub enum HttpBody {
     None,
 }
 
-pub fn send_request(
-    request: Request,
-    body: Option<Value>,
-    content_type: Option<String>,
-    ctrl_c: Option<Arc<AtomicBool>>,
-) -> Result<Response, ShellErrorOrRequestError> {
-    let body = if let Some(body) = body {
-        HttpBody::Value(body)
-    } else {
-        HttpBody::None
-    };
-
-    send_request2(request, body, content_type, ctrl_c)
-}
-
 // remove once all commands have been migrated
-pub fn send_request2(
+pub fn send_request(
     request: Request,
     http_body: HttpBody,
     content_type: Option<String>,

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -163,7 +163,7 @@ fn run_delete(
     input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
     let (data, maybe_metadata) = call
-        .opt::<Value>(engine_state, stack, 1)?
+        .get_flag::<Value>(engine_state, stack, "data")?
         .map(|v| (HttpBody::Value(v), None))
         .unwrap_or_else(|| match input {
             PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
@@ -175,16 +175,6 @@ fn run_delete(
     let content_type = call
         .get_flag(engine_state, stack, "content-type")?
         .or_else(|| maybe_metadata.and_then(|m| m.content_type));
-
-    if let HttpBody::None = data {
-        return Err(ShellError::GenericError {
-            error: "Data must be provided either through pipeline or positional argument".into(),
-            msg: "".into(),
-            span: Some(call.head),
-            help: None,
-            inner: vec![],
-        });
-    }
 
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
     check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
     request_add_authorization_header, request_add_custom_headers, request_handle_response,
-    request_set_timeout, send_request2, HttpBody, RequestFlags,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
 };
 use nu_engine::command_prelude::*;
 
@@ -224,7 +224,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request2(request.clone(), args.data, args.content_type, ctrl_c);
+    let response = send_request(request.clone(), args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/delete.rs
+++ b/crates/nu-command/src/network/http/delete.rs
@@ -1,7 +1,7 @@
 use crate::network::http::client::{
     check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
     request_add_authorization_header, request_add_custom_headers, request_handle_response,
-    request_set_timeout, send_request, RequestFlags,
+    request_set_timeout, send_request2, HttpBody, RequestFlags,
 };
 use nu_engine::command_prelude::*;
 
@@ -15,7 +15,7 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http delete")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .allow_variants_without_examples(true)
             .required(
                 "URL",
@@ -132,6 +132,11 @@ impl Command for SubCommand {
                     "http delete --content-type application/json --data { field: value } https://www.example.com",
                 result: None,
             },
+            Example {
+                description: "Perform an HTTP delete with JSON content from a pipeline to example.com",
+                example: "open foo.json | http delete https://www.example.com",
+                result: None,
+            },
         ]
     }
 }
@@ -139,7 +144,7 @@ impl Command for SubCommand {
 struct Arguments {
     url: Value,
     headers: Option<Value>,
-    data: Option<Value>,
+    data: HttpBody,
     content_type: Option<String>,
     raw: bool,
     insecure: bool,
@@ -155,13 +160,37 @@ fn run_delete(
     engine_state: &EngineState,
     stack: &mut Stack,
     call: &Call,
-    _input: PipelineData,
+    input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
+    let (data, maybe_metadata) = call
+        .opt::<Value>(engine_state, stack, 1)?
+        .map(|v| (HttpBody::Value(v), None))
+        .unwrap_or_else(|| match input {
+            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::ByteStream(byte_stream, metadata) => {
+                (HttpBody::ByteStream(byte_stream), metadata)
+            }
+            _ => (HttpBody::None, None),
+        });
+    let content_type = call
+        .get_flag(engine_state, stack, "content-type")?
+        .or_else(|| maybe_metadata.and_then(|m| m.content_type));
+
+    if let HttpBody::None = data {
+        return Err(ShellError::GenericError {
+            error: "Data must be provided either through pipeline or positional argument".into(),
+            msg: "".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
+    }
+
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,
         headers: call.get_flag(engine_state, stack, "headers")?,
-        data: call.get_flag(engine_state, stack, "data")?,
-        content_type: call.get_flag(engine_state, stack, "content-type")?,
+        data,
+        content_type,
         raw: call.has_flag(engine_state, stack, "raw")?,
         insecure: call.has_flag(engine_state, stack, "insecure")?,
         user: call.get_flag(engine_state, stack, "user")?,
@@ -195,7 +224,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request.clone(), args.data, args.content_type, ctrl_c);
+    let response = send_request2(request.clone(), args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/get.rs
+++ b/crates/nu-command/src/network/http/get.rs
@@ -5,6 +5,8 @@ use crate::network::http::client::{
 };
 use nu_engine::command_prelude::*;
 
+use super::client::HttpBody;
+
 #[derive(Clone)]
 pub struct SubCommand;
 
@@ -180,7 +182,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request.clone(), None, None, ctrl_c);
+    let response = send_request(request.clone(), HttpBody::None, None, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/head.rs
+++ b/crates/nu-command/src/network/http/head.rs
@@ -7,6 +7,8 @@ use nu_engine::command_prelude::*;
 
 use std::sync::{atomic::AtomicBool, Arc};
 
+use super::client::HttpBody;
+
 #[derive(Clone)]
 pub struct SubCommand;
 
@@ -156,7 +158,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request, None, None, ctrlc);
+    let response = send_request(request, HttpBody::None, None, ctrlc);
     check_response_redirection(redirect_mode, span, &response)?;
     request_handle_response_headers(span, response)
 }

--- a/crates/nu-command/src/network/http/options.rs
+++ b/crates/nu-command/src/network/http/options.rs
@@ -4,6 +4,8 @@ use crate::network::http::client::{
 };
 use nu_engine::command_prelude::*;
 
+use super::client::HttpBody;
+
 #[derive(Clone)]
 pub struct SubCommand;
 
@@ -159,7 +161,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request.clone(), None, None, ctrl_c);
+    let response = send_request(request.clone(), HttpBody::None, None, ctrl_c);
 
     // http options' response always showed in header, so we set full to true.
     // And `raw` is useless too because options method doesn't return body, here we set to true

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -1,9 +1,11 @@
 use crate::network::http::client::{
     check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
     request_add_authorization_header, request_add_custom_headers, request_handle_response,
-    request_set_timeout, send_request, RequestFlags,
+    request_set_timeout, RequestFlags,
 };
 use nu_engine::command_prelude::*;
+
+use super::client::{send_request2, HttpBody};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -15,10 +17,10 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http patch")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .allow_variants_without_examples(true)
             .required("URL", SyntaxShape::String, "The URL to post to.")
-            .required("data", SyntaxShape::Any, "The contents of the post body.")
+            .optional("data", SyntaxShape::Any, "The contents of the post body.")
             .named(
                 "user",
                 SyntaxShape::Any,
@@ -131,7 +133,7 @@ impl Command for SubCommand {
 struct Arguments {
     url: Value,
     headers: Option<Value>,
-    data: Value,
+    data: HttpBody,
     content_type: Option<String>,
     raw: bool,
     insecure: bool,
@@ -147,13 +149,37 @@ fn run_patch(
     engine_state: &EngineState,
     stack: &mut Stack,
     call: &Call,
-    _input: PipelineData,
+    input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
+    let (data, maybe_metadata) = call
+        .opt::<Value>(engine_state, stack, 1)?
+        .map(|v| (HttpBody::Value(v), None))
+        .unwrap_or_else(|| match input {
+            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::ByteStream(byte_stream, metadata) => {
+                (HttpBody::ByteStream(byte_stream), metadata)
+            }
+            _ => (HttpBody::None, None),
+        });
+    let content_type = call
+        .get_flag(engine_state, stack, "content-type")?
+        .or_else(|| maybe_metadata.and_then(|m| m.content_type));
+
+    if let HttpBody::None = data {
+        return Err(ShellError::GenericError {
+            error: "Data must be provided either through pipeline or positional argument".into(),
+            msg: "".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
+    }
+
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,
         headers: call.get_flag(engine_state, stack, "headers")?,
-        data: call.req(engine_state, stack, 1)?,
-        content_type: call.get_flag(engine_state, stack, "content-type")?,
+        data,
+        content_type,
         raw: call.has_flag(engine_state, stack, "raw")?,
         insecure: call.has_flag(engine_state, stack, "insecure")?,
         user: call.get_flag(engine_state, stack, "user")?,
@@ -187,7 +213,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request.clone(), Some(args.data), args.content_type, ctrl_c);
+    let response = send_request2(request.clone(), args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -1,11 +1,9 @@
 use crate::network::http::client::{
     check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
     request_add_authorization_header, request_add_custom_headers, request_handle_response,
-    request_set_timeout, RequestFlags,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
 };
 use nu_engine::command_prelude::*;
-
-use super::client::{send_request2, HttpBody};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -218,7 +216,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request2(request.clone(), args.data, args.content_type, ctrl_c);
+    let response = send_request(request.clone(), args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/patch.rs
+++ b/crates/nu-command/src/network/http/patch.rs
@@ -126,6 +126,11 @@ impl Command for SubCommand {
                 example: "http patch --content-type application/json https://www.example.com { field: value }",
                 result: None,
             },
+            Example {
+                description: "Patch JSON content from a pipeline to example.com",
+                example: "open foo.json | http patch https://www.example.com",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -124,6 +124,11 @@ impl Command for SubCommand {
                 example: "http post --content-type application/json https://www.example.com { field: value }",
                 result: None,
             },
+            Example {
+                description: "Post JSON content from a pipeline to example.com",
+                example: "open foo.json | http post https://www.example.com",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -1,11 +1,9 @@
 use crate::network::http::client::{
     check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
     request_add_authorization_header, request_add_custom_headers, request_handle_response,
-    request_set_timeout, HttpBody, RequestFlags,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
 };
 use nu_engine::command_prelude::*;
-
-use super::client::send_request2;
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -216,7 +214,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request2(request.clone(), args.data, args.content_type, ctrl_c);
+    let response = send_request(request.clone(), args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -20,7 +20,7 @@ impl Command for SubCommand {
             .input_output_types(vec![(Type::Any, Type::Any)])
             .allow_variants_without_examples(true)
             .required("URL", SyntaxShape::String, "The URL to post to.")
-            .optional("data", SyntaxShape::Any, "The contents of the post body. Required unless part of pipeline.")
+            .optional("data", SyntaxShape::Any, "The contents of the post body. Required unless part of a pipeline.")
             .named(
                 "user",
                 SyntaxShape::Any,
@@ -162,6 +162,20 @@ fn run_post(
     let content_type = call
         .get_flag(engine_state, stack, "content-type")?
         .or_else(|| maybe_metadata.and_then(|m| m.content_type));
+
+    match data {
+        HttpBody::None => {
+            return Err(ShellError::GenericError {
+                error: "Data must be provided either through pipeline or positional argument"
+                    .into(),
+                msg: "".into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            })
+        }
+        _ => (),
+    }
 
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,

--- a/crates/nu-command/src/network/http/post.rs
+++ b/crates/nu-command/src/network/http/post.rs
@@ -163,18 +163,14 @@ fn run_post(
         .get_flag(engine_state, stack, "content-type")?
         .or_else(|| maybe_metadata.and_then(|m| m.content_type));
 
-    match data {
-        HttpBody::None => {
-            return Err(ShellError::GenericError {
-                error: "Data must be provided either through pipeline or positional argument"
-                    .into(),
-                msg: "".into(),
-                span: Some(call.head),
-                help: None,
-                inner: vec![],
-            })
-        }
-        _ => (),
+    if let HttpBody::None = data {
+        return Err(ShellError::GenericError {
+            error: "Data must be provided either through pipeline or positional argument".into(),
+            msg: "".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
     }
 
     let args = Arguments {

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -160,18 +160,14 @@ fn run_put(
             _ => (HttpBody::None, None),
         });
 
-    match data {
-        HttpBody::None => {
-            return Err(ShellError::GenericError {
-                error: "Data must be provided either through pipeline or positional argument"
-                    .into(),
-                msg: "".into(),
-                span: Some(call.head),
-                help: None,
-                inner: vec![],
-            })
-        }
-        _ => (),
+    if let HttpBody::None = data {
+        return Err(ShellError::GenericError {
+            error: "Data must be provided either through pipeline or positional argument".into(),
+            msg: "".into(),
+            span: Some(call.head),
+            help: None,
+            inner: vec![],
+        });
     }
 
     let content_type = call

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -1,9 +1,11 @@
 use crate::network::http::client::{
     check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
     request_add_authorization_header, request_add_custom_headers, request_handle_response,
-    request_set_timeout, send_request, RequestFlags,
+    request_set_timeout, RequestFlags,
 };
 use nu_engine::command_prelude::*;
+
+use super::client::{send_request2, HttpBody};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -15,10 +17,10 @@ impl Command for SubCommand {
 
     fn signature(&self) -> Signature {
         Signature::build("http put")
-            .input_output_types(vec![(Type::Nothing, Type::Any)])
+            .input_output_types(vec![(Type::Any, Type::Any)])
             .allow_variants_without_examples(true)
             .required("URL", SyntaxShape::String, "The URL to post to.")
-            .required("data", SyntaxShape::Any, "The contents of the post body.")
+            .optional("data", SyntaxShape::Any, "The contents of the post body. Required unless part of a pipeline.")
             .named(
                 "user",
                 SyntaxShape::Any,
@@ -129,7 +131,7 @@ impl Command for SubCommand {
 struct Arguments {
     url: Value,
     headers: Option<Value>,
-    data: Value,
+    data: HttpBody,
     content_type: Option<String>,
     raw: bool,
     insecure: bool,
@@ -145,13 +147,42 @@ fn run_put(
     engine_state: &EngineState,
     stack: &mut Stack,
     call: &Call,
-    _input: PipelineData,
+    input: PipelineData,
 ) -> Result<PipelineData, ShellError> {
+    let (data, maybe_metadata) = call
+        .opt::<Value>(engine_state, stack, 1)?
+        .map(|v| (HttpBody::Value(v), None))
+        .unwrap_or_else(|| match input {
+            PipelineData::Value(v, metadata) => (HttpBody::Value(v), metadata),
+            PipelineData::ByteStream(byte_stream, metadata) => {
+                (HttpBody::ByteStream(byte_stream), metadata)
+            }
+            _ => (HttpBody::None, None),
+        });
+
+    match data {
+        HttpBody::None => {
+            return Err(ShellError::GenericError {
+                error: "Data must be provided either through pipeline or positional argument"
+                    .into(),
+                msg: "".into(),
+                span: Some(call.head),
+                help: None,
+                inner: vec![],
+            })
+        }
+        _ => (),
+    }
+
+    let content_type = call
+        .get_flag(engine_state, stack, "content-type")?
+        .or_else(|| maybe_metadata.and_then(|m| m.content_type));
+
     let args = Arguments {
         url: call.req(engine_state, stack, 0)?,
         headers: call.get_flag(engine_state, stack, "headers")?,
-        data: call.req(engine_state, stack, 1)?,
-        content_type: call.get_flag(engine_state, stack, "content-type")?,
+        data,
+        content_type,
         raw: call.has_flag(engine_state, stack, "raw")?,
         insecure: call.has_flag(engine_state, stack, "insecure")?,
         user: call.get_flag(engine_state, stack, "user")?,
@@ -185,7 +216,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request(request.clone(), Some(args.data), args.content_type, ctrl_c);
+    let response = send_request2(request.clone(), args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -1,11 +1,9 @@
 use crate::network::http::client::{
     check_response_redirection, http_client, http_parse_redirect_mode, http_parse_url,
     request_add_authorization_header, request_add_custom_headers, request_handle_response,
-    request_set_timeout, RequestFlags,
+    request_set_timeout, send_request, HttpBody, RequestFlags,
 };
 use nu_engine::command_prelude::*;
-
-use super::client::{send_request2, HttpBody};
 
 #[derive(Clone)]
 pub struct SubCommand;
@@ -217,7 +215,7 @@ fn helper(
     request = request_add_authorization_header(args.user, args.password, request);
     request = request_add_custom_headers(args.headers, request)?;
 
-    let response = send_request2(request.clone(), args.data, args.content_type, ctrl_c);
+    let response = send_request(request.clone(), args.data, args.content_type, ctrl_c);
 
     let request_flags = RequestFlags {
         raw: args.raw,

--- a/crates/nu-command/src/network/http/put.rs
+++ b/crates/nu-command/src/network/http/put.rs
@@ -124,6 +124,11 @@ impl Command for SubCommand {
                 example: "http put --content-type application/json https://www.example.com { field: value }",
                 result: None,
             },
+            Example {
+                description: "Put JSON content from a pipeline to example.com",
+                example: "open foo.json | http put https://www.example.com",
+                result: None,
+            },
         ]
     }
 }

--- a/crates/nu-command/src/viewers/table.rs
+++ b/crates/nu-command/src/viewers/table.rs
@@ -605,6 +605,7 @@ fn handle_row_stream(
         // First, `ls` sources:
         Some(PipelineMetadata {
             data_source: DataSource::Ls,
+            ..
         }) => {
             let config = get_config(input.engine_state, input.stack);
             let ls_colors_env_str = match input.stack.get_env_var(input.engine_state, "LS_COLORS") {
@@ -636,6 +637,7 @@ fn handle_row_stream(
         // Next, `to html -l` sources:
         Some(PipelineMetadata {
             data_source: DataSource::HtmlThemes,
+            ..
         }) => {
             stream.map(|mut value| {
                 if let Value::Record { val: record, .. } = &mut value {

--- a/crates/nu-command/tests/commands/network/http/delete.rs
+++ b/crates/nu-command/tests/commands/network/http/delete.rs
@@ -21,6 +21,25 @@ fn http_delete_is_success() {
 }
 
 #[test]
+fn http_delete_is_success_pipeline() {
+    let mut server = Server::new();
+
+    let _mock = server.mock("DELETE", "/").create();
+
+    let actual = nu!(pipeline(
+        format!(
+            r#"
+        "foo" | http delete {url}
+        "#,
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert!(actual.out.is_empty())
+}
+
+#[test]
 fn http_delete_failed_due_to_server_error() {
     let mut server = Server::new();
 

--- a/crates/nu-command/tests/commands/network/http/patch.rs
+++ b/crates/nu-command/tests/commands/network/http/patch.rs
@@ -21,6 +21,25 @@ fn http_patch_is_success() {
 }
 
 #[test]
+fn http_patch_is_success_pipeline() {
+    let mut server = Server::new();
+
+    let _mock = server.mock("PATCH", "/").match_body("foo").create();
+
+    let actual = nu!(pipeline(
+        format!(
+            r#"
+        "foo" | http patch {url}
+        "#,
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert!(actual.out.is_empty())
+}
+
+#[test]
 fn http_patch_failed_due_to_server_error() {
     let mut server = Server::new();
 
@@ -55,7 +74,9 @@ fn http_patch_failed_due_to_missing_body() {
         .as_str()
     ));
 
-    assert!(actual.err.contains("Usage: http patch"))
+    assert!(actual
+        .err
+        .contains("Data must be provided either through pipeline or positional argument"))
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/network/http/post.rs
+++ b/crates/nu-command/tests/commands/network/http/post.rs
@@ -19,6 +19,24 @@ fn http_post_is_success() {
 
     assert!(actual.out.is_empty())
 }
+#[test]
+fn http_post_is_success_pipeline() {
+    let mut server = Server::new();
+
+    let _mock = server.mock("POST", "/").match_body("foo").create();
+
+    let actual = nu!(pipeline(
+        format!(
+            r#"
+        "foo" | http post {url}
+        "#,
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert!(actual.out.is_empty())
+}
 
 #[test]
 fn http_post_failed_due_to_server_error() {
@@ -55,7 +73,9 @@ fn http_post_failed_due_to_missing_body() {
         .as_str()
     ));
 
-    assert!(actual.err.contains("Usage: http post"))
+    assert!(actual
+        .err
+        .contains("Data must be provided either through pipeline or positional argument"))
 }
 
 #[test]

--- a/crates/nu-command/tests/commands/network/http/put.rs
+++ b/crates/nu-command/tests/commands/network/http/put.rs
@@ -21,6 +21,25 @@ fn http_put_is_success() {
 }
 
 #[test]
+fn http_put_is_success_pipeline() {
+    let mut server = Server::new();
+
+    let _mock = server.mock("PUT", "/").match_body("foo").create();
+
+    let actual = nu!(pipeline(
+        format!(
+            r#"
+        "foo" | http put {url} 
+        "#,
+            url = server.url()
+        )
+        .as_str()
+    ));
+
+    assert!(actual.out.is_empty())
+}
+
+#[test]
 fn http_put_failed_due_to_server_error() {
     let mut server = Server::new();
 
@@ -55,7 +74,9 @@ fn http_put_failed_due_to_missing_body() {
         .as_str()
     ));
 
-    assert!(actual.err.contains("Usage: http put"))
+    assert!(actual
+        .err
+        .contains("Data must be provided either through pipeline or positional argument"))
 }
 
 #[test]

--- a/crates/nu-plugin-core/src/interface/tests.rs
+++ b/crates/nu-plugin-core/src/interface/tests.rs
@@ -18,6 +18,7 @@ use std::{path::Path, sync::Arc};
 fn test_metadata() -> PipelineMetadata {
     PipelineMetadata {
         data_source: DataSource::FilePath("/test/path".into()),
+        content_type: None,
     }
 }
 
@@ -258,7 +259,7 @@ fn read_pipeline_data_prepared_properly() -> Result<(), ShellError> {
     });
     match manager.read_pipeline_data(header, None)? {
         PipelineData::ListStream(_, meta) => match meta {
-            Some(PipelineMetadata { data_source }) => match data_source {
+            Some(PipelineMetadata { data_source, .. }) => match data_source {
                 DataSource::FilePath(path) => {
                     assert_eq!(Path::new("/test/path"), path);
                     Ok(())

--- a/crates/nu-protocol/src/pipeline/metadata.rs
+++ b/crates/nu-protocol/src/pipeline/metadata.rs
@@ -1,19 +1,21 @@
 use std::path::PathBuf;
 
 /// Metadata that is valid for the whole [`PipelineData`](crate::PipelineData)
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct PipelineMetadata {
     pub data_source: DataSource,
+    pub content_type: Option<String>,
 }
 
 /// Describes where the particular [`PipelineMetadata`] originates.
 ///
 /// This can either be a particular family of commands (useful so downstream commands can adjust
 /// the presentation e.g. `Ls`) or the opened file to protect against overwrite-attempts properly.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub enum DataSource {
     Ls,
     HtmlThemes,
     FilePath(PathBuf),
-    ContentType(String)
+    #[default]
+    None,
 }

--- a/crates/nu-protocol/src/pipeline/metadata.rs
+++ b/crates/nu-protocol/src/pipeline/metadata.rs
@@ -15,4 +15,5 @@ pub enum DataSource {
     Ls,
     HtmlThemes,
     FilePath(PathBuf),
+    ContentType(String)
 }

--- a/crates/nu-protocol/src/pipeline/metadata.rs
+++ b/crates/nu-protocol/src/pipeline/metadata.rs
@@ -7,6 +7,22 @@ pub struct PipelineMetadata {
     pub content_type: Option<String>,
 }
 
+impl PipelineMetadata {
+    pub fn with_data_source(self, data_source: DataSource) -> Self {
+        Self {
+            data_source,
+            ..self
+        }
+    }
+
+    pub fn with_content_type(self, content_type: Option<String>) -> Self {
+        Self {
+            content_type,
+            ..self
+        }
+    }
+}
+
 /// Describes where the particular [`PipelineMetadata`] originates.
 ///
 /// This can either be a particular family of commands (useful so downstream commands can adjust


### PR DESCRIPTION
# Description
Provides the ability to use http commands as part of a pipeline. Additionally, this pull requests extends the pipeline metadata to add a content_type field. The content_type metadata field allows commands such as `to json` to set the metadata in the pipeline allowing the http commands to use it when making requests. 

This pull request also introduces the ability to directly stream http requests from streaming pipelines.

One other small change is that Content-Type will always be set if it is passed in to the http commands, either indirectly or throw the content type flag. Previously it was not preserved with requests that were not of type json or form data.

# User-Facing Changes
* `http post`, `http put`, `http patch`, `http delete` can be used as part of a pipeline
* `to text`, `to json`, `from json` all set the content_type metadata field and the http commands will utilize them when making requests.

