### PR TITLE
Upgrade Ubuntu runners to 22.04 to fix nightly build errors, fix #13255

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -99,13 +99,13 @@ jobs:
           extra: msi
           os: windows-latest
         - target: x86_64-unknown-linux-gnu
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - target: x86_64-unknown-linux-musl
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - target: aarch64-unknown-linux-gnu
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - target: armv7-unknown-linux-gnueabihf
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,13 @@ jobs:
           extra: msi
           os: windows-latest
         - target: x86_64-unknown-linux-gnu
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - target: x86_64-unknown-linux-musl
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - target: aarch64-unknown-linux-gnu
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - target: armv7-unknown-linux-gnueabihf
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - target: riscv64gc-unknown-linux-gnu
           os: ubuntu-latest
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->
Upgrade Ubuntu runners to 22.04 to fix nightly build errors related to `GLIBC` versions like:
https://github.com/nushell/nushell/actions/runs/9727979044/job/26848189346
Should close #13255

BTW: The [workflow of `nushell/nightly`](https://github.com/nushell/nightly/blob/6faf3c3aed728b641701add604cf58f28a87e67f/.github/workflows/nightly-build.yml#L108) has been upgraded a long time ago

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Older linux system users can download `*-x86_64-unknown-linux-musl.tar.gz` binaries if any `GLIBC` error found while starting `nu` binary


