### PR TITLE
feat: replace `unfold` with `from_fn` for the generate command

### DIFF
--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -1,4 +1,3 @@
-use itertools::unfold;
 use nu_engine::{command_prelude::*, ClosureEval};
 use nu_protocol::engine::Closure;
 

--- a/crates/nu-command/src/generators/generate.rs
+++ b/crates/nu-command/src/generators/generate.rs
@@ -81,7 +81,8 @@ used as the next argument to the closure, otherwise generation stops.
         // A type of Option<S> is used to represent state. Invocation
         // will stop on None. Using Option<S> allows functions to output
         // one final value before stopping.
-        let iter = unfold(Some(initial), move |state| {
+        let mut state = Some(initial);
+        let iter = std::iter::from_fn(move || {
             let arg = state.take()?;
 
             let (output, next_input) = match closure.run_with_value(arg) {
@@ -160,7 +161,7 @@ used as the next argument to the closure, otherwise generation stops.
             // We use `state` to control when to stop, not `output`. By wrapping
             // it in a `Some`, we allow the generator to output `None` as a valid output
             // value.
-            *state = next_input;
+            state = next_input;
             Some(output)
         });
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.


you can also mention related issues, PRs or discussions!
-->
This PR should close #13247 

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

- The deprecated `itertools::unfold` function is replaced with `std::iter::from_fn`  for the generate command.
- The mutable iterator state is no longer passed as an argument to `from_fn` but it gets captured with the closure's `move`. 

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->
No user facing changes

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Tests for the generate command are passing locally.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
