### PR TITLE
don't show result in error make examples

### DIFF
--- a/crates/nu-cmd-lang/src/core_commands/error_make.rs
+++ b/crates/nu-cmd-lang/src/core_commands/error_make.rs
@@ -56,16 +56,7 @@ impl Command for ErrorMake {
             Example {
                 description: "Create a simple custom error",
                 example: r#"error make {msg: "my custom error message"}"#,
-                result: Some(Value::error(
-                    ShellError::GenericError {
-                        error: "my custom error message".into(),
-                        msg: "".into(),
-                        span: None,
-                        help: None,
-                        inner: vec![],
-                    },
-                    Span::unknown(),
-                )),
+                result: None,
             },
             Example {
                 description: "Create a more complex custom error",
@@ -82,16 +73,7 @@ impl Command for ErrorMake {
         }
         help: "A help string, suggesting a fix to the user"  # optional
     }"#,
-                result: Some(Value::error(
-                    ShellError::GenericError {
-                        error: "my custom error message".into(),
-                        msg: "my custom label text".into(),
-                        span: Some(Span::new(123, 456)),
-                        help: Some("A help string, suggesting a fix to the user".into()),
-                        inner: vec![],
-                    },
-                    Span::unknown(),
-                )),
+                result: None,
             },
             Example {
                 description:

--- a/crates/nu-std/tests/test_help.nu
+++ b/crates/nu-std/tests/test_help.nu
@@ -7,3 +7,8 @@ def show_help_on_commands [] {
     assert ("item not found" not-in $help_result)
 }
 
+#[test]
+def show_help_on_error_make [] {
+    let help_result = (help error make)
+    assert ("Error: nu::shell::eval_block_with_input" not-in $help_result)
+}


### PR DESCRIPTION
# Description
Fixes: #13189 

The issue is caused `error make` returns a `Value::Errror`, and when nushell pass it to `table -e` in `std help`, it directly stop and render the error message.
To solve it, I think it's safe to make these examples return None directly, it doesn't change the reult of `help error make`.

# User-Facing Changes
## Before
```nushell
~> help "error make"
Error: nu::shell::eval_block_with_input

  × Eval block failed with pipeline input
     ╭─[NU_STDLIB_VIRTUAL_DIR/std/help.nu:692:21]
 691 │ ] {
 692 │     let commands = (scope commands | sort-by name)
     ·                     ───────┬──────
     ·                            ╰── source value
 693 │
     ╰────

Error:   × my custom error message
```

## After
```nushell
Create an error.

Search terms: panic, crash, throw

Category: core

This command:
- does not create a scope.
- is a built-in command.
- is a subcommand.
- is not part of a plugin.
- is not a custom command.
- is not a keyword.

Usage:
  > error make {flags} <error_struct>


Flags:

  -u, --unspanned - remove the origin label from the error
  -h, --help - Display the help message for this command

Signatures:

  <nothing> | error make[ <record>] -> <any>

Parameters:

  error_struct: <record> The error to create.


Examples:
  Create a simple custom error
  > error make {msg: "my custom error message"}


  Create a more complex custom error
  > error make {
        msg: "my custom error message"
        label: {
            text: "my custom label text"  # not mandatory unless $.label exists
            # optional
            span: {
                # if $.label.span exists, both start and end must be present
                start: 123
                end: 456
            }
        }
        help: "A help string, suggesting a fix to the user"  # optional
    }


  Create a custom error for a custom command that shows the span of the argument
  > def foo [x] {
        error make {
            msg: "this is fishy"
            label: {
                text: "fish right here"
                span: (metadata $x).span
            }
        }
    }
```
# Tests + Formatting
Added 1 test
