### PR TITLE
Preserve attributes on external ByteStreams

### DIFF
--- a/crates/nu-command/tests/commands/conversions/into/binary.rs
+++ b/crates/nu-command/tests/commands/conversions/into/binary.rs
@@ -1,0 +1,13 @@
+use nu_test_support::nu;
+
+#[test]
+fn sets_stream_from_internal_command_as_binary() {
+    let result = nu!("seq 1 10 | to text | into binary | describe");
+    assert_eq!("binary (stream)", result.out);
+}
+
+#[test]
+fn sets_stream_from_external_command_as_binary() {
+    let result = nu!("^nu --testbin cococo | into binary | describe");
+    assert_eq!("binary (stream)", result.out);
+}

--- a/crates/nu-command/tests/commands/conversions/into/mod.rs
+++ b/crates/nu-command/tests/commands/conversions/into/mod.rs
@@ -1,1 +1,2 @@
+mod binary;
 mod int;


### PR DESCRIPTION
# Description

Bug fix: `PipelineData::check_external_failed()` was not preserving the original `type_` and `known_size` attributes of the stream passed in for streams that come from children, so `external-command | into binary` did not work properly and always ended up still being unknown type.

# User-Facing Changes
The following test case now works as expected:

```nushell
> head -c 2 /dev/urandom | into binary
# Expected: pretty hex dump of binary
# Previous behavior: just raw binary in the terminal
```

# Tests + Formatting
Added a test to cover this to `into binary`
