### PR TITLE
Limit drilling down inside `explore`

### DIFF
--- a/crates/nu-explore/src/commands/nu.rs
+++ b/crates/nu-explore/src/commands/nu.rs
@@ -65,7 +65,7 @@ impl ViewCommand for NuCmd {
         let mut view = RecordView::new(columns, values);
 
         if is_record {
-            view.set_orientation_current(Orientation::Left);
+            view.set_top_layer_orientation(Orientation::Left);
         }
 
         Ok(NuView::Records(view))

--- a/crates/nu-explore/src/commands/table.rs
+++ b/crates/nu-explore/src/commands/table.rs
@@ -58,11 +58,11 @@ impl ViewCommand for TableCmd {
         let mut view = RecordView::new(columns, data);
 
         if is_record {
-            view.set_orientation_current(Orientation::Left);
+            view.set_top_layer_orientation(Orientation::Left);
         }
 
         if let Some(o) = self.settings.orientation {
-            view.set_orientation_current(o);
+            view.set_top_layer_orientation(o);
         }
 
         if self.settings.turn_on_cursor_mode {

--- a/crates/nu-explore/src/lib.rs
+++ b/crates/nu-explore/src/lib.rs
@@ -75,7 +75,7 @@ fn create_record_view(
 ) -> Option<Page> {
     let mut view = RecordView::new(columns, data);
     if is_record {
-        view.set_orientation_current(Orientation::Left);
+        view.set_top_layer_orientation(Orientation::Left);
     }
 
     if config.tail {

--- a/crates/nu-explore/src/views/try.rs
+++ b/crates/nu-explore/src/views/try.rs
@@ -242,8 +242,8 @@ impl View for TryView {
 
         if let Some(view) = &mut self.table {
             view.setup(config);
-            view.set_orientation(r.get_orientation_current());
-            view.set_orientation_current(r.get_orientation_current());
+            view.set_orientation(r.get_top_layer_orientation());
+            view.set_top_layer_orientation(r.get_top_layer_orientation());
         }
     }
 }
@@ -262,7 +262,7 @@ fn run_command(
 
     let mut view = RecordView::new(columns, values);
     if is_record {
-        view.set_orientation_current(Orientation::Left);
+        view.set_top_layer_orientation(Orientation::Left);
     }
 
     Ok(view)


### PR DESCRIPTION
This PR fixes an issue with `explore` where you can "drill down" into the same value forever. For example:

1. Run `ls | explore`
2. Press Enter to enter cursor mode
3. Press Enter again to open the selected string in a new layer
4. Press Enter again to open that string in a new layer
5. Press Enter again to open that string in a new layer
6. Repeat and eventually you have a bajillion layers open with the same string

IMO it only makes sense to "drill down" into lists and records.

In a separate commit I also did a little refactoring, cleaning up naming and comments.