### PR TITLE
change duration mod duration to duration instead of float

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -292,7 +292,7 @@ pub fn math_result_type(
                 (Type::Filesize, Type::Filesize) => (Type::Float, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Filesize, Type::Float) => (Type::Filesize, None),
-                (Type::Duration, Type::Duration) => (Type::Float, None),
+                (Type::Duration, Type::Duration) => (Type::Duration, None),
                 (Type::Duration, Type::Int) => (Type::Duration, None),
                 (Type::Duration, Type::Float) => (Type::Duration, None),
 


### PR DESCRIPTION
# Description

closes #13298 so that duration mod duration / duration = duration

### Before
```nushell
(92sec mod 1min) / 1sec
Error: nu::parser::unsupported_operation

  × division is not supported between float and duration.
   ╭─[entry #5:1:1]
 1 │ (92sec mod 1min) / 1sec
   · ────────┬─────── ┬ ──┬─
   ·         │        │   ╰── duration
   ·         │        ╰── doesn't support these values
   ·         ╰── float
   ╰────
```
### After
```nushell
❯ (92sec mod 1min) / 1sec
32
```

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
