### PR TITLE
feat: prefer exact match when completion mode is prefix

### DIFF
--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -76,6 +76,13 @@ fn complete_rec(
                         completions.push(built);
                     }
                 }
+                // isdir tells us whether the current path has a trailing slash.
+                // Parsing a path string into a pathbuf loses that bit of information.
+                // We use isdir to confirm that the current component has at least one
+                // next component or a slash.
+
+                // This acts as a confirmation to ignore longer completions for components
+                // in between.
                 if entry_name.eq(base)
                     && matches!(options.match_algorithm, MatchAlgorithm::Prefix)
                     && isdir

--- a/crates/nu-cli/src/completions/completion_common.rs
+++ b/crates/nu-cli/src/completions/completion_common.rs
@@ -14,7 +14,7 @@ use std::path::{
     is_separator, Component, Path, PathBuf, MAIN_SEPARATOR as SEP, MAIN_SEPARATOR_STR,
 };
 
-use super::SortBy;
+use super::{MatchAlgorithm, SortBy};
 
 #[derive(Clone, Default)]
 pub struct PathBuiltFromString {
@@ -75,6 +75,12 @@ fn complete_rec(
                     } else {
                         completions.push(built);
                     }
+                }
+                if entry_name.eq(base)
+                    && matches!(options.match_algorithm, MatchAlgorithm::Prefix)
+                    && isdir
+                {
+                    break;
                 }
             }
             None => {


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

Fixes #13204

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

When the completion mode is set to `prefix`, path completions explicitly check for and prefer an exact match for a basename instead of longer or similar names.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Exact match is inactive since there's no trailing slash

```
~/Public/nushell| ls crates/nu-plugin<tab>
crates/nu-plugin/               crates/nu-plugin-core/          crates/nu-plugin-engine/        crates/nu-plugin-protocol/      
crates/nu-plugin-test-support/
```

Exact match is active

```
~/Public/nushell| ls crates/nu-plugin/<tab>
crates/nu-plugin/Cargo.toml  crates/nu-plugin/LICENSE     crates/nu-plugin/README.md   crates/nu-plugin/src/
```

Fuzzy matching persists its behavior

```
~/Public/nushell> $env.config.completions.algorithm = "fuzzy";
~/Public/nushell| ls crates/nu-plugin/car
crates/nu-cmd-plugin/Cargo.toml           crates/nu-plugin/Cargo.toml               crates/nu-plugin-core/Cargo.toml          crates/nu-plugin-engine/Cargo.toml        
crates/nu-plugin-protocol/Cargo.toml      crates/nu-plugin-test-support/Cargo.toml
```

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
