### PR TITLE
Fix variable completion sort order

### DIFF
--- a/crates/nu-cli/src/completions/variable_completions.rs
+++ b/crates/nu-cli/src/completions/variable_completions.rs
@@ -229,6 +229,8 @@ impl Completer for VariableCompletion {
             }
         }
 
+        output = sort_suggestions(&prefix_str, output, SortBy::Ascending);
+
         output.dedup(); // TODO: Removes only consecutive duplicates, is it intended?
 
         output

--- a/crates/nu-cli/tests/completions/mod.rs
+++ b/crates/nu-cli/tests/completions/mod.rs
@@ -107,7 +107,7 @@ fn subcommand_completer() -> NuCompleter {
 }
 
 #[test]
-fn variables_dollar_sign_with_varialblecompletion() {
+fn variables_dollar_sign_with_variablecompletion() {
     let (_, _, engine, stack) = new_engine();
 
     let mut completer = NuCompleter::new(Arc::new(engine), Arc::new(stack));
@@ -906,6 +906,11 @@ fn variables_completions() {
     let expected: Vec<String> = vec!["TEST".into()];
 
     // Match results
+    match_suggestions(expected, suggestions);
+
+    let suggestions = completer.complete("$", 1);
+    let expected: Vec<String> = vec!["$actor".into(), "$env".into(), "$in".into(), "$nu".into()];
+
     match_suggestions(expected, suggestions);
 }
 


### PR DESCRIPTION
<!--
if this PR closes one or more issues, you can automatically link the PR with
them by using one of the [*linking keywords*](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword), e.g.
- this PR should close #xxxx
- fixes #xxxx

you can also mention related issues, PRs or discussions!
-->

# Description
<!--
Thank you for improving Nushell. Please, check our [contributing guide](../CONTRIBUTING.md) and talk to the core team before making major changes.

Description of your pull request goes here. **Provide examples and/or screenshots** if your changes affect the user experience.
-->

My last PR (https://github.com/nushell/nushell/pull/13242) made it so that the last branch in the variable completer doesn't sort suggestions. Sorry about that. This should fix it.

# User-Facing Changes
<!-- List of all changes that impact the user experience here. This helps us keep track of breaking changes. -->

Variables will now be sorted properly.

# Tests + Formatting
<!--
Don't forget to add tests that cover your changes.

Make sure you've run and fixed any issues with these commands:

- `cargo fmt --all -- --check` to check standard code formatting (`cargo fmt --all` applies these changes)
- `cargo clippy --workspace -- -D warnings -D clippy::unwrap_used` to check that you're using the standard code style
- `cargo test --workspace` to check that all tests pass (on Windows make sure to [enable developer mode](https://learn.microsoft.com/en-us/windows/apps/get-started/developer-mode-features-and-debugging))
- `cargo run -- -c "use toolkit.nu; toolkit test stdlib"` to run the tests for the standard library

> **Note**
> from `nushell` you can also use the `toolkit` as follows
> ```bash
> use toolkit.nu  # or use an `env_change` hook to activate it automatically
> toolkit check pr
> ```
-->

Added one test case to verify this won't happen again.

# After Submitting
<!-- If your PR had any user-facing changes, update [the documentation](https://github.com/nushell/nushell.github.io) after the PR is merged, if necessary. This will help us keep the docs up to date. -->
