### PR TITLE
fix: exotic types return float on division, self on modulo

### DIFF
--- a/crates/nu-parser/src/type_check.rs
+++ b/crates/nu-parser/src/type_check.rs
@@ -278,8 +278,7 @@ pub fn math_result_type(
                     )
                 }
             },
-            Operator::Math(Math::Divide) | Operator::Math(Math::Modulo) => match (&lhs.ty, &rhs.ty)
-            {
+            Operator::Math(Math::Divide) => match (&lhs.ty, &rhs.ty) {
                 (Type::Int, Type::Int) => (Type::Int, None),
                 (Type::Float, Type::Int) => (Type::Float, None),
                 (Type::Int, Type::Float) => (Type::Float, None),
@@ -290,6 +289,55 @@ pub fn math_result_type(
                 (Type::Number, Type::Float) => (Type::Number, None),
                 (Type::Float, Type::Number) => (Type::Number, None),
                 (Type::Filesize, Type::Filesize) => (Type::Float, None),
+                (Type::Filesize, Type::Int) => (Type::Filesize, None),
+                (Type::Filesize, Type::Float) => (Type::Filesize, None),
+                (Type::Duration, Type::Duration) => (Type::Float, None),
+                (Type::Duration, Type::Int) => (Type::Duration, None),
+                (Type::Duration, Type::Float) => (Type::Duration, None),
+
+                (Type::Custom(a), Type::Custom(b)) if a == b => (Type::Custom(a.clone()), None),
+                (Type::Custom(a), _) => (Type::Custom(a.clone()), None),
+
+                (Type::Any, _) => (Type::Any, None),
+                (_, Type::Any) => (Type::Any, None),
+                (Type::Int | Type::Float | Type::Filesize | Type::Duration, _) => {
+                    *op = Expression::garbage(working_set, op.span);
+                    (
+                        Type::Any,
+                        Some(ParseError::UnsupportedOperationRHS(
+                            "division".into(),
+                            op.span,
+                            lhs.span,
+                            lhs.ty.clone(),
+                            rhs.span,
+                            rhs.ty.clone(),
+                        )),
+                    )
+                }
+                _ => {
+                    *op = Expression::garbage(working_set, op.span);
+                    (
+                        Type::Any,
+                        Some(ParseError::UnsupportedOperationLHS(
+                            "division".into(),
+                            op.span,
+                            lhs.span,
+                            lhs.ty.clone(),
+                        )),
+                    )
+                }
+            },
+            Operator::Math(Math::Modulo) => match (&lhs.ty, &rhs.ty) {
+                (Type::Int, Type::Int) => (Type::Int, None),
+                (Type::Float, Type::Int) => (Type::Float, None),
+                (Type::Int, Type::Float) => (Type::Float, None),
+                (Type::Float, Type::Float) => (Type::Float, None),
+                (Type::Number, Type::Number) => (Type::Number, None),
+                (Type::Number, Type::Int) => (Type::Number, None),
+                (Type::Int, Type::Number) => (Type::Number, None),
+                (Type::Number, Type::Float) => (Type::Number, None),
+                (Type::Float, Type::Number) => (Type::Number, None),
+                (Type::Filesize, Type::Filesize) => (Type::Filesize, None),
                 (Type::Filesize, Type::Int) => (Type::Filesize, None),
                 (Type::Filesize, Type::Float) => (Type::Filesize, None),
                 (Type::Duration, Type::Duration) => (Type::Duration, None),


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

Related to #13298

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

Exotic types like `Duration` and `Filesize` return a float on division by the same type, i.e., the unit is gone since division results in a scalar. When using the modulo operator, the output type has the same unit.   

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Division results in a float like the following:

```sh
~/Public/nushell> 512sec / 3sec
170.66666666666666
```

Modulo results in an output with the same unit:

```sh
~/Public/nushell> 512sec mod 3sec
2sec
```

Type checking isn't confused with output types:

```sh
~/Public/nushell> (512sec mod 3sec) / 0.5sec
4
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->
Existing tests are passing.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
